### PR TITLE
Fix multi-memory and simd load/store lane instructions

### DIFF
--- a/crates/wast/src/ast/expr.rs
+++ b/crates/wast/src/ast/expr.rs
@@ -499,9 +499,11 @@ macro_rules! instructions {
     (@encode $dst:ident $($bytes:tt)*) => ($dst.extend_from_slice(&[$($bytes)*]););
 
     (@get_memarg $name:ident MemArg<$amt:tt>) => (Some($name));
+    (@get_memarg $name:ident LoadOrStoreLane<$amt:tt>) => (Some(&mut $name.memarg));
     (@get_memarg $($other:tt)*) => (None);
 
     (@memarg_binding $name:ident MemArg<$amt:tt>) => ($name);
+    (@memarg_binding $name:ident LoadOrStoreLane<$amt:tt>) => ($name);
     (@memarg_binding $name:ident $other:ty) => (_);
 }
 

--- a/tests/local/multi-memory.wast
+++ b/tests/local/multi-memory.wast
@@ -189,6 +189,14 @@
     i32.const 0 v128.load64_splat (memory $b) drop
     i32.const 0 v128.load32_zero (memory $b) drop
     i32.const 0 v128.load64_zero (memory $b) drop
+    i32.const 0 v128.const i64x2 0 0 v128.load8_lane (memory $b) 0 drop
+    i32.const 0 v128.const i64x2 0 0 v128.load16_lane (memory $b) 0 drop
+    i32.const 0 v128.const i64x2 0 0 v128.load32_lane (memory $b) 0 drop
+    i32.const 0 v128.const i64x2 0 0 v128.load64_lane (memory $b) 0 drop
+    i32.const 0 v128.const i64x2 0 0 v128.store8_lane (memory $b) 0
+    i32.const 0 v128.const i64x2 0 0 v128.store16_lane (memory $b) 0
+    i32.const 0 v128.const i64x2 0 0 v128.store32_lane (memory $b) 0
+    i32.const 0 v128.const i64x2 0 0 v128.store64_lane (memory $b) 0
     i32.const 0 i32.const 0 i8x16.splat v128.store (memory $b)
   )
 )


### PR DESCRIPTION
These were accidentally from the new `memarg_mut` function when
attemping to resolve various `MemArg` values.