### PR TITLE
Rename assert_uncaught_exception to assert_exception

### DIFF
--- a/crates/wast/src/ast/mod.rs
+++ b/crates/wast/src/ast/mod.rs
@@ -330,6 +330,7 @@ pub mod kw {
     custom_keyword!(anyref);
     custom_keyword!(arg);
     custom_keyword!(array);
+    custom_keyword!(assert_exception);
     custom_keyword!(assert_exhaustion);
     custom_keyword!(assert_invalid);
     custom_keyword!(assert_malformed);
@@ -343,7 +344,6 @@ pub mod kw {
     custom_keyword!(assert_return_func);
     custom_keyword!(assert_trap);
     custom_keyword!(assert_unlinkable);
-    custom_keyword!(assert_uncaught_exception);
     custom_keyword!(before);
     custom_keyword!(binary);
     custom_keyword!(block);

--- a/crates/wast/src/ast/wast.rs
+++ b/crates/wast/src/ast/wast.rs
@@ -93,7 +93,7 @@ pub enum WastDirective<'a> {
         module: ast::Module<'a>,
         message: &'a str,
     },
-    AssertUncaughtException {
+    AssertException {
         span: ast::Span,
         exec: WastExecute<'a>,
     },
@@ -112,7 +112,7 @@ impl WastDirective<'_> {
             | WastDirective::AssertExhaustion { span, .. }
             | WastDirective::AssertUnlinkable { span, .. }
             | WastDirective::AssertInvalid { span, .. }
-            | WastDirective::AssertUncaughtException { span, .. } => *span,
+            | WastDirective::AssertException { span, .. } => *span,
             WastDirective::Invoke(i) => i.span,
         }
     }
@@ -252,9 +252,9 @@ impl<'a> Parse<'a> for WastDirective<'a> {
                 module: parser.parens(|p| p.parse())?,
                 message: parser.parse()?,
             })
-        } else if l.peek::<kw::assert_uncaught_exception>() {
-            let span = parser.parse::<kw::assert_uncaught_exception>()?.0;
-            Ok(WastDirective::AssertUncaughtException {
+        } else if l.peek::<kw::assert_exception>() {
+            let span = parser.parse::<kw::assert_exception>()?.0;
+            Ok(WastDirective::AssertException {
                 span,
                 exec: parser.parens(|p| p.parse())?,
             })


### PR DESCRIPTION
The `assert_uncaught_exception` assertion used for exception handling was renamed to `assert_exception` in the final version of

  https://github.com/WebAssembly/exception-handling/pull/160

but was out-of-date in the wast crate. This PR does the renaming.

(example of the current assertion syntax used in tests here: https://github.com/WebAssembly/exception-handling/blob/master/test/core/try_catch.wast#L157)

Note: the upstream "testsuite" repo isn't updated for exceptions yet, but I tested it by updating it locally. There are some differences in error messages vs. expected messages (will try to fix these sometime), but otherwise it looks pretty good after this change.