### PR TITLE
wasm-smith: Generate fail-to-instantiate modules far less frequently

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [workspace]
-members = ['fuzz', 'crates/wasm-encoder']
+members = ['fuzz', 'crates/wasm-encoder', 'crates/fuzz-stats']
 
 [dependencies]
 anyhow = "1.0"

--- a/crates/fuzz-stats/Cargo.toml
+++ b/crates/fuzz-stats/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "fuzz-stats"
+version = "0.1.0"
+edition = "2018"
+publish = false
+
+[dependencies]
+anyhow = "1.0"
+arbitrary = "1.0"
+num_cpus = "1.13"
+rand = "0.8"
+wasm-smith = { path = '../wasm-smith' }
+wasmtime = "0.29"
+
+[lib]
+doctest = false
+test = false

--- a/crates/fuzz-stats/src/bin/failed-instantiations.rs
+++ b/crates/fuzz-stats/src/bin/failed-instantiations.rs
@@ -1,0 +1,207 @@
+use arbitrary::{Arbitrary, Error, Unstructured};
+use rand::RngCore;
+use std::sync::atomic::{AtomicIsize, AtomicUsize, Ordering::SeqCst};
+use std::sync::Arc;
+use wasm_smith::SwarmConfig;
+use wasmtime::*;
+
+struct State {
+    engine: Engine,
+    print: bool,
+    remaining: AtomicIsize,
+    total: AtomicUsize,
+    instantiate_trap: AtomicUsize,
+    instantiate_oom: AtomicUsize,
+}
+
+fn main() {
+    Arc::new(State::new()).run();
+}
+
+// Theoretically this test can fail because it's based on random data. In
+// practice it's expected that the "fails to instantiate" rate is <2%, so if we
+// cross the 10% threshold that's quite bad.
+#[test]
+fn under_10_percent() {
+    let mut state = State::new();
+    state.print = false;
+    state.remaining.store(1000, SeqCst);
+    let state = Arc::new(state);
+    state.run();
+
+    let total = state.total.load(SeqCst);
+    let bad = state.instantiate_trap.load(SeqCst) + state.instantiate_oom.load(SeqCst);
+    assert!(
+        bad < total / 10,
+        "{} modules failed to instantiate out of {}, this failure rate is too high",
+        bad,
+        total
+    );
+}
+
+impl State {
+    fn new() -> State {
+        let mut config = Config::new();
+        config.wasm_multi_memory(true);
+        State {
+            engine: Engine::new(&config).unwrap(),
+            print: true,
+            total: AtomicUsize::new(0),
+            remaining: AtomicIsize::new(isize::max_value()),
+            instantiate_trap: AtomicUsize::new(0),
+            instantiate_oom: AtomicUsize::new(0),
+        }
+    }
+
+    fn run(self: &Arc<Self>) {
+        let threads = (0..num_cpus::get())
+            .map(|_| {
+                let state = self.clone();
+                std::thread::spawn(move || state.run_worker())
+            })
+            .collect::<Vec<_>>();
+        for thread in threads {
+            thread.join().unwrap();
+        }
+    }
+
+    fn run_worker(&self) {
+        let mut rng = rand::thread_rng();
+        let mut data = Vec::new();
+
+        while self.remaining.fetch_sub(1, SeqCst) >= 0 {
+            data.truncate(0);
+            data.resize(1024, 0);
+            rng.fill_bytes(&mut data);
+            loop {
+                match self.run_once(&mut data) {
+                    Ok(()) => break,
+                    Err(Error::NotEnoughData) => {
+                        let cur = data.len();
+                        let extra = 1024;
+                        data.resize(cur + extra, 0);
+                        rng.fill_bytes(&mut data[cur..]);
+                    }
+                    Err(e) => panic!("failed to generated module: {}", e),
+                }
+            }
+        }
+    }
+
+    /// Generates a random modules using `data`, and then attempts to
+    /// instantiate it.
+    ///
+    /// Records when instantiation fails and why it fails.
+    fn run_once(&self, data: &[u8]) -> Result<(), Error> {
+        let mut u = Unstructured::new(data);
+        // Here `SwarmConfig` is used to get hopefully a bit more coverage of
+        // interesting states, and we also forcibly disable all `start`
+        // functions for now. Not much work has gone into minimizing the traps
+        // generated from wasm functions themselves, and this shouldn't be
+        // enabled until that's been worked on.
+        let mut config = SwarmConfig::arbitrary(&mut u)?;
+        config.allow_start_export = false;
+        let mut wasm = wasm_smith::Module::new(config, &mut u)?;
+        wasm.ensure_termination(10_000);
+        let wasm = wasm.to_bytes();
+
+        // We install a resource limiter in the store which limits the store to
+        // 1gb of memory. That's half the default allocation of memory for
+        // libfuzzer-based fuzzers by default, and ideally we're not in a
+        // situation where most of the modules are above this threshold.
+        let module = Module::new(&self.engine, &wasm).expect("failed to compile module");
+        let mut store = Store::new(
+            &self.engine,
+            StoreLimits {
+                remaining_memory: 1 << 30,
+                oom: false,
+            },
+        );
+        store.limiter(|s| s as &mut dyn ResourceLimiter);
+
+        // Synthesize dummy imports based on what the module asked for, and then
+        // instantiate!
+        let instance = fuzz_stats::dummy::dummy_imports(&mut store, &module)
+            .and_then(|imports| Instance::new(&mut store, &module, &imports));
+
+        match instance {
+            // If instantiation succeeded, we're not too interested in anything
+            // else right now. In the future we should probably run exported
+            // functions and record whether a trap happened or not.
+            Ok(_i) => {}
+
+            Err(e) => {
+                // Traps are ok if they happen during instantiation. This is an
+                // expected occurrence we want to account for.
+                if e.downcast_ref::<Trap>().is_some() {
+                    // std::fs::write("trap.wasm", &wasm).unwrap();
+                    self.instantiate_trap.fetch_add(1, SeqCst);
+
+                // Ooms, like traps, are normal during instantiations. This
+                // can happen, for example, if a defined memory is very large.
+                } else if store.data().oom {
+                    self.instantiate_oom.fetch_add(1, SeqCst);
+
+                // In theory nothing else fails to instantiate. If it does, then
+                // panic.
+                } else {
+                    std::fs::write("panic.wasm", &wasm).unwrap();
+                    panic!("unknown: {}", e);
+                }
+            }
+        }
+
+        let prev_total = self.total.fetch_add(1, SeqCst);
+        if prev_total % 10_000 == 0 && self.print {
+            self.print(prev_total + 1);
+        }
+
+        Ok(())
+    }
+
+    /// Prints summary statistics of how many modules have been instantiated so
+    /// far and how many of them have oom'd or trap'd.
+    fn print(&self, total: usize) {
+        print!("total: {:8}", total);
+        let stat = |name: &str, stat: &AtomicUsize| {
+            let stat = stat.load(SeqCst);
+            if stat > 0 {
+                print!(" {} {:5.02}% ", name, (stat as f64) / (total as f64) * 100.);
+            }
+        };
+        stat("i-oom", &self.instantiate_oom);
+        stat("i-trap", &self.instantiate_trap);
+        println!();
+    }
+}
+
+struct StoreLimits {
+    remaining_memory: usize,
+    oom: bool,
+}
+
+impl StoreLimits {
+    fn alloc(&mut self, amt: usize) -> bool {
+        match self.remaining_memory.checked_sub(amt) {
+            Some(mem) => {
+                self.remaining_memory = mem;
+                true
+            }
+            None => {
+                self.oom = true;
+                false
+            }
+        }
+    }
+}
+
+impl ResourceLimiter for StoreLimits {
+    fn memory_growing(&mut self, current: u32, desired: u32, _maximum: Option<u32>) -> bool {
+        self.alloc((desired - current) as usize * 64 * 1024)
+    }
+
+    fn table_growing(&mut self, current: u32, desired: u32, _maximum: Option<u32>) -> bool {
+        let delta = (desired - current) as usize * std::mem::size_of::<usize>();
+        self.alloc(delta)
+    }
+}

