### PR TITLE
Fix aliasing parent items before they're defined 

### DIFF
--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -111,12 +111,12 @@ pub struct Validator {
     /// the last part of the module index space. Consequently we have a second
     /// map `module_code_section_definitions` here which is the same length as
     /// `expected_modules`. This is a map from position in the module code
-    /// section to index of the module we're defining. This index can then be
-    /// used to lookup in `module_type_indices` to determine what the expected
-    /// type of the module in the module code section is.
+    /// section to the size of the index/module spaces at the point of when the
+    /// corresponding module was declared. This enables us to validate the
+    /// submodule with a proper subset of the parent's index spaces.
     expected_modules: Option<u32>,
     module_code_section_index: usize,
-    module_code_section_definitions: Vec<usize>,
+    module_code_section_definitions: Vec<ModuleCodeDefinition>,
 
     /// If this validator is for a nested module then this keeps track of the
     /// type of the module that we're matching against. The `expected_type` is
@@ -146,7 +146,18 @@ struct ModuleState {
     module_type_indices: Vec<Def<u32>>,
     instance_type_indices: Vec<Def<InstanceDef>>,
     function_references: HashSet<u32>,
-    parent: Option<Arc<ModuleState>>,
+    parent: Option<Parent>,
+}
+
+struct Parent {
+    state: Arc<ModuleState>,
+    num_types: u32,
+    num_modules: u32,
+}
+
+struct ModuleCodeDefinition {
+    num_types: u32,
+    num_modules: u32,
 }
 
 /// Flags for features that are enabled for validation.
@@ -891,19 +902,28 @@ impl Validator {
                 }
             }
             AliasedInstance::Parent => {
-                let idx = match self.state.depth.checked_sub(1) {
-                    None => return self.create_error("no parent module to alias from"),
-                    Some(depth) => Def {
-                        depth,
-                        item: alias.index,
-                    },
+                let parent = match &self.state.parent {
+                    Some(parent) => parent,
+                    None => {
+                        return self.create_error("no parent module to alias from");
+                    }
+                };
+                let idx = Def {
+                    depth: self.state.depth - 1,
+                    item: alias.index,
                 };
                 match alias.kind {
                     ExternalKind::Module => {
+                        if alias.index >= parent.num_modules {
+                            return self.create_error("alias to module not defined in parent yet");
+                        }
                         let ty = self.get_module_type_index(idx)?;
                         self.state.assert_mut().module_type_indices.push(ty);
                     }
                     ExternalKind::Type => {
+                        if alias.index >= parent.num_types {
+                            return self.create_error("alias to type not defined in parent yet");
+                        }
                         // make sure this type actually exists, then push it as
                         // ourselve aliasing that type.
                         self.get_type(idx)?;
@@ -939,8 +959,13 @@ impl Validator {
             // Record which module index that we're defining in the module
             // section with the `module_code_section_definitions` list, and then
             // push the expected type onto our list of module types so far.
+            let num_types = me.state.types.len() as u32;
             let dst = &mut me.state.assert_mut().module_type_indices;
-            me.module_code_section_definitions.push(dst.len());
+            me.module_code_section_definitions
+                .push(ModuleCodeDefinition {
+                    num_types,
+                    num_modules: dst.len() as u32,
+                });
             dst.push(type_index);
             Ok(())
         })
@@ -1622,12 +1647,15 @@ impl Validator {
     pub fn module_code_section_entry<'a>(&mut self) -> Validator {
         let mut ret = Validator::default();
         ret.features = self.features.clone();
-        let module_type_index =
-            self.module_code_section_definitions[self.module_code_section_index];
-        ret.expected_type = Some(self.state.module_type_indices[module_type_index]);
+        let definition = &self.module_code_section_definitions[self.module_code_section_index];
+        ret.expected_type = Some(self.state.module_type_indices[definition.num_modules as usize]);
         self.module_code_section_index += 1;
         let state = ret.state.assert_mut();
-        state.parent = Some(self.state.arc().clone());
+        state.parent = Some(Parent {
+            state: self.state.arc().clone(),
+            num_modules: definition.num_modules,
+            num_types: definition.num_types,
+        });
         state.depth = self.state.depth + 1;
         return ret;
     }
@@ -1773,7 +1801,7 @@ impl ModuleState {
     ) -> Option<&'me T> {
         let mut cur = self;
         for _ in 0..(self.depth - idx.depth) {
-            cur = cur.parent.as_ref().unwrap();
+            cur = &cur.parent.as_ref().unwrap().state;
         }
         get_list(cur).get(idx.item as usize)
     }

--- a/tests/dump/bundled.wat.dump
+++ b/tests/dump/bundled.wat.dump
@@ -60,15 +60,15 @@
   0x00a3 | 66 04       | alias section
   0x00a5 | 01          | 1 count
   0x00a6 | 01 07 01    | [alias] Alias { instance: Parent, kind: Type, index: 1 }
-  0x00a9 | 01 04       | type section
+  0x00a9 | 02 0f       | import section
   0x00ab | 01          | 1 count
-  0x00ac | 60 00 00    | [type 1] Func(FuncType { params: [], returns: [] })
-  0x00af | 02 0f       | import section
-  0x00b1 | 01          | 1 count
-  0x00b2 | 09 77 61 73 | import [instance 0] Import { module: "wasi_file", field: None, ty: Instance(0) }
+  0x00ac | 09 77 61 73 | import [instance 0] Import { module: "wasi_file", field: None, ty: Instance(0) }
          | 69 5f 66 69
          | 6c 65 00 ff
          | 06 00      
+  0x00ba | 01 04       | type section
+  0x00bc | 01          | 1 count
+  0x00bd | 60 00 00    | [type 1] Func(FuncType { params: [], returns: [] })
   0x00c0 | 03 02       | func section
   0x00c2 | 01          | 1 count
   0x00c3 | 01          | [func 0] type 1
@@ -97,16 +97,16 @@
   0x00f5 | 66 04       | alias section
   0x00f7 | 01          | 1 count
   0x00f8 | 01 07 01    | [alias] Alias { instance: Parent, kind: Type, index: 1 }
-  0x00fb | 01 08       | type section
+  0x00fb | 02 0f       | import section
   0x00fd | 01          | 1 count
-  0x00fe | 60 03 7f 7f | [type 1] Func(FuncType { params: [I32, I32, I32], returns: [I32] })
-         | 7f 01 7f   
-  0x0105 | 02 0f       | import section
-  0x0107 | 01          | 1 count
-  0x0108 | 09 77 61 73 | import [instance 0] Import { module: "wasi_file", field: None, ty: Instance(0) }
+  0x00fe | 09 77 61 73 | import [instance 0] Import { module: "wasi_file", field: None, ty: Instance(0) }
          | 69 5f 66 69
          | 6c 65 00 ff
          | 06 00      
+  0x010c | 01 08       | type section
+  0x010e | 01          | 1 count
+  0x010f | 60 03 7f 7f | [type 1] Func(FuncType { params: [I32, I32, I32], returns: [I32] })
+         | 7f 01 7f   
   0x0116 | 03 03       | func section
   0x0118 | 02          | 2 count
   0x0119 | 01          | [func 0] type 1

--- a/tests/local/module-linking/alias.wast
+++ b/tests/local/module-linking/alias.wast
@@ -656,3 +656,20 @@
   (instance $i (instantiate $m))
   (alias (instance $i.$a) (func 0))
 )
+
+(assert_invalid
+  (module
+    (module
+      (alias parent (module 0))
+    )
+  )
+  "alias to module not defined in parent")
+(assert_invalid
+  (module
+    (type (module))
+    (module (type 0)
+      (alias parent (type $f))
+    )
+    (type $f (func))
+  )
+  "alias to type not defined in parent")


### PR DESCRIPTION


This commit fixes an issue in validating module linking nested modules
using `parent` alias annotations. The specification indicates that only
the items defined before a module are available for aliasing, but we
were accidentally validating with the entire parent's context available.
This adds a snapshot of the length of the type/module vectors whenever a
module is defined, and then we use that snapshot when validating parent
alias annotations to ensure they're in-bounds.

This also updates the encoding of `*.wat` modules where there's a hack
to sort all types first in a module, but we avoid doing that if we don't
actually need to elaborate any module types. This will preserve our
round-trip-ability and also makes it possible to write a textual test
for this issue.

