### PR TITLE
Add exception-handling proposal to wasm-smith

### DIFF
--- a/crates/wasm-encoder/src/code.rs
+++ b/crates/wasm-encoder/src/code.rs
@@ -213,6 +213,10 @@ pub enum Instruction<'a> {
     Loop(BlockType),
     If(BlockType),
     Else,
+    Try(BlockType),
+    Delegate(u32),
+    Catch(u32),
+    CatchAll,
     End,
     Br(u32),
     BrIf(u32),
@@ -220,6 +224,8 @@ pub enum Instruction<'a> {
     Return,
     Call(u32),
     CallIndirect { ty: u32, table: u32 },
+    Throw(u32),
+    Rethrow(u32),
 
     // Parametric instructions.
     Drop,
@@ -679,6 +685,22 @@ impl Instruction<'_> {
                 bt.encode(bytes);
             }
             Instruction::Else => bytes.push(0x05),
+            Instruction::Try(bt) => {
+                bytes.push(0x06);
+                bt.encode(bytes);
+            }
+            Instruction::Catch(t) => {
+                bytes.push(0x07);
+                bytes.extend(encoders::u32(t));
+            }
+            Instruction::Throw(t) => {
+                bytes.push(0x08);
+                bytes.extend(encoders::u32(t));
+            }
+            Instruction::Rethrow(l) => {
+                bytes.push(0x09);
+                bytes.extend(encoders::u32(l));
+            }
             Instruction::End => bytes.push(0x0B),
             Instruction::Br(l) => {
                 bytes.push(0x0C);
@@ -705,6 +727,13 @@ impl Instruction<'_> {
                 bytes.push(0x11);
                 bytes.extend(encoders::u32(ty));
                 bytes.extend(encoders::u32(table));
+            }
+            Instruction::Delegate(l) => {
+                bytes.push(0x18);
+                bytes.extend(encoders::u32(l));
+            }
+            Instruction::CatchAll => {
+                bytes.push(0x19);
             }
 
             // Parametric instructions.

