### PR TITLE
Exclude the /benches directory from packaging

### DIFF
--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -9,6 +9,7 @@ name = "wasm-smith"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools"
 version = "0.7.1"
+exclude = ["/benches"]
 
 [[bench]]
 name = "corpus"

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "wasm-smith"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools"
-version = "0.7.1"
+version = "0.7.2"
 exclude = ["/benches"]
 
 [[bench]]


### PR DESCRIPTION
As discussed, it seems reasonable to not package the 1000+ corpus files for easier vendoring of the package.