### PR TITLE
Fix a missing `expand_expr` for data segment offsets

### DIFF
--- a/crates/wast/src/resolve/aliases.rs
+++ b/crates/wast/src/resolve/aliases.rs
@@ -110,8 +110,9 @@ impl<'a> Expander<'a> {
             }
 
             ModuleField::Data(e) => {
-                if let DataKind::Active { memory, .. } = &mut e.kind {
+                if let DataKind::Active { memory, offset, .. } = &mut e.kind {
                     self.expand(memory);
+                    self.expand_expr(offset);
                 }
             }
 

--- a/tests/local/module-linking/alias.wast
+++ b/tests/local/module-linking/alias.wast
@@ -718,3 +718,8 @@
   (module
     (elem (f32.load (memory 2 ""))))
   "unknown instance")
+
+(assert_invalid
+  (module
+    (data (i32.load (memory 2 ""))))
+  "unknown instance")


### PR DESCRIPTION
This is the same as #244, but for data segments! Hats off to fuzzing
which is discovering things I should have checked in my previous PR...