### PR TITLE
Fix an assertion failure on invalid modules

### DIFF
--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -1255,6 +1255,7 @@ impl Validator {
             None => return self.create_error("type mismatch: init_expr is empty"),
         };
         self.offset = offset;
+        let mut function_reference = None;
         let ty = match op {
             Operator::I32Const { .. } => Type::I32,
             Operator::I64Const { .. } => Type::I64,
@@ -1272,12 +1273,8 @@ impl Validator {
                 global.content_type
             }
             Operator::RefFunc { function_index } => {
+                function_reference = Some(function_index);
                 self.get_func_type(function_index)?;
-                self.cur
-                    .state
-                    .assert_mut()
-                    .function_references
-                    .insert(function_index);
                 Type::FuncRef
             }
             Operator::End => return self.create_error("type mismatch: init_expr is empty"),
@@ -1290,6 +1287,14 @@ impl Validator {
             if !allow32 || ty != Type::I32 {
                 return self.create_error("type mismatch: invalid init_expr type");
             }
+        }
+
+        if let Some(index) = function_reference {
+            self.cur
+                .state
+                .assert_mut()
+                .function_references
+                .insert(index);
         }
 
         // Make sure the next instruction is an `end`

--- a/tests/local/invalid-funcref-in-data-segment.wast
+++ b/tests/local/invalid-funcref-in-data-segment.wast
@@ -1,0 +1,6 @@
+(assert_invalid
+  (module
+    (memory 0)
+    (func $f)
+    (data (ref.func $f) ""))
+  "type mismatch")


### PR DESCRIPTION
This commit fixes an issue in wasmparser where if an invalid module used
a `ref.func` instruction in the offset of the data segment it would
attempt what has since become immutable state.

The fix here is to delay the mutation to happen until after the
typechecking happens, where if the type is valid then we're guaranteed
our state is still mutable.