### PR TITLE
Fix panic in module linking validation

### DIFF
--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -526,7 +526,7 @@ impl Validator {
         }
         // ... otherwise if this is a repeated section then only the "module
         // linking header" is allows to have repeats
-        if order == self.order && self.order == Order::ModuleLinkingHeader {
+        if prev == self.order && self.order == Order::ModuleLinkingHeader {
             return Ok(());
         }
         self.create_error("section out of order")

--- a/crates/wasmparser/tests/errors.rs
+++ b/crates/wasmparser/tests/errors.rs
@@ -1,4 +1,4 @@
-use wasmparser::{Range, Validator};
+use wasmparser::*;
 
 #[test]
 fn simd_not_enabled() {
@@ -15,4 +15,17 @@ fn massive_data_count() {
     assert!(v
         .data_count_section(0x0fffffff, &Range { start: 0, end: 0 })
         .is_err());
+}
+
+#[test]
+fn module_linking_sections_out_of_order() {
+    let mut v = Validator::new();
+    v.wasm_module_linking(true);
+    v.type_section(&TypeSectionReader::new(&[0], 0).unwrap())
+        .unwrap();
+    v.data_section(&DataSectionReader::new(&[0], 0).unwrap())
+        .unwrap();
+    assert!(v
+        .type_section(&TypeSectionReader::new(&[0], 0).unwrap())
+        .is_err())
 }


### PR DESCRIPTION
The section order code accidentally wasn't testing section orders
correctly. The fix here was to basically make sure we're comparing the
right things!