### PR TITLE
Sync encoding of module linking with upstream spec

### DIFF
--- a/crates/wast/src/binary.rs
+++ b/crates/wast/src/binary.rs
@@ -1081,7 +1081,7 @@ impl Encode for Instance<'_> {
             InstanceKind::Inline { module, items } => (module, items),
             _ => panic!("should only have inline instances in emission"),
         };
-
+        e.push(0x00);
         module.encode(e);
         items.encode(e);
     }

--- a/tests/dump/alias2.wat.dump
+++ b/tests/dump/alias2.wat.dump
@@ -38,48 +38,48 @@
 0x0079 | 64 02       | module section
 0x007b | 01          | 1 count
 0x007c | 04          | [module 1] type 4
-0x007d | 65 0f       | instance section
+0x007d | 65 10       | instance section
 0x007f | 01          | 1 count
-0x0080 | 01          | [instance 2] module:1
-0x0081 | 06          | 6 count
-0x0082 | 00 00       | [instantiate arg] Function 0
-0x0084 | 02 00       | [instantiate arg] Memory 0
-0x0086 | 03 00       | [instantiate arg] Global 0
-0x0088 | 01 00       | [instantiate arg] Table 0
-0x008a | 05 00       | [instantiate arg] Module 0
-0x008c | 06 01       | [instantiate arg] Instance 1
-0x008e | 67 45       | module code section
-0x0090 | 01          | 1 count
-0x0091 | 43          | inline module size
-  0x0092 | 00 61 73 6d | version 1
+0x0080 | 00 01       | [instance 2] module:1
+0x0082 | 06          | 6 count
+0x0083 | 00 00       | [instantiate arg] Function 0
+0x0085 | 02 00       | [instantiate arg] Memory 0
+0x0087 | 03 00       | [instantiate arg] Global 0
+0x0089 | 01 00       | [instantiate arg] Table 0
+0x008b | 05 00       | [instantiate arg] Module 0
+0x008d | 06 01       | [instantiate arg] Instance 1
+0x008f | 67 45       | module code section
+0x0091 | 01          | 1 count
+0x0092 | 43          | inline module size
+  0x0093 | 00 61 73 6d | version 1
          | 01 00 00 00
-  0x009a | 01 09       | type section
-  0x009c | 03          | 3 count
-  0x009d | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
-  0x00a0 | 61 00 00    | [type 1] Module(ModuleType { imports: [], exports: [] })
-  0x00a3 | 62 00       | [type 2] Instance(InstanceType { exports: [] })
-  0x00a5 | 02 23       | import section
-  0x00a7 | 06          | 6 count
-  0x00a8 | 00 01 c0 00 | import [func 0] Import { module: "", field: None, ty: Function(0) }
+  0x009b | 01 09       | type section
+  0x009d | 03          | 3 count
+  0x009e | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
+  0x00a1 | 61 00 00    | [type 1] Module(ModuleType { imports: [], exports: [] })
+  0x00a4 | 62 00       | [type 2] Instance(InstanceType { exports: [] })
+  0x00a6 | 02 23       | import section
+  0x00a8 | 06          | 6 count
+  0x00a9 | 00 01 c0 00 | import [func 0] Import { module: "", field: None, ty: Function(0) }
          | 00         
-  0x00ad | 00 01 c0 02 | import [memory 0] Import { module: "", field: None, ty: Memory(MemoryType { limits: ResizableLimits { initial: 1, maximum: None }, shared: false }) }
+  0x00ae | 00 01 c0 02 | import [memory 0] Import { module: "", field: None, ty: Memory(MemoryType { limits: ResizableLimits { initial: 1, maximum: None }, shared: false }) }
          | 00 01      
-  0x00b3 | 00 01 c0 03 | import [global 0] Import { module: "", field: None, ty: Global(GlobalType { content_type: I32, mutable: false }) }
+  0x00b4 | 00 01 c0 03 | import [global 0] Import { module: "", field: None, ty: Global(GlobalType { content_type: I32, mutable: false }) }
          | 7f 00      
