### PR TITLE
Validate implicit instances in wasmparser

### DIFF
--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -59,6 +59,7 @@ struct ModuleState {
     names: HashMap<u32, Naming>,
     local_names: HashMap<u32, HashMap<u32, Naming>>,
     module_name: Option<Naming>,
+    implicit_instances_seen: HashSet<String>,
 }
 
 struct Naming {
@@ -409,6 +410,19 @@ impl Printer {
     fn print_imports(&mut self, parser: ImportSectionReader<'_>) -> Result<()> {
         for import in parser {
             let import = import?;
+
+            // Handle the module linking proposal here where the first time we
+            // see the module-name of a two-level import that translates to an
+            // implicit instance we need to account for in our numbering.
+            if import.field.is_some() {
+                if self
+                    .state
+                    .implicit_instances_seen
+                    .insert(import.module.to_string())
+                {
+                    self.state.instance += 1;
+                }
+            }
             self.print_import(&import, true)?;
             match import.ty {
                 ImportSectionEntryType::Function(_) => self.state.func += 1,
@@ -1568,11 +1582,11 @@ impl Printer {
     }
 
     fn print_instances(&mut self, instances: InstanceSectionReader) -> Result<()> {
-        for (i, instance) in instances.into_iter().enumerate() {
+        for instance in instances.into_iter() {
             let instance = instance?;
             self.newline();
             self.start_group("instance");
-            write!(self.result, " (;{};)", i)?;
+            write!(self.result, " (;{};)", self.state.instance)?;
             self.newline();
             self.start_group("instantiate");
             write!(self.result, " {}", instance.module())?;
@@ -1593,6 +1607,7 @@ impl Printer {
             }
             self.end_group(); // instantiate
             self.end_group(); // instance
+            self.state.instance += 1;
         }
         Ok(())
     }

--- a/tests/local/module-linking/implicit-instance.wast
+++ b/tests/local/module-linking/implicit-instance.wast
@@ -1,0 +1,29 @@
+(module
+  (import "" "" (func (param i32)))
+  (alias (func 0 ""))
+  (func
+    i32.const 0
+    call 1)
+)
+
+(module
+  (import "" "" (func))
+  (module $m
+    (import "" (instance (export "" (func)))))
+  (instance (instantiate $m (arg "" (instance 0))))
+)
+
+(module
+  (import "" "a" (instance $i (export "a" (func))))
+  (import "" "" (func))
+
+  (module $m1
+    (import "" (instance (export "" (func)))))
+  (module $m2
+    (import "" (instance (export "a" (func)))))
+
+  ;; implicit instance should satisfy m1
+  (instance (instantiate $m1 (arg "" (instance 0))))
+  ;; explicit instance should also still work
+  (instance (instantiate $m2 (arg "" (instance $i))))
+)


### PR DESCRIPTION
This commit implements validation of the creation of implicit instances
through two-level imports as proposed by the module-linking proposal.
The first time a module's name in a two-level import is seen it's as-if
an instance is imported instead of the two-level import (and as-if an
`alias` annotation came next).