### PR TITLE
Allow more invalid AST states in elem expressions

### DIFF
--- a/crates/wast/src/resolve/aliases.rs
+++ b/crates/wast/src/resolve/aliases.rs
@@ -100,10 +100,8 @@ impl<'a> Expander<'a> {
                         }
                     }
                     ElemPayload::Exprs { exprs, .. } => {
-                        for func in exprs {
-                            if let Some(func) = func {
-                                self.expand(func);
-                            }
+                        for expr in exprs {
+                            self.expand_expr(expr);
                         }
                     }
                 }

--- a/crates/wast/src/resolve/names.rs
+++ b/crates/wast/src/resolve/names.rs
@@ -237,10 +237,8 @@ impl<'a> Resolver<'a> {
                         }
                     }
                     ElemPayload::Exprs { exprs, ty } => {
-                        for funcref in exprs {
-                            if let Some(idx) = funcref {
-                                self.resolve_item_ref(idx)?;
-                            }
+                        for expr in exprs {
+                            self.resolve_expr(expr)?;
                         }
                         self.resolve_heaptype(&mut ty.heap)?;
                     }

--- a/tests/local/elem.wast
+++ b/tests/local/elem.wast
@@ -1,0 +1,7 @@
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (elem (i32.const 0) funcref (ref.null extern))
+  )
+  "type mismatch"
+)


### PR DESCRIPTION
Previously we would store elem segment expressions as actually optional
indices, but this meant that some parse-time errors happened instead of
later validation-time errors. Looks like the upstream test suite expects
to be able to parse some more element segments than we support (for them
to later fail in validation), so this updates the parser to parse full
expressions and store those so we can faithfully carry over those items
in to the output to get errors during wasm validation.

Closes #294