### PR TITLE
wasm-encoder: Derive Clone and Debug for most types

### DIFF
--- a/crates/wasm-encoder/src/aliases.rs
+++ b/crates/wasm-encoder/src/aliases.rs
@@ -21,6 +21,7 @@ use super::*;
 ///
 /// let wasm_bytes = module.finish();
 /// ```
+#[derive(Clone, Debug)]
 pub struct AliasSection {
     bytes: Vec<u8>,
     num_added: u32,

--- a/crates/wasm-encoder/src/code.rs
+++ b/crates/wasm-encoder/src/code.rs
@@ -31,6 +31,7 @@ use super::*;
 ///
 /// let wasm_bytes = module.finish();
 /// ```
+#[derive(Clone, Debug)]
 pub struct CodeSection {
     bytes: Vec<u8>,
     num_added: u32,
@@ -95,6 +96,7 @@ impl Section for CodeSection {
 /// let mut code = CodeSection::new();
 /// code.function(&func);
 /// ```
+#[derive(Clone, Debug)]
 pub struct Function {
     bytes: Vec<u8>,
 }
@@ -186,7 +188,7 @@ impl BlockType {
 }
 
 /// WebAssembly instructions.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 #[allow(missing_docs, non_camel_case_types)]
 pub enum Instruction<'a> {

--- a/crates/wasm-encoder/src/custom.rs
+++ b/crates/wasm-encoder/src/custom.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 /// A custom section holding arbitrary data.
+#[derive(Clone, Debug)]
 pub struct CustomSection<'a> {
     /// The name of this custom section.
     pub name: &'a str,

--- a/crates/wasm-encoder/src/data.rs
+++ b/crates/wasm-encoder/src/data.rs
@@ -31,12 +31,14 @@ use super::*;
 ///
 /// let wasm_bytes = module.finish();
 /// ```
+#[derive(Clone, Debug)]
 pub struct DataSection {
     bytes: Vec<u8>,
     num_added: u32,
 }
 
 /// A segment in the data section.
+#[derive(Clone, Copy, Debug)]
 pub struct DataSegment<'a, D> {
     /// This data segment's mode.
     pub mode: DataSegmentMode<'a>,
@@ -45,6 +47,7 @@ pub struct DataSegment<'a, D> {
 }
 
 /// A data segment's mode.
+#[derive(Clone, Copy, Debug)]
 pub enum DataSegmentMode<'a> {
     /// An active data segment.
     Active {
@@ -161,6 +164,7 @@ impl Section for DataSection {
 }
 
 /// An encoder for the data count section.
+#[derive(Clone, Copy, Debug)]
 pub struct DataCountSection {
     /// The number of segments in the data section.
     pub count: u32,

--- a/crates/wasm-encoder/src/elements.rs
+++ b/crates/wasm-encoder/src/elements.rs
@@ -35,12 +35,14 @@ use super::*;
 ///
 /// let wasm_bytes = module.finish();
 /// ```
+#[derive(Clone, Debug)]
 pub struct ElementSection {
     bytes: Vec<u8>,
     num_added: u32,
 }
 
 /// A sequence of elements in a segment in the element section.
+#[derive(Clone, Copy, Debug)]
 pub enum Elements<'a> {
     /// A sequences of references to functions by their indices.
     Functions(&'a [u32]),
@@ -49,6 +51,7 @@ pub enum Elements<'a> {
 }
 
 /// An element in a segment in the element section.
+#[derive(Clone, Copy, Debug)]
 pub enum Element {
     /// A null reference.
     Null,
@@ -57,6 +60,7 @@ pub enum Element {
 }
 
 /// An element segment's mode.
+#[derive(Clone, Copy, Debug)]
 pub enum ElementMode<'a> {
     /// A passive element segment.
     ///
@@ -79,6 +83,7 @@ pub enum ElementMode<'a> {
 }
 
 /// An element segment in the element section.
+#[derive(Clone, Copy, Debug)]
 pub struct ElementSegment<'a> {
     /// The element segment's mode.
     pub mode: ElementMode<'a>,

--- a/crates/wasm-encoder/src/exports.rs
+++ b/crates/wasm-encoder/src/exports.rs
@@ -28,6 +28,7 @@ use super::*;
 ///
 /// let wasm_bytes = module.finish();
 /// ```
+#[derive(Clone, Debug)]
 pub struct ExportSection {
     bytes: Vec<u8>,
     num_added: u32,
@@ -71,6 +72,7 @@ impl Section for ExportSection {
 }
 
 /// A WebAssembly export.
+#[derive(Clone, Copy, Debug)]
 pub enum Export {
     /// An export of the `n`th function.
     Function(u32),
@@ -131,6 +133,7 @@ impl Export {
 /// Kinds of WebAssembly items
 #[allow(missing_docs)]
 #[repr(u8)]
+#[derive(Clone, Copy, Debug)]
 pub enum ItemKind {
     Function = 0x00,
     Table = 0x01,

--- a/crates/wasm-encoder/src/functions.rs
+++ b/crates/wasm-encoder/src/functions.rs
@@ -20,6 +20,7 @@ use super::*;
 ///
 /// let wasm_bytes = module.finish();
 /// ```
+#[derive(Clone, Debug)]
 pub struct FunctionSection {
     bytes: Vec<u8>,
     num_added: u32,

--- a/crates/wasm-encoder/src/globals.rs
+++ b/crates/wasm-encoder/src/globals.rs
@@ -21,6 +21,7 @@ use super::*;
 ///
 /// let wasm_bytes = module.finish();
 /// ```
+#[derive(Clone, Debug)]
 pub struct GlobalSection {
     bytes: Vec<u8>,
     num_added: u32,
@@ -65,6 +66,7 @@ impl Section for GlobalSection {
 }
 
 /// A global's type.
+#[derive(Clone, Copy, Debug)]
 pub struct GlobalType {
     /// This global's value type.
     pub val_type: ValType,

--- a/crates/wasm-encoder/src/imports.rs
+++ b/crates/wasm-encoder/src/imports.rs
@@ -25,6 +25,7 @@ use std::convert::TryFrom;
 ///
 /// let wasm_bytes = module.finish();
 /// ```
+#[derive(Clone, Debug)]
 pub struct ImportSection {
     bytes: Vec<u8>,
     num_added: u32,
@@ -80,6 +81,7 @@ impl Section for ImportSection {
 }
 
 /// The type of an entity.
+#[derive(Clone, Copy, Debug)]
 pub enum EntityType {
     /// The `n`th type, which is a function.
     Function(u32),

--- a/crates/wasm-encoder/src/instances.rs
+++ b/crates/wasm-encoder/src/instances.rs
@@ -24,6 +24,7 @@ use super::*;
 ///
 /// let wasm_bytes = module.finish();
 /// ```
+#[derive(Clone, Debug)]
 pub struct InstanceSection {
     bytes: Vec<u8>,
     num_added: u32,

--- a/crates/wasm-encoder/src/lib.rs
+++ b/crates/wasm-encoder/src/lib.rs
@@ -68,7 +68,7 @@
 //! assert!(wasmparser::validate(&wasm_bytes).is_ok());
 //! ```
 
-#![deny(missing_docs)]
+#![deny(missing_docs, missing_debug_implementations)]
 
 mod aliases;
 mod code;
@@ -134,6 +134,7 @@ pub trait Section {
 /// A section made up of uninterpreted, raw bytes.
 ///
 /// Allows you to splat any data into a Wasm section.
+#[derive(Clone, Copy, Debug)]
 pub struct RawSection<'a> {
     /// The id for this section.
     pub id: u8,
@@ -230,6 +231,7 @@ impl From<SectionId> for u8 {
 }
 
 /// Limits for a table or memory.
+#[derive(Clone, Copy, Debug)]
 pub struct Limits {
     /// The minimum size.
     pub min: u32,

--- a/crates/wasm-encoder/src/linking.rs
+++ b/crates/wasm-encoder/src/linking.rs
@@ -36,6 +36,7 @@ use std::convert::TryInto;
 /// module.section(&linking);
 /// let wasm_bytes = module.finish();
 /// ```
+#[derive(Clone, Debug)]
 pub struct LinkingSection {
     bytes: Vec<u8>,
 }
@@ -96,6 +97,7 @@ const WASM_SYMBOL_TABLE: u8 = 8;
 /// A subsection of the [linking custom section][crate::LinkingSection] that
 /// provides extra information about the symbols present in this Wasm object
 /// file.
+#[derive(Clone, Debug)]
 pub struct SymbolTable {
     bytes: Vec<u8>,
     num_added: u32,
@@ -274,6 +276,7 @@ impl SymbolTable {
 }
 
 /// The definition of a data symbol within a symbol table.
+#[derive(Clone, Debug)]
 pub struct DataSymbolDefinition {
     /// The index of the data segment that this symbol is in.
     pub index: u32,

--- a/crates/wasm-encoder/src/memories.rs
+++ b/crates/wasm-encoder/src/memories.rs
@@ -20,6 +20,7 @@ use super::*;
 ///
 /// let wasm_bytes = module.finish();
 /// ```
+#[derive(Clone, Debug)]
 pub struct MemorySection {
     bytes: Vec<u8>,
     num_added: u32,
@@ -62,6 +63,7 @@ impl Section for MemorySection {
 }
 
 /// A memory's type.
+#[derive(Clone, Copy, Debug)]
 pub struct MemoryType {
     /// This memory's limits (in units of pages).
     pub limits: Limits,

--- a/crates/wasm-encoder/src/modules.rs
+++ b/crates/wasm-encoder/src/modules.rs
@@ -21,6 +21,7 @@ use super::*;
 ///
 /// let wasm_bytes = module.finish();
 /// ```
+#[derive(Clone, Debug)]
 pub struct ModuleSection {
     bytes: Vec<u8>,
     num_added: u32,

--- a/crates/wasm-encoder/src/start.rs
+++ b/crates/wasm-encoder/src/start.rs
@@ -19,6 +19,7 @@ use super::*;
 ///
 /// let wasm_bytes = module.finish();
 /// ```
+#[derive(Clone, Copy, Debug)]
 pub struct StartSection {
     /// The index of the start function.
     pub function_index: u32,

--- a/crates/wasm-encoder/src/tables.rs
+++ b/crates/wasm-encoder/src/tables.rs
@@ -21,6 +21,7 @@ use super::*;
 ///
 /// let wasm_bytes = module.finish();
 /// ```
+#[derive(Clone, Debug)]
 pub struct TableSection {
     bytes: Vec<u8>,
     num_added: u32,
@@ -63,6 +64,7 @@ impl Section for TableSection {
 }
 
 /// A table's type.
+#[derive(Clone, Copy, Debug)]
 pub struct TableType {
     /// The table's element type.
     pub element_type: ValType,

--- a/crates/wasm-encoder/src/types.rs
+++ b/crates/wasm-encoder/src/types.rs
@@ -18,6 +18,7 @@ use std::convert::TryFrom;
 ///
 /// let wasm_bytes = module.finish();
 /// ```
+#[derive(Clone, Debug)]
 pub struct TypeSection {
     bytes: Vec<u8>,
     num_added: u32,


### PR DESCRIPTION
I need `Clone` for Wizer, but `Debug` is also just generally helpful to have.