### PR TITLE
wast: Add a cache for copying types from other modules

### DIFF
--- a/crates/wast/src/resolve/names.rs
+++ b/crates/wast/src/resolve/names.rs
@@ -64,6 +64,13 @@ pub struct Module<'a> {
     /// currently-being-processed field. This should always be empty after
     /// processing is complete.
     to_prepend: Vec<ModuleField<'a>>,
+
+    /// Cache for copying over types from other modules, used for module-linking
+    /// module types. The key of this map is the `(module_index, type_index)`
+    /// and the value is the copied over item into this module.
+    ///
+    /// This is used by the `copy_type_from_module` method.
+    type_cache: HashMap<(usize, Index<'a>), Item<'a>>,
 }
 
 enum InstanceDef<'a> {
@@ -694,8 +701,22 @@ impl<'a> Resolver<'a> {
         type_idx: &Index<'a>,
         switch_module_to_instance: bool,
     ) -> Result<Item<'a>, Error> {
+        // First check the cache to avoid doing this work multiple times if
+        // necessary. Note that we also don't do this in the
+        // `switch_module_to_instance` case which happens only in rare cases
+        // above anyway.
+        //
+        // This prevents us from recursively realizing we don't need to copy
+        // over types each time we are asked to copy a type. This short-circuit
+        // prevents an exponential blowup of runtime for deeply nested modules.
+        if !switch_module_to_instance {
+            if let Some(ret) = self.modules[self.cur].type_cache.get(&(child, *type_idx)) {
+                return Ok(ret.clone());
+            }
+        }
+
         let (ty, child) = self.type_for(child, type_idx)?;
