### PR TITLE
Updates for integrating validation in Wasmtime

### DIFF
--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -6,7 +6,7 @@ use criterion::Criterion;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
-use wasmparser::{DataKind, ElementKind, Parser, Payload, Validator};
+use wasmparser::{DataKind, ElementKind, Parser, Payload, Validator, WasmFeatures};
 
 /// A benchmark input.
 pub struct BenchmarkInput {
@@ -206,13 +206,16 @@ fn it_works_benchmark(c: &mut Criterion) {
 fn validate_benchmark(c: &mut Criterion) {
     fn validator() -> Validator {
         let mut ret = Validator::new();
-        ret.wasm_reference_types(true)
-            .wasm_multi_value(true)
-            .wasm_simd(true)
-            .wasm_module_linking(true)
-            .wasm_bulk_memory(true)
-            .wasm_threads(true)
-            .wasm_tail_call(true);
+        ret.wasm_features(WasmFeatures {
+            reference_types: true,
+            multi_value: true,
+            simd: true,
+            module_linking: true,
+            bulk_memory: true,
+            threads: true,
+            tail_call: true,
+            deterministic_only: false,
+        });
         return ret;
     }
     let mut inputs = collect_benchmark_inputs();

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -73,7 +73,7 @@ impl Range {
 }
 
 /// A binary reader of the WebAssembly structures and types.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Hash)]
 pub struct BinaryReader<'a> {
     pub(crate) buffer: &'a [u8],
     pub(crate) position: usize,
@@ -192,37 +192,6 @@ impl<'a> BinaryReader<'a> {
                 self.original_position() - 1,
             )),
         }
-    }
-
-    /// Read a `count` indicating the number of times to call `read_local_decl`.
-    pub fn read_local_count(&mut self) -> Result<usize> {
-        let local_count = self.read_var_u32()? as usize;
-        if local_count > MAX_WASM_FUNCTION_LOCALS {
-            return Err(BinaryReaderError::new(
-                "local_count is out of bounds",
-                self.original_position() - 1,
-            ));
-        }
-        Ok(local_count)
-    }
-
-    /// Read a `(count, value_type)` declaration of local variables of the same type.
-    pub fn read_local_decl(&mut self, locals_total: &mut usize) -> Result<(u32, Type)> {
-        let count = self.read_var_u32()?;
-        let value_type = self.read_type()?;
-        *locals_total = locals_total.checked_add(count as usize).ok_or_else(|| {
-            BinaryReaderError::new(
-                "locals_total is out of bounds",
-                self.original_position() - 1,
-            )
-        })?;
-        if *locals_total > MAX_WASM_FUNCTION_LOCALS {
-            return Err(BinaryReaderError::new(
-                "locals_total is out of bounds",
-                self.original_position() - 1,
-            ));
-        }
-        Ok((count, value_type))
     }
 
     pub(crate) fn read_external_kind(&mut self) -> Result<ExternalKind> {

--- a/crates/wasmparser/src/lib.rs
+++ b/crates/wasmparser/src/lib.rs
@@ -54,15 +54,7 @@ pub use crate::primitives::TypeDef;
 pub use crate::primitives::TypeOrFuncType;
 pub use crate::primitives::V128;
 
-pub use crate::module_resources::WasmFuncType;
-pub use crate::module_resources::WasmGlobalType;
-pub use crate::module_resources::WasmMemoryType;
-pub use crate::module_resources::WasmModuleResources;
-pub use crate::module_resources::WasmTableType;
-pub use crate::module_resources::WasmType;
-
-pub(crate) use crate::module_resources::{wasm_func_type_inputs, wasm_func_type_outputs};
-
+pub use crate::module_resources::*;
 pub use crate::parser::*;
 pub use crate::readers::*;
 pub use crate::validator::*;

--- a/crates/wasmparser/src/lib.rs
+++ b/crates/wasmparser/src/lib.rs
@@ -60,11 +60,8 @@ pub use crate::module_resources::WasmMemoryType;
 pub use crate::module_resources::WasmModuleResources;
 pub use crate::module_resources::WasmTableType;
 pub use crate::module_resources::WasmType;
-pub use crate::module_resources::WasmTypeDef;
 
 pub(crate) use crate::module_resources::{wasm_func_type_inputs, wasm_func_type_outputs};
-
-pub use crate::operators_validator::OperatorValidatorConfig;
 
 pub use crate::parser::*;
 pub use crate::readers::*;

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -32,7 +32,7 @@ pub(crate) struct BinaryReaderErrorInner {
     pub(crate) needed_hint: Option<usize>,
 }
 
-pub type Result<T> = result::Result<T, BinaryReaderError>;
+pub type Result<T, E = BinaryReaderError> = result::Result<T, E>;
 
 impl Error for BinaryReaderError {}
 

--- a/crates/wasmparser/src/readers/code_section.rs
+++ b/crates/wasmparser/src/readers/code_section.rs
@@ -18,7 +18,7 @@ use super::{
     SectionReader, SectionWithLimitedItems, Type,
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FunctionBody<'a> {
     offset: usize,
     data: &'a [u8],
@@ -170,7 +170,7 @@ impl<'a> CodeSectionReader<'a> {
     /// for _ in 0..code_reader.get_count() {
     ///     let body = code_reader.read().expect("function body");
     ///     let mut binary_reader = body.get_binary_reader();
-    ///     assert!(binary_reader.read_local_count().expect("local count") == 0);
+    ///     assert!(binary_reader.read_var_u32().expect("local count") == 0);
     ///     let op = binary_reader.read_operator().expect("first operator");
     ///     println!("First operator: {:?}", op);
     /// }
@@ -227,7 +227,7 @@ impl<'a> IntoIterator for CodeSectionReader<'a> {
     /// let mut code_reader = CodeSectionReader::new(data, 0).unwrap();
     /// for body in code_reader {
     ///     let mut binary_reader = body.expect("b").get_binary_reader();
-    ///     assert!(binary_reader.read_local_count().expect("local count") == 0);
+    ///     assert!(binary_reader.read_var_u32().expect("local count") == 0);
     ///     let op = binary_reader.read_operator().expect("first operator");
     ///     println!("First operator: {:?}", op);
     /// }

--- a/crates/wasmparser/src/validator/func.rs
+++ b/crates/wasmparser/src/validator/func.rs
@@ -103,4 +103,9 @@ impl<T: WasmModuleResources> FuncValidator<T> {
         }
         Ok(())
     }
+
+    /// Returns the underlying module resources that this validator is using.
+    pub fn resources(&self) -> &T {
+        &self.resources
+    }
 }

--- a/crates/wasmparser/src/validator/func.rs
+++ b/crates/wasmparser/src/validator/func.rs
@@ -1,8 +1,6 @@
-use super::ModuleState;
 use crate::operators_validator::{FunctionEnd, OperatorValidator};
-use crate::{BinaryReaderError, Result, Type};
-use crate::{Operator, WasmModuleResources, WasmTypeDef};
-use std::sync::Arc;
+use crate::{BinaryReader, BinaryReaderError, Result, Type};
+use crate::{FunctionBody, Operator, WasmFeatures, WasmModuleResources};
 
 /// Validation context for a WebAssembly function.
 ///
@@ -11,24 +9,78 @@ use std::sync::Arc;
 /// and is created per-function in a WebAssembly module. This structure is
 /// suitable for sending to other threads while the original
 /// [`Validator`](crate::Validator) continues processing other functions.
-pub struct FuncValidator {
-    pub(super) validator: OperatorValidator,
-    pub(super) state: Arc<ModuleState>,
-    pub(super) offset: usize,
-    pub(super) eof_found: bool,
+pub struct FuncValidator<T> {
+    validator: OperatorValidator,
+    resources: T,
+    eof_found: bool,
 }
 
-impl FuncValidator {
+impl<T: WasmModuleResources> FuncValidator<T> {
+    /// Creates a new `FuncValidator`.
+    ///
+    /// The returned `FuncValidator` can be used to validate a function with
+    /// the type `ty` specified. The `resources` indicate what the containing
+    /// module has for the function to use, and the `features` configure what
+    /// WebAssembly proposals are enabled for this function.
+    ///
+    /// The returned validator can be used to then parse a [`FunctionBody`], for
+    /// example, to read locals and validate operators.
+    pub fn new(ty: &T::FuncType, resources: T, features: &WasmFeatures) -> FuncValidator<T> {
+        FuncValidator {
+            validator: OperatorValidator::new(ty, features),
+            resources,
+            eof_found: false,
+        }
+    }
+
+    /// Convenience function to validate an entire function's body.
+    ///
+    /// You may not end up using this in final implementations because you'll
+    /// often want to interleave validation with parsing.
+    pub fn validate(&mut self, body: &FunctionBody<'_>) -> Result<()> {
+        let mut reader = body.get_binary_reader();
+        self.read_locals(&mut reader)?;
+        while !reader.eof() {
+            let pos = reader.original_position();
+            let op = reader.read_operator()?;
+            self.op(pos, &op)?;
+        }
+        self.finish(reader.original_position())
+    }
+
+    /// Reads the local defintions from the given `BinaryReader`, often sourced
+    /// from a `FunctionBody`.
+    ///
+    /// This function will automatically advance the `BinaryReader` forward,
+    /// leaving reading operators up to the caller afterwards.
+    pub fn read_locals(&mut self, reader: &mut BinaryReader<'_>) -> Result<()> {
+        for _ in 0..reader.read_var_u32()? {
+            let offset = reader.original_position();
+            let cnt = reader.read_var_u32()?;
+            let ty = reader.read_type()?;
+            self.define_locals(offset, cnt, ty)?;
+        }
+        Ok(())
+    }
+
+    /// Defines locals into this validator.
+    ///
+    /// This should be used if the application is already reading local
+    /// definitions and there's no need to re-parse the function again.
+    pub fn define_locals(&mut self, offset: usize, count: u32, ty: Type) -> Result<()> {
+        self.validator.define_locals(offset, count, ty)
+    }
+
     /// Validates the next operator in a function.
     ///
     /// This functions is expected to be called once-per-operator in a
     /// WebAssembly function. Each operator's offset in the original binary and
-    /// the operator itself are passed to this function.
+    /// the operator itself are passed to this function to provide more useful
+    /// error messages.
     pub fn op(&mut self, offset: usize, operator: &Operator<'_>) -> Result<()> {
-        self.offset = offset;
         let end = self
             .validator
-            .process_operator(operator, &*self.state)
+            .process_operator(operator, &self.resources)
             .map_err(|e| e.set_offset(offset))?;
         match end {
             FunctionEnd::Yes => self.eof_found = true,
@@ -42,71 +94,13 @@ impl FuncValidator {
     /// This will validate that the function was properly terminated with the
     /// `end` opcode. If this function is not called then the function will not
     /// be properly validated.
-    pub fn finish(&mut self) -> Result<()> {
+    ///
+    /// The `offset` provided to this function will be used as a position for an
+    /// error if validation fails.
+    pub fn finish(&mut self, offset: usize) -> Result<()> {
         if !self.eof_found {
-            return Err(BinaryReaderError::new(
-                "end of function not found",
-                self.offset,
-            ));
+            return Err(BinaryReaderError::new("end of function not found", offset));
         }
         Ok(())
-    }
-}
-
-impl WasmModuleResources for ModuleState {
-    type TypeDef = super::TypeDef;
-    type TableType = crate::TableType;
-    type MemoryType = crate::MemoryType;
-    type GlobalType = crate::GlobalType;
-
-    fn type_at(&self, at: u32) -> Option<&Self::TypeDef> {
-        self.get_type(self.def(at)).map(|t| t.item)
-    }
-
-    fn table_at(&self, at: u32) -> Option<&Self::TableType> {
-        self.get_table(self.def(at)).map(|t| &t.item)
-    }
-
-    fn memory_at(&self, at: u32) -> Option<&Self::MemoryType> {
-        self.get_memory(self.def(at))
-    }
-
-    fn global_at(&self, at: u32) -> Option<&Self::GlobalType> {
-        self.get_global(self.def(at)).map(|t| &t.item)
-    }
-
-    fn func_type_at(&self, at: u32) -> Option<&super::FuncType> {
-        let ty = self.get_func_type_index(self.def(at))?;
-        match self.get_type(ty)?.item {
-            super::TypeDef::Func(f) => Some(f),
-            _ => None,
-        }
-    }
-
-    fn element_type_at(&self, at: u32) -> Option<Type> {
-        self.element_types.get(at as usize).cloned()
-    }
-
-    fn element_count(&self) -> u32 {
-        self.element_types.len() as u32
-    }
-
-    fn data_count(&self) -> u32 {
-        self.data_count.unwrap_or(0)
-    }
-
-    fn is_function_referenced(&self, idx: u32) -> bool {
-        self.function_references.contains(&idx)
-    }
-}
-
-impl WasmTypeDef for super::TypeDef {
-    type FuncType = crate::FuncType;
-
-    fn as_func(&self) -> Option<&Self::FuncType> {
-        match self {
-            super::TypeDef::Func(f) => Some(f),
-            _ => None,
-        }
     }
 }

--- a/crates/wasmparser/tests/errors.rs
+++ b/crates/wasmparser/tests/errors.rs
@@ -4,7 +4,10 @@ use wasmparser::*;
 fn simd_not_enabled() {
     let bytes = wat::parse_str("(module (func (param v128)))").unwrap();
     let mut v = Validator::new();
-    v.wasm_simd(false);
+    v.wasm_features(WasmFeatures {
+        simd: false,
+        ..WasmFeatures::default()
+    });
     let result = v.validate_all(&bytes).unwrap_err();
     assert_eq!(result.offset(), 11);
 }
@@ -20,7 +23,10 @@ fn massive_data_count() {
 #[test]
 fn module_linking_sections_out_of_order() {
     let mut v = Validator::new();
-    v.wasm_module_linking(true);
+    v.wasm_features(WasmFeatures {
+        module_linking: true,
+        ..WasmFeatures::default()
+    });
     v.type_section(&TypeSectionReader::new(&[0], 0).unwrap())
         .unwrap();
     v.data_section(&DataSectionReader::new(&[0], 0).unwrap())

--- a/fuzz/fuzz_targets/validate.rs
+++ b/fuzz/fuzz_targets/validate.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use libfuzzer_sys::*;
-use wasmparser::Validator;
+use wasmparser::{Validator, WasmFeatures};
 
 fuzz_target!(|data: &[u8]| {
     let mut validator = Validator::new();
@@ -9,14 +9,16 @@ fuzz_target!(|data: &[u8]| {
         Some(byte) => byte,
         None => return,
     };
-    validator.wasm_reference_types((byte & 0b0000_0001) != 0);
-    validator.wasm_multi_value((byte & 0b0000_0010) != 0);
-    validator.wasm_threads((byte & 0b0000_0100) != 0);
-    validator.wasm_simd((byte & 0b0000_1000) != 0);
-    validator.wasm_module_linking((byte & 0b0001_0000) != 0);
-    validator.wasm_tail_call((byte & 0b0010_0000) != 0);
-    validator.wasm_bulk_memory((byte & 0b0100_0000) != 0);
-    validator.deterministic_only((byte & 0b1000_0000) != 0);
+    validator.wasm_features(WasmFeatures {
+        reference_types: (byte & 0b0000_0001) != 0,
+        multi_value: (byte & 0b0000_0010) != 0,
+        threads: (byte & 0b0000_0100) != 0,
+        simd: (byte & 0b0000_1000) != 0,
+        module_linking: (byte & 0b0001_0000) != 0,
+        tail_call: (byte & 0b0010_0000) != 0,
+        bulk_memory: (byte & 0b0100_0000) != 0,
+        deterministic_only: (byte & 0b1000_0000) != 0,
+    });
 
     drop(validator.validate_all(&data[1..]));
 });

--- a/tests/local/externref-elem-segment.wast
+++ b/tests/local/externref-elem-segment.wast
@@ -1,0 +1,24 @@
+(module
+  (elem $a externref)
+  (elem $b externref (ref.null extern))
+)
+
+(assert_invalid
+  (module
+    (elem $a externref (ref.func 0))
+    (func)
+  )
+  "type mismatch")
+
+(assert_invalid
+  (module binary
+    "\00asm\01\00\00\00"
+
+    "\09" ;; element section
+    "\07" ;; size of section
+    "\01" ;; 1 element
+
+    ;; passive segment, extrenref type, 1 element, (ref.null func)
+    "\05\6f\01\d0\70\0b"
+  )
+  "type mismatch")

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -620,37 +620,34 @@ impl TestState {
     }
 
     fn wasmparser_validator_for(&self, test: &Path) -> Validator {
-        let mut ret = Validator::new();
-        ret.wasm_threads(true)
-            .wasm_reference_types(true)
-            .wasm_simd(true)
-            .wasm_bulk_memory(true)
-            .wasm_tail_call(true)
-            .wasm_module_linking(true);
+        let mut features = WasmFeatures {
+            threads: true,
+            reference_types: true,
+            simd: true,
+            bulk_memory: true,
+            tail_call: true,
+            module_linking: true,
+            deterministic_only: false,
+            multi_value: true,
+        };
         for part in test.iter().filter_map(|t| t.to_str()) {
             match part {
                 "testsuite" | "wasmtime905.wast" | "missing-features" => {
-                    ret = Validator::new();
+                    features = WasmFeatures::default();
                 }
-                "threads" => {
-                    ret.wasm_threads(true);
-                }
-                "simd" => {
-                    ret.wasm_simd(true);
-                }
+                "threads" => features.threads = true,
+                "simd" => features.simd = true,
                 "reference-types" => {
-                    ret.wasm_bulk_memory(true);
-                    ret.wasm_reference_types(true);
+                    features.bulk_memory = true;
+                    features.reference_types = true;
                 }
-                "bulk-memory-operations" => {
-                    ret.wasm_bulk_memory(true);
-                }
-                "tail-call" => {
-                    ret.wasm_tail_call(true);
-                }
+                "bulk-memory-operations" => features.bulk_memory = true,
+                "tail-call" => features.tail_call = true,
                 _ => {}
             }
         }
+        let mut ret = Validator::new();
+        ret.wasm_features(features);
         return ret;
     }
 


### PR DESCRIPTION
This commit is a batch of updates I've made and found when integrating
wasmparser's validation more intrusively into Wasmtime. The changes made
here are:

* `WasmFeatures` is now exposed as a standalone type so it can be shared
  with other crates. This way only one crate, wasmparser, declares the
  "bag of features" and everyone else can just reference that one bag.

* Parsing locals is deferred in `code_section_entry` to actual
  validation. Helper methods have been added to advance a `BinaryReader`
  by reading the locals, as well as methods added to define locals
  yourself. The intention here is to avoid parsing the locals section
  twice, once in `wasmparser` and once by the application. This also
  removed a few `read_local*` methods from `BinaryReader` to defer
  validation to `Validator`.

* `WasmTypeDef` and `type_at` have been removed from
  `WasmModuleResources`. These weren't ever really that useful and
  callers only ever cared about function types anyway. The previous
  `func_type_at` method has been repurposed for looking up a type index
  and a new `type_of_function` looks up the type of a function by index.

* Parsing for element segments was slightly updated to ensure that
  `externref` segments don't have `ref.func` in them.