### PR TITLE
Add support for fuzzing the module/module code section

### DIFF
--- a/crates/wasm-encoder/src/lib.rs
+++ b/crates/wasm-encoder/src/lib.rs
@@ -81,6 +81,8 @@ mod globals;
 mod imports;
 mod instances;
 mod memories;
+mod module_code;
+mod modules;
 mod start;
 mod tables;
 mod types;
@@ -96,6 +98,8 @@ pub use globals::*;
 pub use imports::*;
 pub use instances::*;
 pub use memories::*;
+pub use module_code::*;
+pub use modules::*;
 pub use start::*;
 pub use tables::*;
 pub use types::*;
@@ -213,8 +217,10 @@ pub enum SectionId {
     Code = 10,
     Data = 11,
     DataCount = 12,
+    Module = 14,
     Instance = 15,
     Alias = 16,
+    ModuleCode = 17,
 }
 
 impl From<SectionId> for u8 {

--- a/crates/wasm-encoder/src/module_code.rs
+++ b/crates/wasm-encoder/src/module_code.rs
@@ -1,0 +1,78 @@
+use super::*;
+
+/// An encoder for the module code section.
+///
+/// Note that this is part of the [module linking proposal][proposal] and is
+/// not currently part of stable WebAssembly.
+///
+/// [proposal]: https://github.com/webassembly/module-linking
+///
+/// # Example
+///
+/// ```
+/// use wasm_encoder::{
+///     ModuleCodeSection, Function, ModuleSection, Instruction, Module,
+///     TypeSection, ValType
+/// };
+///
+/// let mut types = TypeSection::new();
+/// types.module(vec![], vec![]);
+///
+/// let mut modules = ModuleSection::new();
+/// let type_index = 0;
+/// modules.module(type_index);
+///
+/// let mut module_code = ModuleCodeSection::new();
+/// module_code.module(&Module::new());
+///
+/// let mut module = Module::new();
+/// module
+///     .section(&types)
+///     .section(&modules)
+///     .section(&module_code);
+///
+/// let wasm_bytes = module.finish();
+/// ```
+pub struct ModuleCodeSection {
+    bytes: Vec<u8>,
+    num_added: u32,
+}
+
+impl ModuleCodeSection {
+    /// Create a new code section encoder.
+    pub fn new() -> ModuleCodeSection {
+        ModuleCodeSection {
+            bytes: vec![],
+            num_added: 0,
+        }
+    }
+
+    /// Write a function body into this code section.
+    pub fn module(&mut self, module: &Module) -> &mut Self {
+        self.bytes.extend(
+            encoders::u32(u32::try_from(module.bytes.len()).unwrap())
+                .chain(module.bytes.iter().copied()),
+        );
+        self.num_added += 1;
+        self
+    }
+}
+
+impl Section for ModuleCodeSection {
+    fn id(&self) -> u8 {
+        SectionId::ModuleCode.into()
+    }
+
+    fn encode<S>(&self, sink: &mut S)
+    where
+        S: Extend<u8>,
+    {
+        let num_added = encoders::u32(self.num_added);
+        let n = num_added.len();
+        sink.extend(
+            encoders::u32(u32::try_from(n + self.bytes.len()).unwrap())
+                .chain(num_added)
+                .chain(self.bytes.iter().copied()),
+        );
+    }
+}

--- a/crates/wasm-encoder/src/modules.rs
+++ b/crates/wasm-encoder/src/modules.rs
@@ -1,0 +1,67 @@
+use super::*;
+
+/// An encoder for the module section.
+///
+/// Note that this is part of the [module linking proposal][proposal] and is not
+/// currently part of stable WebAssembly.
+///
+/// [proposal]: https://github.com/webassembly/module-linking
+///
+/// # Example
+///
+/// ```
+/// use wasm_encoder::{Module, ModuleSection, ValType};
+///
+/// let mut submodules = ModuleSection::new();
+/// let type_index = 0;
+/// submodules.module(type_index);
+///
+/// let mut module = Module::new();
+/// module.section(&submodules);
+///
+/// // Note: this will generate an invalid module because we didn't generate a
+/// // module code section containing the function body. See the documentation
+/// // for `ModuleCodeSection` for details.
+///
+/// let wasm_bytes = module.finish();
+/// ```
+pub struct ModuleSection {
+    bytes: Vec<u8>,
+    num_added: u32,
+}
+
+impl ModuleSection {
+    /// Construct a new module section encoder.
+    pub fn new() -> ModuleSection {
+        ModuleSection {
+            bytes: vec![],
+            num_added: 0,
+        }
+    }
+
+    /// Define a module that uses the given type.
+    pub fn module(&mut self, type_index: u32) -> &mut Self {
+        self.bytes.extend(encoders::u32(type_index));
+        self.num_added += 1;
+        self
+    }
+}
+
+impl Section for ModuleSection {
+    fn id(&self) -> u8 {
+        SectionId::Module.into()
+    }
+
+    fn encode<S>(&self, sink: &mut S)
+    where
+        S: Extend<u8>,
+    {
+        let num_added = encoders::u32(self.num_added);
+        let n = num_added.len();
+        sink.extend(
+            encoders::u32(u32::try_from(n + self.bytes.len()).unwrap())
+                .chain(num_added)
+                .chain(self.bytes.iter().copied()),
+        );
+    }
+}


### PR DESCRIPTION
This commit adds support to wasm-smith and wasm-encoder to generate the
module and module code sections for module-linking modules. The module
section in wasm-smith is generated by using `Arbitrary for
ConfiguredModule<C>` to create a submodule, and then the type of the
submodule is copied out of the child into the parent for insertion into
the type section. Some deduplication is attempted but in general new
module/instance/func types will always be added to type the new module.