-  0x00b9 | 00 01 c0 01 | import [table 0] Import { module: "", field: None, ty: Table(TableType { element_type: FuncRef, limits: ResizableLimits { initial: 1, maximum: None } }) }
+  0x00ba | 00 01 c0 01 | import [table 0] Import { module: "", field: None, ty: Table(TableType { element_type: FuncRef, limits: ResizableLimits { initial: 1, maximum: None } }) }
          | 70 00 01   
-  0x00c0 | 00 01 c0 05 | import [module 0] Import { module: "", field: None, ty: Module(1) }
+  0x00c1 | 00 01 c0 05 | import [module 0] Import { module: "", field: None, ty: Module(1) }
          | 01         
-  0x00c5 | 00 01 c0 06 | import [instance 0] Import { module: "", field: None, ty: Instance(2) }
+  0x00c6 | 00 01 c0 06 | import [instance 0] Import { module: "", field: None, ty: Instance(2) }
          | 02         
-  0x00ca | 00 09 04 6e | custom section: "name"
+  0x00cb | 00 09 04 6e | custom section: "name"
          | 61 6d 65   
-  0x00d1 | 00 02       | module name
-  0x00d3 | 01 6d       | "m"
-0x00d5 | 00 11 04 6e | custom section: "name"
+  0x00d2 | 00 02       | module name
+  0x00d4 | 01 6d       | "m"
+0x00d6 | 00 11 04 6e | custom section: "name"
        | 61 6d 65   
-0x00dc | 01 0a       | function names
-0x00de | 01          | 1 count
-0x00df | 00 07 69 2e | Naming { index: 0, name: "i.$func" }
+0x00dd | 01 0a       | function names
+0x00df | 01          | 1 count
+0x00e0 | 00 07 69 2e | Naming { index: 0, name: "i.$func" }
        | 24 66 75 6e
        | 63         

--- a/tests/dump/bundled.wat.dump
+++ b/tests/dump/bundled.wat.dump
@@ -34,119 +34,119 @@
 0x0071 | 02          | 2 count
 0x0072 | 03          | [module 0] type 3
 0x0073 | 04          | [module 1] type 4
-0x0074 | 65 09       | instance section
+0x0074 | 65 0b       | instance section
 0x0076 | 02          | 2 count
-0x0077 | 01          | [instance 1] module:1
-0x0078 | 01          | 1 count
-0x0079 | 06 00       | [instantiate arg] Instance 0
-0x007b | 00          | [instance 2] module:0
-0x007c | 01          | 1 count
-0x007d | 06 01       | [instantiate arg] Instance 1
-0x007f | 66 05       | alias section
-0x0081 | 01          | 1 count
-0x0082 | 00 02 00 00 | [alias] Alias { instance: Child(2), kind: Function, index: 0 }
-0x0086 | 03 02       | func section
-0x0088 | 01          | 1 count
-0x0089 | 02          | [func 1] type 2
-0x008a | 07 08       | export section
-0x008c | 01          | 1 count
-0x008d | 04 77 6f 72 | export Export { field: "work", kind: Function, index: 1 }
+0x0077 | 00 01       | [instance 1] module:1
+0x0079 | 01          | 1 count
+0x007a | 06 00       | [instantiate arg] Instance 0
+0x007c | 00 00       | [instance 2] module:0
+0x007e | 01          | 1 count
+0x007f | 06 01       | [instantiate arg] Instance 1
+0x0081 | 66 05       | alias section
+0x0083 | 01          | 1 count
+0x0084 | 00 02 00 00 | [alias] Alias { instance: Child(2), kind: Function, index: 0 }
+0x0088 | 03 02       | func section
+0x008a | 01          | 1 count
+0x008b | 02          | [func 1] type 2
+0x008c | 07 08       | export section
+0x008e | 01          | 1 count
+0x008f | 04 77 6f 72 | export Export { field: "work", kind: Function, index: 1 }
        | 6b 00 01   
