### PR TITLE
Fix offset reported from validating function headers

### DIFF
--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -1670,7 +1670,8 @@ impl Validator {
         let ty = self.func_type_at(ty_index)?;
         Ok((
             FuncValidator {
-                validator: OperatorValidator::new(ty.item, &list, config).map_err(|e| e.0)?,
+                validator: OperatorValidator::new(ty.item, &list, config)
+                    .map_err(|e| e.set_offset(self.offset))?,
                 state: self.state.arc().clone(),
                 offset: body.get_binary_reader().original_position(),
                 eof_found: false,

--- a/crates/wasmparser/tests/errors.rs
+++ b/crates/wasmparser/tests/errors.rs
@@ -1,0 +1,10 @@
+use wasmparser::Validator;
+
+#[test]
+fn simd_not_enabled() {
+    let bytes = wat::parse_str("(module (func (param v128)))").unwrap();
+    let mut v = Validator::new();
+    v.wasm_simd(false);
+    let result = v.validate_all(&bytes).unwrap_err();
+    assert_eq!(result.offset(), 11);
+}


### PR DESCRIPTION
I forgot to call `set_offset` in a recent refactoring, instead it just
accesses a raw `.0` error which doesn't have the correct offset set.