### PR TITLE
Type propagation

### DIFF
--- a/crates/wasm-mutate/src/info.rs
+++ b/crates/wasm-mutate/src/info.rs
@@ -52,7 +52,7 @@ impl<'a> ModuleInfo<'a> {
         info.input_wasm = wasm;
 
         loop {
-            let (payload, consumed) = match parser.parse(&wasm, true)? {
+            let (payload, consumed) = match parser.parse(wasm, true)? {
                 Chunk::NeedMoreData(hint) => {
                     panic!("Invalid Wasm module {:?}", hint);
                 }
@@ -79,10 +79,9 @@ impl<'a> ModuleInfo<'a> {
 
                     // Save function types
                     for _ in 0..reader.get_count() {
-                        reader.read().and_then(|ty| {
+                        reader.read().map(|ty| {
                             let typeinfo = TypeInfo::try_from(ty).unwrap();
                             info.types_map.push(typeinfo);
-                            Ok(())
                         })?;
                     }
                 }
@@ -91,7 +90,7 @@ impl<'a> ModuleInfo<'a> {
                     info.section(SectionId::Import.into(), reader.range(), input_wasm);
 
                     for _ in 0..reader.get_count() {
-                        reader.read().and_then(|ty| {
+                        reader.read().map(|ty| {
                             match ty.ty {
                                 wasmparser::ImportSectionEntryType::Function(ty) => {
                                     // Save imported functions
@@ -106,7 +105,6 @@ impl<'a> ModuleInfo<'a> {
                                     // Do nothing
                                 }
                             }
-                            Ok(())
                         })?;
                     }
                 }
@@ -115,9 +113,8 @@ impl<'a> ModuleInfo<'a> {
                     info.section(SectionId::Function.into(), reader.range(), input_wasm);
 
                     for _ in 0..reader.get_count() {
-                        reader.read().and_then(|ty| {
+                        reader.read().map(|ty| {
                             info.function_map.push(ty);
-                            Ok(())
                         })?;
                     }
                 }
@@ -134,11 +131,10 @@ impl<'a> ModuleInfo<'a> {
                     info.section(SectionId::Global.into(), reader.range(), input_wasm);
 
                     for _ in 0..reader.get_count() {
-                        reader.read().and_then(|ty| {
+                        reader.read().map(|ty| {
                             // We only need the type of the global, not necesarily if is mutable or not
                             let ty = PrimitiveTypeInfo::try_from(ty.ty.content_type).unwrap();
                             info.global_types.push(ty);
-                            Ok(())
                         })?;
                     }
                 }
@@ -210,11 +206,11 @@ impl<'a> ModuleInfo<'a> {
     }
 
     pub fn get_code_section(&self) -> RawSection {
-        return self.raw_sections[self.code.unwrap()];
+        self.raw_sections[self.code.unwrap()]
     }
 
     pub fn get_exports_section(&self) -> &RawSection {
-        return &self.raw_sections[self.exports.unwrap()];
+        &self.raw_sections[self.exports.unwrap()]
     }
 
     pub fn has_exports(&self) -> bool {

--- a/crates/wasm-mutate/src/lib.rs
+++ b/crates/wasm-mutate/src/lib.rs
@@ -148,7 +148,7 @@ impl WasmMutate {
     /// Run this configured `WasmMutate` on the given input Wasm.
     pub fn run<'a>(&self, input_wasm: &'a [u8]) -> Result<Vec<u8>> {
         let mut rng = SmallRng::seed_from_u64(self.seed);
-        let info = ModuleInfo::new(&input_wasm)?;
+        let info = ModuleInfo::new(input_wasm)?;
 
         let mutators: Vec<Box<dyn Mutator>> = vec![
             Box::new(RenameExportMutator { max_name_size: 100 }),
@@ -165,7 +165,7 @@ impl WasmMutate {
         while !mutators.is_empty() {
             let i = rng.gen_range(0, mutators.len());
             let mutator = mutators.swap_remove(i);
-            if let Ok(module) = mutator.mutate(&self, &mut rng, &info) {
+            if let Ok(module) = mutator.mutate(self, &mut rng, &info) {
                 return Ok(module.finish());
             }
         }

--- a/crates/wasm-mutate/src/module/mod.rs
+++ b/crates/wasm-mutate/src/module/mod.rs
@@ -13,6 +13,13 @@ pub enum PrimitiveTypeInfo {
     F64,
     Empty,
 }
+
+impl PartialEq for PrimitiveTypeInfo {
+    fn eq(&self, other: &Self) -> bool {
+        self == other
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct FuncInfo {
     pub params: Vec<PrimitiveTypeInfo>,

--- a/crates/wasm-mutate/src/module/mod.rs
+++ b/crates/wasm-mutate/src/module/mod.rs
@@ -5,19 +5,13 @@ use wasmparser::{Type, TypeDef};
 
 use crate::error::EitherType;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum PrimitiveTypeInfo {
     I32,
     I64,
     F32,
     F64,
     Empty,
-}
-
-impl PartialEq for PrimitiveTypeInfo {
-    fn eq(&self, other: &Self) -> bool {
-        self == other
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/wasm-mutate/src/mutators/mod.rs
+++ b/crates/wasm-mutate/src/mutators/mod.rs
@@ -40,7 +40,7 @@ pub(crate) fn match_mutation(original: &str, mutator: &dyn Mutator, expected: &s
     let info = ModuleInfo::new(original).unwrap();
     let can_mutate = mutator.can_mutate(&wasmmutate, &info);
 
-    assert_eq!(can_mutate, true);
+    assert!(can_mutate == true);
 
     let mut rnd = SmallRng::seed_from_u64(0);
     let mutation = mutator.mutate(&wasmmutate, &mut rnd, &info);

--- a/crates/wasm-mutate/src/mutators/mod.rs
+++ b/crates/wasm-mutate/src/mutators/mod.rs
@@ -40,7 +40,7 @@ pub(crate) fn match_mutation(original: &str, mutator: &dyn Mutator, expected: &s
     let info = ModuleInfo::new(original).unwrap();
     let can_mutate = mutator.can_mutate(&wasmmutate, &info);
 
-    assert!(can_mutate == true);
+    assert!(can_mutate);
 
     let mut rnd = SmallRng::seed_from_u64(0);
     let mutation = mutator.mutate(&wasmmutate, &mut rnd, &info);

--- a/crates/wasm-mutate/src/mutators/peephole/dfg/mod.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/dfg/mod.rs
@@ -86,25 +86,18 @@ impl MiniDFG {
         let mut colors = vec![];
         let mut worklist = vec![entry];
 
-        loop {
-            match worklist.pop() {
-                Some(entry) => {
-                    colors.push(entry.color);
+        while let Some(entry) = worklist.pop() {
+            colors.push(entry.color);
 
-                    entry.operands.iter().for_each(|i| {
-                        worklist.push(&self.entries[*i]);
-                    });
-                }
-                None => {
-                    break;
-                }
-            }
+            entry.operands.iter().for_each(|i| {
+                worklist.push(&self.entries[*i]);
+            });
         }
 
         // All nodes in the tree should have the same color
         colors
             .get(0)
-            .and_then(|&val| Some(colors.iter().all(|&x| x == val)))
+            .map(|&val| colors.iter().all(|&x| x == val))
             .or(Some(false))
             .unwrap()
     }
@@ -155,7 +148,7 @@ impl MiniDFG {
             builder: &mut String,
         ) {
             let entry = &minidfg.entries[entryidx];
-            builder.push_str(&format!("{}", &preffix));
+            builder.push_str(&(&preffix).to_string());
             let color = get_color(entry.color);
             builder.push_str(
                 format!(
@@ -174,7 +167,7 @@ impl MiniDFG {
                     let preffix = format!("{}{}", childrenpreffix, "├──");
                     let childrenpreffix = format!("{}{}", childrenpreffix, "│   ");
                     write_child(
-                        &minidfg,
+                        minidfg,
                         *op,
                         &preffix,
                         entryformatter,
@@ -185,7 +178,7 @@ impl MiniDFG {
                     let preffix = format!("{}{}", childrenpreffix, "└──");
                     let childrenpreffix = format!("{}{}", childrenpreffix, "    ");
                     write_child(
-                        &minidfg,
+                        minidfg,
                         *op,
                         &preffix,
                         entryformatter,
@@ -198,7 +191,7 @@ impl MiniDFG {
         // Get roots
         for (entryidx, idx) in self.parents.iter().enumerate() {
             if *idx == -1 {
-                write_child(&self, entryidx, &"", entryformatter, &"", &mut builder);
+                write_child(self, entryidx, "", entryformatter, "", &mut builder);
             }
         }
 
@@ -310,8 +303,7 @@ impl<'a> DFGBuilder {
     }
 
     fn pop_operand(&mut self, operator_idx: usize, insertindfg: bool) -> usize {
-        let idx = self
-            .stack
+        self.stack
             .pop()
             .or_else(|| {
                 // Since this represents the same for all
@@ -334,8 +326,7 @@ impl<'a> DFGBuilder {
                 self.parents.push(-1); // no parent yet
                 Some(entry_idx)
             })
-            .unwrap();
-        idx
+            .unwrap()
     }
 
     /// This method should build lane dfg information
@@ -388,7 +379,7 @@ impl<'a> DFGBuilder {
                                 idx,
                                 operands.clone(),
                                 color,
-                                if tpe.returns.len() == 0 {
+                                if tpe.returns.is_empty() {
                                     PrimitiveTypeInfo::Empty
                                 } else {
                                     tpe.returns[0].clone()

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/analysis.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/analysis.rs
@@ -38,7 +38,7 @@ impl PeepholeMutationAnalysis {
     pub fn get_stack_entry_from_symbol(&self, symbol: String) -> Option<&StackEntry> {
         self.lang_to_stack_entries
             .get(&Lang::Symbol(symbol.into()))
-            .and_then(|(_, entries)| entries.get(0).and_then(|&x| Some(&self.minidfg.entries[x])))
+            .and_then(|(_, entries)| entries.get(0).map(|&x| &self.minidfg.entries[x]))
     }
     /// Return the parental relations in the DFG
     pub fn get_roots(&self) -> &Vec<i32> {
@@ -84,7 +84,7 @@ impl Analysis<Lang> for PeepholeMutationAnalysis {
         // The node id to stack is consistent then with the order in which this method is call
         if egraph.analysis.lang_to_stack_entries.contains_key(l) {
             Some(ClassData {
-                eclass_and_stackentries: egraph.analysis.lang_to_stack_entries[&l].clone(),
+                eclass_and_stackentries: egraph.analysis.lang_to_stack_entries[l].clone(),
                 current_entry: 0,
             })
         } else {

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder.rs
@@ -396,7 +396,7 @@ impl Encoder {
                         | Lang::RemS(operands)
                         | Lang::RemU(operands) => {
                             let operands = *operands;
-                            for (_, operand) in operands.iter().enumerate().rev() {
+                            for operand in operands.iter().rev() {
                                 worklist.push(Context::new(*operand, TraversalEvent::Exit));
                                 worklist.push(Context::new(*operand, TraversalEvent::Enter));
                             }
@@ -412,7 +412,7 @@ impl Encoder {
                         | Lang::GeS(operands)
                         | Lang::GeU(operands) => {
                             let operands = *operands;
-                            for (_idx, operand) in operands.iter().enumerate().rev() {
+                            for operand in operands.iter().rev() {
                                 // The type is one of the siblings
                                 worklist.push(Context::new(*operand, TraversalEvent::Exit));
                                 worklist.push(Context::new(*operand, TraversalEvent::Enter));
@@ -432,7 +432,7 @@ impl Encoder {
                         }
                         Lang::Call(operands) => {
                             // The first operand is always the helper Arg to identify the function
-                            for (_idx, operand) in operands.iter().skip(1).enumerate().rev() {
+                            for operand in operands.iter().skip(1).rev() {
                                 worklist.push(Context::new(*operand, TraversalEvent::Exit));
                                 worklist.push(Context::new(*operand, TraversalEvent::Enter));
                             }

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder.rs
@@ -28,8 +28,9 @@ enum TraversalEvent {
 }
 
 impl Encoder {
-    /// Infers types for the rewriting egraph tree
-    /// During the translation from Wasm to the egraph some type information is missin
+    /// Infers types for the rewriting egraph tree.
+    ///
+    /// During the translation from Wasm to the egraph some type information is missing.
     /// However, it can be inferred by the type relations between the nodes, for example
     /// for `i32.wrap_i64` operator, we always know that it returns an i32 constant and waits
     /// for the operand to be an i64 integer. This information could be propagated to the other

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder.rs
@@ -40,7 +40,7 @@ impl Encoder {
     fn infer_types(
         info: &ModuleInfo,
         expr: &RecExpr<Lang>,
-        node_to_eclass: &Vec<Id>,
+        node_to_eclass: &[Id],
         egraph: &EG,
     ) -> crate::Result<Vec<Option<PrimitiveTypeInfo>>> {
         let nodes = expr.as_ref();
@@ -175,10 +175,10 @@ impl Encoder {
                         .or(types[usize::from(operands[1])].clone())
                         .or(gettpe(Id::from(idx))); // Last from collected info during Wasm2eterm translation
                                                     // Set the type for the children
-                    if let None = types[usize::from(operands[0])] {
+                    if types[usize::from(operands[0])].is_none() {
                         types[usize::from(operands[0])] = types[idx].clone();
                     }
-                    if let None = types[usize::from(operands[1])] {
+                    if types[usize::from(operands[1])].is_none() {
                         types[usize::from(operands[1])] = types[idx].clone();
                     }
                 }
@@ -216,10 +216,10 @@ impl Encoder {
                             .or(types[usize::from(operands[1])].clone())
                             .or(gettpe(Id::from(idx))); // Last from collected info during Wasm2eterm translation
                                                         // Set the type for the children
-                        if let None = types[usize::from(operands[0])] {
+                        if types[usize::from(operands[0])].is_none() {
                             types[usize::from(operands[0])] = types[idx].clone();
                         }
-                        if let None = types[usize::from(operands[1])] {
+                        if types[usize::from(operands[1])].is_none() {
                             types[usize::from(operands[1])] = types[idx].clone();
                         }
                     }
@@ -321,7 +321,7 @@ impl Encoder {
         info: &ModuleInfo,
         rnd: &mut rand::prelude::SmallRng,
         expr: &RecExpr<Lang>,
-        node_to_eclass: &Vec<Id>,
+        node_to_eclass: &[Id],
         newfunc: &mut Function,
         egraph: &EG,
     ) -> crate::Result<()> {
@@ -392,7 +392,7 @@ impl Encoder {
                         | Lang::GeS(operands)
                         | Lang::GeU(operands) => {
                             let operands = *operands;
-                            for (idx, operand) in operands.iter().enumerate().rev() {
+                            for (_idx, operand) in operands.iter().enumerate().rev() {
                                 // The type is one of the siblings
                                 worklist.push(Context::new(*operand, TraversalEvent::Exit));
                                 worklist.push(Context::new(*operand, TraversalEvent::Enter));
@@ -412,7 +412,7 @@ impl Encoder {
                         }
                         Lang::Call(operands) => {
                             // The first operand is always the helper Arg to identify the function
-                            for (idx, operand) in operands.iter().skip(1).enumerate().rev() {
+                            for (_idx, operand) in operands.iter().skip(1).enumerate().rev() {
                                 worklist.push(Context::new(*operand, TraversalEvent::Exit));
                                 worklist.push(Context::new(*operand, TraversalEvent::Enter));
                             }
@@ -428,7 +428,7 @@ impl Encoder {
                 TraversalEvent::Exit => {
                     let tpe = types[usize::from(context.current_node)].as_ref();
                     match rootlang {
-                        Lang::Add(operands) => match tpe.expect("Type information is needed") {
+                        Lang::Add(_operands) => match tpe.expect("Type information is needed") {
                             PrimitiveTypeInfo::I32 => {
                                 newfunc.instruction(&Instruction::I32Add);
                             }
@@ -437,7 +437,7 @@ impl Encoder {
                             }
                             _ => unreachable!("bad type"),
                         },
-                        Lang::Shl(operands) => match tpe.expect("Type information is needed") {
+                        Lang::Shl(_operands) => match tpe.expect("Type information is needed") {
                             PrimitiveTypeInfo::I32 => {
                                 newfunc.instruction(&Instruction::I32Shl);
                             }
@@ -446,7 +446,7 @@ impl Encoder {
                             }
                             _ => unreachable!("bad type"),
                         },
-                        Lang::ShrU(operands) => match tpe.expect("Type information is needed") {
+                        Lang::ShrU(_operands) => match tpe.expect("Type information is needed") {
                             PrimitiveTypeInfo::I32 => {
                                 newfunc.instruction(&Instruction::I32ShrU);
                             }
@@ -455,7 +455,7 @@ impl Encoder {
                             }
                             _ => unreachable!("bad type"),
                         },
-                        Lang::Sub(operands) => match tpe.expect("Type information is needed") {
+                        Lang::Sub(_operands) => match tpe.expect("Type information is needed") {
                             PrimitiveTypeInfo::I32 => {
                                 newfunc.instruction(&Instruction::I32Sub);
                             }
@@ -464,7 +464,7 @@ impl Encoder {
                             }
                             _ => unreachable!("bad type"),
                         },
-                        Lang::Mul(operands) => match tpe.expect("Type information is needed") {
+                        Lang::Mul(_operands) => match tpe.expect("Type information is needed") {
                             PrimitiveTypeInfo::I32 => {
                                 newfunc.instruction(&Instruction::I32Mul);
                             }
@@ -473,7 +473,7 @@ impl Encoder {
                             }
                             _ => unreachable!("bad type"),
                         },
-                        Lang::And(operands) => match tpe.expect("Type information is needed") {
+                        Lang::And(_operands) => match tpe.expect("Type information is needed") {
                             PrimitiveTypeInfo::I32 => {
                                 newfunc.instruction(&Instruction::I32And);
                             }
@@ -482,7 +482,7 @@ impl Encoder {
                             }
                             _ => unreachable!("bad type"),
                         },
-                        Lang::Or(operands) => match tpe.expect("Type information is needed") {
+                        Lang::Or(_operands) => match tpe.expect("Type information is needed") {
                             PrimitiveTypeInfo::I32 => {
                                 newfunc.instruction(&Instruction::I32Or);
                             }
@@ -491,7 +491,7 @@ impl Encoder {
                             }
                             _ => unreachable!("bad type"),
                         },
-                        Lang::Xor(operands) => match tpe.expect("Type information is needed") {
+                        Lang::Xor(_operands) => match tpe.expect("Type information is needed") {
                             PrimitiveTypeInfo::I32 => {
                                 newfunc.instruction(&Instruction::I32Xor);
                             }
@@ -500,7 +500,7 @@ impl Encoder {
                             }
                             _ => unreachable!("bad type"),
                         },
-                        Lang::ShrS(operands) => match tpe.expect("Type information is needed") {
+                        Lang::ShrS(_operands) => match tpe.expect("Type information is needed") {
                             PrimitiveTypeInfo::I32 => {
                                 newfunc.instruction(&Instruction::I32ShrS);
                             }
@@ -509,7 +509,7 @@ impl Encoder {
                             }
                             _ => unreachable!("bad type"),
                         },
-                        Lang::DivS(operands) => match tpe.expect("Type information is needed") {
+                        Lang::DivS(_operands) => match tpe.expect("Type information is needed") {
                             PrimitiveTypeInfo::I32 => {
                                 newfunc.instruction(&Instruction::I32DivS);
                             }
@@ -518,7 +518,7 @@ impl Encoder {
                             }
                             _ => unreachable!("bad type"),
                         },
-                        Lang::DivU(operands) => match tpe.expect("Type information is needed") {
+                        Lang::DivU(_operands) => match tpe.expect("Type information is needed") {
                             PrimitiveTypeInfo::I32 => {
                                 newfunc.instruction(&Instruction::I32DivU);
                             }
@@ -527,7 +527,7 @@ impl Encoder {
                             }
                             _ => unreachable!("bad type"),
                         },
-                        Lang::RotR(operands) => match tpe.expect("Type information is needed") {
+                        Lang::RotR(_operands) => match tpe.expect("Type information is needed") {
                             PrimitiveTypeInfo::I32 => {
                                 newfunc.instruction(&Instruction::I32Rotr);
                             }
@@ -536,7 +536,7 @@ impl Encoder {
                             }
                             _ => unreachable!("bad type"),
                         },
-                        Lang::RotL(operands) => match tpe.expect("Type information is needed") {
+                        Lang::RotL(_operands) => match tpe.expect("Type information is needed") {
                             PrimitiveTypeInfo::I32 => {
                                 newfunc.instruction(&Instruction::I32Rotl);
                             }
@@ -905,9 +905,11 @@ impl Encoder {
                             let entry = &egraph
                                 .analysis
                                 .get_stack_entry_from_symbol(s.to_string())
-                                .ok_or(crate::Error::UnsupportedType(EitherType::EggError(
-                                    "The current symbol cannot be retrieved".into(),
-                                )))?;
+                                .ok_or_else(|| {
+                                    crate::Error::UnsupportedType(EitherType::EggError(
+                                        "The current symbol cannot be retrieved".into(),
+                                    ))
+                                })?;
 
                             match entry.operator {
                                 StackType::LocalGet(idx) => {
@@ -943,7 +945,7 @@ impl Encoder {
         info: &ModuleInfo,
         egraph: &EG,
         entry: &StackEntry,
-        operators: &Vec<OperatorAndByteOffset>,
+        operators: &[OperatorAndByteOffset],
         newfunc: &mut Function,
     ) -> crate::Result<()> {
         let mut worklist = vec![
@@ -1041,8 +1043,8 @@ impl Encoder {
         rnd: &mut rand::prelude::SmallRng,
         insertion_point: usize,
         expr: &RecExpr<Lang>,
-        node_to_eclass: &Vec<Id>,
-        operators: &Vec<OperatorAndByteOffset>,
+        node_to_eclass: &[Id],
+        operators: &[OperatorAndByteOffset],
         basicblock: &BBlock, // move to the analysis
         newfunc: &mut Function,
         egraph: &EG,
@@ -1065,7 +1067,7 @@ impl Encoder {
                     Encoder::expr2wasm(info, rnd, expr, node_to_eclass, newfunc, egraph)?;
                 } else {
                     // Copy the stack entry as it is
-                    Encoder::writestackentry(info, &egraph, entry, operators, newfunc)?;
+                    Encoder::writestackentry(info, egraph, entry, operators, newfunc)?;
                 }
             }
         }
@@ -1090,7 +1092,7 @@ impl Encoder {
     pub fn wasm2expr(
         dfg: &MiniDFG,
         oidx: usize,
-        operators: &Vec<OperatorAndByteOffset>,
+        operators: &[OperatorAndByteOffset],
         // The wasm expressions will be added here
         expr: &mut RecExpr<Lang>, // Replace this by RecExpr
     ) -> crate::Result<HashMap<Lang, (Id, Vec<usize>)>> {
@@ -1470,8 +1472,8 @@ impl Encoder {
     /// Build RecExpr from tree information
     pub fn build_expr(
         root: Id,
-        id_to_node: &Vec<(&Lang, Id)>,
-        operands: &Vec<Vec<Id>>,
+        id_to_node: &[(&Lang, Id)],
+        operands: &[Vec<Id>],
     ) -> (RecExpr<Lang>, Vec<Id>) {
         let mut expr = RecExpr::default();
 
@@ -1534,9 +1536,9 @@ impl Encoder {
                         Lang::ExtendI32S(_) => expr.add(Lang::ExtendI32S([operand(0)])),
                         Lang::ExtendI32U(_) => expr.add(Lang::ExtendI32U([operand(0)])),
                         Lang::Popcnt(_) => expr.add(Lang::Popcnt([operand(0)])),
-                        Lang::Call(op) => expr.add(Lang::Call(
-                            (0..op.len()).map(|id| operand(id)).collect::<Vec<Id>>(),
-                        )),
+                        Lang::Call(op) => {
+                            expr.add(Lang::Call((0..op.len()).map(operand).collect::<Vec<Id>>()))
+                        }
                         Lang::Tee(_) => expr.add(Lang::Tee([operand(0)])),
                         Lang::Unfold(_) => expr.add(Lang::Unfold(operand(0))),
                         Lang::ILoad(_) => expr.add(Lang::ILoad([

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/mod.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/mod.rs
@@ -24,7 +24,7 @@ fn cmp<T: PartialOrd>(a: &Option<T>, b: &Option<T>) -> Ordering {
         (None, None) => Ordering::Equal,
         (None, Some(_)) => Ordering::Greater,
         (Some(_), None) => Ordering::Less,
-        (Some(a), Some(b)) => a.partial_cmp(&b).unwrap(),
+        (Some(a), Some(b)) => a.partial_cmp(b).unwrap(),
     }
 }
 
@@ -97,7 +97,7 @@ where
         if node.children().iter().all(has_cost) {
             let costs = &costs;
             let cost_f = |id| costs[&egraph.find(id)].0.clone();
-            Some(self.cost_function.cost(&node, cost_f))
+            Some(self.cost_function.cost(node, cost_f))
         } else {
             None
         }
@@ -116,7 +116,7 @@ where
         rnd: &mut rand::prelude::SmallRng,
         eclass: Id,
         max_depth: u32,
-        expression_builder: impl Fn(Id, &Vec<(&L, Id)>, &Vec<Vec<Id>>) -> (RecExpr<L>, Vec<Id>),
+        expression_builder: impl Fn(Id, &[(&L, Id)], &[Vec<Id>]) -> (RecExpr<L>, Vec<Id>),
         max_tries: u32,
         oracle: impl Fn(RecExpr<L>) -> bool,
     ) -> crate::Result<(RecExpr<L>, Vec<Id>)> // return the random tree, TODO, improve the way the tree is returned
@@ -174,20 +174,18 @@ where
         // Build the tree with the right language constructor
         let (expr, classes) = expression_builder(Id::from(0), &id_to_node, &operands);
 
-        if !oracle(expr.clone()) {
-            if max_tries > 0 {
-                return self.extract_random(
-                    rnd,
-                    eclass,
-                    max_depth,
-                    expression_builder,
-                    max_tries - 1,
-                    oracle,
-                );
-            }
+        if !oracle(expr.clone()) && max_tries > 0 {
+            return self.extract_random(
+                rnd,
+                eclass,
+                max_depth,
+                expression_builder,
+                max_tries - 1,
+                oracle,
+            );
         };
 
-        return Ok((expr, classes));
+        Ok((expr, classes))
     }
 }
 

--- a/crates/wasm-mutate/src/mutators/peephole/mod.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/mod.rs
@@ -693,6 +693,48 @@ mod tests {
     }
 
     #[test]
+    fn test_peep_wrap() {
+        let rules: &[Rewrite<super::Lang, PeepholeMutationAnalysis>] =
+            &[rewrite!("strength-undo";  "?x" => "(add ?x 0)")];
+
+        test_peephole_mutator(
+            r#"
+        (module
+            (func (export "exported_func") (result i32) (local i64)
+                local.get 0
+                i64.const 0
+                i64.shl
+                i32.wrap_i64
+                i32.const -441701230
+                i32.const 441701230
+                i32.add
+                i32.add
+            )
+        )
+        "#,
+            rules,
+            r#"
+            (module
+                (type (;0;) (func (result i32) ))
+                (func (;0;) (type 0) (result i32)
+                    (local i64)
+                    local.get 0
+                    i64.const 0
+                    i64.shl
+                    i32.wrap_i64
+                    i32.const -441701230
+                    i32.const 441701230
+                    i32.add
+                    i32.add
+                    i32.const 0
+                    i32.add)
+              (export "exported_func" (func 0)))
+            "#,
+            0,
+        );
+    }
+
+    #[test]
     fn test_peep_irelop1() {
         let rules: &[Rewrite<super::Lang, PeepholeMutationAnalysis>] =
             &[rewrite!("strength-undo";  "(eqz ?x)" => "(eq ?x 0)")];

--- a/crates/wasm-mutate/src/mutators/peephole/mod.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/mod.rs
@@ -65,9 +65,9 @@ impl PeepholeMutator {
 
                 Ok(all_locals)
             }
-            _ => Err(crate::Error::UnsupportedType(EitherType::TypeDef(format!(
-                "The type for this function is not a function tyupe definition"
-            )))),
+            _ => Err(crate::Error::UnsupportedType(EitherType::TypeDef(
+                "The type for this function is not a function tyupe definition".to_string(),
+            ))),
         }
     }
     fn copy_locals(&self, reader: FunctionBody) -> Result<Function> {
@@ -113,7 +113,7 @@ impl PeepholeMutator {
             let operatorscount = operators.len();
             let opcode_to_mutate = rnd.gen_range(0, operatorscount);
 
-            let locals = self.get_func_locals(&info, fidx + info.imported_functions_count /* the function type is shifted by the imported functions*/, &mut localsreader)?;
+            let locals = self.get_func_locals(info, fidx + info.imported_functions_count /* the function type is shifted by the imported functions*/, &mut localsreader)?;
 
             for oidx in (opcode_to_mutate..operatorscount).chain(0..opcode_to_mutate) {
                 let mut dfg = DFGBuilder::new();
@@ -134,7 +134,7 @@ impl PeepholeMutator {
 
                 match basicblock {
                     Some(basicblock) => {
-                        let minidfg = dfg.get_dfg(&info, &operators, &basicblock, &locals);
+                        let minidfg = dfg.get_dfg(info, &operators, &basicblock, &locals);
 
                         match minidfg {
                             None => {
@@ -376,7 +376,7 @@ pub(crate) trait CodeMutator {
     fn can_mutate<'a>(
         &self,
         config: &'a WasmMutate,
-        operators: &Vec<OperatorAndByteOffset<'a>>,
+        operators: &[OperatorAndByteOffset<'a>],
         at: usize,
     ) -> Result<bool>;
 
@@ -1604,7 +1604,7 @@ mod tests {
 
         let mutator = PeepholeMutator; // the string is empty
 
-        let mut info = ModuleInfo::new(original).unwrap();
+        let info = ModuleInfo::new(original).unwrap();
         let can_mutate = mutator.can_mutate(&wasmmutate, &info);
 
         let mut rnd = SmallRng::seed_from_u64(seed);
@@ -1612,7 +1612,7 @@ mod tests {
         assert_eq!(can_mutate, true);
 
         let mutated = mutator
-            .mutate_with_rules(&wasmmutate, &mut rnd, &mut info, rules)
+            .mutate_with_rules(&wasmmutate, &mut rnd, &info, rules)
             .unwrap();
 
         let mut validator = wasmparser::Validator::new();


### PR DESCRIPTION
When inferring types for the rewriting egraph tree during the translation from Wasm to the egraph some type information is missing. However, it can be inferred by the type relations between the nodes. For example for the `i32.wrap_i64` operator, we always know that it returns an i32 constant and waits for the operand to be an i64 integer. This information could be propagated to the other nodes in the tree. 

This new implementation does exactly that, it fixes some nodes to expect and receive specific types using fixed operators and function signatures. The type tree is traversed until is converges, if for some reason, a node has not a type (when it should) this type is gathered from the egraph eclass data.

cc @fitzgen 