### PR TITLE
Third iteration on egg for wasm-mutate integration

### DIFF
--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/analysis.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/analysis.rs
@@ -15,7 +15,7 @@ use egg::{Analysis, EGraph, Id};
 #[derive(Clone, Debug, Default)]
 pub struct PeepholeMutationAnalysis {
     /// Egraph node ID to Stack entry in the minidfg entries
-    /// The Lang eterm is hashed, which means that if the first entrance is the expression to mutated, the eclass data could be maintained by using the 
+    /// The Lang eterm is hashed, which means that if the first entrance is the expression to mutated, the eclass data could be maintained by using the
     /// Hashing of the original eterm
     lang_to_stack_entries: HashMap<Lang, (Id, Vec<usize>)>,
     /// DFG data mapping from the input Wasm basic block
@@ -24,13 +24,10 @@ pub struct PeepholeMutationAnalysis {
 
 impl PeepholeMutationAnalysis {
     /// Returns a new analysis from the given DFG
-    pub fn new(
-        lang_to_stack_entries: HashMap<Lang, (Id, Vec<usize>)>,
-        minidfg: MiniDFG,
-    ) -> Self {
+    pub fn new(lang_to_stack_entries: HashMap<Lang, (Id, Vec<usize>)>, minidfg: MiniDFG) -> Self {
         PeepholeMutationAnalysis {
             lang_to_stack_entries,
-            minidfg
+            minidfg,
         }
     }
 
@@ -43,9 +40,7 @@ impl PeepholeMutationAnalysis {
     pub fn get_stack_entry_from_symbol(&self, symbol: String) -> Option<&StackEntry> {
         self.lang_to_stack_entries
             .get(&Lang::Symbol(symbol.into()))
-            .and_then(|(_, entries)| entries.get(0).and_then(|&x|
-                Some(&self.minidfg.entries[x])
-            ))
+            .and_then(|(_, entries)| entries.get(0).and_then(|&x| Some(&self.minidfg.entries[x])))
     }
     /// Return the parental relations in the DFG
     pub fn get_roots(&self) -> &Vec<i32> {
@@ -57,28 +52,20 @@ impl PeepholeMutationAnalysis {
 pub struct ClassData {
     /// Index to the dfg stack entry
     pub eclass_and_stackentries: (Id, Vec<usize>),
-    
+
     // The eclass can represent several stack entries
     // Every time a new stack entry information is requested
-    current_entry:  usize
+    current_entry: usize,
 }
 
-
 impl ClassData {
-
-    pub fn get_entries_len(&self) -> usize{
-        return self.eclass_and_stackentries.1.len()
-    }
-
     /// Returns the stack enntry that corresponds to this equivalence class.
     /// The method will check if this equivalence class has a stack entry in the DFG of the analysis.
     /// If true the StackEntry is then returned
     pub fn get_next_stack_entry(&self, analysis: &PeepholeMutationAnalysis) -> StackEntry {
         let idx = self.eclass_and_stackentries.1[self.current_entry];
-        //self.current_entry = (self.current_entry + 1)%self.get_entries_len();
-        //let idx = self.eclass_and_stackentries.1[idx];
         analysis.minidfg.entries[idx].clone()
-   }
+    }
 }
 
 impl PartialEq for ClassData {
@@ -94,14 +81,15 @@ impl PartialEq for ClassData {
 impl Analysis<Lang> for PeepholeMutationAnalysis {
     type Data = Option<ClassData>;
 
-    fn make(egraph: &EGraph<Lang, Self>, l: &Lang) -> Self::Data {        
+    fn make(egraph: &EGraph<Lang, Self>, l: &Lang) -> Self::Data {
         // This works beacuase always the first expression is the one constructed from the DFG
         // The node id to stack is consistent then with the order in which this method is call
         //
         if egraph.analysis.lang_to_stack_entries.contains_key(l) {
+            println!("eg {:?} {:?}", l, egraph.analysis.lang_to_stack_entries[&l]);
             Some(ClassData {
-                eclass_and_stackentries: egraph.analysis.lang_to_stack_entries[&l].clone(),// ,
-                current_entry: 0
+                eclass_and_stackentries: egraph.analysis.lang_to_stack_entries[&l].clone(),
+                current_entry: 0,
             })
         } else {
             None
@@ -112,7 +100,5 @@ impl Analysis<Lang> for PeepholeMutationAnalysis {
         egg::merge_if_different(to, to.clone().or(from))
     }
 
-    fn modify(egraph: &mut EGraph<Lang, Self>, id: Id) {
-
-    }
+    fn modify(egraph: &mut EGraph<Lang, Self>, id: Id) {}
 }

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
@@ -15,7 +15,7 @@ define_language! {
         "popcnt" = Popcnt(Id),
         "drop" = Drop,
         // Memory operations
-        "load" = ILoad([Id;1]), // dynamic offset, offset, align mem value
+        "load" = ILoad([Id;4]), // dynamic offset, offset, align mem value
         // TODO add the others
 
         // Custom mutation operations and instructions
@@ -37,5 +37,15 @@ define_language! {
         Num(i64),
         // NB: must be last since variants are parsed in order.
         Symbol(Symbol),
+
+        // Use the following to internally pass arguments and not parsed as number constants
+        // Since variants will be parsed in order, this wont be created directly from `parse`
+        Arg(u64),
+    }
+}
+
+impl Default for Lang {
+    fn default() -> Self {
+        Lang::Undef
     }
 }

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/mod.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/mod.rs
@@ -138,10 +138,12 @@ where
             .children()
             .iter()
             .rev()
-            .map(|id| (eclass, 0, id, 0)) // (root, operant, depth)
+            .map(|id| (0, id, 0)) // (root, operant, depth)
             .collect();
 
-        while let Some((_, parentidx, &node, depth)) = worklist.pop() {
+        // The RecExpr can be built directly here following the following rules
+        // The childrens of a node are before in the array
+        while let Some((parentidx, &node, depth)) = worklist.pop() {
             let node_idx = if depth >= max_depth {
                 // look nearest leaf path, in this case, the best in AST size
                 self.costs[&node].1
@@ -166,7 +168,7 @@ where
                     .children()
                     .iter()
                     .rev()
-                    .map(|id| (operand, operandidx, id, depth + 1)),
+                    .map(|id| (operandidx, id, depth + 1)),
             );
         }
         // Build the tree with the right language constructor


### PR DESCRIPTION
Comments from previous [PR](https://github.com/bytecodealliance/wasm-tools/pull/353) are addressed.

New changes:

- The memarg for mem load operations are included. This will allow us to do the following transformation that expand the offset as a sum of the memory offset operand:
  ```rust
      "load ?x ?offset ?align ?memidx" => "load (add   ?x ?offset) 0 ?align ?memidx"
  ```
