### PR TITLE
FIX: rename export mutator fail because of duplicated entry bug

### DIFF
--- a/crates/wasm-mutate/src/lib.rs
+++ b/crates/wasm-mutate/src/lib.rs
@@ -7,7 +7,7 @@
 //! tool. `wasm-mutate` can serve as a custom mutator for mutation-based
 //! fuzzing.
 #![cfg_attr(not(feature = "structopt"), deny(missing_docs))]
-use std::sync::Arc;
+use std::{collections::HashSet, sync::Arc};
 
 use module::TypeInfo;
 use mutators::Mutator;
@@ -127,7 +127,7 @@ pub struct ModuleInfo<'a> {
     // The following fields are offsets inside the `raw_sections` field.
     // The main idea is to maintain the order of the sections in the input Wasm.
     exports: Option<usize>,
-    export_names: Vec<&'a str>,
+    export_names: HashSet<String>,
 
     types: Option<usize>,
     imports: Option<usize>,
@@ -324,7 +324,7 @@ impl WasmMutate {
 
                     for _ in 0..reader.get_count() {
                         let entry = reader.read()?;
-                        info.export_names.push(entry.field)
+                        info.export_names.insert(entry.field.into());
                     }
 
                     info.section(SectionId::Export.into(), reader.range(), input_wasm);

--- a/crates/wasm-mutate/src/mutators/rename_export.rs
+++ b/crates/wasm-mutate/src/mutators/rename_export.rs
@@ -4,19 +4,23 @@ use rand::prelude::SmallRng;
 use rand::{Rng, RngCore};
 use wasm_encoder::{CodeSection, Export, ExportSection, Function, Instruction, Module};
 use wasmparser::{CodeSectionReader, ExportSectionReader};
+
+/// RenameExportMutator generates a random renaming of prexisting exports.
+/// The export entry is selected randmonly and then a new `field` name is generated/
 pub struct RenameExportMutator {
+    /// The maximum length of the generated export entry 
     pub max_name_size: u32,
 }
 
 impl RenameExportMutator {
     // Copied and transformed from wasm-smith name generation
-    fn limited_string(&self, rnd: &mut SmallRng) -> String {
+    fn limited_string(&self, rnd: &mut SmallRng, info: &ModuleInfo) -> String {
         let size = rnd.gen_range(1, self.max_name_size);
         let size = std::cmp::min(size, self.max_name_size);
         let mut str = vec![0u8; size as usize];
         rnd.fill_bytes(&mut str);
 
-        match std::str::from_utf8(&str) {
+        let s = match std::str::from_utf8(&str) {
             Ok(s) => String::from(s),
             Err(e) => {
                 let i = e.valid_up_to();
@@ -27,6 +31,12 @@ impl RenameExportMutator {
                 };
                 String::from(s)
             }
+        };
+
+        if info.export_names.contains(&s.as_str()) {
+            return self.limited_string(rnd, info);
+        } else {
+            s
         }
     }
 }
@@ -50,7 +60,7 @@ impl Mutator for RenameExportMutator {
                 // otherwise bypass
                 String::from(export.field)
             } else {
-                let new_name = self.limited_string(rnd);
+                let new_name = self.limited_string(rnd, info);
                 log::debug!("Renaming export {:?} by {:?}", export, new_name);
                 new_name
             };

--- a/crates/wasm-mutate/src/mutators/rename_export.rs
+++ b/crates/wasm-mutate/src/mutators/rename_export.rs
@@ -14,14 +14,25 @@ pub struct RenameExportMutator {
 
 impl RenameExportMutator {
     // Copied and transformed from wasm-smith name generation
-    fn limited_string(&self, rnd: &mut SmallRng, info: &ModuleInfo, max_name_size: u32) -> String {
+    fn limited_string(
+        &self,
+        config: &WasmMutate,
+        rnd: &mut SmallRng,
+        info: &ModuleInfo,
+        max_name_size: u32,
+        result: &mut String,
+    ) -> crate::Result<()> {
         let size = rnd.gen_range(1, max_name_size);
-        let size = std::cmp::min(size, max_name_size);
         let mut str = vec![0u8; size as usize];
-        rnd.fill_bytes(&mut str);
 
-        let mut s = match std::str::from_utf8(&str) {
-            Ok(s) => String::from(s),
+        if let Some(fillfunc) = &config.raw_mutate_func {
+            fillfunc(&mut str)?;
+        } else {
+            rnd.fill_bytes(&mut str);
+        }
+
+        match std::str::from_utf8(&str) {
+            Ok(s) => result.push_str(s),
             Err(e) => {
                 let i = e.valid_up_to();
                 let valid = &str[0..i];
@@ -29,14 +40,14 @@ impl RenameExportMutator {
                     debug_assert!(std::str::from_utf8(valid).is_ok());
                     std::str::from_utf8_unchecked(valid)
                 };
-                String::from(s)
+                result.push_str(s);
             }
         };
         // Add one symbol at a time until it is not contained in the export field names
-        while info.export_names.contains(&s.as_str()) {
-            s.push_str(&self.limited_string(rnd, info, 2));
+        while info.export_names.contains(result) {
+            let _ = &self.limited_string(config, rnd, info, 2, result)?;
         }
-        s
+        Ok(())
     }
 }
 
@@ -52,14 +63,15 @@ impl Mutator for RenameExportMutator {
         let max_exports = reader.get_count() as u64;
         let skip_at = rnd.gen_range(0, max_exports);
 
-        (0..max_exports).for_each(|i| {
+        for i in (0..max_exports) {
             let export = reader.read().unwrap();
 
             let new_name = if skip_at != i {
                 // otherwise bypass
                 String::from(export.field)
             } else {
-                let new_name = self.limited_string(rnd, info, self.max_name_size);
+                let mut new_name = String::default();
+                self.limited_string(config, rnd, info, self.max_name_size, &mut new_name)?;
                 log::debug!("Renaming export {:?} by {:?}", export, new_name);
                 new_name
             };
@@ -87,7 +99,7 @@ impl Mutator for RenameExportMutator {
                     panic!("Unknown export {:?}", export)
                 }
             }
-        });
+        }
         Ok(info.replace_section(info.exports.unwrap(), &exports))
     }
 


### PR DESCRIPTION
CC @fitzgen in https://github.com/bytecodealliance/wasm-tools/pull/349
