### PR TITLE
Fix emission of exports.

### DIFF
--- a/crates/wasm-smith/src/lib.rs
+++ b/crates/wasm-smith/src/lib.rs
@@ -1472,7 +1472,7 @@ where
     }
 
     fn arbitrary_exports(&mut self, u: &mut Unstructured) -> Result<()> {
-        if self.type_size < self.config.max_type_size() {
+        if self.config.max_type_size() < self.type_size {
             return Ok(());
         }
 


### PR DESCRIPTION
I think the test for permitting the emission of exports was backwards. Unfortunately I couldn't find a way in wasm-smith/tests to add a test for whether a module has an export or not, but I've tested it myself with a ConfiguredModule with a configuration the requires at least one export (before this patch they have none, afterwards they do) and checking with wasm2wat on the command line.