### PR TITLE
Don't assert function scopes are empty

### DIFF
--- a/crates/wast/src/resolve/names.rs
+++ b/crates/wast/src/resolve/names.rs
@@ -1358,10 +1358,6 @@ impl<'a> Module<'a> {
                     // and then we can resolve the expression!
                     resolver.resolve(expression)?;
 
-                    // All let scopes should be popped after the function has
-                    // been resolced.
-                    debug_assert!(resolver.scopes.len() == 1);
-
                     // specifically save the original `sig`, if it was present,
                     // because that's what we're using for local names.
                     f.ty.inline = inline;

--- a/tests/local/function-references/let-bad.wast
+++ b/tests/local/function-references/let-bad.wast
@@ -1,0 +1,5 @@
+(assert_invalid
+  (module
+    (func let)
+  )
+  "fill me in once wasmparser implements validation")


### PR DESCRIPTION
Invalid wasm files can actually leave multiple scopes in play!