### PR TITLE
Don't check errors in name section

### DIFF
--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -146,7 +146,8 @@ impl Printer {
                     data,
                 } => {
                     let reader = NameSectionReader::new(data, data_offset)?;
-                    self.register_names(reader)?;
+                    // Ignore any error associated with the name section.
+                    drop(self.register_names(reader));
                 }
                 Payload::End => break,
                 _ => {}


### PR DESCRIPTION
There is an issue with using wasm2wat-rs with new LLVM output. The name section now contains other (non-documented?) name types

https://github.com/llvm/llvm-project/blob/831a143e50cac873ec095fc7139a485173ba8c35/llvm/include/llvm/BinaryFormat/Wasm.h#L321-L322

All invalid custom section shall be ignored -- doing that in this patch. (I think we can keep what's partially read as valid)