### PR TITLE
Continue to tweak type size calculations in `wasm-smith`

### DIFF
--- a/crates/wast/src/lexer.rs
+++ b/crates/wast/src/lexer.rs
@@ -817,12 +817,19 @@ impl fmt::Display for LexError {
         use LexError::*;
         match self {
             DanglingBlockComment => f.write_str("unterminated block comment")?,
-            Unexpected(c) => write!(f, "unexpected character {:?}", c)?,
-            InvalidStringElement(c) => write!(f, "invalid character in string {:?}", c)?,
-            InvalidStringEscape(c) => write!(f, "invalid string escape {:?}", c)?,
-            InvalidHexDigit(c) => write!(f, "invalid hex digit {:?}", c)?,
-            InvalidDigit(c) => write!(f, "invalid decimal digit {:?}", c)?,
-            Expected { wanted, found } => write!(f, "expected {:?} but found {:?}", wanted, found)?,
+            Unexpected(c) => write!(f, "unexpected character '{}'", escape_char(*c))?,
+            InvalidStringElement(c) => {
+                write!(f, "invalid character in string '{}'", escape_char(*c))?
+            }
+            InvalidStringEscape(c) => write!(f, "invalid string escape '{}'", escape_char(*c))?,
+            InvalidHexDigit(c) => write!(f, "invalid hex digit '{}'", escape_char(*c))?,
+            InvalidDigit(c) => write!(f, "invalid decimal digit '{}'", escape_char(*c))?,
+            Expected { wanted, found } => write!(
+                f,
+                "expected '{}' but found '{}'",
+                escape_char(*wanted),
+                escape_char(*found)
+            )?,
             UnexpectedEof => write!(f, "unexpected end-of-file")?,
             NumberTooBig => f.write_str("number is too big to parse")?,
             InvalidUnicodeValue(c) => write!(f, "invalid unicode scalar value 0x{:x}", c)?,
@@ -830,6 +837,19 @@ impl fmt::Display for LexError {
             __Nonexhaustive => unreachable!(),
         }
         Ok(())
+    }
+}
+
+fn escape_char(c: char) -> String {
+    match c {
+        '\t' => String::from("\\\t"),
+        '\r' => String::from("\\\r"),
+        '\n' => String::from("\\\n"),
+        '\\' => String::from("\\\\"),
+        '\'' => String::from("\\\'"),
+        '\"' => String::from("\""),
+        '\x20'..='\x7e' => String::from(c),
+        _ => c.escape_unicode().to_string(),
     }
 }
 

--- a/crates/wast/tests/parse-fail/string13.wat.err
+++ b/crates/wast/tests/parse-fail/string13.wat.err
@@ -1,4 +1,4 @@
-expected '{' but found '\"'
+expected '{' but found '"'
      --> tests/parse-fail/string13.wat:1:4
       |
     1 | "\u"

--- a/crates/wast/tests/parse-fail/string14.wat.err
+++ b/crates/wast/tests/parse-fail/string14.wat.err
@@ -1,4 +1,4 @@
-invalid hex digit '\"'
+invalid hex digit '"'
      --> tests/parse-fail/string14.wat:1:5
       |
     1 | "\u{"

--- a/crates/wast/tests/parse-fail/string15.wat.err
+++ b/crates/wast/tests/parse-fail/string15.wat.err
@@ -1,4 +1,4 @@
-expected '}' but found '\"'
+expected '}' but found '"'
      --> tests/parse-fail/string15.wat:1:6
       |
     1 | "\u{3"

--- a/crates/wast/tests/parse-fail/string3.wat.err
+++ b/crates/wast/tests/parse-fail/string3.wat.err
@@ -1,4 +1,4 @@
-invalid hex digit '\"'
+invalid hex digit '"'
      --> tests/parse-fail/string3.wat:2:14
       |
     2 |   (import "\0"))


### PR DESCRIPTION


This commit updates the type size calculation since Wasmtime was getting
requests to instantiate modules with multiple thousands of memories, but
that shouldn't be valid since the maximum type size is 1000.

The fix here is to basically say that when calculating the size of an
instance or module, adding an import/export is where the `+1` happens.
This means that the size of an instance/module is the number of
imports/exports plus the recursive size of each import/export. This fix
is applied to generating instance/module types, but it's also applied
when adding imports/exports (the `+1` happens on the addition of the
import/export.

This also refactors the loop that adds exports to build a list of all
candidate exports and then it's filtered down to only exports whose type
size fits within the remaining budget of type size.

