### PR TITLE
Check memory index in attomics operations

### DIFF
--- a/crates/wasmparser/src/operators_validator.rs
+++ b/crates/wasmparser/src/operators_validator.rs
@@ -418,10 +418,10 @@ impl OperatorValidator {
 
     fn check_shared_memarg_wo_align(
         &self,
-        _: MemoryImmediate,
+        memarg: MemoryImmediate,
         resources: impl WasmModuleResources,
     ) -> OperatorValidatorResult<Type> {
-        self.check_memory_index(0, resources)
+        self.check_memory_index(memarg.memory, resources)
     }
 
     fn check_simd_lane_index(&self, index: SIMDLaneIndex, max: u8) -> OperatorValidatorResult<()> {

--- a/tests/local/atomics.wast
+++ b/tests/local/atomics.wast
@@ -1,0 +1,25 @@
+(module
+  (func
+    atomic.fence)
+)
+
+(module
+  (memory 1)
+  (func (result i32)
+    i32.const 0
+    i32.const 0
+    memory.atomic.notify 0 offset=0
+  )
+)
+
+(assert_invalid
+  (module
+    (memory 1)
+    (func (result i32)
+      i32.const 0
+      i32.const 0
+      i64.const 0
+      memory.atomic.wait32 1 offset=0
+    )
+  )
+  "unknown memory 1")

--- a/tests/local/atomics.wat
+++ b/tests/local/atomics.wat
@@ -1,4 +1,0 @@
-(module
-  (func
-    atomic.fence)
-)


### PR DESCRIPTION
Removes hardcoded `0` for memory index in the `check_shared_memarg_wo_align`