### PR TITLE
Fix validate fuzz target

### DIFF
--- a/fuzz/fuzz_targets/validate.rs
+++ b/fuzz/fuzz_targets/validate.rs
@@ -18,5 +18,5 @@ fuzz_target!(|data: &[u8]| {
     validator.wasm_bulk_memory((byte & 0b0100_0000) != 0);
     validator.deterministic_only((byte & 0b1000_0000) != 0);
 
-    drop(validator.validate_all(data));
+    drop(validator.validate_all(&data[1..]));
 });


### PR DESCRIPTION
The first byte was intended as a list of flags for validation, but that
first byte shouldn't also then be interpreted as the first byte of the
wasm binary.