### PR TITLE
Use `IndexMap` in wasm-smith to accelerate subtype testing

### DIFF
--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -24,6 +24,7 @@ arbitrary = { version = "0.4.6", features = ["derive"] }
 leb128 = "0.2.4"
 structopt = { version = "0.3.16", optional = true }
 wasm-encoder = { version = "0.2.0", path = "../wasm-encoder" }
+indexmap = "1.6"
 
 [dev-dependencies]
 criterion = "0.3.3"


### PR DESCRIPTION
This should greatly reduce the number of string comparisons since we
don't need to iterate over entire export lists, instead we can just do
O(1) lookups in a map.