### PR TITLE
Fix README

### DIFF
--- a/crates/wasm-encoder/README.md
+++ b/crates/wasm-encoder/README.md
@@ -68,7 +68,6 @@ let wasm_bytes = module.finish();
 // We generated a valid Wasm module!
 assert!(wasmparser::validate(&wasm_bytes).is_ok());
 ```
-```
 
 # License
 


### PR DESCRIPTION
README in `wasm-encoder` has an extra "```" which causes to be rendered improperly