### PR TITLE
Add initial support for fuzzing the `alias` section

### DIFF
--- a/crates/wasm-encoder/src/aliases.rs
+++ b/crates/wasm-encoder/src/aliases.rs
@@ -1,0 +1,63 @@
+use super::*;
+
+/// An encoder for the alias section.
+pub struct AliasSection {
+    bytes: Vec<u8>,
+    num_added: u32,
+}
+
+impl AliasSection {
+    /// Construct a new alias section encoder.
+    pub fn new() -> AliasSection {
+        AliasSection {
+            bytes: vec![],
+            num_added: 0,
+        }
+    }
+
+    /// Define an alias that references the export of a defined instance.
+    pub fn instance_export(&mut self, instance: u32, export: crate::Export) -> &mut Self {
+        self.bytes.push(0x00);
+        self.bytes.extend(encoders::u32(instance));
+        export.encode(&mut self.bytes);
+        self.num_added += 1;
+        self
+    }
+
+    /// Define an alias that references a parent's type.
+    pub fn parent_type(&mut self, ty: u32) -> &mut Self {
+        self.bytes.push(0x01);
+        self.bytes.push(0x07);
+        self.bytes.extend(encoders::u32(ty));
+        self.num_added += 1;
+        self
+    }
+
+    /// Define an alias that references a parent's module.
+    pub fn parent_module(&mut self, module: u32) -> &mut Self {
+        self.bytes.push(0x01);
+        self.bytes.push(0x05);
+        self.bytes.extend(encoders::u32(module));
+        self.num_added += 1;
+        self
+    }
+}
+
+impl Section for AliasSection {
+    fn id(&self) -> u8 {
+        SectionId::Alias.into()
+    }
+
+    fn encode<S>(&self, sink: &mut S)
+    where
+        S: Extend<u8>,
+    {
+        let num_added = encoders::u32(self.num_added);
+        let n = num_added.len();
+        sink.extend(
+            encoders::u32(u32::try_from(n + self.bytes.len()).unwrap())
+                .chain(num_added)
+                .chain(self.bytes.iter().copied()),
+        );
+    }
+}

--- a/crates/wasm-encoder/src/aliases.rs
+++ b/crates/wasm-encoder/src/aliases.rs
@@ -1,6 +1,26 @@
 use super::*;
 
 /// An encoder for the alias section.
