### PR TITLE
Add missing validation for the exceptions proposal

### DIFF
--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -724,6 +724,9 @@ impl Validator {
     }
 
     fn tag_type(&self, ty: &TagType) -> Result<()> {
+        if !self.features.exceptions {
+            return self.create_error("exceptions proposal not enabled");
+        }
         let ty = self.func_type_at(ty.type_index)?;
         if ty.returns.len() > 0 {
             return self.create_error("invalid result arity for exception type");
@@ -1186,6 +1189,9 @@ impl Validator {
     }
 
     pub fn tag_section(&mut self, section: &crate::TagSectionReader<'_>) -> Result<()> {
+        if !self.features.exceptions {
+            return self.create_error("exceptions proposal not enabled");
+        }
         self.check_max(
             self.cur.state.tags.len(),
             section.get_count(),

--- a/tests/local/missing-features/missing-exceptions.wast
+++ b/tests/local/missing-features/missing-exceptions.wast
@@ -1,0 +1,12 @@
+(assert_invalid
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\0d\01\00"
+    )
+  "exceptions proposal not enabled")
+
+(assert_invalid
+  (module
+    (import "" "" (tag))
+    )
+  "exceptions proposal not enabled")


### PR DESCRIPTION
Wasmparser's validator would accidentally let a module through with the
tag section or with tag imports, even if the exceptions proposal wasn't
enabled.