-0x0094 | 67 b5 01    | module code section
-0x0097 | 02          | 2 count
-0x0098 | 51          | inline module size
-  0x0099 | 00 61 73 6d | version 1
+0x0096 | 67 b5 01    | module code section
+0x0099 | 02          | 2 count
+0x009a | 51          | inline module size
+  0x009b | 00 61 73 6d | version 1
          | 01 00 00 00
-  0x00a1 | 66 04       | alias section
-  0x00a3 | 01          | 1 count
-  0x00a4 | 01 07 01    | [alias] Alias { instance: Parent, kind: Type, index: 1 }
-  0x00a7 | 01 04       | type section
-  0x00a9 | 01          | 1 count
-  0x00aa | 60 00 00    | [type 1] Func(FuncType { params: [], returns: [] })
-  0x00ad | 02 0f       | import section
-  0x00af | 01          | 1 count
-  0x00b0 | 09 77 61 73 | import [instance 0] Import { module: "wasi_file", field: None, ty: Instance(0) }
+  0x00a3 | 66 04       | alias section
+  0x00a5 | 01          | 1 count
+  0x00a6 | 01 07 01    | [alias] Alias { instance: Parent, kind: Type, index: 1 }
+  0x00a9 | 01 04       | type section
+  0x00ab | 01          | 1 count
+  0x00ac | 60 00 00    | [type 1] Func(FuncType { params: [], returns: [] })
+  0x00af | 02 0f       | import section
+  0x00b1 | 01          | 1 count
+  0x00b2 | 09 77 61 73 | import [instance 0] Import { module: "wasi_file", field: None, ty: Instance(0) }
          | 69 5f 66 69
          | 6c 65 01 c0
          | 06 00      
-  0x00be | 03 02       | func section
-  0x00c0 | 01          | 1 count
-  0x00c1 | 01          | [func 0] type 1
-  0x00c2 | 07 08       | export section
-  0x00c4 | 01          | 1 count
-  0x00c5 | 04 70 6c 61 | export Export { field: "play", kind: Function, index: 0 }
+  0x00c0 | 03 02       | func section
+  0x00c2 | 01          | 1 count
+  0x00c3 | 01          | [func 0] type 1
+  0x00c4 | 07 08       | export section
+  0x00c6 | 01          | 1 count
+  0x00c7 | 04 70 6c 61 | export Export { field: "play", kind: Function, index: 0 }
          | 79 00 00   
-  0x00cc | 0a 04       | code section
-  0x00ce | 01          | 1 count
+  0x00ce | 0a 04       | code section
+  0x00d0 | 01          | 1 count
 ============== func 0 ====================
-  0x00cf | 02          | size of function
-  0x00d0 | 00          | 0 local blocks
-  0x00d1 | 0b          | End
-  0x00d2 | 00 16 04 6e | custom section: "name"
+  0x00d1 | 02          | size of function
+  0x00d2 | 00          | 0 local blocks
+  0x00d3 | 0b          | End
+  0x00d4 | 00 16 04 6e | custom section: "name"
          | 61 6d 65   
-  0x00d9 | 00 06       | module name
-  0x00db | 05 43 48 49 | "CHILD"
+  0x00db | 00 06       | module name
+  0x00dd | 05 43 48 49 | "CHILD"
          | 4c 44      
-  0x00e1 | 01 07       | function names
-  0x00e3 | 01          | 1 count
-  0x00e4 | 00 04 70 6c | Naming { index: 0, name: "play" }
+  0x00e3 | 01 07       | function names
+  0x00e5 | 01          | 1 count
+  0x00e6 | 00 04 70 6c | Naming { index: 0, name: "play" }
          | 61 79      
-0x00ea | 61          | inline module size
-  0x00eb | 00 61 73 6d | version 1
+0x00ec | 61          | inline module size
+  0x00ed | 00 61 73 6d | version 1
          | 01 00 00 00
