### PR TITLE
Support inline import in event declarations

### DIFF
--- a/crates/wast/src/ast/event.rs
+++ b/crates/wast/src/ast/event.rs
@@ -12,6 +12,8 @@ pub struct Event<'a> {
     pub exports: ast::InlineExport<'a>,
     /// The type of event that is defined.
     pub ty: EventType<'a>,
+    /// What kind of event this is defined as.
+    pub kind: EventKind<'a>,
 }
 
 /// Listing of various types of events that can be defined in a wasm module.
@@ -22,17 +24,36 @@ pub enum EventType<'a> {
     Exception(ast::TypeUse<'a, ast::FunctionType<'a>>),
 }
 
+/// Different kinds of events that can be defined in a module.
+#[derive(Debug)]
+pub enum EventKind<'a> {
+    /// An event which is actually defined as an import, such as:
+    ///
+    /// ```text
+    /// (event (type 0) (import "foo" "bar"))
+    /// ```
+    Import(ast::InlineImport<'a>),
+
+    /// An event defined inline in the module itself
+    Inline(),
+}
+
 impl<'a> Parse<'a> for Event<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
         let span = parser.parse::<kw::event>()?.0;
         let id = parser.parse()?;
         let exports = parser.parse()?;
-        let ty = parser.parse()?;
+        let (ty, kind) = if let Some(import) = parser.parse()? {
+            (parser.parse()?, EventKind::Import(import))
+        } else {
+            (parser.parse()?, EventKind::Inline())
+        };
         Ok(Event {
             span,
             id,
             exports,
             ty,
+            kind,
         })
     }
 }

--- a/crates/wast/src/binary.rs
+++ b/crates/wast/src/binary.rs
@@ -1130,6 +1130,10 @@ impl Encode for Custom<'_> {
 impl Encode for Event<'_> {
     fn encode(&self, e: &mut Vec<u8>) {
         self.ty.encode(e);
+        match &self.kind {
+            EventKind::Inline() => {}
+            _ => panic!("EventKind should be inline during encoding"),
+        }
     }
 }
 

--- a/crates/wast/src/resolve/deinline_import_export.rs
+++ b/crates/wast/src/resolve/deinline_import_export.rs
@@ -176,6 +176,22 @@ pub fn run(fields: &mut Vec<ModuleField>) {
                 for name in e.exports.names.drain(..) {
                     to_append.push(export(e.span, name, ExportKind::Event, &mut e.id));
                 }
+                match e.kind {
+                    EventKind::Import(import) => {
+                        *item = ModuleField::Import(Import {
+                            span: e.span,
+                            module: import.module,
+                            field: import.field,
+                            item: ItemSig {
+                                span: e.span,
+                                id: e.id,
+                                name: None,
+                                kind: ItemKind::Event(e.ty.clone()),
+                            },
+                        });
+                    }
+                    EventKind::Inline { .. } => {}
+                }
             }
 
             ModuleField::Instance(i) => {

--- a/tests/local/exception-handling.wast
+++ b/tests/local/exception-handling.wast
@@ -2,7 +2,7 @@
 (module 
   (type (func (param i32 i64)))
   (type (func (param i32)))
-  (event (type 0))
+  (event (import "m" "t") (type 0))
   (event (type 1))
   (func $check-throw
     i32.const 1


### PR DESCRIPTION
This adds support for inline `import` for `event` declarations, similar to how it works for `global` and other forms.

(the motivation for this is that some of the proposed spec tests for exception handling uses this syntax, so it's useful for test harnesses in, e.g., SpiderMonkey)