### PR TITLE
Fix a panic with malformed `let` blocks

### DIFF
--- a/crates/wast/src/resolve/names.rs
+++ b/crates/wast/src/resolve/names.rs
@@ -1883,7 +1883,7 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
             // `End` and `Else` instructions if they have labels listed we
             // verify that they match the label at the beginning of the block.
             Else(_) | End(_) => {
-                let (matching_block, label) = match instr {
+                let (matching_block, label) = match &instr {
                     Else(label) => (self.blocks.last().cloned(), label),
                     End(label) => (self.blocks.pop(), label),
                     _ => unreachable!(),
@@ -1895,7 +1895,9 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
 
                 // Reset the local scopes to before this block was entered
                 if matching_block.pushed_scope {
-                    self.scopes.pop();
+                    if let End(_) = instr {
+                        self.scopes.pop();
+                    }
                 }
 
                 let label = match label {

--- a/tests/local/invalid-let.wast
+++ b/tests/local/invalid-let.wast
@@ -1,0 +1,9 @@
+(assert_invalid
+  (module
+    (func
+      let
+      else
+      else
+      local.get 1
+      ))
+  "Unknown opcode: 0x17") ;; update this error once wasmparser is updated


### PR DESCRIPTION
When resolving we don't pop label scopes when we see an `else` block, so
don't pop local scopes as well. It's technically invalid to have an
`else` inside of a `let` anyway, but let's hobble along in the text
parser and let the binary validator figure that out.