### PR TITLE
Bump wast version to 25.0.0

### DIFF
--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wast"
-version = "24.0.0"
+version = "25.0.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wat/Cargo.toml
+++ b/crates/wat/Cargo.toml
@@ -13,4 +13,4 @@ Rust parser for the WebAssembly Text format, WAT
 """
 
 [dependencies]
-wast = { path = '../wast', version = '24.0.0' }
+wast = { path = '../wast', version = '25.0.0' }


### PR DESCRIPTION
This PR bumps the `wast` version to `25.0.0`. Hoping a new release can be made so that I can update the dependency for the language server (for recent SIMD changes and other testsuite fixes).