### PR TITLE
Bump wast to 35.0.2

### DIFF
--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wast"
-version = "35.0.1"
+version = "35.0.2"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"


### PR DESCRIPTION
Publish some recent fixes about some panics in handling offsets in
data/elem segments.