### PR TITLE
Fix handling of indentation printing invalid modules

### DIFF
--- a/crates/wasmprinter/tests/all.rs
+++ b/crates/wasmprinter/tests/all.rs
@@ -94,3 +94,16 @@ fn memarg_too_big() {
         err
     );
 }
+
+#[test]
+fn no_panic_dangling_else() {
+    let bytes = wat::parse_str(
+        r#"
+            (module
+                (func else)
+            )
+        "#,
+    )
+    .unwrap();
+    wasmprinter::print_bytes(&bytes).unwrap();
+}


### PR DESCRIPTION
This commit fixes a panic on integer overflow in the `wasmprinter` crate
where when an invalid module was printed it could confuse the
indentation handling logic. Instead the logic is refactored to be
handled in just one place and better handles invalid modules.