### PR TITLE
Enable reference types spec tests

### DIFF
--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -1313,9 +1313,7 @@ impl<'a> BinaryReader<'a> {
             0xd0 => Operator::RefNull {
                 ty: self.read_type()?,
             },
-            0xd1 => Operator::RefIsNull {
-                ty: self.read_type()?,
-            },
+            0xd1 => Operator::RefIsNull,
             0xd2 => Operator::RefFunc {
                 function_index: self.read_var_u32()?,
             },

--- a/crates/wasmparser/src/operators_validator.rs
+++ b/crates/wasmparser/src/operators_validator.rs
@@ -60,15 +60,21 @@ impl FuncState {
     fn last_block(&self) -> &BlockState {
         self.blocks.last().unwrap()
     }
-    fn assert_stack_type_at(&self, index: usize, expected: Type) -> bool {
+    fn stack_type_at(&self, index: usize) -> Option<Type> {
         let stack_starts_at = self.last_block().stack_starts_at;
         if self.last_block().is_stack_polymorphic()
             && stack_starts_at + index >= self.stack_types.len()
         {
-            return true;
+            return None;
         }
         assert!(stack_starts_at + index < self.stack_types.len());
-        self.stack_types[self.stack_types.len() - 1 - index] == expected
+        Some(self.stack_types[self.stack_types.len() - 1 - index])
+    }
+    fn assert_stack_type_at(&self, index: usize, expected: Type) -> bool {
+        match self.stack_type_at(index) {
+            Some(ty) => ty == expected,
+            None => true,
+        }
     }
     fn assert_block_stack_len(&self, depth: usize, minimal_len: usize) -> bool {
         assert!(depth < self.blocks.len());
@@ -1537,17 +1543,17 @@ impl OperatorValidator {
                 }
                 self.func_state.change_frame_with_type(0, ty)?;
             }
-            Operator::RefIsNull { ty } => {
+            Operator::RefIsNull => {
                 self.check_reference_types_enabled()?;
-                match ty {
-                    Type::FuncRef | Type::ExternRef => {}
+                self.check_frame_size(1)?;
+                match self.func_state.stack_type_at(0) {
+                    None | Some(Type::FuncRef) | Some(Type::ExternRef) => {}
                     _ => {
                         return Err(OperatorValidatorError::new(
-                            "invalid reference type in ref.is_null",
+                            "type mismatch: invalid reference type in ref.is_null",
                         ))
                     }
                 }
-                self.check_operands_1(ty)?;
                 self.func_state.change_frame_with_type(1, Type::I32)?;
             }
             Operator::RefFunc { function_index } => {

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -361,7 +361,7 @@ pub enum Operator<'a> {
     F32Const { value: Ieee32 },
     F64Const { value: Ieee64 },
     RefNull { ty: Type },
-    RefIsNull { ty: Type },
+    RefIsNull,
     RefFunc { function_index: u32 },
     I32Eqz,
     I32Eq,

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -571,7 +571,10 @@ impl Validator {
     fn get_func_type_index<'me>(&'me self, idx: Def<u32>) -> Result<Def<u32>> {
         match self.state.get_func_type_index(idx) {
             Some(t) => Ok(t),
-            None => self.create_error("unknown function: func index out of bounds"),
+            None => self.create_error(format!(
+                "unknown function {}: func index out of bounds",
+                idx.item
+            )),
         }
     }
 
@@ -1349,8 +1352,10 @@ impl Validator {
         };
         if index as usize >= total {
             return self.create_error(&format!(
-                "unknown {0}: {1} {0} index out of bounds",
-                ty, desc
+                "unknown {ty} {index}: {desc} {ty} index out of bounds",
+                desc = desc,
+                index = index,
+                ty = ty,
             ));
         }
         if let ExternalKind::Function = kind {

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -760,10 +760,7 @@ impl Printer {
                 self.result.push_str("ref.null ");
                 self.print_reftype(*ty)?;
             }
-            RefIsNull { ty } => {
-                self.result.push_str("ref.is_null ");
-                self.print_reftype(*ty)?;
-            }
+            RefIsNull => self.result.push_str("ref.is_null"),
             RefFunc { function_index } => {
                 self.result.push_str("ref.func ");
                 self.print_func_idx(*function_index)?;

--- a/crates/wast/src/resolve/names.rs
+++ b/crates/wast/src/resolve/names.rs
@@ -1446,10 +1446,17 @@ impl<'a> Module<'a> {
                 Ok(())
             }
 
+            ModuleField::Table(t) => {
+                if let TableKind::Normal(t) = &mut t.kind {
+                    self.resolve_heaptype(&mut t.elem.heap)?;
+                }
+                Ok(())
+            }
+
             // Everything about aliases is handled in `expand` above
             ModuleField::Alias(_) => Ok(()),
 
-            ModuleField::Table(_) | ModuleField::Memory(_) | ModuleField::Custom(_) => Ok(()),
+            ModuleField::Memory(_) | ModuleField::Custom(_) => Ok(()),
         }
     }
 

--- a/tests/local/ref.wat
+++ b/tests/local/ref.wat
@@ -9,10 +9,10 @@
     local.set 1)
   (func (;1;) (type 1) (param funcref)
     global.get 0
-    ref.is_null extern
+    ref.is_null
     drop
     local.get 0
-    ref.is_null func
+    ref.is_null
     drop)
   (global (;0;) externref (ref.null extern))
 

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -147,6 +147,15 @@ fn skip_test(test: &Path, contents: &[u8]) -> bool {
         return true;
     }
 
+    // These test suites in the upstream proposals repo have not been
+    // implemented in this tooling yet.
+    if test.iter().any(|t| t == "function-references") {
+        return true;
+    }
+    if test.iter().any(|t| t == "exception-handling") {
+        return true;
+    }
+
     if let Ok(contents) = str::from_utf8(contents) {
         // Skip tests that are supposed to fail
         if contents.contains(";; ERROR") {

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -130,15 +130,6 @@ fn skip_test(test: &Path, contents: &[u8]) -> bool {
         // anywhere else, and I'm not entirely certain if it's vaild, and for now I
         // don't feel like filing an issue or adding parsing for this.
         "roundtrip/table-init-index.txt",
-        // The following tests are broken until wabt removes the ref.is_null
-        // type annotation.
-        "local/ref.wat",
-        "proposals/reference-types/table_set.wast",
-        "proposals/reference-types/table_grow.wast",
-        "proposals/reference-types/table_get.wast",
-        "proposals/reference-types/ref_is_null.wast",
-        "proposals/reference-types/ref_func.wast",
-        "proposals/reference-types/ref_func.wast",
         "dump/reference-types.txt",
         "interp/reference-types.txt",
         "expr/reference-types.txt",
@@ -213,7 +204,8 @@ impl TestState {
             && !test.ends_with("invalid-elem-segment-offset.txt")
         {
             if let Some(expected) = self.wat2wasm(&test)? {
-                self.binary_compare(&binary, &expected, true)?;
+                self.binary_compare(&binary, &expected, true)
+                    .context("`wat` doesn't match wabt's `wat2wasm`")?;
             }
         }
 
@@ -234,7 +226,6 @@ impl TestState {
             && !test.ends_with("dump/import.txt")
             // uses exceptions
             && !test.ends_with("parse/all-features.txt")
-            && !test.iter().any(|t| t == "module-linking")
         {
             self.test_wasm(test, &binary, true)
                 .context("failed testing the binary output of `wat`")?;
@@ -262,6 +253,10 @@ impl TestState {
 
             // not implemented in wabt
             && !test.iter().any(|t| t == "module-linking")
+
+            // wabt's encoding of `ref.is_null` hasn't been updated
+            && !test.ends_with("local/ref.wat")
+            && !test.iter().any(|t| t == "reference-types")
         {
             if let Some(expected) = self.wasm2wat(contents)? {
                 self.string_compare(&string, &expected)?;
@@ -356,7 +351,8 @@ impl TestState {
                     ModuleKind::Text(_) => {
                         if let Some(expected) = &expected {
                             let expected = fs::read(expected)?;
-                            self.binary_compare(&actual, &expected, true)?;
+                            self.binary_compare(&actual, &expected, true)
+                                .context("`wat` doesn't match output of wabt")?;
                         }
                         true
                     }
@@ -777,10 +773,6 @@ fn error_matches(error: &str, message: &str) -> bool {
 
     if message == "bad magic" {
         return error.contains("Bad magic number");
-    }
-
-    if message.starts_with("unknown function ") {
-        return error.contains("unknown function");
     }
 
     return false;


### PR DESCRIPTION
Update the encoding of `ref.is_null` to run the reference types spec test suite, and tweak a few things here and there to get everything working.