### PR TITLE
Don't have wasm-smith be entirely generic

### DIFF
--- a/crates/wasm-smith/src/config.rs
+++ b/crates/wasm-smith/src/config.rs
@@ -15,7 +15,7 @@ use arbitrary::{Arbitrary, Result, Unstructured};
 /// Every trait method has a provided default implementation, so that you only
 /// need to override the methods for things you want to change away from the
 /// default.
-pub trait Config: Clone {
+pub trait Config: 'static + std::fmt::Debug {
     /// The minimum number of types to generate. Defaults to 0.
     fn min_types(&self) -> usize {
         0

--- a/crates/wasm-smith/src/encode.rs
+++ b/crates/wasm-smith/src/encode.rs
@@ -4,16 +4,6 @@ use std::convert::TryFrom;
 impl Module {
     /// Encode this Wasm module into bytes.
     pub fn to_bytes(&self) -> Vec<u8> {
-        self.inner.to_bytes()
-    }
-}
-
-impl<C> ConfiguredModule<C>
-where
-    C: Config,
-{
-    /// Encode this Wasm module into bytes.
-    pub fn to_bytes(&self) -> Vec<u8> {
         self.encoded().finish()
     }
 

--- a/crates/wasm-smith/src/terminate.rs
+++ b/crates/wasm-smith/src/terminate.rs
@@ -12,24 +12,6 @@ impl Module {
     /// The index of the fuel global is returned, so that you may control how
     /// much fuel the module is given.
     pub fn ensure_termination(&mut self, default_fuel: u32) -> u32 {
-        self.inner.ensure_termination(default_fuel)
-    }
-}
-
-impl<C> ConfiguredModule<C>
-where
-    C: Config,
-{
-    /// Ensure that all of this Wasm module's functions will terminate when
-    /// executed.
-    ///
-    /// This adds a new mutable, exported global to the module to keep track of
-    /// how much "fuel" is left. Fuel is decremented at the head of each loop
-    /// and function. When fuel reaches zero, a trap is raised.
-    ///
-    /// The index of the fuel global is returned, so that you may control how
-    /// much fuel the module is given.
-    pub fn ensure_termination(&mut self, default_fuel: u32) -> u32 {
         let fuel_global = self.globals.len() as u32;
         self.globals.push(GlobalType {
             val_type: ValType::I32,

--- a/crates/wasm-smith/tests/tests.rs
+++ b/crates/wasm-smith/tests/tests.rs
@@ -1,6 +1,6 @@
 use arbitrary::{Arbitrary, Unstructured};
 use rand::{rngs::SmallRng, RngCore, SeedableRng};
-use wasm_smith::{Config, ConfiguredModule, Module, SwarmConfig};
+use wasm_smith::{ConfiguredModule, Module, SwarmConfig};
 use wasmparser::{Validator, WasmFeatures};
 
 fn wasm_features() -> WasmFeatures {
@@ -58,6 +58,7 @@ fn smoke_test_swarm_config() {
         rng.fill_bytes(&mut buf);
         let u = Unstructured::new(&buf);
         if let Ok(module) = ConfiguredModule::<SwarmConfig>::arbitrary_take_rest(u) {
+            let module = module.module;
             let wasm_bytes = module.to_bytes();
 
             let mut validator = Validator::new();

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -1,6 +1,6 @@
 use libfuzzer_sys::arbitrary::{Result, Unstructured};
 use std::fmt::Debug;
-use wasm_smith::{ConfiguredModule, SwarmConfig};
+use wasm_smith::{Module, SwarmConfig};
 
 pub fn generate_valid_module(
     input: &[u8],
@@ -19,7 +19,7 @@ pub fn generate_valid_module(
 
     // Use wasm-smith to generate an arbitrary module and convert it to wasm
     // bytes.
-    let module = ConfiguredModule::new(config.clone(), &mut u)?;
+    let module = Module::new(config.clone(), &mut u)?;
     let bytes = module.to_bytes();
 
     log_wasm(&bytes, &config);

--- a/src/bin/wasm-smith.rs
+++ b/src/bin/wasm-smith.rs
@@ -5,7 +5,7 @@ use std::io::{stdin, stdout, Read, Write};
 use std::path::PathBuf;
 use std::process;
 use structopt::StructOpt;
-use wasm_smith::{ConfiguredModule, MaybeInvalidModule};
+use wasm_smith::{MaybeInvalidModule, Module};
 
 /// A WebAssembly test case generator.
 ///
@@ -77,7 +77,7 @@ struct Options {
     module_config: Config,
 }
 
-#[derive(Default, StructOpt, Clone, serde::Deserialize)]
+#[derive(Default, Debug, StructOpt, Clone, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
 struct Config {
     #[structopt(long = "min-types")]
@@ -212,7 +212,7 @@ fn main() -> anyhow::Result<()> {
             json,
             cli: opts.module_config.clone(),
         };
-        let mut module = ConfiguredModule::new(config, &mut u).unwrap_or_else(|e| {
+        let mut module = Module::new(config, &mut u).unwrap_or_else(|e| {
             eprintln!("error: failed to generate module: {}", e);
             process::exit(2);
         });
@@ -240,7 +240,7 @@ macro_rules! fields {
     )*)
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct CliAndJsonConfig {
     json: Config,
     cli: Config,


### PR DESCRIPTION
Working on fuzzers using wasm-smith takes forever because they take so
long to compile. I believe the primary reason for this is that the
entire wasm-smith crate is monomorphized into each individual fuzzer due
to the usage of generics on the `Config` trait. This means each fuzzer
instantiates this entire crate, and the wasm-smith crate is no small
chunk of change.

This commit moves the configuration to being a trait object instead of a
generic, which should not lose that much in runtime and should allow
fuzzers to benefit from separate compilation of wasm-smith itself. If
this becomes a performance bottleneck for whatever reason we can also
remove the trait and simply have struct-based configuration too.