### PR TITLE
Validate functions are defined with function types

### DIFF
--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -624,6 +624,8 @@ impl<'a> ValidatingParser<'a> {
                     self.set_validation_error("unknown type: func type index out of bounds");
                 } else if self.resources.func_type_indices.len() >= MAX_WASM_FUNCTIONS {
                     self.set_validation_error("functions count out of bounds");
+                } else if let Err(err) = self.func_type_at(type_index) {
+                    self.validation_error = Some(err);
                 } else {
                     self.resources.func_type_indices.push(type_index);
                 }

--- a/tests/local/module-linking/instantiate.wast
+++ b/tests/local/module-linking/instantiate.wast
@@ -249,3 +249,9 @@
   ))
   (instance (instantiate $m (instance $i)))
 )
+
+(assert_invalid
+  (module
+    (instance (instantiate 0))
+  )
+  "module is not defined")

--- a/tests/local/module-linking/types.wast
+++ b/tests/local/module-linking/types.wast
@@ -1,0 +1,59 @@
+(assert_invalid
+  (module
+    (type (instance))
+    (func (type 0))
+  )
+  "type index is not a function")
+
+(assert_invalid
+  (module
+    (type (instance))
+    (import "" (func (type 0)))
+  )
+  "type index is not a function")
+
+(assert_invalid
+  (module
+    (type (instance))
+    (module (type 0))
+  )
+  "type index is not a module")
+
+(assert_invalid
+  (module
+    (type (instance))
+    (import "" (module (type 0)))
+  )
+  "type index is not a module")
+
+(assert_invalid
+  (module
+    (type (func))
+    (import "" (instance (type 0)))
+  )
+  "type index is not an instance")
+
+(assert_invalid
+  (module
+    (type (func))
+    (type (module
+      (import "" (instance (type 0)))
+    ))
+  )
+  "type index is not an instance")
+(assert_invalid
+  (module
+    (type (func))
+    (type (module
+      (import "" (module (type 0)))
+    ))
+  )
+  "type index is not a module")
+(assert_invalid
+  (module
+    (type (instance))
+    (type (module
+      (import "" (func (type 0)))
+    ))
+  )
+  "type index is not a func")


### PR DESCRIPTION
Was writing tests for module linking and hit a panic where functions
weren't validated to be defined with function types, leading to a panic
in a later unwrap.