### PR TITLE
Update wabt submodule

### DIFF
--- a/crates/wast/src/resolve/deinline_import_export.rs
+++ b/crates/wast/src/resolve/deinline_import_export.rs
@@ -90,11 +90,7 @@ pub fn run(fields: &mut Vec<ModuleField>) {
                             kind: DataKind::Active {
                                 memory: Index::Id(id),
                                 offset: Expression {
-                                    instrs: Box::new([if is_32 {
-                                        Instruction::I32Const(0)
-                                    } else {
-                                        Instruction::I64Const(0)
-                                    }]),
+                                    instrs: Box::new([Instruction::I32Const(0)]),
                                 },
                             },
                             data,


### PR DESCRIPTION
Looks like expansion of inline `data` on 64-bit memories has been
tweaked to always having 32-bit offsets for data segments.