### PR TITLE
First implementation for shift load operation

### DIFF
--- a/crates/wasm-mutate/src/lib.rs
+++ b/crates/wasm-mutate/src/lib.rs
@@ -140,6 +140,7 @@ pub struct ModuleInfo<'a> {
     is_start_defined: bool,
     function_count: u32,
     exports_count: u32,
+    memory_count: u32,
 
     // types for inner functions
     types_map: Vec<TypeInfo>,
@@ -305,6 +306,7 @@ impl WasmMutate {
                 }
                 Payload::MemorySection(reader) => {
                     info.memories = Some(info.raw_sections.len());
+                    info.memory_count = reader.get_count();
                     info.section(SectionId::Memory.into(), reader.range(), input_wasm);
                 }
                 Payload::GlobalSection(reader) => {

--- a/crates/wasm-mutate/src/mutators/peephole/strength_reduction.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/strength_reduction.rs
@@ -116,7 +116,8 @@ impl CodeMutator for StrengthReduction {
 
     fn can_mutate<'a>(
         &self,
-        _: &'a WasmMutate,
+        config: &'a WasmMutate,
+        info: &crate::ModuleInfo,
         operators: &Vec<TupleType<'a>>,
         at: usize,
     ) -> Result<bool> {


### PR DESCRIPTION
Select a random `load` instruction and then place random constant addition before to shift the load offset.