### PR TITLE
wasm-encoder: Add `v128` type and const instruction

### DIFF
--- a/crates/wasm-encoder/src/lib.rs
+++ b/crates/wasm-encoder/src/lib.rs
@@ -263,6 +263,10 @@ pub enum ValType {
     F32 = 0x7D,
     /// The `f64` type.
     F64 = 0x7C,
+    /// The `v128` type.
+    ///
+    /// Part of the SIMD proposal.
+    V128 = 0x7B,
     /// The `funcref` type.
     ///
     /// Part of the reference types proposal when used anywhere other than a


### PR DESCRIPTION
This should be just enough for unblocking
https://github.com/bytecodealliance/wasmtime/issues/2498