### PR TITLE
wasmparser version 0.69.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -956,7 +956,7 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "diff",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "27.0.0"
+version = "28.0.0"
 dependencies = [
  "anyhow",
  "leb128",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.28"
+version = "1.0.29"
 dependencies = [
  "wast",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.68.0"
+version = "0.69.0"
 dependencies = [
  "anyhow",
  "criterion",

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.68.0"
+version = "0.69.0"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser"

--- a/crates/wasmprinter/Cargo.toml
+++ b/crates/wasmprinter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmprinter"
-version = "0.2.15"
+version = "0.2.16"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasmprinter/Cargo.toml
+++ b/crates/wasmprinter/Cargo.toml
@@ -14,7 +14,7 @@ Rust converter from the WebAssembly binary format to the text format.
 
 [dependencies]
 anyhow = "1.0"
-wasmparser = { path = '../wasmparser', version = '0.68' }
+wasmparser = { path = '../wasmparser', version = '0.69' }
 
 [dev-dependencies]
 diff = "0.1"

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wast"
-version = "27.0.0"
+version = "28.0.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wat/Cargo.toml
+++ b/crates/wat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wat"
-version = "1.0.28"
+version = "1.0.29"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -13,4 +13,4 @@ Rust parser for the WebAssembly Text format, WAT
 """
 
 [dependencies]
-wast = { path = '../wast', version = '27.0.0' }
+wast = { path = '../wast', version = '28.0.0' }


### PR DESCRIPTION
API did not change much: just validation logic and linking stuff.