### PR TITLE
Create the initial skeleton for a `wasm-mutate` tool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ getopts = "0.2"
 log = "0.4"
 rayon = "1.0"
 structopt = "0.3.16"
+wasm-mutate = { path = "crates/wasm-mutate", features = ["structopt"] }
 wasm-smith = { path = "crates/wasm-smith" }
 wasmparser = { path = "crates/wasmparser" }
 wasmparser-dump = { path = "crates/dump" }

--- a/crates/wasm-mutate/Cargo.toml
+++ b/crates/wasm-mutate/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "wasm-mutate"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+structopt = { optional = true, version = "0.3" }
+thiserror = "1.0.28"
+wasmparser = { version = "0.80", path = "../wasmparser" }
+
+[dev-dependencies]
+anyhow = "1"
+wat = { version = "1", path = "../wat" }

--- a/crates/wasm-mutate/src/error.rs
+++ b/crates/wasm-mutate/src/error.rs
@@ -1,0 +1,10 @@
+/// An error encountered when choosing or applying a Wasm mutation.
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// The input Wasm module did not parse or validate okay.
+    #[error("Failed to parse or validate the input Wasm module.")]
+    Parse(#[from] wasmparser::BinaryReaderError),
+}
+
+/// A `Result` type that is either `Ok(T)` or `Err(wasm_mutate::Error)`.
+pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/wasm-mutate/src/lib.rs
+++ b/crates/wasm-mutate/src/lib.rs
@@ -1,0 +1,140 @@
+//! A WebAssembly test case mutator.
+//!
+//! `wasm-mutate` takes in an existing Wasm module and then applies a
+//! pseudo-random transformation to it, producing a new, mutated Wasm
+//! module. This new, mutated Wasm module can be fed as a test input to your
+//! Wasm parser, validator, compiler, or any other Wasm-consuming
+//! tool. `wasm-mutate` can serve as a custom mutator for mutation-based
+//! fuzzing.
+
+#![cfg_attr(not(feature = "structopt"), deny(missing_docs))]
+
+use std::sync::Arc;
+
+#[cfg(feature = "structopt")]
+use structopt::StructOpt;
+
+mod error;
+pub use error::{Error, Result};
+
+// NB: only add this doc comment if we are not building the CLI, since otherwise
+// it will override the main CLI's about text.
+#[cfg_attr(
+    not(feature = "structopt"),
+    doc = r###"
+A WebAssembly test case mutator.
+
+This is the main entry point into this crate. It provides various methods
+for configuring what kinds of mutations might be applied to the input
+Wasm. Once configured, you can apply a transformation to the input Wasm via
+the [`run`][wasm_mutate::WasmMutate::run] method.
+
+# Example
+
+```
+# fn _foo() -> anyhow::Result<()> {
+use wasm_mutate::WasmMutate;
+
+let input_wasm = wat::parse_str(r#"
+           (module
+            (func (export "hello") (result i32)
+             (i32.const 1234)
+            )
+           )
+           "#)?;
+
+// Create a `WasmMutate` builder, configure its seed, and then run it on the
+// input Wasm!
+let mutated_wasm = WasmMutate::default()
+    .seed(42)
+    .run(&input_wasm)?;
+
+// Feed `mutated_wasm` into your tests...
+# Ok(())
+# }
+```
+"###
+)]
+#[derive(Clone)]
+#[cfg_attr(feature = "structopt", derive(StructOpt))]
+pub struct WasmMutate {
+    /// The RNG seed used to choose which transformation to apply. Given the
+    /// same input Wasm and same seed, `wasm-mutate` will always generate the
+    /// same output Wasm.
+    #[cfg_attr(feature = "structopt", structopt(short, long))]
+    seed: u64,
+
+    /// Only perform semantics-preserving transformations on the Wasm module.
+    #[cfg_attr(feature = "structopt", structopt(long))]
+    preserve_semantics: bool,
+
+    /// Only perform size-reducing transformations on the Wasm module. This
+    /// allows `wasm-mutate` to be used as a test case reducer.
+    #[cfg_attr(feature = "structopt", structopt(long))]
+    reduce: bool,
+
+    // Note: this is only exposed via the programmatic interface, not via the
+    // CLI.
+    #[cfg_attr(feature = "structopt", structopt(skip = None))]
+    raw_mutate_func: Option<Arc<dyn Fn(&mut Vec<u8>) -> Result<()>>>,
+}
+
+impl Default for WasmMutate {
+    fn default() -> Self {
+        WasmMutate {
+            seed: 0,
+            preserve_semantics: false,
+            reduce: false,
+            raw_mutate_func: None,
+        }
+    }
+}
+
+impl WasmMutate {
+    /// Set the RNG seed used to choose which transformation to apply.
+    ///
+    /// Given the same input Wasm and same seed, `wasm-mutate` will always
+    /// generate the same output Wasm.
+    pub fn seed(&mut self, seed: u64) -> &mut Self {
+        self.seed = seed;
+        self
+    }
+
+    /// Configure whether we will only perform semantics-preserving
+    /// transformations on the Wasm module.
+    pub fn preserve_semantics(&mut self, preserve_semantics: bool) -> &mut Self {
+        self.preserve_semantics = preserve_semantics;
+        self
+    }
+
+    /// Configure whether we will only perform size-reducing transformations on
+    /// the Wasm module.
+    ///
+    /// Setting this to `true` allows `wasm-mutate` to be used as a test case
+    /// reducer.
+    pub fn reduce(&mut self, reduce: bool) -> &mut Self {
+        self.reduce = reduce;
+        self
+    }
+
+    /// Set a custom raw mutation function.
+    ///
+    /// This is used when we need some underlying raw bytes, for example when
+    /// mutating the contents of a data segment.
+    ///
+    /// You can override this to use `libFuzzer`'s `LLVMFuzzerMutate` function
+    /// to get raw bytes from `libFuzzer`, for example.
+    pub fn raw_mutate_func(
+        &mut self,
+        raw_mutate_func: Option<Arc<dyn Fn(&mut Vec<u8>) -> Result<()>>>,
+    ) -> &mut Self {
+        self.raw_mutate_func = raw_mutate_func;
+        self
+    }
+
+    /// Run this configured `WasmMutate` on the given input Wasm.
+    pub fn run(&self, input_wasm: &[u8]) -> Result<Vec<u8>> {
+        let _ = input_wasm;
+        todo!()
+    }
+}


