### PR TITLE
Add parsing for folded `try` statements.

### DIFF
--- a/crates/wast/src/ast/mod.rs
+++ b/crates/wast/src/ast/mod.rs
@@ -343,9 +343,11 @@ pub mod kw {
     custom_keyword!(before);
     custom_keyword!(binary);
     custom_keyword!(block);
+    custom_keyword!(catch);
     custom_keyword!(code);
     custom_keyword!(data);
     custom_keyword!(declare);
+    custom_keyword!(r#do = "do");
     custom_keyword!(elem);
     custom_keyword!(end);
     custom_keyword!(event);
@@ -411,6 +413,7 @@ pub mod kw {
     custom_keyword!(r#struct = "struct");
     custom_keyword!(table);
     custom_keyword!(then);
+    custom_keyword!(r#try = "try");
     custom_keyword!(v128);
 }
 

--- a/tests/local/try.wast
+++ b/tests/local/try.wast
@@ -1,0 +1,38 @@
+;; --enable-exceptions
+
+(assert_malformed
+  (module quote
+    "(func (try (catch)))"
+  )
+  "previous `try` had no `do`")
+
+(assert_malformed
+  (module quote
+    "(func (try (unreachable) (catch)))"
+  )
+  "previous `try` had no `do`")
+
+(assert_malformed
+  (module quote
+    "(func (try (do)))"
+  )
+  "previous `try` had no `catch`")
+
+(assert_malformed
+  (module quote
+    "(func (try (do) (unreachable)))"
+  )
+  "previous `try` had no `catch`")
+
+(assert_malformed
+  (module quote
+    "(func (try (do) (catch) drop))"
+  )
+  "expected `(`")
+
+(assert_malformed
+  (module quote
+    "(func (try (do) (catch) (drop)))"
+  )
+  "too many payloads inside of `(try)`")
+

--- a/tests/local/try.wat
+++ b/tests/local/try.wat
@@ -1,0 +1,9 @@
+;; --enable-exceptions
+
+(module $m
+  (func (try (do) (catch drop)))
+  (func (try (do) (catch rethrow)))
+  (func (result i32)
+    (try (result i32)
+      (do (i32.const 42))
+      (catch drop (i32.const 42)))))


### PR DESCRIPTION
Currently folded `try` statements for the exception handling proposal like `(try (do ...) (catch ...)` are not supported in the parser. This pull request adds support for those.

I added success tests in a `try.wat` and error tests in a `try.wast` as putting the success tests in `.wast` seemed to also trigger validation testing, which isn't supported yet for exceptions AFAICT. (though I did start working on commits for validation as well, not in this PR)