### PR TITLE
Disallow module linking sections by default

### DIFF
--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -610,6 +610,11 @@ impl<'a> ValidatingParser<'a> {
             Some(state) => state,
             None => return Ok(self.cur_module().section_order_state),
         };
+        if state == SectionOrderState::ModuleLinkingHeader
+            && !self.config.operator_config.enable_module_linking
+        {
+            return self.create_error("module linking proposal not enabled");
+        }
         Ok(match self.cur_module().section_order_state {
             // Did we just start? In that case move to our newly-found state.
             Initial => state,

--- a/tests/local/missing-features/linking-not-enabled.wast
+++ b/tests/local/missing-features/linking-not-enabled.wast
@@ -1,0 +1,7 @@
+(assert_invalid
+  (module binary
+    "\00asm"
+    "\01\00\00\00"
+    "\64\01\00"
+    )
+  "module linking proposal not enabled")

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -665,7 +665,7 @@ impl TestState {
         };
         for part in test.iter().filter_map(|t| t.to_str()) {
             match part {
-                "testsuite" | "wasmtime905.wast" => {
+                "testsuite" | "wasmtime905.wast" | "missing-features" => {
                     config.operator_config.enable_threads = false;
                     config.operator_config.enable_reference_types = false;
                     config.operator_config.enable_simd = false;


### PR DESCRIPTION
Only allow module linking sections, even if they're empty, to show up if
the module linking feature is enabled.