### PR TITLE
Make wasmparser compile for #![no_std]

### DIFF
--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -11,6 +11,9 @@ A simple event-driven library for parsing WebAssembly binary files.
 """
 edition = "2018"
 
+[dependencies]
+hashbrown = { version = "0.9.1", features = ["ahash"], default-features = false }
+
 [dev-dependencies]
 anyhow = "1.0"
 criterion = "0.3"
@@ -25,6 +28,8 @@ name = "benchmark"
 harness = false
 
 [features]
+std = []
+
 # The "deterministic" feature supports only Wasm code with "deterministic" execution
 # across any hardware. This feature is very critical for many Blockchain infrastructures
 # that rely on deterministic executions of smart contracts across different hardwares.

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -28,6 +28,7 @@ name = "benchmark"
 harness = false
 
 [features]
+default = ["std"]
 std = []
 
 # The "deterministic" feature supports only Wasm code with "deterministic" execution

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -13,9 +13,10 @@
  * limitations under the License.
  */
 
-use std::convert::TryInto;
-use std::fmt;
-use std::str;
+use alloc::{boxed::Box, format, vec::Vec};
+use core::convert::TryInto;
+use core::fmt;
+use core::str;
 
 use crate::limits::*;
 
@@ -1072,7 +1073,7 @@ impl<'a> BinaryReader<'a> {
         } else {
             self.position = position;
             let idx = self.read_var_s33()?;
-            if idx < 0 || idx > (std::u32::MAX as i64) {
+            if idx < 0 || idx > (core::u32::MAX as i64) {
                 return Err(BinaryReaderError::new("invalid function type", position));
             }
             Ok(TypeOrFuncType::FuncType(idx as u32))

--- a/crates/wasmparser/src/lib.rs
+++ b/crates/wasmparser/src/lib.rs
@@ -23,6 +23,10 @@
 //! this is not the right library for you. You could however, build such
 //! a data-structure using this library.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
 pub use crate::binary_reader::BinaryReader;
 pub use crate::binary_reader::Range;
 

--- a/crates/wasmparser/src/module_resources.rs
+++ b/crates/wasmparser/src/module_resources.rs
@@ -14,7 +14,7 @@
  */
 
 use crate::{EventType, FuncType, GlobalType, MemoryType, TableType, Type};
-use std::ops::Range;
+use core::ops::Range;
 
 /// Types that qualify as Wasm function types for validation purposes.
 pub trait WasmFuncType {

--- a/crates/wasmparser/src/operators_validator.rs
+++ b/crates/wasmparser/src/operators_validator.rs
@@ -28,6 +28,8 @@ use crate::primitives::{
 };
 use crate::{BinaryReaderError, Result, WasmFeatures, WasmFuncType, WasmModuleResources};
 
+use alloc::{format, string::String, vec, vec::Vec};
+
 /// A wrapper around a `BinaryReaderError` where the inner error's offset is a
 /// temporary placeholder value. This can be converted into a proper
 /// `BinaryReaderError` via the `set_offset` method, which replaces the
@@ -51,7 +53,7 @@ macro_rules! bail_op_err {
 impl OperatorValidatorError {
     /// Create a new `OperatorValidatorError` with a placeholder offset.
     pub(crate) fn new(message: impl Into<String>) -> Self {
-        let offset = std::usize::MAX;
+        let offset = core::usize::MAX;
         let e = BinaryReaderError::new(message, offset);
         OperatorValidatorError(e)
     }
@@ -59,13 +61,13 @@ impl OperatorValidatorError {
     /// Convert this `OperatorValidatorError` into a `BinaryReaderError` by
     /// supplying an actual offset to replace the internal placeholder offset.
     pub(crate) fn set_offset(mut self, offset: usize) -> BinaryReaderError {
-        debug_assert_eq!(self.0.inner.offset, std::usize::MAX);
+        debug_assert_eq!(self.0.inner.offset, core::usize::MAX);
         self.0.inner.offset = offset;
         self.0
     }
 }
 
-type OperatorValidatorResult<T> = std::result::Result<T, OperatorValidatorError>;
+type OperatorValidatorResult<T> = core::result::Result<T, OperatorValidatorError>;
 
 pub(crate) struct OperatorValidator {
     // The total number of locals that this function contains

--- a/crates/wasmparser/src/parser.rs
+++ b/crates/wasmparser/src/parser.rs
@@ -4,9 +4,10 @@ use crate::{BinaryReader, BinaryReaderError, FunctionBody, Range, Result};
 use crate::{DataSectionReader, ElementSectionReader, ExportSectionReader};
 use crate::{FunctionSectionReader, ImportSectionReader, TypeSectionReader};
 use crate::{GlobalSectionReader, MemorySectionReader, TableSectionReader};
-use std::convert::TryInto;
-use std::fmt;
-use std::iter;
+use alloc::{format, vec::Vec};
+use core::convert::TryInto;
+use core::fmt;
+use core::iter;
 
 /// An incremental parser of a binary WebAssembly module.
 ///

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -13,7 +13,10 @@
  * limitations under the License.
  */
 
-use alloc::{boxed::Box, string::{String, ToString}};
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+};
 use core::fmt;
 use core::result;
 

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -13,9 +13,12 @@
  * limitations under the License.
  */
 
+use alloc::{boxed::Box, string::{String, ToString}};
+use core::fmt;
+use core::result;
+
+#[cfg(feature = "std")]
 use std::error::Error;
-use std::fmt;
-use std::result;
 
 #[derive(Debug, Clone)]
 pub struct BinaryReaderError {
@@ -34,6 +37,7 @@ pub(crate) struct BinaryReaderErrorInner {
 
 pub type Result<T, E = BinaryReaderError> = result::Result<T, E>;
 
+#[cfg(feature = "std")]
 impl Error for BinaryReaderError {}
 
 impl fmt::Display for BinaryReaderError {

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -21,7 +21,12 @@ use crate::{BinaryReaderError, EventType, GlobalType, MemoryType, Range, Result,
 use crate::{DataKind, ElementItem, ElementKind, InitExpr, Instance, Operator};
 use crate::{Export, ExportType, FunctionBody, Parser, Payload};
 use crate::{FuncType, ResizableLimits, SectionReader, SectionWithLimitedItems};
-use alloc::{format, string::{String, ToString}, sync::Arc, vec::Vec};
+use alloc::{
+    format,
+    string::{String, ToString},
+    sync::Arc,
+    vec::Vec,
+};
 use core::mem;
 use hashbrown::{HashMap, HashSet};
 

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -21,9 +21,9 @@ use crate::{BinaryReaderError, EventType, GlobalType, MemoryType, Range, Result,
 use crate::{DataKind, ElementItem, ElementKind, InitExpr, Instance, Operator};
 use crate::{Export, ExportType, FunctionBody, Parser, Payload};
 use crate::{FuncType, ResizableLimits, SectionReader, SectionWithLimitedItems};
-use std::collections::{HashMap, HashSet};
-use std::mem;
-use std::sync::Arc;
+use alloc::{format, string::{String, ToString}, sync::Arc, vec::Vec};
+use core::mem;
+use hashbrown::{HashMap, HashSet};
 
 /// Test whether the given buffer contains a valid WebAssembly module,
 /// analogous to [`WebAssembly.validate`][js] in the JS API.
@@ -1927,8 +1927,8 @@ impl WasmModuleResources for ValidatorResources {
 }
 
 mod arc {
-    use std::ops::Deref;
-    use std::sync::Arc;
+    use alloc::sync::Arc;
+    use core::ops::Deref;
 
     pub struct MaybeOwned<T> {
         owned: bool,


### PR DESCRIPTION
This make makes the `wasmparser` crate successfully compile for no-std platforms.
The PR was very mechanical, but feel free to reject if this is out of scope of the repository.

I've added an `std` feature just because of a single `impl std::error::Error for ... {}`.
My personal opinion would be to ditch this `impl` and the `std` feature entirely, but I went for the non-breaking option. Let me know if I should do this.
