### PR TITLE
Stop being byte-for-byte compatible with wabt

### DIFF
--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -25,10 +25,7 @@
 
 use anyhow::{bail, Context, Result};
 use rayon::prelude::*;
-use std::env;
-use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::str;
 use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 use wasmparser::*;
@@ -139,11 +136,6 @@ fn skip_test(test: &Path, contents: &[u8]) -> bool {
         return true;
     }
 
-    // FIXME(WebAssembly/wabt#1404) - wast2json infinite loops here on macos
-    if test.ends_with("annotations.wast") {
-        return true;
-    }
-
     if let Ok(contents) = str::from_utf8(contents) {
         // Skip tests that are supposed to fail
         if contents.contains(";; ERROR") {
@@ -162,12 +154,6 @@ fn skip_test(test: &Path, contents: &[u8]) -> bool {
 #[derive(Default)]
 struct TestState {
     ntests: AtomicUsize,
-    wabt_available: AtomicUsize,
-}
-
-struct Wast2Json {
-    _td: tempfile::TempDir,
-    modules: Vec<PathBuf>,
 }
 
 impl TestState {
@@ -192,20 +178,6 @@ impl TestState {
         // wasm file.
         let binary = wat::parse_file(test)?;
         self.bump_ntests();
-
-        // Next up, if enabled, we execute `wat2wasm` to make sure `wat
-        // `produces the same binary encoding.
-        //
-        // Currently our encoding of tests two tests differs from wabt, but
-        // they're invalid anyway so it's not that worrisome.
-        if !test.ends_with("invalid-data-segment-offset.txt")
-            && !test.ends_with("invalid-elem-segment-offset.txt")
-        {
-            if let Some(expected) = self.wat2wasm(&test)? {
-                self.binary_compare(&binary, &expected, true)
-                    .context("`wat` doesn't match wabt's `wat2wasm`")?;
-            }
-        }
 
         let contents = str::from_utf8(contents)?;
 
@@ -242,56 +214,6 @@ impl TestState {
         let string = wasmprinter::print_bytes(contents).context("failed to print wasm")?;
         self.bump_ntests();
 
-        // TODO: honestly there's so many bugs with this check it doesn't
-        // seem worth it to keep up. In addition to all the exceptions
-        // below the final straw which added this comment is handling of
-        // the extended name section proposal. It looks like wasm prints
-        // the custom names found in the binary in some places but not in
-        // others, which causes quite a few tests (>=86) to fail if we actually
-        // run these tests.
-        //
-        // To tell the truth it's been awhile since we got mileage out of
-        // running these tests. It'd be nice to rerun them at some point but
-        // it's not clear at this time how we can compare against wabt's
-        // textual output without causing a lot of overhead for ourselves.
-        if false &&
-            !test.ends_with("local/reloc.wasm")
-            // FIXME(WebAssembly/wabt#1447)
-            && !test.ends_with("bulk-memory-operations/binary.wast")
-            && !test.ends_with("reference-types/binary.wast")
-            && !test.ends_with("exception-handling/binary.wast")
-
-            // not implemented in wabt
-            && !test.iter().any(|t| t == "module-linking")
-            && !test.ends_with("multi-memory.wast")
-            && !test.ends_with("multi-memory64.wast")
-
-            // FIXME(WebAssembly/wabt#1649)
-            && !test.ends_with("local/simd.wat")
-            && !test.ends_with("dump/simd-store-lane.txt")
-            && !test.ends_with("dump/simd-load-lane.txt")
-            && !test.ends_with("simd_load8_lane.wast")
-            && !test.ends_with("simd_load16_lane.wast")
-            && !test.ends_with("simd_load32_lane.wast")
-            && !test.ends_with("simd_load64_lane.wast")
-            && !test.ends_with("simd_store8_lane.wast")
-            && !test.ends_with("simd_store16_lane.wast")
-            && !test.ends_with("simd_store32_lane.wast")
-            && !test.ends_with("simd_store64_lane.wast")
-
-            // FIXME wabt doesn't print conflict or empty names in the same way
-            // that we do.
-            && !test.ends_with("local/names.wast")
-
-            // FIXME this can be removed once wabt support for catch-less try is merged
-            && !test.ends_with("local/try.wat")
-        {
-            if let Some(expected) = self.wasm2wat(contents)? {
-                self.string_compare(&string, &expected)
-                    .context("`wasmprinter` disagrees with `wabt`")?;
-            }
-        }
-
         // If we can, convert the string back to bytes and assert it has the
         // same binary representation.
         if test_roundtrip {
@@ -319,28 +241,12 @@ impl TestState {
         let wast = parser::parse::<Wast>(&buf).map_err(|e| adjust!(e))?;
         self.bump_ntests();
 
-        let json = self.wast2json(&test)?;
-
-        // Pair each `Module` directive with the result of wast2json's output
-        // `*.wasm` file, and then execute each test in parallel.
-        let mut modules = 0;
-        let directives = wast
+        let errors = wast
             .directives
-            .into_iter()
-            .map(|directive| match directive {
-                WastDirective::Module(_) => {
-                    modules += 1;
-                    (directive, json.as_ref().map(|j| &j.modules[modules - 1]))
-                }
-                other => (other, None),
-            })
-            .collect::<Vec<_>>();
-
-        let errors = directives
             .into_par_iter()
-            .filter_map(|(directive, expected)| {
+            .filter_map(|directive| {
                 let (line, col) = directive.span().linecol_in(contents);
-                self.test_wast_directive(test, directive, expected)
+                self.test_wast_directive(test, directive)
                     .with_context(|| {
                         format!(
                             "failed directive on {}:{}:{}",
@@ -367,12 +273,7 @@ impl TestState {
         bail!("{}", s)
     }
 
-    fn test_wast_directive(
-        &self,
-        test: &Path,
-        directive: WastDirective,
-        expected: Option<&PathBuf>,
-    ) -> Result<()> {
+    fn test_wast_directive(&self, test: &Path, directive: WastDirective) -> Result<()> {
         // Only test parsing and encoding of modules that wabt doesn't support
         let skip_verify = test.iter().any(|t| t == "function-references");
 
@@ -384,18 +285,7 @@ impl TestState {
                     return Ok(());
                 }
                 let test_roundtrip = match module.kind {
-                    ModuleKind::Text(_) => {
-                        if let Some(expected) = &expected {
-                            // TODO: waiting on wabt to sync with the upstream
-                            // simd spec to agree on encodings.
-                            if !test.iter().any(|t| t == "simd") {
-                                let expected = fs::read(expected)?;
-                                self.binary_compare(&actual, &expected, true)
-                                    .context("`wat` doesn't match output of wabt")?;
-                            }
-                        }
-                        true
-                    }
+                    ModuleKind::Text(_) => true,
 
                     // Don't test the wasmprinter round trip since these bytes
                     // may not be in their canonical form (didn't come from teh
@@ -505,52 +395,6 @@ impl TestState {
                 self.bump_ntests();
                 Ok(err)
             }
-        }
-    }
-
-    fn string_compare(&self, actual: &str, expected: &str) -> Result<()> {
-        let actual = normalize(&actual);
-        let expected = normalize(&expected);
-
-        fn normalize(s: &str) -> String {
-            let mut s = s.trim().to_string();
-
-            // We seem to have different decimal float printing than wabt, and a
-            // hand-check seems to show that they're equivalent just different
-            // renderings. To paper over these inconsequential differences delete
-            // these comments.
-            while let Some(i) = s.find(" (;=") {
-                let end = s[i..].find(";)").unwrap();
-                s.drain(i..end + i + 2);
-            }
-            return s;
-        }
-
-        let mut bad = false;
-        let mut result = String::new();
-        for diff in diff::lines(&expected, &actual) {
-            match diff {
-                diff::Result::Left(s) => {
-                    bad = true;
-                    result.push_str("-");
-                    result.push_str(s);
-                }
-                diff::Result::Right(s) => {
-                    bad = true;
-                    result.push_str("+");
-                    result.push_str(s);
-                }
-                diff::Result::Both(s, _) => {
-                    result.push_str(" ");
-                    result.push_str(s);
-                }
-            }
-            result.push_str("\n");
-        }
-        if bad {
-            bail!("expected != actual\n\n{}", result);
-        } else {
-            Ok(())
         }
     }
 
@@ -736,121 +580,6 @@ impl TestState {
 
     fn bump_ntests(&self) {
         self.ntests.fetch_add(1, SeqCst);
-    }
-
-    fn wat2wasm(&self, test: &Path) -> Result<Option<Vec<u8>>> {
-        if !self.wabt_available()? {
-            return Ok(None);
-        }
-        let f = tempfile::NamedTempFile::new()?;
-        let result = Command::new("wat2wasm")
-            .arg(test)
-            .arg("--enable-all")
-            .arg("--no-check")
-            .arg("-o")
-            .arg(f.path())
-            .output()
-            .context("failed to spawn `wat2wasm`")?;
-        Ok(if result.status.success() {
-            Some(fs::read(f.path())?)
-        } else {
-            // TODO: handle this case better
-            None
-        })
-    }
-
-    fn wasm2wat(&self, contents: &[u8]) -> Result<Option<String>> {
-        if !self.wabt_available()? {
-            return Ok(None);
-        }
-        let f = tempfile::TempDir::new().unwrap();
-        let wasm = f.path().join("wasm");
-        let wat = f.path().join("wat");
-        fs::write(&wasm, contents).context("failed to write wasm file")?;
-        let result = Command::new("wasm2wat")
-            .arg(&wasm)
-            .arg("--enable-all")
-            .arg("--no-check")
-            .arg("-o")
-            .arg(&wat)
-            .output()
-            .context("failed to spawn `wasm2wat`")?;
-        if result.status.success() {
-            Ok(Some(
-                fs::read_to_string(&wat).context("failed to read wat file")?,
-            ))
-        } else {
-            bail!(
-                "failed to run wasm2wat: {}\n\n    {}",
-                result.status,
-                String::from_utf8_lossy(&result.stderr).replace("\n", "\n    "),
-            )
-        }
-    }
-
-    fn wast2json(&self, test: &Path) -> Result<Option<Wast2Json>> {
-        if !self.wabt_available()? {
-            return Ok(None);
-        }
-        let td = tempfile::TempDir::new()?;
-        let result = Command::new("wast2json")
-            .arg(test)
-            .arg("--enable-all")
-            .arg("--no-check")
-            .arg("-o")
-            .arg(td.path().join("foo.json"))
-            .output()
-            .context("failed to spawn `wat2wasm`")?;
-        if !result.status.success() {
-            // TODO: handle this case better
-            return Ok(None);
-        }
-        let json = fs::read_to_string(td.path().join("foo.json"))?;
-        let json: serde_json::Value = serde_json::from_str(&json)?;
-        let commands = json["commands"].as_array().unwrap();
-        let modules = commands
-            .iter()
-            .filter_map(|m| {
-                if m["type"] == "module" {
-                    Some(td.path().join(m["filename"].as_str().unwrap()))
-                } else {
-                    None
-                }
-            })
-            .collect();
-        Ok(Some(Wast2Json { _td: td, modules }))
-    }
-
-    fn wabt_available(&self) -> Result<bool> {
-        // Check if we've cached whether wabt is available...
-        match self.wabt_available.load(SeqCst) {
-            1 => return Ok(false),
-            2 => return Ok(true),
-            _ => {}
-        }
-
-        // ... otherwise figure it out ourselves and try to be the singular
-        // thread which flags whether wabt is here or not.
-        let available = Command::new("wasm2wat").arg("--version").output().is_ok() as usize + 1;
-        if self
-            .wabt_available
-            .compare_exchange(0, available, SeqCst, SeqCst)
-            .is_ok()
-        {
-            // If we were the singular thread to indicate whether we know wabt
-            // is available or not, then we also return an error if it's
-            // supposed to be available and it's not.
-            if available == 1 && env::var("SKIP_WABT").is_err() {
-                bail!(
-                    "\
-                        failed to locate `wabt` tools as a reference to run tests \
-                        against; you either install wabt from the `tests/wabt` \
-                        directory or set the SKIP_WABT=1 env var to fix this
-                    "
-                )
-            }
-        }
-        Ok(available == 2)
     }
 }
 


### PR DESCRIPTION
This commit removes all reference testing against wabt in the
`roundtrip.rs` suite. Historically this project has attempted to be
byte-for-byte compatible with upstream `wabt`, but over time it's
accrued so many workarounds in both the implementation and while testing
that I don't think that it's worth it any more.

The original motivation for this change is that this module does not
appropriately roundtrip in the Rust tooling:

    (module
      (elem funcref))

The reason for this is that a hack in the implementation was changing
the `funcref` representation to `func`, which means it's round-trip as:

    (module
      (elem func))

and this was found by the fuzzers last night when reference types was
enabled for round-tripping for the first time.

Overall I don't think we have much to gain any more for byte-for-byte
compatibility with wabt. There's a number of long-open issues which
require workarounds in this crate. I think at this point this tooling is
solid enough that comparisons can be made but it isn't necessary to do
so in an automated fashion. This should make it much easier to implement
new features and such because there doesn't need to be so many
workarounds in the test suite for comparing against wabt.