### PR TITLE
Add an exception-handling argument to wasm-validate

### DIFF
--- a/src/bin/wasm-validate-rs.rs
+++ b/src/bin/wasm-validate-rs.rs
@@ -29,6 +29,11 @@ const FEATURES: &[(&str, &str, fn(&mut WasmFeatures) -> &mut bool)] = &[
     ("multi-memory", "wasm multi-memory feature", |f| {
         &mut f.multi_memory
     }),
+    (
+        "exception-handling",
+        "wasm exception-handling feature",
+        |f| &mut f.exceptions,
+    ),
     ("memory64", "wasm memory64 feature", |f| &mut f.memory64),
 ];
 


### PR DESCRIPTION
Exposes the exception handling feature via the CLI to play around with
locally.