-  0x00f3 | 66 04       | alias section
-  0x00f5 | 01          | 1 count
-  0x00f6 | 01 07 01    | [alias] Alias { instance: Parent, kind: Type, index: 1 }
-  0x00f9 | 01 08       | type section
-  0x00fb | 01          | 1 count
-  0x00fc | 60 03 7f 7f | [type 1] Func(FuncType { params: [I32, I32, I32], returns: [I32] })
+  0x00f5 | 66 04       | alias section
+  0x00f7 | 01          | 1 count
+  0x00f8 | 01 07 01    | [alias] Alias { instance: Parent, kind: Type, index: 1 }
+  0x00fb | 01 08       | type section
+  0x00fd | 01          | 1 count
+  0x00fe | 60 03 7f 7f | [type 1] Func(FuncType { params: [I32, I32, I32], returns: [I32] })
          | 7f 01 7f   
-  0x0103 | 02 0f       | import section
-  0x0105 | 01          | 1 count
-  0x0106 | 09 77 61 73 | import [instance 0] Import { module: "wasi_file", field: None, ty: Instance(0) }
+  0x0105 | 02 0f       | import section
+  0x0107 | 01          | 1 count
+  0x0108 | 09 77 61 73 | import [instance 0] Import { module: "wasi_file", field: None, ty: Instance(0) }
          | 69 5f 66 69
          | 6c 65 01 c0
          | 06 00      
-  0x0114 | 03 03       | func section
-  0x0116 | 02          | 2 count
-  0x0117 | 01          | [func 0] type 1
-  0x0118 | 01          | [func 1] type 1
-  0x0119 | 07 10       | export section
-  0x011b | 02          | 2 count
-  0x011c | 04 72 65 61 | export Export { field: "read", kind: Function, index: 0 }
+  0x0116 | 03 03       | func section
+  0x0118 | 02          | 2 count
+  0x0119 | 01          | [func 0] type 1
+  0x011a | 01          | [func 1] type 1
+  0x011b | 07 10       | export section
+  0x011d | 02          | 2 count
+  0x011e | 04 72 65 61 | export Export { field: "read", kind: Function, index: 0 }
          | 64 00 00   
-  0x0123 | 05 77 72 69 | export Export { field: "write", kind: Function, index: 1 }
+  0x0125 | 05 77 72 69 | export Export { field: "write", kind: Function, index: 1 }
          | 74 65 00 01
-  0x012b | 0a 0b       | code section
-  0x012d | 02          | 2 count
+  0x012d | 0a 0b       | code section
+  0x012f | 02          | 2 count
 ============== func 0 ====================
-  0x012e | 04          | size of function
-  0x012f | 00          | 0 local blocks
-  0x0130 | 41 00       | I32Const { value: 0 }
-  0x0132 | 0b          | End
+  0x0130 | 04          | size of function
+  0x0131 | 00          | 0 local blocks
+  0x0132 | 41 00       | I32Const { value: 0 }
+  0x0134 | 0b          | End
 ============== func 1 ====================
-  0x0133 | 04          | size of function
-  0x0134 | 00          | 0 local blocks
-  0x0135 | 41 00       | I32Const { value: 0 }
-  0x0137 | 0b          | End
-  0x0138 | 00 12 04 6e | custom section: "name"
+  0x0135 | 04          | size of function
+  0x0136 | 00          | 0 local blocks
+  0x0137 | 41 00       | I32Const { value: 0 }
+  0x0139 | 0b          | End
+  0x013a | 00 12 04 6e | custom section: "name"
          | 61 6d 65   
-  0x013f | 00 0b       | module name
-  0x0141 | 0a 56 49 52 | "VIRTUALIZE"
+  0x0141 | 00 0b       | module name
+  0x0143 | 0a 56 49 52 | "VIRTUALIZE"
          | 54 55 41 4c
          | 49 5a 45   
-0x014c | 0a 06       | code section
-0x014e | 01          | 1 count
+0x014e | 0a 06       | code section
+0x0150 | 01          | 1 count
 ============== func 1 ====================
