### PR TITLE
Remove `unwind` instruction for exception handling

### DIFF
--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -1110,7 +1110,6 @@ impl<'a> BinaryReader<'a> {
             0x09 => Operator::Rethrow {
                 relative_depth: self.read_var_u32()?,
             },
-            0x0a => Operator::Unwind,
             0x0b => Operator::End,
             0x0c => Operator::Br {
                 relative_depth: self.read_var_u32()?,

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -365,7 +365,6 @@ pub enum Operator<'a> {
     Rethrow {
         relative_depth: u32,
     },
-    Unwind,
     End,
     Br {
         relative_depth: u32,

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -681,10 +681,7 @@ impl Printer {
                     // `else`/`catch` are special in that it's printed at
                     // the previous indentation, but it doesn't actually change
                     // our nesting level.
-                    Operator::Else
-                    | Operator::Catch { .. }
-                    | Operator::CatchAll
-                    | Operator::Unwind => {
+                    Operator::Else | Operator::Catch { .. } | Operator::CatchAll => {
                         self.nesting -= 1;
                         self.newline();
                         self.nesting += 1;
@@ -762,7 +759,6 @@ impl Printer {
                     label(*relative_depth)
                 )?;
             }
-            Unwind => self.result.push_str("unwind"),
             End => self.result.push_str("end"),
             Br { relative_depth } => {
                 write!(

--- a/crates/wast/src/ast/mod.rs
+++ b/crates/wast/src/ast/mod.rs
@@ -419,7 +419,6 @@ pub mod kw {
     custom_keyword!(table);
     custom_keyword!(then);
     custom_keyword!(r#try = "try");
-    custom_keyword!(unwind);
     custom_keyword!(v128);
 }
 

--- a/tests/local/exception-handling.wast
+++ b/tests/local/exception-handling.wast
@@ -23,16 +23,6 @@
     drop
     drop
   )
-  (func $check-unwind (local i32)
-    try
-      i32.const 1
-      local.set 0
-      call $check-throw
-    unwind
-      i32.const 0
-      local.set 0
-    end
-  )
 )
 
 (assert_invalid
@@ -50,11 +40,6 @@
   (module
     (func try catch_all catch 0 end))
   "catch found outside of an `try` block")
-
-(assert_invalid
-  (module
-    (func try unwind i32.const 1 end))
-  "type mismatch: values remaining on stack at end of block")
 
 (assert_invalid
   (module

--- a/tests/local/try.wast
+++ b/tests/local/try.wast
@@ -38,12 +38,6 @@
 
 (assert_malformed
   (module quote
-    "(func (try (do) (unwind) (drop)))"
-  )
-  "too many payloads inside of `(try)`")
-
-(assert_malformed
-  (module quote
     "(func (try (do) (delegate 0) (drop)))"
   )
   "too many payloads inside of `(try)`")

--- a/tests/local/try.wat
+++ b/tests/local/try.wat
@@ -7,7 +7,6 @@
   (func (try (do) (catch $exn rethrow 0)))
   (func (try (do) (catch_all rethrow 0)))
   (func (try (do) (catch $exn) (catch_all rethrow 0)))
-  (func (try (do) (unwind nop)))
   (func (try (do (try (do) (delegate 0))) (catch $exn)))
   (func (result i32)
     (try (result i32)

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -141,6 +141,11 @@ fn skip_test(test: &Path, contents: &[u8]) -> bool {
         // Usage of `assert_invalid` which should be `assert_malformed`
         "testsuite/proposals/memory64/memory.wast",
         "testsuite/proposals/memory64/address.wast",
+        // Unwind is being removed from the exceptions proposal.
+        "dump/try-unwind.txt",
+        "parse/expr/try-unwind.txt",
+        "roundtrip/try-unwind.txt",
+        "roundtrip/fold-try-unwind.txt",
     ];
     if broken.iter().any(|x| test.ends_with(x)) {
         return true;


### PR DESCRIPTION
The `unwind` instruction was recently removed from the exception handling proposal spec (https://github.com/WebAssembly/exception-handling/pull/156), so this PR is for removing it from wasm-tools.

I plan to also make this change in wabt soon, but until then I added all unwind tests to the skipped test list in this PR.