### PR TITLE
Try to fix wasmparser benchmarks

### DIFF
--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -19,6 +19,10 @@ wat = { path = "../wat" }
 wast = { path = "../wast" }
 rayon = "1.3"
 
+[[bench]]
+name = "benchmark"
+harness = false
+
 [features]
 # The "deterministic" feature supports only Wasm code with "deterministic" execution
 # across any hardware. This feature is very critical for many Blockchain infrastructures

--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -44,7 +44,7 @@ where
 
 fn it_works_benchmark(c: &mut Criterion) {
     let mut data: Vec<Vec<u8>> = vec![];
-    for entry in read_dir("tests").unwrap() {
+    for entry in read_dir("../../tests").unwrap() {
         let dir = entry.unwrap();
         if !dir.file_type().unwrap().is_file() {
             continue;
@@ -60,7 +60,7 @@ fn it_works_benchmark(c: &mut Criterion) {
 
 fn validator_not_fails_benchmark(c: &mut Criterion) {
     let mut data: Vec<Vec<u8>> = vec![];
-    for entry in read_dir("tests").unwrap() {
+    for entry in read_dir("../../tests").unwrap() {
         let dir = entry.unwrap();
         if !dir.file_type().unwrap().is_file() {
             continue;
@@ -76,7 +76,7 @@ fn validator_not_fails_benchmark(c: &mut Criterion) {
 
 fn validate_benchmark(c: &mut Criterion) {
     let mut data: Vec<Vec<u8>> = vec![vec![]];
-    for entry in read_dir("tests").unwrap() {
+    for entry in read_dir("../../tests").unwrap() {
         let dir = entry.unwrap();
         if !dir.file_type().unwrap().is_file() {
             continue;

--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -12,6 +12,7 @@ const VALIDATOR_CONFIG: Option<ValidatingParserConfig> = Some(ValidatingParserCo
         enable_simd: true,
         enable_bulk_memory: true,
         enable_multi_value: true,
+        enable_tail_call: true,
     },
 });
 

--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -28,7 +28,7 @@ where
 {
     loop {
         match *d.read() {
-            ParserState::Error(ref e) => panic!("unexpected error {}", e),
+            ParserState::Error(ref e) => panic!("unexpected error while reading Wasm: {}", e),
             ParserState::EndWasm => return,
             _ => (),
         }

--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -1,9 +1,15 @@
-pub fn read_file_data(path: &PathBuf) -> Vec<u8> {
-    let mut data = Vec::new();
-    let mut f = File::open(path).ok().unwrap();
-    f.read_to_end(&mut data).unwrap();
-    data
-}
+#[macro_use]
+extern crate criterion;
+
+use criterion::Criterion;
+use std::fs::{read_dir, File};
+use std::io::Read;
+use std::path::Path;
+use std::path::PathBuf;
+use wasmparser::{
+    validate, OperatorValidatorConfig, Parser, ParserState, ValidatingParser,
+    ValidatingParserConfig, WasmDecoder,
+};
 
 const VALIDATOR_CONFIG: Option<ValidatingParserConfig> = Some(ValidatingParserConfig {
     operator_config: OperatorValidatorConfig {
@@ -15,20 +21,6 @@ const VALIDATOR_CONFIG: Option<ValidatingParserConfig> = Some(ValidatingParserCo
         enable_tail_call: true,
     },
 });
-
-#[macro_use]
-extern crate criterion;
-extern crate wasmparser;
-
-use criterion::Criterion;
-use wasmparser::{
-    validate, OperatorValidatorConfig, Parser, ParserState, ValidatingParser,
-    ValidatingParserConfig, WasmDecoder,
-};
-
-use std::fs::{read_dir, File};
-use std::io::Read;
-use std::path::PathBuf;
 
 fn read_all_wasm<'a, T>(mut d: T)
 where
@@ -43,6 +35,12 @@ where
     }
 }
 
+fn read_file_data(path: &PathBuf) -> Vec<u8> {
+    let mut data = Vec::new();
+    let mut f = File::open(path).ok().unwrap();
+    f.read_to_end(&mut data).unwrap();
+    data
+}
 fn it_works_benchmark(c: &mut Criterion) {
     let mut data: Vec<Vec<u8>> = vec![];
     for entry in read_dir("../../tests").unwrap() {

--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -41,15 +41,24 @@ fn read_file_data(path: &PathBuf) -> Vec<u8> {
     f.read_to_end(&mut data).unwrap();
     data
 }
-fn it_works_benchmark(c: &mut Criterion) {
-    let mut data: Vec<Vec<u8>> = vec![];
-    for entry in read_dir("../../tests").unwrap() {
+
+fn collect_test_files<P>(path: P) -> Vec<Vec<u8>>
+where
+    P: AsRef<Path>,
+{
+    let mut file_contents: Vec<Vec<u8>> = vec![];
+    for entry in read_dir(path).expect("cannot find the benchmark test files") {
         let dir = entry.unwrap();
         if !dir.file_type().unwrap().is_file() {
             continue;
         }
-        data.push(read_file_data(&dir.path()));
+        file_contents.push(read_file_data(&dir.path()));
     }
+    file_contents
+}
+
+fn it_works_benchmark(c: &mut Criterion) {
+    let mut data = collect_test_files("../../tests");
     c.bench_function("it works benchmark", move |b| {
         for d in &mut data {
             b.iter(|| read_all_wasm(Parser::new(d.as_slice())));
@@ -58,14 +67,7 @@ fn it_works_benchmark(c: &mut Criterion) {
 }
 
 fn validator_not_fails_benchmark(c: &mut Criterion) {
-    let mut data: Vec<Vec<u8>> = vec![];
-    for entry in read_dir("../../tests").unwrap() {
-        let dir = entry.unwrap();
-        if !dir.file_type().unwrap().is_file() {
-            continue;
-        }
-        data.push(read_file_data(&dir.path()));
-    }
+    let mut data = collect_test_files("../../tests");
     c.bench_function("validator no fails benchmark", move |b| {
         for d in &mut data {
             b.iter(|| read_all_wasm(ValidatingParser::new(d.as_slice(), VALIDATOR_CONFIG)));
@@ -74,14 +76,7 @@ fn validator_not_fails_benchmark(c: &mut Criterion) {
 }
 
 fn validate_benchmark(c: &mut Criterion) {
-    let mut data: Vec<Vec<u8>> = vec![vec![]];
-    for entry in read_dir("../../tests").unwrap() {
-        let dir = entry.unwrap();
-        if !dir.file_type().unwrap().is_file() {
-            continue;
-        }
-        data.push(read_file_data(&dir.path()));
-    }
+    let mut data = collect_test_files("../../tests");
     c.bench_function("validate benchmark", move |b| {
         for d in &mut data {
             b.iter(|| validate(&d, VALIDATOR_CONFIG));


### PR DESCRIPTION
This PR fixes the search paths for the benchmarks as well as the `wasmparser` `Cargo.toml` file to respect the `criterion` provided benchmark suite.
Also removes some code dupe in benchmarks and generally polish the implementation.

The error we still see is the following:
```
Benchmarking it works benchmark: Warming up for 3.0000 sthread 'main' panicked at 'unexpected error while reading Wasm Bad magic number (at offset 0)', crates/wasmparser/benches/benchmark.rs:31:42
```

Please tell me how I can fix it or what is actually wrong. :S I assume it is some benchmark `.wast` files that are broken?