### PR TITLE
Rename atomic wait/notify operators

### DIFF
--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -789,13 +789,13 @@ impl<'a> BinaryReader<'a> {
     fn read_0xfe_operator(&mut self) -> Result<Operator<'a>> {
         let code = self.read_u8()? as u8;
         Ok(match code {
-            0x00 => Operator::AtomicNotify {
+            0x00 => Operator::MemoryAtomicNotify {
                 memarg: self.read_memarg_of_align(2)?,
             },
-            0x01 => Operator::I32AtomicWait {
+            0x01 => Operator::MemoryAtomicWait32 {
                 memarg: self.read_memarg_of_align(2)?,
             },
-            0x02 => Operator::I64AtomicWait {
+            0x02 => Operator::MemoryAtomicWait64 {
                 memarg: self.read_memarg_of_align(3)?,
             },
             0x03 => Operator::AtomicFence {

--- a/crates/wasmparser/src/operators_validator.rs
+++ b/crates/wasmparser/src/operators_validator.rs
@@ -1505,19 +1505,19 @@ impl OperatorValidator {
                 self.check_operands_3(Type::I32, Type::I64, Type::I64)?;
                 self.func_state.change_frame_with_type(3, Type::I64)?;
             }
-            Operator::AtomicNotify { memarg } => {
+            Operator::MemoryAtomicNotify { memarg } => {
                 self.check_threads_enabled()?;
                 self.check_shared_memarg_wo_align(memarg, resources)?;
                 self.check_operands_2(Type::I32, Type::I32)?;
                 self.func_state.change_frame_with_type(2, Type::I32)?;
             }
-            Operator::I32AtomicWait { memarg } => {
+            Operator::MemoryAtomicWait32 { memarg } => {
                 self.check_threads_enabled()?;
                 self.check_shared_memarg_wo_align(memarg, resources)?;
                 self.check_operands_3(Type::I32, Type::I32, Type::I64)?;
                 self.func_state.change_frame_with_type(3, Type::I32)?;
             }
-            Operator::I64AtomicWait { memarg } => {
+            Operator::MemoryAtomicWait64 { memarg } => {
                 self.check_threads_enabled()?;
                 self.check_shared_memarg_wo_align(memarg, resources)?;
                 self.check_operands_3(Type::I32, Type::I64, Type::I64)?;

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -520,9 +520,9 @@ pub enum Operator<'a> {
 
     // 0xFE operators
     // https://github.com/WebAssembly/threads/blob/master/proposals/threads/Overview.md
-    AtomicNotify { memarg: MemoryImmediate },
-    I32AtomicWait { memarg: MemoryImmediate },
-    I64AtomicWait { memarg: MemoryImmediate },
+    MemoryAtomicNotify { memarg: MemoryImmediate },
+    MemoryAtomicWait32 { memarg: MemoryImmediate },
+    MemoryAtomicWait64 { memarg: MemoryImmediate },
     AtomicFence { flags: u8 },
     I32AtomicLoad { memarg: MemoryImmediate },
     I64AtomicLoad { memarg: MemoryImmediate },

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -946,9 +946,9 @@ impl Printer {
             TableSize { table } => write!(self.result, "table.size {}", table)?,
             TableFill { table } => write!(self.result, "table.fill {}", table)?,
 
-            AtomicNotify { memarg } => self.mem_instr("atomic.notify", memarg, 4)?,
-            I32AtomicWait { memarg } => self.mem_instr("i32.atomic.wait", memarg, 4)?,
-            I64AtomicWait { memarg } => self.mem_instr("i64.atomic.wait", memarg, 8)?,
+            MemoryAtomicNotify { memarg } => self.mem_instr("memory.atomic.notify", memarg, 4)?,
+            MemoryAtomicWait32 { memarg } => self.mem_instr("memory.atomic.wait32", memarg, 4)?,
+            MemoryAtomicWait64 { memarg } => self.mem_instr("memory.atomic.wait64", memarg, 8)?,
             AtomicFence { flags: _ } => self.result.push_str("atomic.fence"),
 
             I32AtomicLoad { memarg } => self.mem_instr("i32.atomic.load", memarg, 4)?,

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -257,6 +257,13 @@ impl TestState {
             // wabt's encoding of `ref.is_null` hasn't been updated
             && !test.ends_with("local/ref.wat")
             && !test.iter().any(|t| t == "reference-types")
+
+            // wabt uses old instruction names for atomics
+            && !test.ends_with("atomic-no-shared-memory.txt")
+            && !test.ends_with("fold-atomic.txt")
+            && !test.ends_with("atomic.txt")
+            && !test.ends_with("atomic-align.txt")
+            && !test.ends_with("atomic.wast")
         {
             if let Some(expected) = self.wasm2wat(contents)? {
                 self.string_compare(&string, &expected)?;


### PR DESCRIPTION
This changed a long time ago in WebAssembly/threads#149 and this carries
through the change to wasmparser.