### PR TITLE
Use loop start_types to infer dead code operands

### DIFF
--- a/crates/wasmparser/src/operators_validator.rs
+++ b/crates/wasmparser/src/operators_validator.rs
@@ -226,7 +226,18 @@ impl FuncState {
         Ok(())
     }
     fn change_frame_to_exact_types_from(&mut self, depth: usize) -> OperatorValidatorResult<()> {
-        let types = self.block_at(depth).return_types.clone();
+        let types = match self.block_at(depth) {
+            BlockState {
+                jump_to_top: false,
+                return_types,
+                ..
+            } => return_types.clone(),
+            BlockState {
+                jump_to_top: true,
+                start_types,
+                ..
+            } => start_types.clone(),
+        };
         let last_block = self.blocks.last_mut().unwrap();
         let keep = last_block.stack_starts_at;
         if keep + types.len() <= self.stack_types.len() {

--- a/tests/local/br_if-loop-unreachable.wat
+++ b/tests/local/br_if-loop-unreachable.wat
@@ -1,0 +1,14 @@
+;;; --enable-multi-value
+(module
+  (type (;0;) (func))
+  (type (;1;) (func (result f64 i32)))
+  (func (;0;) (type 1) (result f64 i32)
+    loop (result f64 i32)  ;; label = @1
+      br 0 (;@1;)
+      call 0
+      br_if 0 (;@1;)
+      i32.trunc_f64_u
+      unreachable
+    end
+    unreachable)
+)


### PR DESCRIPTION
Fixes #83