### PR TITLE
FIX: bypass code section in the input_wasm instead of remaining stream

### DIFF
--- a/crates/wasm-mutate/src/info.rs
+++ b/crates/wasm-mutate/src/info.rs
@@ -68,8 +68,8 @@ impl<'a> ModuleInfo<'a> {
                     info.function_count = count;
                     info.section(SectionId::Code.into(), range, input_wasm);
                     parser.skip_section();
-                    // update slice
-                    wasm = &wasm[range.end - range.start + consumed - 1..];
+                    // update slice, bypass the section
+                    wasm = &input_wasm[range.end..];
 
                     continue;
                 }


### PR DESCRIPTION
The AST information building in `wasm-mutate` sometimes fails. It fails because the bypassing of the code section is done over the remaining data (`wasm` variable) instead of the input wasm bytes.