### PR TITLE
Support running tests without `wabt` installed.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,3 +101,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: cargo check --benches -p wasm-smith
+
+  # Make sure running tests without wabt is supported
+  test_no_wabt:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Install Rust (rustup)
+      run: rustup update stable --no-self-update && rustup default stable
+      shell: bash
+    - run: cargo test --all
+      env:
+        SKIP_WABT: 1


### PR DESCRIPTION
This commit adds support for running the test suite without the `wabt`
tools installed because they're largely optional for testing anyway. We
still run quite a few tests without them! This still requires an opt-in
to acknowledge that we're running fewer tests, but the error messages is
intended to convey that.