### PR TITLE
Fix shebang in wasmparser compare-master script

### DIFF
--- a/crates/wasmparser/compare-master.sh
+++ b/crates/wasmparser/compare-master.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/usr/bin/env bash
 
 # record current bench results
 cargo bench --bench benchmark -- --noplot --save-baseline after


### PR DESCRIPTION
Before the change when trying to execute the script at least my system told me the following:
```
Failed to execute process './compare-master.sh'. Reason:
exec: Exec format error
The file './compare-master.sh' is marked as an executable but could not be run by the operating system.
```

This not only adds the missing `!` to the shebang but also changes from `/bin/bash` to `/usr/bin/env bash` because it has the advantage of searching the user's `PATH` for `bash` which is more universally applicable since `bash` is not always found under `/bin/bash`.