### PR TITLE
Implement inline `alias` annotations

### DIFF
--- a/crates/wast/src/ast/alias.rs
+++ b/crates/wast/src/ast/alias.rs
@@ -1,5 +1,5 @@
 use crate::ast::{self, kw};
-use crate::parser::{Parse, Parser, Result};
+use crate::parser::{Cursor, Parse, Parser, Peek, Result};
 
 /// An `alias` statement used to juggle indices with nested modules.
 #[derive(Debug)]
@@ -17,7 +17,7 @@ pub struct Alias<'a> {
     pub kind: ast::ExportKind,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[allow(missing_docs)]
 pub enum AliasSource<'a> {
     InstanceExport {
@@ -36,17 +36,7 @@ pub enum AliasSource<'a> {
 impl<'a> Parse<'a> for Alias<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
         let span = parser.parse::<kw::alias>()?.0;
-        let source = if parser.parse::<Option<kw::outer>>()?.is_some() {
-            AliasSource::Outer {
-                module: parser.parse()?,
-                index: parser.parse()?,
-            }
-        } else {
-            AliasSource::InstanceExport {
-                instance: parser.parse::<ast::IndexOrRef<_>>()?.0,
-                export: parser.parse()?,
-            }
-        };
+        let source = parser.parse()?;
         let (kind, id, name) = parser.parens(|p| Ok((p.parse()?, p.parse()?, p.parse()?)))?;
 
         Ok(Alias {
@@ -56,5 +46,59 @@ impl<'a> Parse<'a> for Alias<'a> {
             kind,
             source,
         })
+    }
+}
+
+impl<'a> Parse<'a> for AliasSource<'a> {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        Ok(if parser.parse::<Option<kw::outer>>()?.is_some() {
+            AliasSource::Outer {
+                module: parser.parse()?,
+                index: parser.parse()?,
+            }
+        } else {
+            AliasSource::InstanceExport {
+                instance: parser.parse::<ast::IndexOrRef<_>>()?.0,
+                export: parser.parse()?,
+            }
+        })
+    }
+}
+
+/// A listing of a inline `(alias $i "foo")` statement.
+///
+/// Note that when parsing this type it is somewhat unconventional that it
+/// parses its own surrounding parentheses. This is typically an optional type,
+/// so it's so far been a bit nicer to have the optionality handled through
+/// `Peek` rather than `Option<T>`.
+#[derive(Debug)]
+#[allow(missing_docs)]
+pub struct InlineAlias<'a> {
+    pub source: AliasSource<'a>,
+}
+
+impl<'a> Parse<'a> for InlineAlias<'a> {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        parser.parens(|p| {
+            p.parse::<kw::alias>()?;
+            Ok(InlineAlias { source: p.parse()? })
+        })
+    }
+}
+
+impl Peek for InlineAlias<'_> {
+    fn peek(cursor: Cursor<'_>) -> bool {
+        let cursor = match cursor.lparen() {
+            Some(cursor) => cursor,
+            None => return false,
+        };
+        match cursor.keyword() {
+            Some(("alias", _)) => true,
+            _ => false,
+        }
+    }
+
+    fn display() -> &'static str {
+        "inline alias"
     }
 }

--- a/crates/wast/src/ast/instance.rs
+++ b/crates/wast/src/ast/instance.rs
@@ -19,13 +19,16 @@ pub struct Instance<'a> {
 /// Possible ways to define a instance in the text format.
 #[derive(Debug)]
 pub enum InstanceKind<'a> {
-    /// An instance which is actually defined as an import, such as:
+    /// An instance which is actually defined as an import
     Import {
         /// Where we're importing from
         import: ast::InlineImport<'a>,
         /// The type that this instance will have.
         ty: ast::TypeUse<'a, ast::InstanceType<'a>>,
     },
