### PR TITLE
Fix a panic in processing malformed input

### DIFF
--- a/crates/wasmparser/src/readers/element_section.rs
+++ b/crates/wasmparser/src/readers/element_section.rs
@@ -93,11 +93,11 @@ impl<'a> ElementItemsReader<'a> {
             let ret = match self.reader.read_operator()? {
                 Operator::RefNull { ty } => ElementItem::Null(ty),
                 Operator::RefFunc { function_index } => ElementItem::Func(function_index),
-                _ => return Err(BinaryReaderError::new("invalid passive segment", offset)),
+                _ => return Err(BinaryReaderError::new("invalid element segment", offset)),
             };
             match self.reader.read_operator()? {
                 Operator::End => {}
-                _ => return Err(BinaryReaderError::new("invalid passive segment", offset)),
+                _ => return Err(BinaryReaderError::new("invalid element segment", offset)),
             }
             Ok(ret)
         } else {

--- a/crates/wast/src/resolve/types.rs
+++ b/crates/wast/src/resolve/types.rs
@@ -124,6 +124,11 @@ impl<'a> Expander<'a> {
                 if let ElemKind::Active { offset, .. } = &mut e.kind {
                     self.expand_expression(offset);
                 }
+                if let ElemPayload::Exprs { exprs, .. } = &mut e.payload {
+                    for expr in exprs {
+                        self.expand_expression(expr);
+                    }
+                }
             }
             ModuleField::Tag(t) => match &mut t.ty {
                 TagType::Exception(ty) => {

--- a/tests/local/elem.wast
+++ b/tests/local/elem.wast
@@ -5,3 +5,10 @@
   )
   "type mismatch"
 )
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (elem (i32.const 0) funcref (if))
+  )
+  "invalid element segment"
+)


### PR DESCRIPTION
With the recent change to support full expressions in element segments
there's at least one missing location where an expression needed to get
processed for type expansion which was forgotten.