### PR TITLE
Add a roundtrip fuzzer

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -39,3 +39,8 @@ test = false
 name = "print"
 path = "fuzz_targets/print.rs"
 test = false
+
+[[bin]]
+name = "roundtrip"
+path = "fuzz_targets/roundtrip.rs"
+test = false

--- a/fuzz/fuzz_targets/roundtrip.rs
+++ b/fuzz/fuzz_targets/roundtrip.rs
@@ -1,0 +1,26 @@
+#![no_main]
+
+use libfuzzer_sys::*;
+use std::str;
+
+fuzz_target!(|data: &[u8]| {
+    let string = match str::from_utf8(data) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    if string.contains("binary") {
+        return;
+    }
+    let wasm = match wat::parse_str(string) {
+        Ok(bytes) => bytes,
+        Err(_) => return,
+    };
+    if wasmparser::validate(&wasm, None).is_err() {
+        return;
+    }
+    let string = match wasmprinter::print_bytes(&wasm) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    assert_eq!(wasm, wat::parse_str(&string).unwrap());
+});


### PR DESCRIPTION
Fuzz that the cycle of:

* `wat` produces bytes
* `wasmparser` validates
* `wasmprinter` prints
* `wat` parses again

produces the exact same wasm binary on both parses. This should
ideally provide a guarantee that if wasmparser validates something that
all three tools agree on textual and binary formats.