### PR TITLE
Remove some duplication between wasm-smith and wasm-encoder

### DIFF
--- a/crates/wasm-encoder/src/code.rs
+++ b/crates/wasm-encoder/src/code.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::borrow::Cow;
 
 /// An encoder for the code section.
 ///
@@ -124,7 +125,7 @@ impl Function {
     }
 
     /// Write an instruction into this function body.
-    pub fn instruction(&mut self, instruction: Instruction) -> &mut Self {
+    pub fn instruction(&mut self, instruction: &Instruction) -> &mut Self {
         instruction.encode(&mut self.bytes);
         self
     }
@@ -202,7 +203,7 @@ impl BlockType {
 }
 
 /// WebAssembly instructions.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 #[non_exhaustive]
 #[allow(missing_docs, non_camel_case_types)]
 pub enum Instruction<'a> {
@@ -220,7 +221,7 @@ pub enum Instruction<'a> {
     End,
     Br(u32),
     BrIf(u32),
-    BrTable(&'a [u32], u32),
+    BrTable(Cow<'a, [u32]>, u32),
     Return,
     Call(u32),
     CallIndirect { ty: u32, table: u32 },
@@ -727,10 +728,10 @@ impl Instruction<'_> {
                 bytes.push(0x0D);
                 bytes.extend(encoders::u32(l));
             }
-            Instruction::BrTable(ls, l) => {
+            Instruction::BrTable(ref ls, l) => {
                 bytes.push(0x0E);
                 bytes.extend(encoders::u32(u32::try_from(ls.len()).unwrap()));
-                for l in ls {
+                for l in ls.as_ref() {
                     bytes.extend(encoders::u32(*l));
                 }
                 bytes.extend(encoders::u32(l));

--- a/crates/wasm-encoder/src/data.rs
+++ b/crates/wasm-encoder/src/data.rs
@@ -37,7 +37,7 @@ pub struct DataSection {
 }
 
 /// A segment in the data section.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct DataSegment<'a, D> {
     /// This data segment's mode.
     pub mode: DataSegmentMode<'a>,
@@ -46,14 +46,14 @@ pub struct DataSegment<'a, D> {
 }
 
 /// A data segment's mode.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub enum DataSegmentMode<'a> {
     /// An active data segment.
     Active {
         /// The memory this segment applies to.
         memory_index: u32,
         /// The offset where this segment's data is initialized at.
-        offset: Instruction<'a>,
+        offset: &'a Instruction<'a>,
     },
     /// A passive data segment.
     ///
@@ -117,7 +117,7 @@ impl DataSection {
     pub fn active<'a, D>(
         &mut self,
         memory_index: u32,
-        offset: Instruction<'a>,
+        offset: &Instruction<'a>,
         data: D,
     ) -> &mut Self
     where

--- a/crates/wasm-encoder/src/elements.rs
+++ b/crates/wasm-encoder/src/elements.rs
@@ -58,7 +58,7 @@ pub enum Element {
 }
 
 /// An element segment's mode.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub enum ElementMode<'a> {
     /// A passive element segment.
     ///
@@ -76,12 +76,12 @@ pub enum ElementMode<'a> {
         /// reference types proposal.
         table: Option<u32>,
         /// The offset within the table to place this segment.
-        offset: Instruction<'a>,
+        offset: &'a Instruction<'a>,
     },
 }
 
 /// An element segment in the element section.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct ElementSegment<'a> {
     /// The element segment's mode.
     pub mode: ElementMode<'a>,
@@ -179,12 +179,12 @@ impl ElementSection {
     }
 
     /// Define an active element segment.
-    pub fn active<'a>(
+    pub fn active(
         &mut self,
         table_index: Option<u32>,
-        offset: Instruction,
+        offset: &Instruction<'_>,
         element_type: ValType,
-        elements: Elements<'a>,
+        elements: Elements<'_>,
     ) -> &mut Self {
         self.segment(ElementSegment {
             mode: ElementMode::Active {

--- a/crates/wasm-encoder/src/globals.rs
+++ b/crates/wasm-encoder/src/globals.rs
@@ -42,7 +42,7 @@ impl GlobalSection {
     }
 
     /// Define a global.
-    pub fn global(&mut self, global_type: GlobalType, init_expr: Instruction) -> &mut Self {
+    pub fn global(&mut self, global_type: GlobalType, init_expr: &Instruction<'_>) -> &mut Self {
         global_type.encode(&mut self.bytes);
         init_expr.encode(&mut self.bytes);
         Instruction::End.encode(&mut self.bytes);
@@ -71,7 +71,7 @@ impl Section for GlobalSection {
 }
 
 /// A global's type.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct GlobalType {
     /// This global's value type.
     pub val_type: ValType,

--- a/crates/wasm-encoder/src/lib.rs
+++ b/crates/wasm-encoder/src/lib.rs
@@ -234,7 +234,7 @@ impl From<SectionId> for u8 {
 }
 
 /// The type of a value.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 #[repr(u8)]
 pub enum ValType {
     /// The `i32` type.

--- a/crates/wasm-smith/src/encode.rs
+++ b/crates/wasm-smith/src/encode.rs
@@ -43,10 +43,7 @@ impl Module {
         for ty in types {
             match ty {
                 Type::Func(ty) => {
-                    section.function(
-                        ty.params.iter().map(|t| translate_val_type(*t)),
-                        ty.results.iter().map(|t| translate_val_type(*t)),
-                    );
+                    section.function(ty.params.iter().cloned(), ty.results.iter().cloned());
                 }
                 Type::Module(ty) => {
                     section.module(
@@ -92,7 +89,7 @@ impl Module {
                     kind,
                     name,
                 } => {
-                    section.instance_export(*instance, translate_item_kind(kind), name);
+                    section.instance_export(*instance, *kind, name);
                 }
                 Alias::OuterType { depth, index } => {
                     section.outer_type(*depth, *index);
@@ -113,7 +110,7 @@ impl Module {
                 instance
                     .args
                     .iter()
-                    .map(|(name, export)| (name.as_str(), translate_export(export))),
+                    .map(|(name, export)| (name.as_str(), *export)),
             );
         }
         module.section(&section);
@@ -159,7 +156,7 @@ impl Module {
         }
         let mut tables = wasm_encoder::TableSection::new();
         for t in self.tables[self.tables.len() - self.num_defined_tables..].iter() {
-            tables.table(translate_table_type(t));
+            tables.table(*t);
         }
         module.section(&tables);
     }
@@ -170,7 +167,7 @@ impl Module {
         }
         let mut mems = wasm_encoder::MemorySection::new();
         for m in self.memories[self.memories.len() - self.num_defined_memories..].iter() {
-            mems.memory(translate_memory_type(m));
+            mems.memory(*m);
         }
         module.section(&mems);
     }
@@ -182,7 +179,7 @@ impl Module {
         let mut globals = wasm_encoder::GlobalSection::new();
         for (idx, expr) in &self.defined_globals {
             let ty = &self.globals[*idx as usize];
-            globals.global(translate_global_type(ty), translate_instruction(expr));
+            globals.global(*ty, expr);
         }
         module.section(&globals);
     }
@@ -193,7 +190,7 @@ impl Module {
         }
         let mut exports = wasm_encoder::ExportSection::new();
         for (name, export) in &self.exports {
-            exports.export(name, translate_export(export));
+            exports.export(name, *export);
         }
         module.section(&exports);
     }
@@ -211,7 +208,6 @@ impl Module {
         let mut elems = wasm_encoder::ElementSection::new();
         let mut exps = vec![];
         for el in &self.elems {
-            let elem_ty = translate_val_type(el.ty);
             let elements = match &el.items {
                 Elements::Expressions(es) => {
                     exps.clear();
@@ -225,13 +221,13 @@ impl Module {
             };
             match &el.kind {
                 ElementKind::Active { table, offset } => {
-                    elems.active(*table, translate_instruction(offset), elem_ty, elements);
+                    elems.active(*table, offset, el.ty, elements);
                 }
                 ElementKind::Passive => {
-                    elems.passive(elem_ty, elements);
+                    elems.passive(el.ty, elements);
                 }
                 ElementKind::Declared => {
-                    elems.declared(elem_ty, elements);
+                    elems.declared(el.ty, elements);
                 }
             }
         }
@@ -260,14 +256,13 @@ impl Module {
         for c in &self.code {
             // Skip the run-length encoding because it is a little
             // annoying to compute; use a length of one for every local.
-            let mut func =
-                wasm_encoder::Function::new(c.locals.iter().map(|l| (1, translate_val_type(*l))));
+            let mut func = wasm_encoder::Function::new(c.locals.iter().map(|l| (1, *l)));
             match &c.instructions {
                 Instructions::Generated(instrs) => {
                     for instr in instrs {
-                        func.instruction(translate_instruction(instr));
+                        func.instruction(instr);
                     }
-                    func.instruction(wasm_encoder::Instruction::End);
+                    func.instruction(&wasm_encoder::Instruction::End);
                 }
                 Instructions::Arbitrary(body) => {
                     func.raw(body.iter().copied());
@@ -289,11 +284,7 @@ impl Module {
                     memory_index,
                     offset,
                 } => {
-                    data.active(
-                        *memory_index,
-                        translate_instruction(offset),
-                        seg.init.iter().copied(),
-                    );
+                    data.active(*memory_index, offset, seg.init.iter().copied());
                 }
                 DataSegmentKind::Passive => {
                     data.passive(seg.init.iter().copied());
@@ -301,18 +292,6 @@ impl Module {
             }
         }
         module.section(&data);
-    }
-}
-
-fn translate_val_type(ty: ValType) -> wasm_encoder::ValType {
-    match ty {
-        ValType::I32 => wasm_encoder::ValType::I32,
-        ValType::I64 => wasm_encoder::ValType::I64,
-        ValType::F32 => wasm_encoder::ValType::F32,
-        ValType::F64 => wasm_encoder::ValType::F64,
-        ValType::V128 => wasm_encoder::ValType::V128,
-        ValType::FuncRef => wasm_encoder::ValType::FuncRef,
-        ValType::ExternRef => wasm_encoder::ValType::ExternRef,
     }
 }
 
@@ -325,600 +304,8 @@ fn translate_entity_type(ty: &EntityType) -> wasm_encoder::EntityType {
         EntityType::Func(f, _) => wasm_encoder::EntityType::Function(*f),
         EntityType::Instance(i, _) => wasm_encoder::EntityType::Instance(*i),
         EntityType::Module(i, _) => wasm_encoder::EntityType::Module(*i),
-        EntityType::Table(ty) => translate_table_type(ty).into(),
-        EntityType::Memory(m) => translate_memory_type(m).into(),
-        EntityType::Global(g) => translate_global_type(g).into(),
-    }
-}
-
-fn translate_table_type(ty: &TableType) -> wasm_encoder::TableType {
-    wasm_encoder::TableType {
-        element_type: translate_val_type(ty.elem_ty),
-        minimum: ty.minimum,
-        maximum: ty.maximum,
-    }
-}
-
-fn translate_memory_type(ty: &MemoryType) -> wasm_encoder::MemoryType {
-    wasm_encoder::MemoryType {
-        minimum: ty.minimum,
-        maximum: ty.maximum,
-        memory64: ty.memory64,
-    }
-}
-
-fn translate_global_type(ty: &GlobalType) -> wasm_encoder::GlobalType {
-    wasm_encoder::GlobalType {
-        val_type: translate_val_type(ty.val_type),
-        mutable: ty.mutable,
-    }
-}
-
-fn translate_block_type(ty: BlockType) -> wasm_encoder::BlockType {
-    match ty {
-        BlockType::Empty => wasm_encoder::BlockType::Empty,
-        BlockType::Result(ty) => wasm_encoder::BlockType::Result(translate_val_type(ty)),
-        BlockType::FuncType(f) => wasm_encoder::BlockType::FunctionType(f),
-    }
-}
-
-fn translate_mem_arg(m: MemArg) -> wasm_encoder::MemArg {
-    wasm_encoder::MemArg {
-        offset: m.offset,
-        align: m.align,
-        memory_index: m.memory_index,
-    }
-}
-
-fn translate_item_kind(kind: &ItemKind) -> wasm_encoder::ItemKind {
-    match kind {
-        ItemKind::Tag => wasm_encoder::ItemKind::Tag,
-        ItemKind::Func => wasm_encoder::ItemKind::Function,
-        ItemKind::Table => wasm_encoder::ItemKind::Table,
-        ItemKind::Memory => wasm_encoder::ItemKind::Memory,
-        ItemKind::Global => wasm_encoder::ItemKind::Global,
-        ItemKind::Instance => wasm_encoder::ItemKind::Instance,
-        ItemKind::Module => wasm_encoder::ItemKind::Module,
-    }
-}
-
-fn translate_export(export: &Export) -> wasm_encoder::Export {
-    match export {
-        Export::Tag(idx) => wasm_encoder::Export::Tag(*idx),
-        Export::Func(idx) => wasm_encoder::Export::Function(*idx),
-        Export::Table(idx) => wasm_encoder::Export::Table(*idx),
-        Export::Memory(idx) => wasm_encoder::Export::Memory(*idx),
-        Export::Global(idx) => wasm_encoder::Export::Global(*idx),
-        Export::Instance(idx) => wasm_encoder::Export::Instance(*idx),
-        Export::Module(idx) => wasm_encoder::Export::Module(*idx),
-    }
-}
-
-fn translate_instruction(inst: &Instruction) -> wasm_encoder::Instruction {
-    use Instruction::*;
-    match *inst {
-        // Control instructions.
-        Unreachable => wasm_encoder::Instruction::Unreachable,
-        Nop => wasm_encoder::Instruction::Nop,
-        Block(bt) => wasm_encoder::Instruction::Block(translate_block_type(bt)),
-        Loop(bt) => wasm_encoder::Instruction::Loop(translate_block_type(bt)),
-        If(bt) => wasm_encoder::Instruction::If(translate_block_type(bt)),
-        Else => wasm_encoder::Instruction::Else,
-        Try(bt) => wasm_encoder::Instruction::Try(translate_block_type(bt)),
-        Delegate(l) => wasm_encoder::Instruction::Delegate(l),
-        Catch(t) => wasm_encoder::Instruction::Catch(t),
-        CatchAll => wasm_encoder::Instruction::CatchAll,
-        End => wasm_encoder::Instruction::End,
-        Br(x) => wasm_encoder::Instruction::Br(x),
-        BrIf(x) => wasm_encoder::Instruction::BrIf(x),
-        BrTable(ref ls, l) => wasm_encoder::Instruction::BrTable(ls, l),
-        Return => wasm_encoder::Instruction::Return,
-        Call(x) => wasm_encoder::Instruction::Call(x),
-        CallIndirect { ty, table } => wasm_encoder::Instruction::CallIndirect { ty, table },
-        Throw(t) => wasm_encoder::Instruction::Throw(t),
-        Rethrow(l) => wasm_encoder::Instruction::Rethrow(l),
-
-        // Parametric instructions.
-        Drop => wasm_encoder::Instruction::Drop,
-        Select => wasm_encoder::Instruction::Select,
-
-        // Variable instructions.
-        LocalGet(x) => wasm_encoder::Instruction::LocalGet(x),
-        LocalSet(x) => wasm_encoder::Instruction::LocalSet(x),
-        LocalTee(x) => wasm_encoder::Instruction::LocalTee(x),
-        GlobalGet(x) => wasm_encoder::Instruction::GlobalGet(x),
-        GlobalSet(x) => wasm_encoder::Instruction::GlobalSet(x),
-
-        // Memory instructions.
-        I32Load(m) => wasm_encoder::Instruction::I32Load(translate_mem_arg(m)),
-        I64Load(m) => wasm_encoder::Instruction::I64Load(translate_mem_arg(m)),
-        F32Load(m) => wasm_encoder::Instruction::F32Load(translate_mem_arg(m)),
-        F64Load(m) => wasm_encoder::Instruction::F64Load(translate_mem_arg(m)),
-        I32Load8_S(m) => wasm_encoder::Instruction::I32Load8_S(translate_mem_arg(m)),
-        I32Load8_U(m) => wasm_encoder::Instruction::I32Load8_U(translate_mem_arg(m)),
-        I32Load16_S(m) => wasm_encoder::Instruction::I32Load16_S(translate_mem_arg(m)),
-        I32Load16_U(m) => wasm_encoder::Instruction::I32Load16_U(translate_mem_arg(m)),
-        I64Load8_S(m) => wasm_encoder::Instruction::I64Load8_S(translate_mem_arg(m)),
-        I64Load8_U(m) => wasm_encoder::Instruction::I64Load8_U(translate_mem_arg(m)),
-        I64Load16_S(m) => wasm_encoder::Instruction::I64Load16_S(translate_mem_arg(m)),
-        I64Load16_U(m) => wasm_encoder::Instruction::I64Load16_U(translate_mem_arg(m)),
-        I64Load32_S(m) => wasm_encoder::Instruction::I64Load32_S(translate_mem_arg(m)),
-        I64Load32_U(m) => wasm_encoder::Instruction::I64Load32_U(translate_mem_arg(m)),
-        I32Store(m) => wasm_encoder::Instruction::I32Store(translate_mem_arg(m)),
-        I64Store(m) => wasm_encoder::Instruction::I64Store(translate_mem_arg(m)),
-        F32Store(m) => wasm_encoder::Instruction::F32Store(translate_mem_arg(m)),
-        F64Store(m) => wasm_encoder::Instruction::F64Store(translate_mem_arg(m)),
-        I32Store8(m) => wasm_encoder::Instruction::I32Store8(translate_mem_arg(m)),
-        I32Store16(m) => wasm_encoder::Instruction::I32Store16(translate_mem_arg(m)),
-        I64Store8(m) => wasm_encoder::Instruction::I64Store8(translate_mem_arg(m)),
-        I64Store16(m) => wasm_encoder::Instruction::I64Store16(translate_mem_arg(m)),
-        I64Store32(m) => wasm_encoder::Instruction::I64Store32(translate_mem_arg(m)),
-        MemorySize(x) => wasm_encoder::Instruction::MemorySize(x),
-        MemoryGrow(x) => wasm_encoder::Instruction::MemoryGrow(x),
-        MemoryInit { mem, data } => wasm_encoder::Instruction::MemoryInit { mem, data },
-        DataDrop(x) => wasm_encoder::Instruction::DataDrop(x),
-        MemoryCopy { src, dst } => wasm_encoder::Instruction::MemoryCopy { src, dst },
-        MemoryFill(x) => wasm_encoder::Instruction::MemoryFill(x),
-
-        // Numeric instructions.
-        I32Const(x) => wasm_encoder::Instruction::I32Const(x),
-        I64Const(x) => wasm_encoder::Instruction::I64Const(x),
-        F32Const(x) => wasm_encoder::Instruction::F32Const(x),
-        F64Const(x) => wasm_encoder::Instruction::F64Const(x),
-        I32Eqz => wasm_encoder::Instruction::I32Eqz,
-        I32Eq => wasm_encoder::Instruction::I32Eq,
-        I32Neq => wasm_encoder::Instruction::I32Neq,
-        I32LtS => wasm_encoder::Instruction::I32LtS,
-        I32LtU => wasm_encoder::Instruction::I32LtU,
-        I32GtS => wasm_encoder::Instruction::I32GtS,
-        I32GtU => wasm_encoder::Instruction::I32GtU,
-        I32LeS => wasm_encoder::Instruction::I32LeS,
-        I32LeU => wasm_encoder::Instruction::I32LeU,
-        I32GeS => wasm_encoder::Instruction::I32GeS,
-        I32GeU => wasm_encoder::Instruction::I32GeU,
-        I64Eqz => wasm_encoder::Instruction::I64Eqz,
-        I64Eq => wasm_encoder::Instruction::I64Eq,
-        I64Neq => wasm_encoder::Instruction::I64Neq,
-        I64LtS => wasm_encoder::Instruction::I64LtS,
-        I64LtU => wasm_encoder::Instruction::I64LtU,
-        I64GtS => wasm_encoder::Instruction::I64GtS,
-        I64GtU => wasm_encoder::Instruction::I64GtU,
-        I64LeS => wasm_encoder::Instruction::I64LeS,
-        I64LeU => wasm_encoder::Instruction::I64LeU,
-        I64GeS => wasm_encoder::Instruction::I64GeS,
-        I64GeU => wasm_encoder::Instruction::I64GeU,
-        F32Eq => wasm_encoder::Instruction::F32Eq,
-        F32Neq => wasm_encoder::Instruction::F32Neq,
-        F32Lt => wasm_encoder::Instruction::F32Lt,
-        F32Gt => wasm_encoder::Instruction::F32Gt,
-        F32Le => wasm_encoder::Instruction::F32Le,
-        F32Ge => wasm_encoder::Instruction::F32Ge,
-        F64Eq => wasm_encoder::Instruction::F64Eq,
-        F64Neq => wasm_encoder::Instruction::F64Neq,
-        F64Lt => wasm_encoder::Instruction::F64Lt,
-        F64Gt => wasm_encoder::Instruction::F64Gt,
-        F64Le => wasm_encoder::Instruction::F64Le,
-        F64Ge => wasm_encoder::Instruction::F64Ge,
-        I32Clz => wasm_encoder::Instruction::I32Clz,
-        I32Ctz => wasm_encoder::Instruction::I32Ctz,
-        I32Popcnt => wasm_encoder::Instruction::I32Popcnt,
-        I32Add => wasm_encoder::Instruction::I32Add,
-        I32Sub => wasm_encoder::Instruction::I32Sub,
-        I32Mul => wasm_encoder::Instruction::I32Mul,
-        I32DivS => wasm_encoder::Instruction::I32DivS,
-        I32DivU => wasm_encoder::Instruction::I32DivU,
-        I32RemS => wasm_encoder::Instruction::I32RemS,
-        I32RemU => wasm_encoder::Instruction::I32RemU,
-        I32And => wasm_encoder::Instruction::I32And,
-        I32Or => wasm_encoder::Instruction::I32Or,
-        I32Xor => wasm_encoder::Instruction::I32Xor,
-        I32Shl => wasm_encoder::Instruction::I32Shl,
-        I32ShrS => wasm_encoder::Instruction::I32ShrS,
-        I32ShrU => wasm_encoder::Instruction::I32ShrU,
-        I32Rotl => wasm_encoder::Instruction::I32Rotl,
-        I32Rotr => wasm_encoder::Instruction::I32Rotr,
-        I64Clz => wasm_encoder::Instruction::I64Clz,
-        I64Ctz => wasm_encoder::Instruction::I64Ctz,
-        I64Popcnt => wasm_encoder::Instruction::I64Popcnt,
-        I64Add => wasm_encoder::Instruction::I64Add,
-        I64Sub => wasm_encoder::Instruction::I64Sub,
-        I64Mul => wasm_encoder::Instruction::I64Mul,
-        I64DivS => wasm_encoder::Instruction::I64DivS,
-        I64DivU => wasm_encoder::Instruction::I64DivU,
-        I64RemS => wasm_encoder::Instruction::I64RemS,
-        I64RemU => wasm_encoder::Instruction::I64RemU,
-        I64And => wasm_encoder::Instruction::I64And,
-        I64Or => wasm_encoder::Instruction::I64Or,
-        I64Xor => wasm_encoder::Instruction::I64Xor,
-        I64Shl => wasm_encoder::Instruction::I64Shl,
-        I64ShrS => wasm_encoder::Instruction::I64ShrS,
-        I64ShrU => wasm_encoder::Instruction::I64ShrU,
-        I64Rotl => wasm_encoder::Instruction::I64Rotl,
-        I64Rotr => wasm_encoder::Instruction::I64Rotr,
-        F32Abs => wasm_encoder::Instruction::F32Abs,
-        F32Neg => wasm_encoder::Instruction::F32Neg,
-        F32Ceil => wasm_encoder::Instruction::F32Ceil,
-        F32Floor => wasm_encoder::Instruction::F32Floor,
-        F32Trunc => wasm_encoder::Instruction::F32Trunc,
-        F32Nearest => wasm_encoder::Instruction::F32Nearest,
-        F32Sqrt => wasm_encoder::Instruction::F32Sqrt,
-        F32Add => wasm_encoder::Instruction::F32Add,
-        F32Sub => wasm_encoder::Instruction::F32Sub,
-        F32Mul => wasm_encoder::Instruction::F32Mul,
-        F32Div => wasm_encoder::Instruction::F32Div,
-        F32Min => wasm_encoder::Instruction::F32Min,
-        F32Max => wasm_encoder::Instruction::F32Max,
-        F32Copysign => wasm_encoder::Instruction::F32Copysign,
-        F64Abs => wasm_encoder::Instruction::F64Abs,
-        F64Neg => wasm_encoder::Instruction::F64Neg,
-        F64Ceil => wasm_encoder::Instruction::F64Ceil,
-        F64Floor => wasm_encoder::Instruction::F64Floor,
-        F64Trunc => wasm_encoder::Instruction::F64Trunc,
-        F64Nearest => wasm_encoder::Instruction::F64Nearest,
-        F64Sqrt => wasm_encoder::Instruction::F64Sqrt,
-        F64Add => wasm_encoder::Instruction::F64Add,
-        F64Sub => wasm_encoder::Instruction::F64Sub,
-        F64Mul => wasm_encoder::Instruction::F64Mul,
-        F64Div => wasm_encoder::Instruction::F64Div,
-        F64Min => wasm_encoder::Instruction::F64Min,
-        F64Max => wasm_encoder::Instruction::F64Max,
-        F64Copysign => wasm_encoder::Instruction::F64Copysign,
-        I32WrapI64 => wasm_encoder::Instruction::I32WrapI64,
-        I32TruncF32S => wasm_encoder::Instruction::I32TruncF32S,
-        I32TruncF32U => wasm_encoder::Instruction::I32TruncF32U,
-        I32TruncF64S => wasm_encoder::Instruction::I32TruncF64S,
-        I32TruncF64U => wasm_encoder::Instruction::I32TruncF64U,
-        I64ExtendI32S => wasm_encoder::Instruction::I64ExtendI32S,
-        I64ExtendI32U => wasm_encoder::Instruction::I64ExtendI32U,
-        I64TruncF32S => wasm_encoder::Instruction::I64TruncF32S,
-        I64TruncF32U => wasm_encoder::Instruction::I64TruncF32U,
-        I64TruncF64S => wasm_encoder::Instruction::I64TruncF64S,
-        I64TruncF64U => wasm_encoder::Instruction::I64TruncF64U,
-        F32ConvertI32S => wasm_encoder::Instruction::F32ConvertI32S,
-        F32ConvertI32U => wasm_encoder::Instruction::F32ConvertI32U,
-        F32ConvertI64S => wasm_encoder::Instruction::F32ConvertI64S,
-        F32ConvertI64U => wasm_encoder::Instruction::F32ConvertI64U,
-        F32DemoteF64 => wasm_encoder::Instruction::F32DemoteF64,
-        F64ConvertI32S => wasm_encoder::Instruction::F64ConvertI32S,
-        F64ConvertI32U => wasm_encoder::Instruction::F64ConvertI32U,
-        F64ConvertI64S => wasm_encoder::Instruction::F64ConvertI64S,
-        F64ConvertI64U => wasm_encoder::Instruction::F64ConvertI64U,
-        F64PromoteF32 => wasm_encoder::Instruction::F64PromoteF32,
-        I32ReinterpretF32 => wasm_encoder::Instruction::I32ReinterpretF32,
-        I64ReinterpretF64 => wasm_encoder::Instruction::I64ReinterpretF64,
-        F32ReinterpretI32 => wasm_encoder::Instruction::F32ReinterpretI32,
-        F64ReinterpretI64 => wasm_encoder::Instruction::F64ReinterpretI64,
-        I32Extend8S => wasm_encoder::Instruction::I32Extend8S,
-        I32Extend16S => wasm_encoder::Instruction::I32Extend16S,
-        I64Extend8S => wasm_encoder::Instruction::I64Extend8S,
-        I64Extend16S => wasm_encoder::Instruction::I64Extend16S,
-        I64Extend32S => wasm_encoder::Instruction::I64Extend32S,
-        I32TruncSatF32S => wasm_encoder::Instruction::I32TruncSatF32S,
-        I32TruncSatF32U => wasm_encoder::Instruction::I32TruncSatF32U,
-        I32TruncSatF64S => wasm_encoder::Instruction::I32TruncSatF64S,
-        I32TruncSatF64U => wasm_encoder::Instruction::I32TruncSatF64U,
-        I64TruncSatF32S => wasm_encoder::Instruction::I64TruncSatF32S,
-        I64TruncSatF32U => wasm_encoder::Instruction::I64TruncSatF32U,
-        I64TruncSatF64S => wasm_encoder::Instruction::I64TruncSatF64S,
-        I64TruncSatF64U => wasm_encoder::Instruction::I64TruncSatF64U,
-        TypedSelect(ty) => wasm_encoder::Instruction::TypedSelect(translate_val_type(ty)),
-        RefNull(ty) => wasm_encoder::Instruction::RefNull(translate_val_type(ty)),
-        RefIsNull => wasm_encoder::Instruction::RefIsNull,
-        RefFunc(x) => wasm_encoder::Instruction::RefFunc(x),
-        TableInit { segment, table } => wasm_encoder::Instruction::TableInit { segment, table },
-        ElemDrop { segment } => wasm_encoder::Instruction::ElemDrop { segment },
-        TableFill { table } => wasm_encoder::Instruction::TableFill { table },
-        TableSet { table } => wasm_encoder::Instruction::TableSet { table },
-        TableGet { table } => wasm_encoder::Instruction::TableGet { table },
-        TableGrow { table } => wasm_encoder::Instruction::TableGrow { table },
-        TableSize { table } => wasm_encoder::Instruction::TableSize { table },
-        TableCopy { src, dst } => wasm_encoder::Instruction::TableCopy { src, dst },
-
-        // SIMD instructions.
-        V128Load { memarg } => wasm_encoder::Instruction::V128Load {
-            memarg: translate_mem_arg(memarg),
-        },
-        V128Load8x8S { memarg } => wasm_encoder::Instruction::V128Load8x8S {
-            memarg: translate_mem_arg(memarg),
-        },
-        V128Load8x8U { memarg } => wasm_encoder::Instruction::V128Load8x8U {
-            memarg: translate_mem_arg(memarg),
-        },
-        V128Load16x4S { memarg } => wasm_encoder::Instruction::V128Load16x4S {
-            memarg: translate_mem_arg(memarg),
-        },
-        V128Load16x4U { memarg } => wasm_encoder::Instruction::V128Load16x4U {
-            memarg: translate_mem_arg(memarg),
-        },
-        V128Load32x2S { memarg } => wasm_encoder::Instruction::V128Load32x2S {
-            memarg: translate_mem_arg(memarg),
-        },
-        V128Load32x2U { memarg } => wasm_encoder::Instruction::V128Load32x2U {
-            memarg: translate_mem_arg(memarg),
-        },
-        V128Load8Splat { memarg } => wasm_encoder::Instruction::V128Load8Splat {
-            memarg: translate_mem_arg(memarg),
-        },
-        V128Load16Splat { memarg } => wasm_encoder::Instruction::V128Load16Splat {
-            memarg: translate_mem_arg(memarg),
-        },
-        V128Load32Splat { memarg } => wasm_encoder::Instruction::V128Load32Splat {
-            memarg: translate_mem_arg(memarg),
-        },
-        V128Load64Splat { memarg } => wasm_encoder::Instruction::V128Load64Splat {
-            memarg: translate_mem_arg(memarg),
-        },
-        V128Load32Zero { memarg } => wasm_encoder::Instruction::V128Load32Zero {
-            memarg: translate_mem_arg(memarg),
-        },
-        V128Load64Zero { memarg } => wasm_encoder::Instruction::V128Load64Zero {
-            memarg: translate_mem_arg(memarg),
-        },
-        V128Store { memarg } => wasm_encoder::Instruction::V128Store {
-            memarg: translate_mem_arg(memarg),
-        },
-        V128Load8Lane { memarg, lane } => wasm_encoder::Instruction::V128Load8Lane {
-            memarg: translate_mem_arg(memarg),
-            lane,
-        },
-        V128Load16Lane { memarg, lane } => wasm_encoder::Instruction::V128Load16Lane {
-            memarg: translate_mem_arg(memarg),
-            lane,
-        },
-        V128Load32Lane { memarg, lane } => wasm_encoder::Instruction::V128Load32Lane {
-            memarg: translate_mem_arg(memarg),
-            lane,
-        },
-        V128Load64Lane { memarg, lane } => wasm_encoder::Instruction::V128Load64Lane {
-            memarg: translate_mem_arg(memarg),
-            lane,
-        },
-        V128Store8Lane { memarg, lane } => wasm_encoder::Instruction::V128Store8Lane {
-            memarg: translate_mem_arg(memarg),
-            lane,
-        },
-        V128Store16Lane { memarg, lane } => wasm_encoder::Instruction::V128Store16Lane {
-            memarg: translate_mem_arg(memarg),
-            lane,
-        },
-        V128Store32Lane { memarg, lane } => wasm_encoder::Instruction::V128Store32Lane {
-            memarg: translate_mem_arg(memarg),
-            lane,
-        },
-        V128Store64Lane { memarg, lane } => wasm_encoder::Instruction::V128Store64Lane {
-            memarg: translate_mem_arg(memarg),
-            lane,
-        },
-        V128Const(c) => wasm_encoder::Instruction::V128Const(c),
-        I8x16Shuffle { lanes } => wasm_encoder::Instruction::I8x16Shuffle { lanes },
-        I8x16ExtractLaneS { lane } => wasm_encoder::Instruction::I8x16ExtractLaneS { lane },
-        I8x16ExtractLaneU { lane } => wasm_encoder::Instruction::I8x16ExtractLaneU { lane },
-        I8x16ReplaceLane { lane } => wasm_encoder::Instruction::I8x16ReplaceLane { lane },
-        I16x8ExtractLaneS { lane } => wasm_encoder::Instruction::I16x8ExtractLaneS { lane },
-        I16x8ExtractLaneU { lane } => wasm_encoder::Instruction::I16x8ExtractLaneU { lane },
-        I16x8ReplaceLane { lane } => wasm_encoder::Instruction::I16x8ReplaceLane { lane },
-        I32x4ExtractLane { lane } => wasm_encoder::Instruction::I32x4ExtractLane { lane },
-        I32x4ReplaceLane { lane } => wasm_encoder::Instruction::I32x4ReplaceLane { lane },
-        I64x2ExtractLane { lane } => wasm_encoder::Instruction::I64x2ExtractLane { lane },
-        I64x2ReplaceLane { lane } => wasm_encoder::Instruction::I64x2ReplaceLane { lane },
-        F32x4ExtractLane { lane } => wasm_encoder::Instruction::F32x4ExtractLane { lane },
-        F32x4ReplaceLane { lane } => wasm_encoder::Instruction::F32x4ReplaceLane { lane },
-        F64x2ExtractLane { lane } => wasm_encoder::Instruction::F64x2ExtractLane { lane },
-        F64x2ReplaceLane { lane } => wasm_encoder::Instruction::F64x2ReplaceLane { lane },
-        I8x16Swizzle => wasm_encoder::Instruction::I8x16Swizzle,
-        I8x16Splat => wasm_encoder::Instruction::I8x16Splat,
-        I16x8Splat => wasm_encoder::Instruction::I16x8Splat,
-        I32x4Splat => wasm_encoder::Instruction::I32x4Splat,
-        I64x2Splat => wasm_encoder::Instruction::I64x2Splat,
-        F32x4Splat => wasm_encoder::Instruction::F32x4Splat,
-        F64x2Splat => wasm_encoder::Instruction::F64x2Splat,
-        I8x16Eq => wasm_encoder::Instruction::I8x16Eq,
-        I8x16Ne => wasm_encoder::Instruction::I8x16Ne,
-        I8x16LtS => wasm_encoder::Instruction::I8x16LtS,
-        I8x16LtU => wasm_encoder::Instruction::I8x16LtU,
-        I8x16GtS => wasm_encoder::Instruction::I8x16GtS,
-        I8x16GtU => wasm_encoder::Instruction::I8x16GtU,
-        I8x16LeS => wasm_encoder::Instruction::I8x16LeS,
-        I8x16LeU => wasm_encoder::Instruction::I8x16LeU,
-        I8x16GeS => wasm_encoder::Instruction::I8x16GeS,
-        I8x16GeU => wasm_encoder::Instruction::I8x16GeU,
-        I16x8Eq => wasm_encoder::Instruction::I16x8Eq,
-        I16x8Ne => wasm_encoder::Instruction::I16x8Ne,
-        I16x8LtS => wasm_encoder::Instruction::I16x8LtS,
-        I16x8LtU => wasm_encoder::Instruction::I16x8LtU,
-        I16x8GtS => wasm_encoder::Instruction::I16x8GtS,
-        I16x8GtU => wasm_encoder::Instruction::I16x8GtU,
-        I16x8LeS => wasm_encoder::Instruction::I16x8LeS,
-        I16x8LeU => wasm_encoder::Instruction::I16x8LeU,
-        I16x8GeS => wasm_encoder::Instruction::I16x8GeS,
-        I16x8GeU => wasm_encoder::Instruction::I16x8GeU,
-        I32x4Eq => wasm_encoder::Instruction::I32x4Eq,
-        I32x4Ne => wasm_encoder::Instruction::I32x4Ne,
-        I32x4LtS => wasm_encoder::Instruction::I32x4LtS,
-        I32x4LtU => wasm_encoder::Instruction::I32x4LtU,
-        I32x4GtS => wasm_encoder::Instruction::I32x4GtS,
-        I32x4GtU => wasm_encoder::Instruction::I32x4GtU,
-        I32x4LeS => wasm_encoder::Instruction::I32x4LeS,
-        I32x4LeU => wasm_encoder::Instruction::I32x4LeU,
-        I32x4GeS => wasm_encoder::Instruction::I32x4GeS,
-        I32x4GeU => wasm_encoder::Instruction::I32x4GeU,
-        I64x2Eq => wasm_encoder::Instruction::I64x2Eq,
-        I64x2Ne => wasm_encoder::Instruction::I64x2Ne,
-        I64x2LtS => wasm_encoder::Instruction::I64x2LtS,
-        I64x2GtS => wasm_encoder::Instruction::I64x2GtS,
-        I64x2LeS => wasm_encoder::Instruction::I64x2LeS,
-        I64x2GeS => wasm_encoder::Instruction::I64x2GeS,
-        F32x4Eq => wasm_encoder::Instruction::F32x4Eq,
-        F32x4Ne => wasm_encoder::Instruction::F32x4Ne,
-        F32x4Lt => wasm_encoder::Instruction::F32x4Lt,
-        F32x4Gt => wasm_encoder::Instruction::F32x4Gt,
-        F32x4Le => wasm_encoder::Instruction::F32x4Le,
-        F32x4Ge => wasm_encoder::Instruction::F32x4Ge,
-        F64x2Eq => wasm_encoder::Instruction::F64x2Eq,
-        F64x2Ne => wasm_encoder::Instruction::F64x2Ne,
-        F64x2Lt => wasm_encoder::Instruction::F64x2Lt,
-        F64x2Gt => wasm_encoder::Instruction::F64x2Gt,
-        F64x2Le => wasm_encoder::Instruction::F64x2Le,
-        F64x2Ge => wasm_encoder::Instruction::F64x2Ge,
-        V128Not => wasm_encoder::Instruction::V128Not,
-        V128And => wasm_encoder::Instruction::V128And,
-        V128AndNot => wasm_encoder::Instruction::V128AndNot,
-        V128Or => wasm_encoder::Instruction::V128Or,
-        V128Xor => wasm_encoder::Instruction::V128Xor,
-        V128Bitselect => wasm_encoder::Instruction::V128Bitselect,
-        V128AnyTrue => wasm_encoder::Instruction::V128AnyTrue,
-        I8x16Abs => wasm_encoder::Instruction::I8x16Abs,
-        I8x16Neg => wasm_encoder::Instruction::I8x16Neg,
-        I8x16Popcnt => wasm_encoder::Instruction::I8x16Popcnt,
-        I8x16AllTrue => wasm_encoder::Instruction::I8x16AllTrue,
-        I8x16Bitmask => wasm_encoder::Instruction::I8x16Bitmask,
-        I8x16NarrowI16x8S => wasm_encoder::Instruction::I8x16NarrowI16x8S,
-        I8x16NarrowI16x8U => wasm_encoder::Instruction::I8x16NarrowI16x8U,
-        I8x16Shl => wasm_encoder::Instruction::I8x16Shl,
-        I8x16ShrS => wasm_encoder::Instruction::I8x16ShrS,
-        I8x16ShrU => wasm_encoder::Instruction::I8x16ShrU,
-        I8x16Add => wasm_encoder::Instruction::I8x16Add,
-        I8x16AddSatS => wasm_encoder::Instruction::I8x16AddSatS,
-        I8x16AddSatU => wasm_encoder::Instruction::I8x16AddSatU,
-        I8x16Sub => wasm_encoder::Instruction::I8x16Sub,
-        I8x16SubSatS => wasm_encoder::Instruction::I8x16SubSatS,
-        I8x16SubSatU => wasm_encoder::Instruction::I8x16SubSatU,
-        I8x16MinS => wasm_encoder::Instruction::I8x16MinS,
-        I8x16MinU => wasm_encoder::Instruction::I8x16MinU,
-        I8x16MaxS => wasm_encoder::Instruction::I8x16MaxS,
-        I8x16MaxU => wasm_encoder::Instruction::I8x16MaxU,
-        I8x16RoundingAverageU => wasm_encoder::Instruction::I8x16RoundingAverageU,
-        I16x8ExtAddPairwiseI8x16S => wasm_encoder::Instruction::I16x8ExtAddPairwiseI8x16S,
-        I16x8ExtAddPairwiseI8x16U => wasm_encoder::Instruction::I16x8ExtAddPairwiseI8x16U,
-        I16x8Abs => wasm_encoder::Instruction::I16x8Abs,
-        I16x8Neg => wasm_encoder::Instruction::I16x8Neg,
-        I16x8Q15MulrSatS => wasm_encoder::Instruction::I16x8Q15MulrSatS,
-        I16x8AllTrue => wasm_encoder::Instruction::I16x8AllTrue,
-        I16x8Bitmask => wasm_encoder::Instruction::I16x8Bitmask,
-        I16x8NarrowI32x4S => wasm_encoder::Instruction::I16x8NarrowI32x4S,
-        I16x8NarrowI32x4U => wasm_encoder::Instruction::I16x8NarrowI32x4U,
-        I16x8ExtendLowI8x16S => wasm_encoder::Instruction::I16x8ExtendLowI8x16S,
-        I16x8ExtendHighI8x16S => wasm_encoder::Instruction::I16x8ExtendHighI8x16S,
-        I16x8ExtendLowI8x16U => wasm_encoder::Instruction::I16x8ExtendLowI8x16U,
-        I16x8ExtendHighI8x16U => wasm_encoder::Instruction::I16x8ExtendHighI8x16U,
-        I16x8Shl => wasm_encoder::Instruction::I16x8Shl,
-        I16x8ShrS => wasm_encoder::Instruction::I16x8ShrS,
-        I16x8ShrU => wasm_encoder::Instruction::I16x8ShrU,
-        I16x8Add => wasm_encoder::Instruction::I16x8Add,
-        I16x8AddSatS => wasm_encoder::Instruction::I16x8AddSatS,
-        I16x8AddSatU => wasm_encoder::Instruction::I16x8AddSatU,
-        I16x8Sub => wasm_encoder::Instruction::I16x8Sub,
-        I16x8SubSatS => wasm_encoder::Instruction::I16x8SubSatS,
-        I16x8SubSatU => wasm_encoder::Instruction::I16x8SubSatU,
-        I16x8Mul => wasm_encoder::Instruction::I16x8Mul,
-        I16x8MinS => wasm_encoder::Instruction::I16x8MinS,
-        I16x8MinU => wasm_encoder::Instruction::I16x8MinU,
-        I16x8MaxS => wasm_encoder::Instruction::I16x8MaxS,
-        I16x8MaxU => wasm_encoder::Instruction::I16x8MaxU,
-        I16x8RoundingAverageU => wasm_encoder::Instruction::I16x8RoundingAverageU,
-        I16x8ExtMulLowI8x16S => wasm_encoder::Instruction::I16x8ExtMulLowI8x16S,
-        I16x8ExtMulHighI8x16S => wasm_encoder::Instruction::I16x8ExtMulHighI8x16S,
-        I16x8ExtMulLowI8x16U => wasm_encoder::Instruction::I16x8ExtMulLowI8x16U,
-        I16x8ExtMulHighI8x16U => wasm_encoder::Instruction::I16x8ExtMulHighI8x16U,
-        I32x4ExtAddPairwiseI16x8S => wasm_encoder::Instruction::I32x4ExtAddPairwiseI16x8S,
-        I32x4ExtAddPairwiseI16x8U => wasm_encoder::Instruction::I32x4ExtAddPairwiseI16x8U,
-        I32x4Abs => wasm_encoder::Instruction::I32x4Abs,
-        I32x4Neg => wasm_encoder::Instruction::I32x4Neg,
-        I32x4AllTrue => wasm_encoder::Instruction::I32x4AllTrue,
-        I32x4Bitmask => wasm_encoder::Instruction::I32x4Bitmask,
-        I32x4ExtendLowI16x8S => wasm_encoder::Instruction::I32x4ExtendLowI16x8S,
-        I32x4ExtendHighI16x8S => wasm_encoder::Instruction::I32x4ExtendHighI16x8S,
-        I32x4ExtendLowI16x8U => wasm_encoder::Instruction::I32x4ExtendLowI16x8U,
-        I32x4ExtendHighI16x8U => wasm_encoder::Instruction::I32x4ExtendHighI16x8U,
-        I32x4Shl => wasm_encoder::Instruction::I32x4Shl,
-        I32x4ShrS => wasm_encoder::Instruction::I32x4ShrS,
-        I32x4ShrU => wasm_encoder::Instruction::I32x4ShrU,
-        I32x4Add => wasm_encoder::Instruction::I32x4Add,
-        I32x4Sub => wasm_encoder::Instruction::I32x4Sub,
-        I32x4Mul => wasm_encoder::Instruction::I32x4Mul,
-        I32x4MinS => wasm_encoder::Instruction::I32x4MinS,
-        I32x4MinU => wasm_encoder::Instruction::I32x4MinU,
-        I32x4MaxS => wasm_encoder::Instruction::I32x4MaxS,
-        I32x4MaxU => wasm_encoder::Instruction::I32x4MaxU,
-        I32x4DotI16x8S => wasm_encoder::Instruction::I32x4DotI16x8S,
-        I32x4ExtMulLowI16x8S => wasm_encoder::Instruction::I32x4ExtMulLowI16x8S,
-        I32x4ExtMulHighI16x8S => wasm_encoder::Instruction::I32x4ExtMulHighI16x8S,
-        I32x4ExtMulLowI16x8U => wasm_encoder::Instruction::I32x4ExtMulLowI16x8U,
-        I32x4ExtMulHighI16x8U => wasm_encoder::Instruction::I32x4ExtMulHighI16x8U,
-        I64x2Abs => wasm_encoder::Instruction::I64x2Abs,
-        I64x2Neg => wasm_encoder::Instruction::I64x2Neg,
-        I64x2AllTrue => wasm_encoder::Instruction::I64x2AllTrue,
-        I64x2Bitmask => wasm_encoder::Instruction::I64x2Bitmask,
-        I64x2ExtendLowI32x4S => wasm_encoder::Instruction::I64x2ExtendLowI32x4S,
-        I64x2ExtendHighI32x4S => wasm_encoder::Instruction::I64x2ExtendHighI32x4S,
-        I64x2ExtendLowI32x4U => wasm_encoder::Instruction::I64x2ExtendLowI32x4U,
-        I64x2ExtendHighI32x4U => wasm_encoder::Instruction::I64x2ExtendHighI32x4U,
-        I64x2Shl => wasm_encoder::Instruction::I64x2Shl,
-        I64x2ShrS => wasm_encoder::Instruction::I64x2ShrS,
-        I64x2ShrU => wasm_encoder::Instruction::I64x2ShrU,
-        I64x2Add => wasm_encoder::Instruction::I64x2Add,
-        I64x2Sub => wasm_encoder::Instruction::I64x2Sub,
-        I64x2Mul => wasm_encoder::Instruction::I64x2Mul,
-        I64x2ExtMulLowI32x4S => wasm_encoder::Instruction::I64x2ExtMulLowI32x4S,
-        I64x2ExtMulHighI32x4S => wasm_encoder::Instruction::I64x2ExtMulHighI32x4S,
-        I64x2ExtMulLowI32x4U => wasm_encoder::Instruction::I64x2ExtMulLowI32x4U,
-        I64x2ExtMulHighI32x4U => wasm_encoder::Instruction::I64x2ExtMulHighI32x4U,
-        F32x4Ceil => wasm_encoder::Instruction::F32x4Ceil,
-        F32x4Floor => wasm_encoder::Instruction::F32x4Floor,
-        F32x4Trunc => wasm_encoder::Instruction::F32x4Trunc,
-        F32x4Nearest => wasm_encoder::Instruction::F32x4Nearest,
-        F32x4Abs => wasm_encoder::Instruction::F32x4Abs,
-        F32x4Neg => wasm_encoder::Instruction::F32x4Neg,
-        F32x4Sqrt => wasm_encoder::Instruction::F32x4Sqrt,
-        F32x4Add => wasm_encoder::Instruction::F32x4Add,
-        F32x4Sub => wasm_encoder::Instruction::F32x4Sub,
-        F32x4Mul => wasm_encoder::Instruction::F32x4Mul,
-        F32x4Div => wasm_encoder::Instruction::F32x4Div,
-        F32x4Min => wasm_encoder::Instruction::F32x4Min,
-        F32x4Max => wasm_encoder::Instruction::F32x4Max,
-        F32x4PMin => wasm_encoder::Instruction::F32x4PMin,
-        F32x4PMax => wasm_encoder::Instruction::F32x4PMax,
-        F64x2Ceil => wasm_encoder::Instruction::F64x2Ceil,
-        F64x2Floor => wasm_encoder::Instruction::F64x2Floor,
-        F64x2Trunc => wasm_encoder::Instruction::F64x2Trunc,
-        F64x2Nearest => wasm_encoder::Instruction::F64x2Nearest,
-        F64x2Abs => wasm_encoder::Instruction::F64x2Abs,
-        F64x2Neg => wasm_encoder::Instruction::F64x2Neg,
-        F64x2Sqrt => wasm_encoder::Instruction::F64x2Sqrt,
-        F64x2Add => wasm_encoder::Instruction::F64x2Add,
-        F64x2Sub => wasm_encoder::Instruction::F64x2Sub,
-        F64x2Mul => wasm_encoder::Instruction::F64x2Mul,
-        F64x2Div => wasm_encoder::Instruction::F64x2Div,
-        F64x2Min => wasm_encoder::Instruction::F64x2Min,
-        F64x2Max => wasm_encoder::Instruction::F64x2Max,
-        F64x2PMin => wasm_encoder::Instruction::F64x2PMin,
-        F64x2PMax => wasm_encoder::Instruction::F64x2PMax,
-        I32x4TruncSatF32x4S => wasm_encoder::Instruction::I32x4TruncSatF32x4S,
-        I32x4TruncSatF32x4U => wasm_encoder::Instruction::I32x4TruncSatF32x4U,
-        F32x4ConvertI32x4S => wasm_encoder::Instruction::F32x4ConvertI32x4S,
-        F32x4ConvertI32x4U => wasm_encoder::Instruction::F32x4ConvertI32x4U,
-        I32x4TruncSatF64x2SZero => wasm_encoder::Instruction::I32x4TruncSatF64x2SZero,
-        I32x4TruncSatF64x2UZero => wasm_encoder::Instruction::I32x4TruncSatF64x2UZero,
-        F64x2ConvertLowI32x4S => wasm_encoder::Instruction::F64x2ConvertLowI32x4S,
-        F64x2ConvertLowI32x4U => wasm_encoder::Instruction::F64x2ConvertLowI32x4U,
-        F32x4DemoteF64x2Zero => wasm_encoder::Instruction::F32x4DemoteF64x2Zero,
-        F64x2PromoteLowF32x4 => wasm_encoder::Instruction::F64x2PromoteLowF32x4,
-        I8x16SwizzleRelaxed => wasm_encoder::Instruction::I8x16SwizzleRelaxed,
-        I32x4TruncSatF32x4SRelaxed => wasm_encoder::Instruction::I32x4TruncSatF32x4SRelaxed,
-        I32x4TruncSatF32x4URelaxed => wasm_encoder::Instruction::I32x4TruncSatF32x4URelaxed,
-        I32x4TruncSatF64x2SZeroRelaxed => wasm_encoder::Instruction::I32x4TruncSatF64x2SZeroRelaxed,
-        I32x4TruncSatF64x2UZeroRelaxed => wasm_encoder::Instruction::I32x4TruncSatF64x2UZeroRelaxed,
-        F32x4FmaRelaxed => wasm_encoder::Instruction::F32x4FmaRelaxed,
-        F32x4FmsRelaxed => wasm_encoder::Instruction::F32x4FmsRelaxed,
-        F64x2FmaRelaxed => wasm_encoder::Instruction::F64x2FmaRelaxed,
-        F64x2FmsRelaxed => wasm_encoder::Instruction::F64x2FmsRelaxed,
-        I8x16LaneSelect => wasm_encoder::Instruction::I8x16LaneSelect,
-        I16x8LaneSelect => wasm_encoder::Instruction::I16x8LaneSelect,
-        I32x4LaneSelect => wasm_encoder::Instruction::I32x4LaneSelect,
-        I64x2LaneSelect => wasm_encoder::Instruction::I64x2LaneSelect,
-        F32x4MinRelaxed => wasm_encoder::Instruction::F32x4MinRelaxed,
-        F32x4MaxRelaxed => wasm_encoder::Instruction::F32x4MaxRelaxed,
-        F64x2MinRelaxed => wasm_encoder::Instruction::F64x2MinRelaxed,
-        F64x2MaxRelaxed => wasm_encoder::Instruction::F64x2MaxRelaxed,
+        EntityType::Table(ty) => (*ty).into(),
+        EntityType::Memory(m) => (*m).into(),
+        EntityType::Global(g) => (*g).into(),
     }
 }

--- a/crates/wasm-smith/src/terminate.rs
+++ b/crates/wasm-smith/src/terminate.rs
@@ -1,5 +1,6 @@
 use super::*;
 use std::mem;
+use wasm_encoder::BlockType;
 
 impl Module {
     /// Ensure that all of this Wasm module's functions will terminate when


### PR DESCRIPTION
This commit changes `wasm-smith` to use raw types from `wasm-encoder`
instead of duplicating them, namely removing one of the definitions of
the list of instructions that wasm has.