### PR TITLE
Fail if non-funcref table used in call_indirect

### DIFF
--- a/crates/wasmparser/src/operators_validator.rs
+++ b/crates/wasmparser/src/operators_validator.rs
@@ -501,10 +501,19 @@ impl OperatorValidator {
         table_index: u32,
         resources: &impl WasmModuleResources,
     ) -> OperatorValidatorResult<()> {
-        if resources.table_at(table_index).is_none() {
-            return Err(OperatorValidatorError::new(
-                "unknown table: table index out of bounds",
-            ));
+        match resources.table_at(table_index) {
+            None => {
+                return Err(OperatorValidatorError::new(
+                    "unknown table: table index out of bounds",
+                ));
+            }
+            Some(tab) => {
+                if tab.element_type != Type::FuncRef {
+                    return Err(OperatorValidatorError::new(
+                        "indirect calls must go through a table of funcref",
+                    ));
+                }
+            }
         }
         let ty = func_type_at(&resources, index)?;
         self.pop_operand(Some(Type::I32))?;

--- a/tests/local/table-funcref.wast
+++ b/tests/local/table-funcref.wast
@@ -1,0 +1,11 @@
+(assert_malformed
+  (module
+    (type (func (result i32)))
+    (func $main (result i32)
+      i32.const 0
+      call_indirect (type 0)
+    )
+    (table (;0;) 1 externref)
+  )
+  "indirect calls must go through a table of funcref"
+)


### PR DESCRIPTION
Implementing check from https://webassembly.github.io/spec/core/valid/instructions.html#xref-syntax-instructions-syntax-instr-control-mathsf-call-indirect-x : "The element type elemtype must be 𝖿𝗎𝗇𝖼𝗋𝖾𝖿."