### PR TITLE
Define a fuzz target for `wasm-mutate`

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,6 +12,7 @@ env_logger = "0.8"
 libfuzzer-sys = "0.4.0"
 log = "0.4"
 tempfile = "3.0"
+wasm-mutate = { path = "../crates/wasm-mutate" }
 wasm-smith = { path = "../crates/wasm-smith" }
 wasmparser = { path = "../crates/wasmparser" }
 wasmprinter = { path = "../crates/wasmprinter" }
@@ -69,5 +70,11 @@ doc = false
 [[bin]]
 name = "roundtrip-valid-module"
 path = "fuzz_targets/roundtrip-valid-module.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "mutate"
+path = "fuzz_targets/mutate.rs"
 test = false
 doc = false

--- a/fuzz/fuzz_targets/mutate.rs
+++ b/fuzz/fuzz_targets/mutate.rs
@@ -1,0 +1,38 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|inputs: (wasm_smith::Module, u64)| {
+    let _ = env_logger::try_init();
+
+    let (wasm, seed) = inputs;
+    log::debug!("seed = {}", seed);
+
+    let wasm = wasm.to_bytes();
+    if log::log_enabled!(log::Level::Debug) {
+        log::debug!("writing input Wasm to `test.wasm`");
+        std::fs::write("test.wasm", &wasm).expect("should write `test.wasm` okay");
+        log::debug!("writing wat disassembly to `test.wat`");
+        let wat = wasmprinter::print_bytes(&wasm).expect("should disassemble Wasm okay");
+        std::fs::write("test.wat", &wat).expect("should write `test.wat` okay");
+    }
+
+    let mutated_wasm = wasm_mutate::WasmMutate::default()
+        .seed(seed)
+        .preserve_semantics(true)
+        .run(&wasm);
+    let mutated_wasm = match mutated_wasm {
+        Ok(w) => w,
+        Err(e) => {
+            log::debug!("failed to mutate the Wasm: {:?}", e);
+            return;
+        }
+    };
+
+    let validation_result = wasmparser::validate(&mutated_wasm);
+    log::debug!("validation result = {:?}", validation_result);
+    assert!(
+        validation_result.is_ok(),
+        "`wasm-mutate` should always produce a valid Wasm file"
+    );
+});


### PR DESCRIPTION
Asserts that if `wasm-mutate` successfully mutates a valid Wasm module, then the
resulting mutated Wasm module should also be valid.

Does not (yet) exercise that the mutated Wasm module has equivalent semantics to
the original module.