-0x014f | 04          | size of function
-0x0150 | 00          | 0 local blocks
-0x0151 | 10 00       | Call { function_index: 0 }
-0x0153 | 0b          | End
-0x0154 | 00 15 04 6e | custom section: "name"
+0x0151 | 04          | size of function
+0x0152 | 00          | 0 local blocks
+0x0153 | 10 00       | Call { function_index: 0 }
+0x0155 | 0b          | End
+0x0156 | 00 15 04 6e | custom section: "name"
        | 61 6d 65   
-0x015b | 01 0e       | function names
-0x015d | 01          | 1 count
-0x015e | 00 0b 63 68 | Naming { index: 0, name: "child.$play" }
+0x015d | 01 0e       | function names
+0x015f | 01          | 1 count
+0x0160 | 00 0b 63 68 | Naming { index: 0, name: "child.$play" }
        | 69 6c 64 2e
        | 24 70 6c 61
        | 79         

--- a/tests/dump/import-modules.wat.dump
+++ b/tests/dump/import-modules.wat.dump
@@ -14,8 +14,8 @@
        | 01         
 0x0029 | 00 01 c0 05 | import [module 1] Import { module: "", field: None, ty: Module(3) }
        | 03         
-0x002e | 65 05       | instance section
+0x002e | 65 06       | instance section
 0x0030 | 01          | 1 count
-0x0031 | 00          | [instance 0] module:0
-0x0032 | 01          | 1 count
-0x0033 | 05 01       | [instantiate arg] Module 1
+0x0031 | 00 00       | [instance 0] module:0
+0x0033 | 01          | 1 count
+0x0034 | 05 01       | [instantiate arg] Module 1

--- a/tests/dump/instantiate.wat.dump
+++ b/tests/dump/instantiate.wat.dump
@@ -13,38 +13,38 @@
        | 00         
 0x0020 | 00 01 c0 06 | import [instance 0] Import { module: "", field: None, ty: Instance(1) }
        | 01         
-0x0025 | 65 0f       | instance section
+0x0025 | 65 10       | instance section
 0x0027 | 01          | 1 count
-0x0028 | 00          | [instance 1] module:0
-0x0029 | 06          | 6 count
-0x002a | 05 01       | [instantiate arg] Module 1
-0x002c | 00 00       | [instantiate arg] Function 0
-0x002e | 03 00       | [instantiate arg] Global 0
-0x0030 | 06 00       | [instantiate arg] Instance 0
-0x0032 | 02 00       | [instantiate arg] Memory 0
-0x0034 | 01 00       | [instantiate arg] Table 0
-0x0036 | 03 02       | func section
-0x0038 | 01          | 1 count
-0x0039 | 02          | [func 0] type 2
-0x003a | 04 04       | table section
-0x003c | 01          | 1 count
-0x003d | 70 00 01    | [table 0] TableType { element_type: FuncRef, limits: ResizableLimits { initial: 1, maximum: None } }
-0x0040 | 05 03       | memory section
-0x0042 | 01          | 1 count
-0x0043 | 00 01       | [memory 0] MemoryType { limits: ResizableLimits { initial: 1, maximum: None }, shared: false }
-0x0045 | 06 06       | global section
-0x0047 | 01          | 1 count
-0x0048 | 7f 00       | [global 0] GlobalType { content_type: I32, mutable: false }
-0x004a | 41 00       | I32Const { value: 0 }
-0x004c | 0b          | End
-0x004d | 0a 04       | code section
-0x004f | 01          | 1 count
+0x0028 | 00 00       | [instance 1] module:0
+0x002a | 06          | 6 count
+0x002b | 05 01       | [instantiate arg] Module 1
+0x002d | 00 00       | [instantiate arg] Function 0
+0x002f | 03 00       | [instantiate arg] Global 0
+0x0031 | 06 00       | [instantiate arg] Instance 0
+0x0033 | 02 00       | [instantiate arg] Memory 0
+0x0035 | 01 00       | [instantiate arg] Table 0
+0x0037 | 03 02       | func section
+0x0039 | 01          | 1 count
+0x003a | 02          | [func 0] type 2
+0x003b | 04 04       | table section
+0x003d | 01          | 1 count
+0x003e | 70 00 01    | [table 0] TableType { element_type: FuncRef, limits: ResizableLimits { initial: 1, maximum: None } }
+0x0041 | 05 03       | memory section
+0x0043 | 01          | 1 count
+0x0044 | 00 01       | [memory 0] MemoryType { limits: ResizableLimits { initial: 1, maximum: None }, shared: false }
+0x0046 | 06 06       | global section
+0x0048 | 01          | 1 count
+0x0049 | 7f 00       | [global 0] GlobalType { content_type: I32, mutable: false }
+0x004b | 41 00       | I32Const { value: 0 }
+0x004d | 0b          | End
+0x004e | 0a 04       | code section
+0x0050 | 01          | 1 count
 ============== func 0 ====================
