### PR TITLE
Rewrite handling of blocks in the operator validator

### DIFF
--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -1568,8 +1568,7 @@ impl Validator {
         let ty_index = self.state.func_type_indices[self.code_section_index];
         self.code_section_index += 1;
         let resources = ValidatorResources(self.state.arc().clone());
-        let ty = self.func_type_at(ty_index)?;
-        Ok(FuncValidator::new(ty.item, resources, &self.features))
+        Ok(FuncValidator::new(ty_index.item, 0, resources, &self.features).unwrap())
     }
 
     /// Validates [`Payload::DataSection`](crate::Payload).

--- a/tests/local/issue192.wast
+++ b/tests/local/issue192.wast
@@ -15,7 +15,7 @@
             (block (param i32))
         )
     )
-    "type mismatch: stack size does not match block type"
+    "type mismatch"
 )
 
 (assert_invalid
@@ -26,5 +26,5 @@
             )
         )
     )
-    "type mismatch: not enough operands"
+    "type mismatch"
 )

--- a/tests/local/issue194.wast
+++ b/tests/local/issue194.wast
@@ -21,7 +21,7 @@
             local.get 0
             br_if 0
         end))
-    "type mismatch: stack size does not match target loop type"
+    "type mismatch"
 )
 
 (assert_invalid
@@ -36,5 +36,5 @@
             br_if 0
             drop
         end))
-    "type mismatch: stack item type does not match block param type"
+    "type mismatch"
 )

--- a/tests/local/unreachable-block.wast
+++ b/tests/local/unreachable-block.wast
@@ -1,0 +1,9 @@
+(module
+  (func
+    unreachable
+    i32.const 0
+    select
+    block (param i32)
+      unreachable
+    end))
+


### PR DESCRIPTION
This commit rewrites how blocks are handled in the `OperatorValidator`
type, primarily motivated by the various bugs we've had recently around
the handling of `unreachable` instructions (#100 being the most recent).

The goal of this refactoring is to update the validator to match, almost
exactly, the [online appendix for the validation algorithm][appendix],
namely around how blocks and `unreachable` are handled. This also should
hopefully make the code a bit easier to read since the trickiness is
handled in a relatively subtle way where the "naive interpretation" ends
up being correct.

I've done some quick benchmarking and this doesn't appear to either
regress or improve performance (yay?), but this does...

Closes #100

[appendix]: https://webassembly.github.io/spec/core/appendix/algorithm.html