### PR TITLE
Fix a panic on printing an invalid code section

### DIFF
--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -124,19 +124,21 @@ impl Printer {
             match payload {
                 Payload::CodeSectionStart { size, range, .. } => {
                     let offset = offset as usize;
-                    code = Some(CodeSectionReader::new(
-                        &wasm[range.start - offset..range.end - offset],
-                        range.start,
-                    )?);
+                    let section = match wasm.get(range.start - offset..range.end - offset) {
+                        Some(slice) => slice,
+                        None => bail!("invalid code section"),
+                    };
+                    code = Some(CodeSectionReader::new(section, range.start)?);
                     parser.skip_section();
                     bytes = &bytes[size as usize..];
                 }
                 Payload::ModuleCodeSectionStart { size, range, .. } => {
                     let offset = offset as usize;
-                    module_code = Some(ModuleCodeSectionReader::new(
-                        &wasm[range.start - offset..range.end - offset],
-                        range.start,
-                    )?);
+                    let section = match wasm.get(range.start - offset..range.end - offset) {
+                        Some(slice) => slice,
+                        None => bail!("invalid module code section"),
+                    };
+                    module_code = Some(ModuleCodeSectionReader::new(section, range.start)?);
                     parser.skip_section();
                     bytes = &bytes[size as usize..];
                 }

--- a/crates/wasmprinter/tests/all.rs
+++ b/crates/wasmprinter/tests/all.rs
@@ -10,3 +10,18 @@ fn no_panic() {
     .unwrap();
     wasmprinter::print_bytes(&bytes).unwrap();
 }
+
+#[test]
+fn code_section_overflow() {
+    let bytes = wat::parse_str(
+        r#"
+            (module binary
+                "\00asm"
+                "\01\00\00\00"
+                "\0a\10\01"
+            )
+        "#,
+    )
+    .unwrap();
+    wasmprinter::print_bytes(&bytes).unwrap_err();
+}


### PR DESCRIPTION
If the code section extends the reach of its bounds then be sure to
return an error instead of panicking.