-0x0050 | 02          | size of function
-0x0051 | 00          | 0 local blocks
-0x0052 | 0b          | End
-0x0053 | 00 0b 04 6e | custom section: "name"
+0x0051 | 02          | size of function
+0x0052 | 00          | 0 local blocks
+0x0053 | 0b          | End
+0x0054 | 00 0b 04 6e | custom section: "name"
        | 61 6d 65   
-0x005a | 01 04       | function names
-0x005c | 01          | 1 count
-0x005d | 00 01 66    | Naming { index: 0, name: "f" }
+0x005b | 01 04       | function names
+0x005d | 01          | 1 count
+0x005e | 00 01 66    | Naming { index: 0, name: "f" }

--- a/tests/dump/instantiate2.wat.dump
+++ b/tests/dump/instantiate2.wat.dump
@@ -9,7 +9,7 @@
 0x0018 | 01          | 1 count
 0x0019 | 00 01 c0 05 | import [module 0] Import { module: "", field: None, ty: Module(1) }
        | 01         
-0x001e | 65 03       | instance section
+0x001e | 65 04       | instance section
 0x0020 | 01          | 1 count
-0x0021 | 00          | [instance 0] module:0
-0x0022 | 00          | 0 count
+0x0021 | 00 00       | [instance 0] module:0
+0x0023 | 00          | 0 count

--- a/tests/dump/module-linking.wat.dump
+++ b/tests/dump/module-linking.wat.dump
@@ -38,48 +38,48 @@
 0x0079 | 64 02       | module section
 0x007b | 01          | 1 count
 0x007c | 04          | [module 1] type 4
-0x007d | 65 0f       | instance section
+0x007d | 65 10       | instance section
 0x007f | 01          | 1 count
-0x0080 | 01          | [instance 2] module:1
-0x0081 | 06          | 6 count
-0x0082 | 00 00       | [instantiate arg] Function 0
-0x0084 | 02 00       | [instantiate arg] Memory 0
-0x0086 | 03 00       | [instantiate arg] Global 0
-0x0088 | 01 00       | [instantiate arg] Table 0
-0x008a | 05 00       | [instantiate arg] Module 0
-0x008c | 06 01       | [instantiate arg] Instance 1
-0x008e | 67 45       | module code section
-0x0090 | 01          | 1 count
-0x0091 | 43          | inline module size
-  0x0092 | 00 61 73 6d | version 1
+0x0080 | 00 01       | [instance 2] module:1
+0x0082 | 06          | 6 count
+0x0083 | 00 00       | [instantiate arg] Function 0
+0x0085 | 02 00       | [instantiate arg] Memory 0
+0x0087 | 03 00       | [instantiate arg] Global 0
+0x0089 | 01 00       | [instantiate arg] Table 0
+0x008b | 05 00       | [instantiate arg] Module 0
+0x008d | 06 01       | [instantiate arg] Instance 1
+0x008f | 67 45       | module code section
+0x0091 | 01          | 1 count
+0x0092 | 43          | inline module size
+  0x0093 | 00 61 73 6d | version 1
          | 01 00 00 00
