### PR TITLE
Store some fields as `Box<[_]>` instead of `Vec<_>`

### DIFF
--- a/crates/wast/src/ast/expr.rs
+++ b/crates/wast/src/ast/expr.rs
@@ -10,7 +10,7 @@ use std::mem;
 #[derive(Debug)]
 #[allow(missing_docs)]
 pub struct Expression<'a> {
-    pub instrs: Vec<Instruction<'a>>,
+    pub instrs: Box<[Instruction<'a>]>,
 }
 
 impl<'a> Parse<'a> for Expression<'a> {
@@ -111,7 +111,6 @@ impl<'a> ExpressionParser<'a> {
                 }
             }
 
-
             match self.paren(parser)? {
                 // No parenthesis seen? Then we just parse the next instruction
                 // and move on.
@@ -207,7 +206,7 @@ impl<'a> ExpressionParser<'a> {
         }
 
         Ok(Expression {
-            instrs: self.instrs,
+            instrs: self.instrs.into(),
         })
     }
 

--- a/crates/wast/src/resolve/deinline_import_export.rs
+++ b/crates/wast/src/resolve/deinline_import_export.rs
@@ -90,11 +90,11 @@ pub fn run(fields: &mut Vec<ModuleField>) {
                             kind: DataKind::Active {
                                 memory: Index::Id(id),
                                 offset: Expression {
-                                    instrs: vec![if is_32 {
+                                    instrs: Box::new([if is_32 {
                                         Instruction::I32Const(0)
                                     } else {
                                         Instruction::I64Const(0)
-                                    }],
+                                    }]),
                                 },
                             },
                             data,
@@ -153,7 +153,7 @@ pub fn run(fields: &mut Vec<ModuleField>) {
                             kind: ElemKind::Active {
                                 table: Index::Id(id),
                                 offset: Expression {
-                                    instrs: vec![Instruction::I32Const(0)],
+                                    instrs: Box::new([Instruction::I32Const(0)]),
                                 },
                             },
                             payload,


### PR DESCRIPTION
In the fuzz OOM case we're running into found on Wasmtime's OSS-Fuzz
integration a lot of allocations are pointing to function types and
expressions, and switching to `Box<[_]>` looks to improve memory by only
allocating precise chunks of memory instead of having an over-allocated
`Vec<_>` which is never actually used.