### PR TITLE
wasmparser: process_operator: Operator::Select: allow selection of V1…

### DIFF
--- a/crates/wasmparser/src/operators_validator.rs
+++ b/crates/wasmparser/src/operators_validator.rs
@@ -655,6 +655,10 @@ impl OperatorValidator {
                     | ty @ Some(Type::I64)
                     | ty @ Some(Type::F32)
                     | ty @ Some(Type::F64) => self.operands.push(ty),
+                    ty @ Some(Type::V128) => {
+                        self.check_simd_enabled()?;
+                        self.operands.push(ty)
+                    }
                     None => self.operands.push(None),
                     Some(_) => bail_op_err!("type mismatch: select only takes integral types"),
                 }

--- a/tests/local/select_v128.wat
+++ b/tests/local/select_v128.wat
@@ -1,0 +1,8 @@
+(module
+  (func (param v128 v128) (result v128)
+    local.get 0
+    local.get 1
+    i32.const 0
+    select
+  )
+)


### PR DESCRIPTION
…28-typed operands.