### PR TITLE
Improve handling of names in wasmprinter

### DIFF
--- a/tests/local/names.wast
+++ b/tests/local/names.wast
@@ -1,0 +1,22 @@
+(module (@name ""))
+(module (@name "a"))
+
+(module
+  (func $foo)
+  (func (@name "foo"))
+  (func $foo_1)
+)
+
+(module
+  (func
+    (local (@name "foo") i32)
+    (local $foo i32)
+    (local $foo_1 i32)
+  )
+)
+
+(module
+  (func (@name "")))
+
+(module
+  (func (local (@name "") i32)))

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -145,6 +145,11 @@ fn skip_test(test: &Path, contents: &[u8]) -> bool {
         return true;
     }
 
+    // FIXME(WebAssembly/wabt#1404) - wast2json infinite loops here on macos
+    if test.ends_with("annotations.wast") {
+        return true;
+    }
+
     if let Ok(contents) = str::from_utf8(contents) {
         // Skip tests that are supposed to fail
         if contents.contains(";; ERROR") {
@@ -266,6 +271,10 @@ impl TestState {
 
             // FIXME uses simd instrs not implemented in wabt yet.
             && !test.ends_with("local/simd.wat")
+
+            // FIXME wabt doesn't print conflict or empty names in the same way
+            // that we do.
+            && !test.ends_with("local/names.wast")
         {
             if let Some(expected) = self.wasm2wat(contents)? {
                 self.string_compare(&string, &expected)


### PR DESCRIPTION
This commit fixes a longstanding issue in `wasmprinter` where names
weren't necessarily printed well. Issues arose when the name section had
non-identifier characters (or were empty) or when the name section
names were duplicates of each other.

The fix here was to add more intelligent logic to `wasmprinter` to
ensure that non-printable names (or duplicates) use `@name` annotations
which allows us to pick an arbitrary name for the function which is a
valid identifier.