### PR TITLE
Implement a nan canonicalization mode for wasm-smith

### DIFF
--- a/crates/wasm-smith/src/config.rs
+++ b/crates/wasm-smith/src/config.rs
@@ -285,6 +285,18 @@ pub trait Config: 'static + std::fmt::Debug {
     fn memory64_enabled(&self) -> bool {
         false
     }
+
+    /// Returns whether NaN values are canonicalized after all f32/f64
+    /// operation.
+    ///
+    /// This can be useful when a generated wasm module is executed in multiple
+    /// runtimes which may produce different NaN values. This ensures that the
+    /// generated module will always use the same NaN representation for all
+    /// instructions which have visible side effects, for example writing floats
+    /// to memory or float-to-int bitcast instructions.
+    fn canonicalize_nans(&self) -> bool {
+        false
+    }
 }
 
 /// The default configuration.
@@ -348,6 +360,7 @@ pub struct SwarmConfig {
     pub simd_enabled: bool,
     pub allow_start_export: bool,
     pub max_type_size: u32,
+    pub canonicalize_nans: bool,
 }
 
 impl<'a> Arbitrary<'a> for SwarmConfig {
@@ -398,6 +411,7 @@ impl<'a> Arbitrary<'a> for SwarmConfig {
             memory64_enabled: false,
             max_type_size: 1000,
             module_linking_enabled: false,
+            canonicalize_nans: false,
         })
     }
 }
@@ -545,5 +559,9 @@ impl Config for SwarmConfig {
 
     fn memory64_enabled(&self) -> bool {
         self.memory64_enabled
+    }
+
+    fn canonicalize_nans(&self) -> bool {
+        self.canonicalize_nans
     }
 }

--- a/crates/wasm-smith/src/lib.rs
+++ b/crates/wasm-smith/src/lib.rs
@@ -2028,8 +2028,8 @@ impl Module {
         allocs: &mut CodeBuilderAllocations,
         allow_invalid: bool,
     ) -> Result<Code> {
-        let locals = self.arbitrary_locals(u)?;
-        let builder = allocs.builder(ty, &locals);
+        let mut locals = self.arbitrary_locals(u)?;
+        let builder = allocs.builder(ty, &mut locals);
         let instructions = if allow_invalid && u.arbitrary().unwrap_or(false) {
             Instructions::Arbitrary(arbitrary_vec_u8(u)?)
         } else {

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -14,6 +14,7 @@ pub fn generate_valid_module(
     config.simd_enabled = u.arbitrary()?;
     config.module_linking_enabled = u.arbitrary()?;
     config.memory64_enabled = u.arbitrary()?;
+    config.canonicalize_nans = u.arbitrary()?;
 
     configure(&mut config, &mut u)?;
 

--- a/src/bin/wasm-smith.rs
+++ b/src/bin/wasm-smith.rs
@@ -151,6 +151,8 @@ struct Config {
     max_type_size: Option<u32>,
     #[structopt(long = "memory64")]
     memory64_enabled: Option<bool>,
+    #[structopt(long = "canonicalize-nans")]
+    canonicalize_nans: Option<bool>,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -280,6 +282,7 @@ impl wasm_smith::Config for CliAndJsonConfig {
         (max_aliases, usize, 1000),
         (max_nesting_depth, usize, 1000),
         (max_type_size, u32, 1000),
+        (canonicalize_nans, bool, false),
     }
 
     fn max_memory_pages(&self, _is_64: bool) -> u64 {


### PR DESCRIPTION
This commit implements a configuration option for `wasm-smith` where the
generated wasm module will internally do NaN canonicalization to ensure
that the wasm module will produce the exact same result in multiple wasm
runtimes. This should help close one of the gaps of nondeterminism in
wasm, NaN values, to ensure that differential fuzzing between runtimes
works correctly.

This was discovered fuzzing the Wasmtime runtime against the wasm OCaml
spec interpreter where OCaml wasn't canonicalizing NaN but Wasmtime was.
To help assuage any possible difference in NaN representations and
implementation choices in Wasmtime this solution should help ensure
that, when enabled for differential fuzzing, we'll get the same NaN
results in both runtimes.