### PR TITLE
Update wabt submodule and fix try-delegate label resolution to match

### DIFF
--- a/crates/wast/src/resolve/names.rs
+++ b/crates/wast/src/resolve/names.rs
@@ -772,7 +772,7 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
                 ));
             }
 
-            Br(i) | BrIf(i) | BrOnNull(i) | Delegate(i) => {
+            Br(i) | BrIf(i) | BrOnNull(i) => {
                 self.resolve_label(i)?;
             }
 
@@ -791,6 +791,12 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
             }
             Catch(i) => {
                 self.resolver.resolve(i, Ns::Tag)?;
+            }
+            Delegate(i) => {
+                // Since a delegate starts counting one layer out from the
+                // current try-delegate block, we pop before we resolve labels.
+                self.blocks.pop();
+                self.resolve_label(i)?;
             }
 
             BrOnCast(l) | BrOnFunc(l) | BrOnData(l) | BrOnI31(l) => {

--- a/tests/dump/try-delegate.wat
+++ b/tests/dump/try-delegate.wat
@@ -1,0 +1,8 @@
+(module
+  (func
+    try $l
+      try
+      delegate $l
+    end
+  )
+)

--- a/tests/dump/try-delegate.wat.dump
+++ b/tests/dump/try-delegate.wat.dump
@@ -1,0 +1,18 @@
+0x0000 | 00 61 73 6d | version 1
+       | 01 00 00 00
+0x0008 | 01 04       | type section
+0x000a | 01          | 1 count
+0x000b | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
+0x000e | 03 02       | func section
+0x0010 | 01          | 1 count
+0x0011 | 00          | [func 0] type 0
+0x0012 | 0a 0b       | code section
+0x0014 | 01          | 1 count
+============== func 0 ====================
+0x0015 | 09          | size of function
+0x0016 | 00          | 0 local blocks
+0x0017 | 06 40       | Try { ty: Type(EmptyBlockType) }
+0x0019 | 06 40       | Try { ty: Type(EmptyBlockType) }
+0x001b | 18 00       | Delegate { relative_depth: 0 }
+0x001d | 0b          | End
+0x001e | 0b          | End

--- a/tests/local/try.wast
+++ b/tests/local/try.wast
@@ -47,3 +47,9 @@
     "(func (try (do) (delegate 0) (drop)))"
   )
   "too many payloads inside of `(try)`")
+
+(assert_malformed
+  (module quote
+    "(func (try $l (do) (delegate $l)))"
+  )
+  "failed to find label")

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -134,18 +134,9 @@ fn skip_test(test: &Path, contents: &[u8]) -> bool {
         "dump/reference-types.txt",
         "interp/reference-types.txt",
         "expr/reference-types.txt",
-        // This test is skipped for now due to a delegate printing bug in wabt.
-        "parse/expr/try-delegate.txt",
-        // Skipped until (WebAssembly/wabt#1605) is merged.
-        "typecheck/delegate.txt",
         // Usage of `assert_invalid` which should be `assert_malformed`
         "testsuite/proposals/memory64/memory.wast",
         "testsuite/proposals/memory64/address.wast",
-        // Unwind is being removed from the exceptions proposal.
-        "dump/try-unwind.txt",
-        "parse/expr/try-unwind.txt",
-        "roundtrip/try-unwind.txt",
-        "roundtrip/fold-try-unwind.txt",
     ];
     if broken.iter().any(|x| test.ends_with(x)) {
         return true;


### PR DESCRIPTION
This PR updates the wabt submodule to the latest and handles two updates:

  * Fixes `try-delegate` label resolution (the companion to this wabt PR https://github.com/WebAssembly/wabt/pull/1675) so that labels are correctly looked up starting one scope out (i.e., one more than a `br` would target).
  * Removes now outdated test exemptions for exception handling cases where wabt and wasm-tools were out of sync.