### PR TITLE
Mark `primitives::Operator` as `non_exhaustive`

### DIFF
--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -347,6 +347,7 @@ pub type SIMDLaneIndex = u8;
 ///
 /// [here]: https://webassembly.github.io/spec/core/binary/instructions.html
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum Operator<'a> {
     Unreachable,
     Nop,


### PR DESCRIPTION
This feels right for `primitives::Operator` given how new ones get added over time.

[What `non_exhaustive` does is described here.](https://rust-lang.github.io/rfcs/2008-non-exhaustive.html)

This is a breaking change.