### PR TITLE
Fix a mismatch issue in nested wasm module validation

### DIFF
--- a/tests/local/module-linking/instantiate.wast
+++ b/tests/local/module-linking/instantiate.wast
@@ -255,3 +255,17 @@
     (instance (instantiate 0))
   )
   "unknown module")
+
+(module
+  (module $m
+    (module $sub (export "module")
+      (func $f (export "") (result i32)
+        i32.const 5))
+  )
+  (instance $a (instantiate $m))
+  (instance $b (instantiate $a.$sub))
+  (alias $b.$f (instance $b) (func 0))
+
+  (func (export "get") (result i32)
+    call $b.$f)
+)

--- a/tests/local/module-linking/nested-modules.wast
+++ b/tests/local/module-linking/nested-modules.wast
@@ -39,3 +39,16 @@
     )
   )
   "type mismatch")
+
+;; interleave module definitions with imports/aliases and ensure that we
+;; typecheck the module code section correctly
+(module
+  (module
+    (func (export "")))
+  (import "" (module))
+  (module
+    (func (export "") (result i32)
+      i32.const 5))
+  (import "" (instance (export "" (module))))
+  (alias (instance 0) (module 0))
+)


### PR DESCRIPTION
The code for validation the module code section was modeled after the
validation of the code section itself, but that included the flawed
assumption that the modules defined by the module code section always
came at the end of the module index space. Modules, unlike functions,
can have their definitions interleaved with imports and aliases, so the
definitions we find aren't guaranteed to define any sort of contiguous
range of modules.

The fix here is relatively simple, to just keep track of a second map of
when we reach the nth code definition it maps to the ith module in the
index space.