### PR TITLE
HOTFIX: Copy correct bypassed functions in code based mutators

### DIFF
--- a/crates/wasm-encoder/src/code.rs
+++ b/crates/wasm-encoder/src/code.rs
@@ -32,7 +32,7 @@ use super::*;
 /// let wasm_bytes = module.finish();
 /// ```
 /// you can also use the `raw` function to write an already encoded function entry to the code section.
-/// This method receives a function entry that was already encoded with its length preffix 
+/// This method receives a function entry that was already encoded as locals + function body 
 /// ``` 
 ///  use wasmparser::CodeSectionReader;
 ///
@@ -42,7 +42,7 @@ use super::*;
 ///  let mut reader = CodeSectionReader::new(&codesection, 0).unwrap();
 ///  let function = reader.read().unwrap();
 ///  let mut codes = CodeSection::new();
-///  // this will copy the function construction, including, length preffix,
+///  // this will copy the function construction:
 ///  // local definitions and function body
 ///  codes.raw(&codesection[function.range().start..function.range().end]);
 /// ```
@@ -74,8 +74,9 @@ impl CodeSection {
     }
 
     /// Add raw bytes as a function body
-    /// The data is expected to be already encoded with the size length preffix.
+    /// The prefix length of the function entry will be calculated during the encoding
     pub fn raw(&mut self, data: &[u8]) -> &mut Self {
+        self.bytes.extend(encoders::u32(u32::try_from(data.len()).unwrap()));
         self.bytes.extend(data);
         self.num_added += 1;
         self

--- a/crates/wasm-mutate/src/lib.rs
+++ b/crates/wasm-mutate/src/lib.rs
@@ -259,7 +259,6 @@ impl WasmMutate {
                     info.code = Some(info.raw_sections.len());
                     info.section(SectionId::Code.into(), range, input_wasm);
                     parser.skip_section();
-                    println!("{:?} {:?}", wasm, consumed);
                     // update slice
                     wasm = &wasm[range.end - range.start + consumed - 1..];
 

--- a/crates/wasm-mutate/src/mutators/function2unreachable.rs
+++ b/crates/wasm-mutate/src/mutators/function2unreachable.rs
@@ -32,7 +32,7 @@ impl Mutator for SetFunction2Unreachable {
                 codes.function(&f);
             } else {
                 let f = reader.read().unwrap();
-                codes.raw(&info.input_wasm[f.range().start..f.range().end]);
+                codes.raw(&code_section.data[f.range().start..f.range().end]);
             }
         });
         Ok(info.replace_section(info.code.unwrap(), &codes))
@@ -62,6 +62,9 @@ mod tests {
             (func (result i32)
                 i32.const 42
             )
+            (func (export "exported_func") (result i32)
+                i32.const 42
+            )
         )
         "#;
         let wasmmutate = WasmMutate::default();
@@ -82,6 +85,6 @@ mod tests {
         // If it fails, it is probably an invalid
         let text = wasmprinter::print_bytes(mutation_bytes).unwrap();
 
-        assert_eq!("(module\n  (type (;0;) (func (result i32)))\n  (func (;0;) (type 0) (result i32)\n    unreachable))", text)
+        assert_eq!("(module\n  (type (;0;) (func (result i32)))\n  (func (;0;) (type 0) (result i32)\n    unreachable)\n  (func (;1;) (type 0) (result i32)\n    i32.const 42)\n  (export \"exported_func\" (func 1)))", text)
     }
 }

--- a/crates/wasm-mutate/src/mutators/snip_function.rs
+++ b/crates/wasm-mutate/src/mutators/snip_function.rs
@@ -52,7 +52,7 @@ impl Mutator for SnipMutator {
                 codes.function(&f);
             } else {
                 let f = reader.read().unwrap();
-                codes.raw(&info.input_wasm[f.range().start..f.range().end]);
+                codes.raw(&code_section.data[f.range().start..f.range().end]);
             }
         });
         Ok(info.replace_section(info.code.unwrap(), &codes))
@@ -82,6 +82,9 @@ mod tests {
             (func (result i64)
                 i64.const 42
             )
+            (func (export "exported_func") (result i32)
+                i32.const 42
+            )
         )
         "#;
         let wasmmutate = WasmMutate::default();
@@ -102,6 +105,6 @@ mod tests {
         // If it fails, it is probably an invalid
         let text = wasmprinter::print_bytes(mutation_bytes).unwrap();
 
-        assert_eq!("(module\n  (type (;0;) (func (result i64)))\n  (func (;0;) (type 0) (result i64)\n    i64.const 0))", text)
+        assert_eq!("(module\n  (type (;0;) (func (result i64)))\n  (type (;1;) (func (result i32)))\n  (func (;0;) (type 0) (result i64)\n    i64.const 0)\n  (func (;1;) (type 1) (result i32)\n    i64.const 42)\n  (export \"exported_func\" (func 1)))", text)
     }
 }


### PR DESCRIPTION
If a mutator decides to mutate an specific function the other functions are copied (in its byte stream repr) to the mutated module. Before this fix, the index from where to copy the function body was referencing the `input_wasm` instead of the code section. Thus, the copied data was wrong.

Besides, the `raw` function in the `CodeSection` struct was missing a correct function entry  length prefix enconding. 