### PR TITLE
Limit the nesting depth of wasm-smith generated modules

### DIFF
--- a/crates/wasm-smith/src/config.rs
+++ b/crates/wasm-smith/src/config.rs
@@ -15,7 +15,7 @@ use arbitrary::{Arbitrary, Result, Unstructured};
 /// Every trait method has a provided default implementation, so that you only
 /// need to override the methods for things you want to change away from the
 /// default.
-pub trait Config: Arbitrary + Default {
+pub trait Config: Arbitrary + Default + Clone {
     /// The minimum number of types to generate. Defaults to 0.
     fn min_types(&self) -> usize {
         0
@@ -248,6 +248,12 @@ pub trait Config: Arbitrary + Default {
     fn max_aliases(&self) -> usize {
         1_000
     }
+
+    /// Returns the maximal nesting depth of modules with the module linking
+    /// proposal.
+    fn max_nesting_depth(&self) -> usize {
+        10
+    }
 }
 
 /// The default configuration.
@@ -287,6 +293,7 @@ pub struct SwarmConfig {
     reference_types_enabled: bool,
     module_linking_enabled: bool,
     max_aliases: usize,
+    max_nesting_depth: usize,
 }
 
 impl Arbitrary for SwarmConfig {
@@ -314,6 +321,7 @@ impl Arbitrary for SwarmConfig {
             reference_types_enabled,
             module_linking_enabled: u.arbitrary()?,
             max_aliases: u.int_in_range(0..=MAX_MAXIMUM)?,
+            max_nesting_depth: u.int_in_range(0..=10)?,
         })
     }
 }
@@ -385,5 +393,9 @@ impl Config for SwarmConfig {
 
     fn max_aliases(&self) -> usize {
         self.max_aliases
+    }
+
+    fn max_nesting_depth(&self) -> usize {
+        self.max_nesting_depth
     }
 }

--- a/crates/wasm-smith/src/lib.rs
+++ b/crates/wasm-smith/src/lib.rs
@@ -94,6 +94,7 @@ where
     C: Config,
 {
     config: C,
+    depth: usize,
     valtypes: Vec<ValType>,
 
     /// The initial sections of this wasm module, including types and imports.
@@ -696,7 +697,9 @@ where
             if self.num_imports < self.config.max_imports() {
                 choices.push(|u, m, _, _| m.arbitrary_imports(0, u));
             }
-            if self.modules.len() < self.config.max_modules() {
+            if self.modules.len() < self.config.max_modules()
+                && self.depth < self.config.max_nesting_depth()
+            {
                 choices.push(|u, m, _, _| m.arbitrary_modules(u));
             }
             aliases.update(self);
@@ -1069,7 +1072,10 @@ where
     fn arbitrary_modules(&mut self, u: &mut Unstructured) -> Result<()> {
         let mut modules = Vec::new();
         arbitrary_loop(u, 0, self.config.max_modules(), |u| {
-            let module = u.arbitrary::<ConfiguredModule<C>>()?;
+            let mut module = ConfiguredModule::<C>::default();
+            module.depth = self.depth + 1;
+            module.config = self.config.clone();
+            module.build(u, false)?;
 
             // After we've generated the `module`, we create `ty` which is its
             // own type signature of itself.


### PR DESCRIPTION
Otherwise we might let fuzzers nest quite deeply and either time out or
run out of memory.