### PR TITLE
wasmprinter: Fix unending indentation on invalid modules

### DIFF
--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -715,6 +715,16 @@ impl Printer {
                 }
                 self.print_operator(&operator, nesting_start)?;
             }
+
+            // If this was an invalid function body then the nesting may not
+            // have reset back to normal. Fix that up here and forcibly insert
+            // a newline as well in case the last instruction was something
+            // like an `if` which has a comment after it which could interfere
+            // with the closing paren printed for the func.
+            if self.nesting != nesting_start {
+                self.nesting = nesting_start;
+                self.newline();
+            }
             self.end_group();
 
             self.state.func += 1;

--- a/crates/wasmprinter/tests/all.rs
+++ b/crates/wasmprinter/tests/all.rs
@@ -137,3 +137,32 @@ fn module_section_too_large() {
         err
     );
 }
+
+#[test]
+fn dangling_if() {
+    let bytes = wat::parse_str(
+        r#"
+            (module
+                (func if)
+            )
+        "#,
+    )
+    .unwrap();
+    let wat = wasmprinter::print_bytes(&bytes).unwrap();
+    wat::parse_str(&wat).unwrap();
+}
+
+#[test]
+fn no_oom() {
+    // Whatever is printed here, it shouldn't take more than 500MB to print
+    // since it's only 20k functions.
+    let mut s = String::new();
+    s.push_str("(module\n");
+    for _ in 0..20_000 {
+        s.push_str("(func if)\n");
+    }
+    s.push_str(")");
+    let bytes = wat::parse_str(&s).unwrap();
+    let wat = wasmprinter::print_bytes(&bytes).unwrap();
+    assert!(wat.len() < 500_000_000);
+}


### PR DESCRIPTION
This commit fixes an issue where `wasmprinter` would have unending
indentation when printing an invalid module which could cause a bad
input to generate exponential amounts of output. The bug happened due to
functions internally being invalid and the nesting level wasn't reset
after processing an invalid function.