### PR TITLE
Fix wasm-smith generating imports that exceed the type size budget

### DIFF
--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "wasm-smith"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools"
-version = "0.4.2"
+version = "0.4.3"
 
 [[bin]]
 name = "wasm-smith"


### PR DESCRIPTION
This commit fixes an issue where it's possible for imports of a module
to be generated such that they exceed the type size budget. The fix is
to generate a type to first and test if it's too large before we
actually add it. Previously items were added and then if the budget was
exceeded we'd stop adding items.