### PR TITLE
Sync syntax/binary of aliases with upstream spec

### DIFF
--- a/crates/dump/src/lib.rs
+++ b/crates/dump/src/lib.rs
@@ -144,8 +144,8 @@ impl<'a> Dump<'a> {
                             ExternalKind::Event => i.events += 1,
                             ExternalKind::Type => i.types += 1,
                         },
-                        Alias::ParentType(_) => i.types += 1,
-                        Alias::ParentModule(_) => i.modules += 1,
+                        Alias::ParentType { .. } => i.types += 1,
+                        Alias::ParentModule { .. } => i.modules += 1,
                     }
                     me.print(end)
                 })?,

--- a/crates/dump/src/lib.rs
+++ b/crates/dump/src/lib.rs
@@ -144,8 +144,8 @@ impl<'a> Dump<'a> {
                             ExternalKind::Event => i.events += 1,
                             ExternalKind::Type => i.types += 1,
                         },
-                        Alias::ParentType { .. } => i.types += 1,
-                        Alias::ParentModule { .. } => i.modules += 1,
+                        Alias::OuterType { .. } => i.types += 1,
+                        Alias::OuterModule { .. } => i.modules += 1,
                     }
                     me.print(end)
                 })?,

--- a/crates/wasmparser/src/readers/alias_section.rs
+++ b/crates/wasmparser/src/readers/alias_section.rs
@@ -11,8 +11,14 @@ pub struct AliasSectionReader<'a> {
 
 #[derive(Debug)]
 pub enum Alias<'a> {
