### PR TITLE
Fix another integer overflow in wasmprinter's nesting

### DIFF
--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -627,7 +627,7 @@ impl Printer {
 
                     // Exiting a block prints `end` at the previous indentation
                     // level.
-                    Operator::End => {
+                    Operator::End if self.nesting > nesting_start => {
                         self.nesting -= 1;
                         self.newline();
                     }

--- a/crates/wasmprinter/tests/all.rs
+++ b/crates/wasmprinter/tests/all.rs
@@ -9,6 +9,16 @@ fn no_panic() {
     )
     .unwrap();
     wasmprinter::print_bytes(&bytes).unwrap();
+
+    let bytes = wat::parse_str(
+        r#"
+            (module
+                (func end)
+            )
+        "#,
+    )
+    .unwrap();
+    wasmprinter::print_bytes(&bytes).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
Don't decrease the current nesting level past where we started in the
case that there's multiple `end` instructions.