### PR TITLE
Fix a missing `expand_expr` for elem segment offsets

### DIFF
--- a/crates/wast/src/resolve/aliases.rs
+++ b/crates/wast/src/resolve/aliases.rs
@@ -89,8 +89,9 @@ impl<'a> Expander<'a> {
             }
 
             ModuleField::Elem(e) => {
-                if let ElemKind::Active { table, .. } = &mut e.kind {
+                if let ElemKind::Active { table, offset, .. } = &mut e.kind {
                     self.expand(table);
+                    self.expand_expr(offset);
                 }
                 match &mut e.payload {
                     ElemPayload::Indices(funcs) => {

--- a/tests/local/module-linking/alias.wast
+++ b/tests/local/module-linking/alias.wast
@@ -713,3 +713,8 @@
     )
   )
 )
+
+(assert_invalid
+  (module
+    (elem (f32.load (memory 2 ""))))
+  "unknown instance")


### PR DESCRIPTION
This fixes an issue found during fuzzing that could cause a panic.