### PR TITLE
[wat] Update reftype parsing to match latest proposals

### DIFF
--- a/crates/wast/src/ast/assert_expr.rs
+++ b/crates/wast/src/ast/assert_expr.rs
@@ -1,4 +1,4 @@
-use crate::ast::{kw, Float32, Float64, Index, RefType};
+use crate::ast::{kw, Float32, Float64, Index, HeapType};
 use crate::parser::{Parse, Parser, Result};
 
 /// An expression that is valid inside an `assert_return` directive.
@@ -17,7 +17,7 @@ pub enum AssertExpression<'a> {
     F64(NanPattern<Float64>),
     V128(V128Pattern),
 
-    RefNull(RefType<'a>),
+    RefNull(HeapType<'a>),
     RefExtern(u32),
     RefFunc(Option<Index<'a>>),
 

--- a/crates/wast/src/ast/expr.rs
+++ b/crates/wast/src/ast/expr.rs
@@ -1,4 +1,4 @@
-use crate::ast::{self, kw, RefType};
+use crate::ast::{self, kw, HeapType};
 use crate::parser::{Parse, Parser, Result};
 use std::mem;
 
@@ -411,7 +411,7 @@ instructions! {
         TableSize(TableArg<'a>) : [0xfc, 0x10] : "table.size",
         TableGrow(TableArg<'a>) : [0xfc, 0x0f] : "table.grow",
 
-        RefNull(RefType<'a>) : [0xd0] : "ref.null",
+        RefNull(HeapType<'a>) : [0xd0] : "ref.null",
         RefIsNull : [0xd1] : "ref.is_null",
         RefExtern(u32) : [0xff] : "ref.extern", // only used in test harness
         RefFunc(ast::Index<'a>) : [0xd2] : "ref.func",

--- a/crates/wast/src/ast/import.rs
+++ b/crates/wast/src/ast/import.rs
@@ -48,7 +48,7 @@ pub struct ItemSig<'a> {
 #[allow(missing_docs)]
 pub enum ItemKind<'a> {
     Func(ast::TypeUse<'a, ast::FunctionType<'a>>),
-    Table(ast::TableType),
+    Table(ast::TableType<'a>),
     Memory(ast::MemoryType),
     Global(ast::GlobalType<'a>),
     Event(ast::EventType<'a>),

--- a/crates/wast/src/ast/mod.rs
+++ b/crates/wast/src/ast/mod.rs
@@ -391,8 +391,6 @@ pub mod kw {
     custom_keyword!(null);
     custom_keyword!(nullref);
     custom_keyword!(offset);
-    custom_keyword!(opt);
-    custom_keyword!(optref);
     custom_keyword!(param);
     custom_keyword!(parent);
     custom_keyword!(passive);

--- a/crates/wast/src/ast/table.rs
+++ b/crates/wast/src/ast/table.rs
@@ -22,16 +22,16 @@ pub enum TableKind<'a> {
     #[allow(missing_docs)]
     Import {
         import: ast::InlineImport<'a>,
-        ty: ast::TableType,
+        ty: ast::TableType<'a>,
     },
 
     /// A typical memory definition which simply says the limits of the table
-    Normal(ast::TableType),
+    Normal(ast::TableType<'a>),
 
     /// The elem segments of this table, starting from 0, explicitly listed
     Inline {
         /// The element type of this table.
-        elem: ast::TableElemType,
+        elem: ast::RefType<'a>,
         /// The element table entries to have, and the length of this list is
         /// the limits of the table as well.
         payload: ElemPayload<'a>,
@@ -50,7 +50,7 @@ impl<'a> Parse<'a> for Table<'a> {
         //  *   `(import "a" "b") limits`
         //  *   `limits`
         let mut l = parser.lookahead1();
-        let kind = if l.peek::<ast::TableElemType>() {
+        let kind = if l.peek::<ast::RefType>() {
             let elem = parser.parse()?;
             let payload = parser.parens(|p| {
                 p.parse::<kw::elem>()?;
@@ -124,7 +124,7 @@ pub enum ElemPayload<'a> {
     /// represented as expressions using `ref.func` and `ref.null`.
     Exprs {
         /// The desired type of each expression below.
-        ty: ast::TableElemType,
+        ty: ast::RefType<'a>,
         /// The expressions, currently optional function indices, in this
         /// segment.
         exprs: Vec<Option<ast::Index<'a>>>,
@@ -180,15 +180,15 @@ impl<'a> Parse<'a> for ElemPayload<'a> {
 }
 
 impl<'a> ElemPayload<'a> {
-    fn parse_tail(parser: Parser<'a>, ty: Option<ast::TableElemType>) -> Result<Self> {
+    fn parse_tail(parser: Parser<'a>, ty: Option<ast::RefType<'a>>) -> Result<Self> {
         let ty = match ty {
             None => {
                 parser.parse::<Option<kw::func>>()?;
-                ast::TableElemType::Funcref
+                ast::RefType::func()
             }
             Some(ty) => ty,
         };
-        if let ast::TableElemType::Funcref = ty {
+        if let ast::HeapType::Func = ty.heap {
             if parser.peek::<ast::Index>() {
                 let mut elems = Vec::new();
                 while !parser.is_empty() {
@@ -217,7 +217,7 @@ impl<'a> ElemPayload<'a> {
 
 fn parse_ref_func<'a>(
     parser: Parser<'a>,
-    ty: ast::TableElemType,
+    ty: ast::RefType<'a>,
 ) -> Result<Option<ast::Index<'a>>> {
     let mut l = parser.lookahead1();
     if l.peek::<kw::ref_null>() {

--- a/crates/wast/src/ast/table.rs
+++ b/crates/wast/src/ast/table.rs
@@ -222,8 +222,8 @@ fn parse_ref_func<'a>(
     let mut l = parser.lookahead1();
     if l.peek::<kw::ref_null>() {
         parser.parse::<kw::ref_null>()?;
-        let null_ty: ast::RefType = parser.parse()?;
-        if null_ty != ty.into() {
+        let null_ty: ast::HeapType = parser.parse()?;
+        if ty.heap != null_ty {
             return Err(parser.error("elem segment item doesn't match elem segment type"));
         }
         Ok(None)

--- a/crates/wast/src/ast/types.rs
+++ b/crates/wast/src/ast/types.rs
@@ -181,11 +181,6 @@ impl<'a> Parse<'a> for RefType<'a> {
         } else if l.peek::<kw::externref>() {
             parser.parse::<kw::externref>()?;
             Ok(RefType::r#extern())
-        } else if l.peek::<kw::anyref>() {
-            // Parse `anyref` as an alias of `externref` until all tests are
-            // ported to use the new name
-            parser.parse::<kw::anyref>()?;
-            Ok(RefType::r#extern())
         } else if l.peek::<kw::exnref>() {
             parser.parse::<kw::exnref>()?;
             Ok(RefType::exn())
@@ -286,11 +281,6 @@ impl<'a> Parse<'a> for TableElemType {
         if l.peek::<kw::funcref>() {
             parser.parse::<kw::funcref>()?;
             Ok(TableElemType::Funcref)
-        } else if l.peek::<kw::anyref>() {
-            // Parse `anyref` as an alias of `externref` until all tests are
-            // ported to use the new name
-            parser.parse::<kw::anyref>()?;
-            Ok(TableElemType::Externref)
         } else if l.peek::<kw::externref>() {
             parser.parse::<kw::externref>()?;
             Ok(TableElemType::Externref)

--- a/crates/wast/src/binary.rs
+++ b/crates/wast/src/binary.rs
@@ -708,7 +708,7 @@ impl Encode for ElemPayload<'_> {
                             Instruction::RefFunc(*idx).encode(e);
                         }
                         None => {
-                            Instruction::RefNull((*ty).into()).encode(e);
+                            Instruction::RefNull(ty.heap).encode(e);
                         }
                     }
                     Instruction::End(None).encode(e);

--- a/crates/wast/src/binary.rs
+++ b/crates/wast/src/binary.rs
@@ -487,20 +487,10 @@ impl Encode for Index<'_> {
     }
 }
 
-impl Encode for TableType {
+impl<'a> Encode for TableType<'a> {
     fn encode(&self, e: &mut Vec<u8>) {
         self.elem.encode(e);
         self.limits.encode(e);
-    }
-}
-
-impl Encode for TableElemType {
-    fn encode(&self, e: &mut Vec<u8>) {
-        match self {
-            TableElemType::Funcref => RefType::func().encode(e),
-            TableElemType::Externref => RefType::r#extern().encode(e),
-            TableElemType::Exnref => RefType::exn().encode(e),
-        }
     }
 }
 
@@ -627,7 +617,11 @@ impl Encode for Elem<'_> {
         // more MVP-compatible encoding.
         let mut to_encode = self.payload.clone();
         if let ElemPayload::Exprs {
-            ty: TableElemType::Funcref,
+            ty:
+                RefType {
+                    nullable: true,
+                    heap: HeapType::Func,
+                },
             exprs,
         } = &to_encode
         {
@@ -663,7 +657,11 @@ impl Encode for Elem<'_> {
                     offset,
                 },
                 ElemPayload::Exprs {
-                    ty: TableElemType::Funcref,
+                    ty:
+                        RefType {
+                            nullable: true,
+                            heap: HeapType::Func,
+                        },
                     ..
                 },
             ) => {

--- a/crates/wast/src/binary.rs
+++ b/crates/wast/src/binary.rs
@@ -356,21 +356,65 @@ impl<'a> Encode for ValType<'a> {
     }
 }
 
+impl<'a> Encode for HeapType<'a> {
+    fn encode(&self, e: &mut Vec<u8>) {
+        match self {
+            HeapType::Func => e.push(0x70),
+            HeapType::Extern => e.push(0x6f),
+            HeapType::Eq => e.push(0x6d),
+            HeapType::I31 => e.push(0x6a),
+            HeapType::Exn => e.push(0x68),
+            HeapType::Index(index) => {
+                index.encode(e);
+            }
+        }
+    }
+}
+
 impl<'a> Encode for RefType<'a> {
     fn encode(&self, e: &mut Vec<u8>) {
         match self {
-            RefType::Func => e.push(0x70),
-            RefType::Extern => e.push(0x6f),
-            RefType::Eq => e.push(0x6b),
-            RefType::I31 => e.push(0x6a),
-            RefType::Exn => e.push(0x68),
-            RefType::Type(index) => {
-                e.push(0x6d);
-                index.encode(e);
-            }
-            RefType::OptType(index) => {
+            // The 'funcref' binary abbreviation
+            RefType {
+                nullable: true,
+                heap: HeapType::Func,
+            } => e.push(0x70),
+            // The 'externref' binary abbreviation
+            RefType {
+                nullable: true,
+                heap: HeapType::Extern,
+            } => e.push(0x6f),
+            // The 'eqref' binary abbreviation
+            RefType {
+                nullable: true,
+                heap: HeapType::Eq,
+            } => e.push(0x6d),
+            // The 'i31ref' binary abbreviation
+            RefType {
+                nullable: true,
+                heap: HeapType::I31,
+            } => e.push(0x6a),
+            // The 'exnref' binary abbreviation
+            RefType {
+                nullable: true,
+                heap: HeapType::Exn,
+            } => e.push(0x68),
+
+            // Generic 'ref opt <heaptype>' encoding
+            RefType {
+                nullable: true,
+                heap,
+            } => {
                 e.push(0x6c);
-                index.encode(e);
+                heap.encode(e);
+            }
+            // Generic 'ref <heaptype>' encoding
+            RefType {
+                nullable: false,
+                heap,
+            } => {
+                e.push(0x6b);
+                heap.encode(e);
             }
         }
     }
@@ -453,9 +497,9 @@ impl Encode for TableType {
 impl Encode for TableElemType {
     fn encode(&self, e: &mut Vec<u8>) {
         match self {
-            TableElemType::Funcref => RefType::Func.encode(e),
-            TableElemType::Externref => RefType::Extern.encode(e),
-            TableElemType::Exnref => RefType::Exn.encode(e),
+            TableElemType::Funcref => RefType::func().encode(e),
+            TableElemType::Externref => RefType::r#extern().encode(e),
+            TableElemType::Exnref => RefType::exn().encode(e),
         }
     }
 }

--- a/crates/wast/src/parser.rs
+++ b/crates/wast/src/parser.rs
@@ -458,21 +458,21 @@ impl<'a> Parser<'a> {
     /// [spec]: https://webassembly.github.io/spec/core/text/types.html#table-types
     ///
     /// ```text
-    /// tabletype ::= lim:limits et:elemtype
+    /// tabletype ::= lim:limits et:reftype
     /// ```
     ///
     /// so to parse a [`TableType`] we recursively need to parse a [`Limits`]
-    /// and a [`TableElemType`]
+    /// and a [`RefType`]
     ///
     /// ```
     /// # use wast::*;
     /// # use wast::parser::*;
-    /// struct TableType {
+    /// struct TableType<'a> {
     ///     limits: Limits,
-    ///     elem: TableElemType,
+    ///     elem: RefType<'a>,
     /// }
     ///
-    /// impl<'a> Parse<'a> for TableType {
+    /// impl<'a> Parse<'a> for TableType<'a> {
     ///     fn parse(parser: Parser<'a>) -> Result<Self> {
     ///         // parse the `lim` then `et` in sequence
     ///         Ok(TableType {
@@ -485,7 +485,7 @@ impl<'a> Parser<'a> {
     ///
     /// [`Limits`]: crate::ast::Limits
     /// [`TableType`]: crate::ast::TableType
-    /// [`TableElemType`]: crate::ast::TableElemType
+    /// [`RefType`]: crate::ast::RefType
     pub fn parse<T: Parse<'a>>(self) -> Result<T> {
         T::parse(self)
     }

--- a/crates/wast/src/parser.rs
+++ b/crates/wast/src/parser.rs
@@ -251,6 +251,16 @@ pub trait Peek {
     /// being too big).
     fn peek(cursor: Cursor<'_>) -> bool;
 
+    /// The same as `peek`, except it checks the token immediately following
+    /// the current token.
+    fn peek2(mut cursor: Cursor<'_>) -> bool {
+        if cursor.advance_token().is_some() {
+            Self::peek(cursor)
+        } else {
+            false
+        }
+    }
+
     /// Returns a human-readable name of this token to display when generating
     /// errors about this token missing.
     fn display() -> &'static str;

--- a/crates/wast/src/resolve/names.rs
+++ b/crates/wast/src/resolve/names.rs
@@ -768,8 +768,10 @@ impl<'a> Resolver<'a> {
             // is only invoked with the module-linking proposal, which means
             // that we have two proposals interacting, and that's always weird
             // territory anywya.
-            ValType::Ref(RefType::Type(_))
-            | ValType::Ref(RefType::OptType(_))
+            ValType::Ref(RefType {
+                nullable: _,
+                heap: HeapType::Index(_),
+            })
             | ValType::Rtt(_) => Err(Error::new(
                 span,
                 format!("cannot copy reference types between modules right now"),
@@ -782,11 +784,26 @@ impl<'a> Resolver<'a> {
             | ValType::V128
             | ValType::I8
             | ValType::I16
-            | ValType::Ref(RefType::Extern)
-            | ValType::Ref(RefType::Func)
-            | ValType::Ref(RefType::Exn)
-            | ValType::Ref(RefType::Eq)
-            | ValType::Ref(RefType::I31) => Ok(ty),
+            | ValType::Ref(RefType {
+                nullable: _,
+                heap: HeapType::Extern,
+            })
+            | ValType::Ref(RefType {
+                nullable: _,
+                heap: HeapType::Func,
+            })
+            | ValType::Ref(RefType {
+                nullable: _,
+                heap: HeapType::Exn,
+            })
+            | ValType::Ref(RefType {
+                nullable: _,
+                heap: HeapType::Eq,
+            })
+            | ValType::Ref(RefType {
+                nullable: _,
+                heap: HeapType::I31,
+            }) => Ok(ty),
         }
     }
 
@@ -1436,10 +1453,13 @@ impl<'a> Module<'a> {
 
     fn resolve_reftype(&self, ty: &mut RefType<'a>) -> Result<(), Error> {
         match ty {
-            RefType::Type(i) | RefType::OptType(i) => {
+            RefType {
+                nullable: _,
+                heap: HeapType::Index(i),
+            } => {
                 self.resolve(i, Ns::Type)?;
             }
-            RefType::Eq | RefType::Func | RefType::Extern | RefType::Exn | RefType::I31 => {}
+            _ => {}
         }
         Ok(())
     }

--- a/crates/wast/src/resolve/names.rs
+++ b/crates/wast/src/resolve/names.rs
@@ -1452,7 +1452,7 @@ impl<'a> Module<'a> {
 
     fn resolve_valtype(&self, ty: &mut ValType<'a>) -> Result<(), Error> {
         match ty {
-            ValType::Ref(ty) => self.resolve_reftype(ty)?,
+            ValType::Ref(ty) => self.resolve_heaptype(&mut ty.heap)?,
             ValType::Rtt(i) => {
                 self.resolve(i, Ns::Type)?;
             }
@@ -1461,12 +1461,9 @@ impl<'a> Module<'a> {
         Ok(())
     }
 
-    fn resolve_reftype(&self, ty: &mut RefType<'a>) -> Result<(), Error> {
+    fn resolve_heaptype(&self, ty: &mut HeapType<'a>) -> Result<(), Error> {
         match ty {
-            RefType {
-                nullable: _,
-                heap: HeapType::Index(i),
-            } => {
+            HeapType::Index(i) => {
                 self.resolve(i, Ns::Type)?;
             }
             _ => {}
@@ -1866,7 +1863,7 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
                 self.module.resolve_valtype(&mut s.to)?;
             }
 
-            RefNull(ty) => self.module.resolve_reftype(ty)?,
+            RefNull(ty) => self.module.resolve_heaptype(ty)?,
 
             _ => {}
         }

--- a/tests/local/gc-struct.wat
+++ b/tests/local/gc-struct.wat
@@ -11,8 +11,8 @@
   (type $a (struct (field f32)))
   (type $b (struct (field f32)))
 
-  (type (struct (field $field_a anyref)))
-  (type (struct (field $field_b anyref) (field $field_c funcref)))
+  (type (struct (field $field_a externref)))
+  (type (struct (field $field_b externref) (field $field_c funcref)))
 
   (func
     struct.new $a
@@ -22,6 +22,6 @@
 
   (func
     struct.narrow i32 f32
-    struct.narrow anyref funcref
+    struct.narrow externref funcref
   )
 )

--- a/tests/local/wasmtime905.wast
+++ b/tests/local/wasmtime905.wast
@@ -1,4 +1,4 @@
 (assert_invalid
-    (module (func (local anyref)))
+    (module (func (local externref)))
     "reference types support is not enabled"
 )


### PR DESCRIPTION
The upstream function-references/gc proposals have had some churn recently around the reftype model. These commits update wat to match.

 * Implements reftype := (ref null? <heaptype>) and associated sugars
 * Removes anyref as an alias of externref (GC proposal still has anyref, we might need to add it as a proper type later)
 * Switches tables to actually use RefType instead of TableElemTyp
 * Fixes ref.null to take <heaptype> now that it's a concept in wat