### PR TITLE
Switch exception tag attribute to u8 from u32

### DIFF
--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -380,7 +380,7 @@ impl<'a> BinaryReader<'a> {
     }
 
     pub(crate) fn read_tag_type(&mut self) -> Result<TagType> {
-        let attribute = self.read_var_u32()?;
+        let attribute = self.read_u8()?;
         if attribute != 0 {
             return Err(BinaryReaderError::new(
                 "invalid tag attributes",


### PR DESCRIPTION
This is a pretty minor fix to change the exception tag attribute to be read as a `u8` instead of `u32`, to match this spec change: https://github.com/WebAssembly/exception-handling/pull/162