### PR TITLE
Fix a wasm-smith issue where `choose` has 0 choices

### DIFF
--- a/crates/wasm-smith/src/lib.rs
+++ b/crates/wasm-smith/src/lib.rs
@@ -688,7 +688,7 @@ where
                 &mut AvailableInstantiations,
             ) -> Result<()>,
         > = Vec::new();
-        while u.arbitrary()? {
+        loop {
             choices.clear();
             if self.types.len() < self.config.max_types() {
                 choices.push(|u, m, _, _| m.arbitrary_types(0, u));
@@ -708,6 +708,9 @@ where
                 && instantiations.choices.len() > 0
             {
                 choices.push(|u, m, _, i| m.arbitrary_instances(i, u));
+            }
+            if choices.is_empty() || !u.arbitrary()? {
+                break;
             }
             u.choose(&choices)?(u, self, &mut aliases, &mut instantiations)?;
         }


### PR DESCRIPTION
Due to restrictions the initial sections portion of a module might not
be able to generate anything, so reorder some logic to prevent an empty
list being passed to `choose`.