--- a/crates/fuzz-stats/src/bin/failed-instantiations.rs
+++ b/crates/fuzz-stats/src/bin/failed-instantiations.rs
@@ -134,12 +134,13 @@ impl State {
                 // Traps are ok if they happen during instantiation. This is an
                 // expected occurrence we want to account for.
                 if e.downcast_ref::<Trap>().is_some() {
-                    // std::fs::write("trap.wasm", &wasm).unwrap();
+                    std::fs::write("trap.wasm", &wasm).unwrap();
                     self.instantiate_trap.fetch_add(1, SeqCst);
 
                 // Ooms, like traps, are normal during instantiations. This
                 // can happen, for example, if a defined memory is very large.
                 } else if store.data().oom {
+                    std::fs::write("oom.wasm", &wasm).unwrap();
                     self.instantiate_oom.fetch_add(1, SeqCst);
 
                 // In theory nothing else fails to instantiate. If it does, then

--- a/crates/fuzz-stats/src/dummy.rs
+++ b/crates/fuzz-stats/src/dummy.rs
@@ -1,0 +1,70 @@
+//! Dummy implementations of things that a Wasm module can import.
+
+use anyhow::Result;
+use wasmtime::*;
+
+/// Create a set of dummy functions/globals/etc for the given imports.
+pub fn dummy_imports<'module, T>(store: &mut Store<T>, module: &Module) -> Result<Vec<Extern>> {
+    let mut result = Vec::new();
+    for import in module.imports() {
+        result.push(dummy_extern(store, import.ty())?);
+    }
+    Ok(result)
+}
+
+/// Construct a dummy `Extern` from its type signature
+pub fn dummy_extern<T>(store: &mut Store<T>, ty: ExternType) -> Result<Extern> {
+    Ok(match ty {
+        ExternType::Func(func_ty) => Extern::Func(dummy_func(store, func_ty)),
+        ExternType::Global(global_ty) => Extern::Global(dummy_global(store, global_ty)),
+        ExternType::Table(table_ty) => Extern::Table(dummy_table(store, table_ty)?),
+        ExternType::Memory(mem_ty) => Extern::Memory(dummy_memory(store, mem_ty)?),
+        ExternType::Instance(_) => unimplemented!(),
+        ExternType::Module(_) => unimplemented!(),
+    })
+}
+
+/// Construct a dummy function for the given function type
+pub fn dummy_func<T>(store: &mut Store<T>, ty: FuncType) -> Func {
+    Func::new(store, ty.clone(), move |_, _, results| {
+        for (ret_ty, result) in ty.results().zip(results) {
+            *result = dummy_value(ret_ty);
+        }
+        Ok(())
+    })
+}
+
+/// Construct a dummy value for the given value type.
+pub fn dummy_value(val_ty: ValType) -> Val {
+    match val_ty {
+        ValType::I32 => Val::I32(0),
+        ValType::I64 => Val::I64(0),
+        ValType::F32 => Val::F32(0),
+        ValType::F64 => Val::F64(0),
+        ValType::V128 => Val::V128(0),
+        ValType::ExternRef => Val::ExternRef(None),
+        ValType::FuncRef => Val::FuncRef(None),
+    }
+}
+
+/// Construct a sequence of dummy values for the given types.
+pub fn dummy_values(val_tys: impl IntoIterator<Item = ValType>) -> Vec<Val> {
+    val_tys.into_iter().map(dummy_value).collect()
+}
+
+/// Construct a dummy global for the given global type.
+pub fn dummy_global<T>(store: &mut Store<T>, ty: GlobalType) -> Global {
+    let val = dummy_value(ty.content().clone());
+    Global::new(store, ty, val).unwrap()
+}
+
+/// Construct a dummy table for the given table type.
+pub fn dummy_table<T>(store: &mut Store<T>, ty: TableType) -> Result<Table> {
+    let init_val = dummy_value(ty.element().clone());
+    Table::new(store, ty, init_val)
+}
+
+/// Construct a dummy memory for the given memory type.
+pub fn dummy_memory<T>(store: &mut Store<T>, ty: MemoryType) -> Result<Memory> {
+    Memory::new(store, ty)
+}

--- a/crates/fuzz-stats/src/lib.rs
+++ b/crates/fuzz-stats/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod dummy;

--- a/crates/wasm-smith/src/config.rs
+++ b/crates/wasm-smith/src/config.rs
@@ -531,6 +531,10 @@ impl Config for SwarmConfig {
         self.simd_enabled
     }
 
+    fn allow_start_export(&self) -> bool {
+        self.allow_start_export
+    }
+
     fn max_aliases(&self) -> usize {
         self.max_aliases
     }

--- a/crates/wasm-smith/src/lib.rs
+++ b/crates/wasm-smith/src/lib.rs
@@ -57,6 +57,16 @@
 // Needed for the `instructions!` macro in `src/code_builder.rs`.
 #![recursion_limit = "512"]
 
+// NB: these constants are used to control the rate at which various events
+// occur. For more information see where these constants are used. Their values
+// are somewhat random in the sense that they're not scientifically determined
+// or anything like that, I just threw a bunch of random data at wasm-smith and
+// measured various rates of ooms/traps/etc and adjusted these so abnormal
+// events were ~1% of the time.
+const GRADUAL_FACTOR_OF_GROWTH: usize = 4; // bigger = more trap
+const CHANCE_OFFSET_INBOUNDS: usize = 10; // bigger = less traps
+const CHANCE_SEGMENT_ON_EMPTY: usize = 10; // bigger = less traps
+
 mod code_builder;
 mod config;
 mod encode;
@@ -65,6 +75,7 @@ mod terminate;
 use crate::code_builder::CodeBuilderAllocations;
 use arbitrary::{Arbitrary, Result, Unstructured};
 use std::collections::{HashMap, HashSet};
+use std::convert::TryFrom;
 use std::marker;
 use std::rc::Rc;
 use std::str;
@@ -1861,7 +1872,6 @@ impl Module {
 
     fn arbitrary_elems(&mut self, u: &mut Unstructured) -> Result<()> {
         let func_max = self.funcs.len() as u32;
-        let table_tys = self.tables.iter().map(|t| t.elem_ty).collect::<Vec<_>>();
 
         // Create a helper closure to choose an arbitrary offset.
         let mut offset_global_choices = vec![];
@@ -1873,65 +1883,73 @@ impl Module {
                 offset_global_choices.push(i as u32);
             }
         }
-        let arbitrary_offset = |u: &mut Unstructured| {
-            Ok(if !offset_global_choices.is_empty() && u.arbitrary()? {
+        let arbitrary_active_elem = |u: &mut Unstructured, min: u32, table: Option<u32>| {
+            let (offset, max_size_hint) = if !offset_global_choices.is_empty() && u.arbitrary()? {
                 let g = u.choose(&offset_global_choices)?;
-                Instruction::GlobalGet(*g)
+                (Instruction::GlobalGet(*g), None)
             } else {
-                Instruction::I32Const(u.arbitrary()?)
-            })
+                let offset = arbitrary_offset(u, min.into(), u32::MAX.into(), 0)? as u32;
+                let max_size_hint =
+                    if offset <= min && u.int_in_range(0..=CHANCE_OFFSET_INBOUNDS)? != 0 {
+                        Some(min - offset)
+                    } else {
+                        None
+                    };
+                (Instruction::I32Const(offset as i32), max_size_hint)
+            };
+            Ok((ElementKind::Active { table, offset }, max_size_hint))
         };
 
-        let mut choices: Vec<Box<dyn Fn(&mut Unstructured) -> Result<(ElementKind, ValType)>>> =
-            Vec::new();
+        type GenElemSegment<'a> =
+            dyn Fn(&mut Unstructured) -> Result<(ElementKind, Option<u32>)> + 'a;
+        let mut funcrefs: Vec<Box<GenElemSegment>> = Vec::new();
+        let mut externrefs: Vec<Box<GenElemSegment>> = Vec::new();
 
-        if table_tys.len() > 0 {
-            // If we have at least one table, then the MVP encoding is always
-            // available so long as it's a funcref table.
-            if table_tys[0] == ValType::FuncRef {
-                choices.push(Box::new(|u| {
-                    Ok((
-                        ElementKind::Active {
-                            table: None,
-                            offset: arbitrary_offset(u)?,
-                        },
-                        table_tys[0],
-                    ))
-                }));
+        for (i, ty) in self.tables.iter().enumerate() {
+            // If this table starts with no capacity then any non-empty element
+            // segment placed onto it will immediately trap, which isn't too
+            // too interesting. If that's the case give it an unlikely chance
+            // of proceeding.
+            if ty.minimum == 0 && u.int_in_range(0..=CHANCE_SEGMENT_ON_EMPTY)? != 0 {
+                continue;
             }
 
-            // If we have reference types enabled, then we can initialize any
-            // table, and we can also use the alternate encoding to initialize
-            // the 0th table.
-            if self.config.reference_types_enabled() {
-                choices.push(Box::new(|u| {
-                    let i = u.int_in_range(0..=table_tys.len() - 1)? as u32;
-                    Ok((
-                        ElementKind::Active {
-                            table: Some(i),
-                            offset: arbitrary_offset(u)?,
-                        },
-                        table_tys[i as usize],
-                    ))
-                }));
+            let dst = if ty.elem_ty == ValType::FuncRef {
+                &mut funcrefs
+            } else {
+                &mut externrefs
+            };
+            let minimum = ty.minimum;
+            // If the first table is a funcref table then it's a candidate for
+            // the MVP encoding of element segments.
+            if i == 0 && ty.elem_ty == ValType::FuncRef {
+                dst.push(Box::new(move |u| arbitrary_active_elem(u, minimum, None)));
             }
+            dst.push(Box::new(move |u| {
+                arbitrary_active_elem(u, minimum, Some(i as u32))
+            }));
         }
 
         // Reference types allows us to create passive and declared element
         // segments.
         if self.config.reference_types_enabled() {
-            choices.push(Box::new(|_| Ok((ElementKind::Passive, ValType::FuncRef))));
-            choices.push(Box::new(|_| Ok((ElementKind::Passive, ValType::ExternRef))));
-            choices.push(Box::new(|_| Ok((ElementKind::Declared, ValType::FuncRef))));
-            choices.push(Box::new(|_| {
-                Ok((ElementKind::Declared, ValType::ExternRef))
-            }));
+            funcrefs.push(Box::new(|_| Ok((ElementKind::Passive, None))));
+            externrefs.push(Box::new(|_| Ok((ElementKind::Passive, None))));
+            funcrefs.push(Box::new(|_| Ok((ElementKind::Declared, None))));
+            externrefs.push(Box::new(|_| Ok((ElementKind::Declared, None))));
+        }
+
+        let mut choices = Vec::new();
+        if !funcrefs.is_empty() {
+            choices.push((&funcrefs, ValType::FuncRef));
+        }
+        if !externrefs.is_empty() {
+            choices.push((&externrefs, ValType::ExternRef));
         }
 
         if choices.is_empty() {
             return Ok(());
         }
-
         arbitrary_loop(
             u,
             self.config.min_element_segments(),
@@ -1939,40 +1957,41 @@ impl Module {
             |u| {
                 // Choose whether to generate a segment whose elements are initialized via
                 // expressions, or one whose elements are initialized via function indices.
-                let (kind, ty) = u.choose(&choices)?(u)?;
+                let (kind_candidates, ty) = *u.choose(&choices)?;
+
+                // Select a kind for this segment now that we know the number of
+                // items the segment will hold.
+                let (kind, max_size_hint) = u.choose(&kind_candidates)?(u)?;
+                let max = max_size_hint
+                    .map(|i| usize::try_from(i).unwrap())
+                    .unwrap_or(self.config.max_elements());
+
+                // Pick whether we're going to use expression elements or
+                // indices. Note that externrefs must use expressions,
+                // and functions without reference types must use indices.
                 let items = if ty == ValType::ExternRef
                     || (self.config.reference_types_enabled() && u.arbitrary()?)
                 {
                     let mut init = vec![];
-                    arbitrary_loop(
-                        u,
-                        self.config.min_elements(),
-                        self.config.max_elements(),
-                        |u| {
-                            init.push(
-                                if ty == ValType::ExternRef || func_max == 0 || u.arbitrary()? {
-                                    None
-                                } else {
-                                    Some(u.int_in_range(0..=func_max - 1)?)
-                                },
-                            );
-                            Ok(true)
-                        },
-                    )?;
+                    arbitrary_loop(u, self.config.min_elements(), max, |u| {
+                        init.push(
+                            if ty == ValType::ExternRef || func_max == 0 || u.arbitrary()? {
+                                None
+                            } else {
+                                Some(u.int_in_range(0..=func_max - 1)?)
+                            },
+                        );
+                        Ok(true)
+                    })?;
                     Elements::Expressions(init)
                 } else {
                     let mut init = vec![];
                     if func_max > 0 {
-                        arbitrary_loop(
-                            u,
-                            self.config.min_elements(),
-                            self.config.max_elements(),
-                            |u| {
-                                let func_idx = u.int_in_range(0..=func_max - 1)?;
-                                init.push(func_idx);
-                                Ok(true)
-                            },
-                        )?;
+                        arbitrary_loop(u, self.config.min_elements(), max, |u| {
+                            let func_idx = u.int_in_range(0..=func_max - 1)?;
+                            init.push(func_idx);
+                            Ok(true)
+                        })?;
                     }
                     Elements::Functions(init)
                 };
@@ -2031,10 +2050,26 @@ impl Module {
             return Ok(());
         }
 
-        let mut choices32: Vec<Box<dyn Fn(&mut Unstructured) -> Result<Instruction>>> = vec![];
-        choices32.push(Box::new(|u| Ok(Instruction::I32Const(u.arbitrary()?))));
-        let mut choices64: Vec<Box<dyn Fn(&mut Unstructured) -> Result<Instruction>>> = vec![];
-        choices64.push(Box::new(|u| Ok(Instruction::I64Const(u.arbitrary()?))));
+        let mut choices32: Vec<Box<dyn Fn(&mut Unstructured, u64, usize) -> Result<Instruction>>> =
+            vec![];
+        choices32.push(Box::new(|u, min_size, data_len| {
+            Ok(Instruction::I32Const(arbitrary_offset(
+                u,
+                min_size.saturating_mul(64 * 1024),
+                u32::MAX.into(),
+                data_len,
+            )? as i32))
+        }));
+        let mut choices64: Vec<Box<dyn Fn(&mut Unstructured, u64, usize) -> Result<Instruction>>> =
+            vec![];
+        choices64.push(Box::new(|u, min_size, data_len| {
+            Ok(Instruction::I64Const(arbitrary_offset(
+                u,
+                min_size.saturating_mul(64 * 1024),
+                u64::MAX,
+                data_len,
+            )? as i64))
+        }));
 
         for (i, g) in self.globals[..self.globals.len() - self.defined_globals.len()]
             .iter()
@@ -2044,10 +2079,33 @@ impl Module {
                 continue;
             }
             if g.val_type == ValType::I32 {
-                choices32.push(Box::new(move |_| Ok(Instruction::GlobalGet(i as u32))));
+                choices32.push(Box::new(move |_, _, _| {
+                    Ok(Instruction::GlobalGet(i as u32))
+                }));
             } else if g.val_type == ValType::I64 {
-                choices64.push(Box::new(move |_| Ok(Instruction::GlobalGet(i as u32))));
+                choices64.push(Box::new(move |_, _, _| {
+                    Ok(Instruction::GlobalGet(i as u32))
+                }));
             }
+        }
+
+        // Build a list of candidate memories that we'll add data initializers
+        // for. If a memory doesn't have an initial size then any initializers
+        // for that memory will trap instantiation, which isn't too
+        // interesting. Try to make this happen less often by making it less
+        // likely that a memory with 0 size will have a data segment.
+        let mut memories = Vec::new();
+        for (i, mem) in self.memories.iter().enumerate() {
+            if mem.minimum > 0 || u.int_in_range(0..=CHANCE_SEGMENT_ON_EMPTY)? == 0 {
+                memories.push(i as u32);
+            }
+        }
+
+        // With memories we can generate data segments, and with bulk memory we
+        // can generate passive segments. Without these though we can't create
+        // a valid module with data segments.
+        if memories.len() == 0 && !self.config.bulk_memory_enabled() {
+            return Ok(());
         }
 
         arbitrary_loop(
@@ -2055,27 +2113,30 @@ impl Module {
             self.config.min_data_segments(),
             self.config.max_data_segments(),
             |u| {
+                let init: Vec<u8> = u.arbitrary()?;
+
                 // Passive data can only be generated if bulk memory is enabled.
                 // Otherwise if there are no memories we *only* generate passive
                 // data. Finally if all conditions are met we use an input byte to
                 // determine if it should be passive or active.
-                let kind =
-                    if self.config.bulk_memory_enabled() && (memories == 0 || u.arbitrary()?) {
-                        DataSegmentKind::Passive
+                let kind = if self.config.bulk_memory_enabled()
+                    && (memories.is_empty() || u.arbitrary()?)
+                {
+                    DataSegmentKind::Passive
+                } else {
+                    let memory_index = *u.choose(&memories)?;
+                    let mem = &self.memories[memory_index as usize];
+                    let f = if mem.memory64 {
+                        u.choose(&choices64)?
                     } else {
-                        let memory_index = u.int_in_range(0..=memories - 1)?;
-                        let f = if self.memories[memory_index as usize].memory64 {
-                            u.choose(&choices64)?
-                        } else {
-                            u.choose(&choices32)?
-                        };
-                        let offset = f(u)?;
-                        DataSegmentKind::Active {
-                            offset,
-                            memory_index,
-                        }
+                        u.choose(&choices32)?
                     };
-                let init = u.arbitrary()?;
+                    let offset = f(u, mem.minimum, init.len())?;
+                    DataSegmentKind::Active {
+                        offset,
+                        memory_index,
+                    }
+                };
                 self.data.push(DataSegment { kind, init });
                 Ok(true)
             },
@@ -2270,23 +2331,43 @@ fn gradually_grow(u: &mut Unstructured, min: u64, max: u64) -> Result<u64> {
     // The idea behind how this works is that we use the input `u` to determin
     // the ceiling, ideally between min/max, and then generate a number between
     // min and our ceiling.
-    //
-    // The actual numbers here may need some tuning over time, but at least
-    // locally when I threw a bunch of random data at this it would generate
-    // instances that would oom on instantiation 1% of the time. If this
-    // function changed to simply use `int_in_range(min, max)` it would oom 50%
-    // of the time.
     assert!(min <= max);
     let mut cur_max = min.saturating_add(10);
     loop {
         if cur_max >= max {
             break u.int_in_range(min..=max);
         }
-        if u.int_in_range(0..=4)? == 0 {
+        if u.int_in_range(0..=GRADUAL_FACTOR_OF_GROWTH)? == 0 {
             break u.int_in_range(min..=cur_max);
         }
         cur_max += cur_max / 2;
     }
+}
+
+/// Selects a reasonable offset for an element or data segment. This favors
+/// having the segment being in-bounds, but it may still generate
+/// any offset.
+fn arbitrary_offset(u: &mut Unstructured, min: u64, max: u64, size: usize) -> Result<u64> {
+    let size = u64::try_from(size).unwrap();
+
+    // If the segment is too big for the whole memory, just give it any
+    // offset.
+    if size > min {
+        return u.int_in_range(0..=max);
+    }
+
+    // Afterwards give it a chance to be guaranteed to be in-bounds
+    if u.int_in_range(0..=CHANCE_OFFSET_INBOUNDS)? != 0 {
+        return u.int_in_range(0..=min - size);
+    }
+
+    // Afterwards give it a "pretty good" chance of being in bounds
+    if u.int_in_range(0..=CHANCE_OFFSET_INBOUNDS)? != 0 {
+        return gradually_grow(u, 0, min);
+    }
+
+    // or just let it be completely arbitrary
+    u.int_in_range(0..=max)
 }
 
 pub(crate) fn arbitrary_loop(

--- a/crates/wasm-smith/src/lib.rs
+++ b/crates/wasm-smith/src/lib.rs
@@ -2378,6 +2378,18 @@ fn gradually_grow(u: &mut Unstructured, min: u64, max_inbounds: u64, max: u64) -
         );
         assert!(value >= input.start, "{} >= {}", value, input.start);
         assert!(value <= input.end, "{} <= {}", value, input.end);
+        assert!(
+            output.start <= output_inbounds.start,
+            "{} <= {}",
+            output.start,
+            output_inbounds.start
+        );
+        assert!(
+            output_inbounds.end <= output.end,
+            "{} <= {}",
+            output_inbounds.end,
+            output.end
+        );
 
         let x = map_linear(value, input.clone(), 0.0..1.0);
         let result = if x < PCT_INBOUNDS {


### PR DESCRIPTION
I ran a small program recently where I threw random data at wasm-smith and then tried to instantiate each module. I kept record of statistics about whether or not the module failed to instantiate, and it turns out with a 1GB memory limit and using `wasmtime` we previously failed to instantiate 50%+ modules coming out of wasm-smith. The goal of this commit is to reduce that percentage.

Overall the goal here is to in theory get "more interesting" modules into fuzzers when generated by wasm-smith. The modules that are all failing to instantiate are indeed interesting, but it's mostly more interesting to  get to wasm code rather than constantly checking the bounds-checks of instantiation on memory segments and such.

This commit reimplements limits around memories/tables as well as the offsets of active segments. The goal of this PR is to still leave all the currently-generated modules as *possible* to generate, but just far-less likely. Some compile-time constants have been introduced which can be used to tune the generation of modules and how frequently they should allocate lots of memory and/or trap.

After this commit the paramter values I've chosen means that ~2% of modules will fail instantiation due to exceeding memory limits and/or offsets being out-of-bounds. I figure for now that that's at least a much better starting point for exercising more bits of the wasm runtime than before!