### PR TITLE
Implement support for tail calls in wasmparser

### DIFF
--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -977,6 +977,13 @@ impl<'a> BinaryReader<'a> {
                 index: self.read_var_u32()?,
                 table_index: self.read_var_u32()?,
             },
+            0x12 => Operator::ReturnCall {
+                function_index: self.read_var_u32()?,
+            },
+            0x13 => Operator::ReturnCallIndirect {
+                index: self.read_var_u32()?,
+                table_index: self.read_var_u32()?,
+            },
             0x1a => Operator::Drop,
             0x1b => Operator::Select,
             0x1c => {

--- a/crates/wasmparser/src/module_resources.rs
+++ b/crates/wasmparser/src/module_resources.rs
@@ -304,6 +304,42 @@ pub trait WasmModuleResources {
     fn data_count(&self) -> u32;
 }
 
+impl<T> WasmModuleResources for &'_ T
+where
+    T: ?Sized + WasmModuleResources,
+{
+    type FuncType = T::FuncType;
+    type TableType = T::TableType;
+    type MemoryType = T::MemoryType;
+    type GlobalType = T::GlobalType;
+
+    fn type_at(&self, at: u32) -> Option<&Self::FuncType> {
+        T::type_at(self, at)
+    }
+    fn table_at(&self, at: u32) -> Option<&Self::TableType> {
+        T::table_at(self, at)
+    }
+    fn memory_at(&self, at: u32) -> Option<&Self::MemoryType> {
+        T::memory_at(self, at)
+    }
+    fn global_at(&self, at: u32) -> Option<&Self::GlobalType> {
+        T::global_at(self, at)
+    }
+    fn func_type_id_at(&self, at: u32) -> Option<u32> {
+        T::func_type_id_at(self, at)
+    }
+    fn element_type_at(&self, at: u32) -> Option<crate::Type> {
+        T::element_type_at(self, at)
+    }
+
+    fn element_count(&self) -> u32 {
+        T::element_count(self)
+    }
+    fn data_count(&self) -> u32 {
+        T::data_count(self)
+    }
+}
+
 impl WasmType for crate::Type {
     fn to_parser_type(&self) -> crate::Type {
         *self

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -274,6 +274,8 @@ pub enum Operator<'a> {
     Return,
     Call { function_index: u32 },
     CallIndirect { index: u32, table_index: u32 },
+    ReturnCall { function_index: u32 },
+    ReturnCallIndirect { index: u32, table_index: u32 },
     Drop,
     Select,
     TypedSelect { ty: Type },

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -517,6 +517,17 @@ impl Printer {
                 }
                 write!(self.result, " (type {})", index)?;
             }
+            ReturnCall { function_index } => {
+                self.result.push_str("return_call ");
+                self.print_func_idx(*function_index)?;
+            }
+            ReturnCallIndirect { table_index, index } => {
+                self.result.push_str("return_call_indirect");
+                if *table_index != 0 {
+                    write!(self.result, " {}", table_index)?;
+                }
+                write!(self.result, " (type {})", index)?;
+            }
 
             Drop => self.result.push_str("drop"),
             Select => self.result.push_str("select"),

--- a/src/bin/wasm-validate-rs.rs
+++ b/src/bin/wasm-validate-rs.rs
@@ -18,6 +18,7 @@ fn main() -> Result<()> {
         "Enable wasm bulk memory operations feature",
     );
     opts.optflag("", "enable-multi-value", "Enable wasm multi-value feature");
+    opts.optflag("", "enable-tail-call", "Enable wasm tail-call feature");
     #[cfg(feature = "deterministic")]
     opts.optflag(
         "",
@@ -45,6 +46,7 @@ fn main() -> Result<()> {
             enable_simd: matches.opt_present("enable-simd"),
             enable_bulk_memory: matches.opt_present("enable-bulk-memory"),
             enable_multi_value: matches.opt_present("enable-multi-value"),
+            enable_tail_call: matches.opt_present("enable-tail-call"),
             #[cfg(feature = "deterministic")]
             deterministic_only: matches.opt_present("deterministic-only"),
         },


### PR DESCRIPTION
This adds the two new opcodes added by the tail-call proposal,
`return_call` and `return_call_indirect`. The main complication here is
the validation.