### PR TITLE
Experimental: Split Operator::BrTable into Operator::{BrTableStart, BrTableTarget}

### DIFF
--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -291,13 +291,6 @@ pub enum RelocType {
     GlobalIndexLEB,
 }
 
-/// A br_table entries representation.
-#[derive(Clone)]
-pub struct BrTable<'a> {
-    pub(crate) reader: crate::BinaryReader<'a>,
-    pub(crate) cnt: usize,
-}
-
 /// An IEEE binary32 immediate floating point value, represented as a u32
 /// containing the bitpattern.
 ///
@@ -339,7 +332,7 @@ pub type SIMDLaneIndex = u8;
 ///
 /// [here]: https://webassembly.github.io/spec/core/binary/instructions.html
 #[derive(Debug, Clone)]
-pub enum Operator<'a> {
+pub enum Operator {
     Unreachable,
     Nop,
     Block { ty: TypeOrFuncType },
@@ -354,7 +347,8 @@ pub enum Operator<'a> {
     End,
     Br { relative_depth: u32 },
     BrIf { relative_depth: u32 },
-    BrTable { table: BrTable<'a> },
+    BrTableStart { targets_len: u32 },
+    BrTableTarget { relative_depth: u32, is_default: bool },
     Return,
     Call { function_index: u32 },
     CallIndirect { index: u32, table_index: u32 },

--- a/crates/wasmparser/src/readers/operators.rs
+++ b/crates/wasmparser/src/readers/operators.rs
@@ -48,10 +48,7 @@ impl<'a> OperatorsReader<'a> {
         ))
     }
 
-    pub fn read<'b>(&mut self) -> Result<Operator<'b>>
-    where
-        'a: 'b,
-    {
+    pub fn read(&mut self) -> Result<Operator> {
         self.reader.read_operator()
     }
 
@@ -65,17 +62,14 @@ impl<'a> OperatorsReader<'a> {
         }
     }
 
-    pub fn read_with_offset<'b>(&mut self) -> Result<(Operator<'b>, usize)>
-    where
-        'a: 'b,
-    {
+    pub fn read_with_offset(&mut self) -> Result<(Operator, usize)> {
         let pos = self.reader.original_position();
         Ok((self.read()?, pos))
     }
 }
 
 impl<'a> IntoIterator for OperatorsReader<'a> {
-    type Item = Result<Operator<'a>>;
+    type Item = Result<Operator>;
     type IntoIter = OperatorsIterator<'a>;
 
     /// Reads content of the code section.
@@ -111,7 +105,7 @@ pub struct OperatorsIterator<'a> {
 }
 
 impl<'a> Iterator for OperatorsIterator<'a> {
-    type Item = Result<Operator<'a>>;
+    type Item = Result<Operator>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.err || self.reader.eof() {
@@ -129,7 +123,7 @@ pub struct OperatorsIteratorWithOffsets<'a> {
 }
 
 impl<'a> Iterator for OperatorsIteratorWithOffsets<'a> {
-    type Item = Result<(Operator<'a>, usize)>;
+    type Item = Result<(Operator, usize)>;
 
     /// Reads content of the code section with offsets.
     ///

--- a/crates/wasmparser/src/validator/func.rs
+++ b/crates/wasmparser/src/validator/func.rs
@@ -88,7 +88,7 @@ impl<T: WasmModuleResources> FuncValidator<T> {
     /// WebAssembly function. Each operator's offset in the original binary and
     /// the operator itself are passed to this function to provide more useful
     /// error messages.
-    pub fn op(&mut self, offset: usize, operator: &Operator<'_>) -> Result<()> {
+    pub fn op(&mut self, offset: usize, operator: &Operator) -> Result<()> {
         self.validator
             .process_operator(operator, &self.resources)
             .map_err(|e| e.set_offset(offset))?;


### PR DESCRIPTION
Implements https://github.com/bytecodealliance/wasm-tools/issues/182.

This PR does not serve as a proposal for the concrete implementation but rather as a place for discussion of #182 .

Tests are failing because I did not yet update the other crates in this repository that are depending on `wasmparser`, e.g.:
```
 error[E0107]: wrong number of lifetime arguments: expected 0, found 1
   --> crates/wasmprinter/src/lib.rs:701:48
    |
701 |     fn print_operator(&mut self, op: &Operator<'_>, nesting_start: u32) -> Result<()> {
    |                                                ^^ unexpected lifetime argument
```

CI dislikes formatting because I wanted to keep the diff of this PR at a bare minimum and formatting would have touched lots of places that are not interesting to this PR apparently.