### PR TITLE
FIX: Incorrect operand ID for unfold operator

### DIFF
--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder.rs
@@ -1574,7 +1574,7 @@ impl Encoder {
                             (0..op.len()).map(|id| operand(id)).collect::<Vec<Id>>(),
                         )),
                         Lang::Tee(_) => expr.add(Lang::Tee([operand(0)])),
-                        Lang::Unfold(op) => expr.add(Lang::Unfold(*op)),
+                        Lang::Unfold(_) => expr.add(Lang::Unfold(operand(0))),
                         Lang::ILoad(_) => expr.add(Lang::ILoad([
                             operand(0),
                             operand(1),


### PR DESCRIPTION
During the translation of the random traversal in the egraph, the operand for the unfold operator was wrong, using the original children. This unleashed an error during the application of this rewriting if the the children ID was not matching with the one in the random tree.

cc @fitzgen 