### PR TITLE
wasm-smith: add some additional configuration options.

### DIFF
--- a/crates/wasm-smith/src/code_builder.rs
+++ b/crates/wasm-smith/src/code_builder.rs
@@ -424,7 +424,7 @@ where
             options: Vec::with_capacity(NUM_OPTIONS),
             functions,
             mutable_globals,
-            num_memories: module.memories.len() as u32 + module.memory_imports(),
+            num_memories: module.total_memories,
             funcref_tables,
             table_tys,
             referenced_functions: referenced_functions.into_iter().collect(),
@@ -1059,7 +1059,7 @@ fn local_tee<C: Config>(
 
 #[inline]
 fn global_get_valid<C: Config>(module: &ConfiguredModule<C>, _: &mut CodeBuilder<C>) -> bool {
-    !module.globals.is_empty() || module.global_imports() > 0
+    module.total_globals > 0
 }
 
 fn global_get<C: Config>(
@@ -1067,7 +1067,7 @@ fn global_get<C: Config>(
     module: &ConfiguredModule<C>,
     builder: &mut CodeBuilder<C>,
 ) -> Result<Instruction> {
-    let n = module.globals.len() + module.global_imports() as usize;
+    let n = module.total_globals;
     debug_assert!(n > 0);
     let mut i = u.int_in_range(0..=n - 1)?;
     let mut global_idx = 0;

--- a/crates/wasm-smith/src/terminate.rs
+++ b/crates/wasm-smith/src/terminate.rs
@@ -30,7 +30,7 @@ where
     /// The index of the fuel global is returned, so that you may control how
     /// much fuel the module is given.
     pub fn ensure_termination(&mut self, default_fuel: u32) -> u32 {
-        let fuel_global = self.global_imports() + self.globals.len() as u32;
+        let fuel_global = self.total_globals;
         self.globals.push(Global {
             ty: GlobalType {
                 val_type: ValType::I32,


### PR DESCRIPTION
This PR adds some options to more tightly control the arbitrary Wasm
modules generated by `wasm-smith`. In particular, it adds minimums
alongside most of the maximums, so that we can require certain elements
to be present (e.g., a memory or at least one function); it allows the
user to omit start functions; and it allows for a limit to be placed on
maximum Wasm memory sizes, which is useful during fuzzing (to reduce
memory overhead).