### PR TITLE
Implement the multi-memory proposal

### DIFF
--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -214,6 +214,7 @@ fn validate_benchmark(c: &mut Criterion) {
             bulk_memory: true,
             threads: true,
             tail_call: true,
+            multi_memory: true,
             deterministic_only: false,
         });
         return ret;

--- a/crates/wasmparser/src/limits.rs
+++ b/crates/wasmparser/src/limits.rs
@@ -31,6 +31,6 @@ pub const MAX_WASM_FUNCTION_RETURNS: usize = 1000;
 pub const _MAX_WASM_TABLE_SIZE: usize = 10_000_000;
 pub const MAX_WASM_TABLE_ENTRIES: usize = 10_000_000;
 pub const MAX_WASM_TABLES: usize = 100;
-pub const MAX_WASM_MEMORIES: usize = 1;
+pub const MAX_WASM_MEMORIES: usize = 100;
 pub const MAX_WASM_MODULES: usize = 1_000;
 pub const MAX_WASM_INSTANCES: usize = 1_000;

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -225,8 +225,10 @@ pub enum ImportSectionEntryType {
 
 #[derive(Debug, Copy, Clone)]
 pub struct MemoryImmediate {
-    pub flags: u32,
+    /// Alignment, stored as `n` where the actual alignment is `2^n`
+    pub align: u8,
     pub offset: u32,
+    pub memory: u32,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -354,8 +356,8 @@ pub enum Operator<'a> {
     I64Store8 { memarg: MemoryImmediate },
     I64Store16 { memarg: MemoryImmediate },
     I64Store32 { memarg: MemoryImmediate },
-    MemorySize { reserved: u32 },
-    MemoryGrow { reserved: u32 },
+    MemorySize { mem: u32, mem_byte: u8 },
+    MemoryGrow { mem: u32, mem_byte: u8 },
     I32Const { value: i32 },
     I64Const { value: i64 },
     F32Const { value: Ieee32 },
@@ -505,10 +507,10 @@ pub enum Operator<'a> {
 
     // 0xFC operators
     // bulk memory https://github.com/WebAssembly/bulk-memory-operations/blob/master/proposals/bulk-memory-operations/Overview.md
-    MemoryInit { segment: u32 },
+    MemoryInit { segment: u32, mem: u32 },
     DataDrop { segment: u32 },
-    MemoryCopy,
-    MemoryFill,
+    MemoryCopy { src: u32, dst: u32 },
+    MemoryFill { mem: u32 },
     TableInit { segment: u32, table: u32 },
     ElemDrop { segment: u32 },
     TableCopy { dst_table: u32, src_table: u32 },

--- a/crates/wast/src/resolve/names.rs
+++ b/crates/wast/src/resolve/names.rs
@@ -1782,8 +1782,16 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
         use crate::ast::Instruction::*;
 
         match instr {
+            MemorySize(i) | MemoryGrow(i) | MemoryFill(i) => {
+                self.module.resolve(&mut i.mem, Ns::Memory)?;
+            }
             MemoryInit(i) => {
                 self.module.datas.resolve(&mut i.data, "data")?;
+                self.module.resolve(&mut i.mem, Ns::Memory)?;
+            }
+            MemoryCopy(i) => {
+                self.module.resolve(&mut i.src, Ns::Memory)?;
+                self.module.resolve(&mut i.dst, Ns::Memory)?;
             }
             DataDrop(i) => {
                 self.module.datas.resolve(i, "data")?;
@@ -1968,6 +1976,110 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
             }
 
             RefNull(ty) => self.module.resolve_heaptype(ty)?,
+
+            I32Load(m)
+            | I64Load(m)
+            | F32Load(m)
+            | F64Load(m)
+            | I32Load8s(m)
+            | I32Load8u(m)
+            | I32Load16s(m)
+            | I32Load16u(m)
+            | I64Load8s(m)
+            | I64Load8u(m)
+            | I64Load16s(m)
+            | I64Load16u(m)
+            | I64Load32s(m)
+            | I64Load32u(m)
+            | I32Store(m)
+            | I64Store(m)
+            | F32Store(m)
+            | F64Store(m)
+            | I32Store8(m)
+            | I32Store16(m)
+            | I64Store8(m)
+            | I64Store16(m)
+            | I64Store32(m)
+            | I32AtomicLoad(m)
+            | I64AtomicLoad(m)
+            | I32AtomicLoad8u(m)
+            | I32AtomicLoad16u(m)
+            | I64AtomicLoad8u(m)
+            | I64AtomicLoad16u(m)
+            | I64AtomicLoad32u(m)
+            | I32AtomicStore(m)
+            | I64AtomicStore(m)
+            | I32AtomicStore8(m)
+            | I32AtomicStore16(m)
+            | I64AtomicStore8(m)
+            | I64AtomicStore16(m)
+            | I64AtomicStore32(m)
+            | I32AtomicRmwAdd(m)
+            | I64AtomicRmwAdd(m)
+            | I32AtomicRmw8AddU(m)
+            | I32AtomicRmw16AddU(m)
+            | I64AtomicRmw8AddU(m)
+            | I64AtomicRmw16AddU(m)
+            | I64AtomicRmw32AddU(m)
+            | I32AtomicRmwSub(m)
+            | I64AtomicRmwSub(m)
+            | I32AtomicRmw8SubU(m)
+            | I32AtomicRmw16SubU(m)
+            | I64AtomicRmw8SubU(m)
+            | I64AtomicRmw16SubU(m)
+            | I64AtomicRmw32SubU(m)
+            | I32AtomicRmwAnd(m)
+            | I64AtomicRmwAnd(m)
+            | I32AtomicRmw8AndU(m)
+            | I32AtomicRmw16AndU(m)
+            | I64AtomicRmw8AndU(m)
+            | I64AtomicRmw16AndU(m)
+            | I64AtomicRmw32AndU(m)
+            | I32AtomicRmwOr(m)
+            | I64AtomicRmwOr(m)
+            | I32AtomicRmw8OrU(m)
+            | I32AtomicRmw16OrU(m)
+            | I64AtomicRmw8OrU(m)
+            | I64AtomicRmw16OrU(m)
+            | I64AtomicRmw32OrU(m)
+            | I32AtomicRmwXor(m)
+            | I64AtomicRmwXor(m)
+            | I32AtomicRmw8XorU(m)
+            | I32AtomicRmw16XorU(m)
+            | I64AtomicRmw8XorU(m)
+            | I64AtomicRmw16XorU(m)
+            | I64AtomicRmw32XorU(m)
+            | I32AtomicRmwXchg(m)
+            | I64AtomicRmwXchg(m)
+            | I32AtomicRmw8XchgU(m)
+            | I32AtomicRmw16XchgU(m)
+            | I64AtomicRmw8XchgU(m)
+            | I64AtomicRmw16XchgU(m)
+            | I64AtomicRmw32XchgU(m)
+            | I32AtomicRmwCmpxchg(m)
+            | I64AtomicRmwCmpxchg(m)
+            | I32AtomicRmw8CmpxchgU(m)
+            | I32AtomicRmw16CmpxchgU(m)
+            | I64AtomicRmw8CmpxchgU(m)
+            | I64AtomicRmw16CmpxchgU(m)
+            | I64AtomicRmw32CmpxchgU(m)
+            | V128Load(m)
+            | I16x8Load8x8S(m)
+            | I16x8Load8x8U(m)
+            | I32x4Load16x4S(m)
+            | I32x4Load16x4U(m)
+            | I64x2Load32x2S(m)
+            | I64x2Load32x2U(m)
+            | V8x16LoadSplat(m)
+            | V16x8LoadSplat(m)
+            | V32x4LoadSplat(m)
+            | V64x2LoadSplat(m)
+            | V128Store(m)
+            | MemoryAtomicNotify(m)
+            | MemoryAtomicWait32(m)
+            | MemoryAtomicWait64(m) => {
+                self.module.resolve(&mut m.memory, Ns::Memory)?;
+            }
 
             _ => {}
         }

--- a/fuzz/fuzz_targets/validate.rs
+++ b/fuzz/fuzz_targets/validate.rs
@@ -5,20 +5,25 @@ use wasmparser::{Validator, WasmFeatures};
 
 fuzz_target!(|data: &[u8]| {
     let mut validator = Validator::new();
-    let byte = match data.get(0) {
+    let byte1 = match data.get(0) {
+        Some(byte) => byte,
+        None => return,
+    };
+    let byte2 = match data.get(1) {
         Some(byte) => byte,
         None => return,
     };
     validator.wasm_features(WasmFeatures {
-        reference_types: (byte & 0b0000_0001) != 0,
-        multi_value: (byte & 0b0000_0010) != 0,
-        threads: (byte & 0b0000_0100) != 0,
-        simd: (byte & 0b0000_1000) != 0,
-        module_linking: (byte & 0b0001_0000) != 0,
-        tail_call: (byte & 0b0010_0000) != 0,
-        bulk_memory: (byte & 0b0100_0000) != 0,
-        deterministic_only: (byte & 0b1000_0000) != 0,
+        reference_types: (byte1 & 0b0000_0001) != 0,
+        multi_value: (byte1 & 0b0000_0010) != 0,
+        threads: (byte1 & 0b0000_0100) != 0,
+        simd: (byte1 & 0b0000_1000) != 0,
+        module_linking: (byte1 & 0b0001_0000) != 0,
+        tail_call: (byte1 & 0b0010_0000) != 0,
+        bulk_memory: (byte1 & 0b0100_0000) != 0,
+        deterministic_only: (byte1 & 0b1000_0000) != 0,
+        multi_memory: (byte2 & 0b0000_0001) != 0,
     });
 
-    drop(validator.validate_all(&data[1..]));
+    drop(validator.validate_all(&data[2..]));
 });

--- a/src/bin/wasm-validate-rs.rs
+++ b/src/bin/wasm-validate-rs.rs
@@ -37,6 +37,11 @@ fn main() -> Result<()> {
     );
     opts.optflag(
         "",
+        "enable-multi-memory",
+        "Enable wasm multi-memory feature",
+    );
+    opts.optflag(
+        "",
         "deterministic-only",
         "Require only deterministic instructions",
     );
@@ -65,6 +70,7 @@ fn main() -> Result<()> {
         multi_value: matches.opt_present("enable-multi-value"),
         tail_call: matches.opt_present("enable-tail-call"),
         module_linking: matches.opt_present("enable-module-linking"),
+        multi_memory: matches.opt_present("enable-multi-memory"),
         deterministic_only: matches.opt_present("deterministic-only"),
     });
 

--- a/tests/local/multi-memory.wast
+++ b/tests/local/multi-memory.wast
@@ -1,0 +1,209 @@
+(module
+  (memory $a 0)
+  (memory $b 0)
+
+  (data $seg "")
+
+  (func $foo
+    i32.const 0
+    i32.load
+    drop
+
+    i32.const 0
+    i32.load 0
+    drop
+
+    i32.const 0
+    i32.load 1
+    drop
+
+    i32.const 0
+    i32.load $a
+    drop
+
+    i32.const 0
+    i32.load $b
+    drop
+
+    i32.const 0
+    i32.const 0
+    i32.store 0
+
+    i32.const 0
+    i32.const 0
+    i32.store 1
+
+    i32.const 0
+    i32.const 0
+    i32.store $a
+
+    i32.const 0
+    i32.const 0
+    i32.store $b
+
+    i32.const 0
+    i32.const 0
+    i32.const 0
+    memory.copy $a $b
+
+    i32.const 0
+    i32.const 0
+    i32.const 0
+    memory.copy $b $a
+
+    i32.const 0
+    i32.const 0
+    i32.const 0
+    memory.fill $a
+
+    i32.const 0
+    i32.const 0
+    i32.const 0
+    memory.fill $b
+
+    i32.const 0
+    i32.const 0
+    i32.const 0
+    memory.init $seg $b
+
+    memory.size $a drop
+    memory.size $b drop
+    i32.const 0 memory.grow $a drop
+    i32.const 0 memory.grow $b drop
+
+    i32.const 0 i32.load drop
+    i32.const 0 i64.load $b drop
+    i32.const 0 f32.load $b drop
+    i32.const 0 f64.load $b drop
+    i32.const 0 i32.load8_s $b drop
+    i32.const 0 i32.load8_u $b drop
+    i32.const 0 i32.load16_s $b drop
+    i32.const 0 i32.load16_u $b drop
+    i32.const 0 i64.load8_s $b drop
+    i32.const 0 i64.load8_u $b drop
+    i32.const 0 i64.load16_s $b drop
+    i32.const 0 i64.load16_u $b drop
+    i32.const 0 i64.load32_s $b drop
+    i32.const 0 i64.load32_u $b drop
+    i32.const 0 i32.const 0 i32.store $b
+    i32.const 0 i64.const 0 i64.store $b
+    i32.const 0 f32.const 0 f32.store $b
+    i32.const 0 f64.const 0 f64.store $b
+    i32.const 0 i32.const 0 i32.store8 $b
+    i32.const 0 i32.const 0 i32.store16 $b
+    i32.const 0 i64.const 0 i64.store8 $b
+    i32.const 0 i64.const 0 i64.store16 $b
+    i32.const 0 i64.const 0 i64.store32 $b
+
+    i32.const 0
+    i32.const 0
+    memory.atomic.notify $b
+    drop
+
+    i32.const 0
+    i32.const 0
+    i64.const 0
+    memory.atomic.wait32 $b
+    drop
+
+    i32.const 0
+    i64.const 0
+    i64.const 0
+    memory.atomic.wait64 $b
+    drop
+
+    i32.const 0 i32.atomic.load $b drop
+    i32.const 0 i64.atomic.load $b drop
+    i32.const 0 i32.atomic.load8_u $b drop
+    i32.const 0 i32.atomic.load16_u $b drop
+    i32.const 0 i64.atomic.load8_u $b drop
+    i32.const 0 i64.atomic.load16_u $b drop
+    i32.const 0 i64.atomic.load32_u $b drop
+    i32.const 0 i32.const 0 i32.atomic.store $b
+    i32.const 0 i64.const 0 i64.atomic.store $b
+    i32.const 0 i32.const 0 i32.atomic.store8 $b
+    i32.const 0 i32.const 0 i32.atomic.store16 $b
+    i32.const 0 i64.const 0 i64.atomic.store8 $b
+    i32.const 0 i64.const 0 i64.atomic.store16 $b
+    i32.const 0 i64.const 0 i64.atomic.store32 $b
+    i32.const 0 i32.const 0 i32.atomic.rmw.add $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw.add $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw8.add_u $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw16.add_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw8.add_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw16.add_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw32.add_u $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw.sub $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw.sub $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw8.sub_u $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw16.sub_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw8.sub_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw16.sub_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw32.sub_u $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw.and $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw.and $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw8.and_u $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw16.and_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw8.and_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw16.and_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw32.and_u $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw.or $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw.or $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw8.or_u $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw16.or_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw8.or_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw16.or_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw32.or_u $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw.xor $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw.xor $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw8.xor_u $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw16.xor_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw8.xor_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw16.xor_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw32.xor_u $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw.xchg $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw.xchg $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw8.xchg_u $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw16.xchg_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw8.xchg_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw16.xchg_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw32.xchg_u $b drop
+    i32.const 0 i32.const 0 i32.const 0 i32.atomic.rmw.cmpxchg $b drop
+    i32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw.cmpxchg $b drop
+    i32.const 0 i32.const 0 i32.const 0 i32.atomic.rmw8.cmpxchg_u $b drop
+    i32.const 0 i32.const 0 i32.const 0 i32.atomic.rmw16.cmpxchg_u $b drop
+    i32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw8.cmpxchg_u $b drop
+    i32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw16.cmpxchg_u $b drop
+    i32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw32.cmpxchg_u $b drop
+
+    i32.const 0 v128.load $b drop
+    i32.const 0 i16x8.load8x8_s $b drop
+    i32.const 0 i16x8.load8x8_u $b drop
+    i32.const 0 i32x4.load16x4_s $b drop
+    i32.const 0 i32x4.load16x4_u $b drop
+    i32.const 0 i64x2.load32x2_s $b drop
+    i32.const 0 i64x2.load32x2_u $b drop
+    i32.const 0 v8x16.load_splat $b drop
+    i32.const 0 v16x8.load_splat $b drop
+    i32.const 0 v32x4.load_splat $b drop
+    i32.const 0 v64x2.load_splat $b drop
+    i32.const 0 i32.const 0 i8x16.splat v128.store $b
+  )
+)
+
+(assert_invalid
+  (module
+    (memory 0)
+    (func
+      i32.const 0
+      i32.load 1
+      drop
+    )
+  )
+  "unknown memory 1")
+
+(assert_malformed
+  (module quote
+    "(func i32.load $a)"
+  )
+  "failed to find memory")

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -254,6 +254,7 @@ impl TestState {
 
             // not implemented in wabt
             && !test.iter().any(|t| t == "module-linking")
+            && !test.ends_with("multi-memory.wast")
 
             // wabt uses old instruction names for atomics
             && !test.ends_with("atomic-no-shared-memory.txt")
@@ -650,6 +651,7 @@ impl TestState {
             module_linking: true,
             deterministic_only: false,
             multi_value: true,
+            multi_memory: true,
         };
         for part in test.iter().filter_map(|t| t.to_str()) {
             match part {


### PR DESCRIPTION
This commit implements the current state of the [multi memory
proposal][repo] where the general idea is that all instructions which
touch memory now take an index of some form to indicate which memory is
being touched. Most of this was pretty simple, it's just plumbing around
the various places that indexes appear which need to be resolved,
validated, and printed.

[repo]: https://github.com/webassembly/multi-memory