### PR TITLE
Add a sample `wasm-dump` program

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ wasmparser = { path = "crates/wasmparser" }
 wasmprinter = { path = "crates/wasmprinter" }
 wast = { path = "crates/wast" }
 wat = { path = "crates/wat" }
+wasmparser-dump = { path = "crates/dump" }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -13,10 +13,9 @@
  * limitations under the License.
  */
 
-use std::boxed::Box;
 use std::convert::TryInto;
+use std::fmt;
 use std::str;
-use std::vec::Vec;
 
 use crate::limits::*;
 
@@ -1805,6 +1804,22 @@ impl<'a> BrTable<'a> {
             )
         })?;
         Ok((table.into_boxed_slice(), default_target))
+    }
+}
+
+impl fmt::Debug for BrTable<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut f = f.debug_struct("BrTable");
+        f.field("count", &self.cnt);
+        match self.read_table() {
+            Ok((targets, default)) => {
+                f.field("targets", &targets).field("default", &default);
+            }
+            Err(_) => {
+                f.field("buffer", &self.buffer);
+            }
+        }
+        f.finish()
     }
 }
 

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -260,7 +260,7 @@ pub enum RelocType {
 }
 
 /// A br_table entries representation.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct BrTable<'a> {
     pub(crate) buffer: &'a [u8],
     pub(crate) cnt: usize,

--- a/src/bin/wasm-dump.rs
+++ b/src/bin/wasm-dump.rs
@@ -1,0 +1,33 @@
+use anyhow::Result;
+use std::env;
+
+fn main() -> Result<()> {
+    env_logger::init();
+
+    // Use the `getopts` crate to parse the `-o` option as well as `-h`
+    let program = env::args().nth(0).unwrap();
+    let mut opts = getopts::Options::new();
+    opts.optflag("h", "help", "print this help menu");
+    let matches = opts.parse(env::args_os().skip(1))?;
+    if matches.opt_present("h") {
+        return Ok(print_usage(&program, opts));
+    }
+    let input = match matches.free.len() {
+        0 => {
+            print_usage(&program, opts);
+            std::process::exit(1);
+        }
+        1 => &matches.free[0],
+        _ => anyhow::bail!("more than one input file specified on command line"),
+    };
+
+    let input = std::fs::read(&input)?;
+    println!("{}", wasmparser_dump::dump_wasm(&input)?);
+
+    Ok(())
+}
+
+fn print_usage(program: &str, opts: getopts::Options) {
+    let brief = format!("Usage: {} FILE [options]", program);
+    print!("{}", opts.usage(&brief));
+}


### PR DESCRIPTION
This is intended to expose the `wasmparser-dump` crate as a helper
program to help debug issues that come up with wasmparser validation and
such.