### PR TITLE
Fix an arithmetic overflow in wasmprinter

### DIFF
--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -607,7 +607,10 @@ impl Printer {
     fn print_operator(&mut self, op: &Operator<'_>, nesting_start: u32) -> Result<()> {
         use Operator::*;
         let cur_label = self.nesting - nesting_start + 1;
-        let label = |relative: u32| match cur_label.checked_sub(relative + 1) {
+        let label = |relative: u32| match cur_label
+            .checked_sub(relative)
+            .and_then(|i| i.checked_sub(1))
+        {
             Some(i) => format!("@{}", i),
             None => format!(" INVALID "),
         };

--- a/crates/wasmprinter/tests/all.rs
+++ b/crates/wasmprinter/tests/all.rs
@@ -1,0 +1,12 @@
+#[test]
+fn no_panic() {
+    let bytes = wat::parse_str(
+        r#"
+            (module
+                (data (br 4294967295) "")
+            )
+        "#,
+    )
+    .unwrap();
+    wasmprinter::print_bytes(&bytes).unwrap();
+}


### PR DESCRIPTION
Need to be careful when printing relative indices and depths to avoid
overflow by accident!