-    ParentType(u32),
-    ParentModule(u32),
+    ParentType {
+        relative_depth: u32,
+        index: u32,
+    },
+    ParentModule {
+        relative_depth: u32,
+        index: u32,
+    },
     InstanceExport {
         instance: u32,
         kind: ExternalKind,
@@ -42,16 +48,25 @@ impl<'a> AliasSectionReader<'a> {
                 kind: self.reader.read_external_kind()?,
                 export: self.reader.read_string()?,
             },
-            0x01 => match self.reader.read_external_kind()? {
-                ExternalKind::Type => Alias::ParentType(self.reader.read_var_u32()?),
-                ExternalKind::Module => Alias::ParentModule(self.reader.read_var_u32()?),
-                _ => {
-                    return Err(BinaryReaderError::new(
-                        "invalid external kind in alias",
-                        self.original_position() - 1,
-                    ))
+            0x01 => {
+                let relative_depth = self.reader.read_var_u32()?;
+                match self.reader.read_external_kind()? {
+                    ExternalKind::Type => Alias::ParentType {
+                        relative_depth,
+                        index: self.reader.read_var_u32()?,
+                    },
+                    ExternalKind::Module => Alias::ParentModule {
+                        relative_depth,
+                        index: self.reader.read_var_u32()?,
+                    },
+                    _ => {
+                        return Err(BinaryReaderError::new(
+                            "invalid external kind in alias",
+                            self.original_position() - 1,
+                        ))
+                    }
                 }
-            },
+            }
             _ => {
                 return Err(BinaryReaderError::new(
                     "invalid byte in alias",

--- a/crates/wasmparser/src/readers/alias_section.rs
+++ b/crates/wasmparser/src/readers/alias_section.rs
@@ -11,11 +11,11 @@ pub struct AliasSectionReader<'a> {
 
 #[derive(Debug)]
 pub enum Alias<'a> {
-    ParentType {
+    OuterType {
         relative_depth: u32,
         index: u32,
     },
-    ParentModule {
+    OuterModule {
         relative_depth: u32,
         index: u32,
     },
@@ -51,11 +51,11 @@ impl<'a> AliasSectionReader<'a> {
             0x01 => {
                 let relative_depth = self.reader.read_var_u32()?;
                 match self.reader.read_external_kind()? {
-                    ExternalKind::Type => Alias::ParentType {
+                    ExternalKind::Type => Alias::OuterType {
                         relative_depth,
                         index: self.reader.read_var_u32()?,
                     },
-                    ExternalKind::Module => Alias::ParentModule {
+                    ExternalKind::Module => Alias::OuterModule {
                         relative_depth,
                         index: self.reader.read_var_u32()?,
                     },

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -923,7 +923,7 @@ impl Validator {
                     _ => return self.create_error("alias kind mismatch with export kind"),
                 }
             }
-            Alias::ParentType {
+            Alias::OuterType {
                 relative_depth,
                 index,
             } => {
@@ -941,7 +941,7 @@ impl Validator {
                 };
                 self.cur.state.assert_mut().types.push(ty);
             }
-            Alias::ParentModule {
+            Alias::OuterModule {
                 relative_depth,
                 index,
             } => {

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -923,27 +923,37 @@ impl Validator {
                     _ => return self.create_error("alias kind mismatch with export kind"),
                 }
             }
-            Alias::ParentType(i) => {
-                let parent = match self.parents.last() {
-                    Some(parent) => parent,
-                    None => {
-                        return self.create_error("no parent module to alias from");
-                    }
-                };
-                let ty = match parent.state.types.get(i as usize) {
+            Alias::ParentType {
+                relative_depth,
+                index,
+            } => {
+                let i = self
+                    .parents
+                    .len()
+                    .checked_sub(relative_depth as usize)
+                    .and_then(|i| i.checked_sub(1))
+                    .ok_or_else(|| {
+                        BinaryReaderError::new("relative depth too large", self.offset)
+                    })?;
+                let ty = match self.parents[i].state.types.get(index as usize) {
                     Some(m) => *m,
                     None => return self.create_error("alias to type not defined in parent yet"),
                 };
                 self.cur.state.assert_mut().types.push(ty);
             }
-            Alias::ParentModule(i) => {
-                let parent = match self.parents.last() {
-                    Some(parent) => parent,
-                    None => {
-                        return self.create_error("no parent module to alias from");
-                    }
-                };
-                let module = match parent.state.submodules.get(i as usize) {
+            Alias::ParentModule {
+                relative_depth,
+                index,
+            } => {
+                let i = self
+                    .parents
+                    .len()
+                    .checked_sub(relative_depth as usize)
+                    .and_then(|i| i.checked_sub(1))
+                    .ok_or_else(|| {
+                        BinaryReaderError::new("relative depth too large", self.offset)
+                    })?;
+                let module = match self.parents[i].state.submodules.get(index as usize) {
                     Some(m) => *m,
                     None => return self.create_error("alias to module not defined in parent yet"),
                 };

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -1656,7 +1656,7 @@ impl Printer {
                     self.print_str(export)?;
                     self.end_group();
                 }
-                Alias::ParentType {
+                Alias::OuterType {
                     relative_depth,
                     index,
                 } => {
@@ -1667,7 +1667,7 @@ impl Printer {
                     )?;
                     self.state.types.push(None);
                 }
-                Alias::ParentModule {
+                Alias::OuterModule {
                     relative_depth,
                     index,
                 } => {

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -331,13 +331,26 @@ impl Printer {
         Ok(())
     }
 
-    fn print_functype_idx(&mut self, idx: u32, names_for: Option<u32>) -> Result<u32> {
+    fn print_functype_idx(
+        &mut self,
+        idx: u32,
+        always_print_type: bool,
+        names_for: Option<u32>,
+    ) -> Result<Option<u32>> {
+        if always_print_type {
+            write!(self.result, " (type {})", idx)?;
+        }
         let ty = match self.state.types.get(idx as usize) {
             Some(Some(ty)) => ty.clone(),
-            Some(None) => bail!("function type index `{}` is not a function", idx),
+            Some(None) => {
+                if !always_print_type {
+                    write!(self.result, " (type {})", idx)?;
+                }
+                return Ok(None);
+            }
             None => bail!("function type index `{}` out of bounds", idx),
         };
-        self.print_functype(&ty, names_for)
+        self.print_functype(&ty, names_for).map(Some)
     }
 
     /// Returns the number of parameters, useful for local index calculations
@@ -502,8 +515,7 @@ impl Printer {
         if index {
             write!(self.result, "(;{};)", self.state.event)?;
         }
-        write!(self.result, " (type {})", ty.type_index)?;
-        self.print_functype_idx(ty.type_index, None)?;
+        self.print_functype_idx(ty.type_index, true, None)?;
         Ok(())
     }
 
@@ -589,8 +601,9 @@ impl Printer {
                 Some(name) => name.write(&mut self.result),
                 None => write!(self.result, "(;{};)", self.state.func)?,
             }
-            write!(self.result, " (type {})", ty)?;
-            let params = self.print_functype_idx(ty, Some(self.state.func))?;
+            let params = self
+                .print_functype_idx(ty, true, Some(self.state.func))?
+                .unwrap_or(0);
 
             let mut first = true;
             let mut local_idx = 0;
@@ -1407,7 +1420,7 @@ impl Printer {
                 Ok(())
             }
             TypeOrFuncType::FuncType(idx) => {
-                self.print_functype_idx(*idx, None)?;
+                self.print_functype_idx(*idx, false, None)?;
                 Ok(())
             }
         }
@@ -1595,9 +1608,6 @@ impl Printer {
                     kind,
                     export,
                 } => {
-                    write!(self.result, "{} ", instance)?;
-                    self.print_str(export)?;
-                    self.result.push_str(" ");
                     match kind {
                         ExternalKind::Function => self.start_group("func"),
                         ExternalKind::Table => self.start_group("table"),
@@ -1642,22 +1652,29 @@ impl Printer {
                         }
                         ExternalKind::Type => self.state.types.push(None),
                     }
+                    write!(self.result, " {} ", instance)?;
+                    self.print_str(export)?;
                     self.end_group();
                 }
-                Alias::ParentType(i) => {
+                Alias::ParentType {
+                    relative_depth,
+                    index,
+                } => {
                     write!(
                         self.result,
-                        "parent (;{};) {} (type)",
-                        self.state.types.len(),
-                        i,
+                        "(type (;{};) outer {} {})",
+                        self.state.module, relative_depth, index
                     )?;
                     self.state.types.push(None);
                 }
-                Alias::ParentModule(i) => {
+                Alias::ParentModule {
+                    relative_depth,
+                    index,
+                } => {
                     write!(
                         self.result,
-                        "parent (;{};) {} (module)",
-                        self.state.module, i
+                        "(module (;{};) outer {} {})",
+                        self.state.module, relative_depth, index
                     )?;
                     self.state.module += 1;
                 }

--- a/crates/wast/src/ast/alias.rs
+++ b/crates/wast/src/ast/alias.rs
@@ -19,7 +19,7 @@ pub struct Alias<'a> {
 #[allow(missing_docs)]
 pub enum AliasKind<'a> {
     InstanceExport {
-        instance: ast::Index<'a>,
+        instance: ast::ItemRef<'a, kw::instance>,
         export: &'a str,
         kind: ast::ExportKind,
     },
@@ -49,7 +49,7 @@ impl<'a> Parse<'a> for Alias<'a> {
             (id, None, AliasKind::Parent { parent_index, kind })
         } else {
             // (alias $instance "export" (type $my_name))
-            let instance = parser.parse()?;
+            let instance = parser.parse::<ast::IndexOrRef<_>>()?.0;
             let export = parser.parse()?;
             let (kind, id, name) = parser.parens(|p| Ok((p.parse()?, p.parse()?, p.parse()?)))?;
             (

--- a/crates/wast/src/ast/expr.rs
+++ b/crates/wast/src/ast/expr.rs
@@ -198,7 +198,9 @@ impl<'a> ExpressionParser<'a> {
                         return Err(parser.error("previous `try` had no `do`"));
                     }
                     Level::Try(Try::CatchOrUnwind) => {
-                        return Err(parser.error("previous `try` had no `catch`, `catch_all`, or `unwind`"));
+                        return Err(
+                            parser.error("previous `try` had no `catch`, `catch_all`, or `unwind`")
+                        );
                     }
                     Level::Try(_) => {
                         self.instrs.push(Instruction::End(None));
@@ -405,7 +407,6 @@ macro_rules! instructions {
                 $(#[$doc])*
                 $name $(( instructions!(@ty $($arg)*) ))?,
             )*
-
         }
 
         #[allow(non_snake_case)]
@@ -448,6 +449,21 @@ macro_rules! instructions {
                 }
             }
         }
+
+        impl<'a> Instruction<'a> {
+            /// Returns the associated [`MemArg`] if one is available for this
+            /// instruction.
+            #[allow(unused_variables, non_snake_case)]
+            pub fn memarg_mut(&mut self) -> Option<&mut MemArg<'a>> {
+                match self {
+                    $(
+                        Instruction::$name $((instructions!(@memarg_binding a $($arg)*)))? => {
+                            instructions!(@get_memarg a $($($arg)*)?)
+                        }
+                    )*
+                }
+            }
+        }
     );
 
     (@ty MemArg<$amt:tt>) => (MemArg<'a>);
@@ -465,6 +481,12 @@ macro_rules! instructions {
         <u32 as crate::binary::Encode>::encode(&$simd, $dst);
     });
     (@encode $dst:ident $($bytes:tt)*) => ($dst.extend_from_slice(&[$($bytes)*]););
+
+    (@get_memarg $name:ident MemArg<$amt:tt>) => (Some($name));
+    (@get_memarg $($other:tt)*) => (None);
+
+    (@memarg_binding $name:ident MemArg<$amt:tt>) => ($name);
+    (@memarg_binding $name:ident $other:ty) => (_);
 }
 
 instructions! {
@@ -481,11 +503,11 @@ instructions! {
         BrIf(ast::Index<'a>) : [0x0d] : "br_if",
         BrTable(BrTableIndices<'a>) : [0x0e] : "br_table",
         Return : [0x0f] : "return",
-        Call(ast::Index<'a>) : [0x10] : "call",
+        Call(ast::IndexOrRef<'a, kw::func>) : [0x10] : "call",
         CallIndirect(CallIndirect<'a>) : [0x11] : "call_indirect",
 
         // tail-call proposal
-        ReturnCall(ast::Index<'a>) : [0x12] : "return_call",
+        ReturnCall(ast::IndexOrRef<'a, kw::func>) : [0x12] : "return_call",
         ReturnCallIndirect(CallIndirect<'a>) : [0x13] : "return_call_indirect",
 
         // function-references proposal
@@ -499,8 +521,8 @@ instructions! {
         LocalGet(ast::Index<'a>) : [0x20] : "local.get" | "get_local",
         LocalSet(ast::Index<'a>) : [0x21] : "local.set" | "set_local",
         LocalTee(ast::Index<'a>) : [0x22] : "local.tee" | "tee_local",
-        GlobalGet(ast::Index<'a>) : [0x23] : "global.get" | "get_global",
-        GlobalSet(ast::Index<'a>) : [0x24] : "global.set" | "set_global",
+        GlobalGet(ast::IndexOrRef<'a, kw::global>) : [0x23] : "global.get" | "get_global",
+        GlobalSet(ast::IndexOrRef<'a, kw::global>) : [0x24] : "global.set" | "set_global",
 
         TableGet(TableArg<'a>) : [0x25] : "table.get",
         TableSet(TableArg<'a>) : [0x26] : "table.set",
@@ -546,7 +568,7 @@ instructions! {
         RefNull(HeapType<'a>) : [0xd0] : "ref.null",
         RefIsNull : [0xd1] : "ref.is_null",
         RefExtern(u32) : [0xff] : "ref.extern", // only used in test harness
-        RefFunc(ast::Index<'a>) : [0xd2] : "ref.func",
+        RefFunc(ast::IndexOrRef<'a, kw::func>) : [0xd2] : "ref.func",
 
         // function-references proposal
         RefAsNonNull : [0xd3] : "ref.as_non_null",
@@ -1168,7 +1190,7 @@ pub struct MemArg<'a> {
     /// The offset, in bytes of this access.
     pub offset: u32,
     /// The memory index we're accessing
-    pub memory: ast::Index<'a>,
+    pub memory: ast::ItemRef<'a, kw::memory>,
 }
 
 impl<'a> MemArg<'a> {
@@ -1203,8 +1225,9 @@ impl<'a> MemArg<'a> {
             })
         }
         let memory = parser
-            .parse::<Option<_>>()?
-            .unwrap_or(ast::Index::Num(0, parser.prev_span()));
+            .parse::<Option<ast::IndexOrRef<_>>>()?
+            .map(|i| i.0)
+            .unwrap_or(idx_zero(parser.prev_span(), kw::memory));
         let offset = parse_field("offset", parser)?.unwrap_or(0);
         let align = match parse_field("align", parser)? {
             Some(n) if !n.is_power_of_two() => {
@@ -1221,11 +1244,19 @@ impl<'a> MemArg<'a> {
     }
 }
 
+fn idx_zero<T>(span: ast::Span, mk_kind: fn(ast::Span) -> T) -> ast::ItemRef<'static, T> {
+    ast::ItemRef::Item {
+        kind: mk_kind(span),
+        idx: ast::Index::Num(0, span),
+        exports: Vec::new(),
+    }
+}
+
 /// Extra data associated with the `call_indirect` instruction.
 #[derive(Debug)]
 pub struct CallIndirect<'a> {
     /// The table that this call is going to be indexing.
-    pub table: ast::Index<'a>,
+    pub table: ast::ItemRef<'a, kw::table>,
     /// Type type signature that this `call_indirect` instruction is using.
     pub ty: ast::TypeUse<'a, ast::FunctionType<'a>>,
 }
@@ -1233,7 +1264,7 @@ pub struct CallIndirect<'a> {
 impl<'a> Parse<'a> for CallIndirect<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
         let prev_span = parser.prev_span();
-        let mut table: Option<_> = parser.parse()?;
+        let mut table: Option<ast::IndexOrRef<_>> = parser.parse()?;
         let ty = parser.parse::<ast::TypeUse<'a, ast::FunctionTypeNoNames<'a>>>()?;
         // Turns out the official test suite at this time thinks table
         // identifiers comes first but wabt's test suites asserts differently
@@ -1242,7 +1273,7 @@ impl<'a> Parse<'a> for CallIndirect<'a> {
             table = parser.parse()?;
         }
         Ok(CallIndirect {
-            table: table.unwrap_or(ast::Index::Num(0, prev_span)),
+            table: table.map(|i| i.0).unwrap_or(idx_zero(prev_span, kw::table)),
             ty: ty.into(),
         })
     }
@@ -1252,7 +1283,7 @@ impl<'a> Parse<'a> for CallIndirect<'a> {
 #[derive(Debug)]
 pub struct TableInit<'a> {
     /// The index of the table we're copying into.
-    pub table: ast::Index<'a>,
+    pub table: ast::ItemRef<'a, kw::table>,
     /// The index of the element segment we're copying into a table.
     pub elem: ast::Index<'a>,
 }
@@ -1260,11 +1291,13 @@ pub struct TableInit<'a> {
 impl<'a> Parse<'a> for TableInit<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
         let prev_span = parser.prev_span();
-        let table_or_elem = parser.parse()?;
-        let (table, elem) = match parser.parse()? {
-            Some(elem) => (table_or_elem, elem),
-            None => (ast::Index::Num(0, prev_span), table_or_elem),
-        };
+        let (elem, table) =
+            if parser.peek::<ast::ItemRef<kw::table>>() || parser.peek2::<ast::Index>() {
+                let table = parser.parse::<ast::IndexOrRef<_>>()?.0;
+                (parser.parse()?, table)
+            } else {
+                (parser.parse()?, idx_zero(prev_span, kw::table))
+            };
         Ok(TableInit { table, elem })
     }
 }
@@ -1273,18 +1306,19 @@ impl<'a> Parse<'a> for TableInit<'a> {
 #[derive(Debug)]
 pub struct TableCopy<'a> {
     /// The index of the destination table to copy into.
-    pub dst: ast::Index<'a>,
+    pub dst: ast::ItemRef<'a, kw::table>,
     /// The index of the source table to copy from.
-    pub src: ast::Index<'a>,
+    pub src: ast::ItemRef<'a, kw::table>,
 }
 
 impl<'a> Parse<'a> for TableCopy<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
-        let (dst, src) = if let Some(dst) = parser.parse()? {
-            (dst, parser.parse()?)
-        } else {
-            let span = parser.prev_span();
-            (ast::Index::Num(0, span), ast::Index::Num(0, span))
+        let (dst, src) = match parser.parse::<Option<ast::IndexOrRef<_>>>()? {
+            Some(dst) => (dst.0, parser.parse::<ast::IndexOrRef<_>>()?.0),
+            None => (
+                idx_zero(parser.prev_span(), kw::table),
+                idx_zero(parser.prev_span(), kw::table),
+            ),
         };
         Ok(TableCopy { dst, src })
     }
@@ -1294,15 +1328,15 @@ impl<'a> Parse<'a> for TableCopy<'a> {
 #[derive(Debug)]
 pub struct TableArg<'a> {
     /// The index of the table argument.
-    pub dst: ast::Index<'a>,
+    pub dst: ast::ItemRef<'a, kw::table>,
 }
 
 impl<'a> Parse<'a> for TableArg<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
-        let dst = if let Some(dst) = parser.parse()? {
-            dst
+        let dst = if let Some(dst) = parser.parse::<Option<ast::IndexOrRef<_>>>()? {
+            dst.0
         } else {
-            ast::Index::Num(0, parser.prev_span())
+            idx_zero(parser.prev_span(), kw::table)
         };
         Ok(TableArg { dst })
     }
@@ -1312,15 +1346,15 @@ impl<'a> Parse<'a> for TableArg<'a> {
 #[derive(Debug)]
 pub struct MemoryArg<'a> {
     /// The index of the memory space.
-    pub mem: ast::Index<'a>,
+    pub mem: ast::ItemRef<'a, kw::memory>,
 }
 
 impl<'a> Parse<'a> for MemoryArg<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
-        let mem = if let Some(mem) = parser.parse()? {
-            mem
+        let mem = if let Some(mem) = parser.parse::<Option<ast::IndexOrRef<_>>>()? {
+            mem.0
         } else {
-            ast::Index::Num(0, parser.prev_span())
+            idx_zero(parser.prev_span(), kw::memory)
         };
         Ok(MemoryArg { mem })
     }
@@ -1332,15 +1366,16 @@ pub struct MemoryInit<'a> {
     /// The index of the data segment we're copying into memory.
     pub data: ast::Index<'a>,
     /// The index of the memory we're copying into,
-    pub mem: ast::Index<'a>,
+    pub mem: ast::ItemRef<'a, kw::memory>,
 }
 
 impl<'a> Parse<'a> for MemoryInit<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
         let data = parser.parse()?;
         let mem = parser
-            .parse::<Option<_>>()?
-            .unwrap_or(ast::Index::Num(0, parser.prev_span()));
+            .parse::<Option<ast::IndexOrRef<_>>>()?
+            .map(|i| i.0)
+            .unwrap_or(idx_zero(parser.prev_span(), kw::memory));
         Ok(MemoryInit { data, mem })
     }
 }
@@ -1349,19 +1384,19 @@ impl<'a> Parse<'a> for MemoryInit<'a> {
 #[derive(Debug)]
 pub struct MemoryCopy<'a> {
     /// The index of the memory we're copying from.
-    pub src: ast::Index<'a>,
+    pub src: ast::ItemRef<'a, kw::memory>,
     /// The index of the memory we're copying to.
-    pub dst: ast::Index<'a>,
+    pub dst: ast::ItemRef<'a, kw::memory>,
 }
 
 impl<'a> Parse<'a> for MemoryCopy<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
-        let (src, dst) = match parser.parse()? {
-            Some(dst) => (parser.parse()?, dst),
-            None => {
-                let idx = ast::Index::Num(0, parser.prev_span());
-                (idx, idx)
-            }
+        let (src, dst) = match parser.parse::<Option<ast::IndexOrRef<_>>>()? {
+            Some(dst) => (parser.parse::<ast::IndexOrRef<_>>()?.0, dst.0),
+            None => (
+                idx_zero(parser.prev_span(), kw::memory),
+                idx_zero(parser.prev_span(), kw::memory),
+            ),
         };
         Ok(MemoryCopy { src, dst })
     }

--- a/crates/wast/src/ast/memory.rs
+++ b/crates/wast/src/ast/memory.rs
@@ -113,7 +113,7 @@ pub enum DataKind<'a> {
     /// memory on module instantiation.
     Active {
         /// The memory that this `Data` will be associated with.
-        memory: ast::Index<'a>,
+        memory: ast::ItemRef<'a, kw::memory>,
 
         /// Initial offset to load this data segment at
         offset: ast::Expression<'a>,
@@ -138,13 +138,14 @@ impl<'a> Parse<'a> for Data<'a> {
         // ... and otherwise we must be attached to a particular memory as well
         // as having an initialization offset.
         } else {
-            let memory = if parser.peek2::<kw::memory>() {
-                Some(parser.parens(|p| {
-                    p.parse::<kw::memory>()?;
-                    p.parse()
-                })?)
+            let memory = if let Some(index) = parser.parse::<Option<ast::IndexOrRef<_>>>()? {
+                index.0
             } else {
-                parser.parse()?
+                ast::ItemRef::Item {
+                    kind: kw::memory(parser.prev_span()),
+                    idx: ast::Index::Num(0, span),
+                    exports: Vec::new(),
+                }
             };
             let offset = parser.parens(|parser| {
                 if parser.peek::<kw::offset>() {
@@ -152,10 +153,7 @@ impl<'a> Parse<'a> for Data<'a> {
                 }
                 parser.parse()
             })?;
-            DataKind::Active {
-                memory: memory.unwrap_or(ast::Index::Num(0, span)),
-                offset,
-            }
+            DataKind::Active { memory, offset }
         };
 
         let mut data = Vec::new();

--- a/crates/wast/src/ast/mod.rs
+++ b/crates/wast/src/ast/mod.rs
@@ -45,7 +45,7 @@ macro_rules! custom_keyword {
     ($name:ident = $kw:expr) => {
         #[allow(non_camel_case_types)]
         #[allow(missing_docs)]
-        #[derive(Debug)]
+        #[derive(Debug, Copy, Clone)]
         pub struct $name(pub $crate::Span);
 
         impl<'a> $crate::parser::Parse<'a> for $name {
@@ -397,6 +397,7 @@ pub mod kw {
     custom_keyword!(null);
     custom_keyword!(nullref);
     custom_keyword!(offset);
+    custom_keyword!(outer);
     custom_keyword!(param);
     custom_keyword!(parent);
     custom_keyword!(passive);

--- a/crates/wast/src/ast/module.rs
+++ b/crates/wast/src/ast/module.rs
@@ -166,7 +166,7 @@ pub enum ModuleField<'a> {
     Memory(ast::Memory<'a>),
     Global(ast::Global<'a>),
     Export(ast::Export<'a>),
-    Start(ast::Index<'a>),
+    Start(ast::ItemRef<'a, kw::func>),
     Elem(ast::Elem<'a>),
     Data(ast::Data<'a>),
     Event(ast::Event<'a>),
@@ -211,7 +211,7 @@ impl<'a> Parse<'a> for ModuleField<'a> {
         }
         if parser.peek::<kw::start>() {
             parser.parse::<kw::start>()?;
-            return Ok(ModuleField::Start(parser.parse()?));
+            return Ok(ModuleField::Start(parser.parse::<ast::IndexOrRef<_>>()?.0));
         }
         if parser.peek::<kw::elem>() {
             return Ok(ModuleField::Elem(parser.parse()?));

--- a/crates/wast/src/ast/table.rs
+++ b/crates/wast/src/ast/table.rs
@@ -108,7 +108,7 @@ pub enum ElemKind<'a> {
     /// An active segment associated with a table.
     Active {
         /// The table this `elem` is initializing.
-        table: ast::Index<'a>,
+        table: ast::ItemRef<'a, kw::table>,
         /// The offset within `table` that we'll initialize at.
         offset: ast::Expression<'a>,
     },
@@ -118,7 +118,7 @@ pub enum ElemKind<'a> {
 #[derive(Debug, Clone)]
 pub enum ElemPayload<'a> {
     /// This element segment has a contiguous list of function indices
-    Indices(Vec<ast::Index<'a>>),
+    Indices(Vec<ast::ItemRef<'a, kw::func>>),
 
     /// This element segment has a list of optional function indices,
     /// represented as expressions using `ref.func` and `ref.null`.
@@ -127,7 +127,7 @@ pub enum ElemPayload<'a> {
         ty: ast::RefType<'a>,
         /// The expressions, currently optional function indices, in this
         /// segment.
-        exprs: Vec<Option<ast::Index<'a>>>,
+        exprs: Vec<Option<ast::ItemRef<'a, kw::func>>>,
     },
 }
 
@@ -136,16 +136,17 @@ impl<'a> Parse<'a> for Elem<'a> {
         let span = parser.parse::<kw::elem>()?.0;
         let id = parser.parse()?;
 
-        let kind = if parser.peek::<u32>() || (parser.peek::<ast::LParen>() && !parser.peek::<ast::RefType>()) {
-            let table = if parser.peek2::<kw::table>() {
-                Some(parser.parens(|p| {
-                    p.parse::<kw::table>()?;
-                    p.parse()
-                })?)
-            } else if parser.peek::<u32>() {
-                Some(parser.parse()?)
+        let kind = if parser.peek::<u32>()
+            || (parser.peek::<ast::LParen>() && !parser.peek::<ast::RefType>())
+        {
+            let table = if let Some(index) = parser.parse::<Option<ast::IndexOrRef<_>>>()? {
+                index.0
             } else {
-                None
+                ast::ItemRef::Item {
+                    kind: kw::table(parser.prev_span()),
+                    idx: ast::Index::Num(0, span),
+                    exports: Vec::new(),
+                }
             };
             let offset = parser.parens(|parser| {
                 if parser.peek::<kw::offset>() {
@@ -153,10 +154,7 @@ impl<'a> Parse<'a> for Elem<'a> {
                 }
                 parser.parse()
             })?;
-            ElemKind::Active {
-                table: table.unwrap_or(ast::Index::Num(0, span)),
-                offset,
-            }
+            ElemKind::Active { table, offset }
         } else if parser.peek::<kw::declare>() {
             parser.parse::<kw::declare>()?;
             ElemKind::Declared
@@ -189,10 +187,10 @@ impl<'a> ElemPayload<'a> {
             Some(ty) => ty,
         };
         if let ast::HeapType::Func = ty.heap {
-            if parser.peek::<ast::Index>() {
+            if parser.peek::<ast::IndexOrRef<kw::func>>() {
                 let mut elems = Vec::new();
                 while !parser.is_empty() {
-                    elems.push(parser.parse()?);
+                    elems.push(parser.parse::<ast::IndexOrRef<_>>()?.0);
                 }
                 return Ok(ElemPayload::Indices(elems));
             }
@@ -218,7 +216,7 @@ impl<'a> ElemPayload<'a> {
 fn parse_ref_func<'a>(
     parser: Parser<'a>,
     ty: ast::RefType<'a>,
-) -> Result<Option<ast::Index<'a>>> {
+) -> Result<Option<ast::ItemRef<'a, kw::func>>> {
     let mut l = parser.lookahead1();
     if l.peek::<kw::ref_null>() {
         parser.parse::<kw::ref_null>()?;
@@ -229,7 +227,7 @@ fn parse_ref_func<'a>(
         Ok(None)
     } else if l.peek::<kw::ref_func>() {
         parser.parse::<kw::ref_func>()?;
-        Ok(Some(parser.parse()?))
+        Ok(Some(parser.parse::<ast::IndexOrRef<_>>()?.0))
     } else {
         Err(l.error())
     }

--- a/crates/wast/src/ast/token.rs
+++ b/crates/wast/src/ast/token.rs
@@ -1,4 +1,4 @@
-use crate::ast::annotation;
+use crate::ast::{annotation, kw};
 use crate::lexer::FloatVal;
 use crate::parser::{Cursor, Parse, Parser, Peek, Result};
 use std::fmt;
@@ -179,6 +179,12 @@ impl Peek for Index<'_> {
     }
 }
 
+impl<'a> From<Id<'a>> for Index<'a> {
+    fn from(id: Id<'a>) -> Index<'a> {
+        Index::Id(id)
+    }
+}
+
 impl PartialEq for Index<'_> {
     fn eq(&self, other: &Index<'_>) -> bool {
         match (self, other) {
@@ -203,6 +209,106 @@ impl Hash for Index<'_> {
                 a.hash(hasher);
             }
         }
+    }
+}
+
+/// Parses `(func $foo)`
+///
+/// Optionally includes export strings for module-linking sugar syntax for alias
+/// injection.
+#[derive(Clone, Debug)]
+#[allow(missing_docs)]
+pub enum ItemRef<'a, K> {
+    Outer {
+        kind: K,
+        module: Index<'a>,
+        idx: Index<'a>,
+    },
+    Item {
+        kind: K,
+        idx: Index<'a>,
+        exports: Vec<&'a str>,
+    },
+}
+
+impl<'a, K> ItemRef<'a, K> {
+    /// Unwraps the underlying `Index` for `ItemRef::Item`.
+    ///
+    /// Panics if this is `ItemRef::Outer` or if exports haven't been expanded
+    /// yet.
+    pub fn unwrap_index(&self) -> &Index<'a> {
+        match self {
+            ItemRef::Item { idx, exports, .. } => {
+                debug_assert!(exports.len() == 0);
+                idx
+            }
+            ItemRef::Outer { .. } => panic!("unwrap_index called on Parent"),
+        }
+    }
+}
+
+impl<'a, K: Parse<'a>> Parse<'a> for ItemRef<'a, K> {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        parser.parens(|parser| {
+            let kind = parser.parse::<K>()?;
+            if parser.peek::<kw::outer>() {
+                parser.parse::<kw::outer>()?;
+                let module = parser.parse()?;
+                let idx = parser.parse()?;
+                Ok(ItemRef::Outer { kind, module, idx })
+            } else {
+                let idx = parser.parse()?;
+                let mut exports = Vec::new();
+                while !parser.is_empty() {
+                    exports.push(parser.parse()?);
+                }
+                Ok(ItemRef::Item { kind, idx, exports })
+            }
+        })
+    }
+}
+
+impl<'a, K: Peek> Peek for ItemRef<'a, K> {
+    fn peek(cursor: Cursor<'_>) -> bool {
+        match cursor.lparen() {
+            Some(remaining) => K::peek(remaining),
+            None => false,
+        }
+    }
+
+    fn display() -> &'static str {
+        "an item reference"
+    }
+}
+
+/// Convenience structure to parse `$f` or `(item $f)`.
+#[derive(Clone, Debug)]
+pub struct IndexOrRef<'a, K>(pub ItemRef<'a, K>);
+
+impl<'a, K> Parse<'a> for IndexOrRef<'a, K>
+where
+    K: Parse<'a> + Default,
+{
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        if parser.peek::<Index<'_>>() {
+            Ok(IndexOrRef(ItemRef::Item {
+                kind: K::default(),
+                idx: parser.parse()?,
+                exports: Vec::new(),
+            }))
+        } else {
+            Ok(IndexOrRef(parser.parse()?))
+        }
+    }
+}
+
+impl<'a, K: Peek> Peek for IndexOrRef<'a, K> {
+    fn peek(cursor: Cursor<'_>) -> bool {
+        Index::peek(cursor) || ItemRef::<K>::peek(cursor)
+    }
+
+    fn display() -> &'static str {
+        "an item reference"
     }
 }
 

--- a/crates/wast/src/ast/types.rs
+++ b/crates/wast/src/ast/types.rs
@@ -764,7 +764,7 @@ impl<'a> Parse<'a> for Type<'a> {
 #[derive(Clone, Debug)]
 pub struct TypeUse<'a, T> {
     /// The type that we're referencing, if it was present.
-    pub index: Option<ast::Index<'a>>,
+    pub index: Option<ast::ItemRef<'a, kw::r#type>>,
     /// The inline type, if present.
     pub inline: Option<T>,
 }
@@ -772,9 +772,13 @@ pub struct TypeUse<'a, T> {
 impl<'a, T> TypeUse<'a, T> {
     /// Constructs a new instance of `TypeUse` without an inline definition but
     /// with an index specified.
-    pub fn new_with_index(index: ast::Index<'a>) -> TypeUse<'a, T> {
+    pub fn new_with_index(idx: ast::Index<'a>) -> TypeUse<'a, T> {
         TypeUse {
-            index: Some(index),
+            index: Some(ast::ItemRef::Item {
+                idx,
+                kind: kw::r#type::default(),
+                exports: Vec::new(),
+            }),
             inline: None,
         }
     }
@@ -783,10 +787,7 @@ impl<'a, T> TypeUse<'a, T> {
 impl<'a, T: Peek + Parse<'a>> Parse<'a> for TypeUse<'a, T> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
         let index = if parser.peek2::<kw::r#type>() {
-            Some(parser.parens(|parser| {
-                parser.parse::<kw::r#type>()?;
-                Ok(parser.parse()?)
-            })?)
+            Some(parser.parse()?)
         } else {
             None
         };

--- a/crates/wast/src/binary.rs
+++ b/crates/wast/src/binary.rs
@@ -1229,10 +1229,15 @@ impl Encode for Alias<'_> {
                 kind.encode(e);
                 export.encode(e);
             }
-            AliasKind::Parent { parent_index, kind } => {
+            AliasKind::Outer {
+                module,
+                index,
+                kind,
+            } => {
                 e.push(0x01);
+                module.encode(e);
                 kind.encode(e);
-                parent_index.encode(e);
+                index.encode(e);
             }
         }
     }

--- a/crates/wast/src/resolve/aliases.rs
+++ b/crates/wast/src/resolve/aliases.rs
@@ -1,0 +1,236 @@
+use crate::ast::*;
+use crate::resolve::gensym;
+use std::collections::{hash_map::Entry, HashMap};
+
+pub fn run(fields: &mut Vec<ModuleField>) {
+    let mut cur = 0;
+    let mut cx = Expander::default();
+    while cur < fields.len() {
+        cx.process(&mut fields[cur]);
+        for item in cx.to_prepend.drain(..) {
+            fields.insert(cur, item);
+            cur += 1;
+        }
+        cur += 1;
+    }
+    assert!(cx.to_prepend.is_empty());
+}
+
+#[derive(Default)]
+struct Expander<'a> {
+    to_prepend: Vec<ModuleField<'a>>,
+    instances: HashMap<(Index<'a>, &'a str, ExportKind), Index<'a>>,
+    parents: HashMap<(Index<'a>, ExportKind), Index<'a>>,
+}
+
+impl<'a> Expander<'a> {
+    fn process(&mut self, field: &mut ModuleField<'a>) {
+        assert!(self.to_prepend.is_empty());
+        match field {
+            ModuleField::Alias(a) => {
+                let id = gensym::fill(a.span, &mut a.id);
+                match &mut a.kind {
+                    AliasKind::InstanceExport {
+                        instance,
+                        export,
+                        kind,
+                    } => {
+                        self.expand(instance);
+                        self.instances
+                            .insert((*instance.unwrap_index(), export, *kind), id.into());
+                    }
+                    AliasKind::Parent { parent_index, kind } => {
+                        self.parents.insert((*parent_index, *kind), id.into());
+                    }
+                }
+            }
+
+            ModuleField::Instance(i) => {
+                if let InstanceKind::Inline { module, args } = &mut i.kind {
+                    self.expand(module);
+                    for arg in args {
+                        self.expand(&mut arg.index);
+                    }
+                }
+            }
+
+            ModuleField::Elem(e) => {
+                if let ElemKind::Active { table, .. } = &mut e.kind {
+                    self.expand(table);
+                }
+                match &mut e.payload {
+                    ElemPayload::Indices(funcs) => {
+                        for func in funcs {
+                            self.expand(func);
+                        }
+                    }
+                    ElemPayload::Exprs { exprs, .. } => {
+                        for func in exprs {
+                            if let Some(func) = func {
+                                self.expand(func);
+                            }
+                        }
+                    }
+                }
+            }
+
+            ModuleField::Data(e) => {
+                if let DataKind::Active { memory, .. } = &mut e.kind {
+                    self.expand(memory);
+                }
+            }
+
+            ModuleField::Export(e) => self.expand(&mut e.index),
+
+            ModuleField::Func(f) => {
+                if let FuncKind::Inline { expression, .. } = &mut f.kind {
+                    self.expand_expr(expression);
+                }
+            }
+
+            ModuleField::Import(i) => self.expand_item_sig(&mut i.item),
+
+            ModuleField::Global(g) => {
+                if let GlobalKind::Inline(expr) = &mut g.kind {
+                    self.expand_expr(expr);
+                }
+            }
+
+            ModuleField::Start(s) => self.expand(s),
+
+            ModuleField::Event(e) => match &mut e.ty {
+                EventType::Exception(t) => self.expand_type_use(t),
+            },
+
+            ModuleField::NestedModule(m) => match &mut m.kind {
+                NestedModuleKind::Import { ty, .. } => self.expand_type_use(ty),
+                NestedModuleKind::Inline { fields } => run(fields),
+            },
+
+            ModuleField::Custom(_)
+            | ModuleField::Memory(_)
+            | ModuleField::Table(_)
+            | ModuleField::Type(_) => {}
+        }
+    }
+
+    fn expand_item_sig(&mut self, sig: &mut ItemSig<'a>) {
+        match &mut sig.kind {
+            ItemKind::Func(t) => self.expand_type_use(t),
+            ItemKind::Module(t) => self.expand_type_use(t),
+            ItemKind::Instance(t) => self.expand_type_use(t),
+            ItemKind::Table(_) => {}
+            ItemKind::Memory(_) => {}
+            ItemKind::Global(_) => {}
+            ItemKind::Event(_) => {}
+        }
+    }
+
+    fn expand_type_use<T>(&mut self, ty: &mut TypeUse<'a, T>) {
+        if let Some(index) = &mut ty.index {
+            self.expand(index);
+        }
+    }
+
+    fn expand_expr(&mut self, expr: &mut Expression<'a>) {
+        for instr in expr.instrs.iter_mut() {
+            self.expand_instr(instr);
+        }
+    }
+
+    fn expand_instr(&mut self, instr: &mut Instruction<'a>) {
+        use Instruction::*;
+
+        if let Some(m) = instr.memarg_mut() {
+            self.expand(&mut m.memory);
+        }
+
+        match instr {
+            Call(i) | ReturnCall(i) | RefFunc(i) => self.expand(&mut i.0),
+            CallIndirect(i) | ReturnCallIndirect(i) => {
+                self.expand(&mut i.table);
+                self.expand_type_use(&mut i.ty);
+            }
+            TableInit(i) => self.expand(&mut i.table),
+            MemoryInit(i) => self.expand(&mut i.mem),
+            TableCopy(i) => {
+                self.expand(&mut i.src);
+                self.expand(&mut i.dst);
+            }
+            MemoryCopy(i) => {
+                self.expand(&mut i.src);
+                self.expand(&mut i.dst);
+            }
+            GlobalSet(g) | GlobalGet(g) => self.expand(&mut g.0),
+            TableGet(t) | TableSet(t) | TableFill(t) | TableSize(t) | TableGrow(t) => {
+                self.expand(&mut t.dst)
+            }
+
+            MemorySize(m) | MemoryGrow(m) | MemoryFill(m) => self.expand(&mut m.mem),
+
+            _ => {}
+        }
+    }
+
+    fn expand<T>(&mut self, item: &mut ItemRef<'a, T>)
+    where
+        T: Into<ExportKind> + Copy,
+    {
+        match item {
+            ItemRef::Outer { kind, module, idx } => {
+                let key = (*idx, (*kind).into());
+                let idx = match self.parents.entry(key) {
+                    Entry::Occupied(e) => *e.get(),
+                    Entry::Vacant(v) => {
+                        let span = idx.span();
+                        let id = gensym::gen(span);
+                        self.to_prepend.push(ModuleField::Alias(Alias {
+                            span,
+                            id: Some(id),
+                            name: None,
+                            kind: AliasKind::Parent {
+                                parent_index: *idx,
+                                kind: (*kind).into(),
+                            },
+                        }));
+                        *v.insert(Index::Id(id))
+                    }
+                };
+                *item = ItemRef::Item {
+                    kind: *kind,
+                    idx,
+                    exports: Vec::new(),
+                };
+            }
+            ItemRef::Item { kind, idx, exports } => {
+                let mut cur = *idx;
+                for export in exports.drain(..) {
+                    let key = (cur, export, (*kind).into());
+                    cur = match self.instances.entry(key) {
+                        Entry::Occupied(e) => *e.get(),
+                        Entry::Vacant(v) => {
+                            let span = idx.span();
+                            let id = gensym::gen(span);
+                            self.to_prepend.push(ModuleField::Alias(Alias {
+                                span,
+                                id: Some(id),
+                                name: None,
+                                kind: AliasKind::InstanceExport {
+                                    kind: (*kind).into(),
+                                    instance: ItemRef::Item {
+                                        kind: kw::instance(span),
+                                        idx: cur,
+                                        exports: Vec::new(),
+                                    },
+                                    export,
+                                },
+                            }));
+                            *v.insert(Index::Id(id))
+                        }
+                    };
+                }
+                *idx = cur;
+            }
+        }
+    }
+}

--- a/crates/wast/src/resolve/deinline_import_export.rs
+++ b/crates/wast/src/resolve/deinline_import_export.rs
@@ -79,7 +79,7 @@ pub fn run(fields: &mut Vec<ModuleField>) {
                             span: m.span,
                             id: None,
                             kind: DataKind::Active {
-                                memory: Index::Id(id),
+                                memory: item_ref(kw::memory(m.span), id),
                                 offset: Expression {
                                     instrs: Box::new([Instruction::I32Const(0)]),
                                 },
@@ -133,7 +133,7 @@ pub fn run(fields: &mut Vec<ModuleField>) {
                             span: t.span,
                             id: None,
                             kind: ElemKind::Active {
-                                table: Index::Id(id),
+                                table: item_ref(kw::table(t.span), id),
                                 offset: Expression {
                                     instrs: Box::new([Instruction::I32Const(0)]),
                                 },
@@ -257,7 +257,14 @@ fn export<'a>(
     ModuleField::Export(Export {
         span,
         name,
-        kind,
-        index: Index::Id(id),
+        index: item_ref(kind, id),
     })
+}
+
+fn item_ref<'a, K>(kind: K, id: impl Into<Index<'a>>) -> ItemRef<'a, K> {
+    ItemRef::Item {
+        kind,
+        idx: id.into(),
+        exports: Vec::new(),
+    }
 }

--- a/crates/wast/src/resolve/mod.rs
+++ b/crates/wast/src/resolve/mod.rs
@@ -1,6 +1,7 @@
 use crate::ast::*;
 use crate::Error;
 
+mod aliases;
 mod deinline_import_export;
 mod gensym;
 mod names;
@@ -49,6 +50,8 @@ pub fn resolve<'a>(module: &mut Module<'a>) -> Result<Names<'a>, Error> {
     // calculate exports we only have to look for a particular kind of module
     // field.
     deinline_import_export::run(fields);
+
+    aliases::run(fields);
 
     // With a canonical form of imports make sure that imports are all listed
     // first.

--- a/crates/wast/src/resolve/mod.rs
+++ b/crates/wast/src/resolve/mod.rs
@@ -76,7 +76,7 @@ pub fn resolve<'a>(module: &mut Module<'a>) -> Result<Names<'a>, Error> {
 
     // Perform name resolution over all `Index` items to resolve them all to
     // indices instead of symbolic names.
-    let resolver = names::resolve(fields)?;
+    let resolver = names::resolve(module.id, fields)?;
     Ok(Names { resolver })
 }
 

--- a/crates/wast/src/resolve/names.rs
+++ b/crates/wast/src/resolve/names.rs
@@ -205,7 +205,7 @@ impl<'a> Resolver<'a> {
             ModuleField::Elem(e) => {
                 match &mut e.kind {
                     ElemKind::Active { table, offset } => {
-                        self.resolve(table, Ns::Table)?;
+                        self.resolve_item_ref(table)?;
                         self.resolve_expr(offset)?;
                     }
                     ElemKind::Passive { .. } | ElemKind::Declared { .. } => {}
@@ -213,13 +213,13 @@ impl<'a> Resolver<'a> {
                 match &mut e.payload {
                     ElemPayload::Indices(elems) => {
                         for idx in elems {
-                            self.resolve(idx, Ns::Func)?;
+                            self.resolve_item_ref(idx)?;
                         }
                     }
                     ElemPayload::Exprs { exprs, ty } => {
                         for funcref in exprs {
                             if let Some(idx) = funcref {
-                                self.resolve(idx, Ns::Func)?;
+                                self.resolve_item_ref(idx)?;
                             }
                         }
                         self.resolve_heaptype(&mut ty.heap)?;
@@ -230,20 +230,19 @@ impl<'a> Resolver<'a> {
 
             ModuleField::Data(d) => {
                 if let DataKind::Active { memory, offset } = &mut d.kind {
-                    self.resolve(memory, Ns::Memory)?;
+                    self.resolve_item_ref(memory)?;
                     self.resolve_expr(offset)?;
                 }
                 Ok(())
             }
 
             ModuleField::Start(i) => {
-                self.resolve(i, Ns::Func)?;
+                self.resolve_item_ref(i)?;
                 Ok(())
             }
 
             ModuleField::Export(e) => {
-                let ns = Ns::from_export(&e.kind);
-                self.resolve(&mut e.index, ns)?;
+                self.resolve_item_ref(&mut e.index)?;
                 Ok(())
             }
 
@@ -266,10 +265,9 @@ impl<'a> Resolver<'a> {
 
             ModuleField::Instance(i) => {
                 if let InstanceKind::Inline { module, args } = &mut i.kind {
-                    self.resolve(module, Ns::Module)?;
+                    self.resolve_item_ref(module)?;
                     for arg in args {
-                        let ns = Ns::from_export(&arg.kind);
-                        self.resolve(&mut arg.index, ns)?;
+                        self.resolve_item_ref(&mut arg.index)?;
                     }
                 }
                 Ok(())
@@ -293,7 +291,7 @@ impl<'a> Resolver<'a> {
             ModuleField::Alias(a) => {
                 match &mut a.kind {
                     AliasKind::InstanceExport { instance, .. } => {
-                        self.resolve(instance, Ns::Instance)?;
+                        self.resolve_item_ref(instance)?;
                     }
                     AliasKind::Parent { parent_index, kind } => {
                         let parent = match parent {
@@ -372,7 +370,7 @@ impl<'a> Resolver<'a> {
         T: TypeReference<'a>,
     {
         let idx = ty.index.as_mut().unwrap();
-        self.resolve(idx, Ns::Type)?;
+        let idx = self.resolve_item_ref(idx)?;
 
         // If the type was listed inline *and* it was specified via a type index
         // we need to assert they're the same.
@@ -401,6 +399,32 @@ impl<'a> Resolver<'a> {
             Ns::Module => self.modules.resolve(idx, "module"),
             Ns::Event => self.events.resolve(idx, "event"),
             Ns::Type => self.types.resolve(idx, "type"),
+        }
+    }
+
+    fn resolve_item_ref<'b, K>(&self, item: &'b mut ItemRef<'a, K>) -> Result<&'b Index<'a>, Error>
+    where
+        K: Into<ExportKind> + Copy,
+    {
+        match item {
+            ItemRef::Item { idx, kind, .. } => {
+                self.resolve(
+                    idx,
+                    match (*kind).into() {
+                        ExportKind::Func => Ns::Func,
+                        ExportKind::Table => Ns::Table,
+                        ExportKind::Global => Ns::Global,
+                        ExportKind::Memory => Ns::Memory,
+                        ExportKind::Instance => Ns::Instance,
+                        ExportKind::Module => Ns::Module,
+                        ExportKind::Event => Ns::Event,
+                        ExportKind::Type => Ns::Type,
+                    },
+                )?;
+                Ok(idx)
+            }
+            // should be expanded by now
+            ItemRef::Outer { .. } => unreachable!(),
         }
     }
 }
@@ -571,17 +595,21 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
     fn resolve_instr(&mut self, instr: &mut Instruction<'a>) -> Result<(), Error> {
         use crate::ast::Instruction::*;
 
+        if let Some(m) = instr.memarg_mut() {
+            self.resolver.resolve_item_ref(&mut m.memory)?;
+        }
+
         match instr {
             MemorySize(i) | MemoryGrow(i) | MemoryFill(i) => {
-                self.resolver.resolve(&mut i.mem, Ns::Memory)?;
+                self.resolver.resolve_item_ref(&mut i.mem)?;
             }
             MemoryInit(i) => {
                 self.resolver.datas.resolve(&mut i.data, "data")?;
-                self.resolver.resolve(&mut i.mem, Ns::Memory)?;
+                self.resolver.resolve_item_ref(&mut i.mem)?;
             }
             MemoryCopy(i) => {
-                self.resolver.resolve(&mut i.src, Ns::Memory)?;
-                self.resolver.resolve(&mut i.dst, Ns::Memory)?;
+                self.resolver.resolve_item_ref(&mut i.src)?;
+                self.resolver.resolve_item_ref(&mut i.dst)?;
             }
             DataDrop(i) => {
                 self.resolver.datas.resolve(i, "data")?;
@@ -589,23 +617,23 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
 
             TableInit(i) => {
                 self.resolver.elems.resolve(&mut i.elem, "elem")?;
-                self.resolver.resolve(&mut i.table, Ns::Table)?;
+                self.resolver.resolve_item_ref(&mut i.table)?;
             }
             ElemDrop(i) => {
                 self.resolver.elems.resolve(i, "elem")?;
             }
 
             TableCopy(i) => {
-                self.resolver.resolve(&mut i.dst, Ns::Table)?;
-                self.resolver.resolve(&mut i.src, Ns::Table)?;
+                self.resolver.resolve_item_ref(&mut i.dst)?;
+                self.resolver.resolve_item_ref(&mut i.src)?;
             }
 
             TableFill(i) | TableSet(i) | TableGet(i) | TableSize(i) | TableGrow(i) => {
-                self.resolver.resolve(&mut i.dst, Ns::Table)?;
+                self.resolver.resolve_item_ref(&mut i.dst)?;
             }
 
             GlobalSet(i) | GlobalGet(i) => {
-                self.resolver.resolve(i, Ns::Global)?;
+                self.resolver.resolve_item_ref(&mut i.0)?;
             }
 
             LocalSet(i) | LocalGet(i) | LocalTee(i) => {
@@ -629,11 +657,11 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
             }
 
             Call(i) | RefFunc(i) | ReturnCall(i) => {
-                self.resolver.resolve(i, Ns::Func)?;
+                self.resolver.resolve_item_ref(&mut i.0)?;
             }
 
             CallIndirect(c) | ReturnCallIndirect(c) => {
-                self.resolver.resolve(&mut c.table, Ns::Table)?;
+                self.resolver.resolve_item_ref(&mut c.table)?;
                 self.resolver.resolve_type_use(&mut c.ty)?;
             }
 
@@ -772,112 +800,6 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
             }
 
             RefNull(ty) => self.resolver.resolve_heaptype(ty)?,
-
-            I32Load(m)
-            | I64Load(m)
-            | F32Load(m)
-            | F64Load(m)
-            | I32Load8s(m)
-            | I32Load8u(m)
-            | I32Load16s(m)
-            | I32Load16u(m)
-            | I64Load8s(m)
-            | I64Load8u(m)
-            | I64Load16s(m)
-            | I64Load16u(m)
-            | I64Load32s(m)
-            | I64Load32u(m)
-            | I32Store(m)
-            | I64Store(m)
-            | F32Store(m)
-            | F64Store(m)
-            | I32Store8(m)
-            | I32Store16(m)
-            | I64Store8(m)
-            | I64Store16(m)
-            | I64Store32(m)
-            | I32AtomicLoad(m)
-            | I64AtomicLoad(m)
-            | I32AtomicLoad8u(m)
-            | I32AtomicLoad16u(m)
-            | I64AtomicLoad8u(m)
-            | I64AtomicLoad16u(m)
-            | I64AtomicLoad32u(m)
-            | I32AtomicStore(m)
-            | I64AtomicStore(m)
-            | I32AtomicStore8(m)
-            | I32AtomicStore16(m)
-            | I64AtomicStore8(m)
-            | I64AtomicStore16(m)
-            | I64AtomicStore32(m)
-            | I32AtomicRmwAdd(m)
-            | I64AtomicRmwAdd(m)
-            | I32AtomicRmw8AddU(m)
-            | I32AtomicRmw16AddU(m)
-            | I64AtomicRmw8AddU(m)
-            | I64AtomicRmw16AddU(m)
-            | I64AtomicRmw32AddU(m)
-            | I32AtomicRmwSub(m)
-            | I64AtomicRmwSub(m)
-            | I32AtomicRmw8SubU(m)
-            | I32AtomicRmw16SubU(m)
-            | I64AtomicRmw8SubU(m)
-            | I64AtomicRmw16SubU(m)
-            | I64AtomicRmw32SubU(m)
-            | I32AtomicRmwAnd(m)
-            | I64AtomicRmwAnd(m)
-            | I32AtomicRmw8AndU(m)
-            | I32AtomicRmw16AndU(m)
-            | I64AtomicRmw8AndU(m)
-            | I64AtomicRmw16AndU(m)
-            | I64AtomicRmw32AndU(m)
-            | I32AtomicRmwOr(m)
-            | I64AtomicRmwOr(m)
-            | I32AtomicRmw8OrU(m)
-            | I32AtomicRmw16OrU(m)
-            | I64AtomicRmw8OrU(m)
-            | I64AtomicRmw16OrU(m)
-            | I64AtomicRmw32OrU(m)
-            | I32AtomicRmwXor(m)
-            | I64AtomicRmwXor(m)
-            | I32AtomicRmw8XorU(m)
-            | I32AtomicRmw16XorU(m)
-            | I64AtomicRmw8XorU(m)
-            | I64AtomicRmw16XorU(m)
-            | I64AtomicRmw32XorU(m)
-            | I32AtomicRmwXchg(m)
-            | I64AtomicRmwXchg(m)
-            | I32AtomicRmw8XchgU(m)
-            | I32AtomicRmw16XchgU(m)
-            | I64AtomicRmw8XchgU(m)
-            | I64AtomicRmw16XchgU(m)
-            | I64AtomicRmw32XchgU(m)
-            | I32AtomicRmwCmpxchg(m)
-            | I64AtomicRmwCmpxchg(m)
-            | I32AtomicRmw8CmpxchgU(m)
-            | I32AtomicRmw16CmpxchgU(m)
-            | I64AtomicRmw8CmpxchgU(m)
-            | I64AtomicRmw16CmpxchgU(m)
-            | I64AtomicRmw32CmpxchgU(m)
-            | V128Load(m)
-            | V128Load8x8S(m)
-            | V128Load8x8U(m)
-            | V128Load16x4S(m)
-            | V128Load16x4U(m)
-            | V128Load32x2S(m)
-            | V128Load32x2U(m)
-            | V128Load8Splat(m)
-            | V128Load16Splat(m)
-            | V128Load32Splat(m)
-            | V128Load64Splat(m)
-            | V128Load32Zero(m)
-            | V128Load64Zero(m)
-            | V128Store(m)
-            | MemoryAtomicNotify(m)
-            | MemoryAtomicWait32(m)
-            | MemoryAtomicWait64(m) => {
-                self.resolver.resolve(&mut m.memory, Ns::Memory)?;
-            }
 
             _ => {}
         }

--- a/crates/wast/src/resolve/types.rs
+++ b/crates/wast/src/resolve/types.rs
@@ -222,7 +222,7 @@ impl<'a> Expander<'a> {
     where
         T: TypeReference<'a>,
     {
-        if let Some(idx) = &item.index {
+        if let Some(ItemRef::Item { idx, .. }) = &item.index {
             return idx.clone();
         }
         let key = match item.inline.as_mut() {
@@ -234,7 +234,11 @@ impl<'a> Expander<'a> {
         };
         let span = Span::from_offset(0); // FIXME: don't manufacture
         let idx = self.key_to_idx(span, key);
-        item.index = Some(idx);
+        item.index = Some(ItemRef::Item {
+            idx,
+            kind: kw::r#type(span),
+            exports: Vec::new(),
+        });
         return idx;
     }
 
@@ -427,11 +431,11 @@ enum Item<'a> {
 impl<'a> Item<'a> {
     fn new(item: &ItemSig<'a>) -> Item<'a> {
         match &item.kind {
-            ItemKind::Func(f) => Item::Func(f.index.expect("should have index")),
-            ItemKind::Instance(f) => Item::Instance(f.index.expect("should have index")),
-            ItemKind::Module(f) => Item::Module(f.index.expect("should have index")),
+            ItemKind::Func(f) => Item::Func(*f.index.as_ref().unwrap().unwrap_index()),
+            ItemKind::Instance(f) => Item::Instance(*f.index.as_ref().unwrap().unwrap_index()),
+            ItemKind::Module(f) => Item::Module(*f.index.as_ref().unwrap().unwrap_index()),
             ItemKind::Event(EventType::Exception(f)) => {
-                Item::Event(f.index.expect("should have index"))
+                Item::Event(*f.index.as_ref().unwrap().unwrap_index())
             }
             ItemKind::Table(t) => Item::Table(t.clone()),
             ItemKind::Memory(t) => Item::Memory(t.clone()),

--- a/crates/wast/src/resolve/types.rs
+++ b/crates/wast/src/resolve/types.rs
@@ -222,8 +222,14 @@ impl<'a> Expander<'a> {
     where
         T: TypeReference<'a>,
     {
-        if let Some(ItemRef::Item { idx, .. }) = &item.index {
-            return idx.clone();
+        if let Some(idx) = &item.index {
+            match idx {
+                ItemRef::Item { idx, exports, .. } => {
+                    debug_assert!(exports.len() == 0);
+                    return idx.clone();
+                }
+                ItemRef::Outer { .. } => unreachable!(),
+            }
         }
         let key = match item.inline.as_mut() {
             Some(ty) => {

--- a/tests/dump/alias.wat
+++ b/tests/dump/alias.wat
@@ -4,10 +4,7 @@
     (export "f2" (func $f2 (param i32)))
   ))
 
-  ;; TODO figure out syntactic sugar here
-  (alias $i "f1" (func $i.$f1))
-
   (func (export "run")
-    call $i.$f1
+    call (func $i "f1")
   )
 )

--- a/tests/dump/alias.wat.dump
+++ b/tests/dump/alias.wat.dump
@@ -29,9 +29,3 @@
 0x0041 | 00          | 0 local blocks
 0x0042 | 10 00       | Call { function_index: 0 }
 0x0044 | 0b          | End
-0x0045 | 00 0f 04 6e | custom section: "name"
-       | 61 6d 65   
-0x004c | 01 08       | function names
-0x004e | 01          | 1 count
-0x004f | 00 05 69 2e | Naming { index: 0, name: "i.$f1" }
-       | 24 66 31   

--- a/tests/dump/alias2.wat
+++ b/tests/dump/alias2.wat
@@ -17,20 +17,12 @@
     (import "6" (instance))
   )
 
-  ;; TODO figure out syntactic sugar here
-  (alias $i "1" (func $i.$func))
-  (alias $i "2" (memory $i.$memory))
-  (alias $i "3" (table $i.$table))
-  (alias $i "4" (global $i.$global))
-  (alias $i "5" (module $i.$module))
-  (alias $i "6" (instance $i.$instance))
-
   (instance (instantiate $m
-    (arg "1" (func $i.$func))
-    (arg "2" (memory $i.$memory))
-    (arg "3" (global $i.$global))
-    (arg "4" (table $i.$table))
-    (arg "5" (module $i.$module))
-    (arg "6" (instance $i.$instance))
+    (arg "1" (func $i "1"))
+    (arg "2" (memory $i "2"))
+    (arg "3" (global $i "4"))
+    (arg "4" (table $i "3"))
+    (arg "5" (module $i "5"))
+    (arg "6" (instance $i "6"))
   ))
 )

--- a/tests/dump/alias2.wat.dump
+++ b/tests/dump/alias2.wat.dump
@@ -51,10 +51,10 @@
        | 31         
 0x008e | 00 00 02 01 | [alias] InstanceExport { instance: 0, kind: Memory, export: "2" }
        | 32         
-0x0093 | 00 00 01 01 | [alias] InstanceExport { instance: 0, kind: Table, export: "3" }
-       | 33         
-0x0098 | 00 00 03 01 | [alias] InstanceExport { instance: 0, kind: Global, export: "4" }
+0x0093 | 00 00 03 01 | [alias] InstanceExport { instance: 0, kind: Global, export: "4" }
        | 34         
+0x0098 | 00 00 01 01 | [alias] InstanceExport { instance: 0, kind: Table, export: "3" }
+       | 33         
 0x009d | 00 00 05 01 | [alias] InstanceExport { instance: 0, kind: Module, export: "5" }
        | 35         
 0x00a2 | 00 00 06 01 | [alias] InstanceExport { instance: 0, kind: Instance, export: "6" }
@@ -75,10 +75,3 @@
        | 01         
 0x00c6 | 01 36 00 06 | [instantiate arg] InstanceArg { name: "6", field: None, kind: Instance, index: 1 }
        | 01         
-0x00cb | 00 11 04 6e | custom section: "name"
-       | 61 6d 65   
-0x00d2 | 01 0a       | function names
-0x00d4 | 01          | 1 count
-0x00d5 | 00 07 69 2e | Naming { index: 0, name: "i.$func" }
-       | 24 66 75 6e
-       | 63         

--- a/tests/dump/bundled.wat
+++ b/tests/dump/bundled.wat
@@ -6,20 +6,15 @@
   (import "wasi_file" (instance $real-wasi (type $WasiFile)))
 
   (module $CHILD
-    ;; TODO implement implicit parent aliases
-    (alias parent $WasiFile (type $WasiFile))
-    (import "wasi_file" (instance $wasi-file (type $WasiFile)))
+    (import "wasi_file" (instance $wasi-file (type outer 0 $WasiFile)))
     (func $play (export "play")
-      ;; TODO: implement this
-      ;;call $wasi-file.$read
+      call (func $wasi-file "read")
     )
   )
 
 
   (module $VIRTUALIZE
-    ;; TODO implement implicit parent aliases
-    (alias parent $WasiFile (type $WasiFile))
-    (import "wasi_file" (instance $wasi-file (type $WasiFile)))
+    (import "wasi_file" (instance $wasi-file (type outer 0 $WasiFile)))
     (func (export "read") (param i32 i32 i32) (result i32)
       i32.const 0
     )
@@ -31,10 +26,7 @@
   (instance $virt-wasi (instantiate $VIRTUALIZE (arg "wasi_file" (instance $real-wasi))))
   (instance $child (instantiate $CHILD (arg "wasi_file" (instance $virt-wasi))))
 
-  ;; TODO implement implicit child aliases
-  (alias $child "play" (func $child.$play))
-
   (func (export "work")
-    call $child.$play
+    call (func $child "play")
   )
 )

--- a/tests/dump/bundled.wat.dump
+++ b/tests/dump/bundled.wat.dump
@@ -22,7 +22,7 @@
          | 01 00 00 00
   0x0041 | 10 05       | alias section
   0x0043 | 01          | 1 count
-  0x0044 | 01 00 07 01 | [alias] ParentType { relative_depth: 0, index: 1 }
+  0x0044 | 01 00 07 01 | [alias] OuterType { relative_depth: 0, index: 1 }
   0x0048 | 02 0f       | import section
   0x004a | 01          | 1 count
   0x004b | 09 77 61 73 | import [instance 0] Import { module: "wasi_file", field: None, ty: Instance(0) }
@@ -64,7 +64,7 @@
          | 01 00 00 00
   0x00a1 | 10 05       | alias section
   0x00a3 | 01          | 1 count
-  0x00a4 | 01 00 07 01 | [alias] ParentType { relative_depth: 0, index: 1 }
+  0x00a4 | 01 00 07 01 | [alias] OuterType { relative_depth: 0, index: 1 }
   0x00a8 | 02 0f       | import section
   0x00aa | 01          | 1 count
   0x00ab | 09 77 61 73 | import [instance 0] Import { module: "wasi_file", field: None, ty: Instance(0) }

--- a/tests/dump/bundled.wat.dump
+++ b/tests/dump/bundled.wat.dump
@@ -15,129 +15,126 @@
        | 69 5f 66 69
        | 6c 65 00 ff
        | 06 01      
-0x0034 | 0e b5 01    | module section
+0x0034 | 0e c4 01    | module section
 0x0037 | 02          | 2 count
-0x0038 | 51          | inline module size
+0x0038 | 5f          | inline module size
   0x0039 | 00 61 73 6d | version 1
          | 01 00 00 00
-  0x0041 | 10 04       | alias section
+  0x0041 | 10 05       | alias section
   0x0043 | 01          | 1 count
-  0x0044 | 01 07 01    | [alias] ParentType(1)
-  0x0047 | 02 0f       | import section
-  0x0049 | 01          | 1 count
-  0x004a | 09 77 61 73 | import [instance 0] Import { module: "wasi_file", field: None, ty: Instance(0) }
+  0x0044 | 01 00 07 01 | [alias] ParentType { relative_depth: 0, index: 1 }
+  0x0048 | 02 0f       | import section
+  0x004a | 01          | 1 count
+  0x004b | 09 77 61 73 | import [instance 0] Import { module: "wasi_file", field: None, ty: Instance(0) }
          | 69 5f 66 69
          | 6c 65 00 ff
          | 06 00      
-  0x0058 | 01 04       | type section
-  0x005a | 01          | 1 count
-  0x005b | 60 00 00    | [type 1] Func(FuncType { params: [], returns: [] })
-  0x005e | 03 02       | func section
-  0x0060 | 01          | 1 count
-  0x0061 | 01          | [func 0] type 1
-  0x0062 | 07 08       | export section
-  0x0064 | 01          | 1 count
-  0x0065 | 04 70 6c 61 | export Export { field: "play", kind: Function, index: 0 }
-         | 79 00 00   
-  0x006c | 0a 04       | code section
-  0x006e | 01          | 1 count
-============== func 0 ====================
-  0x006f | 02          | size of function
-  0x0070 | 00          | 0 local blocks
-  0x0071 | 0b          | End
-  0x0072 | 00 16 04 6e | custom section: "name"
-         | 61 6d 65   
-  0x0079 | 00 06       | module name
-  0x007b | 05 43 48 49 | "CHILD"
-         | 4c 44      
-  0x0081 | 01 07       | function names
-  0x0083 | 01          | 1 count
-  0x0084 | 00 04 70 6c | Naming { index: 0, name: "play" }
-         | 61 79      
-0x008a | 61          | inline module size
-  0x008b | 00 61 73 6d | version 1
-         | 01 00 00 00
-  0x0093 | 10 04       | alias section
-  0x0095 | 01          | 1 count
-  0x0096 | 01 07 01    | [alias] ParentType(1)
-  0x0099 | 02 0f       | import section
-  0x009b | 01          | 1 count
-  0x009c | 09 77 61 73 | import [instance 0] Import { module: "wasi_file", field: None, ty: Instance(0) }
-         | 69 5f 66 69
-         | 6c 65 00 ff
-         | 06 00      
-  0x00aa | 01 08       | type section
-  0x00ac | 01          | 1 count
-  0x00ad | 60 03 7f 7f | [type 1] Func(FuncType { params: [I32, I32, I32], returns: [I32] })
-         | 7f 01 7f   
-  0x00b4 | 03 03       | func section
-  0x00b6 | 02          | 2 count
-  0x00b7 | 01          | [func 0] type 1
-  0x00b8 | 01          | [func 1] type 1
-  0x00b9 | 07 10       | export section
-  0x00bb | 02          | 2 count
-  0x00bc | 04 72 65 61 | export Export { field: "read", kind: Function, index: 0 }
-         | 64 00 00   
-  0x00c3 | 05 77 72 69 | export Export { field: "write", kind: Function, index: 1 }
-         | 74 65 00 01
-  0x00cb | 0a 0b       | code section
-  0x00cd | 02          | 2 count
-============== func 0 ====================
-  0x00ce | 04          | size of function
-  0x00cf | 00          | 0 local blocks
-  0x00d0 | 41 00       | I32Const { value: 0 }
-  0x00d2 | 0b          | End
+  0x0059 | 10 09       | alias section
+  0x005b | 01          | 1 count
+  0x005c | 00 00 00 04 | [alias] InstanceExport { instance: 0, kind: Function, export: "read" }
+         | 72 65 61 64
+  0x0064 | 01 04       | type section
+  0x0066 | 01          | 1 count
+  0x0067 | 60 00 00    | [type 1] Func(FuncType { params: [], returns: [] })
+  0x006a | 03 02       | func section
+  0x006c | 01          | 1 count
+  0x006d | 01          | [func 1] type 1
+  0x006e | 07 08       | export section
+  0x0070 | 01          | 1 count
+  0x0071 | 04 70 6c 61 | export Export { field: "play", kind: Function, index: 1 }
+         | 79 00 01   
+  0x0078 | 0a 06       | code section
+  0x007a | 01          | 1 count
 ============== func 1 ====================
-  0x00d3 | 04          | size of function
-  0x00d4 | 00          | 0 local blocks
-  0x00d5 | 41 00       | I32Const { value: 0 }
-  0x00d7 | 0b          | End
-  0x00d8 | 00 12 04 6e | custom section: "name"
+  0x007b | 04          | size of function
+  0x007c | 00          | 0 local blocks
+  0x007d | 10 00       | Call { function_index: 0 }
+  0x007f | 0b          | End
+  0x0080 | 00 16 04 6e | custom section: "name"
          | 61 6d 65   
-  0x00df | 00 0b       | module name
-  0x00e1 | 0a 56 49 52 | "VIRTUALIZE"
+  0x0087 | 00 06       | module name
+  0x0089 | 05 43 48 49 | "CHILD"
+         | 4c 44      
+  0x008f | 01 07       | function names
+  0x0091 | 01          | 1 count
+  0x0092 | 01 04 70 6c | Naming { index: 1, name: "play" }
+         | 61 79      
+0x0098 | 62          | inline module size
+  0x0099 | 00 61 73 6d | version 1
+         | 01 00 00 00
+  0x00a1 | 10 05       | alias section
+  0x00a3 | 01          | 1 count
+  0x00a4 | 01 00 07 01 | [alias] ParentType { relative_depth: 0, index: 1 }
+  0x00a8 | 02 0f       | import section
+  0x00aa | 01          | 1 count
+  0x00ab | 09 77 61 73 | import [instance 0] Import { module: "wasi_file", field: None, ty: Instance(0) }
+         | 69 5f 66 69
+         | 6c 65 00 ff
+         | 06 00      
+  0x00b9 | 01 08       | type section
+  0x00bb | 01          | 1 count
+  0x00bc | 60 03 7f 7f | [type 1] Func(FuncType { params: [I32, I32, I32], returns: [I32] })
+         | 7f 01 7f   
+  0x00c3 | 03 03       | func section
+  0x00c5 | 02          | 2 count
+  0x00c6 | 01          | [func 0] type 1
+  0x00c7 | 01          | [func 1] type 1
+  0x00c8 | 07 10       | export section
+  0x00ca | 02          | 2 count
+  0x00cb | 04 72 65 61 | export Export { field: "read", kind: Function, index: 0 }
+         | 64 00 00   
+  0x00d2 | 05 77 72 69 | export Export { field: "write", kind: Function, index: 1 }
+         | 74 65 00 01
+  0x00da | 0a 0b       | code section
+  0x00dc | 02          | 2 count
+============== func 0 ====================
+  0x00dd | 04          | size of function
+  0x00de | 00          | 0 local blocks
+  0x00df | 41 00       | I32Const { value: 0 }
+  0x00e1 | 0b          | End
+============== func 1 ====================
+  0x00e2 | 04          | size of function
+  0x00e3 | 00          | 0 local blocks
+  0x00e4 | 41 00       | I32Const { value: 0 }
+  0x00e6 | 0b          | End
+  0x00e7 | 00 12 04 6e | custom section: "name"
+         | 61 6d 65   
+  0x00ee | 00 0b       | module name
+  0x00f0 | 0a 56 49 52 | "VIRTUALIZE"
          | 54 55 41 4c
          | 49 5a 45   
-0x00ec | 0f 21       | instance section
-0x00ee | 02          | 2 count
-0x00ef | 00 01       | [instance 1] instantiate module:1
-0x00f1 | 01          | 1 count
-0x00f2 | 09 77 61 73 | [instantiate arg] InstanceArg { name: "wasi_file", field: None, kind: Instance, index: 0 }
+0x00fb | 0f 21       | instance section
+0x00fd | 02          | 2 count
+0x00fe | 00 01       | [instance 1] instantiate module:1
+0x0100 | 01          | 1 count
+0x0101 | 09 77 61 73 | [instantiate arg] InstanceArg { name: "wasi_file", field: None, kind: Instance, index: 0 }
        | 69 5f 66 69
        | 6c 65 00 06
        | 00         
-0x00ff | 00 00       | [instance 2] instantiate module:0
-0x0101 | 01          | 1 count
-0x0102 | 09 77 61 73 | [instantiate arg] InstanceArg { name: "wasi_file", field: None, kind: Instance, index: 1 }
+0x010e | 00 00       | [instance 2] instantiate module:0
+0x0110 | 01          | 1 count
+0x0111 | 09 77 61 73 | [instantiate arg] InstanceArg { name: "wasi_file", field: None, kind: Instance, index: 1 }
        | 69 5f 66 69
        | 6c 65 00 06
        | 01         
-0x010f | 10 09       | alias section
-0x0111 | 01          | 1 count
-0x0112 | 00 02 00 04 | [alias] InstanceExport { instance: 2, kind: Function, export: "play" }
+0x011e | 10 09       | alias section
+0x0120 | 01          | 1 count
+0x0121 | 00 02 00 04 | [alias] InstanceExport { instance: 2, kind: Function, export: "play" }
        | 70 6c 61 79
-0x011a | 01 04       | type section
-0x011c | 01          | 1 count
-0x011d | 60 00 00    | [type 2] Func(FuncType { params: [], returns: [] })
-0x0120 | 03 02       | func section
-0x0122 | 01          | 1 count
-0x0123 | 02          | [func 1] type 2
-0x0124 | 07 08       | export section
-0x0126 | 01          | 1 count
-0x0127 | 04 77 6f 72 | export Export { field: "work", kind: Function, index: 1 }
+0x0129 | 01 04       | type section
+0x012b | 01          | 1 count
+0x012c | 60 00 00    | [type 2] Func(FuncType { params: [], returns: [] })
+0x012f | 03 02       | func section
+0x0131 | 01          | 1 count
+0x0132 | 02          | [func 1] type 2
+0x0133 | 07 08       | export section
+0x0135 | 01          | 1 count
+0x0136 | 04 77 6f 72 | export Export { field: "work", kind: Function, index: 1 }
        | 6b 00 01   
-0x012e | 0a 06       | code section
-0x0130 | 01          | 1 count
-============== func 1 ====================
-0x0131 | 04          | size of function
-0x0132 | 00          | 0 local blocks
-0x0133 | 10 00       | Call { function_index: 0 }
-0x0135 | 0b          | End
-0x0136 | 00 15 04 6e | custom section: "name"
-       | 61 6d 65   
-0x013d | 01 0e       | function names
+0x013d | 0a 06       | code section
 0x013f | 01          | 1 count
-0x0140 | 00 0b 63 68 | Naming { index: 0, name: "child.$play" }
-       | 69 6c 64 2e
-       | 24 70 6c 61
-       | 79         
+============== func 1 ====================
+0x0140 | 04          | size of function
+0x0141 | 00          | 0 local blocks
+0x0142 | 10 00       | Call { function_index: 0 }
+0x0144 | 0b          | End

--- a/tests/dump/module-linking.wat
+++ b/tests/dump/module-linking.wat
@@ -17,20 +17,12 @@
     (import "6" (instance))
   )
 
-  ;; TODO figure out syntactic sugar here
-  (alias $i "1" (func $i.$func))
-  (alias $i "2" (memory $i.$memory))
-  (alias $i "3" (table $i.$table))
-  (alias $i "4" (global $i.$global))
-  (alias $i "5" (module $i.$module))
-  (alias $i "6" (instance $i.$instance))
-
   (instance (instantiate $m
-    (arg "1" (func $i.$func))
-    (arg "2" (memory $i.$memory))
-    (arg "3" (global $i.$global))
-    (arg "4" (table $i.$table))
-    (arg "5" (module $i.$module))
-    (arg "6" (instance $i.$instance))
+    (arg "1" (func $i "1"))
+    (arg "2" (memory $i "2"))
+    (arg "3" (global $i "4"))
+    (arg "4" (table $i "3"))
+    (arg "5" (module $i "5"))
+    (arg "6" (instance $i "6"))
   ))
 )

--- a/tests/dump/module-linking.wat.dump
+++ b/tests/dump/module-linking.wat.dump
@@ -51,10 +51,10 @@
        | 31         
 0x008e | 00 00 02 01 | [alias] InstanceExport { instance: 0, kind: Memory, export: "2" }
        | 32         
-0x0093 | 00 00 01 01 | [alias] InstanceExport { instance: 0, kind: Table, export: "3" }
-       | 33         
-0x0098 | 00 00 03 01 | [alias] InstanceExport { instance: 0, kind: Global, export: "4" }
+0x0093 | 00 00 03 01 | [alias] InstanceExport { instance: 0, kind: Global, export: "4" }
        | 34         
+0x0098 | 00 00 01 01 | [alias] InstanceExport { instance: 0, kind: Table, export: "3" }
+       | 33         
 0x009d | 00 00 05 01 | [alias] InstanceExport { instance: 0, kind: Module, export: "5" }
        | 35         
 0x00a2 | 00 00 06 01 | [alias] InstanceExport { instance: 0, kind: Instance, export: "6" }
@@ -75,10 +75,3 @@
        | 01         
 0x00c6 | 01 36 00 06 | [instantiate arg] InstanceArg { name: "6", field: None, kind: Instance, index: 1 }
        | 01         
-0x00cb | 00 11 04 6e | custom section: "name"
-       | 61 6d 65   
-0x00d2 | 01 0a       | function names
-0x00d4 | 01          | 1 count
-0x00d5 | 00 07 69 2e | Naming { index: 0, name: "i.$func" }
-       | 24 66 75 6e
-       | 63         

--- a/tests/local/module-linking/alias.wast
+++ b/tests/local/module-linking/alias.wast
@@ -3,10 +3,8 @@
     (export "f1" (func $f1))
     (export "f2" (func $f2 (param i32)))
   ))
-  ;; TODO: alias sugar
-  (alias $i "f1" (func $i.$f1))
   (func (export "run")
-    call $i.$f1
+    call (func $i "f1")
   )
 )
 (assert_malformed
@@ -27,10 +25,8 @@
     (export "f2" (func $f2 (param i32)))
   ))
   (instance $i (instantiate $m))
-  ;; TODO: alias sugar
-  (alias $i "f1" (func $i.$f1))
   (func (export "run")
-    call $i.$f1
+    call (func $i "f1")
   )
 )
 (assert_malformed
@@ -52,10 +48,8 @@
     (func $f2 (export "f2") (param i32))
   )
   (instance $i (instantiate $m))
-  ;; TODO: alias sugar
-  (alias $i "f1" (func $i.$f1))
   (func (export "run")
-    call $i.$f1
+    call (func $i "f1")
   )
 )
 
@@ -76,88 +70,15 @@
     (export "global" (global $glbl i32))
   ))
 
-  ;; TODO: alias sugar
-  (alias $libc "table" (table $libc.$tbl))
-  (alias $libc "global" (global $libc.$glbl))
   (func $table_get
     i32.const 0
-    table.get $libc.$tbl
+    table.get (table $libc "table")
     drop)
 
   (func $global_get
-    global.get $libc.$glbl
+    global.get (global $libc "global")
     drop)
 )
-
-;; make sure auto-expanded aliases can't shadow already-defined names
-;; TODO: reenable with alias sugar
-(; (module ;)
-(;   (import "a" (instance $i ;)
-(;     (export "1" (func $func (param i32))) ;)
-(;     (export "2" (func $memory)) ;)
-(;     (export "3" (func $table)) ;)
-(;     (export "4" (func $global)) ;)
-(;     (export "5" (func $module)) ;)
-(;     (export "6" (func $instance)) ;)
-(;   )) ;)
-(;   (import "b" (instance $i2 ;)
-(;     (export "1" (func $func (param i32))) ;)
-(;     (export "2" (func $memory)) ;)
-(;     (export "3" (func $table)) ;)
-(;     (export "4" (func $global)) ;)
-(;     (export "5" (func $module)) ;)
-(;     (export "6" (func $instance)) ;)
-(;   )) ;)
-
-(;   (import "c" (instance $other ;)
-(;     (export "1" (func $func)) ;)
-(;     (export "2" (memory $memory 1)) ;)
-(;     (export "3" (global $global i32)) ;)
-(;     (export "4" (table $table 1 funcref)) ;)
-(;     (export "5" (module $module)) ;)
-(;     (export "6" (instance $instance)) ;)
-(;   )) ;)
-
-(;   (func $i.$func (import "d")) ;)
-(;   (memory $i.$memory (import "e") 1) ;)
-(;   (global $i.$global (import "f") i32) ;)
-(;   (table $i.$table (import "g") 1 funcref) ;)
-(;   (module $i.$module (import "h")) ;)
-(;   (instance $i.$instance (import "i")) ;)
-
-(;   (alias $i2.$func (instance $other) (func $func)) ;)
-(;   (alias $i2.$global (instance $other) (global $global)) ;)
-(;   (alias $i2.$table (instance $other) (table $table)) ;)
-(;   (alias $i2.$memory (instance $other) (memory $memory)) ;)
-(;   (alias $i2.$instance (instance $other) (instance $instance)) ;)
-(;   (alias $i2.$module (instance $other) (module $module)) ;)
-
-(;   (module $m ;)
-(;     (import "" (func)) ;)
-(;     (import "" (memory 1)) ;)
-(;     (import "" (global i32)) ;)
-(;     (import "" (table 1 funcref)) ;)
-(;     (import "" (module)) ;)
-(;     (import "" (instance)) ;)
-(;   ) ;)
-
-(;   (instance (instantiate $m ;)
-(;     (func $i.$func) ;)
-(;     (memory $i.$memory) ;)
-(;     (global $i.$global) ;)
-(;     (table $i.$table) ;)
-(;     (module $i.$module) ;)
-(;     (instance $i.$instance) ;)
-(;   )) ;)
-(;   (instance (instantiate $m ;)
-(;     (func $i2.$func) ;)
-(;     (memory $i2.$memory) ;)
-(;     (global $i2.$global) ;)
-(;     (table $i2.$table) ;)
-(;     (module $i2.$module) ;)
-(;     (instance $i2.$instance) ;)
-(;   )) ;)
-(; ) ;)
 
 ;; auto-expansion should visit everywhere
 (module
@@ -165,10 +86,8 @@
     (export "" (global $global i32))
   ))
 
-  ;; TODO: alias sugar
-  (alias $i "" (global $i.$global))
   (func
-    global.get $i.$global
+    global.get (global $i "")
     drop)
 )
 (module
@@ -176,22 +95,18 @@
     (export "" (global $global (mut i32)))
   ))
 
-  ;; TODO: alias sugar
-  (alias $i "" (global $i.$global))
   (func
     i32.const 0
-    global.set $i.$global)
+    global.set (global $i ""))
 )
 (module
   (import "" (instance $i
     (export "" (table $table 1 funcref))
   ))
 
-  ;; TODO: alias sugar
-  (alias $i "" (table $i.$table))
   (func
     i32.const 0
-    table.get $i.$table
+    table.get (table $i "")
     drop)
 )
 (module
@@ -199,33 +114,27 @@
     (export "" (table $table 1 funcref))
   ))
 
-  ;; TODO: alias sugar
-  (alias $i "" (table $i.$table))
   (func
     i32.const 0
     ref.null func
-    table.set $i.$table)
+    table.set (table $i ""))
 )
 (module
   (import "" (instance $i
     (export "" (table $table 1 funcref))
   ))
 
-  ;; TODO: alias sugar
-  (alias $i "" (table $i.$table))
   (func
     i32.const 0
-    call_indirect $i.$table)
+    call_indirect (table $i ""))
 )
 (module
   (import "" (instance $i
     (export "" (table $table 1 funcref))
   ))
 
-  ;; TODO: alias sugar
-  (alias $i "" (table $i.$table))
   (func
-    table.size $i.$table
+    table.size (table $i "")
     drop)
 )
 (module
@@ -233,12 +142,10 @@
     (export "" (table $table 1 funcref))
   ))
 
-  ;; TODO: alias sugar
-  (alias $i "" (table $i.$table))
   (func
     ref.null func
     i32.const 0
-    table.grow $i.$table
+    table.grow (table $i "")
     drop)
 )
 (module
@@ -246,26 +153,22 @@
     (export "" (table $table 1 funcref))
   ))
 
-  ;; TODO: alias sugar
-  (alias $i "" (table $i.$table))
   (func
     i32.const 0
     ref.null func
     i32.const 0
-    table.fill $i.$table)
+    table.fill (table $i ""))
 )
 (module
   (import "" (instance $i
     (export "" (table $table 1 funcref))
   ))
 
-  ;; TODO: alias sugar
-  (alias $i "" (table $i.$table))
   (func
     i32.const 0
     i32.const 0
     i32.const 0
-    table.init $i.$table 0)
+    table.init (table $i "") 0)
   (elem func 0)
 )
 (module
@@ -273,140 +176,119 @@
     (export "" (table $table 1 funcref))
   ))
 
-  ;; TODO: alias sugar
-  (alias $i "" (table $i.$table))
   (func
     i32.const 0
     i32.const 0
     i32.const 0
-    table.copy $i.$table $i.$table)
+    table.copy (table $i "") (table $i ""))
 )
 
 (module
   (import "" (instance $i
     (export "" (func $func))
   ))
-  ;; TODO: alias sugar
-  (alias $i "" (func $i.$func))
   (func
-    return_call $i.$func)
+    return_call (func $i ""))
 )
 
 (module
   (import "" (instance $i
     (export "" (table $table 1 funcref))
   ))
-  ;; TODO: alias sugar
-  (alias $i "" (table $i.$table))
   (func
     i32.const 0
-    return_call_indirect $i.$table)
+    return_call_indirect (table $i ""))
 )
 
 (module
   (import "" (instance $i
     (export "" (func $func))
   ))
-  ;; TODO: alias sugar
-  (alias $i "" (func $i.$func))
-  (global funcref (ref.func $i.$func))
+  (global funcref (ref.func (func $i "")))
 )
 (module
   (import "" (instance $i
     (export "" (func $func))
   ))
-  ;; TODO: alias sugar
-  (alias $i "" (func $i.$func))
-  (start $i.$func)
+  (start (func $i ""))
 )
 (module
   (import "" (instance $i
     (export "a" (table $table 1 funcref))
     (export "b" (func $func))
   ))
-  ;; TODO: alias sugar
-  (alias $i "a" (table $i.$table))
-  (alias $i "b" (func $i.$func))
-  (elem (table $i.$table) (i32.const 0) funcref (ref.func $i.$func))
+  (elem (table $i "a") (i32.const 0) funcref (ref.func (func $i "b")))
 )
 (module
   (import "" (instance $i
     (export "a" (table $table 1 funcref))
     (export "b" (func $func))
   ))
-  ;; TODO: alias sugar
-  (alias $i "a" (table $i.$table))
-  (alias $i "b" (func $i.$func))
-  (elem (table $i.$table) (i32.const 0) func $i.$func)
+  (elem (table $i "a") (i32.const 0) func (func $i "b"))
 )
 (module
   (import "" (instance $i
     (export "" (memory $memory 1))
   ))
-  ;; TODO: alias sugar
-  (alias $i "" (memory $i.$memory))
-  (data (memory $i.$memory) (i32.const 0) "")
+  (data (memory $i "") (i32.const 0) "")
 )
 
-;; TODO: reenable with alias sugar
-(; (module ;)
-(;   (import "" (instance $i ;)
-(;     (export "1" (func $func)) ;)
-(;     (export "2" (memory $memory 1)) ;)
-(;     (export "3" (table $table 1 funcref)) ;)
-(;     (export "4" (global $global i32)) ;)
-(;     (export "5" (module $module)) ;)
-(;     (export "6" (instance $instance)) ;)
-(;   )) ;)
-(;   (export "1" (func $i.$func)) ;)
-(;   (export "2" (memory $i.$memory)) ;)
-(;   (export "3" (table $i.$table)) ;)
-(;   (export "4" (global $i.$global)) ;)
-(;   (export "5" (module $i.$module)) ;)
-(;   (export "6" (instance $i.$instance)) ;)
-(; ) ;)
+(module
+  (import "" (instance $i
+    (export "1" (func $func))
+    (export "2" (memory $memory 1))
+    (export "3" (table $table 1 funcref))
+    (export "4" (global $global i32))
+    (export "5" (module $module))
+    (export "6" (instance $instance))
+  ))
+  (export "1" (func $i "1"))
+  (export "2" (memory $i "2"))
+  (export "3" (table $i "3"))
+  (export "4" (global $i "4"))
+  (export "5" (module $i "5"))
+  (export "6" (instance $i "6"))
+)
 
-;; TODO: reenable with alias sugar
-(; (module ;)
-(;   (import "" (instance $i ;)
-(;     (export "1" (func $func)) ;)
-(;     (export "2" (memory $memory 1)) ;)
-(;     (export "3" (table $table 1 funcref)) ;)
-(;     (export "4" (global $global i32)) ;)
-(;     (export "5" (module $module)) ;)
-(;     (export "6" (instance $instance)) ;)
-(;   )) ;)
+(module
+  (import "" (instance $i
+    (export "1" (func $func))
+    (export "2" (memory $memory 1))
+    (export "3" (table $table 1 funcref))
+    (export "4" (global $global i32))
+    (export "5" (module $module))
+    (export "6" (instance $instance))
+  ))
 
-(;   (module $m ;)
-(;     (import "" (func)) ;)
-(;     (import "" (memory 1)) ;)
-(;     (import "" (global i32)) ;)
-(;     (import "" (table 1 funcref)) ;)
-(;     (import "" (module)) ;)
-(;     (import "" (instance)) ;)
-(;   ) ;)
+  (module $m
+    (import "1" (func))
+    (import "2" (memory 1))
+    (import "3" (global i32))
+    (import "4" (table 1 funcref))
+    (import "5" (module))
+    (import "6" (instance))
+  )
 
-(;   (instance (instantiate $m ;)
-(;     (func $i.$func) ;)
-(;     (memory $i.$memory) ;)
-(;     (global $i.$global) ;)
-(;     (table $i.$table) ;)
-(;     (module $i.$module) ;)
-(;     (instance $i.$instance) ;)
-(;   )) ;)
-(; ) ;)
+  (instance (instantiate $m
+    (arg "1" (func $i "1"))
+    (arg "2" (memory $i "2"))
+    (arg "3" (global $i "4"))
+    (arg "4" (table $i "3"))
+    (arg "5" (module $i "5"))
+    (arg "6" (instance $i "6"))
+  ))
+)
 
-;; TODO: reenable with alias sugar
-(; (module ;)
-(;   (module $m ;)
-(;     (func $f (export "")) ;)
-(;   ) ;)
+(module
+  (module $m
+    (func $f (export ""))
+  )
 
-(;   (instance $i (instantiate $m)) ;)
+  (instance $i (instantiate $m))
 
-(;   (func ;)
-(;     call $i.$f) ;)
-(; ) ;)
+  (func
+    call (func $i ""))
+)
 
 (assert_invalid
   (module
@@ -663,52 +545,38 @@
 (module
   (module $m (memory $m (export "x") 1))
   (instance $i (instantiate $m))
-  ;; TODO: alias sugar
-  (alias $i "x" (memory $i.$m))
-  (func unreachable i32.load $i.$m unreachable)
+  (func unreachable i32.load (memory $i "x") unreachable)
 )
 (module
   (module $m (memory $m (export "x") 1))
   (instance $i (instantiate $m))
-  ;; TODO: alias sugar
-  (alias $i "x" (memory $i.$m))
-  (func unreachable memory.init $data $i.$m)
+  (func unreachable memory.init $data (memory $i "x"))
   (data $data "x")
 )
 (module
   (module $m (memory $m (export "x") 1))
   (instance $i (instantiate $m))
-  ;; TODO: alias sugar
-  (alias $i "x" (memory $i.$m))
-  (func unreachable memory.copy $i.$m $i.$m)
+  (func unreachable memory.copy (memory $i "x") (memory $i "x"))
 )
 (module
   (module $m (memory $m (export "x") 1))
   (instance $i (instantiate $m))
-  ;; TODO: alias sugar
-  (alias $i "x" (memory $i.$m))
-  (func unreachable memory.fill $i.$m)
+  (func unreachable memory.fill (memory $i "x"))
 )
 (module
   (module $m (memory $m (export "x") 1))
   (instance $i (instantiate $m))
-  ;; TODO: alias sugar
-  (alias $i "x" (memory $i.$m))
-  (func unreachable memory.size $i.$m unreachable)
+  (func unreachable memory.size (memory $i "x") unreachable)
 )
 (module
   (module $m (memory $m (export "x") 1))
   (instance $i (instantiate $m))
-  ;; TODO: alias sugar
-  (alias $i "x" (memory $i.$m))
-  (func unreachable memory.grow $i.$m unreachable)
+  (func unreachable memory.grow (memory $i "x") unreachable)
 )
 (module
   (module $m (memory $m (export "x") 1))
   (instance $i (instantiate $m))
-  ;; TODO: alias sugar
-  (alias $i "x" (memory $i.$m))
-  (func unreachable f64.load $i.$m unreachable)
+  (func unreachable f64.load (memory $i "x") unreachable)
 )
 
 (module
@@ -718,9 +586,7 @@
     (instance $a (export "") (instantiate $m))
   )
   (instance $i (instantiate $m))
-  ;; TODO: remove with alias sugar
-  (alias $i "" (instance $i.$a))
-  (alias $i.$a "" (func))
+  (alias (instance $i "") "" (func))
 )
 
 (assert_invalid

--- a/tests/local/module-linking/instantiate.wast
+++ b/tests/local/module-linking/instantiate.wast
@@ -260,13 +260,8 @@
         i32.const 5))
   )
   (instance $a (instantiate $m))
-  ;; TODO alias sugar
-  (alias $a "module" (module $a.$sub))
-  (instance $b (instantiate $a.$sub))
-
-  ;; TODO alias sugar
-  (alias $b "" (func $b.$f))
+  (instance $b (instantiate (module $a "module")))
 
   (func (export "get") (result i32)
-    call $b.$f)
+    call (func $b ""))
 )

--- a/tests/local/module-linking/invalid.wast
+++ b/tests/local/module-linking/invalid.wast
@@ -11,7 +11,7 @@
   (module
     (func $f)
     (module
-      (alias parent $f (func $f))
+      (alias (func $f outer 0 $f))
       (func
         call $f)
     )

--- a/tests/local/module-linking/module-link.wast
+++ b/tests/local/module-linking/module-link.wast
@@ -6,6 +6,7 @@
     (instance $b (instantiate (module outer 0 $B)))
   )
 )
+
 (module
   (type $Wasi (instance))
   (import "wasi" (instance $wasi (type $Wasi)))

--- a/tests/local/module-linking/module-link.wast
+++ b/tests/local/module-linking/module-link.wast
@@ -2,12 +2,8 @@
   (type $Wasi (instance))
   (module $B)
   (module $B_wrap
-    ;; TODO: alias sugar
-    (alias parent $Wasi (type $Wasi))
-    (import "wasi" (instance $wasi (type $Wasi)))
-    ;; TODO: alias sugar
-    (alias parent $B (module $B))
-    (instance $b (instantiate $B))
+    (import "wasi" (instance $wasi (type outer 0 $Wasi)))
+    (instance $b (instantiate (module outer 0 $B)))
   )
 )
 (module
@@ -33,16 +29,11 @@
   (module $B_wrap
     (type $Wasi (instance))
     (import "wasi" (instance $wasi (type $Wasi)))
-    ;; TODO: alias sugar
-    (alias parent $B (module $B))
-    (alias parent $A (module $A))
-    (instance $b (instantiate $B
+    (instance $b (instantiate (module outer 0 $B)
       (arg "wasi" (instance $wasi))
-      (arg "A:1.x" (module $A)))
+      (arg "A:1.x" (module outer 0 $A)))
     )
-    ;; TODO: alias sugar
-    (alias $b "b" (func $b))
-    (export "b" (func $b))
+    (export "b" (func $b "b"))
   )
 
   (module $C
@@ -58,16 +49,11 @@
   (module $C_wrap
     (type $Wasi (instance))
     (import "wasi" (instance $wasi (type $Wasi)))
-    ;; TODO: alias sugar
-    (alias parent $C (module $C))
-    (alias parent $B_wrap (module $B_wrap))
-    (instance $c (instantiate $C
+    (instance $c (instantiate (module outer 0 $C)
       (arg "wasi" (instance $wasi))
-      (arg "B:1.x" (module $B_wrap))
+      (arg "B:1.x" (module outer 0 $B_wrap))
     ))
-    ;; TODO: alias sugar
-    (alias $c "c" (func $c))
-    (export "c" (func $c))
+    (export "c" (func $c "c"))
   )
 
   (module $D
@@ -86,7 +72,5 @@
     (arg "C:1.x" (module $C_wrap))
   ))
 
-  ;; TODO: alias sugar
-  (alias $d "d" (func $d))
-  (export "d" (func $d))
+  (export "d" (func $d "d"))
 )

--- a/tests/local/module-linking/nested-modules.wast
+++ b/tests/local/module-linking/nested-modules.wast
@@ -47,5 +47,5 @@
     (func (export "") (result i32)
       i32.const 5))
   (import "b" (instance (export "" (module))))
-  (alias 0 "" (module))
+  (alias (module 0 ""))
 )

--- a/tests/local/module-linking/virtualize.wast
+++ b/tests/local/module-linking/virtualize.wast
@@ -3,13 +3,11 @@
     (export "read" (func $read (param i32 i32 i32) (result i32)))
     (export "write" (func $write (param i32 i32 i32) (result i32)))
   ))
-  ;; TODO: alias sugar
-  (alias $wasi-file "read" (func $wasi-file.$read))
   (func $play (export "play")
     i32.const 0
     i32.const 0
     i32.const 0
-    call $wasi-file.$read
+    call (func $wasi-file "read")
     drop
   )
 )
@@ -20,11 +18,8 @@
     (export "read" (func $read (param i32 i32 i32) (result i32)))
     (export "write" (func $write (param i32 i32 i32) (result i32)))
   ))
-  ;; TODO alias sugar
-  (alias $wasi-file "read" (func $wasi-file.read))
-  (alias $wasi-file "write" (func $wasi-file.write))
-  (export "read" (func $wasi-file.read))
-  (export "write" (func $wasi-file.write))
+  (export "read" (func $wasi-file "read"))
+  (export "write" (func $wasi-file "write"))
 )
 
 
@@ -47,10 +42,8 @@
   (instance $virt-wasi (instantiate $VIRTUALIZE (arg "wasi_file" (instance $real-wasi))))
   (instance $child (instantiate $CHILD (arg "wasi_file" (instance $virt-wasi))))
 
-  ;; TODO alias sugar
-  (alias $child "play" (func $child.$play))
   (func (export "work")
-    call $child.$play
+    call (func $child "play")
   )
 )
 
@@ -64,25 +57,19 @@
   (import "wasi_file" (instance $real-wasi (type $WasiFile)))
 
   (module $CHILD
-    ;; TODO: alias sugar
-    (alias parent $WasiFile (type $WasiFile))
-    (import "wasi_file" (instance $wasi-file (type $WasiFile)))
-    ;; TODO: alias sugar
-    (alias $wasi-file "read" (func $wasi-file.$read))
+    (import "wasi_file" (instance $wasi-file (type outer 0 $WasiFile)))
     (func $play (export "play")
       i32.const 0
       i32.const 0
       i32.const 0
-      call $wasi-file.$read
+      call (func $wasi-file "read")
       drop
     )
   )
 
 
   (module $VIRTUALIZE
-    ;; TODO: alias sugar
-    (alias parent $WasiFile (type $WasiFile))
-    (import "wasi_file" (instance $wasi-file (type $WasiFile)))
+    (import "wasi_file" (instance $wasi-file (type outer 0 $WasiFile)))
     (func (export "read") (param i32 i32 i32) (result i32)
       i32.const 0
     )
@@ -93,9 +80,7 @@
 
   (instance $virt-wasi (instantiate $VIRTUALIZE (arg "wasi_file" (instance $real-wasi))))
   (instance $child (instantiate $CHILD (arg "wasi_file" (instance $virt-wasi))))
-  ;; TODO: alias sugar
-  (alias $child "play" (func $child.$play))
   (func (export "work")
-    call $child.$play
+    call (func $child "play")
   )
 )


### PR DESCRIPTION
This implements two features from https://github.com/WebAssembly/module-linking/pull/26:

* First shorthand syntax of `(func $instance "export_name")` is implemented everywhere for all items as a syntax sugar for alias references.
* Next a depth argument is added to outer aliases in `wasmparser` and validation to allow referring to any outer module.