### PR TITLE
Start implementing module-linking in wasm-smith

### DIFF
--- a/crates/wasm-encoder/src/types.rs
+++ b/crates/wasm-encoder/src/types.rs
@@ -56,6 +56,62 @@ impl TypeSection {
         self.num_added += 1;
         self
     }
+
+    /// Define a module type.
+    pub fn module<'a, I, E>(&mut self, imports: I, exports: E) -> &mut Self
+    where
+        I: IntoIterator<Item = (&'a str, Option<&'a str>, EntityType)>,
+        I::IntoIter: ExactSizeIterator,
+        E: IntoIterator<Item = (&'a str, EntityType)>,
+        E::IntoIter: ExactSizeIterator,
+    {
+        let exports = exports.into_iter();
+        let imports = imports.into_iter();
+
+        self.bytes.push(0x61);
+
+        self.bytes
+            .extend(encoders::u32(u32::try_from(imports.len()).unwrap()));
+        for (module, name, ty) in imports {
+            self.bytes.extend(encoders::str(module));
+            match name {
+                Some(name) => self.bytes.extend(encoders::str(name)),
+                None => self.bytes.extend(&[0x00, 0xff]),
+            }
+            ty.encode(&mut self.bytes);
+        }
+
+        self.bytes
+            .extend(encoders::u32(u32::try_from(exports.len()).unwrap()));
+        for (name, ty) in exports {
+            self.bytes.extend(encoders::str(name));
+            ty.encode(&mut self.bytes);
+        }
+
+        self.num_added += 1;
+        self
+    }
+
+    /// Define an instance type.
+    pub fn instance<'a, E>(&mut self, exports: E) -> &mut Self
+    where
+        E: IntoIterator<Item = (&'a str, EntityType)>,
+        E::IntoIter: ExactSizeIterator,
+    {
+        let exports = exports.into_iter();
+
+        self.bytes.push(0x62);
+
+        self.bytes
+            .extend(encoders::u32(u32::try_from(exports.len()).unwrap()));
+        for (name, ty) in exports {
+            self.bytes.extend(encoders::str(name));
+            ty.encode(&mut self.bytes);
+        }
+
+        self.num_added += 1;
+        self
+    }
 }
 
 impl Section for TypeSection {

--- a/crates/wasm-smith/src/config.rs
+++ b/crates/wasm-smith/src/config.rs
@@ -216,6 +216,13 @@ pub trait Config: Arbitrary + Default {
         false
     }
 
+    /// Determines whether the module linking proposal is enabled.
+    ///
+    /// Defaults to `false`.
+    fn module_linking_enabled(&self) -> bool {
+        true
+    }
+
     /// Determines whether a `start` export may be included. Defaults to `true`.
     fn allow_start_export(&self) -> bool {
         true
@@ -257,6 +264,7 @@ pub struct SwarmConfig {
     max_memory_pages: u32,
     bulk_memory_enabled: bool,
     reference_types_enabled: bool,
+    module_linking_enabled: bool,
 }
 
 impl Arbitrary for SwarmConfig {
@@ -282,6 +290,7 @@ impl Arbitrary for SwarmConfig {
             min_uleb_size: u.int_in_range(0..=5)?,
             bulk_memory_enabled: u.arbitrary()?,
             reference_types_enabled,
+            module_linking_enabled: u.arbitrary()?,
         })
     }
 }
@@ -345,5 +354,9 @@ impl Config for SwarmConfig {
 
     fn reference_types_enabled(&self) -> bool {
         self.reference_types_enabled
+    }
+
+    fn module_linking_enabled(&self) -> bool {
+        self.module_linking_enabled
     }
 }

--- a/crates/wasm-smith/src/encode.rs
+++ b/crates/wasm-smith/src/encode.rs
@@ -32,10 +32,10 @@ where
     }
 
     fn encode_initializers(&self, module: &mut wasm_encoder::Module) {
-        for init in self.initializers.iter() {
+        for init in self.initial_sections.iter() {
             match init {
-                Initializers::Types(types) => self.encode_types(module, types),
-                Initializers::Imports(imports) => self.encode_imports(module, imports),
+                InitialSection::Type(types) => self.encode_types(module, types),
+                InitialSection::Import(imports) => self.encode_imports(module, imports),
             }
         }
     }

--- a/crates/wasm-smith/src/encode.rs
+++ b/crates/wasm-smith/src/encode.rs
@@ -16,8 +16,7 @@ where
     pub fn to_bytes(&self) -> Vec<u8> {
         let mut module = wasm_encoder::Module::new();
 
-        self.encode_types(&mut module);
-        self.encode_imports(&mut module);
+        self.encode_initializers(&mut module);
         self.encode_funcs(&mut module);
         self.encode_tables(&mut module);
         self.encode_memories(&mut module);
@@ -32,38 +31,57 @@ where
         module.finish()
     }
 
-    fn encode_types(&self, module: &mut wasm_encoder::Module) {
-        if self.types.is_empty() {
-            return;
+    fn encode_initializers(&self, module: &mut wasm_encoder::Module) {
+        for init in self.initializers.iter() {
+            match init {
+                Initializers::Types(types) => self.encode_types(module, types),
+                Initializers::Imports(imports) => self.encode_imports(module, imports),
+            }
         }
-        let mut types = wasm_encoder::TypeSection::new();
-        for ty in &self.types {
-            types.function(
-                ty.params.iter().map(|t| translate_val_type(*t)),
-                ty.results.iter().map(|t| translate_val_type(*t)),
-            );
-        }
-        module.section(&types);
     }
 
-    fn encode_imports(&self, module: &mut wasm_encoder::Module) {
-        if self.imports.is_empty() {
-            return;
+    fn encode_types(&self, module: &mut wasm_encoder::Module, types: &[Type]) {
+        let mut section = wasm_encoder::TypeSection::new();
+        for ty in types {
+            match ty {
+                Type::Func(ty) => {
+                    section.function(
+                        ty.params.iter().map(|t| translate_val_type(*t)),
+                        ty.results.iter().map(|t| translate_val_type(*t)),
+                    );
+                }
+                Type::Module(ty) => {
+                    section.module(
+                        ty.imports.iter().map(|(module, name, ty)| {
+                            (module.as_str(), name.as_deref(), translate_entity_type(ty))
+                        }),
+                        ty.exports
+                            .iter()
+                            .map(|(name, ty)| (name.as_str(), translate_entity_type(ty))),
+                    );
+                }
+                Type::Instance(ty) => {
+                    section.instance(
+                        ty.exports
+                            .iter()
+                            .map(|(name, ty)| (name.as_str(), translate_entity_type(ty))),
+                    );
+                }
+            }
         }
-        let mut imports = wasm_encoder::ImportSection::new();
-        for (module, name, imp) in &self.imports {
-            imports.import(
-                module,
-                name,
-                match imp {
-                    Import::Func(f) => wasm_encoder::ImportType::Function(*f),
-                    Import::Table(ty) => translate_table_type(ty).into(),
-                    Import::Memory(m) => translate_memory_type(m).into(),
-                    Import::Global(g) => translate_global_type(g).into(),
-                },
-            );
+        module.section(&section);
+    }
+
+    fn encode_imports(
+        &self,
+        module: &mut wasm_encoder::Module,
+        imports: &[(String, Option<String>, EntityType)],
+    ) {
+        let mut section = wasm_encoder::ImportSection::new();
+        for (module, name, ty) in imports {
+            section.import(module, name.as_deref(), translate_entity_type(ty));
         }
-        module.section(&imports);
+        module.section(&section);
     }
 
     fn encode_funcs(&self, module: &mut wasm_encoder::Module) {
@@ -243,6 +261,17 @@ fn translate_val_type(ty: ValType) -> wasm_encoder::ValType {
         ValType::F64 => wasm_encoder::ValType::F64,
         ValType::FuncRef => wasm_encoder::ValType::FuncRef,
         ValType::ExternRef => wasm_encoder::ValType::ExternRef,
+    }
+}
+
+fn translate_entity_type(ty: &EntityType) -> wasm_encoder::EntityType {
+    match ty {
+        EntityType::Func(f) => wasm_encoder::EntityType::Function(*f),
+        EntityType::Instance(i) => wasm_encoder::EntityType::Instance(*i),
+        EntityType::Module(i) => wasm_encoder::EntityType::Module(*i),
+        EntityType::Table(ty) => translate_table_type(ty).into(),
+        EntityType::Memory(m) => translate_memory_type(m).into(),
+        EntityType::Global(g) => translate_global_type(g).into(),
     }
 }
 

--- a/crates/wasm-smith/tests/tests.rs
+++ b/crates/wasm-smith/tests/tests.rs
@@ -3,6 +3,17 @@ use rand::{rngs::SmallRng, RngCore, SeedableRng};
 use wasm_smith::{ConfiguredModule, Module, SwarmConfig};
 use wasmparser::{Validator, WasmFeatures};
 
+fn wasm_features() -> WasmFeatures {
+    WasmFeatures {
+        multi_value: true,
+        multi_memory: true,
+        bulk_memory: true,
+        reference_types: true,
+        module_linking: true,
+        ..WasmFeatures::default()
+    }
+}
+
 #[test]
 fn smoke_test_module() {
     let mut rng = SmallRng::seed_from_u64(0);
@@ -14,14 +25,7 @@ fn smoke_test_module() {
             let wasm_bytes = module.to_bytes();
 
             let mut validator = Validator::new();
-            validator.wasm_features(WasmFeatures {
-                multi_value: true,
-                multi_memory: true,
-                bulk_memory: true,
-                reference_types: true,
-                ..WasmFeatures::default()
-            });
-
+            validator.wasm_features(wasm_features());
             assert!(validator.validate_all(&wasm_bytes).is_ok());
         }
     }
@@ -39,14 +43,7 @@ fn smoke_test_ensure_termination() {
             let wasm_bytes = module.to_bytes();
 
             let mut validator = Validator::new();
-            validator.wasm_features(WasmFeatures {
-                multi_value: true,
-                multi_memory: true,
-                bulk_memory: true,
-                reference_types: true,
-                ..WasmFeatures::default()
-            });
-
+            validator.wasm_features(wasm_features());
             assert!(validator.validate_all(&wasm_bytes).is_ok());
         }
     }
@@ -63,14 +60,7 @@ fn smoke_test_swarm_config() {
             let wasm_bytes = module.to_bytes();
 
             let mut validator = Validator::new();
-            validator.wasm_features(WasmFeatures {
-                multi_value: true,
-                multi_memory: true,
-                bulk_memory: true,
-                reference_types: true,
-                ..WasmFeatures::default()
-            });
-
+            validator.wasm_features(wasm_features());
             assert!(validator.validate_all(&wasm_bytes).is_ok());
         }
     }

--- a/fuzz/fuzz_targets/validate-valid-module.rs
+++ b/fuzz/fuzz_targets/validate-valid-module.rs
@@ -17,6 +17,7 @@ fuzz_target!(|m: ConfiguredModule<SwarmConfig>| {
         multi_memory: true,
         bulk_memory: true,
         reference_types: true,
+        module_linking: true,
         ..wasmparser::WasmFeatures::default()
     });
     if let Err(e) = validator.validate_all(&bytes) {


### PR DESCRIPTION
This commit starts generating module-linking-using modules in the
`wasm-smith` module generator. It's going to take some time to implement
everything so I figured it's best to do it piecemeal. First up in this
commit is the type section, which includes generation of module and
instance types. This also applied a few internal refactorings:

* The type/import sections may be generated in an interleaved fashion
  now with module linking.
* Lookups in the `types` array are now indirected through other arrays
  that record type indices of a specific kind.
* Iterators over types/imports are now indirected through side arrays
  which index into `initializers`.

Further refactorings will be necessary to account for adjustments in
the index spaces as aliases are introduced, but this seemed like a good
start!