### PR TITLE
Fix incremental parse fuzz target with event section

### DIFF
--- a/fuzz/fuzz_targets/incremental-parse.rs
+++ b/fuzz/fuzz_targets/incremental-parse.rs
@@ -89,6 +89,7 @@ fuzz_target!(|data: Vec<Vec<u8>>| {
             (MemorySection(a), MemorySection(b)) => assert_eq!(a.range(), b.range()),
             (GlobalSection(a), GlobalSection(b)) => assert_eq!(a.range(), b.range()),
             (ExportSection(a), ExportSection(b)) => assert_eq!(a.range(), b.range()),
+            (EventSection(a), EventSection(b)) => assert_eq!(a.range(), b.range()),
             (StartSection { func: a, range: ar }, StartSection { func: b, range: br }) => {
                 assert_eq!(a, b);
                 assert_eq!(ar, br);


### PR DESCRIPTION
Unfortunately the usage of `match` here didn't auto-generate a
compile-time error for the new section that was added, but thankfully
oss-fuzz quickly found the mistake!