### PR TITLE
Fix default alignment in `wast` for new simd instrs

### DIFF
--- a/crates/wast/src/ast/expr.rs
+++ b/crates/wast/src/ast/expr.rs
@@ -993,8 +993,8 @@ instructions! {
         F32x4ConvertI32x4S : [0xfd, 0xfa] : "f32x4.convert_i32x4_s",
         F32x4ConvertI32x4U : [0xfd, 0xfb] : "f32x4.convert_i32x4_u",
 
-        V128Load32Zero(MemArg<2>) : [0xfd, 0xfc] : "v128.load32_zero",
-        V128Load64Zero(MemArg<3>) : [0xfd, 0xfd] : "v128.load64_zero",
+        V128Load32Zero(MemArg<4>) : [0xfd, 0xfc] : "v128.load32_zero",
+        V128Load64Zero(MemArg<8>) : [0xfd, 0xfd] : "v128.load64_zero",
 
         // Exception handling proposal
         Try(BlockType<'a>) : [0x06] : "try",


### PR DESCRIPTION
The literal here is the intended alignment, not the log of the intended
alignment.