### PR TITLE
Update GC proposal parsing

### DIFF
--- a/crates/wast/src/ast/expr.rs
+++ b/crates/wast/src/ast/expr.rs
@@ -424,19 +424,19 @@ instructions! {
         RefEq : [0xd5] : "ref.eq",
 
         // gc proposal: struct
-        StructNew(ast::Index<'a>) : [0xfb, 0x00] : "struct.new",
-        StructNewSub(ast::Index<'a>) : [0xfb, 0x01] : "struct.new_sub",
-        StructNewDefault(ast::Index<'a>) : [0xfb, 0x02] : "struct.new_default",
+        StructNewWithRtt(ast::Index<'a>) : [0xfb, 0x01] : "struct.new_with_rtt",
+        StructNewDefaultWithRtt(ast::Index<'a>) : [0xfb, 0x02] : "struct.new_default_with_rtt",
         StructGet(StructAccess<'a>) : [0xfb, 0x03] : "struct.get",
         StructGetS(StructAccess<'a>) : [0xfb, 0x04] : "struct.get_s",
         StructGetU(StructAccess<'a>) : [0xfb, 0x05] : "struct.get_u",
         StructSet(StructAccess<'a>) : [0xfb, 0x06] : "struct.set",
+
+        // gc proposal (moz specific, will be removed)
         StructNarrow(StructNarrow<'a>) : [0xfb, 0x07] : "struct.narrow",
 
         // gc proposal: array
-        ArrayNew(ast::Index<'a>) : [0xfb, 0x10] : "array.new",
-        ArrayNewSub(ast::Index<'a>) : [0xfb, 0x11] : "array.new_sub",
-        ArrayNewDefault(ast::Index<'a>) : [0xfb, 0x12] : "array.new_default",
+        ArrayNewWithRtt(ast::Index<'a>) : [0xfb, 0x11] : "array.new_with_rtt",
+        ArrayNewDefaultWithRtt(ast::Index<'a>) : [0xfb, 0x12] : "array.new_default_with_rtt",
         ArrayGet(ast::Index<'a>) : [0xfb, 0x13] : "array.get",
         ArrayGetS(ast::Index<'a>) : [0xfb, 0x14] : "array.get_s",
         ArrayGetU(ast::Index<'a>) : [0xfb, 0x15] : "array.get_u",
@@ -449,11 +449,11 @@ instructions! {
         I31GetU : [0xfb, 0x22] : "i31.get_u",
 
         // gc proposal, rtt/casting
-        RTTGet(ast::Index<'a>) : [0xfb, 0x30] : "rtt.get",
-        RTTSub(ast::Index<'a>) : [0xfb, 0x31] : "rtt.sub",
-        RefTest : [0xfb, 0x40] : "ref.test",
-        RefCast : [0xfb, 0x41] : "ref.cast",
-        BrOnCast(ast::Index<'a>) : [0xfb, 0x42] : "br_on_cast",
+        RTTCanon(HeapType<'a>) : [0xfb, 0x30] : "rtt.canon",
+        RTTSub(RTTSub<'a>) : [0xfb, 0x31] : "rtt.sub",
+        RefTest(RefTest<'a>) : [0xfb, 0x40] : "ref.test",
+        RefCast(RefTest<'a>) : [0xfb, 0x41] : "ref.cast",
+        BrOnCast(BrOnCast<'a>) : [0xfb, 0x42] : "br_on_cast",
 
         I32Const(i32) : [0x41] : "i32.const",
         I64Const(i64) : [0x42] : "i64.const",
@@ -1362,5 +1362,57 @@ impl<'a> Parse<'a> for BrOnExn<'a> {
         let label = parser.parse()?;
         let exn = parser.parse()?;
         Ok(BrOnExn { label, exn })
+    }
+}
+
+/// Payload of the `br_on_cast` instruction
+#[derive(Debug)]
+#[allow(missing_docs)]
+pub struct BrOnCast<'a> {
+    pub label: ast::Index<'a>,
+    pub val: HeapType<'a>,
+    pub rtt: HeapType<'a>,
+}
+
+impl<'a> Parse<'a> for BrOnCast<'a> {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        let label = parser.parse()?;
+        let val = parser.parse()?;
+        let rtt = parser.parse()?;
+        Ok(BrOnCast { label, val, rtt })
+    }
+}
+
+/// Payload of the `rtt.sub` instruction
+#[derive(Debug)]
+#[allow(missing_docs)]
+pub struct RTTSub<'a> {
+    pub depth: u32,
+    pub input_rtt: HeapType<'a>,
+    pub output_rtt: HeapType<'a>,
+}
+
+impl<'a> Parse<'a> for RTTSub<'a> {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        let depth = parser.parse()?;
+        let input_rtt = parser.parse()?;
+        let output_rtt = parser.parse()?;
+        Ok(RTTSub { depth, input_rtt, output_rtt })
+    }
+}
+
+/// Payload of the `ref.test/cast` instruction
+#[derive(Debug)]
+#[allow(missing_docs)]
+pub struct RefTest<'a> {
+    pub val: HeapType<'a>,
+    pub rtt: HeapType<'a>,
+}
+
+impl<'a> Parse<'a> for RefTest<'a> {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        let val = parser.parse()?;
+        let rtt = parser.parse()?;
+        Ok(RefTest { val, rtt })
     }
 }

--- a/crates/wast/src/ast/func.rs
+++ b/crates/wast/src/ast/func.rs
@@ -35,14 +35,8 @@ pub enum FuncKind<'a> {
 
     /// Almost all functions, those defined inline in a wasm module.
     Inline {
-        /// The list of locals, if any, for this function. Each local has an
-        /// optional identifier for name resolution and name for the custom
-        /// `name` section associated with it.
-        locals: Vec<(
-            Option<ast::Id<'a>>,
-            Option<ast::NameAnnotation<'a>>,
-            ast::ValType<'a>,
-        )>,
+        /// The list of locals, if any, for this function.
+        locals: Vec<Local<'a>>,
 
         /// The instructions of the function.
         expression: ast::Expression<'a>,
@@ -60,24 +54,7 @@ impl<'a> Parse<'a> for Func<'a> {
             (parser.parse()?, FuncKind::Import(import))
         } else {
             let ty = parser.parse()?;
-            let mut locals = Vec::new();
-            while parser.peek2::<kw::local>() {
-                parser.parens(|p| {
-                    p.parse::<kw::local>()?;
-                    if p.is_empty() {
-                        return Ok(());
-                    }
-                    let id: Option<_> = p.parse()?;
-                    let name: Option<_> = p.parse()?;
-                    let ty = p.parse()?;
-                    let parse_more = id.is_none() && name.is_none();
-                    locals.push((id, name, ty));
-                    while parse_more && !p.is_empty() {
-                        locals.push((None, None, p.parse()?));
-                    }
-                    Ok(())
-                })?;
-            }
+            let locals = Local::parse_remainder(parser)?;
             (
                 ty,
                 FuncKind::Inline {
@@ -95,5 +72,44 @@ impl<'a> Parse<'a> for Func<'a> {
             ty,
             kind,
         })
+    }
+}
+
+/// A local for a `func` or `let` instruction.
+///
+/// Each local has an optional identifier for name resolution, an optional name
+/// for the custom `name` section, and a value type.
+#[derive(Debug)]
+pub struct Local<'a> {
+    /// An identifier that this local is resolved with (optionally) for name
+    /// resolution.
+    pub id: Option<ast::Id<'a>>,
+    /// An optional name for this local stored in the custom `name` section.
+    pub name: Option<ast::NameAnnotation<'a>>,
+    /// The value type of this local.
+    pub ty: ast::ValType<'a>,
+}
+
+impl<'a> Local<'a> {
+    pub(crate) fn parse_remainder(parser: Parser<'a>) -> Result<Vec<Local<'a>>> {
+        let mut locals = Vec::new();
+        while parser.peek2::<kw::local>() {
+            parser.parens(|p| {
+                p.parse::<kw::local>()?;
+                if p.is_empty() {
+                    return Ok(());
+                }
+                let id: Option<_> = p.parse()?;
+                let name: Option<_> = p.parse()?;
+                let ty = p.parse()?;
+                let parse_more = id.is_none() && name.is_none();
+                locals.push(Local { id, name, ty });
+                while parse_more && !p.is_empty() {
+                    locals.push(Local { id: None, name: None, ty: p.parse()? });
+                }
+                Ok(())
+            })?;
+        }
+        Ok(locals)
     }
 }

--- a/crates/wast/src/ast/types.rs
+++ b/crates/wast/src/ast/types.rs
@@ -11,7 +11,7 @@ pub enum ValType<'a> {
     F64,
     V128,
     Ref(RefType<'a>),
-    Rtt(ast::Index<'a>),
+    Rtt(u32, ast::Index<'a>),
 }
 
 impl<'a> Parse<'a> for ValType<'a> {
@@ -39,7 +39,7 @@ impl<'a> Parse<'a> for ValType<'a> {
                 let mut l = p.lookahead1();
                 if l.peek::<kw::rtt>() {
                     p.parse::<kw::rtt>()?;
-                    Ok(ValType::Rtt(p.parse()?))
+                    Ok(ValType::Rtt(p.parse()?, p.parse()?))
                 } else {
                     Err(l.error())
                 }

--- a/crates/wast/src/ast/types.rs
+++ b/crates/wast/src/ast/types.rs
@@ -10,8 +10,6 @@ pub enum ValType<'a> {
     F32,
     F64,
     V128,
-    I8,
-    I16,
     Ref(RefType<'a>),
     Rtt(ast::Index<'a>),
 }
@@ -34,12 +32,6 @@ impl<'a> Parse<'a> for ValType<'a> {
         } else if l.peek::<kw::v128>() {
             parser.parse::<kw::v128>()?;
             Ok(ValType::V128)
-        } else if l.peek::<kw::i8>() {
-            parser.parse::<kw::i8>()?;
-            Ok(ValType::I8)
-        } else if l.peek::<kw::i16>() {
-            parser.parse::<kw::i16>()?;
-            Ok(ValType::I16)
         } else if l.peek::<RefType>() {
             Ok(ValType::Ref(parser.parse()?))
         } else if l.peek::<ast::LParen>() {
@@ -55,6 +47,21 @@ impl<'a> Parse<'a> for ValType<'a> {
         } else {
             Err(l.error())
         }
+    }
+}
+
+impl<'a> Peek for ValType<'a> {
+    fn peek(cursor: Cursor<'_>) -> bool {
+        kw::i32::peek(cursor) ||
+        kw::i64::peek(cursor) ||
+        kw::f32::peek(cursor) ||
+        kw::f64::peek(cursor) ||
+        kw::v128::peek(cursor) ||
+        (ast::LParen::peek(cursor) && kw::rtt::peek2(cursor)) ||
+        RefType::peek(cursor)
+    }
+    fn display() -> &'static str {
+        "valtype"
     }
 }
 
@@ -235,6 +242,32 @@ impl<'a> Peek for RefType<'a> {
     }
     fn display() -> &'static str {
         "reftype"
+    }
+}
+
+/// The types of values that may be used in a struct or array.
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
+pub enum StorageType<'a> {
+    I8,
+    I16,
+    Val(ValType<'a>),
+}
+
+impl<'a> Parse<'a> for StorageType<'a> {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        let mut l = parser.lookahead1();
+        if l.peek::<kw::i8>() {
+            parser.parse::<kw::i8>()?;
+            Ok(StorageType::I8)
+        } else if l.peek::<kw::i16>() {
+            parser.parse::<kw::i16>()?;
+            Ok(StorageType::I16)
+        } else if l.peek::<ValType>() {
+            Ok(StorageType::Val(parser.parse()?))
+        } else {
+            Err(l.error())
+        }
     }
 }
 
@@ -469,8 +502,8 @@ pub struct StructField<'a> {
     pub id: Option<ast::Id<'a>>,
     /// Whether this field may be mutated or not.
     pub mutable: bool,
-    /// The value type stored in this field.
-    pub ty: ValType<'a>,
+    /// The storage type stored in this field.
+    pub ty: StorageType<'a>,
 }
 
 impl<'a> StructField<'a> {
@@ -483,7 +516,7 @@ impl<'a> StructField<'a> {
             })?;
             (ty, true)
         } else {
-            (parser.parse::<ValType<'a>>()?, false)
+            (parser.parse::<StorageType<'a>>()?, false)
         };
         Ok(StructField { id, mutable, ty })
     }
@@ -494,8 +527,8 @@ impl<'a> StructField<'a> {
 pub struct ArrayType<'a> {
     /// Whether this field may be mutated or not.
     pub mutable: bool,
-    /// The value type stored in this field.
-    pub ty: ValType<'a>,
+    /// The storage type stored in this field.
+    pub ty: StorageType<'a>,
 }
 
 impl<'a> Parse<'a> for ArrayType<'a> {
@@ -507,7 +540,7 @@ impl<'a> Parse<'a> for ArrayType<'a> {
             })?;
             (ty, true)
         } else {
-            (parser.parse::<ValType<'a>>()?, false)
+            (parser.parse::<StorageType<'a>>()?, false)
         };
         Ok(ArrayType { mutable, ty })
     }

--- a/crates/wast/src/binary.rs
+++ b/crates/wast/src/binary.rs
@@ -343,8 +343,9 @@ impl<'a> Encode for ValType<'a> {
             ValType::F32 => e.push(0x7d),
             ValType::F64 => e.push(0x7c),
             ValType::V128 => e.push(0x7b),
-            ValType::Rtt(index) => {
+            ValType::Rtt(depth, index) => {
                 e.push(0x69);
+                depth.encode(e);
                 index.encode(e);
             }
             ValType::Ref(ty) => {

--- a/crates/wast/src/binary.rs
+++ b/crates/wast/src/binary.rs
@@ -1060,6 +1060,29 @@ impl Encode for BrOnExn<'_> {
     }
 }
 
+impl Encode for BrOnCast<'_> {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.label.encode(e);
+        self.val.encode(e);
+        self.rtt.encode(e);
+    }
+}
+
+impl Encode for RTTSub<'_> {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.depth.encode(e);
+        self.input_rtt.encode(e);
+        self.output_rtt.encode(e);
+    }
+}
+
+impl Encode for RefTest<'_> {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.val.encode(e);
+        self.rtt.encode(e);
+    }
+}
+
 impl Encode for StructAccess<'_> {
     fn encode(&self, e: &mut Vec<u8>) {
         self.r#struct.encode(e);

--- a/crates/wast/src/binary.rs
+++ b/crates/wast/src/binary.rs
@@ -343,14 +343,12 @@ impl<'a> Encode for ValType<'a> {
             ValType::F32 => e.push(0x7d),
             ValType::F64 => e.push(0x7c),
             ValType::V128 => e.push(0x7b),
-            ValType::I8 => e.push(0x7a),
-            ValType::I16 => e.push(0x79),
-            ValType::Ref(ty) => {
-                ty.encode(e);
-            }
             ValType::Rtt(index) => {
                 e.push(0x69);
                 index.encode(e);
+            }
+            ValType::Ref(ty) => {
+                ty.encode(e);
             }
         }
     }
@@ -416,6 +414,18 @@ impl<'a> Encode for RefType<'a> {
             } => {
                 e.push(0x6b);
                 heap.encode(e);
+            }
+        }
+    }
+}
+
+impl<'a> Encode for StorageType<'a> {
+    fn encode(&self, e: &mut Vec<u8>) {
+        match self {
+            StorageType::I8 => e.push(0x7a),
+            StorageType::I16 => e.push(0x79),
+            StorageType::Val(ty) => {
+                ty.encode(e);
             }
         }
     }

--- a/crates/wast/src/resolve/names.rs
+++ b/crates/wast/src/resolve/names.rs
@@ -1201,6 +1201,7 @@ impl<'a> Module<'a> {
             Instruction::Block(bt)
             | Instruction::If(bt)
             | Instruction::Loop(bt)
+            | Instruction::Let(LetType { block: bt, .. })
             | Instruction::Try(bt) => {
                 // No expansion necessary, a type reference is already here.
                 // We'll verify that it's the same as the inline type, if any,
@@ -1322,8 +1323,8 @@ impl<'a> Module<'a> {
                 };
                 if let FuncKind::Inline { locals, expression } = &mut f.kind {
                     // Resolve (ref T) in locals
-                    for (_, _, valtype) in locals.iter_mut() {
-                        self.resolve_valtype(valtype)?;
+                    for local in locals.iter_mut() {
+                        self.resolve_valtype(&mut local.ty)?;
                     }
 
                     // Build a resolver with local namespace for the function
@@ -1344,8 +1345,8 @@ impl<'a> Module<'a> {
                     }
 
                     // .. followed by locals themselves
-                    for (id, _, _) in locals {
-                        resolver.locals.register(*id, "local")?;
+                    for local in locals {
+                        resolver.locals.register(local.id, "local")?;
                     }
 
                     // and then we can resolve the expression!
@@ -1613,6 +1614,16 @@ impl<'a, T> Namespace<'a, T> {
         return index;
     }
 
+    fn dealloc_to(&mut self, count: u32) {
+        assert!(self.count >= count);
+        if self.count == count {
+            return;
+        }
+        self.count = count;
+        self.names.retain(|_, v| *v < count);
+        self.items.truncate(self.count as usize);
+    }
+
     fn register_specific(&mut self, name: Id<'a>, index: u32, desc: &str) -> Result<(), Error> {
         if let Some(_prev) = self.names.insert(name, index) {
             return Err(Error::new(
@@ -1677,10 +1688,18 @@ impl<'a, T> Default for Namespace<'a, T> {
     }
 }
 
+#[derive(Debug, Clone)]
+struct ExprBlock<'a> {
+    // The label of the block
+    label: Option<Id<'a>>,
+    // The amount of locals before this block was entered
+    locals: u32,
+}
+
 struct ExprResolver<'a, 'b> {
     module: &'b Module<'a>,
     locals: Namespace<'a, ()>,
-    labels: Vec<Option<Id<'a>>>,
+    blocks: Vec<ExprBlock<'a>>,
 }
 
 impl<'a, 'b> ExprResolver<'a, 'b> {
@@ -1688,13 +1707,71 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
         ExprResolver {
             module,
             locals: Default::default(),
-            labels: Vec::new(),
+            blocks: Vec::new(),
         }
     }
 
     fn resolve(&mut self, expr: &mut Expression<'a>) -> Result<(), Error> {
         for instr in expr.instrs.iter_mut() {
             self.resolve_instr(instr)?;
+        }
+        Ok(())
+    }
+
+    fn resolve_block_type(&mut self, bt: &mut BlockType<'a>) -> Result<(), Error> {
+        // Ok things get interesting here. First off when parsing `bt`
+        // *optionally* has an index and a function type listed. If
+        // they're both not present it's equivalent to 0 params and 0
+        // results.
+        //
+        // In MVP wasm blocks can have 0 params and 0-1 results. Now
+        // there's also multi-value. We want to prefer MVP wasm wherever
+        // possible (for backcompat) so we want to list this block as
+        // being an "MVP" block if we can. The encoder only has
+        // `BlockType` to work with, so it'll be looking at `params` and
+        // `results` to figure out what to encode. If `params` and
+        // `results` fit within MVP, then it uses MVP encoding
+        //
+        // To put all that together, here we handle:
+        //
+        // * If the `index` was specified, resolve it and use it as the
+        //   source of truth. If this turns out to be an MVP type,
+        //   record it as such.
+        // * Otherwise use `params` and `results` as the source of
+        //   truth. *If* this were a non-MVP compatible block `index`
+        //   would be filled by by `tyexpand.rs`.
+        //
+        // tl;dr; we handle the `index` here if it's set and then fill
+        // out `params` and `results` if we can, otherwise no work
+        // happens.
+        if bt.ty.index.is_some() {
+            let (ty, _) = self.module.resolve_type_use(&mut bt.ty)?;
+            let n = match ty {
+                Index::Num(n, _) => *n,
+                Index::Id(_) => panic!("expected `Num`"),
+            };
+            let ty = match self
+                .module
+                .types
+                .items
+                .get(n as usize)
+                .and_then(|s| s.item())
+            {
+                Some(TypeInfo::Func(ty)) => ty,
+                _ => return Ok(()),
+            };
+            if ty.0.len() == 0 && ty.1.len() <= 1 {
+                let mut inline = FunctionType::default();
+                inline.results = ty.1.clone();
+                bt.ty.inline = Some(inline);
+                bt.ty.index = None;
+            }
+        }
+
+        // If the inline annotation persists to this point then resolve
+        // all of its inline value types.
+        if let Some(inline) = &mut bt.ty.inline {
+            inline.resolve(self.module)?;
         }
         Ok(())
     }
@@ -1748,83 +1825,53 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
                 self.module.resolve(i, Ns::Type)?;
             }
 
+            Let(t) => {
+                self.blocks.push(ExprBlock {
+                    label: t.block.label,
+                    locals: self.locals.count,
+                });
+
+                // Resolve (ref T) in locals
+                for local in &mut t.locals {
+                    self.module.resolve_valtype(&mut local.ty)?;
+                }
+                // Register all locals defined in this let
+                for local in &t.locals {
+                    self.locals.register(local.id, "local")?;
+                }
+                self.resolve_block_type(&mut t.block)?;
+            }
+
             Block(bt) | If(bt) | Loop(bt) | Try(bt) => {
-                self.labels.push(bt.label);
-
-                // Ok things get interesting here. First off when parsing `bt`
-                // *optionally* has an index and a function type listed. If
-                // they're both not present it's equivalent to 0 params and 0
-                // results.
-                //
-                // In MVP wasm blocks can have 0 params and 0-1 results. Now
-                // there's also multi-value. We want to prefer MVP wasm wherever
-                // possible (for backcompat) so we want to list this block as
-                // being an "MVP" block if we can. The encoder only has
-                // `BlockType` to work with, so it'll be looking at `params` and
-                // `results` to figure out what to encode. If `params` and
-                // `results` fit within MVP, then it uses MVP encoding
-                //
-                // To put all that together, here we handle:
-                //
-                // * If the `index` was specified, resolve it and use it as the
-                //   source of truth. If this turns out to be an MVP type,
-                //   record it as such.
-                // * Otherwise use `params` and `results` as the source of
-                //   truth. *If* this were a non-MVP compatible block `index`
-                //   would be filled by by `tyexpand.rs`.
-                //
-                // tl;dr; we handle the `index` here if it's set and then fill
-                // out `params` and `results` if we can, otherwise no work
-                // happens.
-                if bt.ty.index.is_some() {
-                    let (ty, _) = self.module.resolve_type_use(&mut bt.ty)?;
-                    let n = match ty {
-                        Index::Num(n, _) => *n,
-                        Index::Id(_) => panic!("expected `Num`"),
-                    };
-                    let ty = match self
-                        .module
-                        .types
-                        .items
-                        .get(n as usize)
-                        .and_then(|s| s.item())
-                    {
-                        Some(TypeInfo::Func(ty)) => ty,
-                        _ => return Ok(()),
-                    };
-                    if ty.0.len() == 0 && ty.1.len() <= 1 {
-                        let mut inline = FunctionType::default();
-                        inline.results = ty.1.clone();
-                        bt.ty.inline = Some(inline);
-                        bt.ty.index = None;
-                    }
-                }
-
-                // If the inline annotation persists to this point then resolve
-                // all of its inline value types.
-                if let Some(inline) = &mut bt.ty.inline {
-                    inline.resolve(self.module)?;
-                }
+                self.blocks.push(ExprBlock {
+                    label: bt.label,
+                    locals: self.locals.count,
+                });
+                self.resolve_block_type(bt)?;
             }
 
             // On `End` instructions we pop a label from the stack, and for both
             // `End` and `Else` instructions if they have labels listed we
             // verify that they match the label at the beginning of the block.
             Else(_) | End(_) => {
-                let (matching_label, label) = match instr {
-                    Else(label) => (self.labels.last().cloned(), label),
-                    End(label) => (self.labels.pop(), label),
+                let (matching_block, label) = match instr {
+                    Else(label) => (self.blocks.last().cloned(), label),
+                    End(label) => (self.blocks.pop(), label),
                     _ => unreachable!(),
                 };
-                let matching_label = match matching_label {
+                let matching_block = match matching_block {
                     Some(l) => l,
                     None => return Ok(()),
                 };
+
+                // Reset the local stack to before this block was entered
+                self.locals.dealloc_to(matching_block.locals);
+
                 let label = match label {
                     Some(l) => l,
                     None => return Ok(()),
                 };
-                if Some(*label) == matching_label {
+                if Some(*label) == matching_block.label {
                     return Ok(());
                 }
                 return Err(Error::new(
@@ -1910,11 +1957,11 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
             Index::Id(id) => *id,
         };
         let idx = self
-            .labels
+            .blocks
             .iter()
             .rev()
             .enumerate()
-            .filter_map(|(i, l)| l.map(|l| (i, l)))
+            .filter_map(|(i, b)| b.label.map(|l| (i, l)))
             .find(|(_, l)| *l == id);
         match idx {
             Some((idx, _)) => {

--- a/crates/wast/src/resolve/names.rs
+++ b/crates/wast/src/resolve/names.rs
@@ -803,7 +803,7 @@ impl<'a> Resolver<'a> {
             // is only invoked with the module-linking proposal, which means
             // that we have two proposals interacting, and that's always weird
             // territory anyway.
-            ValType::Rtt(_) => Err(Error::new(
+            ValType::Rtt(..) => Err(Error::new(
                 span,
                 format!("cannot copy reference types between modules right now"),
             )),
@@ -1457,7 +1457,7 @@ impl<'a> Module<'a> {
     fn resolve_valtype(&self, ty: &mut ValType<'a>) -> Result<(), Error> {
         match ty {
             ValType::Ref(ty) => self.resolve_heaptype(&mut ty.heap)?,
-            ValType::Rtt(i) => {
+            ValType::Rtt(_d, i) => {
                 self.resolve(i, Ns::Type)?;
             }
             _ => {}

--- a/crates/wast/src/resolve/names.rs
+++ b/crates/wast/src/resolve/names.rs
@@ -793,13 +793,7 @@ impl<'a> Resolver<'a> {
         ty: ValType<'a>,
     ) -> Result<ValType<'a>, Error> {
         match ty {
-            ValType::I32
-            | ValType::I64
-            | ValType::F32
-            | ValType::F64
-            | ValType::V128
-            | ValType::I8
-            | ValType::I16 => Ok(ty),
+            ValType::I32 | ValType::I64 | ValType::F32 | ValType::F64 | ValType::V128 => Ok(ty),
 
             ValType::Ref(ty) => Ok(ValType::Ref(
                 self.copy_reftype_from_module(span, child, ty)?,
@@ -1310,10 +1304,10 @@ impl<'a> Module<'a> {
                     TypeDef::Func(func) => func.resolve(self)?,
                     TypeDef::Struct(struct_) => {
                         for field in &mut struct_.fields {
-                            self.resolve_valtype(&mut field.ty)?;
+                            self.resolve_storagetype(&mut field.ty)?;
                         }
                     }
-                    TypeDef::Array(array) => self.resolve_valtype(&mut array.ty)?,
+                    TypeDef::Array(array) => self.resolve_storagetype(&mut array.ty)?,
                     TypeDef::Module(m) => m.resolve(self)?,
                     TypeDef::Instance(i) => i.resolve(self)?,
                 }
@@ -1476,6 +1470,14 @@ impl<'a> Module<'a> {
             HeapType::Index(i) => {
                 self.resolve(i, Ns::Type)?;
             }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn resolve_storagetype(&self, ty: &mut StorageType<'a>) -> Result<(), Error> {
+        match ty {
+            StorageType::Val(ty) => self.resolve_valtype(ty)?,
             _ => {}
         }
         Ok(())

--- a/tests/local/gc-struct.wat
+++ b/tests/local/gc-struct.wat
@@ -15,7 +15,8 @@
   (type (struct (field $field_b externref) (field $field_c funcref)))
 
   (func
-    struct.new $a
+    rtt.canon $a
+    struct.new_with_rtt $a
     struct.get $a $field_a
     struct.set $b $field_c
   )

--- a/tests/local/let.wat
+++ b/tests/local/let.wat
@@ -1,0 +1,46 @@
+;; --enable-function-references
+
+(module
+  (func
+    (let)
+
+    let end
+
+    let
+    end
+  )
+  (func
+    i32.const 0
+    (let (param i32) drop)
+
+    i32.const 0
+    let (param i32) drop end
+
+    i32.const 0
+    let (param i32)
+      drop
+    end
+  )
+  (func
+    (let (result i32)
+      i32.const 0
+    )
+    drop
+
+    let (result i32) i32.const 0 end
+    drop
+
+    let (result i32)
+      i32.const 0
+    end
+    drop
+  )
+  (func
+    (let (local $x i32) local.get $x drop)
+    let (local $x i32) local.get $x drop end
+    let (local $x i32)
+      local.get $x
+      drop
+    end
+  )
+)

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -215,9 +215,11 @@ impl TestState {
         // however, that wasmparser doesn't implement all features that wabt
         // does, so we skip some tests here too.
         //
+        // TODO: implement function-references in wasmparser
         // TODO: implement gc types in wasmparser
         // TODO: implement exceptions in wasmparser
         if !contents.contains("--enable-exceptions")
+            && !contents.contains("--enable-function-references")
             && !contents.contains("--enable-gc")
             && !contents.contains("--no-check")
             // intentionally invalid wasm files


### PR DESCRIPTION
These commits improves `wast`'s support for the typed-function-references and gc proposals.