### PR TITLE
Bump wasm-{smith,encoder} versions

### DIFF
--- a/crates/wasm-encoder/Cargo.toml
+++ b/crates/wasm-encoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-encoder"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "wasm-smith"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools"
-version = "0.5.0"
+version = "0.6.0"
 
 [[bench]]
 name = "corpus"
@@ -17,7 +17,7 @@ harness = false
 [dependencies]
 arbitrary = { version = "1.0.0", features = ["derive"] }
 leb128 = "0.2.4"
-wasm-encoder = { version = "0.5.0", path = "../wasm-encoder" }
+wasm-encoder = { version = "0.6.0", path = "../wasm-encoder" }
 indexmap = "1.6"
 
 [dev-dependencies]


### PR DESCRIPTION
Releasing support for memory64 as well as recent updates