### PR TITLE
Fix a few cases where type references weren't expanded

### DIFF
--- a/crates/wast/src/resolve/aliases.rs
+++ b/crates/wast/src/resolve/aliases.rs
@@ -203,6 +203,10 @@ impl<'a> Expander<'a> {
 
             MemorySize(m) | MemoryGrow(m) | MemoryFill(m) => self.expand(&mut m.mem),
 
+            Let(t) => self.expand_type_use(&mut t.block.ty),
+
+            Block(bt) | If(bt) | Loop(bt) | Try(bt) => self.expand_type_use(&mut bt.ty),
+
             _ => {}
         }
     }

--- a/tests/local/module-linking/alias.wast
+++ b/tests/local/module-linking/alias.wast
@@ -692,3 +692,24 @@
     local.get 0
     call (func $i "g"))
 )
+
+(module $PARENT
+  (type $empty (func))
+  (module
+    (event $x)
+
+    (func
+      i32.const 0
+      if (type outer $PARENT $empty)
+      end
+      loop (type outer $PARENT $empty)
+      end
+      block (type outer $PARENT $empty)
+      end
+
+      try (type outer $PARENT $empty)
+      catch $x
+      end
+    )
+  )
+)


### PR DESCRIPTION
A few missing clauses to a `match`, not too hard to add!