### PR TITLE
Bump wasmparser to 0.58.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
-    - run: git fetch origin main && git branch main origin/main
+    - run: git fetch --recurse-submodules=no origin main && git branch main origin/main
       if: github.ref != 'refs/heads/main'
     - run: (cd crates/wasmparser && ./compare-with-main.sh)
 

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.57.0"
+version = "0.58.0"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser"

--- a/crates/wasmparser/compare-with-main.sh
+++ b/crates/wasmparser/compare-with-main.sh
@@ -1,13 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
-# record current bench results
-cargo bench --bench benchmark -- --noplot --save-baseline after
-
 # switch to main branch and record its bench results
 git checkout main && \
 cargo bench --bench benchmark -- --noplot --save-baseline before
 
-# compare
-cargo install critcmp --force && \
-critcmp before after
+# record current bench results
+git checkout - && \
+cargo bench --bench benchmark -- --noplot --baseline before

--- a/crates/wasmprinter/Cargo.toml
+++ b/crates/wasmprinter/Cargo.toml
@@ -14,7 +14,7 @@ Rust converter from the WebAssembly binary format to the text format.
 
 [dependencies]
 anyhow = "1.0"
-wasmparser = { path = '../wasmparser', version = '0.57' }
+wasmparser = { path = '../wasmparser', version = '0.58' }
 
 [dev-dependencies]
 diff = "0.1"


### PR DESCRIPTION
I believe this is necessary to get access to new instructions such as `bitmask`.