### PR TITLE
Add SIMD double-precision conversion instructions

### DIFF
--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -1645,6 +1645,11 @@ impl<'a> BinaryReader<'a> {
             0x50 => Operator::V128Or,
             0x51 => Operator::V128Xor,
             0x52 => Operator::V128Bitselect,
+            0x53 => Operator::F64x2ConvertLowI32x4S,
+            0x54 => Operator::F64x2ConvertLowI32x4U,
+            0x55 => Operator::I32x4TruncSatF64x2SZero,
+            0x56 => Operator::I32x4TruncSatF64x2UZero,
+            0x57 => Operator::F32x4DemoteF64x2Zero,
             0x58 => Operator::V128Load8Lane {
                 memarg: self.read_memarg()?,
                 lane: self.read_lane_index(16)?,
@@ -1684,6 +1689,7 @@ impl<'a> BinaryReader<'a> {
             0x64 => Operator::I8x16Bitmask,
             0x65 => Operator::I8x16NarrowI16x8S,
             0x66 => Operator::I8x16NarrowI16x8U,
+            0x69 => Operator::F64x2PromoteLowF32x4,
             0x6b => Operator::I8x16Shl,
             0x6c => Operator::I8x16ShrS,
             0x6d => Operator::I8x16ShrU,
@@ -1807,12 +1813,6 @@ impl<'a> BinaryReader<'a> {
             0xfd => Operator::V128Load64Zero {
                 memarg: self.read_memarg_of_align(3)?,
             },
-            0x501 => Operator::F32x4DemoteF64x2Zero,
-            0x502 => Operator::F64x2PromoteLowF32x4,
-            0x503 => Operator::F64x2ConvertLowI32x4S,
-            0x504 => Operator::F64x2ConvertLowI32x4U,
-            0x505 => Operator::I32x4TruncSatF64x2SZero,
-            0x506 => Operator::I32x4TruncSatF64x2UZero,
             _ => {
                 return Err(BinaryReaderError::new(
                     format!("Unknown 0xfd subopcode: 0x{:x}", code),

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -1807,6 +1807,12 @@ impl<'a> BinaryReader<'a> {
             0xfd => Operator::V128Load64Zero {
                 memarg: self.read_memarg_of_align(3)?,
             },
+            0x501 => Operator::F32x4DemoteF64x2Zero,
+            0x502 => Operator::F64x2PromoteLowF32x4,
+            0x503 => Operator::F64x2ConvertLowI32x4S,
+            0x504 => Operator::F64x2ConvertLowI32x4U,
+            0x505 => Operator::I32x4TruncSatF64x2SZero,
+            0x506 => Operator::I32x4TruncSatF64x2UZero,
             _ => {
                 return Err(BinaryReaderError::new(
                     format!("Unknown 0xfd subopcode: 0x{:x}", code),

--- a/crates/wasmparser/src/operators_validator.rs
+++ b/crates/wasmparser/src/operators_validator.rs
@@ -1625,6 +1625,12 @@ impl OperatorValidator {
             | Operator::F64x2Abs
             | Operator::F64x2Neg
             | Operator::F64x2Sqrt
+            | Operator::F32x4DemoteF64x2Zero
+            | Operator::F64x2PromoteLowF32x4
+            | Operator::F64x2ConvertLowI32x4S
+            | Operator::F64x2ConvertLowI32x4U
+            | Operator::I32x4TruncSatF64x2SZero
+            | Operator::I32x4TruncSatF64x2UZero
             | Operator::F32x4ConvertI32x4S
             | Operator::F32x4ConvertI32x4U => {
                 self.check_non_deterministic_enabled()?;

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -1196,4 +1196,10 @@ pub enum Operator<'a> {
     I8x16RoundingAverageU,
     I16x8RoundingAverageU,
     I16x8Q15MulrSatS,
+    F32x4DemoteF64x2Zero,
+    F64x2PromoteLowF32x4,
+    F64x2ConvertLowI32x4S,
+    F64x2ConvertLowI32x4U,
+    I32x4TruncSatF64x2SZero,
+    I32x4TruncSatF64x2UZero,
 }

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -1441,6 +1441,13 @@ impl Printer {
             I32x4MaxS => self.result.push_str("i32x4.max_s"),
             I32x4MaxU => self.result.push_str("i32x4.max_u"),
             I32x4DotI16x8S => self.result.push_str("i32x4.dot_i16x8_s"),
+
+            F32x4DemoteF64x2Zero => self.result.push_str("f32x4.demote_f64x2_zero"),
+            F64x2PromoteLowF32x4 => self.result.push_str("f64x2.promote_low_f32x4"),
+            F64x2ConvertLowI32x4S => self.result.push_str("f64x2.convert_low_i32x4_s"),
+            F64x2ConvertLowI32x4U => self.result.push_str("f64x2.convert_low_i32x4_u"),
+            I32x4TruncSatF64x2SZero => self.result.push_str("i32x4.trunc_sat_f64x2_s_zero"),
+            I32x4TruncSatF64x2UZero => self.result.push_str("i32x4.trunc_sat_f64x2_u_zero"),
         }
         Ok(())
     }

--- a/crates/wast/src/ast/expr.rs
+++ b/crates/wast/src/ast/expr.rs
@@ -936,6 +936,13 @@ instructions! {
         V128Or : [0xfd, 0x50] : "v128.or",
         V128Xor : [0xfd, 0x51] : "v128.xor",
         V128Bitselect : [0xfd, 0x52] : "v128.bitselect",
+
+        F64x2ConvertLowI32x4S : [0xfd, 0x53] : "f64x2.convert_low_i32x4_s",
+        F64x2ConvertLowI32x4U : [0xfd, 0x54] : "f64x2.convert_low_i32x4_u",
+        I32x4TruncSatF64x2SZero : [0xfd, 0x55] : "i32x4.trunc_sat_f64x2_s_zero",
+        I32x4TruncSatF64x2UZero : [0xfd, 0x56] : "i32x4.trunc_sat_f64x2_u_zero",
+        F32x4DemoteF64x2Zero : [0xfd, 0x57] : "f32x4.demote_f64x2_zero",
+
         V128Load8Lane(LoadOrStoreLane<1>) : [0xfd, 0x58] : "v128.load8_lane",
         V128Load16Lane(LoadOrStoreLane<2>) : [0xfd, 0x59] : "v128.load16_lane",
         V128Load32Lane(LoadOrStoreLane<4>) : [0xfd, 0x5a] : "v128.load32_lane",
@@ -952,6 +959,7 @@ instructions! {
         I8x16Bitmask : [0xfd, 0x64] : "i8x16.bitmask",
         I8x16NarrowI16x8S : [0xfd, 0x65] : "i8x16.narrow_i16x8_s",
         I8x16NarrowI16x8U : [0xfd, 0x66] : "i8x16.narrow_i16x8_u",
+        F64x2PromoteLowF32x4 : [0xfd, 0x69] : "f64x2.promote_low_f32x4",
         I8x16Shl : [0xfd, 0x6b] : "i8x16.shl",
         I8x16ShrS : [0xfd, 0x6c] : "i8x16.shr_s",
         I8x16ShrU : [0xfd, 0x6d] : "i8x16.shr_u",
@@ -1079,13 +1087,6 @@ instructions! {
 
         V128Load32Zero(MemArg<4>) : [0xfd, 0xfc] : "v128.load32_zero",
         V128Load64Zero(MemArg<8>) : [0xfd, 0xfd] : "v128.load64_zero",
-
-        F32x4DemoteF64x2Zero : [0xfd, 0x501] : "f32x4.demote_f64x2_zero",
-        F64x2PromoteLowF32x4 : [0xfd, 0x502] : "f64x2.promote_low_f32x4",
-        F64x2ConvertLowI32x4S : [0xfd, 0x503] : "f64x2.convert_low_i32x4_s",
-        F64x2ConvertLowI32x4U : [0xfd, 0x504] : "f64x2.convert_low_i32x4_u",
-        I32x4TruncSatF64x2SZero : [0xfd, 0x505] : "i32x4.trunc_sat_f64x2_s_zero",
-        I32x4TruncSatF64x2UZero : [0xfd, 0x506] : "i32x4.trunc_sat_f64x2_u_zero",
 
         // Exception handling proposal
         CatchAll : [0x05] : "catch_all", // Reuses the else opcode.

--- a/crates/wast/src/ast/expr.rs
+++ b/crates/wast/src/ast/expr.rs
@@ -1080,6 +1080,13 @@ instructions! {
         V128Load32Zero(MemArg<4>) : [0xfd, 0xfc] : "v128.load32_zero",
         V128Load64Zero(MemArg<8>) : [0xfd, 0xfd] : "v128.load64_zero",
 
+        F32x4DemoteF64x2Zero : [0xfd, 0x501] : "f32x4.demote_f64x2_zero",
+        F64x2PromoteLowF32x4 : [0xfd, 0x502] : "f64x2.promote_low_f32x4",
+        F64x2ConvertLowI32x4S : [0xfd, 0x503] : "f64x2.convert_low_i32x4_s",
+        F64x2ConvertLowI32x4U : [0xfd, 0x504] : "f64x2.convert_low_i32x4_u",
+        I32x4TruncSatF64x2SZero : [0xfd, 0x505] : "i32x4.trunc_sat_f64x2_s_zero",
+        I32x4TruncSatF64x2UZero : [0xfd, 0x506] : "i32x4.trunc_sat_f64x2_u_zero",
+
         // Exception handling proposal
         CatchAll : [0x05] : "catch_all", // Reuses the else opcode.
         Try(BlockType<'a>) : [0x06] : "try",

--- a/tests/local/simd.wat
+++ b/tests/local/simd.wat
@@ -189,6 +189,36 @@
     i8x16.neg
     drop
 
+    v128.const i32x4 0 0 0 0
+    f32x4.demote_f64x2_zero
+    i8x16.neg
+    drop
+
+    v128.const i32x4 0 0 0 0
+    f64x2.promote_low_f32x4
+    i8x16.neg
+    drop
+
+    v128.const i32x4 0 0 0 0
+    f64x2.convert_low_i32x4_s
+    i8x16.neg
+    drop
+
+    v128.const i32x4 0 0 0 0
+    f64x2.convert_low_i32x4_u
+    i8x16.neg
+    drop
+
+    v128.const i32x4 0 0 0 0
+    i32x4.trunc_sat_f64x2_s_zero
+    i8x16.neg
+    drop
+
+    v128.const i32x4 0 0 0 0
+    i32x4.trunc_sat_f64x2_u_zero
+    i8x16.neg
+    drop
+
     )
 
   (memory (;0;) 1)


### PR DESCRIPTION
See https://github.com/WebAssembly/simd/pull/383. This has been accepted into the spec.

- `f32x4.demote_f64x2_zero`
- `f64x2.promote_low_f32x4`
- `f64x2.convert_low_i32x4_s`
- `f64x2.convert_low_i32x4_u`
- `i32x4.trunc_sat_f64x2_s_zero`
- `i32x4.trunc_sat_f64x2_u_zero`

TODO:
- [x] renumber opcodes