### PR TITLE
wasm-smith: Implement reference types support

### DIFF
--- a/crates/wasm-smith/tests/tests.rs
+++ b/crates/wasm-smith/tests/tests.rs
@@ -18,6 +18,7 @@ fn smoke_test_module() {
                 multi_value: true,
                 multi_memory: true,
                 bulk_memory: true,
+                reference_types: true,
                 ..WasmFeatures::default()
             });
 
@@ -42,6 +43,7 @@ fn smoke_test_ensure_termination() {
                 multi_value: true,
                 multi_memory: true,
                 bulk_memory: true,
+                reference_types: true,
                 ..WasmFeatures::default()
             });
 
@@ -65,6 +67,7 @@ fn smoke_test_swarm_config() {
                 multi_value: true,
                 multi_memory: true,
                 bulk_memory: true,
+                reference_types: true,
                 ..WasmFeatures::default()
             });
 

--- a/fuzz/fuzz_targets/print-valid-module.rs
+++ b/fuzz/fuzz_targets/print-valid-module.rs
@@ -1,11 +1,11 @@
 #![no_main]
 
 use libfuzzer_sys::fuzz_target;
-use wasm_smith::Module;
+use wasm_smith::{ConfiguredModule, SwarmConfig};
 
 // Define a fuzz target that accepts arbitrary
 // `Module`s as input.
-fuzz_target!(|m: Module| {
+fuzz_target!(|m: ConfiguredModule<SwarmConfig>| {
     // Convert the module into Wasm bytes.
     let bytes = m.to_bytes();
 

--- a/fuzz/fuzz_targets/validate-valid-module.rs
+++ b/fuzz/fuzz_targets/validate-valid-module.rs
@@ -16,6 +16,7 @@ fuzz_target!(|m: ConfiguredModule<SwarmConfig>| {
         multi_value: true,
         multi_memory: true,
         bulk_memory: true,
+        reference_types: true,
         ..wasmparser::WasmFeatures::default()
     });
     if let Err(e) = validator.validate_all(&bytes) {


### PR DESCRIPTION
This commit implements the reference types proposal for the wasm-smith
crate, generating modules which use reference types. It covers the new
instructions, multiple-tables, and new kinds of element segments.
Support is gated through `Config::max_tables` and
`Config::reference_types_enabled`.