### PR TITLE
WIP fix for #79

### DIFF
--- a/crates/wasmparser/examples/simple.rs
+++ b/crates/wasmparser/examples/simple.rs
@@ -27,8 +27,8 @@ fn main() -> Result<()> {
                     println!("  Import {}::{}", import.module, import.field.unwrap());
                 }
             }
-            _other => {
-                // println!("found payload {:?}", _other);
+            other => {
+                println!("{:?}", other);
             }
         }
     }

--- a/crates/wasmparser/examples/validate.rs
+++ b/crates/wasmparser/examples/validate.rs
@@ -1,0 +1,12 @@
+fn main() {
+    let mut validator = wasmparser::Validator::new();
+    validator.wasm_features(wasmparser::WasmFeatures {
+        multi_value: true,
+        ..wasmparser::WasmFeatures::default()
+    });
+
+    let bytes = std::fs::read(std::env::args().nth(1).unwrap()).unwrap();
+    if let Err(e) = validator.validate_all(&bytes) {
+        eprintln!("error: {}", e);
+    }
+}

--- a/crates/wasmparser/src/operators_validator.rs
+++ b/crates/wasmparser/src/operators_validator.rs
@@ -225,15 +225,6 @@ impl FuncState {
         self.stack_types.extend(new_items);
         Ok(())
     }
-    fn change_frame_to_exact_types_from(&mut self, depth: usize) -> OperatorValidatorResult<()> {
-        let types = self.block_at(depth).return_types.clone();
-        let last_block = self.blocks.last_mut().unwrap();
-        let keep = last_block.stack_starts_at;
-        self.stack_types.truncate(keep);
-        self.stack_types.extend_from_slice(&types);
-        last_block.polymorphic_values = None;
-        Ok(())
-    }
     fn change_frame_after_select(&mut self, ty: Option<Type>) -> OperatorValidatorResult<()> {
         self.remove_frame_stack_types(3)?;
         if ty.is_none() {
@@ -839,12 +830,7 @@ impl OperatorValidator {
             Operator::BrIf { relative_depth } => {
                 self.check_operands_1(Type::I32)?;
                 self.check_jump_from_block(relative_depth, 1)?;
-                if self.func_state.last_block().is_stack_polymorphic() {
-                    self.func_state
-                        .change_frame_to_exact_types_from(relative_depth as usize)?;
-                } else {
-                    self.func_state.change_frame(1)?;
-                }
+                self.func_state.change_frame(1)?;
             }
             Operator::BrTable { ref table } => {
                 self.check_operands_1(Type::I32)?;


### PR DESCRIPTION
This makes it so that the test case in #79 validates, and all the `wasmparser` tests pass, but introduces failures in this whole repo's round trip tests:

<details>

```
failed test: tests/testsuite/proposals/reference-types/unreached-invalid.wast

Caused by:
    2 test failures in tests/testsuite/proposals/reference-types/unreached-invalid.wast:
    
    	--------------------------------
    
    	failed directive on tests/testsuite/proposals/reference-types/unreached-invalid.wast:690:2
    	
    	Caused by:
    	    no wasm validation error found
    
    	--------------------------------
    
    	failed directive on tests/testsuite/proposals/reference-types/unreached-invalid.wast:701:2
    	
    	Caused by:
    	    no wasm validation error found
failed test: tests/testsuite/unreached-invalid.wast

Caused by:
    2 test failures in tests/testsuite/unreached-invalid.wast:
    
    	--------------------------------
    
    	failed directive on tests/testsuite/unreached-invalid.wast:689:2
    	
    	Caused by:
    	    no wasm validation error found
    
    	--------------------------------
    
    	failed directive on tests/testsuite/unreached-invalid.wast:700:2
    	
    	Caused by:
    	    no wasm validation error found
```

</details>

I'm not sure I totally understand how `wasmparser`'s stack polymorphism handling works, but the bug seems to orbit that code. It looks like `wasmparser` is trying to avoid memory overheads of representing the operand stack as `Vec<Option<Type>>` where `None` is a stack polymorphic value, and is instead keeping track on the side of how many stack polymorphic values we have at what index in the stack? I'm not 100% sure it is relevant to this bug, but what happens when there are two places in the operand stack where we have stack polymorphic values? I guess that once you start popping from a stack polymorphic section, you should never be able to get past it again to earlier values (other than exiting the control frame) right?

Anyways, since you're more familiar with `wasmparser`'s validator, I was hoping you could help investigate what's going on here, @yurydelendik. Thanks!