### PR TITLE
Add parser/printer support for I32x4DotI16x8S

### DIFF
--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -1687,6 +1687,7 @@ impl<'a> BinaryReader<'a> {
             0xb7 => Operator::I32x4MinU,
             0xb8 => Operator::I32x4MaxS,
             0xb9 => Operator::I32x4MaxU,
+            0xba => Operator::I32x4DotI16x8S,
             0xc1 => Operator::I64x2Neg,
             0xcb => Operator::I64x2Shl,
             0xcc => Operator::I64x2ShrS,

--- a/crates/wasmparser/src/operators_validator.rs
+++ b/crates/wasmparser/src/operators_validator.rs
@@ -1472,6 +1472,7 @@ impl OperatorValidator {
             | Operator::I32x4MinU
             | Operator::I32x4MaxS
             | Operator::I32x4MaxU
+            | Operator::I32x4DotI16x8S
             | Operator::I64x2Add
             | Operator::I64x2Sub
             | Operator::I64x2Mul

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -735,6 +735,7 @@ pub enum Operator<'a> {
     I32x4MinU,
     I32x4MaxS,
     I32x4MaxU,
+    I32x4DotI16x8S,
     I64x2Neg,
     I64x2Shl,
     I64x2ShrS,

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -1310,6 +1310,7 @@ impl Printer {
             I32x4MinU => self.result.push_str("i32x4.min_u"),
             I32x4MaxS => self.result.push_str("i32x4.max_s"),
             I32x4MaxU => self.result.push_str("i32x4.max_u"),
+            I32x4DotI16x8S => self.result.push_str("i32x4.dot_i16x8_s"),
         }
         Ok(())
     }


### PR DESCRIPTION
Looks like only partial support was added for the I32x4DotI16x8S opcode.  This adds the rest (I hope).
