### PR TITLE
Try to fix benchmark tests - #2

### DIFF
--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -22,8 +22,49 @@ const VALIDATOR_CONFIG: Option<ValidatingParserConfig> = Some(ValidatingParserCo
     },
 });
 
-fn read_file_data(path: &PathBuf) -> Vec<u8> {
-    wat::parse_file(path).expect("encountered error while parsing Wasm text format file")
+/// A benchmark input.
+pub struct BenchmarkInput {
+    /// The path to the benchmark file important for handling errors.
+    pub path: PathBuf,
+    /// The encoded Wasm module that is run by the benchmark.
+    pub wasm: Vec<u8>,
+}
+
+impl BenchmarkInput {
+    /// Creates a new benchmark input.
+    pub fn new(test_path: PathBuf, encoded_wasm: Vec<u8>) -> Self {
+        Self { path: test_path, wasm: encoded_wasm }
+    }
+}
+
+/// Read a `.wat` formatted benchmark test file as benchmark input.
+fn read_wat_module(path: &PathBuf) -> BenchmarkInput {
+    let encoded_wasm = wat::parse_file(path).expect("encountered error while parsing `.wat` file into `.wasm`");
+    BenchmarkInput::new(path.clone(), encoded_wasm)
+}
+
+/// Read a `.wast` formatted benchmark test file as benchmark input.
+///
+/// We simply pull out all the module directives of the `.wast` file and return them.
+fn read_wast_module(path: &PathBuf) -> Vec<BenchmarkInput> {
+    let mut inputs = Vec::new();
+    let mut wast_file = fs::File::open(path).ok().unwrap();
+    let mut wast_file_contents = String::new();
+    use io::Read as _;
+    wast_file.read_to_string(&mut wast_file_contents).unwrap();
+    let parse_buffer = wast::parser::ParseBuffer::new(&wast_file_contents).unwrap();
+    'outer: while let Ok(directive) = wast::parser::parse::<wast::WastDirective>(&parse_buffer) {
+        match directive {
+            wast::WastDirective::Module(mut module) => {
+                let encoded_wasm = module.encode().expect("encountered error while encoding the Wast module into Wasm");
+                inputs.push(BenchmarkInput::new(path.clone(), encoded_wasm));
+            }
+            _ => {
+                continue 'outer
+            }
+        }
+    }
+    inputs
 }
 
 /// Visits all directory entries within the given directory path.
@@ -51,17 +92,28 @@ where
     Ok(())
 }
 
