### PR TITLE
wast/wat: Make the crates useable in no_std environments

### DIFF
--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -13,7 +13,9 @@ Customizable Rust parsers for the WebAssembly Text formats WAT and WAST
 """
 
 [dependencies]
-leb128 = "0.2"
+nano-leb128 = { version = "0.1.0", default-features = false }
+# only used when std is not set to emulate thread_local
+spin = "0.5.2"
 
 [dev-dependencies]
 anyhow = "1.0"
@@ -22,7 +24,7 @@ wasmparser = { path = "../wasmparser" }
 wat = { path = "../wat" }
 
 [features]
-default = ['wasm-module']
+default = ['wasm-module', 'std']
 
 # Includes default parsing support for `*.wat` and `*.wast` files (wasm
 # modules). This isn't always needed though if you're parsing just an
@@ -31,6 +33,8 @@ default = ['wasm-module']
 #
 # This feature is turned on by default.
 wasm-module = []
+
+std = []
 
 [[test]]
 name = "parse-fail"

--- a/crates/wast/README.md
+++ b/crates/wast/README.md
@@ -38,24 +38,33 @@ interface if all you'd like to do is convert `*.wat` to `*.wasm`.
 
 ## Cargo features
 
-By default this crate enables and exports support necessary to parse `*.wat` and
+* std (enabled by default)
+
+Enables usage of the Rust standatd library. This makes the `Error` type implement
+`std::error::Error`. In addition some performance improvements are gained with this
+feature enabled as `thread_local` and `HashMap` are used as opposed to `spin` and
+`BTreeMap`.
+
+* wasm-module (enabled by default)
+
+This enables and exports support necessary to parse `*.wat` and
 `*.wast` files, or in other words entire wasm modules. If you're using this
 crate, however, to parse simply an s-expression wasm-related format (like
-`*.witx` or `*.wit` perhaps) then you can disable the default set of features to
+`*.witx` or `*.wit` perhaps) then you can disable this feature to
 only include a lexer, the parsing framework, and a few basic token-related
 parsers.
 
 ```toml
 [dependencies]
-wast = { version = "17.0", default-features = false }
+wast = { version = "21.0", default-features = false, features = ['std'] }
 ```
 
-# License
+## License
 
 This project is licensed under the Apache 2.0 license with the LLVM exception.
 See [LICENSE](LICENSE) for more details.
 
-### Contribution
+## Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in this project by you, as defined in the Apache-2.0 license,

--- a/crates/wast/src/ast/custom.rs
+++ b/crates/wast/src/ast/custom.rs
@@ -1,5 +1,6 @@
 use crate::ast::{self, annotation, kw};
 use crate::parser::{Parse, Parser, Result};
+use alloc::vec::Vec;
 
 /// A wasm custom section within a module.
 #[derive(Debug)]

--- a/crates/wast/src/ast/export.rs
+++ b/crates/wast/src/ast/export.rs
@@ -1,5 +1,6 @@
 use crate::ast::{self, kw};
 use crate::parser::{Cursor, Parse, Parser, Peek, Result};
+use alloc::vec::Vec;
 
 /// A entry in a WebAssembly module's export section.
 #[derive(Debug)]

--- a/crates/wast/src/ast/expr.rs
+++ b/crates/wast/src/ast/expr.rs
@@ -1,6 +1,7 @@
 use crate::ast::{self, kw, HeapType};
 use crate::parser::{Parse, Parser, Result};
-use std::mem;
+use core::mem;
+use alloc::vec::Vec;
 
 /// An expression, or a list of instructions, in the WebAssembly text format.
 ///

--- a/crates/wast/src/ast/func.rs
+++ b/crates/wast/src/ast/func.rs
@@ -1,5 +1,6 @@
 use crate::ast::{self, kw};
 use crate::parser::{Parse, Parser, Result};
+use alloc::vec::Vec;
 
 /// A WebAssembly function to be inserted into a module.
 ///

--- a/crates/wast/src/ast/instance.rs
+++ b/crates/wast/src/ast/instance.rs
@@ -1,5 +1,6 @@
 use crate::ast::{self, kw};
 use crate::parser::{Parse, Parser, Result};
+use alloc::vec::Vec;
 
 /// A nested WebAssembly instance to be created as part of a module.
 #[derive(Debug)]

--- a/crates/wast/src/ast/memory.rs
+++ b/crates/wast/src/ast/memory.rs
@@ -1,5 +1,6 @@
 use crate::ast::{self, kw};
 use crate::parser::{Parse, Parser, Result};
+use alloc::vec::Vec;
 
 /// A defined WebAssembly memory instance inside of a module.
 #[derive(Debug)]

--- a/crates/wast/src/ast/module.rs
+++ b/crates/wast/src/ast/module.rs
@@ -1,5 +1,6 @@
 use crate::ast::{self, annotation, kw};
 use crate::parser::{Parse, Parser, Result};
+use alloc::vec::Vec;
 
 pub use crate::resolve::Names;
 
@@ -80,7 +81,7 @@ impl<'a> Module<'a> {
     ///
     /// If an error happens during resolution, such a name resolution error or
     /// items are found in the wrong order, then an error is returned.
-    pub fn resolve(&mut self) -> std::result::Result<Names<'a>, crate::Error> {
+    pub fn resolve(&mut self) -> core::result::Result<Names<'a>, crate::Error> {
         crate::resolve::resolve(self)
     }
 
@@ -108,7 +109,7 @@ impl<'a> Module<'a> {
     ///
     /// This function can return an error for name resolution errors and other
     /// expansion-related errors.
-    pub fn encode(&mut self) -> std::result::Result<Vec<u8>, crate::Error> {
+    pub fn encode(&mut self) -> core::result::Result<Vec<u8>, crate::Error> {
         self.resolve()?;
         Ok(crate::binary::encode(self))
     }

--- a/crates/wast/src/ast/nested_module.rs
+++ b/crates/wast/src/ast/nested_module.rs
@@ -1,5 +1,6 @@
 use crate::ast::{self, kw};
 use crate::parser::{Cursor, Parse, Parser, Peek, Result};
+use alloc::vec::Vec;
 
 /// A nested WebAssembly nested module to be created as part of a module.
 #[derive(Debug)]

--- a/crates/wast/src/ast/table.rs
+++ b/crates/wast/src/ast/table.rs
@@ -1,5 +1,6 @@
 use crate::ast::{self, kw};
 use crate::parser::{Parse, Parser, Result};
+use alloc::vec::Vec;
 
 /// A WebAssembly `table` directive in a module.
 #[derive(Debug)]

--- a/crates/wast/src/ast/token.rs
+++ b/crates/wast/src/ast/token.rs
@@ -1,9 +1,10 @@
 use crate::ast::annotation;
 use crate::lexer::FloatVal;
 use crate::parser::{Cursor, Parse, Parser, Peek, Result};
-use std::fmt;
-use std::hash::{Hash, Hasher};
-use std::str;
+use core::fmt;
+use core::hash::{Hash, Hasher};
+use core::str;
+use alloc::string::{String, ToString};
 
 /// A position in the original source stream, used to render errors.
 #[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash)]
@@ -41,7 +42,7 @@ impl Span {
 ///
 /// An identifier is used to symbolically refer to items in a a wasm module,
 /// typically via the [`Index`] type.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialOrd, Ord)]
 pub struct Id<'a> {
     name: &'a str,
     gen: u32,
@@ -128,7 +129,7 @@ impl Peek for Id<'_> {
 ///
 /// The emission phase of a module will ensure that `Index::Id` is never used
 /// and switch them all to `Index::Num`.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Ord, PartialOrd)]
 pub enum Index<'a> {
     /// A numerical index that this references. The index space this is
     /// referencing is implicit based on where this [`Index`] is stored.
@@ -360,7 +361,7 @@ macro_rules! float {
         fn $parse(val: &FloatVal<'_>) -> Option<$int> {
             // Compute a few well-known constants about the float representation
             // given the parameters to the macro here.
-            let width = std::mem::size_of::<$int>() * 8;
+            let width = core::mem::size_of::<$int>() * 8;
             let neg_offset = width - 1;
             let exp_offset = neg_offset - $exp_bits;
             let signif_bits = width - 1 - $exp_bits;

--- a/crates/wast/src/ast/types.rs
+++ b/crates/wast/src/ast/types.rs
@@ -1,9 +1,10 @@
 use crate::ast::{self, kw};
 use crate::parser::{Cursor, Parse, Parser, Peek, Result};
+use alloc::vec::Vec;
 
 /// The value types for a wasm module.
 #[allow(missing_docs)]
-#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, Ord, PartialOrd)]
 pub enum ValType<'a> {
     I32,
     I64,
@@ -60,7 +61,7 @@ impl<'a> Parse<'a> for ValType<'a> {
 
 /// A heap type for a reference type
 #[allow(missing_docs)]
-#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, Ord, PartialOrd)]
 pub enum HeapType<'a> {
     /// An untyped function reference: funcref. This is part of the reference
     /// types proposal.
@@ -116,7 +117,7 @@ impl<'a> Parse<'a> for HeapType<'a> {
 
 /// A reference type in a wasm module.
 #[allow(missing_docs)]
-#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone, Ord, PartialOrd)]
 pub struct RefType<'a> {
     pub nullable: bool,
     pub heap: HeapType<'a>
@@ -239,7 +240,7 @@ impl<'a> Peek for RefType<'a> {
 }
 
 /// Type for a `global` in a wasm module
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct GlobalType<'a> {
     /// The element type of this `global`
     pub ty: ValType<'a>,
@@ -267,7 +268,7 @@ impl<'a> Parse<'a> for GlobalType<'a> {
 }
 
 /// Min/max limits used for tables/memories.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct Limits {
     /// The minimum number of units for this type.
     pub min: u32,
@@ -288,7 +289,7 @@ impl<'a> Parse<'a> for Limits {
 }
 
 /// Configuration for a table of a wasm mdoule
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct TableType<'a> {
     /// Limits on the element sizes of this table
     pub limits: Limits,
@@ -306,7 +307,7 @@ impl<'a> Parse<'a> for TableType<'a> {
 }
 
 /// Configuration for a memory of a wasm module
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct MemoryType {
     /// Limits on the page sizes of this memory
     pub limits: Limits,

--- a/crates/wast/src/ast/wast.rs
+++ b/crates/wast/src/ast/wast.rs
@@ -1,6 +1,7 @@
 use crate::ast::{self, kw};
 use crate::parser::{Cursor, Parse, Parser, Peek, Result};
 use crate::{AssertExpression, NanPattern, V128Pattern};
+use alloc::{vec, vec::Vec};
 
 /// A parsed representation of a `*.wast` file.
 ///

--- a/crates/wast/src/lexer.rs
+++ b/crates/wast/src/lexer.rs
@@ -25,11 +25,13 @@
 //! [`Lexer`]: crate::lexer::Lexer
 
 use crate::{Error, Span};
-use std::borrow::Cow;
-use std::char;
-use std::fmt;
-use std::iter;
-use std::str;
+use alloc::borrow::Cow;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::char;
+use core::fmt;
+use core::iter;
+use core::str;
 
 /// A structure used to lex the s-expression syntax of WAT files.
 ///

--- a/crates/wast/src/parser.rs
+++ b/crates/wast/src/parser.rs
@@ -65,10 +65,19 @@
 
 use crate::lexer::{Comment, Float, Integer, Lexer, Source, Token};
 use crate::{Error, Span};
-use std::cell::{Cell, RefCell};
-use std::collections::HashMap;
-use std::fmt;
-use std::usize;
+use alloc::boxed::Box;
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use core::cell::{Cell, RefCell};
+use core::fmt;
+use core::usize;
+
+#[cfg(feature = "std")]
+use std::collections::hash_map::HashMap;
+
+#[cfg(not(feature = "std"))]
+use alloc::collections::btree_map::BTreeMap as HashMap;
 
 /// A top-level convenience parseing function that parss a `T` from `buf` and
 /// requires that all tokens in `buf` are consume.
@@ -268,7 +277,7 @@ pub trait Peek {
 
 /// A convenience type definition for `Result` where the error is hardwired to
 /// [`Error`].
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = core::result::Result<T, Error>;
 
 /// A low-level buffer of tokens which represents a completely lexed file.
 ///

--- a/crates/wast/src/resolve/deinline_import_export.rs
+++ b/crates/wast/src/resolve/deinline_import_export.rs
@@ -1,6 +1,7 @@
 use crate::ast::*;
 use crate::resolve::gensym;
-use std::mem;
+use alloc::{vec, vec::Vec};
+use core::mem;
 
 pub fn run(fields: &mut Vec<ModuleField>) {
     let mut cur = 0;

--- a/crates/wast/src/resolve/expand.rs
+++ b/crates/wast/src/resolve/expand.rs
@@ -2,7 +2,20 @@ use crate::ast::*;
 use crate::resolve::gensym;
 use crate::resolve::Ns;
 use crate::Error;
-use std::collections::{HashMap, HashSet};
+use alloc::format;
+use alloc::vec::Vec;
+
+#[cfg(feature = "std")]
+use std::collections::hash_map::HashMap;
+
+#[cfg(feature = "std")]
+use std::collections::hash_set::HashSet;
+
+#[cfg(not(feature = "std"))]
+use alloc::collections::btree_map::BTreeMap as HashMap;
+
+#[cfg(not(feature = "std"))]
+use alloc::collections::btree_set::BTreeSet as HashSet;
 
 /// Runs an expansion process on the fields provided to elaborate and expand
 /// features from the module-linking proposal. Namely this handles>

--- a/crates/wast/src/resolve/gensym.rs
+++ b/crates/wast/src/resolve/gensym.rs
@@ -1,18 +1,17 @@
 use crate::ast::{Id, Span};
-use std::cell::Cell;
+use spin::Mutex;
 
-thread_local!(static NEXT: Cell<u32> = Cell::new(0));
+static NEXT: Mutex<u32> = Mutex::new(0);
 
 pub fn reset() {
-    NEXT.with(|c| c.set(0));
+    let mut next = NEXT.lock();
+    *next = 0;
 }
 
 pub fn gen(span: Span) -> Id<'static> {
-    NEXT.with(|next| {
-        let gen = next.get() + 1;
-        next.set(gen);
-        Id::gensym(span, gen)
-    })
+    let mut next = NEXT.lock();
+    *next = *next + 1;
+    Id::gensym(span, *next)
 }
 
 pub fn fill<'a>(span: Span, slot: &mut Option<Id<'a>>) -> Id<'a> {

--- a/crates/wast/src/resolve/gensym_std.rs
+++ b/crates/wast/src/resolve/gensym_std.rs
@@ -1,0 +1,20 @@
+use crate::ast::{Id, Span};
+use core::cell::Cell;
+
+thread_local!(static NEXT: Cell<u32> = Cell::new(0));
+
+pub fn reset() {
+    NEXT.with(|c| c.set(0));
+}
+
+pub fn gen(span: Span) -> Id<'static> {
+    NEXT.with(|next| {
+        let gen = next.get() + 1;
+        next.set(gen);
+        Id::gensym(span, gen)
+    })
+}
+
+pub fn fill<'a>(span: Span, slot: &mut Option<Id<'a>>) -> Id<'a> {
+    *slot.get_or_insert_with(|| gen(span))
+}

--- a/crates/wast/src/resolve/mod.rs
+++ b/crates/wast/src/resolve/mod.rs
@@ -1,12 +1,21 @@
 use crate::ast::*;
 use crate::Error;
+use alloc::format;
 
 mod deinline_import_export;
 mod expand;
-mod gensym;
 mod names;
 
-#[derive(PartialEq, Eq, Hash, Copy, Clone, Debug)]
+#[cfg(not(feature = "std"))]
+mod gensym;
+
+#[cfg(feature = "std")]
+mod gensym_std;
+
+#[cfg(feature = "std")]
+use gensym_std as gensym;
+
+#[derive(PartialEq, Eq, Hash, Copy, Clone, Debug, Ord, PartialOrd)]
 pub enum Ns {
     Func,
     Table,

--- a/crates/wast/src/resolve/names.rs
+++ b/crates/wast/src/resolve/names.rs
@@ -2,8 +2,16 @@ use crate::ast::*;
 use crate::resolve::gensym;
 use crate::resolve::Ns;
 use crate::Error;
-use std::collections::HashMap;
-use std::mem;
+use alloc::format;
+use alloc::string::ToString;
+use alloc::vec::Vec;
+use core::mem;
+
+#[cfg(feature = "std")]
+use std::collections::hash_map::HashMap;
+
+#[cfg(not(feature = "std"))]
+use alloc::collections::btree_map::BTreeMap as HashMap;
 
 pub fn resolve<'a>(fields: &mut Vec<ModuleField<'a>>) -> Result<Resolver<'a>, Error> {
     let mut resolver = Resolver::default();
@@ -2199,7 +2207,7 @@ impl<'a> TypeKey<'a> for ModuleKey<'a> {
 
 // A lookalike to `ItemKind` except without all non-relevant information for
 // hashing. This is used as a hash key for instance/module type lookup.
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, Ord, PartialOrd)]
 enum Item<'a> {
     Func(Index<'a>),
     Table(TableType<'a>),

--- a/crates/wat/Cargo.toml
+++ b/crates/wat/Cargo.toml
@@ -12,5 +12,12 @@ description = """
 Rust parser for the WebAssembly Text format, WAT
 """
 
-[dependencies]
-wast = { path = '../wast', version = '21.0.0' }
+[dependencies.wast]
+path = '../wast'
+version = '21.0.0'
+features = ['wasm-module']
+default-features = false
+
+[features]
+default = ['std']
+std = ['wast/std']

--- a/crates/wat/README.md
+++ b/crates/wat/README.md
@@ -62,12 +62,20 @@ breaking changes in the WAT format, either for MVP features or post-MVP
 features. No opt-in is required to use WebAssembly features, so using them may
 break if the upstream spec changes.
 
+## Cargo features
+
+* std (enabled by default)
+
+Enables usage of the Rust standatd library. This adds the `parse_file` function to the public
+API. In addition some performance improvements are gained due to the fact that the `wast`
+dependency can make use of Rust standard library.
+
 # License
 
 This project is licensed under the Apache 2.0 license with the LLVM exception.
 See [LICENSE](../../LICENSE) for more details.
 
-### Contribution
+## Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in this project by you, as defined in the Apache-2.0 license,

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -276,7 +276,7 @@ impl TestState {
         macro_rules! adjust {
             ($e:expr) => {{
                 let mut e = wast::Error::from($e);
-                e.set_path(test);
+                e.set_path(test.display().to_string());
                 e.set_text(contents);
                 e
             }};
@@ -323,7 +323,7 @@ impl TestState {
         let mut s = format!("{} test failures in {}:", errors.len(), test.display());
         for mut error in errors {
             if let Some(err) = error.downcast_mut::<wast::Error>() {
-                err.set_path(test);
+                err.set_path(test.display().to_string());
                 err.set_text(contents);
             }
             s.push_str("\n\n\t--------------------------------\n\n\t");


### PR DESCRIPTION
This PR adds the default enabled feature `std` to the `wast` and `wat` crate. Disabling it makes the crate perform in a `no_std` mode.

## Motivation
We need to compile wat -> wasm in a no_std environment and there is no real reason why this crate cannot work in such an environment given that an allocator is provided.

## Changes made

These are the changes I needed to make to have a working no_std build. Most of them are non-controversial but some could have been done in a different way. I tried to not clutter the codebase with conditional compilation.

### Switch `std` to `core` import statements

I switched all imports that have a representation in `core` to just use those instead. I am not sure if this is a recent addition to the compiler but this also happened to just work in std builds.

### Add `alloc` import statements

Mostly collections but also other stuff (`format!`) from the std prelude needs to be added explicitly in no_std build. This also happens to not break the std build.

### Remove usage of `Path` and `PathBuf`

We breaks the API of `wast` here and request the user to supply the path as `String` to the `set_path` function as no_std does not have these types. I figured that the advantage of storing a `PathBuf` instead of a `String` is too small to justify conditional compilation here.

### Conditionally deactivate the `parse_file` API of `wat`

When `wat` is compiled without the `std` feature we remove this API for obvious reasons.

### Replace `leb128` dependency with `nano-leb128`

The currently used `leb128` needs std as it relies on the `std::io::{Read,Write}` traits. The replacement has a no_std mode and works just fine. It has fewer users but does not use unsafe und is very small. When `leb128` adds a no_std mode we could switch back.

### Replace `HashMap` by `BTreeMap` when no_std

`HashMap` is not available in alloc. We use `BTreeMap` as drop in replacement when `std` is deactivated.

### Replace `thread_local!` by `spin::Mutex` when no_std

This seemed to be the easiest solution to implement the gensym as-is. AFAIK there is no way to only depend on `spin? when `std` is **not** set. Or is there one?