### PR TITLE
wasm-encoder: fix custom section encoding

### DIFF
--- a/crates/wasm-encoder/Cargo.toml
+++ b/crates/wasm-encoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-encoder"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasm-encoder/src/custom.rs
+++ b/crates/wasm-encoder/src/custom.rs
@@ -20,15 +20,39 @@ impl Section for CustomSection<'_> {
         let name_len = encoders::u32(u32::try_from(self.name.len()).unwrap());
         let n = name_len.len();
 
-        let data_len = encoders::u32(u32::try_from(self.data.len()).unwrap());
-        let m = data_len.len();
-
         sink.extend(
-            encoders::u32(u32::try_from(n + self.name.len() + m + self.data.len()).unwrap())
+            encoders::u32(u32::try_from(n + self.name.len() + self.data.len()).unwrap())
                 .chain(name_len)
                 .chain(self.name.as_bytes().iter().copied())
-                .chain(data_len)
                 .chain(self.data.iter().copied()),
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_custom_section() {
+        let custom = CustomSection {
+            name: "test",
+            data: &[11, 22, 33, 44],
+        };
+
+        let mut encoded = vec![];
+        custom.encode(&mut encoded);
+
+        #[rustfmt::skip]
+        assert_eq!(encoded, vec![
+            // LEB128 length of section.
+            9,
+            // LEB128 length of name.
+            4,
+            // Name.
+            b't', b'e', b's', b't',
+            // Data.
+            11, 22, 33, 44,
+        ]);
     }
 }


### PR DESCRIPTION
The arbitrary data following the custom section's name is not byte-length
prefixed.

Fixes https://github.com/bytecodealliance/wizer/issues/1
