### PR TITLE
Enable more reference tests against wabt

### DIFF
--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -363,13 +363,8 @@ impl<'a> BinaryReader<'a> {
             Ok(MemoryType::M32 { limits, shared })
         } else {
             let limits = self.read_resizable_limits64((flags & 0x1) != 0)?;
-            if (flags & 0x2) != 0 {
-                return Err(BinaryReaderError::new(
-                    "64-bit memories cannot be shared",
-                    pos,
-                ));
-            }
-            Ok(MemoryType::M64 { limits })
+            let shared = (flags & 0x2) != 0;
+            Ok(MemoryType::M64 { limits, shared })
         }
     }
 

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -215,6 +215,7 @@ pub enum MemoryType {
     },
     M64 {
         limits: ResizableLimits64,
+        shared: bool,
     },
 }
 

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -484,10 +484,13 @@ impl Printer {
                     self.result.push_str(" shared");
                 }
             }
-            MemoryType::M64 { limits } => {
+            MemoryType::M64 { limits, shared } => {
                 write!(self.result, "i64 {}", limits.initial)?;
                 if let Some(max) = limits.maximum {
                     write!(self.result, " {}", max)?;
+                }
+                if *shared {
+                    self.result.push_str(" shared");
                 }
             }
         }

--- a/crates/wast/src/ast/types.rs
+++ b/crates/wast/src/ast/types.rs
@@ -389,6 +389,8 @@ pub enum MemoryType {
     B64 {
         /// Limits on the page sizes of this memory
         limits: Limits64,
+        /// Whether or not this is a shared (atomic) memory type
+        shared: bool,
     },
 }
 
@@ -397,7 +399,8 @@ impl<'a> Parse<'a> for MemoryType {
         if parser.peek::<kw::i64>() {
             parser.parse::<kw::i64>()?;
             let limits = parser.parse()?;
-            Ok(MemoryType::B64 { limits })
+            let shared = parser.parse::<Option<kw::shared>>()?.is_some();
+            Ok(MemoryType::B64 { limits, shared })
         } else {
             parser.parse::<Option<kw::i32>>()?;
             let limits = parser.parse()?;

--- a/crates/wast/src/binary.rs
+++ b/crates/wast/src/binary.rs
@@ -547,8 +547,10 @@ impl Encode for MemoryType {
                     max.encode(e);
                 }
             }
-            MemoryType::B64 { limits } => {
-                let flags = (limits.max.is_some() as u8) | 0x04;
+            MemoryType::B64 { limits, shared } => {
+                let flag_max = limits.max.is_some() as u8;
+                let flag_shared = *shared as u8;
+                let flags = flag_max | (flag_shared << 1) | 0x04;
                 e.push(flags);
                 limits.min.encode(e);
                 if let Some(max) = limits.max {

--- a/crates/wast/src/resolve/deinline_import_export.rs
+++ b/crates/wast/src/resolve/deinline_import_export.rs
@@ -77,6 +77,7 @@ pub fn run(fields: &mut Vec<ModuleField>) {
                                     min: u64::from(pages),
                                     max: Some(u64::from(pages)),
                                 },
+                                shared: false,
                             }
                         });
                         let data = match mem::replace(&mut m.kind, kind) {

--- a/tests/local/memory64.wast
+++ b/tests/local/memory64.wast
@@ -118,7 +118,7 @@
     i64.const 0 i32.const 0 i8x16.splat v128.store
   )
 
-  (data (i64.const 0) "..")
+  (data (i32.const 0) "..")
   (data $seg "..")
 )
 


### PR DESCRIPTION
Looks like wabt simd support has been updated so we can test its
reference output on more files. This entailed parsing the `shared` flag
for 64-bit memories with what I'm guessing is the desired encoding (same
for 32-bit memories).