### PR TITLE
FIX: extend operand types should not be inferred

### DIFF
--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/analysis.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/analysis.rs
@@ -80,7 +80,7 @@ impl Analysis<Lang> for PeepholeMutationAnalysis {
     type Data = Option<ClassData>;
 
     fn make(egraph: &EGraph<Lang, Self>, l: &Lang) -> Self::Data {
-        // This works beacuase always the first expression is the one constructed from the DFG
+        // This works because always the first expression is the one constructed from the DFG
         // The node id to stack is consistent then with the order in which this method is call
         if egraph.analysis.lang_to_stack_entries.contains_key(l) {
             Some(ClassData {

--- a/crates/wasm-mutate/src/mutators/peephole/mod.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/mod.rs
@@ -1364,8 +1364,9 @@ mod tests {
 
         let mut validator = wasmparser::Validator::new();
         let mutated_bytes = &mutated.finish();
-        crate::validate(&mut validator, mutated_bytes);
         let text = wasmprinter::print_bytes(mutated_bytes).unwrap();
+
+        crate::validate(&mut validator, mutated_bytes);
 
         let expected_bytes = &wat::parse_str(expected).unwrap();
         let expectedtext = wasmprinter::print_bytes(expected_bytes).unwrap();


### PR DESCRIPTION
Addressing [issue](https://github.com/bytecodealliance/wasm-tools/issues/373).

The type of some operands are inferred during the translation from `eterm` to `Wasm`, specially, the artificially created nodes. This inferring is sometimes prioritized over the type of the operand. In the case of the `extend` operands this inferring is not needed.