--- a/crates/wasm-encoder/src/exports.rs
+++ b/crates/wasm-encoder/src/exports.rs
@@ -85,6 +85,8 @@ pub enum Export {
     Memory(u32),
     /// An export of the `n`th global.
     Global(u32),
+    /// An export of the `n`th tag.
+    Tag(u32),
     /// An export of the `n`th instance.
     ///
     /// Note that this is part of the [module linking proposal][proposal] and is
@@ -120,6 +122,10 @@ impl Export {
                 bytes.push(ItemKind::Global as u8);
                 x
             }
+            Export::Tag(x) => {
+                bytes.push(ItemKind::Tag as u8);
+                x
+            }
             Export::Instance(x) => {
                 bytes.push(ItemKind::Instance as u8);
                 x
@@ -142,6 +148,7 @@ pub enum ItemKind {
     Table = 0x01,
     Memory = 0x02,
     Global = 0x03,
+    Tag = 0x04,
     Module = 0x05,
     Instance = 0x06,
 }

--- a/crates/wasm-encoder/src/imports.rs
+++ b/crates/wasm-encoder/src/imports.rs
@@ -95,6 +95,8 @@ pub enum EntityType {
     Memory(MemoryType),
     /// A global type.
     Global(GlobalType),
+    /// A tag type.
+    Tag(TagType),
     /// The `n`th type, which is an instance.
     Instance(u32),
     /// The `n`th type, which is a module.
@@ -123,6 +125,12 @@ impl From<GlobalType> for EntityType {
     }
 }
 
+impl From<TagType> for EntityType {
+    fn from(t: TagType) -> Self {
+        EntityType::Tag(t)
+    }
+}
+
 impl EntityType {
     pub(crate) fn encode(&self, dst: &mut Vec<u8>) {
         match self {
@@ -140,6 +148,10 @@ impl EntityType {
             }
             EntityType::Global(ty) => {
                 dst.push(0x03);
+                ty.encode(dst);
+            }
+            EntityType::Tag(ty) => {
+                dst.push(0x04);
                 ty.encode(dst);
             }
             EntityType::Module(ty) => {

--- a/crates/wasm-encoder/src/lib.rs
+++ b/crates/wasm-encoder/src/lib.rs
@@ -85,6 +85,7 @@ mod memories;
 mod modules;
 mod start;
 mod tables;
+mod tags;
 mod types;
 
 pub use aliases::*;
@@ -102,6 +103,7 @@ pub use memories::*;
 pub use modules::*;
 pub use start::*;
 pub use tables::*;
+pub use tags::*;
 pub use types::*;
 
 pub mod encoders;
@@ -218,6 +220,7 @@ pub enum SectionId {
     Code = 10,
     Data = 11,
     DataCount = 12,
+    Tag = 13,
     Module = 14,
     Instance = 15,
     Alias = 16,

--- a/crates/wasm-encoder/src/tags.rs
+++ b/crates/wasm-encoder/src/tags.rs
@@ -2,6 +2,23 @@ use super::*;
 use std::convert::TryFrom;
 
 /// An encoder for the tag section.
+///
+/// # Example
+///
+/// ```
+/// use wasm_encoder::{Module, TagSection, TagType};
+///
+/// let mut tags = TagSection::new();
+/// tags.tag(TagType {
+///     kind: TagKind::Exception,
+///     func_type_idx: 0,
+/// });
+///
+/// let mut module = Module::new();
+/// module.section(&tags);
+///
+/// let wasm_bytes = module.finish();
+/// ```
 #[derive(Clone, Debug)]
 pub struct TagSection {
     bytes: Vec<u8>,

--- a/crates/wasm-encoder/src/tags.rs
+++ b/crates/wasm-encoder/src/tags.rs
@@ -1,0 +1,73 @@
+use super::*;
+use std::convert::TryFrom;
+
+/// An encoder for the tag section.
+#[derive(Clone, Debug)]
+pub struct TagSection {
+    bytes: Vec<u8>,
+    num_added: u32,
+}
+
+impl TagSection {
+    /// Create a new tag section encoder.
+    pub fn new() -> TagSection {
+        TagSection {
+            bytes: vec![],
+            num_added: 0,
+        }
+    }
+
+    /// How many tags have been defined inside this section so far?
+    pub fn len(&self) -> u32 {
+        self.num_added
+    }
+
+    /// Define a tag.
+    pub fn tag(&mut self, tag_type: TagType) -> &mut Self {
+        tag_type.encode(&mut self.bytes);
+        self.num_added += 1;
+        self
+    }
+}
+
+impl Section for TagSection {
+    fn id(&self) -> u8 {
+        SectionId::Tag.into()
+    }
+
+    fn encode<S>(&self, sink: &mut S)
+    where
+        S: Extend<u8>,
+    {
+        let num_added = encoders::u32(self.num_added);
+        let n = num_added.len();
+        sink.extend(
+            encoders::u32(u32::try_from(n + self.bytes.len()).unwrap())
+                .chain(num_added)
+                .chain(self.bytes.iter().copied()),
+        );
+    }
+}
+
+#[allow(missing_docs)]
+#[repr(u8)]
+#[derive(Clone, Copy, Debug)]
+pub enum TagKind {
+    Exception = 0x0,
+}
+
+/// A tag's type.
+#[derive(Clone, Copy, Debug)]
+pub struct TagType {
+    /// The kind of tag
+    pub kind: TagKind,
+    /// The function type this tag uses
+    pub func_type_idx: u32,
+}
+
+impl TagType {
+    pub(crate) fn encode(&self, bytes: &mut Vec<u8>) {
+        bytes.push(self.kind as u8);
+        bytes.extend(encoders::u32(self.func_type_idx));
+    }
+}

--- a/crates/wasm-encoder/src/tags.rs
+++ b/crates/wasm-encoder/src/tags.rs
@@ -6,7 +6,7 @@ use std::convert::TryFrom;
 /// # Example
 ///
 /// ```
-/// use wasm_encoder::{Module, TagSection, TagType};
+/// use wasm_encoder::{Module, TagSection, TagType, TagKind};
 ///
 /// let mut tags = TagSection::new();
 /// tags.tag(TagType {

--- a/crates/wasm-smith/src/code_builder.rs
+++ b/crates/wasm-smith/src/code_builder.rs
@@ -91,7 +91,7 @@ instructions! {
     (Some(return_valid), r#return, 900),
     (Some(call_valid), call),
     (Some(call_indirect_valid), call_indirect),
-    (Some(throw_valid), throw),
+    (Some(throw_valid), throw, 850),
     (Some(rethrow_valid), rethrow),
     // Parametric instructions.
     (Some(drop_valid), drop),

--- a/crates/wasm-smith/src/code_builder.rs
+++ b/crates/wasm-smith/src/code_builder.rs
@@ -78,6 +78,10 @@ instructions! {
     (None, nop, 800),
     (None, block),
     (None, r#loop),
+    (Some(try_valid), r#try),
+    (Some(delegate_valid), delegate),
+    (Some(catch_valid), catch),
+    (Some(catch_all_valid), catch_all),
     (Some(if_valid), r#if),
     (Some(else_valid), r#else),
     (Some(end_valid), end),
@@ -87,6 +91,8 @@ instructions! {
     (Some(return_valid), r#return, 900),
     (Some(call_valid), call),
     (Some(call_indirect_valid), call_indirect),
+    (Some(throw_valid), throw),
+    (Some(rethrow_valid), rethrow),
     // Parametric instructions.
     (Some(drop_valid), drop),
     (Some(select_valid), select),
@@ -543,6 +549,10 @@ pub(crate) struct CodeBuilderAllocations {
     // of functions that have that function type.
     functions: BTreeMap<Vec<ValType>, Vec<u32>>,
 
+    // Like functions above this is a map from tag types to the list of tags
+    // have that tag type.
+    tags: BTreeMap<Vec<ValType>, Vec<u32>>,
+
     // Tables in this module which have a funcref element type.
     funcref_tables: Vec<u32>,
 
@@ -604,6 +614,9 @@ enum ControlKind {
     Block,
     If,
     Loop,
+    Try,
+    Catch,
+    CatchAll,
 }
 
 enum Float {
@@ -623,6 +636,13 @@ impl CodeBuilderAllocations {
                     .or_insert(Vec::new())
                     .push(i as u32);
             }
+        }
+
+        let mut tags = BTreeMap::new();
+        for (idx, tag_type) in module.tags() {
+            tags.entry(tag_type.func_type.params.clone())
+                .or_insert(Vec::new())
+                .push(idx);
         }
 
         let mut functions = BTreeMap::new();
@@ -677,6 +697,7 @@ impl CodeBuilderAllocations {
             operands: Vec::with_capacity(16),
             options: Vec::with_capacity(NUM_OPTIONS),
             functions,
+            tags,
             mutable_globals,
             funcref_tables,
             referenced_functions: referenced_functions.into_iter().collect(),
@@ -1069,6 +1090,94 @@ fn block(u: &mut Unstructured, module: &Module, builder: &mut CodeBuilder) -> Re
     Ok(Instruction::Block(block_ty))
 }
 
+#[inline]
+fn try_valid(module: &Module, _: &mut CodeBuilder) -> bool {
+    module.config.exceptions_enabled()
+}
+
+fn r#try(u: &mut Unstructured, module: &Module, builder: &mut CodeBuilder) -> Result<Instruction> {
+    let block_ty = builder.arbitrary_block_type(u, module)?;
+    let (params, results) = block_ty.params_results(module);
+    let height = builder.allocs.operands.len() - params.len();
+    builder.allocs.controls.push(Control {
+        kind: ControlKind::Try,
+        params,
+        results,
+        height,
+    });
+    Ok(Instruction::Try(block_ty))
+}
+
+#[inline]
+fn delegate_valid(module: &Module, builder: &mut CodeBuilder) -> bool {
+    let control_kind = builder.allocs.controls.last().unwrap().kind;
+    // delegate is only valid if end could be used in a try control frame
+    module.config.exceptions_enabled()
+        && control_kind == ControlKind::Try
+        && end_valid(module, builder)
+}
+
+fn delegate(u: &mut Unstructured, _: &Module, builder: &mut CodeBuilder) -> Result<Instruction> {
+    // There will always be at least the function's return frame and try
+    // control frame if we are emitting delegate
+    let n = builder.allocs.controls.iter().count();
+    debug_assert!(n >= 2);
+    // Delegate must target an outer control from the try block, and is
+    // encoded with relative depth from the outer control
+    let target_relative_from_last = u.int_in_range(1..=n - 1)?;
+    let target_relative_from_outer = target_relative_from_last - 1;
+    // Delegate ends the try block
+    builder.allocs.controls.pop();
+    Ok(Instruction::Delegate(target_relative_from_outer as u32))
+}
+
+#[inline]
+fn catch_valid(module: &Module, builder: &mut CodeBuilder) -> bool {
+    let control_kind = builder.allocs.controls.last().unwrap().kind;
+    // catch is only valid if end could be used in a try or catch (not
+    // catch_all) control frame. There must also be a tag that we can catch.
+    module.config.exceptions_enabled()
+        && (control_kind == ControlKind::Try || control_kind == ControlKind::Catch)
+        && end_valid(module, builder)
+        && module.tags.len() > 0
+}
+
+fn catch(u: &mut Unstructured, module: &Module, builder: &mut CodeBuilder) -> Result<Instruction> {
+    let tag_idx = u.int_in_range(0..=(module.tags.len() - 1))?;
+    let tag_type = &module.tags[tag_idx];
+    let control = builder.allocs.controls.pop().unwrap();
+    // Pop the results for the previous try or catch
+    builder.pop_operands(&control.results);
+    // Push the params of the tag we're catching
+    builder.push_operands(&tag_type.func_type.params);
+    builder.allocs.controls.push(Control {
+        kind: ControlKind::Catch,
+        ..control
+    });
+    Ok(Instruction::Catch(tag_idx as u32))
+}
+
+#[inline]
+fn catch_all_valid(module: &Module, builder: &mut CodeBuilder) -> bool {
+    let control_kind = builder.allocs.controls.last().unwrap().kind;
+    // catch_all is only valid if end could be used in a try or catch (not
+    // catch_all) control frame.
+    module.config.exceptions_enabled()
+        && (control_kind == ControlKind::Try || control_kind == ControlKind::Catch)
+        && end_valid(module, builder)
+}
+
+fn catch_all(_: &mut Unstructured, _: &Module, builder: &mut CodeBuilder) -> Result<Instruction> {
+    let control = builder.allocs.controls.pop().unwrap();
+    // Pop the results for the previous try or catch
+    builder.pop_operands(&control.results);
+    builder.allocs.controls.push(Control {
+        kind: ControlKind::CatchAll,
+        ..control
+    });
+    Ok(Instruction::CatchAll)
+}
+
 fn r#loop(u: &mut Unstructured, module: &Module, builder: &mut CodeBuilder) -> Result<Instruction> {
     let block_ty = builder.arbitrary_block_type(u, module)?;
     let (params, results) = block_ty.params_results(module);
@@ -1330,6 +1439,65 @@ fn call_indirect(
         ty: *type_idx as u32,
         table,
     })
+}
+
+#[inline]
+fn throw_valid(module: &Module, builder: &mut CodeBuilder) -> bool {
+    module.config.exceptions_enabled()
+        && builder
+            .allocs
+            .tags
+            .keys()
+            .any(|k| builder.types_on_stack(k))
+}
+
+fn throw(u: &mut Unstructured, module: &Module, builder: &mut CodeBuilder) -> Result<Instruction> {
+    let candidates = builder
+        .allocs
+        .tags
+        .iter()
+        .filter(|(k, _)| builder.types_on_stack(k))
+        .flat_map(|(_, v)| v.iter().copied())
+        .collect::<Vec<_>>();
+    assert!(candidates.len() > 0);
+    let i = u.int_in_range(0..=candidates.len() - 1)?;
+    let (tag_idx, tag_type) = module.tags().nth(candidates[i] as usize).unwrap();
+    // Tags have no results, throwing cannot return
+    assert!(tag_type.func_type.results.len() == 0);
+    builder.pop_operands(&tag_type.func_type.params);
+    Ok(Instruction::Throw(tag_idx as u32))
+}
+
+#[inline]
+fn rethrow_valid(module: &Module, builder: &mut CodeBuilder) -> bool {
+    // There must be a catch or catch_all control on the stack
+    module.config.exceptions_enabled()
+        && builder
+            .allocs
+            .controls
+            .iter()
+            .any(|l| l.kind == ControlKind::Catch || l.kind == ControlKind::CatchAll)
+}
+
+fn rethrow(u: &mut Unstructured, _: &Module, builder: &mut CodeBuilder) -> Result<Instruction> {
+    let n = builder
+        .allocs
+        .controls
+        .iter()
+        .filter(|l| l.kind == ControlKind::Catch || l.kind == ControlKind::CatchAll)
+        .count();
+    debug_assert!(n > 0);
+    let i = u.int_in_range(0..=n - 1)?;
+    let (target, _) = builder
+        .allocs
+        .controls
+        .iter()
+        .rev()
+        .enumerate()
+        .filter(|(_, l)| l.kind == ControlKind::Catch || l.kind == ControlKind::CatchAll)
+        .nth(i)
+        .unwrap();
+    Ok(Instruction::Rethrow(target as u32))
 }
 
 #[inline]

--- a/crates/wasm-smith/src/config.rs
+++ b/crates/wasm-smith/src/config.rs
@@ -48,6 +48,16 @@ pub trait Config: 'static + std::fmt::Debug {
         100
     }
 
+    /// The minimum number of tags to generate. Defaults to 0.
+    fn min_tags(&self) -> usize {
+        0
+    }
+
+    /// The maximum number of tags to generate. Defaults to 100.
+    fn max_tags(&self) -> usize {
+        100
+    }
+
     /// The minimum number of functions to generate. Defaults to 0.  This
     /// includes imported functions.
     fn min_funcs(&self) -> usize {
@@ -238,8 +248,14 @@ pub trait Config: 'static + std::fmt::Debug {
     }
 
     /// Determines whether the SIMD proposal is enabled for
-    /// generating insructions. Defaults to `true`.
+    /// generating insructions. Defaults to `false`.
     fn simd_enabled(&self) -> bool {
+        false
+    }
+
+    /// Determines whether the exception-handling proposal is enabled for
+    /// generating insructions. Defaults to `false`.
+    fn exceptions_enabled(&self) -> bool {
         false
     }
 
@@ -323,6 +339,7 @@ pub struct SwarmConfig {
     // These fields are configured via `Arbitrary`
     pub max_types: usize,
     pub max_imports: usize,
+    pub max_tags: usize,
     pub max_funcs: usize,
     pub max_globals: usize,
     pub max_exports: usize,
@@ -345,6 +362,7 @@ pub struct SwarmConfig {
     pub memory64_enabled: bool,
     pub min_types: usize,
     pub min_imports: usize,
+    pub min_tags: usize,
     pub min_funcs: usize,
     pub min_globals: usize,
     pub min_exports: usize,
@@ -358,6 +376,7 @@ pub struct SwarmConfig {
     pub memory_offset_choices: (u32, u32, u32),
     pub memory_max_size_required: bool,
     pub simd_enabled: bool,
+    pub exceptions_enabled: bool,
     pub allow_start_export: bool,
     pub max_type_size: u32,
     pub canonicalize_nans: bool,
@@ -373,6 +392,7 @@ impl<'a> Arbitrary<'a> for SwarmConfig {
         Ok(SwarmConfig {
             max_types: u.int_in_range(0..=MAX_MAXIMUM)?,
             max_imports: u.int_in_range(0..=MAX_MAXIMUM)?,
+            max_tags: u.int_in_range(0..=MAX_MAXIMUM)?,
             max_funcs: u.int_in_range(0..=MAX_MAXIMUM)?,
             max_globals: u.int_in_range(0..=MAX_MAXIMUM)?,
             max_exports: u.int_in_range(0..=MAX_MAXIMUM)?,
@@ -394,6 +414,7 @@ impl<'a> Arbitrary<'a> for SwarmConfig {
             // implemented yet so they're turned off by default.
             min_types: 0,
             min_imports: 0,
+            min_tags: 0,
             min_funcs: 0,
             min_globals: 0,
             min_exports: 0,
@@ -408,6 +429,7 @@ impl<'a> Arbitrary<'a> for SwarmConfig {
             memory_offset_choices: (75, 24, 1),
             allow_start_export: true,
             simd_enabled: false,
+            exceptions_enabled: false,
             memory64_enabled: false,
             max_type_size: 1000,
             module_linking_enabled: false,
@@ -543,6 +565,10 @@ impl Config for SwarmConfig {
 
     fn simd_enabled(&self) -> bool {
         self.simd_enabled
+    }
+
+    fn exceptions_enabled(&self) -> bool {
+        self.exceptions_enabled
     }
 
     fn allow_start_export(&self) -> bool {

--- a/crates/wasm-smith/src/lib.rs
+++ b/crates/wasm-smith/src/lib.rs
@@ -145,6 +145,10 @@ pub struct Module {
     /// Number of items aliased into this module.
     num_aliases: usize,
 
+    /// The number of tags defined in this module (not imported or
+    /// aliased).
+    num_defined_tags: usize,
+
     /// The number of functions defined in this module (not imported or
     /// aliased).
     num_defined_funcs: usize,
@@ -160,6 +164,10 @@ pub struct Module {
     /// The indexes and initialization expressions of globals defined in this
     /// module.
     defined_globals: Vec<(u32, Instruction)>,
+
+    /// All tags available to this module, sorted by their index. The list
+    /// entry is the type of each tag.
+    tags: Vec<TagType>,
 
     /// All functions available to this module, sorted by their index. The list
     /// entry points to the index in this module where the function type is
@@ -249,10 +257,12 @@ impl Module {
             instance_types: Vec::new(),
             num_imports: 0,
             num_aliases: 0,
+            num_defined_tags: 0,
             num_defined_funcs: 0,
             num_defined_tables: 0,
             num_defined_memories: 0,
             defined_globals: Vec::new(),
+            tags: Vec::new(),
             funcs: Vec::new(),
             tables: Vec::new(),
             globals: Vec::new(),
@@ -346,6 +356,7 @@ enum EntityType {
     Global(GlobalType),
     Table(TableType),
     Memory(MemoryType),
+    Tag(TagType),
     Func(u32, Rc<FuncType>),
     Instance(u32, Rc<InstanceType>),
     Module(u32, Rc<ModuleType>),
@@ -383,6 +394,12 @@ struct GlobalType {
 }
 
 #[derive(Clone, Debug)]
+struct TagType {
+    func_type_idx: u32,
+    func_type: Rc<FuncType>,
+}
+
+#[derive(Clone, Debug)]
 enum Alias {
     InstanceExport {
         instance: u32,
@@ -411,6 +428,7 @@ enum ItemKind {
     Table,
     Memory,
     Global,
+    Tag,
     Instance,
     Module,
 }
@@ -421,6 +439,7 @@ enum Export {
     Table(u32),
     Memory(u32),
     Global(u32),
+    Tag(u32),
     Instance(u32),
     Module(u32),
 }
@@ -498,6 +517,10 @@ enum Instruction {
     Block(BlockType),
     Loop(BlockType),
     If(BlockType),
+    Try(BlockType),
+    Delegate(u32),
+    Catch(u32),
+    CatchAll,
     Else,
     End,
     Br(u32),
@@ -506,6 +529,8 @@ enum Instruction {
     Return,
     Call(u32),
     CallIndirect { ty: u32, table: u32 },
+    Throw(u32),
+    Rethrow(u32),
 
     // Parametric instructions.
     Drop,
@@ -971,6 +996,7 @@ impl Module {
             self.valtypes.push(ValType::FuncRef);
         }
         self.arbitrary_initial_sections(u)?;
+        self.arbitrary_tags(u)?;
         self.arbitrary_funcs(u)?;
         self.arbitrary_tables(u)?;
         self.arbitrary_memories(u)?;
@@ -1203,6 +1229,15 @@ impl Module {
                 Ok(EntityType::Func(idx, ty.clone()))
             });
         }
+        if self.config.exceptions_enabled()
+            && entities.tags < self.config.max_tags()
+            && self.has_tag_func_types()
+        {
+            choices.push(|u, m, e| {
+                e.tags += 1;
+                Ok(EntityType::Tag(m.arbitrary_tag_type(u)?))
+            });
+        }
         if entities.instances < self.config.max_instances() && self.instance_types.len() > 0 {
             choices.push(|u, m, e| {
                 e.instances += 1;
@@ -1220,6 +1255,12 @@ impl Module {
             });
         }
         u.choose(&choices)?(u, self, entities)
+    }
+
+    fn can_add_local_or_import_tag(&self) -> bool {
+        self.config.exceptions_enabled()
+            && self.has_tag_func_types()
+            && self.tags.len() < self.config.max_tags()
     }
 
     fn can_add_local_or_import_func(&self) -> bool {
@@ -1257,6 +1298,12 @@ impl Module {
         let mut imports = Vec::new();
         arbitrary_loop(u, min, self.config.max_imports() - self.num_imports, |u| {
             choices.clear();
+            if self.can_add_local_or_import_tag() {
+                choices.push(|u, m| {
+                    let ty = m.arbitrary_tag_type(u)?;
+                    Ok(EntityType::Tag(ty))
+                });
+            }
             if self.can_add_local_or_import_func() {
                 choices.push(|u, m| {
                     let idx = *u.choose(&m.func_types)?;
@@ -1336,6 +1383,7 @@ impl Module {
             // we've inserted the implicit instance, then we push the typed item
             // into the appropriate namespace.
             match &ty {
+                EntityType::Tag(ty) => self.tags.push(ty.clone()),
                 EntityType::Func(idx, ty) => self.funcs.push((Some(*idx), ty.clone())),
                 EntityType::Global(ty) => self.globals.push(ty.clone()),
                 EntityType::Table(ty) => self.tables.push(ty.clone()),
@@ -1418,6 +1466,13 @@ impl Module {
                                 _ => unreachable!(),
                             };
                             self.funcs.push((Some(i), ty.clone()));
+                        }
+                        ItemKind::Tag => {
+                            let ty = match &ty.exports[name] {
+                                EntityType::Tag(t) => t,
+                                _ => unreachable!(),
+                            };
+                            self.tags.push(ty.clone());
                         }
                         ItemKind::Module => {
                             let ty = match &ty.exports[name] {
@@ -1582,6 +1637,7 @@ impl Module {
                 let (_idx, ty) = &self.funcs[idx as usize];
                 EntityType::Func(u32::max_value(), ty.clone())
             }
+            Export::Tag(idx) => EntityType::Tag(self.tags[idx as usize].clone()),
             Export::Module(idx) => {
                 EntityType::Module(u32::max_value(), self.modules[idx as usize].clone())
             }
@@ -1631,11 +1687,29 @@ impl Module {
         panic!("looked up an instance type with the wrong index")
     }
 
+    fn tags<'a>(&'a self) -> impl Iterator<Item = (u32, &'a TagType)> + 'a {
+        self.tags
+            .iter()
+            .enumerate()
+            .map(move |(i, ty)| (i as u32, ty))
+    }
+
     fn funcs<'a>(&'a self) -> impl Iterator<Item = (u32, &'a Rc<FuncType>)> + 'a {
         self.funcs
             .iter()
             .enumerate()
             .map(move |(i, (_, ty))| (i as u32, ty))
+    }
+
+    fn has_tag_func_types(&self) -> bool {
+        self.tag_func_types().next().is_some()
+    }
+
+    fn tag_func_types<'a>(&'a self) -> impl Iterator<Item = u32> + 'a {
+        self.func_types
+            .iter()
+            .copied()
+            .filter(move |i| self.func_type(*i).results.len() == 0)
     }
 
     fn arbitrary_valtype(&self, u: &mut Unstructured) -> Result<ValType> {
@@ -1662,6 +1736,31 @@ impl Module {
             },
             minimum,
             maximum,
+        })
+    }
+
+    fn arbitrary_tag_type(&self, u: &mut Unstructured) -> Result<TagType> {
+        let candidate_func_types = self.tag_func_types().collect::<Vec<_>>();
+        let max = candidate_func_types.len() - 1;
+        let ty = candidate_func_types[u.int_in_range(0..=max)?];
+        Ok(TagType {
+            func_type_idx: ty,
+            func_type: self.func_type(ty).clone(),
+        })
+    }
+
+    fn arbitrary_tags(&mut self, u: &mut Unstructured) -> Result<()> {
+        if !self.config.exceptions_enabled() || self.has_tag_func_types() {
+            return Ok(());
+        }
+
+        arbitrary_loop(u, self.config.min_tags(), self.config.max_tags(), |u| {
+            if !self.can_add_local_or_import_tag() {
+                return Ok(false);
+            }
+            self.tags.push(self.arbitrary_tag_type(u)?);
+            self.num_defined_tags += 1;
+            Ok(true)
         })
     }
 
@@ -2164,6 +2263,13 @@ impl Module {
     fn subtypes(&self, skip: &Entities, expected: &EntityType) -> Vec<Export> {
         let mut ret = Vec::new();
         match expected {
+            EntityType::Tag(expected) => {
+                for (i, actual) in self.tags.iter().enumerate().skip(skip.tags) {
+                    if self.is_subtype_tag(actual, expected) {
+                        ret.push(Export::Tag(i as u32));
+                    }
+                }
+            }
             EntityType::Global(expected) => {
                 for (i, actual) in self.globals.iter().enumerate().skip(skip.globals) {
                     if self.is_subtype_global(actual, expected) {
@@ -2213,6 +2319,10 @@ impl Module {
     // Returns whether `a` is a subtype of `b`.
     fn is_subtype(&self, a: &EntityType, b: &EntityType) -> bool {
         match a {
+            EntityType::Tag(a) => match b {
+                EntityType::Tag(b) => self.is_subtype_tag(a, b),
+                _ => false,
+            },
             EntityType::Global(a) => match b {
                 EntityType::Global(b) => self.is_subtype_global(a, b),
                 _ => false,
@@ -2238,6 +2348,11 @@ impl Module {
                 _ => false,
             },
         }
+    }
+
+    // TODO: no published exception-handling spec
+    fn is_subtype_tag(&self, a: &TagType, b: &TagType) -> bool {
+        a.func_type == b.func_type
     }
 
     // https://webassembly.github.io/spec/core/exec/modules.html#globals
@@ -2572,7 +2687,10 @@ fn arbitrary_vec_u8(u: &mut Unstructured) -> Result<Vec<u8>> {
 impl EntityType {
     fn size(&self) -> u32 {
         match self {
-            EntityType::Global(_) | EntityType::Table(_) | EntityType::Memory(_) => 1,
+            EntityType::Tag(_)
+            | EntityType::Global(_)
+            | EntityType::Table(_)
+            | EntityType::Memory(_) => 1,
             EntityType::Func(_, ty) => 1 + (ty.params.len() + ty.results.len()) as u32,
             EntityType::Instance(_, ty) => ty.type_size,
             EntityType::Module(_, ty) => ty.type_size,
@@ -2611,6 +2729,13 @@ impl AvailableAliases {
             let instance = instance as u32;
             for (name, ty) in ty.exports.iter() {
                 match ty {
+                    EntityType::Tag(_) => {
+                        self.aliases.push(Alias::InstanceExport {
+                            instance,
+                            kind: ItemKind::Tag,
+                            name: name.clone(),
+                        });
+                    }
                     EntityType::Global(_) => {
                         self.aliases.push(Alias::InstanceExport {
                             instance,
@@ -2693,6 +2818,10 @@ impl AvailableAliases {
                 ..
             } => module.funcs.len() < module.config.max_funcs(),
             Alias::InstanceExport {
+                kind: ItemKind::Tag,
+                ..
+            } => module.tags.len() < module.config.max_tags(),
+            Alias::InstanceExport {
                 kind: ItemKind::Memory,
                 ..
             } => module.memories.len() < module.config.max_memories(),
@@ -2762,6 +2891,7 @@ impl AvailableInstantiations {
             memories: module.memories.len(),
             tables: module.tables.len(),
             funcs: module.funcs.len(),
+            tags: module.tags.len(),
             modules: module.modules.len(),
             instances: module.instances.len(),
         };
@@ -2814,6 +2944,7 @@ struct Entities {
     memories: usize,
     tables: usize,
     funcs: usize,
+    tags: usize,
     modules: usize,
     instances: usize,
 }

--- a/crates/wasm-smith/src/lib.rs
+++ b/crates/wasm-smith/src/lib.rs
@@ -1750,7 +1750,7 @@ impl Module {
     }
 
     fn arbitrary_tags(&mut self, u: &mut Unstructured) -> Result<()> {
-        if !self.config.exceptions_enabled() || self.has_tag_func_types() {
+        if !self.config.exceptions_enabled() || !self.has_tag_func_types() {
             return Ok(());
         }
 

--- a/crates/wasm-smith/tests/tests.rs
+++ b/crates/wasm-smith/tests/tests.rs
@@ -11,6 +11,7 @@ fn wasm_features() -> WasmFeatures {
         reference_types: true,
         simd: true,
         memory64: true,
+        exceptions: true,
         ..WasmFeatures::default()
     }
 }

--- a/crates/wasmparser/src/operators_validator.rs
+++ b/crates/wasmparser/src/operators_validator.rs
@@ -643,14 +643,8 @@ impl OperatorValidator {
                     bail_op_err!("delegate found outside of an `try` block");
                 }
                 // This operation is not a jump, but we need to check the
-                // depth for validity and that it targets a `try`.
-                let (_, kind) = self.jump(relative_depth)?;
-                if kind != FrameKind::Try
-                    && (kind != FrameKind::Block
-                        || self.control.len() != relative_depth as usize + 1)
-                {
-                    bail_op_err!("must delegate to a try block or caller");
-                }
+                // depth for validity
+                let _ = self.jump(relative_depth)?;
                 for ty in results(frame.block_type, resources)? {
                     self.push_operand(ty)?;
                 }

--- a/fuzz/fuzz_targets/validate-valid-module.rs
+++ b/fuzz/fuzz_targets/validate-valid-module.rs
@@ -21,6 +21,7 @@ fuzz_target!(|m: &[u8]| {
         module_linking: config.module_linking_enabled,
         simd: config.simd_enabled,
         memory64: config.memory64_enabled,
+        exceptions: config.exceptions_enabled,
         ..wasmparser::WasmFeatures::default()
     });
     if let Err(e) = validator.validate_all(&bytes) {

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -14,6 +14,7 @@ pub fn generate_valid_module(
     config.simd_enabled = u.arbitrary()?;
     config.module_linking_enabled = u.arbitrary()?;
     config.memory64_enabled = u.arbitrary()?;
+    config.exceptions_enabled = u.arbitrary()?;
     config.canonicalize_nans = u.arbitrary()?;
 
     configure(&mut config, &mut u)?;

--- a/src/bin/wasm-smith.rs
+++ b/src/bin/wasm-smith.rs
@@ -88,6 +88,10 @@ struct Config {
     min_imports: Option<usize>,
     #[structopt(long = "max-imports")]
     max_imports: Option<usize>,
+    #[structopt(long = "min-tags")]
+    min_tags: Option<usize>,
+    #[structopt(long = "max-tags")]
+    max_tags: Option<usize>,
     #[structopt(long = "min-funcs")]
     min_funcs: Option<usize>,
     #[structopt(long = "max-funcs")]
@@ -137,6 +141,9 @@ struct Config {
     #[structopt(long = "simd")]
     #[serde(rename = "simd")]
     simd_enabled: Option<bool>,
+    #[structopt(long = "exception-handling")]
+    #[serde(rename = "exception-handling")]
+    exceptions_enabled: Option<bool>,
     #[structopt(long = "module-linking")]
     #[serde(rename = "module-linking")]
     module_linking_enabled: Option<bool>,
@@ -254,6 +261,8 @@ impl wasm_smith::Config for CliAndJsonConfig {
         (max_types, usize, 100),
         (min_imports, usize, 0),
         (max_imports, usize, 100),
+        (min_tags, usize, 0),
+        (max_tags, usize, 100),
         (min_funcs, usize, 0),
         (max_funcs, usize, 100),
         (min_globals, usize, 0),
@@ -277,6 +286,7 @@ impl wasm_smith::Config for CliAndJsonConfig {
         (reference_types_enabled, bool, false),
         (memory64_enabled, bool, false),
         (simd_enabled, bool, false),
+        (exceptions_enabled, bool, false),
         (module_linking_enabled, bool, false),
         (allow_start_export, bool, true),
         (max_aliases, usize, 1000),


### PR DESCRIPTION
These commits add support to wasm-smith for the exception-handling proposal. I've manually tested this using `wasm-smith/tests/tests.rs` with the feature enabled (it defaults off) and can confirm it generates exception-handling code and also passes.