+///
+/// Note that this is part of the [module linking proposal][proposal] and is not
+/// currently part of stable WebAssembly.
+///
+/// [proposal]: https://github.com/webassembly/module-linking
+///
+/// # Example
+///
+/// ```
+/// use wasm_encoder::{Module, AliasSection, Export};
+///
+/// let mut aliases = AliasSection::new();
+/// aliases.parent_type(2);
+/// aliases.instance_export(0, Export::Function(1));
+///
+/// let mut module = Module::new();
+/// module.section(&aliases);
+///
+/// let wasm_bytes = module.finish();
+/// ```
 pub struct AliasSection {
     bytes: Vec<u8>,
     num_added: u32,

--- a/crates/wasm-encoder/src/exports.rs
+++ b/crates/wasm-encoder/src/exports.rs
@@ -81,8 +81,18 @@ pub enum Export {
     /// An export of the `n`th global.
     Global(u32),
     /// An export of the `n`th instance.
+    ///
+    /// Note that this is part of the [module linking proposal][proposal] and is
+    /// not currently part of stable WebAssembly.
+    ///
+    /// [proposal]: https://github.com/webassembly/module-linking
     Instance(u32),
     /// An export of the `n`th module.
+    ///
+    /// Note that this is part of the [module linking proposal][proposal] and is
+    /// not currently part of stable WebAssembly.
+    ///
+    /// [proposal]: https://github.com/webassembly/module-linking
     Module(u32),
 }
 

--- a/crates/wasm-encoder/src/exports.rs
+++ b/crates/wasm-encoder/src/exports.rs
@@ -80,10 +80,14 @@ pub enum Export {
     Memory(u32),
     /// An export of the `n`th global.
     Global(u32),
+    /// An export of the `n`th instance.
+    Instance(u32),
+    /// An export of the `n`th module.
+    Module(u32),
 }
 
 impl Export {
-    fn encode(&self, bytes: &mut Vec<u8>) {
+    pub(crate) fn encode(&self, bytes: &mut Vec<u8>) {
         match *self {
             Export::Function(x) => {
                 bytes.push(0x00);
@@ -99,6 +103,14 @@ impl Export {
             }
             Export::Global(x) => {
                 bytes.push(0x03);
+                bytes.extend(encoders::u32(x));
+            }
+            Export::Module(x) => {
+                bytes.push(0x05);
+                bytes.extend(encoders::u32(x));
+            }
+            Export::Instance(x) => {
+                bytes.push(0x06);
                 bytes.extend(encoders::u32(x));
             }
         }

--- a/crates/wasm-encoder/src/lib.rs
+++ b/crates/wasm-encoder/src/lib.rs
@@ -70,6 +70,7 @@
 
 #![deny(missing_docs)]
 
+mod aliases;
 mod code;
 mod custom;
 mod data;
@@ -83,6 +84,7 @@ mod start;
 mod tables;
 mod types;
 
+pub use aliases::*;
 pub use code::*;
 pub use custom::*;
 pub use data::*;
@@ -209,6 +211,7 @@ pub enum SectionId {
     Code = 10,
     Data = 11,
     DataCount = 12,
+    Alias = 16,
 }
 
 impl From<SectionId> for u8 {

--- a/crates/wasm-smith/src/config.rs
+++ b/crates/wasm-smith/src/config.rs
@@ -134,7 +134,7 @@ pub trait Config: Arbitrary + Default {
     ///
     /// Note that more than one memory is in the realm of the multi-memory wasm
     /// proposal.
-    fn max_memories(&self) -> u32 {
+    fn max_memories(&self) -> usize {
         1
     }
 
@@ -149,7 +149,7 @@ pub trait Config: Arbitrary + Default {
     ///
     /// Note that more than one table is in the realm of the reference types
     /// proposal.
-    fn max_tables(&self) -> u32 {
+    fn max_tables(&self) -> usize {
         1
     }
 
@@ -163,6 +163,22 @@ pub trait Config: Arbitrary + Default {
     /// to `false`.
     fn memory_max_size_required(&self) -> bool {
         false
+    }
+
+    /// The maximum number of instances to use. Defaults to 10. This includes
+    /// imported instances.
+    ///
+    /// Note that this is irrelevaant unless module linking is enabled.
+    fn max_instances(&self) -> usize {
+        10
+    }
+
+    /// The maximum number of modules to use. Defaults to 10. This includes
+    /// imported modules.
+    ///
+    /// Note that this is irrelevaant unless module linking is enabled.
+    fn max_modules(&self) -> usize {
+        10
     }
 
     /// Control the probability of generating memory offsets that are in bounds
@@ -220,7 +236,7 @@ pub trait Config: Arbitrary + Default {
     ///
     /// Defaults to `false`.
     fn module_linking_enabled(&self) -> bool {
-        true
+        false
     }
 
     /// Determines whether a `start` export may be included. Defaults to `true`.
@@ -258,9 +274,9 @@ pub struct SwarmConfig {
     max_elements: usize,
     max_data_segments: usize,
     max_instructions: usize,
-    max_memories: u32,
+    max_memories: usize,
     min_uleb_size: u8,
-    max_tables: u32,
+    max_tables: usize,
     max_memory_pages: u32,
     bulk_memory_enabled: bool,
     reference_types_enabled: bool,
@@ -332,11 +348,11 @@ impl Config for SwarmConfig {
         self.max_instructions
     }
 
-    fn max_memories(&self) -> u32 {
+    fn max_memories(&self) -> usize {
         self.max_memories
     }
 
-    fn max_tables(&self) -> u32 {
+    fn max_tables(&self) -> usize {
         self.max_tables
     }
 

--- a/crates/wasm-smith/src/config.rs
+++ b/crates/wasm-smith/src/config.rs
@@ -243,6 +243,11 @@ pub trait Config: Arbitrary + Default {
     fn allow_start_export(&self) -> bool {
         true
     }
+
+    /// Returns the maximal size of the `alias` section.
+    fn max_aliases(&self) -> usize {
+        1_000
+    }
 }
 
 /// The default configuration.
@@ -281,6 +286,7 @@ pub struct SwarmConfig {
     bulk_memory_enabled: bool,
     reference_types_enabled: bool,
     module_linking_enabled: bool,
+    max_aliases: usize,
 }
 
 impl Arbitrary for SwarmConfig {
@@ -307,6 +313,7 @@ impl Arbitrary for SwarmConfig {
             bulk_memory_enabled: u.arbitrary()?,
             reference_types_enabled,
             module_linking_enabled: u.arbitrary()?,
+            max_aliases: u.int_in_range(0..=MAX_MAXIMUM)?,
         })
     }
 }
@@ -374,5 +381,9 @@ impl Config for SwarmConfig {
 
     fn module_linking_enabled(&self) -> bool {
         self.module_linking_enabled
+    }
+
+    fn max_aliases(&self) -> usize {
+        self.max_aliases
     }
 }

--- a/crates/wasm-smith/src/terminate.rs
+++ b/crates/wasm-smith/src/terminate.rs
@@ -30,14 +30,13 @@ where
     /// The index of the fuel global is returned, so that you may control how
     /// much fuel the module is given.
     pub fn ensure_termination(&mut self, default_fuel: u32) -> u32 {
-        let fuel_global = self.total_globals;
-        self.globals.push(Global {
-            ty: GlobalType {
-                val_type: ValType::I32,
-                mutable: true,
-            },
-            expr: Instruction::I32Const(default_fuel as i32),
+        let fuel_global = self.globals.len() as u32;
+        self.globals.push(GlobalType {
+            val_type: ValType::I32,
+            mutable: true,
         });
+        self.defined_globals
+            .push((fuel_global, Instruction::I32Const(default_fuel as i32)));
 
         for code in &mut self.code {
             let check_fuel = |insts: &mut Vec<Instruction>| {


### PR DESCRIPTION
This commit adds the bare-bones support o `wasm-smith` to fuzz the
alias section of a module-linking-using module. This enables the fuzzer
to generate `alias` annotations referencing instances and pull more
items into the index space.

The main bulk of this commit is refactoring the internals of `Module` to
keep track in tables the types of all items, regardless of where they
came from. This simplifies some bits and pieces here and there and
obviates a few now no-longer-necessary caches. After the refactoring a
new `AvailableAliases` type was added to keep track of alias candidates
over time which are filtered as soon as a module's maximum requirements
are met.