### PR TITLE
Use hex for the Debug output of Float32/Float64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,7 +935,7 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.69.0"
+version = "0.69.1"
 dependencies = [
  "anyhow",
  "criterion",

--- a/crates/wast/src/ast/token.rs
+++ b/crates/wast/src/ast/token.rs
@@ -331,10 +331,15 @@ macro_rules! float {
         name: $parse:ident,
     })*) => ($(
         /// A parsed floating-point type
-        #[derive(Debug)]
         pub struct $name {
             /// The raw bits that this floating point number represents.
             pub bits: $int,
+        }
+
+        impl fmt::Debug for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "{}(0x{:X})", stringify!($name), self.bits)
+            }
         }
 
         impl<'a> Parse<'a> for $name {
@@ -643,5 +648,14 @@ mod tests {
             super::strtof(&f!("1" . "00000100000000000" p "-50")),
             Some(0x26800000)
         );
+    }
+
+    #[test]
+    fn hex_debug_float() {
+        assert_eq!(
+            format!("{:?}", super::Float32 { bits: 0x00000042 }),
+            "Float32(0x42)"
+        );
+        assert_eq!(format!("{:?}", super::Float64 { bits: 0 }), "Float64(0x0)");
     }
 }


### PR DESCRIPTION
When visually comparing the output of failed assertions (e.g. "expected = ..., actual = ..."), it is much easier to compare float values as hex than their unsigned integer representation. Optimally we would use actual floats in the output but this is fraught since sometimes it is necessary to do a bit-by-bit comparison. Instead, a hex representation shows the bits and avoids a manual "decimal-to-hex" conversion.