### PR TITLE
wasmparser: Add full payload range to custom sections

### DIFF
--- a/crates/dump/src/lib.rs
+++ b/crates/dump/src/lib.rs
@@ -273,10 +273,13 @@ impl<'a> Dump<'a> {
 
                 Payload::CustomSection {
                     name,
-                    data,
                     data_offset,
+                    data,
+                    range,
                 } => {
-                    write!(self.state, "custom section: {:?}", name)?;
+                    write!(self.state, "custom section")?;
+                    self.print(range.start)?;
+                    write!(self.state, "name: {:?}", name)?;
                     self.print(data_offset)?;
                     if name == "name" {
                         let mut iter = NameSectionReader::new(data, data_offset)?;

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -147,6 +147,7 @@ impl Printer {
                     name: "name",
                     data_offset,
                     data,
+                    range: _,
                 } => {
                     let reader = NameSectionReader::new(data, data_offset)?;
                     // Ignore any error associated with the name section.
@@ -176,6 +177,7 @@ impl Printer {
                     name,
                     data,
                     data_offset,
+                    range: _,
                 } => {
                     let mut printers = mem::replace(&mut self.printers, HashMap::new());
                     if let Some(printer) = printers.get_mut(name) {

--- a/crates/wast/tests/annotations.rs
+++ b/crates/wast/tests/annotations.rs
@@ -99,6 +99,7 @@ fn get_name_section(wasm: &[u8]) -> anyhow::Result<NameSectionReader<'_>> {
             name: "name",
             data,
             data_offset,
+            range: _,
         } = payload?
         {
             return Ok(NameSectionReader::new(data, data_offset)?);

--- a/fuzz/fuzz_targets/incremental-parse.rs
+++ b/fuzz/fuzz_targets/incremental-parse.rs
@@ -113,16 +113,19 @@ fuzz_target!(|data: Vec<Vec<u8>>| {
                     name: a,
                     data_offset: ado,
                     data: ad,
+                    range: ar,
                 },
                 CustomSection {
                     name: b,
                     data_offset: bdo,
                     data: bd,
+                    range: br,
                 },
             ) => {
                 assert_eq!(a, b);
                 assert_eq!(ad, bd);
                 assert_eq!(ado, bdo);
+                assert_eq!(ar, br);
             }
             (
                 CodeSectionStart {

--- a/fuzz/fuzz_targets/roundtrip.rs
+++ b/fuzz/fuzz_targets/roundtrip.rs
@@ -65,6 +65,7 @@ fn validate_name_section(wasm: &[u8]) -> wasmparser::Result<()> {
                 name: "name",
                 data_offset,
                 data,
+                range: _,
             } => NameSectionReader::new(data, data_offset)?,
             _ => continue,
         };

--- a/src/bin/wasm-objdump-rs.rs
+++ b/src/bin/wasm-objdump-rs.rs
@@ -55,6 +55,7 @@ fn main() -> Result<()> {
                 name,
                 data_offset,
                 data,
+                range: _,
             } => printer.section_raw(
                 wasmparser::Range {
                     start: data_offset,

--- a/tests/dump/alias2.wat.dump
+++ b/tests/dump/alias2.wat.dump
@@ -41,8 +41,9 @@
          | 05 01      
   0x0075 | 01 36 00 ff | import [instance 0] Import { module: "6", field: None, ty: Instance(2) }
          | 06 02      
-  0x007b | 00 09 04 6e | custom section: "name"
-         | 61 6d 65   
+  0x007b | 00 09       | custom section
+  0x007d | 04 6e 61 6d | name: "name"
+         | 65         
   0x0082 | 00 02       | module name
   0x0084 | 01 6d       | "m"
 0x0086 | 10 1f       | alias section

--- a/tests/dump/bundled.wat.dump
+++ b/tests/dump/bundled.wat.dump
@@ -50,8 +50,9 @@
   0x007c | 00          | 0 local blocks
   0x007d | 10 00       | Call { function_index: 0 }
   0x007f | 0b          | End
-  0x0080 | 00 16 04 6e | custom section: "name"
-         | 61 6d 65   
+  0x0080 | 00 16       | custom section
+  0x0082 | 04 6e 61 6d | name: "name"
+         | 65         
   0x0087 | 00 06       | module name
   0x0089 | 05 43 48 49 | "CHILD"
          | 4c 44      
@@ -97,8 +98,9 @@
   0x00e3 | 00          | 0 local blocks
   0x00e4 | 41 00       | I32Const { value: 0 }
   0x00e6 | 0b          | End
-  0x00e7 | 00 12 04 6e | custom section: "name"
-         | 61 6d 65   
+  0x00e7 | 00 12       | custom section
+  0x00e9 | 04 6e 61 6d | name: "name"
+         | 65         
   0x00ee | 00 0b       | module name
   0x00f0 | 0a 56 49 52 | "VIRTUALIZE"
          | 54 55 41 4c

--- a/tests/dump/instantiate.wat.dump
+++ b/tests/dump/instantiate.wat.dump
@@ -49,8 +49,9 @@
 0x0069 | 02          | size of function
 0x006a | 00          | 0 local blocks
 0x006b | 0b          | End
-0x006c | 00 0b 04 6e | custom section: "name"
-       | 61 6d 65   
+0x006c | 00 0b       | custom section
+0x006e | 04 6e 61 6d | name: "name"
+       | 65         
 0x0073 | 01 04       | function names
 0x0075 | 01          | 1 count
 0x0076 | 00 01 66    | Naming { index: 0, name: "f" }

--- a/tests/dump/module-linking.wat.dump
+++ b/tests/dump/module-linking.wat.dump
@@ -41,8 +41,9 @@
          | 05 01      
   0x0075 | 01 36 00 ff | import [instance 0] Import { module: "6", field: None, ty: Instance(2) }
          | 06 02      
-  0x007b | 00 09 04 6e | custom section: "name"
-         | 61 6d 65   
+  0x007b | 00 09       | custom section
+  0x007d | 04 6e 61 6d | name: "name"
+         | 65         
   0x0082 | 00 02       | module name
   0x0084 | 01 6d       | "m"
 0x0086 | 10 1f       | alias section

--- a/tests/dump/names.wat.dump
+++ b/tests/dump/names.wat.dump
@@ -13,8 +13,9 @@
 0x0017 | 01          | 1 local blocks
 0x0018 | 01 7c       | 1 locals of type F64
 0x001a | 0b          | End
-0x001b | 00 1c 04 6e | custom section: "name"
-       | 61 6d 65   
+0x001b | 00 1c       | custom section
+0x001d | 04 6e 61 6d | name: "name"
+       | 65         
 0x0022 | 00 04       | module name
 0x0024 | 03 66 6f 6f | "foo"
 0x0028 | 01 04       | function names

--- a/tests/dump/nested-module.wat.dump
+++ b/tests/dump/nested-module.wat.dump
@@ -34,8 +34,9 @@
   0x0055 | 13          | inline module size
     0x0056 | 00 61 73 6d | version 1
            | 01 00 00 00
-    0x005e | 00 09 04 6e | custom section: "name"
-           | 61 6d 65   
+    0x005e | 00 09       | custom section
+    0x0060 | 04 6e 61 6d | name: "name"
+           | 65         
     0x0065 | 00 02       | module name
     0x0067 | 01 6d       | "m"
   0x0069 | 01 05       | type section

--- a/tests/dump/simple.wat.dump
+++ b/tests/dump/simple.wat.dump
@@ -65,9 +65,9 @@
 0x0068 |-------------| ... 1 bytes of data
 0x006a | 01 01       | data passive
 0x006c |-------------| ... 1 bytes of data
-0x006d | 00 17 0f 6e | custom section: "name-of-section"
-       | 61 6d 65 2d
-       | 6f 66 2d 73
-       | 65 63 74 69
-       | 6f 6e      
+0x006d | 00 17       | custom section
+0x006f | 0f 6e 61 6d | name: "name-of-section"
+       | 65 2d 6f 66
+       | 2d 73 65 63
+       | 74 69 6f 6e
 0x007f |-------------| ... 7 bytes of data


### PR DESCRIPTION
Only the range of the raw custom data could be recovered via `data_offset` and
`data.len()` before. This allows easily getting the range of the whole section,
similar to other section-specific readers via the `SectionReader::range` trait
method.