### PR TITLE
Fix location of injection of alias annotations

### DIFF
--- a/crates/wast/src/resolve/aliases.rs
+++ b/crates/wast/src/resolve/aliases.rs
@@ -5,13 +5,52 @@ use std::collections::{hash_map::Entry, HashMap};
 pub fn run(fields: &mut Vec<ModuleField>) {
     let mut cur = 0;
     let mut cx = Expander::default();
+
+    // Note that insertion here is somewhat tricky. We're injecting aliases
+    // which will affect the index spaces for each kind of item being aliased.
+    // In the final binary aliases will come before all locally defined items,
+    // notably via the sorting in binary emission of this crate. To account for
+    // this index space behavior we need to ensure that aliases all appear at
+    // the right place in the module.
+    //
+    // The general algorithm here is that aliases discovered in the "header" of
+    // the module, e.g. imports/aliases/types/etc, are all inserted preceding
+    // the field that the alias is found within. After the header, however, the
+    // position of the header is recorded and all future aliases will be
+    // inserted at that location.
+    //
+    // This ends up meaning that aliases found in globals/functions/tables/etc
+    // will precede all of those definitions, being positioned at a point that
+    // should come after all the instances that are defined as well. Overall
+    // this isn't the cleanest algorithm and probably isn't the final form of
+    // those. It's hoped that discussion on WebAssembly/module-linking#25 might
+    // lead to a good solution.
+    let mut insertion_point = None;
     while cur < fields.len() {
-        cx.process(&mut fields[cur]);
-        for item in cx.to_prepend.drain(..) {
-            fields.insert(cur, item);
-            cur += 1;
+        let field = &mut fields[cur];
+        match field {
+            ModuleField::Alias(_)
+            | ModuleField::Type(_)
+            | ModuleField::Import(_)
+            | ModuleField::NestedModule(_)
+            | ModuleField::Instance(_) => {}
+            _ if insertion_point.is_none() => insertion_point = Some(cur),
+            _ => {}
+        }
+        cx.process(field);
+        if insertion_point.is_none() {
+            for item in cx.to_prepend.drain(..) {
+                fields.insert(cur, item);
+                cur += 1;
+            }
         }
         cur += 1;
+    }
+    if let Some(mut i) = insertion_point {
+        for item in cx.to_prepend.drain(..) {
+            fields.insert(i, item);
+            i += 1;
+        }
     }
     assert!(cx.to_prepend.is_empty());
 }
@@ -25,7 +64,6 @@ struct Expander<'a> {
 
 impl<'a> Expander<'a> {
     fn process(&mut self, field: &mut ModuleField<'a>) {
-        assert!(self.to_prepend.is_empty());
         match field {
             ModuleField::Alias(a) => {
                 let id = gensym::fill(a.span, &mut a.id);

--- a/tests/local/module-linking/alias.wast
+++ b/tests/local/module-linking/alias.wast
@@ -678,3 +678,17 @@
   (func
     call (func $a "b" "c" "d" "f"))
 )
+
+(module
+  (import "b" "i" (instance $i
+    ;; notice that this order is swapped
+    (export "g" (func (param i32) (result i32)))
+    (export "f" (func (result i32)))
+  ))
+
+  (func (export "f") (result i32)
+    call (func $i "f"))
+  (func (export "g") (param i32) (result i32)
+    local.get 0
+    call (func $i "g"))
+)


### PR DESCRIPTION
This commit fixes an issue in wasm text parsing where alias sugar in the
module linking proposal injected the `alias` directtive in the wrong
location in the module, confusing the name resolver and the index
numbering to have wast/wasmparser disagree and cause issues. More
details can be found in the code comment itself for the solution
selected.