### PR TITLE
Fix event lookup for validating throw/br_on_exn

### DIFF
--- a/crates/wasmparser/src/module_resources.rs
+++ b/crates/wasmparser/src/module_resources.rs
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-use crate::{FuncType, GlobalType, MemoryType, TableType, Type};
+use crate::{EventType, FuncType, GlobalType, MemoryType, TableType, Type};
 use std::ops::Range;
 
 /// Types that qualify as Wasm function types for validation purposes.
@@ -202,6 +202,8 @@ pub trait WasmModuleResources {
     fn table_at(&self, at: u32) -> Option<TableType>;
     /// Returns the linear memory at given index.
     fn memory_at(&self, at: u32) -> Option<MemoryType>;
+    /// Returns the event at given index.
+    fn event_at(&self, at: u32) -> Option<EventType>;
     /// Returns the global variable at given index.
     fn global_at(&self, at: u32) -> Option<GlobalType>;
     /// Returns the `FuncType` associated with the given type index.
@@ -231,6 +233,9 @@ where
     }
     fn memory_at(&self, at: u32) -> Option<MemoryType> {
         T::memory_at(self, at)
+    }
+    fn event_at(&self, at: u32) -> Option<EventType> {
+        T::event_at(self, at)
     }
     fn global_at(&self, at: u32) -> Option<GlobalType> {
         T::global_at(self, at)

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -1838,6 +1838,10 @@ impl WasmModuleResources for ValidatorResources {
         self.0.get_memory(self.0.def(at)).copied()
     }
 
+    fn event_at(&self, at: u32) -> Option<EventType> {
+        self.0.get_event(self.0.def(at)).copied()
+    }
+
     fn global_at(&self, at: u32) -> Option<GlobalType> {
         self.0.get_global(self.0.def(at)).map(|t| t.item)
     }

--- a/crates/wasmparser/src/validator/func.rs
+++ b/crates/wasmparser/src/validator/func.rs
@@ -130,6 +130,9 @@ mod tests {
         fn memory_at(&self, _at: u32) -> Option<crate::MemoryType> {
             todo!()
         }
+        fn event_at(&self, _at: u32) -> Option<crate::EventType> {
+            todo!()
+        }
         fn global_at(&self, _at: u32) -> Option<crate::GlobalType> {
             todo!()
         }

--- a/tests/local/exception-handling.wast
+++ b/tests/local/exception-handling.wast
@@ -27,3 +27,17 @@
     end
   )
 )
+
+(assert_invalid
+  (module
+    (type (func))
+    (func throw 0))
+  "unknown event: event index out of bounds")
+
+(assert_invalid
+  (module
+    (type (func))
+    (func (param exnref)
+      local.get 0
+      br_on_exn 0 0))
+  "unknown event: event index out of bounds")


### PR DESCRIPTION
This PR addresses issue #153, about event index lookup for `throw` and `br_on_exn`.

I was originally thinking of pushing this after PR #152, but this PR is a simpler patch so maybe better if this is merged before and then I can fix up #152 to merge cleanly with this change.