### PR TITLE
Sync with the upstream memory64 proposal

### DIFF
--- a/crates/wasmparser/src/limits.rs
+++ b/crates/wasmparser/src/limits.rs
@@ -21,7 +21,7 @@ pub const MAX_WASM_IMPORTS: usize = 100_000;
 pub const MAX_WASM_EXPORTS: usize = 100_000;
 pub const MAX_WASM_GLOBALS: usize = 1_000_000;
 pub const MAX_WASM_DATA_SEGMENTS: usize = 100_000;
-pub const MAX_WASM_MEMORY_PAGES: usize = 65536;
+pub const MAX_WASM_MEMORY32_PAGES: u64 = 65536;
 pub const MAX_WASM_MEMORY64_PAGES: u64 = 1 << 48;
 pub const MAX_WASM_STRING_SIZE: usize = 100_000;
 pub const _MAX_WASM_MODULE_SIZE: usize = 1024 * 1024 * 1024; //= 1 GiB

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -193,33 +193,41 @@ pub struct ExportType<'a> {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct ResizableLimits {
+pub struct TableType {
+    pub element_type: Type,
+    /// Initial size of this table, in elements.
     pub initial: u32,
+    /// Optional maximum size of the table, in elements.
     pub maximum: Option<u32>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct ResizableLimits64 {
+pub struct MemoryType {
+    /// Whether or not this is a 64-bit memory, using i64 as an index. If this
+    /// is false it's a 32-bit memory using i32 as an index.
+    ///
+    /// This is part of the memory64 proposal in WebAssembly.
+    pub memory64: bool,
+
+    /// Whether or not this is a "shared" memory, indicating that it should be
+    /// send-able across threads and the `maximum` field is always present for
+    /// valid types.
+    ///
+    /// This is part of the threads proposal in WebAssembly.
+    pub shared: bool,
+
+    /// Initial size of this memory, in wasm pages.
+    ///
+    /// For 32-bit memories (when `memory64` is `false`) this is guaranteed to
+    /// be at most `u32::MAX` for valid types.
     pub initial: u64,
+
+    /// Optional maximum size of this memory, in wasm pages.
+    ///
+    /// For 32-bit memories (when `memory64` is `false`) this is guaranteed to
+    /// be at most `u32::MAX` for valid types. This field is always present for
+    /// valid wasm memories when `shared` is `true`.
     pub maximum: Option<u64>,
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct TableType {
-    pub element_type: Type,
-    pub limits: ResizableLimits,
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum MemoryType {
-    M32 {
-        limits: ResizableLimits,
-        shared: bool,
-    },
-    M64 {
-        limits: ResizableLimits64,
-        shared: bool,
-    },
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -229,9 +237,10 @@ pub struct TagType {
 
 impl MemoryType {
     pub fn index_type(&self) -> Type {
-        match self {
-            MemoryType::M32 { .. } => Type::I32,
-            MemoryType::M64 { .. } => Type::I64,
+        if self.memory64 {
+            Type::I64
+        } else {
+            Type::I32
         }
     }
 }

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -257,7 +257,7 @@ pub enum ImportSectionEntryType {
 pub struct MemoryImmediate {
     /// Alignment, stored as `n` where the actual alignment is `2^n`
     pub align: u8,
-    pub offset: u32,
+    pub offset: u64,
     pub memory: u32,
 }
 

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -266,7 +266,20 @@ pub enum ImportSectionEntryType {
 pub struct MemoryImmediate {
     /// Alignment, stored as `n` where the actual alignment is `2^n`
     pub align: u8,
+
+    /// A fixed byte-offset that this memory immediate specifies.
+    ///
+    /// Note that the memory64 proposal can specify a full 64-bit byte offset
+    /// while otherwise only 32-bit offsets are allowed. Once validated
+    /// memory immediates for 32-bit memories are guaranteed to be at most
+    /// `u32::MAX` whereas 64-bit memories can use the full 64-bits.
     pub offset: u64,
+
+    /// The index of the memory this immediate points to.
+    ///
+    /// Note that this points within the module's own memory index space, and
+    /// is always zero unless the multi-memory proposal of WebAssembly is
+    /// enabled.
     pub memory: u32,
 }
 

--- a/crates/wasmparser/src/readers/operators.rs
+++ b/crates/wasmparser/src/readers/operators.rs
@@ -38,6 +38,10 @@ impl<'a> OperatorsReader<'a> {
         self.reader.original_position()
     }
 
+    pub fn allow_memarg64(&mut self, allow: bool) {
+        self.reader.allow_memarg64(allow);
+    }
+
     pub fn ensure_end(&self) -> Result<()> {
         if self.eof() {
             return Ok(());

--- a/crates/wasmparser/src/validator/func.rs
+++ b/crates/wasmparser/src/validator/func.rs
@@ -51,6 +51,7 @@ impl<T: WasmModuleResources> FuncValidator<T> {
     pub fn validate(&mut self, body: &FunctionBody<'_>) -> Result<()> {
         let mut reader = body.get_binary_reader();
         self.read_locals(&mut reader)?;
+        reader.allow_memarg64(self.validator.features.memory64);
         while !reader.eof() {
             let pos = reader.original_position();
             let op = reader.read_operator()?;

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -677,6 +677,7 @@ impl Printer {
             self.state.label = 0;
             let nesting_start = self.nesting;
             let mut reader = body.get_operators_reader()?;
+            reader.allow_memarg64(true);
             while !reader.eof() {
                 let operator = reader.read()?;
                 match operator {

--- a/crates/wast/src/ast/expr.rs
+++ b/crates/wast/src/ast/expr.rs
@@ -1,5 +1,5 @@
 use crate::ast::{self, kw, HeapType};
-use crate::parser::{Parse, Parser, Result};
+use crate::parser::{Cursor, Parse, Parser, Result};
 use std::mem;
 
 /// An expression, or a list of instructions, in the WebAssembly text format.
@@ -1240,14 +1240,18 @@ pub struct MemArg<'a> {
     /// 8, etc).
     pub align: u32,
     /// The offset, in bytes of this access.
-    pub offset: u32,
+    pub offset: u64,
     /// The memory index we're accessing
     pub memory: ast::ItemRef<'a, kw::memory>,
 }
 
 impl<'a> MemArg<'a> {
     fn parse(parser: Parser<'a>, default_align: u32) -> Result<Self> {
-        fn parse_field(name: &str, parser: Parser<'_>) -> Result<Option<u32>> {
+        fn parse_field<T>(
+            name: &str,
+            parser: Parser<'_>,
+            f: impl FnOnce(Cursor<'_>, &str, u32) -> Result<T>,
+        ) -> Result<Option<T>> {
             parser.step(|c| {
                 let (kw, rest) = match c.keyword() {
                     Some(p) => p,
@@ -1262,25 +1266,32 @@ impl<'a> MemArg<'a> {
                 }
                 let num = &kw[1..];
                 let num = if num.starts_with("0x") {
-                    match u32::from_str_radix(&num[2..], 16) {
-                        Ok(n) => n,
-                        Err(_) => return Err(c.error("i32 constant out of range")),
-                    }
+                    f(c, &num[2..], 16)?
                 } else {
-                    match num.parse() {
-                        Ok(n) => n,
-                        Err(_) => return Err(c.error("i32 constant out of range")),
-                    }
+                    f(c, num, 10)?
                 };
 
                 Ok((Some(num), rest))
             })
         }
+
+        fn parse_u32(name: &str, parser: Parser<'_>) -> Result<Option<u32>> {
+            parse_field(name, parser, |c, num, radix| {
+                u32::from_str_radix(num, radix).map_err(|_| c.error("i32 constant out of range"))
+            })
+        }
+
+        fn parse_u64(name: &str, parser: Parser<'_>) -> Result<Option<u64>> {
+            parse_field(name, parser, |c, num, radix| {
+                u64::from_str_radix(num, radix).map_err(|_| c.error("i64 constant out of range"))
+            })
+        }
+
         let memory = parser
             .parse::<Option<ast::ItemRef<'a, kw::memory>>>()?
             .unwrap_or(idx_zero(parser.prev_span(), kw::memory));
-        let offset = parse_field("offset", parser)?.unwrap_or(0);
-        let align = match parse_field("align", parser)? {
+        let offset = parse_u64("offset", parser)?.unwrap_or(0);
+        let align = match parse_u32("align", parser)? {
             Some(n) if !n.is_power_of_two() => {
                 return Err(parser.error("alignment must be a power of two"))
             }

--- a/crates/wast/src/ast/wast.rs
+++ b/crates/wast/src/ast/wast.rs
@@ -64,7 +64,7 @@ pub enum WastDirective<'a> {
     },
     AssertInvalid {
         span: ast::Span,
-        module: ast::Module<'a>,
+        module: QuoteModule<'a>,
         message: &'a str,
     },
     Register {
@@ -106,7 +106,7 @@ impl WastDirective<'_> {
             WastDirective::Module(m) => m.span,
             WastDirective::AssertMalformed { span, .. }
             | WastDirective::Register { span, .. }
-            | WastDirective::QuoteModule{ span, .. }
+            | WastDirective::QuoteModule { span, .. }
             | WastDirective::AssertTrap { span, .. }
             | WastDirective::AssertReturn { span, .. }
             | WastDirective::AssertExhaustion { span, .. }
@@ -359,9 +359,21 @@ mod tests {
 
     #[test]
     fn assert_nan() {
-        assert_parses_to_directive!("assert_return_canonical_nan_f32x4 (invoke \"foo\" (f32.const 0))", WastDirective::AssertReturn { .. });
-        assert_parses_to_directive!("assert_return_canonical_nan_f64x2 (invoke \"foo\" (f32.const 0))", WastDirective::AssertReturn { .. });
-        assert_parses_to_directive!("assert_return_arithmetic_nan_f32x4 (invoke \"foo\" (f32.const 0))", WastDirective::AssertReturn { .. });
-        assert_parses_to_directive!("assert_return_arithmetic_nan_f64x2 (invoke \"foo\" (f32.const 0))", WastDirective::AssertReturn { .. });
+        assert_parses_to_directive!(
+            "assert_return_canonical_nan_f32x4 (invoke \"foo\" (f32.const 0))",
+            WastDirective::AssertReturn { .. }
+        );
+        assert_parses_to_directive!(
+            "assert_return_canonical_nan_f64x2 (invoke \"foo\" (f32.const 0))",
+            WastDirective::AssertReturn { .. }
+        );
+        assert_parses_to_directive!(
+            "assert_return_arithmetic_nan_f32x4 (invoke \"foo\" (f32.const 0))",
+            WastDirective::AssertReturn { .. }
+        );
+        assert_parses_to_directive!(
+            "assert_return_arithmetic_nan_f64x2 (invoke \"foo\" (f32.const 0))",
+            WastDirective::AssertReturn { .. }
+        );
     }
 }

--- a/tests/dump/alias2.wat.dump
+++ b/tests/dump/alias2.wat.dump
@@ -5,7 +5,7 @@
 0x000b | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
 0x000e | 61 00 00    | [type 1] Module(ModuleType { imports: [], exports: [] })
 0x0011 | 62 00       | [type 2] Instance(InstanceType { exports: [] })
-0x0013 | 62 06 01 31 | [type 3] Instance(InstanceType { exports: [ExportType { name: "1", ty: Function(0) }, ExportType { name: "2", ty: Memory(M32 { limits: ResizableLimits { initial: 1, maximum: None }, shared: false }) }, ExportType { name: "3", ty: Table(TableType { element_type: FuncRef, limits: ResizableLimits { initial: 1, maximum: None } }) }, ExportType { name: "4", ty: Global(GlobalType { content_type: I32, mutable: false }) }, ExportType { name: "5", ty: Module(1) }, ExportType { name: "6", ty: Instance(2) }] })
+0x0013 | 62 06 01 31 | [type 3] Instance(InstanceType { exports: [ExportType { name: "1", ty: Function(0) }, ExportType { name: "2", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None }) }, ExportType { name: "3", ty: Table(TableType { element_type: FuncRef, initial: 1, maximum: None }) }, ExportType { name: "4", ty: Global(GlobalType { content_type: I32, mutable: false }) }, ExportType { name: "5", ty: Module(1) }, ExportType { name: "6", ty: Instance(2) }] })
        | 00 00 01 32
        | 02 00 01 01
        | 33 01 70 00
@@ -31,11 +31,11 @@
   0x0052 | 06          | 6 count
   0x0053 | 01 31 00 ff | import [func 0] Import { module: "1", field: None, ty: Function(0) }
          | 00 00      
-  0x0059 | 01 32 00 ff | import [memory 0] Import { module: "2", field: None, ty: Memory(M32 { limits: ResizableLimits { initial: 1, maximum: None }, shared: false }) }
+  0x0059 | 01 32 00 ff | import [memory 0] Import { module: "2", field: None, ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None }) }
          | 02 00 01   
   0x0060 | 01 33 00 ff | import [global 0] Import { module: "3", field: None, ty: Global(GlobalType { content_type: I32, mutable: false }) }
          | 03 7f 00   
-  0x0067 | 01 34 00 ff | import [table 0] Import { module: "4", field: None, ty: Table(TableType { element_type: FuncRef, limits: ResizableLimits { initial: 1, maximum: None } }) }
+  0x0067 | 01 34 00 ff | import [table 0] Import { module: "4", field: None, ty: Table(TableType { element_type: FuncRef, initial: 1, maximum: None }) }
          | 01 70 00 01
   0x006f | 01 35 00 ff | import [module 0] Import { module: "5", field: None, ty: Module(1) }
          | 05 01      

--- a/tests/dump/instantiate.wat.dump
+++ b/tests/dump/instantiate.wat.dump
@@ -34,10 +34,10 @@
 0x0052 | 02          | [func 0] type 2
 0x0053 | 04 04       | table section
 0x0055 | 01          | 1 count
-0x0056 | 70 00 01    | [table 0] TableType { element_type: FuncRef, limits: ResizableLimits { initial: 1, maximum: None } }
+0x0056 | 70 00 01    | [table 0] TableType { element_type: FuncRef, initial: 1, maximum: None }
 0x0059 | 05 03       | memory section
 0x005b | 01          | 1 count
-0x005c | 00 01       | [memory 0] M32 { limits: ResizableLimits { initial: 1, maximum: None }, shared: false }
+0x005c | 00 01       | [memory 0] MemoryType { memory64: false, shared: false, initial: 1, maximum: None }
 0x005e | 06 06       | global section
 0x0060 | 01          | 1 count
 0x0061 | 7f 00       | [global 0] GlobalType { content_type: I32, mutable: false }

--- a/tests/dump/module-linking.wat.dump
+++ b/tests/dump/module-linking.wat.dump
@@ -5,7 +5,7 @@
 0x000b | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
 0x000e | 61 00 00    | [type 1] Module(ModuleType { imports: [], exports: [] })
 0x0011 | 62 00       | [type 2] Instance(InstanceType { exports: [] })
-0x0013 | 62 06 01 31 | [type 3] Instance(InstanceType { exports: [ExportType { name: "1", ty: Function(0) }, ExportType { name: "2", ty: Memory(M32 { limits: ResizableLimits { initial: 1, maximum: None }, shared: false }) }, ExportType { name: "3", ty: Table(TableType { element_type: FuncRef, limits: ResizableLimits { initial: 1, maximum: None } }) }, ExportType { name: "4", ty: Global(GlobalType { content_type: I32, mutable: false }) }, ExportType { name: "5", ty: Module(1) }, ExportType { name: "6", ty: Instance(2) }] })
+0x0013 | 62 06 01 31 | [type 3] Instance(InstanceType { exports: [ExportType { name: "1", ty: Function(0) }, ExportType { name: "2", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None }) }, ExportType { name: "3", ty: Table(TableType { element_type: FuncRef, initial: 1, maximum: None }) }, ExportType { name: "4", ty: Global(GlobalType { content_type: I32, mutable: false }) }, ExportType { name: "5", ty: Module(1) }, ExportType { name: "6", ty: Instance(2) }] })
        | 00 00 01 32
        | 02 00 01 01
        | 33 01 70 00
@@ -31,11 +31,11 @@
   0x0052 | 06          | 6 count
   0x0053 | 01 31 00 ff | import [func 0] Import { module: "1", field: None, ty: Function(0) }
          | 00 00      
-  0x0059 | 01 32 00 ff | import [memory 0] Import { module: "2", field: None, ty: Memory(M32 { limits: ResizableLimits { initial: 1, maximum: None }, shared: false }) }
+  0x0059 | 01 32 00 ff | import [memory 0] Import { module: "2", field: None, ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None }) }
          | 02 00 01   
   0x0060 | 01 33 00 ff | import [global 0] Import { module: "3", field: None, ty: Global(GlobalType { content_type: I32, mutable: false }) }
          | 03 7f 00   
-  0x0067 | 01 34 00 ff | import [table 0] Import { module: "4", field: None, ty: Table(TableType { element_type: FuncRef, limits: ResizableLimits { initial: 1, maximum: None } }) }
+  0x0067 | 01 34 00 ff | import [table 0] Import { module: "4", field: None, ty: Table(TableType { element_type: FuncRef, initial: 1, maximum: None }) }
          | 01 70 00 01
   0x006f | 01 35 00 ff | import [module 0] Import { module: "5", field: None, ty: Module(1) }
          | 05 01      

--- a/tests/dump/module-types.wat.dump
+++ b/tests/dump/module-types.wat.dump
@@ -5,7 +5,7 @@
 0x000b | 62 00       | [type 0] Instance(InstanceType { exports: [] })
 0x000d | 61 00 00    | [type 1] Module(ModuleType { imports: [], exports: [] })
 0x0010 | 60 00 00    | [type 2] Func(FuncType { params: [], returns: [] })
-0x0013 | 61 06 00 00 | [type 3] Module(ModuleType { imports: [Import { module: "", field: None, ty: Module(1) }, Import { module: "", field: None, ty: Function(2) }, Import { module: "", field: None, ty: Global(GlobalType { content_type: I32, mutable: false }) }, Import { module: "", field: None, ty: Table(TableType { element_type: FuncRef, limits: ResizableLimits { initial: 1, maximum: None } }) }, Import { module: "", field: None, ty: Instance(0) }, Import { module: "", field: None, ty: Memory(M32 { limits: ResizableLimits { initial: 1, maximum: None }, shared: false }) }], exports: [] })
+0x0013 | 61 06 00 00 | [type 3] Module(ModuleType { imports: [Import { module: "", field: None, ty: Module(1) }, Import { module: "", field: None, ty: Function(2) }, Import { module: "", field: None, ty: Global(GlobalType { content_type: I32, mutable: false }) }, Import { module: "", field: None, ty: Table(TableType { element_type: FuncRef, initial: 1, maximum: None }) }, Import { module: "", field: None, ty: Instance(0) }, Import { module: "", field: None, ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None }) }], exports: [] })
        | ff 05 01 00
        | 00 ff 00 02
        | 00 00 ff 03

--- a/tests/dump/simple.wat.dump
+++ b/tests/dump/simple.wat.dump
@@ -15,10 +15,10 @@
 0x0020 | 01          | [func 3] type 1
 0x0021 | 04 04       | table section
 0x0023 | 01          | 1 count
-0x0024 | 70 00 01    | [table 0] TableType { element_type: FuncRef, limits: ResizableLimits { initial: 1, maximum: None } }
+0x0024 | 70 00 01    | [table 0] TableType { element_type: FuncRef, initial: 1, maximum: None }
 0x0027 | 05 03       | memory section
 0x0029 | 01          | 1 count
-0x002a | 00 01       | [memory 0] M32 { limits: ResizableLimits { initial: 1, maximum: None }, shared: false }
+0x002a | 00 01       | [memory 0] MemoryType { memory64: false, shared: false, initial: 1, maximum: None }
 0x002c | 06 06       | global section
 0x002e | 01          | 1 count
 0x002f | 7f 00       | [global 0] GlobalType { content_type: I32, mutable: false }

--- a/tests/local/memory64.wast
+++ b/tests/local/memory64.wast
@@ -12,6 +12,8 @@
     memory.size i32.load drop
     i64.const 0 memory.grow i64.load drop
 
+    i64.const 0 i32.load offset=0xffffffffffff drop
+
     i64.const 0 i32.load drop
     i64.const 0 i64.load drop
     i64.const 0 f32.load drop

--- a/tests/local/module-linking/memory64.wast
+++ b/tests/local/module-linking/memory64.wast
@@ -1,0 +1,21 @@
+(assert_invalid
+  (module
+    (module $A
+      (import "" (memory 1)))
+    (module $B
+      (memory (export "") i64 1))
+    (instance $b (instantiate $B))
+    (instance $a (instantiate $A (import "" (memory $b ""))))
+  )
+  "memory type mismatch")
+
+(assert_invalid
+  (module
+    (module $A
+      (import "" (memory i64 1)))
+    (module $B
+      (memory (export "") 1))
+    (instance $b (instantiate $B))
+    (instance $a (instantiate $A (import "" (memory $b ""))))
+  )
+  "memory type mismatch")


### PR DESCRIPTION
This commit updates the support for the memory64 proposal,
printing/parsing/validation, to match the latest upstream spec. I've
double-checked all the type-checking and such, and the only piece that
this crate was missing was parsing 64-bit offsets in `memarg`
structures. I've threaded through various bits and pieces to parse
32-bit offsets primarily but optionally allow 64-bit offsets when the
memory64 proposal is enabled.

I've also done some updates to the test suite so we can run all the
`*.wast` tests (or at least most) in the upstream wasm64 proposal.