### PR TITLE
Update wasm-smith for recent changes to module-linking

### DIFF
--- a/crates/wasm-encoder/src/aliases.rs
+++ b/crates/wasm-encoder/src/aliases.rs
@@ -13,7 +13,7 @@ use super::*;
 /// use wasm_encoder::{Module, AliasSection, ItemKind};
 ///
 /// let mut aliases = AliasSection::new();
-/// aliases.parent_type(2);
+/// aliases.outer_type(0, 2);
 /// aliases.instance_export(0, ItemKind::Function, "foo");
 ///
 /// let mut module = Module::new();

--- a/crates/wasm-encoder/src/aliases.rs
+++ b/crates/wasm-encoder/src/aliases.rs
@@ -50,18 +50,20 @@ impl AliasSection {
         self
     }
 
-    /// Define an alias that references a parent's type.
-    pub fn parent_type(&mut self, ty: u32) -> &mut Self {
+    /// Define an alias that references an outer module's type.
+    pub fn outer_type(&mut self, depth: u32, ty: u32) -> &mut Self {
         self.bytes.push(0x01);
+        self.bytes.extend(encoders::u32(depth));
         self.bytes.push(0x07);
         self.bytes.extend(encoders::u32(ty));
         self.num_added += 1;
         self
     }
 
-    /// Define an alias that references a parent's module.
-    pub fn parent_module(&mut self, module: u32) -> &mut Self {
+    /// Define an alias that references an outer module's module.
+    pub fn outer_module(&mut self, depth: u32, module: u32) -> &mut Self {
         self.bytes.push(0x01);
+        self.bytes.extend(encoders::u32(depth));
         self.bytes.push(ItemKind::Module as u8);
         self.bytes.extend(encoders::u32(module));
         self.num_added += 1;

--- a/crates/wasm-encoder/src/instances.rs
+++ b/crates/wasm-encoder/src/instances.rs
@@ -14,9 +14,9 @@ use super::*;
 ///
 /// let mut instances = InstanceSection::new();
 /// instances.instantiate(0, vec![
-///     ("x", None, Export::Function(0)),
-///     ("", Some("y"), Export::Module(2)),
-///     ("foo", None, Export::Global(0)),
+///     ("x", Export::Function(0)),
+///     ("", Export::Module(2)),
+///     ("foo", Export::Global(0)),
 /// ]);
 ///
 /// let mut module = Module::new();

--- a/crates/wasm-encoder/src/instances.rs
+++ b/crates/wasm-encoder/src/instances.rs
@@ -42,7 +42,7 @@ impl InstanceSection {
     /// arguments to the instantiation.
     pub fn instantiate<'a, I>(&mut self, module: u32, args: I) -> &mut Self
     where
-        I: IntoIterator<Item = (&'a str, Option<&'a str>, Export)>,
+        I: IntoIterator<Item = (&'a str, Export)>,
         I::IntoIter: ExactSizeIterator,
     {
         let args = args.into_iter();
@@ -51,17 +51,8 @@ impl InstanceSection {
         self.bytes.extend(encoders::u32(module));
         self.bytes
             .extend(encoders::u32(u32::try_from(args.len()).unwrap()));
-        for (name, field, export) in args {
+        for (name, export) in args {
             self.bytes.extend(encoders::str(name));
-            match field {
-                Some(field) => {
-                    self.bytes.push(0x01);
-                    self.bytes.extend(encoders::str(field));
-                }
-                None => {
-                    self.bytes.push(0x00);
-                }
-            }
             export.encode(&mut self.bytes);
         }
         self.num_added += 1;

--- a/crates/wasm-smith/src/encode.rs
+++ b/crates/wasm-smith/src/encode.rs
@@ -103,11 +103,11 @@ where
                 } => {
                     section.instance_export(*instance, translate_item_kind(kind), name);
                 }
-                Alias::ParentType(ty) => {
-                    section.parent_type(*ty);
+                Alias::OuterType { depth, index } => {
+                    section.outer_type(*depth, *index);
                 }
-                Alias::ParentModule(m) => {
-                    section.parent_module(*m);
+                Alias::OuterModule { depth, index } => {
+                    section.outer_module(*depth, *index);
                 }
             }
         }

--- a/crates/wasm-smith/src/encode.rs
+++ b/crates/wasm-smith/src/encode.rs
@@ -119,9 +119,10 @@ where
         for instance in list {
             section.instantiate(
                 instance.module,
-                instance.args.iter().map(|(name, field, export)| {
-                    (name.as_str(), field.as_deref(), translate_export(export))
-                }),
+                instance
+                    .args
+                    .iter()
+                    .map(|(name, export)| (name.as_str(), translate_export(export))),
             );
         }
         module.section(&section);

--- a/crates/wasm-smith/src/lib.rs
+++ b/crates/wasm-smith/src/lib.rs
@@ -1396,6 +1396,20 @@ where
             });
         }
 
+        if self.instances.len() > 0 {
+            choices.push(|u, m| {
+                let idx = u.int_in_range(0..=m.instances.len() - 1)?;
+                Ok(Export::Instance(idx as u32))
+            });
+        }
+
+        if self.modules.len() > 0 {
+            choices.push(|u, m| {
+                let idx = u.int_in_range(0..=m.modules.len() - 1)?;
+                Ok(Export::Module(idx as u32))
+            });
+        }
+
         if choices.is_empty() {
             return Ok(());
         }

--- a/fuzz/fuzz_targets/validate-valid-module.rs
+++ b/fuzz/fuzz_targets/validate-valid-module.rs
@@ -21,7 +21,10 @@ fuzz_target!(|m: ConfiguredModule<SwarmConfig>| {
         ..wasmparser::WasmFeatures::default()
     });
     if let Err(e) = validator.validate_all(&bytes) {
-        std::fs::write("test.wasm", bytes).unwrap();
+        std::fs::write("test.wasm", &bytes).unwrap();
+        if let Ok(wat) = wasmprinter::print_bytes(&bytes) {
+            std::fs::write("test.wat", wat).unwrap();
+        }
         panic!("Invalid module: {}", e);
     }
 });


### PR DESCRIPTION
* Implement exporting modules/instances
* Implement implicit instances from two-level imports
* Update encoding of instance arguments
* Implement outer aliases to types/modules