### PR TITLE
Refactoring mutation tests

### DIFF
--- a/crates/wasm-mutate/src/mutators/function2unreachable.rs
+++ b/crates/wasm-mutate/src/mutators/function2unreachable.rs
@@ -51,7 +51,7 @@ mod tests {
 
     #[test]
     fn test_code_unreachable_mutator() {
-        crate::match_mutation!(
+        crate::mutators::match_mutation(
             r#"
             (module
                 (func (result i64)
@@ -65,14 +65,14 @@ mod tests {
                 )
             )
         "#,
-            SetFunction2Unreachable,
+            &SetFunction2Unreachable,
             r#"(module
               (type (;0;) (func (result i64)))
               (type (;1;) (func (result i32)))
               (func (;0;) (type 0) (result i64)
                   i64.const 42)  (func (;1;) (type 0) (result i64)
                   i64.const 42)  (func (;2;) (type 1) (result i32)    unreachable)
-                (export "exported_func" (func 2)))"#
+                (export "exported_func" (func 2)))"#,
         );
     }
 }

--- a/crates/wasm-mutate/src/mutators/mod.rs
+++ b/crates/wasm-mutate/src/mutators/mod.rs
@@ -54,8 +54,6 @@ macro_rules! match_mutation {
         // If it fails, it is probably an invalid
         // reformatting expected
         let text = wasmprinter::print_bytes(mutation_bytes).unwrap();
-        println!("{}", text);
-
         let expected = &wat::parse_str($expected).unwrap();
         let expected_text = wasmprinter::print_bytes(expected).unwrap();
 

--- a/crates/wasm-mutate/src/mutators/mod.rs
+++ b/crates/wasm-mutate/src/mutators/mod.rs
@@ -31,3 +31,34 @@ pub mod peephole;
 pub mod remove_export;
 pub mod rename_export;
 pub mod snip_function;
+
+// macro for mutation assesment
+#[cfg(test)]
+#[macro_export]
+macro_rules! match_mutation {
+    (
+        $original: tt, $mutator: expr, $expected: tt
+    ) => {{
+        let wasmmutate = WasmMutate::default();
+        let original = &wat::parse_str($original).unwrap();
+
+        let mut info = wasmmutate.get_module_info(original).unwrap();
+        let can_mutate = $mutator.can_mutate(&wasmmutate, &info).unwrap();
+
+        assert_eq!(can_mutate, true);
+
+        let mut rnd = SmallRng::seed_from_u64(0);
+        let mutation = $mutator.mutate(&wasmmutate, &mut rnd, &mut info);
+
+        let mutation_bytes = mutation.unwrap().finish();
+        // If it fails, it is probably an invalid
+        // reformatting expected
+        let text = wasmprinter::print_bytes(mutation_bytes).unwrap();
+        println!("{}", text);
+
+        let expected = &wat::parse_str($expected).unwrap();
+        let expected_text = wasmprinter::print_bytes(expected).unwrap();
+
+        assert_eq!(text, expected_text);
+    }};
+}

--- a/crates/wasm-mutate/src/mutators/peephole/mod.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/mod.rs
@@ -97,7 +97,7 @@ impl Mutator for PeepholeMutator {
         let peepholes: Vec<Box<dyn CodeMutator>> = vec![
             Box::new(SwapCommutativeOperator),
             Box::new(StrengthReduction::new(false)), // Do not stress the stack
-            Box::new(StrengthReduction::new(true)), // Stress the stack
+            Box::new(StrengthReduction::new(true)),  // Stress the stack
         ];
         let (new_function, function_to_mutate) =
             self.random_mutate(config, rnd, info, peepholes)?;

--- a/crates/wasm-mutate/src/mutators/remove_export.rs
+++ b/crates/wasm-mutate/src/mutators/remove_export.rs
@@ -67,7 +67,7 @@ mod tests {
 
     #[test]
     fn test_remove_export_mutator() {
-        crate::match_mutation!(
+        crate::mutators::match_mutation(
             r#"
             (module
                 (func (export "exported_func") (result i32)
@@ -75,12 +75,12 @@ mod tests {
                 )
             )
             "#,
-            RemoveExportMutator,
+            &RemoveExportMutator,
             r#"
                 (module  (type (;0;)
                  (func (result i32)))
                  (func (;0;) (type 0) (result i32)
-                    i32.const 42))"#
+                    i32.const 42))"#,
         );
     }
 }

--- a/crates/wasm-mutate/src/mutators/remove_export.rs
+++ b/crates/wasm-mutate/src/mutators/remove_export.rs
@@ -67,35 +67,20 @@ mod tests {
 
     #[test]
     fn test_remove_export_mutator() {
-        // From https://developer.mozilla.org/en-US/docs/WebAssembly/Text_format_to_wasm
-        let wat = r#"
-        (module
-            (func (export "exported_func") (result i32)
-                i32.const 42
+        crate::match_mutation!(
+            r#"
+            (module
+                (func (export "exported_func") (result i32)
+                    i32.const 42
+                )
             )
-        )
-        "#;
-
-        let wasmmutate = WasmMutate::default();
-        let original = &wat::parse_str(wat).unwrap();
-
-        let mutator = RemoveExportMutator {};
-
-        let mut info = wasmmutate.get_module_info(original).unwrap();
-        let can_mutate = mutator.can_mutate(&wasmmutate, &info).unwrap();
-
-        assert_eq!(can_mutate, true);
-
-        let mut rnd = SmallRng::seed_from_u64(0);
-        let mutation = mutator.mutate(&wasmmutate, &mut rnd, &mut info);
-
-        let mutation_bytes = mutation.unwrap().finish();
-
-        // validate
-        let mut validator = wasmparser::Validator::new();
-        crate::validate(&mut validator, &mutation_bytes);
-        // If it fails, it is probably an invalid
-        let text = wasmprinter::print_bytes(mutation_bytes).unwrap();
-        assert_eq!("(module\n  (type (;0;) (func (result i32)))\n  (func (;0;) (type 0) (result i32)\n    i32.const 42))", text)
+            "#,
+            RemoveExportMutator,
+            r#"
+                (module  (type (;0;)
+                 (func (result i32)))
+                 (func (;0;) (type 0) (result i32)
+                    i32.const 42))"#
+        );
     }
 }

--- a/crates/wasm-mutate/src/mutators/rename_export.rs
+++ b/crates/wasm-mutate/src/mutators/rename_export.rs
@@ -98,7 +98,7 @@ mod tests {
     fn test_rename_export_mutator() {
         // From https://developer.mozilla.org/en-US/docs/WebAssembly/Text_format_to_wasm
 
-        crate::match_mutation!(
+        crate::mutators::match_mutation(
             r#"
         (module
             (func (export "exported_func") (result i32)
@@ -106,12 +106,12 @@ mod tests {
             )
         )
         "#,
-            RenameExportMutator { max_name_size: 2 }, // the string is empty,
+            &RenameExportMutator { max_name_size: 2 }, // the string is empty,
             r#"(module
             (type (;0;) (func (result i32)))
             (func (;0;) (type 0) (result i32)
             i32.const 42)
-        (export "" (func 0)))"#
+        (export "" (func 0)))"#,
         );
     }
 }

--- a/crates/wasm-mutate/src/mutators/rename_export.rs
+++ b/crates/wasm-mutate/src/mutators/rename_export.rs
@@ -97,34 +97,21 @@ mod tests {
     #[test]
     fn test_rename_export_mutator() {
         // From https://developer.mozilla.org/en-US/docs/WebAssembly/Text_format_to_wasm
-        let wat = r#"
+
+        crate::match_mutation!(
+            r#"
         (module
             (func (export "exported_func") (result i32)
                 i32.const 42
             )
         )
-        "#;
-
-        let wasmmutate = WasmMutate::default();
-        let original = &wat::parse_str(wat).unwrap();
-
-        let mutator = RenameExportMutator { max_name_size: 2 }; // the string is empty
-
-        let mut info = wasmmutate.get_module_info(original).unwrap();
-        let can_mutate = mutator.can_mutate(&wasmmutate, &info).unwrap();
-
-        assert_eq!(can_mutate, true);
-
-        let mut rnd = SmallRng::seed_from_u64(0);
-        let mutation = mutator.mutate(&wasmmutate, &mut rnd, &mut info);
-
-        let mutation_bytes = mutation.unwrap().finish();
-
-        // validate
-        let mut validator = wasmparser::Validator::new();
-        crate::validate(&mut validator, &mutation_bytes);
-        // If it fails, it is probably an invalid
-        let text = wasmprinter::print_bytes(mutation_bytes).unwrap();
-        assert_eq!("(module\n  (type (;0;) (func (result i32)))\n  (func (;0;) (type 0) (result i32)\n    i32.const 42)\n  (export \"\" (func 0)))", text)
+        "#,
+            RenameExportMutator { max_name_size: 2 }, // the string is empty,
+            r#"(module
+            (type (;0;) (func (result i32)))
+            (func (;0;) (type 0) (result i32)
+            i32.const 42)
+        (export "" (func 0)))"#
+        );
     }
 }

--- a/crates/wasm-mutate/src/mutators/snip_function.rs
+++ b/crates/wasm-mutate/src/mutators/snip_function.rs
@@ -72,7 +72,8 @@ mod tests {
 
     #[test]
     fn test_code_snip_mutator() {
-        let wat = r#"
+        crate::match_mutation!(
+            r#"
         (module
             (func (result i64)
                 i64.const 42
@@ -81,24 +82,18 @@ mod tests {
                 i32.const 42
             )
         )
-        "#;
-        let wasmmutate = WasmMutate::default();
-        let original = &wat::parse_str(wat).unwrap();
-
-        let mutator = SnipMutator;
-
-        let mut info = wasmmutate.get_module_info(original).unwrap();
-        let can_mutate = mutator.can_mutate(&wasmmutate, &info).unwrap();
-
-        assert_eq!(can_mutate, true);
-
-        let mut rnd = SmallRng::seed_from_u64(0);
-        let mutation = mutator.mutate(&wasmmutate, &mut rnd, &mut info);
-
-        let mutation_bytes = mutation.unwrap().finish();
-        // If it fails, it is probably an invalid
-        let text = wasmprinter::print_bytes(mutation_bytes).unwrap();
-
-        assert_eq!("(module\n  (type (;0;) (func (result i64)))\n  (type (;1;) (func (result i32)))\n  (func (;0;) (type 0) (result i64)\n    i64.const 0)\n  (func (;1;) (type 1) (result i32)\n    i64.const 42)\n  (export \"exported_func\" (func 1)))", text)
+        "#,
+            SnipMutator,
+            r#"
+        (module
+            (type (;0;) (func (result i64)))
+            (type (;1;) (func (result i32)))
+            (func (;0;) (type 0) (result i64)
+              i64.const 0)
+            (func (;1;) (type 1) (result i32)
+              i64.const 42)
+            (export "exported_func" (func 1)))
+        "#
+        );
     }
 }

--- a/crates/wasm-mutate/src/mutators/snip_function.rs
+++ b/crates/wasm-mutate/src/mutators/snip_function.rs
@@ -72,28 +72,22 @@ mod tests {
 
     #[test]
     fn test_code_snip_mutator() {
-        crate::match_mutation!(
+        crate::mutators::match_mutation(
             r#"
         (module
             (func (result i64)
                 i64.const 42
             )
-            (func (export "exported_func") (result i32)
-                i32.const 42
-            )
         )
         "#,
-            SnipMutator,
+            &SnipMutator,
             r#"
         (module
             (type (;0;) (func (result i64)))
-            (type (;1;) (func (result i32)))
             (func (;0;) (type 0) (result i64)
               i64.const 0)
-            (func (;1;) (type 1) (result i32)
-              i64.const 42)
-            (export "exported_func" (func 1)))
-        "#
+        )
+        "#,
         );
     }
 }


### PR DESCRIPTION
Some code deduplication for mutation tests. We have now a macro_rule to asses a concrete mutation.