### PR TITLE
Allow bare `try` blocks for exceptions

### DIFF
--- a/crates/wasmparser/src/operators_validator.rs
+++ b/crates/wasmparser/src/operators_validator.rs
@@ -677,9 +677,6 @@ impl OperatorValidator {
                         self.push_ctrl(FrameKind::Else, frame.block_type, resources)?;
                         frame = self.pop_ctrl(resources)?;
                     }
-                    FrameKind::Try => {
-                        bail_op_err!("expected catch block");
-                    }
                     _ => (),
                 }
 

--- a/crates/wast/src/ast/expr.rs
+++ b/crates/wast/src/ast/expr.rs
@@ -193,16 +193,11 @@ impl<'a> ExpressionParser<'a> {
                         self.instrs.push(Instruction::End(None));
                     }
 
-                    // Both `do` and `catch` are required in a `try` statement, so
-                    // we will signal those errors here. Otherwise, terminate with
+                    // The `do` clause is required in a `try` statement, so
+                    // we will signal that error here. Otherwise, terminate with
                     // an `end` or `delegate` instruction.
                     Level::Try(Try::Do(_)) => {
                         return Err(parser.error("previous `try` had no `do`"));
-                    }
-                    Level::Try(Try::CatchOrDelegate) => {
-                        return Err(parser.error(
-                            "previous `try` had no `catch`, `catch_all`, or `delegate`",
-                        ));
                     }
                     Level::Try(Try::Delegate) => {}
                     Level::Try(_) => {
@@ -372,7 +367,7 @@ impl<'a> ExpressionParser<'a> {
                     Paren::Right => return Ok(true),
                 }
             }
-            return Ok(false);
+            return Err(parser.error("expected a `catch`, `catch_all`, or `delegate`"));
         }
 
         if let Try::Catch = i {

--- a/tests/local/try.wast
+++ b/tests/local/try.wast
@@ -2,6 +2,12 @@
 
 (assert_malformed
   (module quote
+    "(func (try))"
+  )
+  "previous `try` had no `do`")
+
+(assert_malformed
+  (module quote
     "(func (try (catch $exn)))"
   )
   "previous `try` had no `do`")
@@ -14,15 +20,15 @@
 
 (assert_malformed
   (module quote
-    "(func (try (do)))"
+    "(func (try (do) (unreachable)))"
   )
-  "previous `try` had no `catch`")
+  "expected a `catch`, `catch_all`, or `delegate`")
 
 (assert_malformed
   (module quote
-    "(func (try (do) (unreachable)))"
+    "(func (try (do) (catch_all) (unreachable)))"
   )
-  "previous `try` had no `catch`")
+  "too many payloads inside of `(try)`")
 
 (assert_malformed
   (module quote

--- a/tests/local/try.wat
+++ b/tests/local/try.wat
@@ -3,6 +3,7 @@
 (module $m
   (type (func))
   (event $exn (type 0))
+  (func (try (do)))
   (func (try (do) (catch $exn)))
   (func (try (do) (catch $exn rethrow 0)))
   (func (try (do) (catch_all rethrow 0)))

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -280,6 +280,9 @@ impl TestState {
             // FIXME wabt doesn't print conflict or empty names in the same way
             // that we do.
             && !test.ends_with("local/names.wast")
+
+            // FIXME this can be removed once wabt support for catch-less try is merged
+            && !test.ends_with("local/try.wat")
         {
             if let Some(expected) = self.wasm2wat(contents)? {
                 self.string_compare(&string, &expected)


### PR DESCRIPTION
This PR add support for bare `try` blocks (try blocks that have no `catch`, `delegate`, etc). These are equivalent to a plain `block` and were added to the spec recently (in order to simplify the grammar and avoid special cases): https://github.com/WebAssembly/exception-handling/pull/157

There's a PR pending review for wabt as well: https://github.com/WebAssembly/wabt/pull/1676

I tested the wasm-tools patch against the pending wabt PR and I believe they should agree. It should be ok to merge this before wabt as the only conflicting test is a failure test (`bad-try-no-catch.txt`) that is not run by `roundtrip.rs`.