### PR TITLE
Disable module linking in round-trip fuzz test

### DIFF
--- a/fuzz/fuzz_targets/print-valid-module.rs
+++ b/fuzz/fuzz_targets/print-valid-module.rs
@@ -3,7 +3,7 @@
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|bytes: &[u8]| {
-    let (bytes, _config) = match wasm_tools_fuzz::generate_valid_module(bytes) {
+    let (bytes, _config) = match wasm_tools_fuzz::generate_valid_module(bytes, |_, _| Ok(())) {
         Ok(m) => m,
         Err(_) => return,
     };

--- a/fuzz/fuzz_targets/roundtrip-valid-module.rs
+++ b/fuzz/fuzz_targets/roundtrip-valid-module.rs
@@ -3,7 +3,15 @@
 use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|bytes: &[u8]| {
-    let (bytes, _config) = match wasm_tools_fuzz::generate_valid_module(bytes) {
+    let (bytes, _config) = match wasm_tools_fuzz::generate_valid_module(bytes, |config, _u| {
+        // It's a known bug that the textual format for module linking is not
+        // round-trip-able. This is because the encoder will sometimes reorder
+        // fields before others, but it technically shouldn't do that if module
+        // linking is present. This should be fixed with future iterations of
+        // the module linking text format.
+        config.module_linking_enabled = false;
+        Ok(())
+    }) {
         Ok(m) => m,
         Err(_) => return,
     };

--- a/fuzz/fuzz_targets/validate-valid-module.rs
+++ b/fuzz/fuzz_targets/validate-valid-module.rs
@@ -5,7 +5,7 @@ use libfuzzer_sys::fuzz_target;
 // Define a fuzz target that accepts arbitrary
 // `Module`s as input.
 fuzz_target!(|m: &[u8]| {
-    let (bytes, config) = match wasm_tools_fuzz::generate_valid_module(m) {
+    let (bytes, config) = match wasm_tools_fuzz::generate_valid_module(m, |_, _| Ok(())) {
         Ok(m) => m,
         Err(_) => return,
     };

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -2,7 +2,10 @@ use libfuzzer_sys::arbitrary::{Result, Unstructured};
 use std::fmt::Debug;
 use wasm_smith::{ConfiguredModule, SwarmConfig};
 
-pub fn generate_valid_module(input: &[u8]) -> Result<(Vec<u8>, SwarmConfig)> {
+pub fn generate_valid_module(
+    input: &[u8],
+    configure: impl FnOnce(&mut SwarmConfig, &mut Unstructured<'_>) -> Result<()>,
+) -> Result<(Vec<u8>, SwarmConfig)> {
     let mut u = Unstructured::new(input);
     let mut config: SwarmConfig = u.arbitrary()?;
 
@@ -11,6 +14,8 @@ pub fn generate_valid_module(input: &[u8]) -> Result<(Vec<u8>, SwarmConfig)> {
     config.simd_enabled = u.arbitrary()?;
     config.module_linking_enabled = u.arbitrary()?;
     config.memory64_enabled = u.arbitrary()?;
+
+    configure(&mut config, &mut u)?;
 
     // Use wasm-smith to generate an arbitrary module and convert it to wasm
     // bytes.


### PR DESCRIPTION
The module linking text format is well-known to not round-trip well
right now due to ambiguities with the original text format. This is
expected with the next iteration of the text format where adapter
modules are entirely separate from core wasm modules, which means that
the text format will be much more easily round-trip-able.