### PR TITLE
wasmparser: Remove `form` member from `FuncType`

### DIFF
--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -243,7 +243,13 @@ impl<'a> BinaryReader<'a> {
     }
 
     pub(crate) fn read_func_type(&mut self) -> Result<FuncType> {
-        let form = self.read_type()?;
+        if self.read_type()? != Type::Func {
+            return Err(BinaryReaderError::new(
+                "type signature is not a func",
+                self.original_position() - 1,
+            ));
+        }
+
         let params_len = self.read_var_u32()? as usize;
         if params_len > MAX_WASM_FUNCTION_PARAMS {
             return Err(BinaryReaderError::new(
@@ -267,7 +273,6 @@ impl<'a> BinaryReader<'a> {
             returns.push(self.read_type()?);
         }
         Ok(FuncType {
-            form,
             params: params.into_boxed_slice(),
             returns: returns.into_boxed_slice(),
         })

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -139,7 +139,6 @@ pub enum ExternalKind {
 
 #[derive(Debug, Clone)]
 pub struct FuncType {
-    pub form: Type,
     pub params: Box<[Type]>,
     pub returns: Box<[Type]>,
 }

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -137,7 +137,7 @@ pub enum ExternalKind {
     Global,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct FuncType {
     pub params: Box<[Type]>,
     pub returns: Box<[Type]>,

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -242,16 +242,12 @@ impl<'a> ValidatingParser<'a> {
     }
 
     fn check_func_type(&self, func_type: &FuncType) -> ValidatorResult<'a, ()> {
-        if let Type::Func = func_type.form {
-            self.check_value_types(&*func_type.params)?;
-            self.check_value_types(&*func_type.returns)?;
-            if !self.config.operator_config.enable_multi_value && func_type.returns.len() > 1 {
-                self.create_error("invalid result arity: func type returns multiple values")
-            } else {
-                Ok(())
-            }
+        self.check_value_types(&*func_type.params)?;
+        self.check_value_types(&*func_type.returns)?;
+        if !self.config.operator_config.enable_multi_value && func_type.returns.len() > 1 {
+            self.create_error("invalid result arity: func type returns multiple values")
         } else {
-            self.create_error("type signature is not a func")
+            Ok(())
         }
     }
 

--- a/tests/dump/select.wat.dump
+++ b/tests/dump/select.wat.dump
@@ -2,7 +2,7 @@
        | 01 00 00 00
 0x0008 | 01 04       | section Type
 0x000a | 01          | 1 count
-0x000b | 60 00 00    | type FuncType { form: Func, params: [], returns: [] }
+0x000b | 60 00 00    | type FuncType { params: [], returns: [] }
 0x000e | 03 02       | section Function
 0x0010 | 01          | 1 count
 0x0011 | 00          | [func 0] type 0

--- a/tests/dump/simple.wat.dump
+++ b/tests/dump/simple.wat.dump
@@ -2,8 +2,8 @@
        | 01 00 00 00
 0x0008 | 01 08       | section Type
 0x000a | 02          | 2 count
-0x000b | 60 01 7f 00 | type FuncType { form: Func, params: [I32], returns: [] }
-0x000f | 60 00 00    | type FuncType { form: Func, params: [], returns: [] }
+0x000b | 60 01 7f 00 | type FuncType { params: [I32], returns: [] }
+0x000f | 60 00 00    | type FuncType { params: [], returns: [] }
 0x0012 | 02 07       | section Import
 0x0014 | 01          | 1 count
 0x0015 | 01 6d 01 6e | import [func 0] Import { module: "m", field: "n", ty: Function(0) }


### PR DESCRIPTION
It is only used to check that the `form` type is a `Type::Func`, which we can do
at parse time, rather than keeping it around.