-  0x009a | 01 09       | type section
-  0x009c | 03          | 3 count
-  0x009d | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
-  0x00a0 | 61 00 00    | [type 1] Module(ModuleType { imports: [], exports: [] })
-  0x00a3 | 62 00       | [type 2] Instance(InstanceType { exports: [] })
-  0x00a5 | 02 23       | import section
-  0x00a7 | 06          | 6 count
-  0x00a8 | 00 01 c0 00 | import [func 0] Import { module: "", field: None, ty: Function(0) }
+  0x009b | 01 09       | type section
+  0x009d | 03          | 3 count
+  0x009e | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
+  0x00a1 | 61 00 00    | [type 1] Module(ModuleType { imports: [], exports: [] })
+  0x00a4 | 62 00       | [type 2] Instance(InstanceType { exports: [] })
+  0x00a6 | 02 23       | import section
+  0x00a8 | 06          | 6 count
+  0x00a9 | 00 01 c0 00 | import [func 0] Import { module: "", field: None, ty: Function(0) }
          | 00         
-  0x00ad | 00 01 c0 02 | import [memory 0] Import { module: "", field: None, ty: Memory(MemoryType { limits: ResizableLimits { initial: 1, maximum: None }, shared: false }) }
+  0x00ae | 00 01 c0 02 | import [memory 0] Import { module: "", field: None, ty: Memory(MemoryType { limits: ResizableLimits { initial: 1, maximum: None }, shared: false }) }
          | 00 01      
-  0x00b3 | 00 01 c0 03 | import [global 0] Import { module: "", field: None, ty: Global(GlobalType { content_type: I32, mutable: false }) }
+  0x00b4 | 00 01 c0 03 | import [global 0] Import { module: "", field: None, ty: Global(GlobalType { content_type: I32, mutable: false }) }
          | 7f 00      
-  0x00b9 | 00 01 c0 01 | import [table 0] Import { module: "", field: None, ty: Table(TableType { element_type: FuncRef, limits: ResizableLimits { initial: 1, maximum: None } }) }
+  0x00ba | 00 01 c0 01 | import [table 0] Import { module: "", field: None, ty: Table(TableType { element_type: FuncRef, limits: ResizableLimits { initial: 1, maximum: None } }) }
          | 70 00 01   
-  0x00c0 | 00 01 c0 05 | import [module 0] Import { module: "", field: None, ty: Module(1) }
+  0x00c1 | 00 01 c0 05 | import [module 0] Import { module: "", field: None, ty: Module(1) }
          | 01         
-  0x00c5 | 00 01 c0 06 | import [instance 0] Import { module: "", field: None, ty: Instance(2) }
+  0x00c6 | 00 01 c0 06 | import [instance 0] Import { module: "", field: None, ty: Instance(2) }
          | 02         
-  0x00ca | 00 09 04 6e | custom section: "name"
+  0x00cb | 00 09 04 6e | custom section: "name"
          | 61 6d 65   
-  0x00d1 | 00 02       | module name
-  0x00d3 | 01 6d       | "m"
-0x00d5 | 00 11 04 6e | custom section: "name"
+  0x00d2 | 00 02       | module name
+  0x00d4 | 01 6d       | "m"
+0x00d6 | 00 11 04 6e | custom section: "name"
        | 61 6d 65   
-0x00dc | 01 0a       | function names
-0x00de | 01          | 1 count
-0x00df | 00 07 69 2e | Naming { index: 0, name: "i.$func" }
+0x00dd | 01 0a       | function names
+0x00df | 01          | 1 count
+0x00e0 | 00 07 69 2e | Naming { index: 0, name: "i.$func" }
        | 24 66 75 6e
        | 63         


### PR DESCRIPTION
In the merging of WebAssembly/module-linking#11 a prefix byte was added
for local instances to differentiate instantiated modules and
collections of other items.