+
+    /// An instance which is actually defined as an alias
+    Alias(ast::InlineAlias<'a>),
 
     /// Instances whose instantiation is defined inline.
     Inline {
@@ -55,6 +58,8 @@ impl<'a> Parse<'a> for Instance<'a> {
                 import,
                 ty: parser.parse()?,
             }
+        } else if let Some(alias) = parser.parse()? {
+            InstanceKind::Alias(alias)
         } else {
             parser.parens(|p| {
                 p.parse::<kw::instantiate>()?;

--- a/crates/wast/src/ast/memory.rs
+++ b/crates/wast/src/ast/memory.rs
@@ -25,6 +25,9 @@ pub enum MemoryKind<'a> {
         ty: ast::MemoryType,
     },
 
+    /// This memory is actually an inlined alias definition.
+    Alias(ast::InlineAlias<'a>),
+
     /// A typical memory definition which simply says the limits of the memory
     Normal(ast::MemoryType),
 
@@ -54,6 +57,8 @@ impl<'a> Parse<'a> for Memory<'a> {
                 import,
                 ty: parser.parse()?,
             }
+        } else if let Some(alias) = parser.parse()? {
+            MemoryKind::Alias(alias)
         } else if l.peek::<ast::LParen>() || parser.peek2::<ast::LParen>() {
             let is_32 = if parser.parse::<Option<kw::i32>>()?.is_some() {
                 true

--- a/crates/wast/src/ast/nested_module.rs
+++ b/crates/wast/src/ast/nested_module.rs
@@ -34,6 +34,10 @@ pub enum NestedModuleKind<'a> {
         /// Fields in the nested module.
         fields: Vec<ast::ModuleField<'a>>,
     },
+    // TODO: there should be an inline `Alias` kind here, but that has weird
+    // lookahead requirements which are sort of uncomfortable to implement right
+    // now:
+    // https://github.com/WebAssembly/module-linking/pull/26#issuecomment-780828000
 }
 
 impl<'a> Parse<'a> for NestedModule<'a> {

--- a/crates/wast/src/ast/table.rs
+++ b/crates/wast/src/ast/table.rs
@@ -25,6 +25,9 @@ pub enum TableKind<'a> {
         ty: ast::TableType<'a>,
     },
 
+    /// This table is actually an inlined alias definition.
+    Alias(ast::InlineAlias<'a>),
+
     /// A typical memory definition which simply says the limits of the table
     Normal(ast::TableType<'a>),
 
@@ -69,6 +72,8 @@ impl<'a> Parse<'a> for Table<'a> {
                 import,
                 ty: parser.parse()?,
             }
+        } else if let Some(alias) = parser.parse()? {
+            TableKind::Alias(alias)
         } else {
             return Err(l.error());
         };

--- a/crates/wast/src/resolve/aliases.rs
+++ b/crates/wast/src/resolve/aliases.rs
@@ -117,8 +117,8 @@ impl<'a> Expander<'a> {
             ModuleField::Export(e) => self.expand(&mut e.index),
 
             ModuleField::Func(f) => {
-                self.expand_type_use(&mut f.ty);
-                if let FuncKind::Inline { expression, .. } = &mut f.kind {
+                if let FuncKind::Inline { expression, ty, .. } = &mut f.kind {
+                    self.expand_type_use(ty);
                     self.expand_expr(expression);
                 }
             }
@@ -126,8 +126,8 @@ impl<'a> Expander<'a> {
             ModuleField::Import(i) => self.expand_item_sig(&mut i.item),
 
             ModuleField::Global(g) => {
-                if let GlobalKind::Inline(expr) = &mut g.kind {
-                    self.expand_expr(expr);
+                if let GlobalKind::Inline { init, .. } = &mut g.kind {
+                    self.expand_expr(init);
                 }
             }
 

--- a/crates/wast/src/resolve/types.rs
+++ b/crates/wast/src/resolve/types.rs
@@ -105,14 +105,14 @@ impl<'a> Expander<'a> {
                 }
             }
             ModuleField::Func(f) => {
-                self.expand_type_use(&mut f.ty);
-                if let FuncKind::Inline { expression, .. } = &mut f.kind {
+                if let FuncKind::Inline { expression, ty, .. } = &mut f.kind {
+                    self.expand_type_use(ty);
                     self.expand_expression(expression);
                 }
             }
             ModuleField::Global(g) => {
-                if let GlobalKind::Inline(expr) = &mut g.kind {
-                    self.expand_expression(expr);
+                if let GlobalKind::Inline { init, .. } = &mut g.kind {
+                    self.expand_expression(init);
                 }
             }
             ModuleField::Data(d) => {

--- a/tests/local/module-linking/alias.wast
+++ b/tests/local/module-linking/alias.wast
@@ -692,3 +692,38 @@
     local.get 0
     call (func $i "g"))
 )
+
+;; inline alias annotations
+(module
+  (import "" (instance $i (export "f" (func))))
+  (func $f (alias $i "f"))
+  (func call $f)
+)
+(module
+  (import "" (instance $i (export "f" (memory 1))))
+  (memory (alias $i "f"))
+  (func
+    i32.const 0
+    i32.load
+    drop)
+)
+(module
+  (import "" (instance $i (export "f" (table 1 funcref))))
+  (table (alias $i "f"))
+  (func
+    i32.const 0
+    call_indirect)
+)
+(module
+  (import "" (instance $i (export "f" (global (mut i32)))))
+  (global (alias $i "f"))
+  (func
+    i32.const 0
+    global.set 0)
+)
+(module
+  (import "" (instance $i (export "f" (instance (export "f" (func))))))
+  (instance $i2 (alias $i "f"))
+  (func (alias $i2 "f"))
+  (func call 0)
+)


### PR DESCRIPTION
This implements a text format sugar similar to inline `import`
annotations, but for `alias` directives. This does not implement inline
`alias` annotations for modules just yet because that could currently
require arbitrary lookahead.