### PR TITLE
Use glob exports to avoid forgetting to export something

### DIFF
--- a/crates/wasmparser/src/lib.rs
+++ b/crates/wasmparser/src/lib.rs
@@ -66,52 +66,8 @@ pub(crate) use crate::module_resources::{wasm_func_type_inputs, wasm_func_type_o
 
 pub use crate::operators_validator::OperatorValidatorConfig;
 
-pub use crate::readers::Alias;
-pub use crate::readers::AliasSectionReader;
-pub use crate::readers::AliasedInstance;
-pub use crate::readers::CodeSectionReader;
-pub use crate::readers::Data;
-pub use crate::readers::DataKind;
-pub use crate::readers::DataSectionReader;
-pub use crate::readers::Element;
-pub use crate::readers::ElementItem;
-pub use crate::readers::ElementItems;
-pub use crate::readers::ElementItemsReader;
-pub use crate::readers::ElementKind;
-pub use crate::readers::ElementSectionReader;
-pub use crate::readers::Export;
-pub use crate::readers::ExportSectionReader;
-pub use crate::readers::FunctionBody;
-pub use crate::readers::FunctionSectionReader;
-pub use crate::readers::Global;
-pub use crate::readers::GlobalSectionReader;
-pub use crate::readers::Import;
-pub use crate::readers::ImportSectionReader;
-pub use crate::readers::InitExpr;
-pub use crate::readers::LinkingSectionReader;
-pub use crate::readers::LocalsReader;
-pub use crate::readers::MemorySectionReader;
-pub use crate::readers::ModuleCodeSectionReader;
-pub use crate::readers::ModuleSectionReader;
-pub use crate::readers::Name;
-pub use crate::readers::NameSectionReader;
-pub use crate::readers::NamingReader;
-pub use crate::readers::OperatorsReader;
-pub use crate::readers::ProducersField;
-pub use crate::readers::ProducersFieldValue;
-pub use crate::readers::ProducersFieldValuesReader;
-pub use crate::readers::ProducersSectionReader;
-pub use crate::readers::Reloc;
-pub use crate::readers::RelocSectionReader;
-pub use crate::readers::SectionIterator;
-pub use crate::readers::SectionIteratorLimited;
-pub use crate::readers::SectionReader;
-pub use crate::readers::SectionWithLimitedItems;
-pub use crate::readers::TableSectionReader;
-pub use crate::readers::TypeSectionReader;
-pub use crate::readers::{Instance, InstanceSectionReader};
-
 pub use crate::parser::*;
+pub use crate::readers::*;
 pub use crate::validator::*;
 
 mod binary_reader;

--- a/crates/wasmparser/src/readers/mod.rs
+++ b/crates/wasmparser/src/readers/mod.rs
@@ -18,59 +18,27 @@ use super::{
     Naming, Operator, Range, RelocType, Result, SectionCode, TableType, Type,
 };
 
-pub use self::code_section::CodeSectionReader;
-pub use self::code_section::FunctionBody;
-pub use self::code_section::LocalsReader;
-pub use self::data_section::Data;
-pub use self::data_section::DataKind;
-pub use self::data_section::DataSectionReader;
-pub use self::element_section::Element;
-pub use self::element_section::ElementItem;
-pub use self::element_section::ElementItems;
-pub use self::element_section::ElementItemsReader;
-pub use self::element_section::ElementKind;
-pub use self::element_section::ElementSectionReader;
-pub use self::export_section::Export;
-pub use self::export_section::ExportSectionReader;
-pub use self::function_section::FunctionSectionReader;
-pub use self::global_section::Global;
-pub use self::global_section::GlobalSectionReader;
-pub use self::import_section::Import;
-pub use self::import_section::ImportSectionReader;
-pub use self::init_expr::InitExpr;
-pub use self::memory_section::MemorySectionReader;
-pub use self::table_section::TableSectionReader;
-pub use self::type_section::TypeSectionReader;
-
-pub use self::section_reader::SectionIterator;
-pub use self::section_reader::SectionIteratorLimited;
-pub use self::section_reader::SectionReader;
-pub use self::section_reader::SectionWithLimitedItems;
-
-pub use self::name_section::FunctionLocalReader;
-pub use self::name_section::FunctionName;
-pub use self::name_section::LocalName;
-pub use self::name_section::ModuleName;
-pub use self::name_section::Name;
-pub use self::name_section::NameSectionReader;
-pub use self::name_section::NamingReader;
-
-pub use self::producers_section::ProducersField;
-pub use self::producers_section::ProducersFieldValue;
-pub use self::producers_section::ProducersFieldValuesReader;
-pub use self::producers_section::ProducersSectionReader;
-
-pub use self::linking_section::LinkingSectionReader;
-
-pub use self::reloc_section::Reloc;
-pub use self::reloc_section::RelocSectionReader;
-
-pub use self::operators::OperatorsReader;
-
 pub use self::alias_section::*;
+pub use self::code_section::*;
+pub use self::data_section::*;
+pub use self::element_section::*;
+pub use self::export_section::*;
+pub use self::function_section::*;
+pub use self::global_section::*;
+pub use self::import_section::*;
+pub use self::init_expr::*;
 pub use self::instance_section::*;
+pub use self::linking_section::*;
+pub use self::memory_section::*;
 pub use self::module_code_section::*;
 pub use self::module_section::*;
+pub use self::name_section::*;
+pub use self::operators::*;
+pub use self::producers_section::*;
+pub use self::reloc_section::*;
+pub use self::section_reader::*;
+pub use self::table_section::*;
+pub use self::type_section::*;
 
 mod alias_section;
 mod code_section;


### PR DESCRIPTION
This fixes issues as pointed out [here]. All of the items in each
submodule are intended to be reexported at the root anyway, so it's a
bit easier to reexport via globs rather than each name individually.

[here]: https://github.com/bytecodealliance/wasm-tools/pull/40#pullrequestreview-446571360