### PR TITLE
Add an "exhaustive checking mode" to `wast`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,6 +61,9 @@ jobs:
       shell: bash
 
     - run: cargo test --all
+    - run: cargo test --all
+      env:
+        RUSTFLAGS: --cfg=wast_check_exhaustive
     - run: cargo test --manifest-path crates/wasmparser/Cargo.toml --features deterministic
     - run: cargo build --manifest-path crates/wast/Cargo.toml --no-default-features
     - run: cargo build --manifest-path crates/wast/Cargo.toml --no-default-features --features wasm-module

--- a/crates/wast/src/ast/expr.rs
+++ b/crates/wast/src/ast/expr.rs
@@ -1311,6 +1311,8 @@ fn idx_zero<T>(span: ast::Span, mk_kind: fn(ast::Span) -> T) -> ast::ItemRef<'st
         kind: mk_kind(span),
         idx: ast::Index::Num(0, span),
         exports: Vec::new(),
+        #[cfg(wast_check_exhaustive)]
+        visited: false,
     }
 }
 

--- a/crates/wast/src/ast/memory.rs
+++ b/crates/wast/src/ast/memory.rs
@@ -145,6 +145,8 @@ impl<'a> Parse<'a> for Data<'a> {
                     kind: kw::memory(parser.prev_span()),
                     idx: ast::Index::Num(0, span),
                     exports: Vec::new(),
+                    #[cfg(wast_check_exhaustive)]
+                    visited: false,
                 }
             };
             let offset = parser.parens(|parser| {

--- a/crates/wast/src/ast/table.rs
+++ b/crates/wast/src/ast/table.rs
@@ -146,6 +146,8 @@ impl<'a> Parse<'a> for Elem<'a> {
                     kind: kw::table(parser.prev_span()),
                     idx: ast::Index::Num(0, span),
                     exports: Vec::new(),
+                    #[cfg(wast_check_exhaustive)]
+                    visited: false,
                 }
             };
             let offset = parser.parens(|parser| {

--- a/crates/wast/src/ast/token.rs
+++ b/crates/wast/src/ast/token.rs
@@ -232,6 +232,8 @@ pub enum ItemRef<'a, K> {
         kind: K,
         idx: Index<'a>,
         exports: Vec<&'a str>,
+        #[cfg(wast_check_exhaustive)]
+        visited: bool,
     },
 }
 
@@ -266,7 +268,13 @@ impl<'a, K: Parse<'a>> Parse<'a> for ItemRef<'a, K> {
                 while !parser.is_empty() {
                     exports.push(parser.parse()?);
                 }
-                Ok(ItemRef::Item { kind, idx, exports })
+                Ok(ItemRef::Item {
+                    kind,
+                    idx,
+                    exports,
+                    #[cfg(wast_check_exhaustive)]
+                    visited: false,
+                })
             }
         })
     }
@@ -299,6 +307,8 @@ where
                 kind: K::default(),
                 idx: parser.parse()?,
                 exports: Vec::new(),
+                #[cfg(wast_check_exhaustive)]
+                visited: false,
             }))
         } else {
             Ok(IndexOrRef(parser.parse()?))

--- a/crates/wast/src/ast/types.rs
+++ b/crates/wast/src/ast/types.rs
@@ -777,6 +777,8 @@ impl<'a, T> TypeUse<'a, T> {
                 idx,
                 kind: kw::r#type::default(),
                 exports: Vec::new(),
+                #[cfg(wast_check_exhaustive)]
+                visited: true,
             }),
             inline: None,
         }

--- a/crates/wast/src/binary.rs
+++ b/crates/wast/src/binary.rs
@@ -509,7 +509,15 @@ impl<T> Encode for ItemRef<'_, T> {
     fn encode(&self, e: &mut Vec<u8>) {
         match self {
             ItemRef::Outer { .. } => panic!("should be expanded previously"),
-            ItemRef::Item { idx, exports, .. } => {
+            ItemRef::Item {
+                idx,
+                exports,
+                #[cfg(wast_check_exhaustive)]
+                visited,
+                ..
+            } => {
+                #[cfg(wast_check_exhaustive)]
+                assert!(*visited);
                 assert!(exports.is_empty());
                 idx.encode(e);
             }

--- a/crates/wast/src/resolve/deinline_import_export.rs
+++ b/crates/wast/src/resolve/deinline_import_export.rs
@@ -266,5 +266,7 @@ fn item_ref<'a, K>(kind: K, id: impl Into<Index<'a>>) -> ItemRef<'a, K> {
         kind,
         idx: id.into(),
         exports: Vec::new(),
+        #[cfg(wast_check_exhaustive)]
+        visited: false,
     }
 }

--- a/crates/wast/src/resolve/names.rs
+++ b/crates/wast/src/resolve/names.rs
@@ -430,7 +430,22 @@ impl<'a> Resolver<'a> {
         K: Into<ExportKind> + Copy,
     {
         match item {
-            ItemRef::Item { idx, kind, exports } => {
+            ItemRef::Item {
+                idx,
+                kind,
+                exports,
+                #[cfg(wast_check_exhaustive)]
+                visited,
+            } => {
+                #[cfg(wast_check_exhaustive)]
+                {
+                    if !*visited {
+                        return Err(Error::new(
+                            idx.span(),
+                            format!("BUG: this index wasn't visited"),
+                        ));
+                    }
+                }
                 debug_assert!(exports.len() == 0);
                 self.resolve(
                     idx,

--- a/crates/wast/src/resolve/types.rs
+++ b/crates/wast/src/resolve/types.rs
@@ -244,6 +244,8 @@ impl<'a> Expander<'a> {
             idx,
             kind: kw::r#type(span),
             exports: Vec::new(),
+            #[cfg(wast_check_exhaustive)]
+            visited: true,
         });
         return idx;
     }


### PR DESCRIPTION
This commit adds a conditional compilation mode to `wast` where new
fields are injected into some AST nodes to add assertions later on that
all AST nodes were visited by the resolution passes. There have been
quite a few bugs recently related to the alias pass forgetting to run on
some AST nodes, so this is intended to fix the last of those once and
for all.

When the `--cfg check_exhaustive` flag is used when compiling `wast`
(must be passed via `RUSTFLAGS`) the crate will insert boolean fields
into all item references along with a "visited" flag. This "visited"
flag is then set during alias expansion (and perhaps later we could
check it during resolve expansion too). Resolution and binary encoding
passes which already visit all of these nodes anyway then check this
flag and return a bug or assert if something is encountered.

Another possible solution to this would be some sort of `Visit` trait
but that sort of feels like overkill when just two passes are in
question here (alias expansion and resolution). I'm hoping that we can
leverage this to be a bit lighter weight in the long run, but we'll see!