### PR TITLE
Use `.min` instead of `&` to calculate max pages

### DIFF
--- a/crates/wasm-smith/src/config.rs
+++ b/crates/wasm-smith/src/config.rs
@@ -489,9 +489,9 @@ impl Config for SwarmConfig {
 
     fn max_memory_pages(&self, is_64: bool) -> u64 {
         if is_64 {
-            self.max_memory_pages & ((1 << 48) - 1)
+            self.max_memory_pages.min(1 << 48)
         } else {
-            self.max_memory_pages & ((1 << 16) - 1)
+            self.max_memory_pages.min(1 << 16)
         }
     }
 


### PR DESCRIPTION
The function here intends clamping semantics rather than altering the
input with bit-wise arithmetic (which only really works if the input is
randomly generated).