### PR TITLE
Support `delegate` instruction and update other exception instructions

### DIFF
--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -1139,6 +1139,7 @@ impl<'a> BinaryReader<'a> {
             0x18 => Operator::Delegate {
                 relative_depth: self.read_var_u32()?,
             },
+            0x19 => Operator::CatchAll,
             0x1a => Operator::Drop,
             0x1b => Operator::Select,
             0x1c => {

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -1136,6 +1136,9 @@ impl<'a> BinaryReader<'a> {
                 index: self.read_var_u32()?,
                 table_index: self.read_var_u32()?,
             },
+            0x18 => Operator::Delegate {
+                relative_depth: self.read_var_u32()?,
+            },
             0x1a => Operator::Drop,
             0x1b => Operator::Select,
             0x1c => {

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -393,6 +393,7 @@ pub enum Operator<'a> {
     Delegate {
         relative_depth: u32,
     },
+    CatchAll,
     Drop,
     Select,
     TypedSelect {

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -390,6 +390,9 @@ pub enum Operator<'a> {
         index: u32,
         table_index: u32,
     },
+    Delegate {
+        relative_depth: u32,
+    },
     Drop,
     Select,
     TypedSelect {

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -684,8 +684,8 @@ impl Printer {
                     }
 
                     // Exiting a block prints `end` at the previous indentation
-                    // level.
-                    Operator::End if self.nesting > nesting_start => {
+                    // level. `delegate` also ends a block like `end` for `try`.
+                    Operator::End | Operator::Delegate { .. } if self.nesting > nesting_start => {
                         self.nesting -= 1;
                         self.newline();
                     }
@@ -803,6 +803,10 @@ impl Printer {
                     write!(self.result, " {}", table_index)?;
                 }
                 write!(self.result, " (type {})", index)?;
+            }
+
+            Delegate { relative_depth } => {
+                write!(self.result, "delegate {}", relative_depth)?;
             }
 
             Drop => self.result.push_str("drop"),

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -677,7 +677,10 @@ impl Printer {
                     // `else`/`catch` are special in that it's printed at
                     // the previous indentation, but it doesn't actually change
                     // our nesting level.
-                    Operator::Else | Operator::Catch { .. } | Operator::Unwind => {
+                    Operator::Else
+                    | Operator::Catch { .. }
+                    | Operator::CatchAll
+                    | Operator::Unwind => {
                         self.nesting -= 1;
                         self.newline();
                         self.nesting += 1;
@@ -808,6 +811,7 @@ impl Printer {
             Delegate { relative_depth } => {
                 write!(self.result, "delegate {}", relative_depth)?;
             }
+            CatchAll => self.result.push_str("catch_all"),
 
             Drop => self.result.push_str("drop"),
             Select => self.result.push_str("select"),

--- a/crates/wast/src/ast/expr.rs
+++ b/crates/wast/src/ast/expr.rs
@@ -1113,13 +1113,13 @@ instructions! {
         V128Load64Zero(MemArg<8>) : [0xfd, 0xfd] : "v128.load64_zero",
 
         // Exception handling proposal
-        CatchAll : [0x05] : "catch_all", // Reuses the else opcode.
         Try(BlockType<'a>) : [0x06] : "try",
         Catch(ast::Index<'a>) : [0x07] : "catch",
         Throw(ast::Index<'a>) : [0x08] : "throw",
         Rethrow(ast::Index<'a>) : [0x09] : "rethrow",
         Unwind : [0x0a] : "unwind",
         Delegate(ast::Index<'a>) : [0x18] : "delegate",
+        CatchAll : [0x19] : "catch_all",
     }
 }
 

--- a/crates/wast/src/ast/mod.rs
+++ b/crates/wast/src/ast/mod.rs
@@ -352,6 +352,7 @@ pub mod kw {
     custom_keyword!(data);
     custom_keyword!(dataref);
     custom_keyword!(declare);
+    custom_keyword!(delegate);
     custom_keyword!(r#do = "do");
     custom_keyword!(elem);
     custom_keyword!(end);

--- a/tests/local/exception-handling.wast
+++ b/tests/local/exception-handling.wast
@@ -44,8 +44,7 @@
 (assert_invalid
   (module
     (func try catch_all catch_all end))
-  ;; we can't distinguish between `catch_all` and `else` in error cases
-  "else found outside of an `if` block")
+  "only one catch_all allowed per `try` block")
 
 (assert_invalid
   (module

--- a/tests/local/try.wast
+++ b/tests/local/try.wast
@@ -41,3 +41,9 @@
     "(func (try (do) (unwind) (drop)))"
   )
   "too many payloads inside of `(try)`")
+
+(assert_malformed
+  (module quote
+    "(func (try (do) (delegate 0) (drop)))"
+  )
+  "too many payloads inside of `(try)`")

--- a/tests/local/try.wat
+++ b/tests/local/try.wat
@@ -3,7 +3,7 @@
 (module $m
   (type (func))
   (event $exn (type 0))
-  (func (try (do) (catch $exn drop)))
+  (func (try (do) (catch $exn)))
   (func (try (do) (catch $exn rethrow 0)))
   (func (try (do) (catch_all rethrow 0)))
   (func (try (do) (catch $exn) (catch_all rethrow 0)))
@@ -11,4 +11,4 @@
   (func (result i32)
     (try (result i32)
       (do (i32.const 42))
-      (catch $exn drop (i32.const 42)))))
+      (catch $exn (i32.const 42)))))

--- a/tests/local/try.wat
+++ b/tests/local/try.wat
@@ -8,6 +8,7 @@
   (func (try (do) (catch_all rethrow 0)))
   (func (try (do) (catch $exn) (catch_all rethrow 0)))
   (func (try (do) (unwind nop)))
+  (func (try (do (try (do) (delegate 0))) (catch $exn)))
   (func (result i32)
     (try (result i32)
       (do (i32.const 42))


### PR DESCRIPTION
This PR adds support for the `delegate` instruction that's part of the exception handling proposal. It was previously left out because it didn't have an opcode assignment, but the latest spec explainer (https://github.com/WebAssembly/exception-handling/pull/137#issuecomment-778482300) includes it.

It also updates/fixes support for other instructions to match recent spec updates. For example, `catch_all` is no longer sharing an opcode with `else`.

With these patches, exception support should also match the behavior in wabt's tests (when including these pending PRs: https://github.com/WebAssembly/wabt/pull/1608 and https://github.com/WebAssembly/wabt/pull/1605).  I can submit a PR later to enable exception handling tests that are currently disabled once wabt PRs are merged and the submodule can be updated.