### PR TITLE
Fix a panic by resolving indices with `delegate`

### DIFF
--- a/crates/wast/src/resolve/names.rs
+++ b/crates/wast/src/resolve/names.rs
@@ -759,7 +759,7 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
                 ));
             }
 
-            Br(i) | BrIf(i) | BrOnNull(i) => {
+            Br(i) | BrIf(i) | BrOnNull(i) | Delegate(i) => {
                 self.resolve_label(i)?;
             }
 


### PR DESCRIPTION
Looks like this case was forgotten in the resolver, so this PR adds
resolution of the `delegate` instruction's index.