### PR DESCRIPTION
`wasm-mutate` will be a new tool for fuzzing Wasm compilers, runtimes,
validators, and other Wasm-consuming programs. `wasm-mutate` will take in an
existing Wasm module and then apply a pseudo-random transformation to it,
producing a new, mutated Wasm module. This new Wasm module will be fed into the
system under test, potentially triggering a bug that users can then diagnose and
fix.

`wasm-mutate` should additionally support the following features:

* `wasm-mutate` should have the ability to restrict mutations to only those that
  shrink the size of the Wasm module, e.g. removing a function from the Wasm
  module. When used in this mode, `wasm-mutate` essentially becomes a Wasm
  test-case reducer.

* `wasm-mutate` should have the ability to only apply semantics-preserving
  changes to the input Wasm module. When used in this mode, the mutated Wasm
  should compute identical results when given the same inputs as the original
  Wasm module.

* `wasm-mutate` should be deterministic. When given the same input Wasm module
  and the same seed, it should always produce the same mutated output Wasm
  module.

* `wasm-mutate` should play nice with mutation-based fuzzers like libFuzzer. It
  should reuse the fuzzer's raw input strings when it makes sense (e.g. when
  adding an export, use the raw fuzzer input when choosing an export name) so
  that fuzzer features like dictionary files can be leveraged. `wasm-mutate`
  should integrate with the `LLVMFuzzerCustomMutator` hook and the
  `libfuzzer_sys::fuzz_mutator!` macro.

--------------------------------------------------------------------------------

cc @jacarte: 

You can run the CLI via `cargo run --bin wasm-mutate` in the root of this repo

You can run its (pretty much non-existant) tests via `cargo test -p wasm-mutate` in the root of the repo.

The library is at `crates/wasm-mutate/src/lib.rs` and the executable CLI that wraps it is at `src/bin/wasm-mutate.rs`.