### PR TITLE
Fix wasm-smith generating v128 globals w/o simd enabled

### DIFF
--- a/crates/wasm-smith/src/lib.rs
+++ b/crates/wasm-smith/src/lib.rs
@@ -450,7 +450,7 @@ impl Module {
         self.valtypes.push(ValType::I64);
         self.valtypes.push(ValType::F32);
         self.valtypes.push(ValType::F64);
-        if self.config.simd_enabled() || self.config.relaxed_simd_enabled() {
+        if self.config.simd_enabled() {
             self.valtypes.push(ValType::V128);
         }
         if self.config.reference_types_enabled() {

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -12,7 +12,7 @@ pub fn generate_valid_module(
     // These are disabled in the swarm config by default, but we want to test
     // them. Use the input data to determine whether these features are enabled.
     config.simd_enabled = u.arbitrary()?;
-    config.relaxed_simd_enabled = u.arbitrary()?;
+    config.relaxed_simd_enabled = config.simd_enabled && u.arbitrary()?;
     config.module_linking_enabled = u.arbitrary()?;
     config.memory64_enabled = u.arbitrary()?;
     config.exceptions_enabled = u.arbitrary()?;


### PR DESCRIPTION
Only enable the `v128` type if the simd proposal is activated, whereas
previously it was enabled if either the simd or relaxed simd proposal
were activated. Additionally this updates the fuzz logic to only
possibly enable relaxed simd if simd is itself already enabled.