### PR TITLE
Add "unknown" as name subsection type

### DIFF
--- a/crates/dump/src/lib.rs
+++ b/crates/dump/src/lib.rs
@@ -359,6 +359,11 @@ impl<'a> Dump<'a> {
                     }
                 }
             }
+            Name::Unknown { ty, range, .. } => {
+                write!(self.state, "unknown names: {}", ty)?;
+                self.print(range.start)?;
+                self.print(end)?;
+            }
         }
         Ok(())
     }

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -1864,10 +1864,7 @@ impl<'a> BinaryReader<'a> {
             0 => Ok(NameType::Module),
             1 => Ok(NameType::Function),
             2 => Ok(NameType::Local),
-            _ => Err(BinaryReaderError::new(
-                "Invalid name type",
-                self.original_position() - 1,
-            )),
+            _ => Ok(NameType::Unknown(code)),
         }
     }
 

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -272,6 +272,7 @@ pub enum NameType {
     Module,
     Function,
     Local,
+    Unknown(u32),
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/crates/wasmparser/src/readers/name_section.rs
+++ b/crates/wasmparser/src/readers/name_section.rs
@@ -176,7 +176,16 @@ pub enum Name<'a> {
     Module(ModuleName<'a>),
     Function(FunctionName<'a>),
     Local(LocalName<'a>),
-    Unknown { ty: u32, data: &'a [u8] },
+    /// An unknown [name subsection](https://webassembly.github.io/spec/core/appendix/custom.html#subsections).
+    Unknown {
+        /// The identifier for this subsection.
+        ty: u32,
+        /// The contents of this subsection.
+        data: &'a [u8],
+        /// The range of bytes, relative to the start of the original data
+        /// stream, that the contents of this subsection reside in.
+        range: Range,
+    },
 }
 
 pub struct NameSectionReader<'a> {
@@ -224,7 +233,11 @@ impl<'a> NameSectionReader<'a> {
             NameType::Module => Name::Module(ModuleName { data, offset }),
             NameType::Function => Name::Function(FunctionName { data, offset }),
             NameType::Local => Name::Local(LocalName { data, offset }),
-            NameType::Unknown(ty) => Name::Unknown { ty, data },
+            NameType::Unknown(ty) => Name::Unknown {
+                ty,
+                data,
+                range: Range::new(offset, offset + payload_len),
+            },
         })
     }
 }

--- a/crates/wasmparser/src/readers/name_section.rs
+++ b/crates/wasmparser/src/readers/name_section.rs
@@ -176,6 +176,7 @@ pub enum Name<'a> {
     Module(ModuleName<'a>),
     Function(FunctionName<'a>),
     Local(LocalName<'a>),
+    Unknown { ty: u32, data: &'a [u8] },
 }
 
 pub struct NameSectionReader<'a> {
@@ -223,6 +224,7 @@ impl<'a> NameSectionReader<'a> {
             NameType::Module => Name::Module(ModuleName { data, offset }),
             NameType::Function => Name::Function(FunctionName { data, offset }),
             NameType::Local => Name::Local(LocalName { data, offset }),
+            NameType::Unknown(ty) => Name::Unknown { ty, data },
         })
     }
 }

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -212,9 +212,7 @@ impl Printer {
                     *wasm = &wasm[size as usize..];
                     parser.skip_section();
                 }
-                Payload::CodeSectionEntry(_) => {
-                    unreachable!()
-                }
+                Payload::CodeSectionEntry(_) => unreachable!(),
 
                 Payload::DataSection(s) => self.print_data(s)?,
                 Payload::AliasSection(s) => self.print_aliases(s)?,
@@ -285,6 +283,7 @@ impl Printer {
                             .insert(local_name.func_index, local_map);
                     }
                 }
+                Name::Unknown { .. } => (),
             }
         }
         Ok(())

--- a/fuzz/fuzz_targets/roundtrip.rs
+++ b/fuzz/fuzz_targets/roundtrip.rs
@@ -90,6 +90,7 @@ fn validate_name_section(wasm: &[u8]) -> wasmparser::Result<()> {
                         }
                     }
                 }
+                Name::Unknown { .. } => (),
             }
         }
     }


### PR DESCRIPTION
In principal, the [format of the "name" custom section](https://webassembly.github.io/spec/core/appendix/custom.html#subsections) can support arbitrary custom subsections. I'd be surprised if any tools actually uses this ability for truly custom stuff, but it provides some decent forwards compatibility even once wasmparser gains support for proposals such as "extended name section" (which I am also working on now as a separate PR).