### PR TITLE
Fix an out-of-bounds shift in wasmprinter

### DIFF
--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -1308,6 +1308,9 @@ impl Printer {
         if memarg.offset != 0 {
             write!(self.result, " offset={}", memarg.offset)?;
         }
+        if memarg.align >= 32 {
+            bail!("alignment in memarg too large");
+        }
         let align = 1 << memarg.align;
         if default_align != align {
             write!(self.result, " align={}", align)?;

--- a/crates/wasmprinter/tests/all.rs
+++ b/crates/wasmprinter/tests/all.rs
@@ -66,3 +66,31 @@ fn locals_overflow() {
         err
     );
 }
+
+#[test]
+fn memarg_too_big() {
+    let bytes = wat::parse_str(
+        r#"
+            (module binary
+                "\00asm" "\01\00\00\00"     ;; module header
+
+                "\0b"           ;; data section
+                "\07"           ;; size of section
+                "\01"           ;; number of segments
+                "\00"           ;; flags=active
+                "\2e"           ;; i32.load16_s
+                "\3f"           ;; alignment
+                "\00"           ;; offset
+                "\0b"           ;; end
+                "\00"           ;; data size
+            )
+        "#,
+    )
+    .unwrap();
+    let err = wasmprinter::print_bytes(&bytes).unwrap_err();
+    assert!(
+        err.to_string().contains("alignment in memarg too large"),
+        "{:?}",
+        err
+    );
+}


### PR DESCRIPTION
Instead of tripping a debug assert return an error instead.