### PR TITLE
Validate `ref.func` instruction references

### DIFF
--- a/crates/wasmparser/src/module_resources.rs
+++ b/crates/wasmparser/src/module_resources.rs
@@ -302,6 +302,9 @@ pub trait WasmModuleResources {
     fn element_count(&self) -> u32;
     /// Returns the number of bytes in the Wasm data section.
     fn data_count(&self) -> u32;
+    /// Returns whether the function index is referenced in the module anywhere
+    /// outside of the start/function sections.
+    fn is_function_referenced(&self, idx: u32) -> bool;
 }
 
 impl<T> WasmModuleResources for &'_ T
@@ -337,6 +340,9 @@ where
     }
     fn data_count(&self) -> u32 {
         T::data_count(self)
+    }
+    fn is_function_referenced(&self, idx: u32) -> bool {
+        T::is_function_referenced(self, idx)
     }
 }
 

--- a/crates/wasmparser/src/operators_validator.rs
+++ b/crates/wasmparser/src/operators_validator.rs
@@ -1638,6 +1638,9 @@ impl OperatorValidator {
                         "unknown function: function index out of bounds",
                     ));
                 }
+                if !resources.is_function_referenced(function_index) {
+                    return Err(OperatorValidatorError::new("undeclared function reference"));
+                }
                 self.func_state.change_frame_with_type(0, Type::FuncRef)?;
             }
             Operator::V128Load { memarg } => {

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -649,16 +649,6 @@ impl TestState {
     }
 
     fn wasmparser_disabled(&self, test: &Path, line: usize) -> bool {
-        // Waiting for WebAssembly/reference-types#76 to get resolved
-        if test.ends_with("reference-types/ref_func.wast") {
-            return line == 108 || line == 112;
-        }
-
-        // Waiting for WebAssembly/reference-types#76 to get resolved
-        if test.ends_with("reference-types/ref_func.wast") {
-            return line == 108 || line == 112;
-        }
-
         // these tests still use the old binary encoding, need to be
         // updated for the new one
         if test.ends_with("simd_const.wast") {


### PR DESCRIPTION
Implement the currently proposed rule of validating that function
references from `ref.func` are referenced by something else in the
module other than functions or the start function. This means that
functions must be referenced by element segments, globals,
initialization expressions, or exports.