### PR TITLE
Update GC proposal slightly

### DIFF
--- a/crates/wast/src/ast/expr.rs
+++ b/crates/wast/src/ast/expr.rs
@@ -521,6 +521,9 @@ instructions! {
         // gc proposal: eqref
         RefEq : [0xd5] : "ref.eq",
 
+        // gc proposal (moz specific, will be removed)
+        StructNew(ast::Index<'a>) : [0xfb, 0x0] : "struct.new",
+
         // gc proposal: struct
         StructNewWithRtt(ast::Index<'a>) : [0xfb, 0x01] : "struct.new_with_rtt",
         StructNewDefaultWithRtt(ast::Index<'a>) : [0xfb, 0x02] : "struct.new_default_with_rtt",

--- a/crates/wast/src/ast/types.rs
+++ b/crates/wast/src/ast/types.rs
@@ -113,16 +113,8 @@ impl<'a> Parse<'a> for HeapType<'a> {
         } else if l.peek::<kw::i31>() {
             parser.parse::<kw::i31>()?;
             Ok(HeapType::I31)
-        } else if l.peek::<ast::LParen>() {
-            parser.parens(|p| {
-                let mut l = parser.lookahead1();
-                if l.peek::<kw::r#type>() {
-                    p.parse::<kw::r#type>()?;
-                    Ok(HeapType::Index(p.parse()?))
-                } else {
-                    Err(l.error())
-                }
-            })
+        } else if l.peek::<ast::Index>() {
+            Ok(HeapType::Index(parser.parse()?))
         } else {
             Err(l.error())
         }
@@ -238,17 +230,10 @@ impl<'a> Parse<'a> for RefType<'a> {
                         nullable = true;
                     }
 
-                    if parser.peek::<ast::Index>() {
-                        Ok(RefType {
-                            nullable,
-                            heap: HeapType::Index(parser.parse()?),
-                        })
-                    } else {
-                        Ok(RefType {
-                            nullable,
-                            heap: parser.parse()?,
-                        })
-                    }
+                    Ok(RefType {
+                        nullable,
+                        heap: parser.parse()?,
+                    })
                 } else {
                     Err(l.error())
                 }

--- a/crates/wast/src/resolve/names.rs
+++ b/crates/wast/src/resolve/names.rs
@@ -1943,7 +1943,8 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
                 }
             }
 
-            StructNewWithRtt(i)
+            StructNew(i)
+            | StructNewWithRtt(i)
             | StructNewDefaultWithRtt(i)
             | ArrayNewWithRtt(i)
             | ArrayNewDefaultWithRtt(i)

--- a/tests/local/gc-struct.wat
+++ b/tests/local/gc-struct.wat
@@ -15,7 +15,7 @@
   (type (struct (field $field_b externref) (field $field_c funcref)))
 
   (func
-    rtt.canon (type $a)
+    rtt.canon $a
     struct.new_with_rtt $a
     struct.get $a $field_a
     struct.set $b $field_c


### PR DESCRIPTION
1. Add back the 'struct.new' instruction as a temporary compat measure for SM
2. Update implementation of heaptype syntax to match latest proposal