### PR TITLE
Run more reference tests against wabt

### DIFF
--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -128,6 +128,13 @@ fn skip_test(test: &Path, contents: &[u8]) -> bool {
         return true;
     }
 
+    // this has syntax of an element segment `(elem $e 0)` which isn't used
+    // anywhere else, and I'm not entirely certain if it's vaild, and for now I
+    // don't feel like filing an issue or adding parsing for this.
+    if test.ends_with("roundtrip/table-init-index.txt") {
+        return true;
+    }
+
     if let Ok(contents) = str::from_utf8(contents) {
         // Skip tests that are supposed to fail
         if contents.contains(";; ERROR") {
@@ -225,20 +232,20 @@ impl TestState {
         let string = wasmprinter::print_bytes(contents)?;
         self.bump_ntests();
         if !test.ends_with("local/reloc.wasm")
-            // FIXME(WebAssembly/wabt#1443)
-            && !test.ends_with("dump/reference-types.txt")
-            && !test.ends_with("table-multi.txt")
+
+            // FIXME(WebAssembly/wabt#1447)
+            && !test.ends_with("bulk-memory-operations/binary.wast")
+            && !test.ends_with("reference-types/binary.wast")
+
+            // FIXME(WebAssembly/wabt#1448)
+            && !test.ends_with("reference-types/linking.wast")
+
+            // FIXME(WebAssembly/wabt#1449)
+            && !test.ends_with("reference-types/elem.wast")
 
             // FIXME(WebAssembly/wabt#1444)
             && !test.ends_with("local/ref.wat")
-
-            // FIXME(WebAssembly/wabt#1445)
-            && !test.ends_with("local/table-copy.wat")
-
-            // thought to be some combination of the above issues for these test
-            // suites
-            && !test.iter().any(|t| t == "reference-types")
-            && !test.iter().any(|t| t == "bulk-memory-operations")
+            && !test.ends_with("reference-types/select.wast")
         {
             if let Some(expected) = self.wasm2wat(contents)? {
                 self.string_compare(&string, &expected)?;


### PR DESCRIPTION
A few fixes landed upstream so I've gone through and now we're only
ignoring singular test files instead of blanket test suites. I've also
ensured that all remaining issues have upstream issues with wabt.