### PR TITLE
Require `global.get` init expr points to imported global

### DIFF
--- a/crates/wasm-smith/src/lib.rs
+++ b/crates/wasm-smith/src/lib.rs
@@ -1440,6 +1440,7 @@ where
     fn arbitrary_globals(&mut self, u: &mut Unstructured) -> Result<()> {
         let mut choices: Vec<Box<dyn Fn(&mut Unstructured, ValType) -> Result<Instruction>>> =
             vec![];
+        let num_imported_globals = self.globals.len();
 
         arbitrary_loop(
             u,
@@ -1472,7 +1473,7 @@ where
                     })
                 }));
 
-                for (i, g) in self.globals.iter().enumerate() {
+                for (i, g) in self.globals[..num_imported_globals].iter().enumerate() {
                     if !g.mutable && g.val_type == ty.val_type {
                         choices.push(Box::new(move |_, _| Ok(Instruction::GlobalGet(i as u32))));
                     }
@@ -1586,7 +1587,10 @@ where
 
         // Create a helper closure to choose an arbitrary offset.
         let mut offset_global_choices = vec![];
-        for (i, g) in self.globals.iter().enumerate() {
+        for (i, g) in self.globals[..self.globals.len() - self.defined_globals.len()]
+            .iter()
+            .enumerate()
+        {
             if !g.mutable && g.val_type == ValType::I32 {
                 offset_global_choices.push(i as u32);
             }

--- a/tests/local/globals.wast
+++ b/tests/local/globals.wast
@@ -1,0 +1,22 @@
+(assert_invalid
+  (module
+    (global i32 (i32.const 0))
+    (global i32 (global.get 0))
+  )
+  "global.get of locally defined global")
+
+(assert_invalid
+  (module
+    (global i32 (i32.const 0))
+    (table 1 funcref)
+    (elem (offset global.get 0))
+  )
+  "global.get of locally defined global")
+
+(assert_invalid
+  (module
+    (global i32 (i32.const 0))
+    (memory 1)
+    (data (offset global.get 0))
+  )
+  "global.get of locally defined global")

--- a/tests/local/module-linking/globals.wast
+++ b/tests/local/module-linking/globals.wast
@@ -1,0 +1,7 @@
+(module
+  (module
+    (global (export "g") i32 (i32.const 0)))
+  (instance (instantiate 0))
+  (alias 0 "g" (global))
+  (global i32 (global.get 0))
+)


### PR DESCRIPTION
I'm mostly surprised this isn't covered by wasm's own test suite! Sure
enough though there's a clause [online] which says that for now there's
a constraint that globals initialized with `global.get` must reference
imported globals.

Closes #282

[online]: https://webassembly.github.io/spec/core/valid/instructions.html#valid-constant