-        match ty {
+        let item = match ty {
             TypeInfo::Func(key) => {
                 let key = key.clone();
                 let my_key = (
@@ -708,7 +729,7 @@ impl<'a> Resolver<'a> {
                         .map(|ty| self.copy_valtype_from_module(span, child, *ty))
                         .collect::<Result<Box<[_]>, Error>>()?,
                 );
-                Ok(Item::Func(self.modules[self.cur].key_to_idx(span, my_key)))
+                Item::Func(self.modules[self.cur].key_to_idx(span, my_key))
             }
 
             TypeInfo::Instance { key, .. } => {
@@ -720,9 +741,7 @@ impl<'a> Resolver<'a> {
                             .map(|x| (*name, x))
                     })
                     .collect::<Result<Vec<_>, Error>>()?;
-                Ok(Item::Instance(
-                    self.modules[self.cur].key_to_idx(span, my_key),
-                ))
+                Item::Instance(self.modules[self.cur].key_to_idx(span, my_key))
             }
 
             TypeInfo::Module { key, .. } => {
@@ -748,16 +767,20 @@ impl<'a> Resolver<'a> {
                             .map(|x| (*module, *field, x))
                     })
                     .collect::<Result<Vec<_>, Error>>()?;
-                Ok(Item::Module(
-                    self.modules[self.cur].key_to_idx(span, (imports, exports)),
-                ))
+                Item::Module(self.modules[self.cur].key_to_idx(span, (imports, exports)))
             }
 
-            TypeInfo::Other => Err(Error::new(
-                span,
-                format!("cannot copy reference types between modules right now"),
-            )),
-        }
+            TypeInfo::Other => {
+                return Err(Error::new(
+                    span,
+                    format!("cannot copy reference types between modules right now"),
+                ))
+            }
+        };
+        self.modules[self.cur]
+            .type_cache
+            .insert((child, *type_idx), item.clone());
+        Ok(item)
     }
 
     fn copy_reftype_from_module(

--- a/tests/local/module-linking/very-nested.wast
+++ b/tests/local/module-linking/very-nested.wast
@@ -1,0 +1,1565 @@
+(assert_invalid
+  (module $$esl
+    (module
+      (export "c t.*************")
+      (export "00AG")
+      (module
+        (export "c 3@EGG*****+*****e $$qq")
+      )
+      (module
+        (export "q**")
+        (export "00AGG554M******+*****e 4$qq")
+      )
+      (module
+        (export "q**")
+        (export "00AGGGGle $$qq")
+      )
+      (module
+        (export "q")
+      )
+      (module
+        (export "c 3@E*******************")
+        (import "01AGGGGle*$$qq")
+      )
+      (module
+        (export "c t.*************")
+        (export "00AG")
+        (module
+          (export "c 3@EGG*****+*****e $$qq")
+        )
+        (module
+          (export "q**")
+          (export "00AGGGGle $$qq")
+        )
+        (module
+          (export "q")
+        )
+        (module
+          (export "c 3@E*******************")
+          (import "00AGGGGle*$$qq")
+        )
+        (module
+          (export "c=t.*************")
+          (export "00AG")
+          (module
+            (export "c 3@EGGyGG$qq**")
+            (export "00AGGGGle $$qq")
+          )
+          (module
+            (export "q")
+          )
+          (module
+            (export "c 3@E*******************")
+            (import "00AGGGGl$$qq")
+          )
+          (module
+            (export "q")
+          )
+          (module
+            (export "c 3@E*******************")
+            (import "00AGGGGi64x2.splatle*$$qq")
+          )
+          (module
+            (export "c t.****0*********")
+            (export "00AG")
+            (module
+              (export "c 3@EGG*****+*****e $$qq")
+            )
+            (module
+              (export "q**")
+              (export "00AGGGGle $$qq")
+            )
+            (module
+              (export "q")
+            )
+            (module
+              (export "c 3@E*******************")
+              (import "00AGGGGle*$$qq")
+            )
+            (module
+              (export "c=t.*************")
+              (export "00AG")
+              (module
+                (export "c 3@EGGyGG$qq**")
+                (export "00AGGGGle $$qq")
+              )
+              (module
+                (export "q")
+              )
+              (module
+                (export "c 6Ǻ*******************")
+                (import "00AGGG^Glllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllle*$$qq")
+              )
+              (module
+                (export "c EGGyGG$qq**")
+                (export "15AGGG.Gle '$$qq")
+              )
+              (module
+                (export "q")
+              )
+              (module
+                (export "b 3@E*******************")
+                (import "00AGGGGle*$$qq")
+              )
+              (module
+                (export "c 0.*************")
+                (export "00AGGWGle A*$$qq")
+              )
+              (module)
+            )
+            (module
+              (export "q")
+            )
+            (module
+              (export "c 3@E*********GG$qq**")
+              (export "00AGGGGle $$qq")
+            )
+            (module
+              (export "q")
+            )
+            (module
+              (export "c 3@E************[******")
+              (import "00AGGGGle*$$qq")
+            )
+            (module
+              (export "c t.*************")
+              (export "00AGGGGle *$$qq")
+            )
+            (module)
+          )
+          (module
+            (export "q")
+          )
+          (module
+            (export "c 3@E$*************7777777777777777777777777777777777777777777MM~MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM777777777777777777777777777777777777777777*****")
+            (import "00e*$$qq")
+          )
+          (module
+            (export "c EGGyGG$qq**")
+            (export "0+AGGG.Gle $$qq")
+          )
+          (module
+            (export "q")
+          )
+          (module
+            (export "c 3@E*******************")
+            (import "00A$qq")
+          )
+          (module
+            (export "c t.*************")
+            (export "GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG00AGGGGle *$$qq")
+          )
+          (module)
+        )
+        (module
+          (export "q")
+        )
+        (module
+          (export "c 3@E*******************")
+          (import "15AG:GG!le*$$qq")
+        )
+        (module
+          (export "c t.*")
+          (module
+            (export "c 3@EGGGG$qq**")
+            (export "00AGGGGle*$$qq")
+          )
+          (module
+            (export "c t.********)*eleo &m Nx2GGGGle*$$qq")
+          )
+          (module
+            (export "c 1.*************")
+            (export "00AGGGGle A*$$qq")
+          )
+          (module)
+        )
+        (module
+          (export "q")
+        )
+        (module
+          (export "c Gle $$qq")
+        )
+        (module
+          (export "q")
+        )
+        (module
+          (export "c 3@E*******************")
+          (import "01AGGGGle*$$qq")
+        )
+        (module
+          (export "c t.*************")
+          (export "00AG")
+          (module
+            (export "c 3@EGG*****+*****e $$qq")
+          )
+          (module
+            (export "q**")
+            (export "00AGGGGle $$qq")
+          )
+          (module
+            (export "q")
+          )
+          (module
+            (export "c 3@E*******************")
+            (import "00AGGGGle*$$qq")
+          )
+          (module
+            (export "c=t.*************")
+            (export "00AG")
+            (module
+              (export "c 3@EGGyGG$qq**")
+              (export "00AGGGGle $$qq")
+            )
+            (module
+              (export "q")
+            )
+            (module
+              (export "c 3@E*******************")
+              (import "00AGGGGl$$qq")
+            )
+            (module
+              (export "q")
+            )
+            (module
+              (export "c 3@E*******************")
+              (import "00AGGGGle*$$qq")
+            )
+            (module
+              (export "c t.*************")
+              (export "0*************")
+              (import "00AGGGGle*$$qq")
+            )
+            (module
+              (export "c t.*************")
+              (export "00AG")
+              (module
+                (export "c 3@EGG*****+*****e $$qq")
+              )
+              (module
+                (export "q**")
+                (export "00AGG554M******+*****e 4$qq")
+              )
+              (module
+                (export "q**")
+                (export "00AGGGGle $$qq")
+              )
+              (module
+                (export "q")
+              )
+              (module
+                (export "c 3@E*******************")
+                (import "01AGGGGle*$$qq")
+              )
+              (module
+                (export "c t.*************")
+                (export "00AG")
+                (module
+                  (export "c 3@EGG*****+*****e $$qq")
+                )
+                (module
+                  (export "q**")
+                  (export "00AGGGGle $$qq")
+                )
+                (module
+                  (export "q")
+                )
+                (module
+                  (export "c 3@E*******************")
+                  (import "00AGGGGle*$$qq")
+                )
+                (module
+                  (export "c=t.*************")
+                  (export "00AG")
+                  (module
+                    (export "c 3@EGGyGG$qq**")
+                    (export "00AGGGGle $$qq")
+                  )
+                  (module
+                    (export "q")
+                  )
+                  (module
+                    (export "c 3@E*******************")
+                    (import "00AGGGGl$$qq")
+                  )
+                  (module
+                    (export "q")
+                  )
+                  (module
+                    (export "c 3@E*******************")
+                    (import "00AGGGGi64x2.splatle*$$qq")
+                  )
+                  (module
+                    (export "c t.****0*********")
+                    (export "00AG")
+                    (module
+                      (export "c 3@EGG*****+*****e $$qq")
+                    )
+                    (module
+                      (export "q**")
+                      (export "00AGGGGle $$qq")
+                    )
+                    (module
+                      (export "q")
+                    )
+                    (module
+                      (export "c 3@E*******************")
+                      (import "00AGGGGle*$$qq")
+                    )
+                    (module
+                      (export "c=t.*************")
+                      (export "00AG")
+                      (module
+                        (export "c 3@EGGyGG$qq**")
+                        (export "00AGGGGle $$qq")
+                      )
+                      (module
+                        (export "q")
+                      )
+                      (module
+                        (export "c 6Ǻ*******************")
+                        (import "00AGGG^Glllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllle*$$qq")
+                      )
+                      (module
+                        (export "c EGGyGG$qq**")
+                        (export "15AGGG.Gle '$$qq")
+                      )
+                      (module
+                        (export "q")
+                      )
+                      (module
+                        (export "b 3@E*******************")
+                        (import "00AGGGGle*$$qq")
+                      )
+                      (module
+                        (export "c 0.*************")
+                        (export "00AGGWGle A*$$qq")
+                      )
+                      (module)
+                    )
+                    (module
+                      (export "q")
+                    )
+                    (module
+                      (export "c 3@E*********GG$qq**")
+                      (export "00AGGGGle $$qq")
+                    )
+                    (module
+                      (export "q")
+                    )
+                    (module
+                      (export "c 3@E************[******")
+                      (import "00AGGGGle*$$qq")
+                    )
+                    (module
+                      (export "c t.*************")
+                      (export "00AGGGGle *$$qq")
+                    )
+                    (module)
+                  )
+                  (module
+                    (export "q")
+                  )
+                  (module
+                    (export "c 3@E$*************7777777777777777777777777777777777777777777MM~MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM777777777777777777777777777777777777777777*****")
+                    (import "00e*$$qq")
+                  )
+                  (module
+                    (export "c EGGyGG$qq**")
+                    (export "0+AGGG.Gle $$qq")
+                  )
+                  (module
+                    (export "q")
+                  )
+                  (module
+                    (export "c 3@E*******************")
+                    (import "00A$qq")
+                  )
+                  (module
+                    (export "c t.*************")
+                    (export "GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG00AGGGGle *$$qq")
+                  )
+                  (module)
+                )
+                (module
+                  (export "q")
+                )
+                (module
+                  (export "c 3@E*******************")
+                  (import "15AG:GG!le*$$qq")
+                )
+                (module
+                  (export "c .t*")
+                  (module
+                    (export "c 3@EGGGG$qq**")
+                    (export "00AGGGGle*$$qq")
+                  )
+                  (module
+                    (export "c t.********)*eleo &m Nx2GGGGle*$$qq")
+                  )
+                  (module
+                    (export "c 1.*************")
+                    (export "00AGGGGle A*$$qq")
+                  )
+                  (module)
+                )
+                (module
+                  (export "q")
+                )
+                (module
+                  (export "c Gle $$qq")
+                )
+                (module
+                  (export "q")
+                )
+                (module
+                  (export "c 3@E*******************")
+                  (import "01AGGGGle*$$qq")
+                )
+                (module
+                  (export "c t.*************")
+                  (export "00AG")
+                  (module
+                    (export "c 3@EGG*****+*****e $$qq")
+                  )
+                  (module
+                    (export "q**")
+                    (export "00AGGGGle $$qq")
+                  )
+                  (module
+                    (export "q")
+                  )
+                  (module
+                    (export "c 3@E*******************")
+                    (import "00AGGGGle*$$qq")
+                  )
+                  (module
+                    (export "c=t.*************")
+                    (export "00AG")
+                    (module
+                      (export "c 3@EGGyGG$qq**")
+                      (export "00AGGGGle $$qq")
+                    )
+                    (module
+                      (export "q")
+                    )
+                    (module
+                      (export "c 3@E*******************")
+                      (import "00AGGGGl$$qq")
+                    )
+                    (module
+                      (export "q")
+                    )
+                    (module
+                      (export "c 3@E*******************")
+                      (import "00AGGGGle*$$qq")
+                    )
+                    (module
+                      (export "c t.*************")
+                      (export "00AG")
+                      (module
+                        (export "c 3@EGG*****+*****e $$qq")
+                      )
+                      (module
+                        (export "q**")
+                        (export "00AGGGGle $$qq")
+                      )
+                      (module
+                        (export "q")
+                      )
+                      (module
+                        (export "c 3@E*******************")
+                        (import "00AGGGGle*$$qq")
+                      )
+                      (module
+                        (export "c=t.*************")
+                        (export "00AG")
+                        (module
+                          (export "c 3@EGGyGG$qq**")
+                          (export "00AGGGGle $$qq")
+                        )
+                        (module
+                          (export "q")
+                        )
+                        (module
+                          (export "c 6Ǻ*******************")
+                          (import "00AGGG^Glllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllle*$$qq")
+                        )
+                        (module
+                          (export "c EGGyGG$qq**")
+                          (export "00AGGG.Gle '$$qq")
+                        )
+                        (module
+                          (export "q")
+                        )
+                        (module
+                          (export "b 3@E*******************")
+                          (import "00AGGGGle*$$qq")
+                        )
+                        (module
+                          (export "c 0.*************")
+                          (export "00AGGWGle A*$$qq")
+                        )
+                        (module)
+                      )
+                      (module
+                        (export "q")
+                      )
+                      (module
+                        (export "c 3@E*********GG$qq**")
+                        (export "00AGGGGle $$qq")
+                      )
+                      (module
+                        (export "q")
+                      )
+                      (module
+                        (export "c 3@E************[******")
+                        (import "00AGGGGle*$$qq")
+                      )
+                      (module
+                        (export "c t.*************")
+                        (export "00AGGGGle *$$qq")
+                      )
+                      (module)
+                    )
+                    (module
+                      (export "q")
+                    )
+                    (module
+                      (export "c 6@E$*************7777777777777777777777777777777777777777777MM~MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM777777777777777777777777777777777777777777*****")
+                      (import "00e*$$qq")
+                    )
+                    (module
+                      (export "c EGGyGG$qq**")
+                      (export "00AGGG.Gle $$qq")
+                    )
+                    (module
+                      (export "q")
+                    )
+                    (module
+                      (export "c 3@E*******************")
+                      (import "00AGGGGle*$$qq")
+                    )
+                    (module
+                      (export "c *****")
+                      (export "00AG")
+                      (module
+                        (export "c 3@EGG*****+*****e $$qq")
+                      )
+                      (module
+                        (export "q**")
+                        (export "00AGG554M******+*****e 4$qq")
+                      )
+                      (module
+                        (export "q**")
+                        (export "00AGGGGle $$qq")
+                      )
+                      (module
+                        (export "q")
+                      )
+                      (module
+                        (export "c 3@E*******************")
+                        (import "01AGGGGle*$$qq")
+                      )
+                      (module
+                        (export "c t.*************")
+                        (export "00AG")
+                        (module
+                          (export "c 3@EGG*****+*****e $$qq")
+                        )
+                        (module
+                          (export "q**")
+                          (export "00AGGGGle $$qq")
+                        )
+                        (module
+                          (export "q")
+                        )
+                        (module
+                          (export "c 3@E*******************")
+                          (import "00AGGGGle*$$qq")
+                        )
+                        (module
+                          (export "c=t.*************")
+                          (export "00AG")
+                          (module
+                            (export "c 3@EGGyGG$qq**")
+                            (export "00AGGGGle $$qq")
+                          )
+                          (module
+                            (export "q")
+                          )
+                          (module
+                            (export "c 3@E*******************")
+                            (import "00AGGGGl$$qq")
+                          )
+                          (module
+                            (export "q")
+                          )
+                          (module
+                            (export "c 3@E*******************")
+                            (import "00AGGGGi64x2.splatle*$$qq")
+                          )
+                          (module
+                            (export "c t.****0*********")
+                            (export "00AG")
+                            (module
+                              (export "c 3@EGG*****+*****e $$qq")
+                            )
+                            (module
+                              (export "q**")
+                              (export "00AGGGGle $$qq")
+                            )
+                            (module
+                              (export "q")
+                            )
+                            (module
+                              (export "c 3@E*******************")
+                              (import "00AGGGGle*$$qq")
+                            )
+                            (module
+                              (export "c=t.*************")
+                              (export "00AG")
+                              (module
+                                (export "c 3@EGGyGG$qq**")
+                                (export "00AGGGGle $$qq")
+                              )
+                              (module
+                                (export "q")
+                              )
+                              (module
+                                (export "c 6Ǻ*******************")
+                                (import "00AGGG^Glllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllle*$$qq")
+                              )
+                              (module
+                                (export "c EGGyGG$qq**")
+                                (export "15AGGG.Gle '$$qq")
+                              )
+                              (module
+                                (export "q")
+                              )
+                              (module
+                                (export "b 3@E*******************")
+                                (import "00AGGGGle*$$qq")
+                              )
+                              (module
+                                (export "c 0.*************")
+                                (export "00AGGWGle A*$$qq")
+                              )
+                              (module)
+                            )
+                            (module
+                              (export "q")
+                            )
+                            (module
+                              (export "c 3@E*********GG$qq**")
+                              (export "00AGGGGle $$qq")
+                            )
+                            (module
+                              (export "q")
+                            )
+                            (module
+                              (export "c 3@E************[******")
+                              (import "00AGGGGle*$$qq")
+                            )
+                            (module
+                              (export "c t.*************")
+                              (export "00AGGGGle *$$qq")
+                            )
+                            (module)
+                          )
+                          (module
+                            (export "q")
+                          )
+                          (module
+                            (export "c 3@E$*************7777777777777777777777777777777777777777777MM~MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM777777777777777777777777777777777777777777*****")
+                            (import "00e*$$qq")
+                          )
+                          (module
+                            (export "c EGGyGG$qq**")
+                            (export "0+AGGG.Gle $$qq")
+                          )
+                          (module
+                            (export "q")
+                          )
+                          (module
+                            (export "c 3@E*******************")
+                            (import "00A$qq")
+                          )
+                          (module
+                            (export "c t.*************")
+                            (export "GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG00AGGGGle *$$qq")
+                          )
+                          (module)
+                        )
+                        (module
+                          (export "q")
+                        )
+                        (module
+                          (export "c 3@E*******************")
+                          (import "15AG:GG!le*$$qq")
+                        )
+                        (module
+                          (export "c t.*")
+                          (module
+                            (export "c 3@EGGGG$qq**")
+                            (export "00AGGGGle*$$qq")
+                          )
+                          (module
+                            (export "c t.********)*eleo &m Nx2GGGGle*$$qq")
+                          )
+                          (module
+                            (export "c 1.*************")
+                            (export "00AGGGGle A*$$qq")
+                          )
+                          (module)
+                        )
+                        (module
+                          (export "q")
+                        )
+                        (module
+                          (export "c Gle $$qq")
+                        )
+                        (module
+                          (export "q")
+                        )
+                        (module
+                          (export "c 3@E*******************")
+                          (import "01AGGGGle*$$qq")
+                        )
+                        (module
+                          (export "c t.*************")
+                          (export "00AG")
+                          (module
+                            (export "c 3@EGG*****+*****e $$qq")
+                          )
+                          (module
+                            (export "q**")
+                            (export "00AGGGGle $$qq")
+                          )
+                          (module
+                            (export "q")
+                          )
+                          (module
+                            (export "c 3@E*******************")
+                            (import "00AGGGGle*$$qq")
+                          )
+                          (module
+                            (export "c=t.*************")
+                            (export "00AG")
+                            (module
+                              (export "c 3@EGGyGG$qq**")
+                              (export "00AGGGGle $$qq")
+                            )
+                            (module
+                              (export "q")
+                            )
+                            (module
+                              (export "c 3@E*******************")
+                              (import "00AGGGGl$$qq")
+                            )
+                            (module
+                              (export "q")
+                            )
+                            (module
+                              (export "c 3@E*******************")
+                              (import "00AGGGGle*$$qq")
+                            )
+                            (module
+                              (export "c t.*************")
+                              (export "0*************")
+                              (import "00AGGGGle*$$qq")
+                            )
+                            (module
+                              (export "c t.*************")
+                              (export "00AG")
+                              (module
+                                (export "c 3@EGG*****+*****e $$qq")
+                              )
+                              (module
+                                (export "q**")
+                                (export "00AGG554M******+*****e 4$qq")
+                              )
+                              (module
+                                (export "q**")
+                                (export "00AGGGGle $$qq")
+                              )
+                              (module
+                                (export "q")
+                              )
+                              (module
+                                (export "c 3@E*******************")
+                                (import "01AGGGGle*$$qq")
+                              )
+                              (module
+                                (export "c t.*************")
+                                (export "00AG")
+                                (module
+                                  (export "c 3@EGG*****+*****e $$qq")
+                                )
+                                (module
+                                  (export "q**")
+                                  (export "00AGGGGle $$qq")
+                                )
+                                (module
+                                  (export "q")
+                                )
+                                (module
+                                  (export "c 3@E*******************")
+                                  (import "00AGGGGle*$$qq")
+                                )
+                                (module
+                                  (export "c=t.*************")
+                                  (export "00AG")
+                                  (module
+                                    (export "c 3@EGGyGG$qq**")
+                                    (export "00AGGGGle $$qq")
+                                  )
+                                  (module
+                                    (export "q")
+                                  )
+                                  (module
+                                    (export "c 3@E*******************")
+                                    (import "00AGGGGl$$qq")
+                                  )
+                                  (module
+                                    (export "q")
+                                  )
+                                  (module
+                                    (export "c 3@E*******************")
+                                    (import "00AGGGGi64x2.splatle*$$qq")
+                                  )
+                                  (module
+                                    (export "c t.****0*********")
+                                    (export "00AG")
+                                    (module
+                                      (export "c 3@EGG*****+*****e $$qq")
+                                    )
+                                    (module
+                                      (export "q**")
+                                      (export "00AGGGGle $$qq")
+                                    )
+                                    (module
+                                      (export "q")
+                                    )
+                                    (module
+                                      (export "c 3@E*******************")
+                                      (import "00AGGGGle*$$qq")
+                                    )
+                                    (module
+                                      (export "c=t.*************")
+                                      (export "00AG")
+                                      (module
+                                        (export "c 3@EGGyGG$qq**")
+                                        (export "00AGGGGle $$qq")
+                                      )
+                                      (module
+                                        (export "q")
+                                      )
+                                      (module
+                                        (export "c 6Ǻ*******************")
+                                        (import "00AGGG^Glllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllle*$$qq")
+                                      )
+                                      (module
+                                        (export "c EGGyGG$qq**")
+                                        (export "15AGGG.Gle '$$qq")
+                                      )
+                                      (module
+                                        (export "q")
+                                      )
+                                      (module
+                                        (export "b 3@E*******************")
+                                        (import "00AGGGGle*$$qq")
+                                      )
+                                      (module
+                                        (export "c 0.*************")
+                                        (export "00AGGWGle A*$$qq")
+                                      )
+                                      (module)
+                                    )
+                                    (module
+                                      (export "q")
+                                    )
+                                    (module
+                                      (export "c 3@E*********GG$qq**")
+                                      (export "00AGGGGle $$qq")
+                                    )
+                                    (module
+                                      (export "q")
+                                    )
+                                    (module
+                                      (export "c 3@E************[******")
+                                      (import "00AGGGGle*$$qq")
+                                    )
+                                    (module
+                                      (export "c t.*************")
+                                      (export "00AGGGGle *$$qq")
+                                    )
+                                    (module)
+                                  )
+                                  (module
+                                    (export "q")
+                                  )
+                                  (module
+                                    (export "c 3@E$*************7777777777777777777777777777777777777777777MM~MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM777777777777777777777777777777777777777777*****")
+                                    (import "00e*$$qq")
+                                  )
+                                  (module
+                                    (export "c EGGyGG$qq**")
+                                    (export "0+AGGG.Gle $$qq")
+                                  )
+                                  (module
+                                    (export "q")
+                                  )
+                                  (module
+                                    (export "c 3@E*******************")
+                                    (import "00A$qq")
+                                  )
+                                  (module
+                                    (export "c t.*************")
+                                    (export "GGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG00AGGGGle *$$qq")
+                                  )
+                                  (module)
+                                )
+                                (module
+                                  (export "q")
+                                )
+                                (module
+                                  (export "c 3@E*******************")
+                                  (import "15AG:GG!le*$$qq")
+                                )
+                                (module
+                                  (export "c .t*")
+                                  (module
+                                    (export "c 3@EGGGG$qq**")
+                                    (export "00AGGGGle*$$qq")
+                                  )
+                                  (module
+                                    (export "c t.********)*eleo &m Nx2GGGGle*$$qq")
+                                  )
+                                  (module
+                                    (export "c 1.*************")
+                                    (export "00AGGGGle A*$$qq")
+                                  )
+                                  (module)
+                                )
+                                (module
+                                  (export "q")
+                                )
+                                (module
+                                  (export "c Gle $$qq")
+                                )
+                                (module
+                                  (export "q")
+                                )
+                                (module
+                                  (export "c 3@E*******************")
+                                  (import "01AGGGGle*$$qq")
+                                )
+                                (module
+                                  (export "c t.*************")
+                                  (export "00AG")
+                                  (module
+                                    (export "c 3@EGG*****+*****e $$qq")
+                                  )
+                                  (module
+                                    (export "q**")
+                                    (export "00AGGGGle $$qq")
+                                  )
+                                  (module
+                                    (export "q")
+                                  )
+                                  (module
+                                    (export "c 3@E*******************")
+                                    (import "00AGGGGle*$$qq")
+                                  )
+                                  (module
+                                    (export "c=t.*************")
+                                    (export "00AG")
+                                    (module
+                                      (export "c 3@EGGyGG$qq**")
+                                      (export "00AGGGGle $$qq")
+                                    )
+                                    (module
+                                      (export "q")
+                                    )
+                                    (module
+                                      (export "c 3@E*******************")
+                                      (import "00AGGGGl$$qq")
+                                    )
+                                    (module
+                                      (export "q")
+                                    )
+                                    (module
+                                      (export "c 3@E*******************")
+                                      (import "00AGGGGle*$$qq")
+                                    )
+                                    (module
+                                      (export "c t.*************")
+                                      (export "00AG")
+                                      (module
+                                        (export "c 3@EGG*****+*****e $$qq")
+                                      )
+                                      (module
+                                        (export "q**")
+                                        (export "00AGGGGle $$qq")
+                                      )
+                                      (module
+                                        (export "q")
+                                      )
+                                      (module
+                                        (export "c 3@E*******************")
+                                        (import "00AGGGGle*$$qq")
+                                      )
+                                      (module
+                                        (export "c=t.*************")
+                                        (export "00AG")
+                                        (module
+                                          (export "c 3@EGGyGG$qq**")
+                                          (export "00AGGGGle $$qq")
+                                        )
+                                        (module
+                                          (export "q")
+                                        )
+                                        (module
+                                          (export "c 6Ǻ*******************")
+                                          (import "00AGGG^Glllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllle*$$qq")
+                                        )
+                                        (module
+                                          (export "c EGGyGG$qq**")
+                                          (export "00AGGG.Gle '$$qq")
+                                        )
+                                        (module
+                                          (export "q")
+                                        )
+                                        (module
+                                          (export "b 3@E*******************")
+                                          (import "00AGGGGle*$$qq")
+                                        )
+                                        (module
+                                          (export "c 0.*************")
+                                          (export "00AGGWGle A*$$qq")
+                                        )
+                                        (module)
+                                      )
+                                      (module
+                                        (export "q")
+                                      )
+                                      (module
+                                        (export "c 3@E*********GG$qq**")
+                                        (export "00AGGGGle $$qq")
+                                      )
+                                      (module
+                                        (export "q")
+                                      )
+                                      (module
+                                        (export "c 3@E************[******")
+                                        (import "00AGGGGle*$$qq")
+                                      )
+                                      (module
+                                        (export "c t.*************")
+                                        (export "00AGGGGle *$$qq")
+                                      )
+                                      (module)
+                                    )
+                                    (module
+                                      (export "q")
+                                    )
+                                    (module
+                                      (export "c 6@E$*************7777777777777777777777777777777777777777777MM~MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM777777777777777777777777777777777777777777*****")
+                                      (import "00e*$$qq")
+                                    )
+                                    (module
+                                      (export "c EGGyGG$qq**")
+                                      (export "00AGGG.Gle $$qq")
+                                    )
+                                    (module
+                                      (export "q")
+                                    )
+                                    (module
+                                      (export "c 3@E*******************")
+                                      (import "00AGGGGle*$$qq")
+                                    )
+                                    (module
+                                      (export "c 1.*************")
+                                      (export "00AGGGGle A*$$qq")
+                                    )
+                                    (module)
+                                  )
+                                  (module
+                                    (export "q")
+                                  )
+                                  (module
+                                    (export "c 4@E****\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*****GG$qq**")
+                                    (export "00AGGGGle $$qq")
+                                  )
+                                  (module
+                                    (export "q")
+                                  )
+                                  (module
+                                    (export "c 3@E*******************")
+                                    (import "00CGGGGle*$$qq")
+                                  )
+                                  (module
+                                    (export "c t.*************")
+                                    (export "00AGGGGle *$$qq")
+                                  )
+                                  (module)
+                                )
+                                (module
+                                  (export "q")
+                                )
+                                (module
+                                  (export "c 3@E*******77777777777777777777777777777777GG)le 0AGGGGle $$qq")
+                                )
+                                (module
+                                  (export "q")
+                                )
+                                (module
+                                  (export "c 3@E*******************")
+                                  (import "00CGGGGle*$$qq")
+                                )
+                                (module
+                                  (export "c t.*************")
+                                  (export "00AGGGGl4@E****\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*****GG$qq**")
+                                  (export "00AGGGGle $$qq")
+                                )
+                                (module
+                                  (export "q")
+                                )
+                                (module
+                                  (export "c 3@E*******************")
+                                  (import "00CGGGGle*$$qq")
+                                )
+                                (module
+                                  (export "c t.*************")
+                                  (export "00AGGGGle *$$qq")
+                                )
+                                (module)
+                              )
+                              (module
+                                (export "q")
+                              )
+                              (module
+                                (export "c 3@E*******77777777777777777777777777777777GG)le 0AGGGGle $$qq")
+                              )
+                              (module
+                                (export "q")
+                              )
+                              (module
+                                (export "c 3@E*******************")
+                                (import "00CGGGGle*$$qq")
+                              )
+                              (module
+                                (export "c t.*************")
+                                (export "00AGGGGle *$$qq")
+                              )
+                              (module)
+                            )
+                            (module
+                              (export "q")
+                            )
+                            (module
+                              (export "c 3@E***0AG")
+                              (module
+                                (export "c 3@EGG*****+*****e $$qq")
+                              )
+                              (module
+                                (export "q**")
+                                (export "00AGGGGle $$qq")
+                              )
+                              (module
+                                (export "q")
+                              )
+                              (module
+                                (export "c 3@E*******************")
+                                (import "00AGGGGle*$$qq")
+                              )
+                              (module
+                                (export "c=t.*************")
+                                (export "00AG")
+                                (module
+                                  (export "c 3@EGGyGG$qq**")
+                                  (export "00AGGGGle $$qq")
+                                )
+                                (module
+                                  (export "q")
+                                )
+                                (module
+                                  (export "c 6Ǻ*******************")
+                                  (import "00AGGG^Glllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllle*$$qq")
+                                )
+                                (module
+                                  (export "c EGGyGG$qq**")
+                                  (export "00AGGG.Gle '$$qq")
+                                )
+                                (module
+                                  (export "q")
+                                )
+                                (module
+                                  (export "b 3@E*******************")
+                                  (import "00AGGGGle*$$qq")
+                                )
+                                (module
+                                  (export "c 0.*************")
+                                  (export "00AGGWGle A*$$qq")
+                                )
+                                (module)
+                              )
+                              (module
+                                (export "q")
+                              )
+                              (module
+                                (export "c 3@E*********GG$qq**")
+                                (export "00AGGGGle $$qq")
+                              )
+                              (module
+                                (export "q")
+                              )
+                              (module
+                                (export "c 3@E************[******")
+                                (import "00AGGGGle*$$qq")
+                              )
+                              (module
+                                (export "c t.*************")
+                                (export "00AGGGGle *$$qq")
+                              )
+                              (module)
+                            )
+                            (module
+                              (export "q")
+                            )
+                            (module
+                              (export "c 6@E$*************7777777777777777777777777777777777777777777MM~MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM777777777777777777777777777777777777777777*****")
+                              (import "00e*$$qq")
+                            )
+                            (module
+                              (export "c EGGyGG$qq**")
+                              (export "00AGGG.Gle $$qq")
+                            )
+                            (module
+                              (export "q")
+                            )
+                            (module
+                              (export "c 3@E*******************")
+                              (import "00AGGGGle*$$qq")
+                            )
+                            (module
+                              (export "c 1.*************")
+                              (export "00AGGGGle A*$$qq")
+                            )
+                            (module)
+                          )
+                          (module
+                            (export "q")
+                          )
+                          (module
+                            (export "c 4@E****\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*****GG$qq**")
+                            (export "00AGGGGle $$qq")
+                          )
+                          (module
+                            (export "q")
+                          )
+                          (module
+                            (export "c 3@E*******************")
+                            (import "00CGGGGle*$$qq")
+                          )
+                          (module
+                            (export "c t.*************")
+                            (export "00AGGGGle *$$qq")
+                          )
+                          (module)
+                        )
+                        (module
+                          (export "q")
+                        )
+                        (module
+                          (export "c 3@E*******77777777777777777777777777777777GG)le 0AGGGGle $$qq")
+                        )
+                        (module
+                          (export "q")
+                        )
+                        (module
+                          (export "c 3@E*******************")
+                          (import "00CGGGGle*$$qq")
+                        )
+                        (module
+                          (export "c t.*************")
+                          (export "00AGGGGl4@E****\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*****GG$qq**")
+                          (export "00AGGGGle $$qq")
+                        )
+                        (module
+                          (export "q")
+                        )
+                        (module
+                          (export "c 3@E*******************")
+                          (import "00CGGGGle*$$qq")
+                        )
+                        (module
+                          (export "c t.*************")
+                          (export "00AGGGGle *$$qq")
+                        )
+                        (module)
+                      )
+                      (module
+                        (export "q")
+                      )
+                      (module
+                        (export "c 3@E*******77777777777777777777777777777777GG)le 0AGGGGle $$qq")
+                      )
+                      (module
+                        (export "q")
+                      )
+                      (module
+                        (export "c 3@E*******************")
+                        (import "00CGGGGle*$$qq")
+                      )
+                      (module
+                        (export "c t.*************")
+                        (export "00AGGGGle *$$qq")
+                      )
+                      (module)
+                    )
+                    (module
+                      (export "q")
+                    )
+                    (module
+                      (export "c 3@E**************777777777777777777777777777777777777777777777777777777777777771.*************")
+                      (export "00AGGGGle A*$$qq")
+                    )
+                    (module)
+                  )
+                  (module
+                    (export "q")
+                  )
+                  (module
+                    (export "c 4@E****\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*****GG$qq**")
+                    (export "00AGGGGle $$qq")
+                  )
+                  (module
+                    (export "q")
+                  )
+                  (module
+                    (export "c 3@E*******************")
+                    (import "00CGGGGle*$$qq")
+                  )
+                  (module
+                    (export "c t.*************")
+                    (export "00AGGGGle *$$qq")
+                  )
+                  (module)
+                )
+                (module
+                  (export "q")
+                )
+                (module
+                  (export "c 3@E*******77777777777777777777777777777777GG)le 0AGGGGle $$qq")
+                )
+                (module
+                  (export "q")
+                )
+                (module
+                  (export "c 3@E*******************")
+                  (import "00CGGGGle*$$qq")
+                )
+                (module
+                  (export "c t.*************")
+                  (export "00AGGGGl4@E****\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*****GG$qq**")
+                  (export "00AGGGGle $$qq")
+                )
+                (module
+                  (export "q")
+                )
+                (module
+                  (export "c 3@E*******************")
+                  (import "00CGGGGle*$$qq")
+                )
+                (module
+                  (export "c t.*************")
+                  (export "00AGGGGle *$$qq")
+                )
+                (module)
+              )
+              (module
+                (export "q")
+              )
+              (module
+                (export "c 3@E*******77777777777777777777777777777777GG)le 0AGGGGle $$qq")
+              )
+              (module
+                (export "q")
+              )
+              (module
+                (export "c 3@E*******************")
+                (import "00CGGGGle*$$qq")
+              )
+              (module
+                (export "c t.*************")
+                (export "00AGGGGle *$$qq")
+              )
+              (module)
+            )
+            (module
+              (export "q")
+            )
+            (module
+              (export "c 3@E***0AG")
+              (module
+                (export "c 3@EGG*****+*****e $$qq")
+              )
+              (module
+                (export "q**")
+                (export "00AGGGGle $$qq")
+              )
+              (module
+                (export "q")
+              )
+              (module
+                (export "c 3@E*******************")
+                (import "00AGGGGle*$$qq")
+              )
+              (module
+                (export "c=t.*************")
+                (export "00AG")
+                (module
+                  (export "c 3@EGGyGG$qq**")
+                  (export "00AGGGGle $$qq")
+                )
+                (module
+                  (export "q")
+                )
+                (module
+                  (export "c 6Ǻ*******************")
+                  (import "00AGGG^Glllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllle*$$qq")
+                )
+                (module
+                  (export "c EGGyGG$qq**")
+                  (export "00AGGG.Gle '$$qq")
+                )
+                (module
+                  (export "q")
+                )
+                (module
+                  (export "b 3@E*******************")
+                  (import "00AGGGGle*$$qq")
+                )
+                (module
+                  (export "c 0.*************")
+                  (export "00AGGWGle A*$$qq")
+                )
+                (module)
+              )
+              (module
+                (export "q")
+              )
+              (module
+                (export "c 3@E*********GG$qq**")
+                (export "00AGGGGle $$qq")
+              )
+              (module
+                (export "q")
+              )
+              (module
+                (export "c 3@E************[******")
+                (import "00AGGGGle*$$qq")
+              )
+              (module
+                (export "c t.*************")
+                (export "00AGGGGle *$$qq")
+              )
+              (module)
+            )
+            (module
+              (export "q")
+            )
+            (module
+              (export "c 6@E$*************7777777777777777777777777777777777777777777MM~MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM777777777777777777777777777777777777777777*****")
+              (import "00e*$$qq")
+            )
+            (module
+              (export "c EGGyGG$qq**")
+              (export "00AGGG.Gle $$qq")
+            )
+            (module
+              (export "q")
+            )
+            (module
+              (export "c 3@E*******************")
+              (import "00AGGGGle*$$qq")
+            )
+            (module
+              (export "c 1.*************")
+              (export "00AGGGGle A*$$qq")
+            )
+            (module)
+          )
+          (module
+            (export "q")
+          )
+          (module
+            (export "c 4@E****\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*****GG$qq**")
+            (export "00AGGGGle $$qq")
+          )
+          (module
+            (export "q")
+          )
+          (module
+            (export "c 3@E*******************")
+            (import "00CGGGGle*$$qq")
+          )
+          (module
+            (export "c t.*************")
+            (export "00AGGGGle *$$qq")
+          )
+          (module)
+        )
+        (module
+          (export "q")
+        )
+        (module
+          (export "c 3@E*******77777777777777777777777777777777GG)le 0AGGGGle $$qq")
+        )
+        (module
+          (export "q")
+        )
+        (module
+          (export "c 3@E*******************")
+          (import "00CGGGGle*$$qq")
+        )
+        (module
+          (export "c t.*************")
+          (export "00AGGGGl4@E****\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*****GG$qq**")
+          (export "00AGGGGle $$qq")
+        )
+        (module
+          (export "q")
+        )
+        (module
+          (export "c 3@E*******************")
+          (import "00CGGGGle*$$qq")
+        )
+        (module
+          (export "c t.*************")
+          (export "00AGGGGle *$$qq")
+        )
+        (module)
+      )
+      (module
+        (export "q")
+      )
+      (module
+        (export "c 3@E*******77777777777777777777777777777777GG)le 0AGGGGle $$qq")
+      )
+      (module
+        (export "q")
+      )
+      (module
+        (export "c 3@E*******************")
+        (import "00CGGGGle*$$qq")
+      )
+      (module
+        (export "c t.*************")
+        (export "00AGGGGle *$$qq")
+      )
+      (module)
+    )
+  )
+  "duplicate export name")


### PR DESCRIPTION
This should fix an exponential blowup in runtime for highly-nested
module-linking modules.

Closes #129