-fn collect_test_files<P>(path: P) -> Vec<Vec<u8>>
+/// Returns a vector of all found benchmark input files under the given directory.
+///
+/// Benchmark input files can be `.wat` or `.wast` formatted files.
+/// For `.wast` files we pull out all the module directives and run them in the benchmarks.
+fn collect_test_files<P>(path: P) -> Vec<BenchmarkInput>
 where
     P: AsRef<Path>,
 {
-    let mut file_contents: Vec<Vec<u8>> = vec![];
+    let mut file_contents: Vec<BenchmarkInput> = vec![];
     visit_dirs(
         path.as_ref(),
-        &|dir_entry| dir_entry.file_name().to_str() != Some("proposals"),
+        &|_| true, // accept all benchmarks
         &mut |dir_entry| {
-            if dir_entry.path().extension().and_then(|ext| ext.to_str()) == Some("wast") {
-                file_contents.push(read_file_data(&dir_entry.path()))
+            let ext: Option<String> = dir_entry.path().extension().and_then(|ext| ext.to_str().map(|str| str.to_string()));
+            match ext.as_ref().map(|string| string.as_str()) {
+                Some("wat") => file_contents.push(read_wat_module(&dir_entry.path())),
+                Some("wast") => {
+                    for wasm_module in read_wast_module(&dir_entry.path()) {
+                        file_contents.push(wasm_module)
+                    }
+                }
+                _ => (),
             }
         },
     )
@@ -69,13 +121,17 @@ where
     file_contents
 }
 
-fn read_all_wasm<'a, T>(mut d: T)
+/// Reads the input given the Wasm parser or validator.
+///
+/// The `path` specifies which benchmark input file we are currently operating on
+/// so that we can report better errors in case of failures.
+fn read_all_wasm<'a, T>(path: &PathBuf, mut d: T)
 where
     T: WasmDecoder<'a>,
 {
     loop {
         match *d.read() {
-            ParserState::Error(ref e) => panic!("unexpected error while reading Wasm: {}", e),
+            ParserState::Error(ref e) => panic!("unexpected error while reading Wasm at {:?}: {}", path, e),
             ParserState::EndWasm => return,
             _ => (),
         }
@@ -83,28 +139,28 @@ where
 }
 
 fn it_works_benchmark(c: &mut Criterion) {
-    let mut data = collect_test_files("../../tests");
+    let mut inputs = collect_test_files("../../testsuite");
     c.bench_function("it works benchmark", move |b| {
-        for d in &mut data {
-            b.iter(|| read_all_wasm(Parser::new(d.as_slice())));
+        for input in &mut inputs {
+            b.iter(|| read_all_wasm(&input.path, Parser::new(input.wasm.as_slice())));
         }
     });
 }
 
 fn validator_not_fails_benchmark(c: &mut Criterion) {
-    let mut data = collect_test_files("../../tests");
+    let mut inputs = collect_test_files("../../testsuite");
     c.bench_function("validator no fails benchmark", move |b| {
-        for d in &mut data {
-            b.iter(|| read_all_wasm(ValidatingParser::new(d.as_slice(), VALIDATOR_CONFIG)));
+        for input in &mut inputs {
+            b.iter(|| read_all_wasm(&input.path, ValidatingParser::new(input.wasm.as_slice(), VALIDATOR_CONFIG)));
         }
     });
 }
 
 fn validate_benchmark(c: &mut Criterion) {
-    let mut data = collect_test_files("../../tests");
+    let mut inputs = collect_test_files("../../testsuite");
     c.bench_function("validate benchmark", move |b| {
-        for d in &mut data {
-            b.iter(|| validate(&d, VALIDATOR_CONFIG));
+        for input in &mut inputs {
+            b.iter(|| validate(input.wasm.as_slice(), VALIDATOR_CONFIG));
         }
     });
 }

--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -33,13 +33,17 @@ pub struct BenchmarkInput {
 impl BenchmarkInput {
     /// Creates a new benchmark input.
     pub fn new(test_path: PathBuf, encoded_wasm: Vec<u8>) -> Self {
-        Self { path: test_path, wasm: encoded_wasm }
+        Self {
+            path: test_path,
+            wasm: encoded_wasm,
+        }
     }
 }
 
 /// Read a `.wat` formatted benchmark test file as benchmark input.
 fn read_wat_module(path: &PathBuf) -> BenchmarkInput {
-    let encoded_wasm = wat::parse_file(path).expect("encountered error while parsing `.wat` file into `.wasm`");
+    let encoded_wasm =
+        wat::parse_file(path).expect("encountered error while parsing `.wat` file into `.wasm`");
     BenchmarkInput::new(path.clone(), encoded_wasm)
 }
 
@@ -56,12 +60,12 @@ fn read_wast_module(path: &PathBuf) -> Vec<BenchmarkInput> {
     'outer: while let Ok(directive) = wast::parser::parse::<wast::WastDirective>(&parse_buffer) {
         match directive {
             wast::WastDirective::Module(mut module) => {
-                let encoded_wasm = module.encode().expect("encountered error while encoding the Wast module into Wasm");
+                let encoded_wasm = module
+                    .encode()
+                    .expect("encountered error while encoding the Wast module into Wasm");
                 inputs.push(BenchmarkInput::new(path.clone(), encoded_wasm));
             }
-            _ => {
-                continue 'outer
-            }
+            _ => continue 'outer,
         }
     }
     inputs
@@ -105,7 +109,10 @@ where
         path.as_ref(),
         &|_| true, // accept all benchmarks
         &mut |dir_entry| {
-            let ext: Option<String> = dir_entry.path().extension().and_then(|ext| ext.to_str().map(|str| str.to_string()));
+            let ext: Option<String> = dir_entry
+                .path()
+                .extension()
+                .and_then(|ext| ext.to_str().map(|str| str.to_string()));
             match ext.as_ref().map(|string| string.as_str()) {
                 Some("wat") => file_contents.push(read_wat_module(&dir_entry.path())),
                 Some("wast") => {
@@ -131,7 +138,9 @@ where
 {
     loop {
         match *d.read() {
-            ParserState::Error(ref e) => panic!("unexpected error while reading Wasm at {:?}: {}", path, e),
+            ParserState::Error(ref e) => {
+                panic!("unexpected error while reading Wasm at {:?}: {}", path, e)
+            }
             ParserState::EndWasm => return,
             _ => (),
         }
@@ -151,7 +160,12 @@ fn validator_not_fails_benchmark(c: &mut Criterion) {
     let mut inputs = collect_test_files("../../testsuite");
     c.bench_function("validator no fails benchmark", move |b| {
         for input in &mut inputs {
-            b.iter(|| read_all_wasm(&input.path, ValidatingParser::new(input.wasm.as_slice(), VALIDATOR_CONFIG)));
+            b.iter(|| {
+                read_all_wasm(
+                    &input.path,
+                    ValidatingParser::new(input.wasm.as_slice(), VALIDATOR_CONFIG),
+                )
+            });
         }
     });
 }

--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -75,7 +75,7 @@ where
         path.as_ref(),
         &|dir_entry| dir_entry.file_name().to_str() != Some("proposals"),
         &mut |dir_entry| {
-            if dir_entry.path().extension() == Some(std::ffi::OsStr::new("wast")) {
+            if dir_entry.path().extension().and_then(|ext| ext.to_str()) == Some("wast") {
                 file_contents.push(read_file_data(&dir_entry.path()))
             }
         },

--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -22,19 +22,6 @@ const VALIDATOR_CONFIG: Option<ValidatingParserConfig> = Some(ValidatingParserCo
     },
 });
 
-fn read_all_wasm<'a, T>(mut d: T)
-where
-    T: WasmDecoder<'a>,
-{
-    loop {
-        match *d.read() {
-            ParserState::Error(ref e) => panic!("unexpected error while reading Wasm: {}", e),
-            ParserState::EndWasm => return,
-            _ => (),
-        }
-    }
-}
-
 fn read_file_data(path: &PathBuf) -> Vec<u8> {
     wat::parse_file(path).expect("encountered error while parsing Wasm text format file")
 }
@@ -80,6 +67,19 @@ where
     )
     .expect("encountered error while reading test directory");
     file_contents
+}
+
+fn read_all_wasm<'a, T>(mut d: T)
+where
+    T: WasmDecoder<'a>,
+{
+    loop {
+        match *d.read() {
+            ParserState::Error(ref e) => panic!("unexpected error while reading Wasm: {}", e),
+            ParserState::EndWasm => return,
+            _ => (),
+        }
+    }
 }
 
 fn it_works_benchmark(c: &mut Criterion) {

--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -3,9 +3,7 @@ extern crate criterion;
 
 use criterion::Criterion;
 use std::fs;
-use std::fs::File;
 use std::io;
-use std::io::Read;
 use std::path::Path;
 use std::path::PathBuf;
 use wasmparser::{

--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -144,7 +144,7 @@ where
     loop {
         match *d.read() {
             ParserState::Error(ref e) => {
-                panic!("unexpected error while reading Wasm at {:?}: {}", path, e)
+                panic!("unexpected error while reading Wasm from {:?}: {}", path, e)
             }
             ParserState::EndWasm => return,
             _ => (),

--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate criterion;
 
-use criterion::Criterion;
+use criterion::{black_box, Criterion};
 use std::fs;
 use std::io;
 use std::path::Path;
@@ -178,9 +178,14 @@ fn it_works_benchmark(c: &mut Criterion) {
         }
     });
     c.bench_function("it works benchmark", move |b| {
-        for input in &mut inputs {
-            b.iter(|| read_all_wasm(&input.path, Parser::new(input.wasm.as_slice())));
-        }
+        b.iter(|| {
+            for input in &mut inputs {
+                let _ = black_box(read_all_wasm(
+                    &input.path,
+                    Parser::new(input.wasm.as_slice()),
+                ));
+            }
+        })
     });
 }
 
@@ -198,14 +203,14 @@ fn validator_not_fails_benchmark(c: &mut Criterion) {
         }
     });
     c.bench_function("validator no fails benchmark", move |b| {
-        for input in &mut inputs {
-            b.iter(|| {
-                read_all_wasm(
+        b.iter(|| {
+            for input in &mut inputs {
+                let _ = black_box(read_all_wasm(
                     &input.path,
                     ValidatingParser::new(input.wasm.as_slice(), VALIDATOR_CONFIG),
-                )
-            });
-        }
+                ));
+            }
+        });
     });
 }
 
@@ -214,9 +219,11 @@ fn validate_benchmark(c: &mut Criterion) {
     // Filter out all benchmark inputs that fail to validate via `wasmparser`.
     inputs.retain(|input| validate(input.wasm.as_slice(), VALIDATOR_CONFIG).is_ok());
     c.bench_function("validate benchmark", move |b| {
-        for input in &mut inputs {
-            b.iter(|| validate(input.wasm.as_slice(), VALIDATOR_CONFIG));
-        }
+        b.iter(|| {
+            for input in &mut inputs {
+                let _ = black_box(validate(input.wasm.as_slice(), VALIDATOR_CONFIG));
+            }
+        })
     });
 }
 

--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -61,7 +61,8 @@ fn read_wast_module(path: &PathBuf) -> Vec<BenchmarkInput> {
         .expect("encountered error while reading `.wast` benchmark file to string");
     let mut inputs = Vec::new();
     if let Ok(parse_buffer) = wast::parser::ParseBuffer::new(&wast_file_contents) {
-        'outer: while let Ok(directive) = wast::parser::parse::<wast::WastDirective>(&parse_buffer) {
+        'outer: while let Ok(directive) = wast::parser::parse::<wast::WastDirective>(&parse_buffer)
+        {
             match directive {
                 wast::WastDirective::Module(mut module) => {
                     let encoded_wasm = module
@@ -157,7 +158,10 @@ where
 fn collect_benchmark_inputs() -> Vec<BenchmarkInput> {
     let from_testsuite = collect_test_files("../../testsuite");
     let from_tests = collect_test_files("../../tests");
-    from_testsuite.into_iter().chain(from_tests.into_iter()).collect::<Vec<_>>()
+    from_testsuite
+        .into_iter()
+        .chain(from_tests.into_iter())
+        .collect::<Vec<_>>()
 }
 
 fn it_works_benchmark(c: &mut Criterion) {
@@ -208,9 +212,7 @@ fn validator_not_fails_benchmark(c: &mut Criterion) {
 fn validate_benchmark(c: &mut Criterion) {
     let mut inputs = collect_benchmark_inputs();
     // Filter out all benchmark inputs that fail to validate via `wasmparser`.
-    inputs.retain(|input| {
-        validate(input.wasm.as_slice(), VALIDATOR_CONFIG).is_ok()
-    });
+    inputs.retain(|input| validate(input.wasm.as_slice(), VALIDATOR_CONFIG).is_ok());
     c.bench_function("validate benchmark", move |b| {
         for input in &mut inputs {
             b.iter(|| validate(input.wasm.as_slice(), VALIDATOR_CONFIG));


### PR DESCRIPTION
**NOTE:** Benchmarks are not yet running but we got way closer.

- Now iterates recursively over the `tests` directory instead of just taking the top-level directory entires (which are no `.wast` files).
- Adds a filter to filter out problematic `.wast` in `proposals` directory.
- The `.wast` files in the `tests` directories are now initially converted into `.wasm` files before benchmarking.

It looks to me like some test `.wast` files are just broken or not up-to-date.

Also not sure if this procedure for reading `.wast` files would be more correct than what is used at the moment: (Please help to clarify!)

```rust
// Note sure if this procedure is more correct since we are operating on `.wast` files:
let mut f = File::open(path).ok().unwrap();
let mut wast = String::new();
f.read_to_string(&mut wast).unwrap();
let parse_buffer = wast::parser::ParseBuffer::new(&wast).unwrap();
wast::parser::parse::<wast::Module>(&parse_buffer)
    .unwrap()
    .encode()
    .unwrap()
```

Most recently produced error is this when running `cargo bench`:
```
thread 'main' panicked at 'encountered error while parsing Wasm text format file: Error { kind: Wast(Error { inner: ErrorInner { text: Some(Text { line: 180, col: 0, snippet: "(assert_return (invoke \"i32_add\") (i32.const 0x0102))     (assert_return (invoke \"i64_add\") (i32.const 0x0102))" }), file: Some("../../tests/testsuite/left-to-right.wast"), span: Span { offset: 15542 }, kind: Custom("extra tokens remaining after parse") } }) }', crates/wasmparser/benches/benchmark.rs:45:5
stack backtrace:
   0: backtrace::backtrace::libunwind::trace
             at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/libunwind.rs:86
   1: backtrace::backtrace::trace_unsynchronized
             at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/mod.rs:66
   2: std::sys_common::backtrace::_print_fmt
             at src/libstd/sys_common/backtrace.rs:78
   3: <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt
             at src/libstd/sys_common/backtrace.rs:59
   4: core::fmt::write
             at src/libcore/fmt/mod.rs:1076
   5: std::io::Write::write_fmt
             at src/libstd/io/mod.rs:1537
   6: std::sys_common::backtrace::_print
             at src/libstd/sys_common/backtrace.rs:62
   7: std::sys_common::backtrace::print
             at src/libstd/sys_common/backtrace.rs:49
   8: std::panicking::default_hook::{{closure}}
             at src/libstd/panicking.rs:198
   9: std::panicking::default_hook
             at src/libstd/panicking.rs:218
  10: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:486
  11: rust_begin_unwind
             at src/libstd/panicking.rs:388
  12: core::panicking::panic_fmt
             at src/libcore/panicking.rs:101
  13: core::option::expect_none_failed
             at src/libcore/option.rs:1272
  14: benchmark::visit_dirs
  15: benchmark::visit_dirs
  16: benchmark::main
  17: std::rt::lang_start::{{closure}}
  18: std::rt::lang_start_internal::{{closure}}
             at src/libstd/rt.rs:52
  19: std::panicking::try::do_call
             at src/libstd/panicking.rs:297
  20: std::panicking::try
             at src/libstd/panicking.rs:274
  21: std::panic::catch_unwind
             at src/libstd/panic.rs:394
  22: std::rt::lang_start_internal
             at src/libstd/rt.rs:51
  23: main
  24: __libc_start_main
  25: _start
```