### PR TITLE
Code motion mutator

### DIFF
--- a/crates/wasm-mutate/src/error.rs
+++ b/crates/wasm-mutate/src/error.rs
@@ -13,6 +13,9 @@ pub enum Error {
     /// There is a type/operator that wasm-mutate cannot process
     #[error("Unsupported mapping.")]
     UnsupportedType(EitherType),
+    /// Ast parsing error for code motion mutators
+    #[error("Invalid Ast parsing for code motion")]
+    InvalidAstOperation(String),
 }
 
 #[derive(Debug)]

--- a/crates/wasm-mutate/src/lib.rs
+++ b/crates/wasm-mutate/src/lib.rs
@@ -14,7 +14,11 @@ pub(crate) mod info;
 pub(crate) mod module;
 pub mod mutators;
 
-use crate::mutators::{codemotion::CodemotionMutator, function_body_unreachable::FunctionBodyUnreachable, peephole::PeepholeMutator, remove_export::RemoveExportMutator, rename_export::RenameExportMutator, snip_function::SnipMutator};
+use crate::mutators::{
+    codemotion::CodemotionMutator, function_body_unreachable::FunctionBodyUnreachable,
+    peephole::PeepholeMutator, remove_export::RemoveExportMutator,
+    rename_export::RenameExportMutator, snip_function::SnipMutator,
+};
 use info::ModuleInfo;
 use mutators::Mutator;
 use rand::{rngs::SmallRng, Rng, SeedableRng};

--- a/crates/wasm-mutate/src/lib.rs
+++ b/crates/wasm-mutate/src/lib.rs
@@ -14,11 +14,7 @@ pub(crate) mod info;
 pub(crate) mod module;
 pub mod mutators;
 
-use crate::mutators::{
-    function_body_unreachable::FunctionBodyUnreachable, peephole::PeepholeMutator,
-    remove_export::RemoveExportMutator, rename_export::RenameExportMutator,
-    snip_function::SnipMutator,
-};
+use crate::mutators::{codemotion::CodemotionMutator, function_body_unreachable::FunctionBodyUnreachable, peephole::PeepholeMutator, remove_export::RemoveExportMutator, rename_export::RenameExportMutator, snip_function::SnipMutator};
 use info::ModuleInfo;
 use mutators::Mutator;
 use rand::{rngs::SmallRng, Rng, SeedableRng};
@@ -156,6 +152,7 @@ impl WasmMutate {
             Box::new(SnipMutator),
             Box::new(FunctionBodyUnreachable),
             Box::new(PeepholeMutator),
+            Box::new(CodemotionMutator),
         ];
         let mut mutators: Vec<_> = mutators
             .into_iter()

--- a/crates/wasm-mutate/src/module/mod.rs
+++ b/crates/wasm-mutate/src/module/mod.rs
@@ -1,7 +1,7 @@
 use std::convert::TryFrom;
 
-use wasm_encoder::ValType;
-use wasmparser::{Type, TypeDef};
+use wasm_encoder::{BlockType, ValType};
+use wasmparser::{Type, TypeDef, TypeOrFuncType};
 
 use crate::error::EitherType;
 
@@ -74,5 +74,19 @@ pub fn map_type(tpe: Type) -> super::Result<ValType> {
         Type::F32 => Ok(ValType::F32),
         Type::F64 => Ok(ValType::F64),
         _ => Err(super::Error::UnsupportedType(EitherType::Type(tpe))),
+    }
+}
+
+pub fn map_block_type(ty: TypeOrFuncType) -> super::Result<BlockType> {
+    match ty {
+        TypeOrFuncType::Type(ty) => match ty {
+            Type::I32 => Ok(BlockType::Result(ValType::I32)),
+            Type::I64 => Ok(BlockType::Result(ValType::I64)),
+            Type::F32 => Ok(BlockType::Result(ValType::F32)),
+            Type::F64 => Ok(BlockType::Result(ValType::F64)),
+            Type::EmptyBlockType => Ok(BlockType::Empty),
+            _ => Err(super::Error::NoMutationsApplicable),
+        },
+        TypeOrFuncType::FuncType(_) => Err(super::Error::NoMutationsApplicable),
     }
 }

--- a/crates/wasm-mutate/src/mutators/codemotion/ir/mod.rs
+++ b/crates/wasm-mutate/src/mutators/codemotion/ir/mod.rs
@@ -1,0 +1,970 @@
+use std::{borrow::Borrow, cell::RefCell, collections::HashMap, io::Write, process::Command, slice::{ChunksExactMut, Iter}, time::{SystemTime, UNIX_EPOCH}};
+
+use wasm_encoder::{BlockType, Function, Instruction};
+use wasmparser::{Operator, Range};
+use crate::{error::EitherType, mutators::OperatorAndByteOffset};
+pub struct ASTBuilder;
+
+#[derive(Debug)]
+struct AST {
+    // Index of the root node
+    root: usize,
+    // Nodes of the tree
+    nodes: Vec<Node>
+}
+
+impl AST {
+
+    /// Build a new empty AST
+    pub fn new(root: usize, nodes: Vec<Node>) -> Self {
+        AST{
+            root,
+            nodes
+        }
+    }
+
+
+    /// Encodes the AST
+    /// It traverses the AST starting from the last root
+    pub fn write_ast<'a>(&self, newfunc: &mut Function, operators: &Vec<OperatorAndByteOffset>, input_wasm: &'a [u8]) -> crate::Result<()> {
+        
+        println!("AST {:?}", self);
+        
+        fn write_ast_rec<'a>(ast: &AST, current_node: &Node, newfunc: &mut Function, operators: &Vec<OperatorAndByteOffset>, input_wasm: &'a [u8]) {
+            match current_node {
+                Node::IfElse(condition, then, alternative) => {
+                    // write condition first
+                    write_ast_rec(ast, &ast.nodes[*condition], newfunc,operators, input_wasm);
+                    newfunc.instruction(&Instruction::If(BlockType::Empty));
+                    for ch in then {
+                        write_ast_rec(ast, &ast.nodes[*ch], newfunc,operators, input_wasm);
+                    }
+
+                    if let Some(alternative) = alternative {
+                        newfunc.instruction(&Instruction::Else);
+
+                        for ch in alternative {
+                            write_ast_rec(ast, &ast.nodes[*ch], newfunc,operators, input_wasm);
+                        }
+                    }
+                    newfunc.instruction(&Instruction::End);
+
+                },
+                Node::Code { range } => {
+                    let operator_range = (range.start, range.end);
+
+
+                    //print operator
+                    for operator in &operators[range.start..range.end]{
+                        println!("{:?}", operator.0)
+                    }
+
+                    let bytes_range = (&operators[operator_range.0].1, &operators[operator_range.1].1);
+                    let piece_of_code = &input_wasm[*bytes_range.0..*bytes_range.1];
+                    
+                    newfunc.raw(piece_of_code.to_vec());
+                },
+                Node::Loop(body) => {
+                    newfunc.instruction(&Instruction::Loop(BlockType::Empty));
+                    for ch in body {
+                        write_ast_rec(ast, &ast.nodes[*ch], newfunc,operators, input_wasm);
+                    }
+                    newfunc.instruction(&Instruction::End);
+
+                },
+                Node::Block(body) => {
+                    newfunc.instruction(&Instruction::Block(BlockType::Empty));
+                    for ch in body {
+                        write_ast_rec(ast, &ast.nodes[*ch], newfunc,operators, input_wasm);
+                    }
+                    newfunc.instruction(&Instruction::End);
+                },
+                Node::Root(body) => {
+
+                    for ch in body {
+                        write_ast_rec(ast, &ast.nodes[*ch], newfunc,operators, input_wasm);
+                    }
+                    // Closing end
+                    newfunc.instruction(&Instruction::End);
+                },
+            }
+        }
+
+        write_ast_rec(self, &self.nodes[self.root], newfunc, operators, input_wasm);
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone)]
+enum Node {
+    IfElse(usize, Vec<usize>, Option<Vec<usize>>),
+    Code{
+        range: Range
+    },
+    Loop(Vec<usize>),
+    Block(Vec<usize>),
+    Root(Vec<usize>)
+}
+
+
+impl ASTBuilder {
+
+    fn dotify_ast<'a>(&self, root: usize, nodes: &[Node], operators: &'a [OperatorAndByteOffset]) -> String {
+        let mut r = String::new();
+        r.push_str("digraph AST {\n   node [shape=box]; \n");
+
+        let mut worklist = Vec::new();
+        worklist.push(root);
+
+        let bbcontent = |r: Range| {
+            operators[r.start..r.end].iter().map(|(o, _)|format!("{:?}", o)).collect::<Vec<String>>().join("\n")
+        };
+        let mut uniqueid = nodes.len();
+        while let Some(id) = worklist.pop(){
+            let node = &nodes[id];
+            match node {
+                Node::IfElse(condition, then, alternative) => {
+                    // Add edges to children then and push into worklist
+                    r.push_str(&format!(
+                        "{} -> {}[label=\"condition\", style=dashed, color=red];\n",
+                    id, condition),);
+                    worklist.push(*condition);
+                    r.push_str(&format!("\t{} [label=\"if\"]\n", id));
+                    // Create then branch
+                    uniqueid += 1;
+                    r.push_str(&format!(
+                        "{} -> {}[label=\"then\"];\n",
+                        id, uniqueid),);
+                    r.push_str(&format!("\t{} [label=\"\"]\n", uniqueid));
+                    for ch in then {
+                        r.push_str(&format!(
+                        "{} -> {};\n",
+                            uniqueid, ch),);
+                        worklist.push(*ch)
+                    }
+
+                    if let Some(alternative) = alternative {
+                        uniqueid += 1;
+                        r.push_str(&format!(
+                            "{} -> {}[label=\"else\"];\n",
+                            id, uniqueid),);
+                        r.push_str(&format!("\t{} [label=\"\"]\n", uniqueid));
+                        for ch in alternative {
+                            r.push_str(&format!(
+                            "{} -> {};\n",
+                                uniqueid, ch),);
+                            worklist.push(*ch)
+                        }
+                    }
+                },
+                Node::Code{range} => {
+                    r.push_str(&format!("\t{} [label=\"{}\"]\n", id, bbcontent(*range)));
+                },
+                Node::Loop(children) => {
+                    r.push_str(&format!("\t{} [label=\"loop\"]\n", id));
+
+                    for ch in children {
+                        r.push_str(&format!(
+                        "{} -> {};\n",
+                            id, ch),);
+                        worklist.push(*ch)
+                    }
+                },
+                Node::Block(body) | Node::Root(body) => {
+                    r.push_str(&format!("\t{} [label=\"block\"]\n", id));
+
+                    for ch in body {
+                        r.push_str(&format!(
+                        "{} -> {};\n",
+                            id, ch),);
+                        worklist.push(*ch)
+                    }
+                },
+            }
+        }
+
+        r.push_str("\n}");
+        println!("root {}", r);
+        r
+    }
+
+    fn build_ast<'a>(&mut self, position: usize, operators: &'a [OperatorAndByteOffset]) -> crate::Result<AST>{
+        
+        let (root, nodes) = self.parse(position, operators)?;
+        println!("root {:?}", root);
+
+        let dot = self.dotify_ast(root, &nodes, operators);
+        // debug purposes, remove
+        let name = format!("{}.dot", std::thread::current().name().unwrap());
+        let bin =  std::env::var("DOT").unwrap();
+        let mut f = std::fs::File::create(name.clone()).unwrap();
+        f.write(dot.as_bytes()).unwrap();
+
+        Command::new(&bin)
+            .arg("-Tpng")
+            .arg(name.clone())
+            .arg("-o")
+            .arg(format!("{}.png", name))
+            .spawn()
+            .expect("Process cannot be launched");
+            
+        Ok(AST::new(root, nodes))
+    }
+
+
+    fn parse<'a>(&mut self, position: usize, operators: &'a [OperatorAndByteOffset]) -> crate::Result<(usize, Vec<Node>)>{
+
+        #[derive(Debug)]
+        enum State {
+            If,
+            Else,
+            Loop,
+            Block,
+            Root
+        }
+
+        let mut nodes = Vec::new();
+        let mut nodes = RefCell::new(nodes);
+       
+        let mut frame_stack = vec![
+            State::Root
+        ];
+        let mut state_stack = RefCell::new(Vec::new());
+        let mut current_parsing = RefCell::new(Vec::new());
+        
+        let push_state = || {
+            state_stack.borrow_mut().push(current_parsing.clone());
+            *current_parsing.borrow_mut() = vec![]
+        };
+        let pop_state = ||  {
+            state_stack.borrow_mut().pop().expect("Missing state").borrow().clone()
+        };
+
+        let mut current_code = Range::new(0,0);
+
+        for (idx, (operator, _)) in operators.iter().enumerate() {
+
+            println!("{} operator {:?}",idx,  operator);
+            match operator {
+                Operator::If { .. } => {
+                    // push current code 
+                    if current_code.end != current_code.start {
+                        let id= nodes.borrow().len();
+                        nodes.borrow_mut().push(Node::Code{
+                            range: current_code.clone()
+                        });
+                        current_parsing.borrow_mut().push(id);
+                    }
+                    current_code.start = idx + 1;
+                    current_code.end = idx + 1;
+                    push_state();
+                    frame_stack.push(State::If);
+                }
+                Operator::Else { .. } => {
+                    println!("range {:?}", current_code);
+                    if current_code.end != current_code.start {
+                        let id= nodes.borrow().len();
+                        nodes.borrow_mut().push(Node::Code{
+                            range: current_code.clone()
+                        });
+                        current_parsing.borrow_mut().push(id);
+                    }
+                    current_code.start = idx + 1;
+                    current_code.end = idx + 1;
+                    push_state();
+                    frame_stack.push(State::Else);
+                }
+                Operator::Block {..} => {
+                    if current_code.end != current_code.start {
+                        let id= nodes.borrow().len();
+                        nodes.borrow_mut().push(Node::Code{
+                            range: current_code.clone()
+                        });
+                        current_parsing.borrow_mut().push(id);
+                    }
+                    current_code.start = idx + 1;
+                    current_code.end = idx + 1;
+                    push_state();
+                    frame_stack.push(State::Block);
+                }
+                Operator::Loop {.. } => {
+                    if current_code.end != current_code.start {
+                        let id= nodes.borrow().len();
+                        nodes.borrow_mut().push(Node::Code{
+                            range: current_code.clone()
+                        });
+                        current_parsing.borrow_mut().push(id);
+                    }
+                    current_code.start = idx + 1;
+                    current_code.end = idx + 1;
+                    frame_stack.push(State::Loop);
+                    push_state();
+                }
+                Operator::End => {
+                    if current_code.end != current_code.start {
+                        let id= nodes.borrow().len();
+                        nodes.borrow_mut().push(Node::Code{
+                            range: current_code.clone()
+                        });
+                        current_parsing.borrow_mut().push(id);
+                    }
+                    current_code.start = idx + 1;
+                    current_code.end = idx + 1;
+                    println!("Pop state {:?} {:?}", frame_stack, state_stack.borrow());
+                    let last_frame = frame_stack.pop().expect("Missing frame");
+                    match last_frame {
+                        State::If => {                            
+                            let then_branch = current_parsing.borrow().clone();
+                            *current_parsing.borrow_mut() = pop_state();
+
+                            println!("{:?}", current_parsing.borrow());
+                            let condition = current_parsing.borrow_mut().pop().expect("Missing condition");
+                            let id = nodes.borrow().len();
+                            nodes.borrow_mut().push(Node::IfElse(
+                                condition, then_branch, None
+                            ));
+
+                            current_parsing.borrow_mut().push(id);
+                        },
+                        State::Else => {
+                            let last_frame = frame_stack.pop().expect("Missing frame");
+                            // Validate parent
+                            match last_frame {
+                                State::If => {  },
+                                _ => unreachable!("Invalid parent frame")
+                            }
+                            let else_branch = current_parsing.borrow().clone();
+                            let then_branch = pop_state();
+                            *current_parsing.borrow_mut() = pop_state();
+
+                            let condition = current_parsing.borrow_mut().pop().expect("Missing condition");
+                            let id = nodes.borrow().len();
+                            nodes.borrow_mut().push(Node::IfElse(
+                                condition, then_branch, Some(else_branch)
+                            ));
+
+                            current_parsing.borrow_mut().push(id);
+                        },
+                        State::Loop => {
+                            
+                            let children = current_parsing.borrow().clone();
+                            *current_parsing.borrow_mut() = pop_state();
+                            let id = nodes.borrow().len();
+                            nodes.borrow_mut().push(Node::Loop(children));
+                            current_parsing.borrow_mut().push(id);
+                        },
+                        State::Block => {
+                            let children = current_parsing.borrow().clone();
+                            *current_parsing.borrow_mut() = pop_state();
+                            let id = nodes.borrow().len();
+                            nodes.borrow_mut().push(Node::Block(children));
+                            current_parsing.borrow_mut().push(id);
+                        },
+                        State::Root => {
+                            // break
+                            break
+                        },
+                    }
+                }
+                _ => {
+                    current_code.end += 1;
+                }
+            }
+        }
+        
+        let roots = current_parsing.borrow().clone();
+        // Create a block with the current parsing state
+        let root = Node::Root(roots.clone());
+        let root_id = nodes.borrow().len();
+        nodes.borrow_mut().push(root);
+        let nodes = nodes.borrow().clone();
+        Ok((root_id, nodes))
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use crate::{WasmMutate, mutators::{Mutator, OperatorAndByteOffset, codemotion::ir::ASTBuilder, peephole::PeepholeMutator}};
+    use rand::{rngs::SmallRng, SeedableRng};
+    use wasm_encoder::{CodeSection, Function, FunctionSection, Instruction, Module, TypeSection, ValType};
+    use wasmparser::Parser;
+
+    use super::AST;
+
+    fn assert_correct_ast(wasm: &str, expected_ast: &AST) -> bool {
+        
+        let original = &wat::parse_str(wasm,
+        )
+        .unwrap();
+        let mut parser = Parser::new(0);
+        let mut consumed = 0;
+        loop {
+            let (payload, size) = match parser.parse(&original[consumed..], true).unwrap() {
+                wasmparser::Chunk::NeedMoreData(_) => {
+                    panic!("This should not happen")
+                }
+                wasmparser::Chunk::Parsed { consumed, payload } => (payload, consumed),
+            };
+
+            consumed += size;
+
+            match payload {
+                wasmparser::Payload::CodeSectionEntry(reader) => {
+                    let operators = reader
+                        .get_operators_reader()
+                        .unwrap()
+                        .into_iter_with_offsets()
+                        .collect::<wasmparser::Result<Vec<OperatorAndByteOffset>>>()
+                        .unwrap();
+
+                    let ast = ASTBuilder.build_ast(0, &operators).unwrap();
+
+                    todo!();
+                    //assert!(ast.is_ok());
+                    //let ast = ast.unwrap();
+
+                    // If the check fails the dotify string will be printed in console
+                    //println!("AST\n{}", ast.dotify(&operators, true));
+                    //println!("successors\n{:?}", ast.successors);
+                    //println!("pred\n{:?}", ast.parents);
+
+                    // assert_eq!(ast.successors, expected_ast.successors);
+
+                    return true
+                }
+                wasmparser::Payload::End => {
+                    break;
+                }
+                _ => {
+                    // Do nothing
+                }
+            }
+        }
+        false
+    }
+
+    #[test]
+    fn test_ast_builder_block1() {
+        assert_correct_ast(r#"
+        (module
+            (memory 1)
+            (func (export "exported_func") (param i32) (result i32)
+                block
+                    i32.const 100
+                    drop
+                end
+                i32.const 101
+            )
+        )
+        "#, &AST{
+            root: 0,
+            nodes: vec![]
+        });
+    }
+
+    #[test]
+    fn test_ast_builder_block2() {
+        assert_correct_ast(r#"
+        (module
+            (memory 1)
+            (func (export "exported_func") (param i32) (result i32)
+                block
+                    i32.const 100
+                    drop
+                    block
+                        i32.const 100
+                        drop
+                    end
+                end
+            )
+        )
+        "#, &AST{
+            root: 0,
+            nodes: vec![]
+        });
+    }
+
+    #[test]
+    fn test_ast_builder_block3() {
+        assert_correct_ast(r#"
+        (module
+            (memory 1)
+            (func (export "exported_func") (param i32) (result i32)
+                block
+                    i32.const 100
+                    drop
+                    block
+                        i32.const 101
+                        br_if 2
+                    end
+                end
+            )
+        )
+        "#, &AST{
+            root: 0,
+            nodes: vec![]
+        });
+    }
+
+    #[test]
+    fn test_ast_builder_block_and_loop() {
+        assert_correct_ast(r#"
+        (module
+            (memory 1)
+            (func (export "exported_func") (param i32) (result i32)
+                block
+                    i32.const 100
+                    drop
+                    loop
+                        i32.const 100
+                        br 1
+                    end
+                end
+            )
+        )
+        "#, &AST{
+            root: 0,
+            nodes: vec![]
+        });
+    }
+
+    #[test]
+    fn test_ast_builder_if() {
+        assert_correct_ast(r#"
+        (module
+            (memory 1)
+            (func (export "exported_func") (param i32) (result i32)
+                local.get 0
+                local.get 0
+                i32.add
+                i32.load
+                if
+                    i32.const 100
+                    i32.const 87
+                end
+                i32.const -14
+            )
+        )
+        "#, &AST{
+            root: 0,
+            nodes: vec![]
+        });
+    }
+    #[test]
+    fn test_ast_builder_if_else_nested() {
+        assert_correct_ast(r#"
+        (module
+            (memory 1)
+            (func (export "exported_func") (param i32) (result i32)
+
+                local.get 0
+                local.get 0
+                i32.add
+                i32.load
+                if
+                    i32.const 100
+                else
+                    i32.const 99
+                    if
+                        i32.const 98
+                    else
+                        i32.const 97
+                    end
+                    i32.const -96
+                end
+                i32.const -95
+            )
+        )
+        "#, &AST{
+            root: 0,
+            nodes: vec![]
+        });
+    }
+
+
+    #[test]
+    fn test_ast_builder_if_else_nested2() {
+        assert_correct_ast(r#"
+        (module
+            (memory 1)
+            (func (export "exported_func") (param i32) (result i32)
+
+                local.get 0
+                local.get 0
+                i32.add
+                i32.load
+                if
+                    i32.const 100
+                else
+                    i32.const 87
+                    if 
+                        i32.const 88
+                    else
+                        i32.const 89
+                    end
+                    if
+                        i32.const 88
+                    else
+                        i32.const 89
+                    end
+                end
+                
+                i32.const -14
+            )
+        )
+        "#, &AST{
+            root: 0,
+            nodes: vec![]
+        });
+    }
+
+    #[test]
+    fn test_ast_builder_if_else_appended() {
+        assert_correct_ast(r#"
+        (module
+            (memory 1)
+            (func (export "exported_func") (param i32) (result i32)
+
+                local.get 0
+                local.get 0
+                i32.add
+                i32.load
+                if
+                    i32.const 100
+                else
+                    i32.const 87
+                    i32.const -10
+                end
+                i32.const 100
+                i32.add
+                if
+                    i32.const 88
+                else
+                    i32.const 89
+                end
+                i32.const -14
+            )
+        )
+        "#, &AST{
+            root: 0,
+            nodes: vec![]
+        });
+    }
+    #[test]
+    fn test_ast_builder_break2() {
+
+        assert_correct_ast(r#"
+        (module
+                (memory 1)
+                (func (export "exported_func") (param i32) (result i32)
+                    loop
+                        i32.const 10
+                        local.get 0
+                        i32.add
+                        local.tee 0
+                        br_if 1
+                        i32.const 100
+                        loop
+                            i32.const 10
+                            local.get 0
+                            i32.add
+                            local.tee 0
+                            br 2
+                        end
+                    end
+                    local.get 0
+                )
+            )
+        "#, &AST{
+            root: 0,
+            nodes: vec![]
+        });
+    }
+
+    #[test]
+    fn test_ast_builder_break3() {
+
+        assert_correct_ast(r#"
+        (module
+                (memory 1)
+                (func (export "exported_func") (param i32) (result i32)
+                    loop
+                        i32.const 10
+                        local.get 0
+                        i32.add
+                        local.tee 0
+                        br_if 1
+                        i32.const 100
+                        loop
+                            i32.const 10
+                            local.get 0
+                            i32.add
+                            local.tee 0
+                            br_if 1
+                        end
+                    end
+                    local.get 0
+                )
+            )
+        "#, &AST{
+            root: 0,
+            nodes: vec![]
+        });
+    }
+
+    #[test]
+    fn test_ast_builder_break4() {
+
+        assert_correct_ast(r#"
+        (module
+                (memory 1)
+                (func (export "exported_func") (param i32) (result i32)
+                    loop
+                        i32.const 10
+                        local.get 0
+                        i32.add
+                        local.tee 0
+                        br_if 1
+                        i32.const 100
+                        loop
+                            i32.const 10
+                            local.get 0
+                            i32.add
+                            local.tee 0
+                            br_table 1 2
+                        end
+                    end
+                    local.get 0
+                )
+            )
+        "#, &AST{
+            root: 0,
+            nodes: vec![]
+        });
+    }
+    #[test]
+    fn test_ast_builder_break1() {
+
+        assert_correct_ast(r#"
+        (module
+                (memory 1)
+                (func (export "exported_func") (param i32) (result i32)
+                    loop
+                        i32.const 10
+                        local.get 0
+                        i32.add
+                        local.tee 0
+                        br_if 1
+                        i32.const 100
+                        br_if 1
+                    end
+                    local.get 0
+                )
+            )
+        "#, &AST{
+            root: 0,
+            nodes: vec![]
+        });
+    }
+    #[test]
+    fn test_ast_builder_if_else1() {
+
+        assert_correct_ast(r#"
+        (module
+                (memory 1)
+                (func (export "exported_func") (param i32) (result i32)
+
+                    local.get 0
+                    local.get 0
+                    i32.add
+                    i32.load
+                    if
+                        i32.const 100
+                    else
+                        i32.const 87
+                    end
+                    i32.const 100
+                    end
+                )
+            )
+        "#, &AST{
+            root: 0,
+            nodes: vec![]
+        });
+    }
+    #[test]
+    fn test_ast_builder_loop() {
+        assert_correct_ast(r#"
+        (module
+            (memory 1)
+            (func (export "exported_func") (param i32) (result i32)
+
+                loop
+                i32.const 1
+                local.get 0
+                i32.add
+                local.set 0
+            end
+            )
+        )
+        "#, &AST{
+            root: 0,
+            nodes: vec![]
+        });
+    }
+
+    #[test]
+    fn test_ast_builder_if_else_with_return() {
+        
+        assert_correct_ast(r#"
+        (module
+            (memory 1)
+            (func (export "exported_func") (param i32) (result i32)
+
+                local.get 0
+                local.get 0
+                i32.add
+                i32.load
+                if
+                    i32.const 100
+                else
+                    return
+                    i32.const 130
+                end
+            )
+        )
+        "#, &AST{
+            root: 0,
+            nodes: vec![]
+        });
+    }
+    #[test]
+    fn test_ast_builder_and_encode() {
+        let original = &wat::parse_str(
+            r#"
+        (module
+            (func (param i32) (result i32)
+
+                local.get 0
+                local.get 0
+                i32.add
+                i32.load
+                if
+                    i32.const 54
+                    if
+                        i32.const 55
+                        i32.const -55
+                    end
+                    if
+                        i32.const -10
+                        call 0
+                    else
+                        return
+                        i32.const 120
+                    end
+                    i32.const -10
+                else
+                    i32.const 87
+                end
+                i32.const 56
+                i32.add
+                loop
+                    i32.const 1
+                    local.get 0
+                    i32.add
+                    local.set 0
+                    loop
+                        local.get 0
+                        local.set 0
+                        br 1
+                        
+                    end
+                    loop
+                        i32.const 1
+                        local.get 0
+                        i32.add
+                        local.set 0
+                        loop
+                            local.get 0
+                            local.set 0
+                            br 1
+                        end
+                        br 1
+                    end
+
+                    br 1
+                end
+            
+            )
+        )
+        "#,
+        )
+        .unwrap();
+
+        let mut parser = Parser::new(0);
+        let mut consumed = 0;
+        loop {
+            let (payload, size) = match parser.parse(&original[consumed..], true).unwrap() {
+                wasmparser::Chunk::NeedMoreData(_) => {
+                    panic!("This should not happen")
+                }
+                wasmparser::Chunk::Parsed { consumed, payload } => (payload, consumed),
+            };
+
+            consumed += size;
+
+            match payload {
+                wasmparser::Payload::CodeSectionEntry(reader) => {
+                    let operators = reader
+                        .get_operators_reader()
+                        .unwrap()
+                        .into_iter_with_offsets()
+                        .collect::<wasmparser::Result<Vec<OperatorAndByteOffset>>>()
+                        .unwrap();
+
+                        
+                    let ast = ASTBuilder.build_ast(0, &operators);
+
+                    assert!(ast.is_ok());
+
+                    let mut module = Module::new();
+                    let mut code = CodeSection::new();
+                    let mut newfunc = Function::new(vec![]);
+
+                    let ast = ast.unwrap();
+                    ast.write_ast(&mut newfunc, &operators, &original);                    
+                    code.function(&newfunc);
+
+                    let mut types = TypeSection::new();
+                    let params = vec![ValType::I32];
+                    let results = vec![ValType::I32];
+                    types.function(params, results);
+                    module.section(&types);
+                    
+                    // Encode the function section.
+                    let mut functions = FunctionSection::new();
+                    let type_index = 0;
+                    functions.function(type_index);
+                    module.section(&functions);
+                    
+                    module.section(&code);
+
+                    let encoded = module.finish();
+                    let text = wasmprinter::print_bytes(encoded.clone()).unwrap();
+                    println!("{}", text);
+
+                    assert_eq!(&encoded, original); 
+
+                }
+                wasmparser::Payload::End => {
+                    break;
+                }
+                _ => {
+                    // Do nothing
+                }
+            }
+        }
+    }
+}

--- a/crates/wasm-mutate/src/mutators/codemotion/ir/mod.rs
+++ b/crates/wasm-mutate/src/mutators/codemotion/ir/mod.rs
@@ -1,970 +1,377 @@
-use std::{borrow::Borrow, cell::RefCell, collections::HashMap, io::Write, process::Command, slice::{ChunksExactMut, Iter}, time::{SystemTime, UNIX_EPOCH}};
+use crate::{
+    module::map_block_type,
+    mutators::{codemotion::ir::parse_context::ParseContext, OperatorAndByteOffset},
+};
+use wasm_encoder::{Function, Instruction};
+use wasmparser::{Operator, Range, TypeOrFuncType};
 
-use wasm_encoder::{BlockType, Function, Instruction};
-use wasmparser::{Operator, Range};
-use crate::{error::EitherType, mutators::OperatorAndByteOffset};
-pub struct ASTBuilder;
+use self::parse_context::{Ast, Node, State};
+pub struct AstBuilder;
+pub mod parse_context;
 
-#[derive(Debug)]
-struct AST {
-    // Index of the root node
-    root: usize,
-    // Nodes of the tree
-    nodes: Vec<Node>
-}
-
-impl AST {
-
-    /// Build a new empty AST
-    pub fn new(root: usize, nodes: Vec<Node>) -> Self {
-        AST{
-            root,
-            nodes
-        }
+/// Encodes the Wasm Ast
+pub trait AstWriter {
+    /// Encodes a loop node.
+    ///
+    /// Redefine this if your implementation mutates loops. For example, if your
+    /// implementation unrolls the first iteration of a particular loop, override
+    /// this method. For the other loops in the Wasm that your implementation is not
+    /// mutating, you can call `write_loop_default`.
+    ///
+    fn write_loop<'a>(
+        &self,
+        ast: &Ast,
+        nodeidx: usize,
+        body: &[usize],
+        newfunc: &mut Function,
+        operators: &Vec<OperatorAndByteOffset>,
+        input_wasm: &'a [u8],
+        ty: &TypeOrFuncType,
+    ) -> crate::Result<()> {
+        self.write_loop_default(ast, nodeidx, body, newfunc, operators, input_wasm, ty)
     }
 
+    /// Default encoding for a loop node
+    /// This function is called by the defaut implementation
+    /// of the `write_loop` method
+    ///
+    fn write_loop_default<'a>(
+        &self,
+        ast: &Ast,
+        _nodeidx: usize,
+        body: &[usize],
+        newfunc: &mut Function,
+        operators: &Vec<OperatorAndByteOffset>,
+        input_wasm: &'a [u8],
+        ty: &TypeOrFuncType,
+    ) -> crate::Result<()> {
+        newfunc.instruction(&Instruction::Loop(map_block_type(*ty)?));
+        for ch in body {
+            self.write(ast, *ch, newfunc, operators, input_wasm)?;
+        }
+        newfunc.instruction(&Instruction::End);
+        Ok(())
+    }
 
-    /// Encodes the AST
-    /// It traverses the AST starting from the last root
-    pub fn write_ast<'a>(&self, newfunc: &mut Function, operators: &Vec<OperatorAndByteOffset>, input_wasm: &'a [u8]) -> crate::Result<()> {
-        
-        println!("AST {:?}", self);
-        
-        fn write_ast_rec<'a>(ast: &AST, current_node: &Node, newfunc: &mut Function, operators: &Vec<OperatorAndByteOffset>, input_wasm: &'a [u8]) {
-            match current_node {
-                Node::IfElse(condition, then, alternative) => {
-                    // write condition first
-                    write_ast_rec(ast, &ast.nodes[*condition], newfunc,operators, input_wasm);
-                    newfunc.instruction(&Instruction::If(BlockType::Empty));
-                    for ch in then {
-                        write_ast_rec(ast, &ast.nodes[*ch], newfunc,operators, input_wasm);
-                    }
+    /// Default encoding for a loop node
+    /// This function is called by the defaut implementation
+    /// of the `write_block` method
+    ///
+    fn write_block_default<'a>(
+        &self,
+        ast: &Ast,
+        _nodeidx: usize,
+        body: &[usize],
+        newfunc: &mut Function,
+        operators: &Vec<OperatorAndByteOffset>,
+        input_wasm: &'a [u8],
+        ty: &TypeOrFuncType,
+    ) -> crate::Result<()> {
+        newfunc.instruction(&Instruction::Block(map_block_type(*ty)?));
+        for ch in body {
+            self.write(ast, *ch, newfunc, operators, input_wasm)?;
+        }
+        newfunc.instruction(&Instruction::End);
+        Ok(())
+    }
 
-                    if let Some(alternative) = alternative {
-                        newfunc.instruction(&Instruction::Else);
+    /// Encodes a block node.
+    ///
+    /// Redefine this if your implementation mutates blocks. For example, if your
+    /// implementation modifies the internal structure of a particular block, by
+    /// for example, inserting some nop operations between its children, override
+    /// this method. For the other blocks in the Wasm that your implementation is not
+    /// mutating, you can call `write_block_default`.
+    ///
+    fn write_block<'a>(
+        &self,
+        ast: &Ast,
+        nodeidx: usize,
+        body: &[usize],
+        newfunc: &mut Function,
+        operators: &Vec<OperatorAndByteOffset>,
+        input_wasm: &'a [u8],
+        ty: &TypeOrFuncType,
+    ) -> crate::Result<()> {
+        self.write_block_default(ast, nodeidx, body, newfunc, operators, input_wasm, ty)
+    }
 
-                        for ch in alternative {
-                            write_ast_rec(ast, &ast.nodes[*ch], newfunc,operators, input_wasm);
-                        }
-                    }
-                    newfunc.instruction(&Instruction::End);
+    /// Encodes a if/else node.
+    ///
+    /// Redefine this if your implementation mutates if/else constructions. For example, if your
+    /// implementation modifies a particular if/else, override
+    /// this method. For the other if/else constructions in the Wasm that your implementation is not
+    /// mutating, you can call `write_if_else_default`.
+    ///
+    fn write_if_else<'a>(
+        &self,
+        ast: &Ast,
+        nodeidx: usize,
+        then: &[usize],
+        alternative: &Option<Vec<usize>>,
+        newfunc: &mut Function,
+        operators: &Vec<OperatorAndByteOffset>,
+        input_wasm: &'a [u8],
+        ty: &TypeOrFuncType,
+    ) -> crate::Result<()> {
+        self.write_if_else_default(
+            ast,
+            nodeidx,
+            then,
+            alternative,
+            newfunc,
+            operators,
+            input_wasm,
+            ty,
+        )
+    }
 
-                },
-                Node::Code { range } => {
-                    let operator_range = (range.start, range.end);
+    /// Default encoding for an if-else node
+    /// This function is called by the defaut implementation
+    /// of the `write_if_else` method
+    ///
+    fn write_if_else_default<'a>(
+        &self,
+        ast: &Ast,
+        _nodeidx: usize,
+        then: &[usize],
+        alternative: &Option<Vec<usize>>,
+        newfunc: &mut Function,
+        operators: &Vec<OperatorAndByteOffset>,
+        input_wasm: &'a [u8],
+        ty: &TypeOrFuncType,
+    ) -> crate::Result<()> {
+        newfunc.instruction(&Instruction::If(map_block_type(*ty)?));
 
-
-                    //print operator
-                    for operator in &operators[range.start..range.end]{
-                        println!("{:?}", operator.0)
-                    }
-
-                    let bytes_range = (&operators[operator_range.0].1, &operators[operator_range.1].1);
-                    let piece_of_code = &input_wasm[*bytes_range.0..*bytes_range.1];
-                    
-                    newfunc.raw(piece_of_code.to_vec());
-                },
-                Node::Loop(body) => {
-                    newfunc.instruction(&Instruction::Loop(BlockType::Empty));
-                    for ch in body {
-                        write_ast_rec(ast, &ast.nodes[*ch], newfunc,operators, input_wasm);
-                    }
-                    newfunc.instruction(&Instruction::End);
-
-                },
-                Node::Block(body) => {
-                    newfunc.instruction(&Instruction::Block(BlockType::Empty));
-                    for ch in body {
-                        write_ast_rec(ast, &ast.nodes[*ch], newfunc,operators, input_wasm);
-                    }
-                    newfunc.instruction(&Instruction::End);
-                },
-                Node::Root(body) => {
-
-                    for ch in body {
-                        write_ast_rec(ast, &ast.nodes[*ch], newfunc,operators, input_wasm);
-                    }
-                    // Closing end
-                    newfunc.instruction(&Instruction::End);
-                },
-            }
+        for ch in then {
+            self.write(ast, *ch, newfunc, operators, input_wasm)?;
         }
 
-        write_ast_rec(self, &self.nodes[self.root], newfunc, operators, input_wasm);
+        if let Some(alternative) = alternative {
+            newfunc.instruction(&Instruction::Else);
 
+            for ch in alternative {
+                self.write(ast, *ch, newfunc, operators, input_wasm)?;
+            }
+        }
+        newfunc.instruction(&Instruction::End);
+        Ok(())
+    }
+
+    /// Redefine this if your implementation mutates basic block constructions. For example, if your
+    /// implementation replaces the basic block with an unreachable instruction, override
+    /// this method. For the other nodes in the Wasm that your implementation is not
+    /// mutating, you can call `write_if_else_default`.
+    ///
+    fn write_code<'a>(
+        &self,
+        _ast: &Ast,
+        _nodeidx: usize,
+        range: Range,
+        newfunc: &mut Function,
+        operators: &Vec<OperatorAndByteOffset>,
+        input_wasm: &'a [u8],
+    ) -> crate::Result<()> {
+        let operator_range = (range.start, range.end);
+        let bytes_range = (
+            &operators[operator_range.0].1,
+            &operators[operator_range.1].1,
+        );
+        let piece_of_code = &input_wasm[*bytes_range.0..*bytes_range.1];
+        newfunc.raw(piece_of_code.to_vec());
+        Ok(())
+    }
+
+    /// Default encoding for code node
+    /// This function is called by the defaut implementation
+    /// of the `write_code` method
+    ///
+    fn write_code_default<'a>(
+        &self,
+        ast: &Ast,
+        nodeidx: usize,
+        range: Range,
+        newfunc: &mut Function,
+        operators: &Vec<OperatorAndByteOffset>,
+        input_wasm: &'a [u8],
+    ) -> crate::Result<()> {
+        self.write_code(ast, nodeidx, range, newfunc, operators, input_wasm)
+    }
+
+    /// Encoding discriminator for the Ast nodes, it calls
+    /// the corresponding methods depending on the node type
+    ///
+    fn write<'a>(
+        &self,
+        ast: &Ast,
+        nodeidx: usize,
+        newfunc: &mut Function,
+        operators: &Vec<OperatorAndByteOffset>,
+        input_wasm: &'a [u8],
+    ) -> crate::Result<()> {
+        let node = &ast.get_nodes()[nodeidx];
+
+        match node {
+            Node::IfElse {
+                consequent,
+                alternative,
+                ty,
+            } => {
+                self.write_if_else(
+                    ast,
+                    nodeidx,
+                    consequent,
+                    alternative,
+                    newfunc,
+                    operators,
+                    input_wasm,
+                    ty,
+                )?;
+            }
+            Node::Code { range } => {
+                self.write_code(ast, nodeidx, *range, newfunc, operators, input_wasm)?;
+            }
+            Node::Loop(body, ty) => {
+                self.write_loop(ast, nodeidx, body, newfunc, operators, input_wasm, ty)?
+            }
+            Node::Block(body, ty) => {
+                self.write_block(ast, nodeidx, body, newfunc, operators, input_wasm, ty)?
+            }
+            Node::Root(body) => {
+                for ch in body {
+                    self.write(ast, *ch, newfunc, operators, input_wasm)?;
+                }
+                // Closing end
+                newfunc.instruction(&Instruction::End);
+            }
+        }
         Ok(())
     }
 }
 
-#[derive(Debug, Clone)]
-enum Node {
-    IfElse(usize, Vec<usize>, Option<Vec<usize>>),
-    Code{
-        range: Range
-    },
-    Loop(Vec<usize>),
-    Block(Vec<usize>),
-    Root(Vec<usize>)
+impl AstWriter for Ast {
+    /* It has the default implementation */
 }
 
-
-impl ASTBuilder {
-
-    fn dotify_ast<'a>(&self, root: usize, nodes: &[Node], operators: &'a [OperatorAndByteOffset]) -> String {
-        let mut r = String::new();
-        r.push_str("digraph AST {\n   node [shape=box]; \n");
-
-        let mut worklist = Vec::new();
-        worklist.push(root);
-
-        let bbcontent = |r: Range| {
-            operators[r.start..r.end].iter().map(|(o, _)|format!("{:?}", o)).collect::<Vec<String>>().join("\n")
-        };
-        let mut uniqueid = nodes.len();
-        while let Some(id) = worklist.pop(){
-            let node = &nodes[id];
-            match node {
-                Node::IfElse(condition, then, alternative) => {
-                    // Add edges to children then and push into worklist
-                    r.push_str(&format!(
-                        "{} -> {}[label=\"condition\", style=dashed, color=red];\n",
-                    id, condition),);
-                    worklist.push(*condition);
-                    r.push_str(&format!("\t{} [label=\"if\"]\n", id));
-                    // Create then branch
-                    uniqueid += 1;
-                    r.push_str(&format!(
-                        "{} -> {}[label=\"then\"];\n",
-                        id, uniqueid),);
-                    r.push_str(&format!("\t{} [label=\"\"]\n", uniqueid));
-                    for ch in then {
-                        r.push_str(&format!(
-                        "{} -> {};\n",
-                            uniqueid, ch),);
-                        worklist.push(*ch)
-                    }
-
-                    if let Some(alternative) = alternative {
-                        uniqueid += 1;
-                        r.push_str(&format!(
-                            "{} -> {}[label=\"else\"];\n",
-                            id, uniqueid),);
-                        r.push_str(&format!("\t{} [label=\"\"]\n", uniqueid));
-                        for ch in alternative {
-                            r.push_str(&format!(
-                            "{} -> {};\n",
-                                uniqueid, ch),);
-                            worklist.push(*ch)
-                        }
-                    }
-                },
-                Node::Code{range} => {
-                    r.push_str(&format!("\t{} [label=\"{}\"]\n", id, bbcontent(*range)));
-                },
-                Node::Loop(children) => {
-                    r.push_str(&format!("\t{} [label=\"loop\"]\n", id));
-
-                    for ch in children {
-                        r.push_str(&format!(
-                        "{} -> {};\n",
-                            id, ch),);
-                        worklist.push(*ch)
-                    }
-                },
-                Node::Block(body) | Node::Root(body) => {
-                    r.push_str(&format!("\t{} [label=\"block\"]\n", id));
-
-                    for ch in body {
-                        r.push_str(&format!(
-                        "{} -> {};\n",
-                            id, ch),);
-                        worklist.push(*ch)
-                    }
-                },
-            }
-        }
-
-        r.push_str("\n}");
-        println!("root {}", r);
-        r
+impl AstBuilder {
+    /// Returns an Ast from the operators collected from the Wasm function
+    ///
+    pub fn build_ast<'a>(&self, operators: &'a [OperatorAndByteOffset]) -> crate::Result<Ast> {
+        self.parse(operators)
     }
 
-    fn build_ast<'a>(&mut self, position: usize, operators: &'a [OperatorAndByteOffset]) -> crate::Result<AST>{
-        
-        let (root, nodes) = self.parse(position, operators)?;
-        println!("root {:?}", root);
+    /// Parsing algorith to construct the Ast
+    ///
+    fn parse<'a>(&self, operators: &'a [OperatorAndByteOffset]) -> crate::Result<Ast> {
+        let mut ifs = Vec::new();
+        let mut loops = Vec::new();
+        let mut blocks = Vec::new();
 
-        let dot = self.dotify_ast(root, &nodes, operators);
-        // debug purposes, remove
-        let name = format!("{}.dot", std::thread::current().name().unwrap());
-        let bin =  std::env::var("DOT").unwrap();
-        let mut f = std::fs::File::create(name.clone()).unwrap();
-        f.write(dot.as_bytes()).unwrap();
-
-        Command::new(&bin)
-            .arg("-Tpng")
-            .arg(name.clone())
-            .arg("-o")
-            .arg(format!("{}.png", name))
-            .spawn()
-            .expect("Process cannot be launched");
-            
-        Ok(AST::new(root, nodes))
-    }
-
-
-    fn parse<'a>(&mut self, position: usize, operators: &'a [OperatorAndByteOffset]) -> crate::Result<(usize, Vec<Node>)>{
-
-        #[derive(Debug)]
-        enum State {
-            If,
-            Else,
-            Loop,
-            Block,
-            Root
-        }
-
-        let mut nodes = Vec::new();
-        let mut nodes = RefCell::new(nodes);
-       
-        let mut frame_stack = vec![
-            State::Root
-        ];
-        let mut state_stack = RefCell::new(Vec::new());
-        let mut current_parsing = RefCell::new(Vec::new());
-        
-        let push_state = || {
-            state_stack.borrow_mut().push(current_parsing.clone());
-            *current_parsing.borrow_mut() = vec![]
-        };
-        let pop_state = ||  {
-            state_stack.borrow_mut().pop().expect("Missing state").borrow().clone()
-        };
-
-        let mut current_code = Range::new(0,0);
+        let mut parse_context = ParseContext::default();
+        // Push the first frame, the root
+        parse_context.push_frame(State::Root, None);
 
         for (idx, (operator, _)) in operators.iter().enumerate() {
-
-            println!("{} operator {:?}",idx,  operator);
             match operator {
-                Operator::If { .. } => {
-                    // push current code 
-                    if current_code.end != current_code.start {
-                        let id= nodes.borrow().len();
-                        nodes.borrow_mut().push(Node::Code{
-                            range: current_code.clone()
-                        });
-                        current_parsing.borrow_mut().push(id);
+                Operator::If { ty } => {
+                    // push current code first
+                    if !parse_context.current_code_is_empty() {
+                        parse_context.push_current_code_as_node();
                     }
-                    current_code.start = idx + 1;
-                    current_code.end = idx + 1;
-                    push_state();
-                    frame_stack.push(State::If);
+                    parse_context.reset_code_range_at(idx + 1);
+                    parse_context.push_state();
+                    parse_context.push_frame(State::If, Some(*ty));
                 }
-                Operator::Else { .. } => {
-                    println!("range {:?}", current_code);
-                    if current_code.end != current_code.start {
-                        let id= nodes.borrow().len();
-                        nodes.borrow_mut().push(Node::Code{
-                            range: current_code.clone()
-                        });
-                        current_parsing.borrow_mut().push(id);
+                Operator::Else => {
+                    if !parse_context.current_code_is_empty() {
+                        parse_context.push_current_code_as_node();
                     }
-                    current_code.start = idx + 1;
-                    current_code.end = idx + 1;
-                    push_state();
-                    frame_stack.push(State::Else);
+                    parse_context.reset_code_range_at(idx + 1);
+                    parse_context.push_state();
+                    parse_context.push_frame(State::Else, None);
                 }
-                Operator::Block {..} => {
-                    if current_code.end != current_code.start {
-                        let id= nodes.borrow().len();
-                        nodes.borrow_mut().push(Node::Code{
-                            range: current_code.clone()
-                        });
-                        current_parsing.borrow_mut().push(id);
+                Operator::Block { ty } => {
+                    if !parse_context.current_code_is_empty() {
+                        parse_context.push_current_code_as_node();
                     }
-                    current_code.start = idx + 1;
-                    current_code.end = idx + 1;
-                    push_state();
-                    frame_stack.push(State::Block);
+                    parse_context.reset_code_range_at(idx + 1);
+                    parse_context.push_state();
+                    parse_context.push_frame(State::Block, Some(*ty));
                 }
-                Operator::Loop {.. } => {
-                    if current_code.end != current_code.start {
-                        let id= nodes.borrow().len();
-                        nodes.borrow_mut().push(Node::Code{
-                            range: current_code.clone()
-                        });
-                        current_parsing.borrow_mut().push(id);
+                Operator::Loop { ty } => {
+                    if !parse_context.current_code_is_empty() {
+                        parse_context.push_current_code_as_node();
                     }
-                    current_code.start = idx + 1;
-                    current_code.end = idx + 1;
-                    frame_stack.push(State::Loop);
-                    push_state();
+                    parse_context.reset_code_range_at(idx + 1);
+                    parse_context.push_state();
+                    parse_context.push_frame(State::Loop, Some(*ty));
                 }
                 Operator::End => {
-                    if current_code.end != current_code.start {
-                        let id= nodes.borrow().len();
-                        nodes.borrow_mut().push(Node::Code{
-                            range: current_code.clone()
-                        });
-                        current_parsing.borrow_mut().push(id);
+                    if !parse_context.current_code_is_empty() {
+                        parse_context.push_current_code_as_node();
                     }
-                    current_code.start = idx + 1;
-                    current_code.end = idx + 1;
-                    println!("Pop state {:?} {:?}", frame_stack, state_stack.borrow());
-                    let last_frame = frame_stack.pop().expect("Missing frame");
+                    parse_context.reset_code_range_at(idx + 1);
+
+                    let (last_frame, ty) = parse_context.pop_frame()?;
                     match last_frame {
-                        State::If => {                            
-                            let then_branch = current_parsing.borrow().clone();
-                            *current_parsing.borrow_mut() = pop_state();
-
-                            println!("{:?}", current_parsing.borrow());
-                            let condition = current_parsing.borrow_mut().pop().expect("Missing condition");
-                            let id = nodes.borrow().len();
-                            nodes.borrow_mut().push(Node::IfElse(
-                                condition, then_branch, None
-                            ));
-
-                            current_parsing.borrow_mut().push(id);
-                        },
+                        State::If => {
+                            let then_branch = parse_context.get_current_parsing();
+                            parse_context.pop_state();
+                            // if return type of condition is empty, then the condition is the previous
+                            let id = parse_context.push_node_to_current_parsing(Node::IfElse {
+                                consequent: then_branch,
+                                alternative: None,
+                                ty: ty.expect("Missing if type"),
+                            });
+                            ifs.push(id);
+                        }
                         State::Else => {
-                            let last_frame = frame_stack.pop().expect("Missing frame");
+                            let (last_frame, ty) = parse_context.pop_frame()?;
                             // Validate parent
                             match last_frame {
-                                State::If => {  },
-                                _ => unreachable!("Invalid parent frame")
+                                State::If => {}
+                                _ => unreachable!("Invalid parent frame"),
                             }
-                            let else_branch = current_parsing.borrow().clone();
-                            let then_branch = pop_state();
-                            *current_parsing.borrow_mut() = pop_state();
-
-                            let condition = current_parsing.borrow_mut().pop().expect("Missing condition");
-                            let id = nodes.borrow().len();
-                            nodes.borrow_mut().push(Node::IfElse(
-                                condition, then_branch, Some(else_branch)
-                            ));
-
-                            current_parsing.borrow_mut().push(id);
-                        },
+                            let else_branch = parse_context.get_current_parsing();
+                            let then_branch = parse_context.pop_state()?;
+                            parse_context.pop_state();
+                            // if return type of condition is empty, then the condition is the previous
+                            let id = parse_context.push_node_to_current_parsing(Node::IfElse {
+                                consequent: then_branch,
+                                alternative: Some(else_branch),
+                                ty: ty.expect("Missing if type"),
+                            });
+                            ifs.push(id);
+                        }
                         State::Loop => {
-                            
-                            let children = current_parsing.borrow().clone();
-                            *current_parsing.borrow_mut() = pop_state();
-                            let id = nodes.borrow().len();
-                            nodes.borrow_mut().push(Node::Loop(children));
-                            current_parsing.borrow_mut().push(id);
-                        },
+                            let children = parse_context.get_current_parsing();
+                            parse_context.pop_state();
+
+                            let id = parse_context.push_node_to_current_parsing(Node::Loop(
+                                children,
+                                ty.expect("Missing block type for loop"),
+                            ));
+                            loops.push(id);
+                        }
                         State::Block => {
-                            let children = current_parsing.borrow().clone();
-                            *current_parsing.borrow_mut() = pop_state();
-                            let id = nodes.borrow().len();
-                            nodes.borrow_mut().push(Node::Block(children));
-                            current_parsing.borrow_mut().push(id);
-                        },
+                            let children = parse_context.get_current_parsing();
+                            parse_context.pop_state();
+
+                            let id = parse_context.push_node_to_current_parsing(Node::Block(
+                                children,
+                                ty.expect("Missing block type for loop"),
+                            ));
+                            blocks.push(id);
+                        }
                         State::Root => {
                             // break
-                            break
-                        },
+                            break;
+                        }
                     }
                 }
-                _ => {
-                    current_code.end += 1;
-                }
+                _ => parse_context.append_instruction_to_current_code(),
             }
         }
-        
-        let roots = current_parsing.borrow().clone();
-        // Create a block with the current parsing state
-        let root = Node::Root(roots.clone());
-        let root_id = nodes.borrow().len();
-        nodes.borrow_mut().push(root);
-        let nodes = nodes.borrow().clone();
-        Ok((root_id, nodes))
-    }
-}
-
-
-#[cfg(test)]
-mod tests {
-    use crate::{WasmMutate, mutators::{Mutator, OperatorAndByteOffset, codemotion::ir::ASTBuilder, peephole::PeepholeMutator}};
-    use rand::{rngs::SmallRng, SeedableRng};
-    use wasm_encoder::{CodeSection, Function, FunctionSection, Instruction, Module, TypeSection, ValType};
-    use wasmparser::Parser;
-
-    use super::AST;
-
-    fn assert_correct_ast(wasm: &str, expected_ast: &AST) -> bool {
-        
-        let original = &wat::parse_str(wasm,
-        )
-        .unwrap();
-        let mut parser = Parser::new(0);
-        let mut consumed = 0;
-        loop {
-            let (payload, size) = match parser.parse(&original[consumed..], true).unwrap() {
-                wasmparser::Chunk::NeedMoreData(_) => {
-                    panic!("This should not happen")
-                }
-                wasmparser::Chunk::Parsed { consumed, payload } => (payload, consumed),
-            };
-
-            consumed += size;
-
-            match payload {
-                wasmparser::Payload::CodeSectionEntry(reader) => {
-                    let operators = reader
-                        .get_operators_reader()
-                        .unwrap()
-                        .into_iter_with_offsets()
-                        .collect::<wasmparser::Result<Vec<OperatorAndByteOffset>>>()
-                        .unwrap();
-
-                    let ast = ASTBuilder.build_ast(0, &operators).unwrap();
-
-                    todo!();
-                    //assert!(ast.is_ok());
-                    //let ast = ast.unwrap();
-
-                    // If the check fails the dotify string will be printed in console
-                    //println!("AST\n{}", ast.dotify(&operators, true));
-                    //println!("successors\n{:?}", ast.successors);
-                    //println!("pred\n{:?}", ast.parents);
-
-                    // assert_eq!(ast.successors, expected_ast.successors);
-
-                    return true
-                }
-                wasmparser::Payload::End => {
-                    break;
-                }
-                _ => {
-                    // Do nothing
-                }
-            }
-        }
-        false
-    }
-
-    #[test]
-    fn test_ast_builder_block1() {
-        assert_correct_ast(r#"
-        (module
-            (memory 1)
-            (func (export "exported_func") (param i32) (result i32)
-                block
-                    i32.const 100
-                    drop
-                end
-                i32.const 101
-            )
-        )
-        "#, &AST{
-            root: 0,
-            nodes: vec![]
-        });
-    }
-
-    #[test]
-    fn test_ast_builder_block2() {
-        assert_correct_ast(r#"
-        (module
-            (memory 1)
-            (func (export "exported_func") (param i32) (result i32)
-                block
-                    i32.const 100
-                    drop
-                    block
-                        i32.const 100
-                        drop
-                    end
-                end
-            )
-        )
-        "#, &AST{
-            root: 0,
-            nodes: vec![]
-        });
-    }
-
-    #[test]
-    fn test_ast_builder_block3() {
-        assert_correct_ast(r#"
-        (module
-            (memory 1)
-            (func (export "exported_func") (param i32) (result i32)
-                block
-                    i32.const 100
-                    drop
-                    block
-                        i32.const 101
-                        br_if 2
-                    end
-                end
-            )
-        )
-        "#, &AST{
-            root: 0,
-            nodes: vec![]
-        });
-    }
-
-    #[test]
-    fn test_ast_builder_block_and_loop() {
-        assert_correct_ast(r#"
-        (module
-            (memory 1)
-            (func (export "exported_func") (param i32) (result i32)
-                block
-                    i32.const 100
-                    drop
-                    loop
-                        i32.const 100
-                        br 1
-                    end
-                end
-            )
-        )
-        "#, &AST{
-            root: 0,
-            nodes: vec![]
-        });
-    }
-
-    #[test]
-    fn test_ast_builder_if() {
-        assert_correct_ast(r#"
-        (module
-            (memory 1)
-            (func (export "exported_func") (param i32) (result i32)
-                local.get 0
-                local.get 0
-                i32.add
-                i32.load
-                if
-                    i32.const 100
-                    i32.const 87
-                end
-                i32.const -14
-            )
-        )
-        "#, &AST{
-            root: 0,
-            nodes: vec![]
-        });
-    }
-    #[test]
-    fn test_ast_builder_if_else_nested() {
-        assert_correct_ast(r#"
-        (module
-            (memory 1)
-            (func (export "exported_func") (param i32) (result i32)
-
-                local.get 0
-                local.get 0
-                i32.add
-                i32.load
-                if
-                    i32.const 100
-                else
-                    i32.const 99
-                    if
-                        i32.const 98
-                    else
-                        i32.const 97
-                    end
-                    i32.const -96
-                end
-                i32.const -95
-            )
-        )
-        "#, &AST{
-            root: 0,
-            nodes: vec![]
-        });
-    }
-
-
-    #[test]
-    fn test_ast_builder_if_else_nested2() {
-        assert_correct_ast(r#"
-        (module
-            (memory 1)
-            (func (export "exported_func") (param i32) (result i32)
-
-                local.get 0
-                local.get 0
-                i32.add
-                i32.load
-                if
-                    i32.const 100
-                else
-                    i32.const 87
-                    if 
-                        i32.const 88
-                    else
-                        i32.const 89
-                    end
-                    if
-                        i32.const 88
-                    else
-                        i32.const 89
-                    end
-                end
-                
-                i32.const -14
-            )
-        )
-        "#, &AST{
-            root: 0,
-            nodes: vec![]
-        });
-    }
-
-    #[test]
-    fn test_ast_builder_if_else_appended() {
-        assert_correct_ast(r#"
-        (module
-            (memory 1)
-            (func (export "exported_func") (param i32) (result i32)
-
-                local.get 0
-                local.get 0
-                i32.add
-                i32.load
-                if
-                    i32.const 100
-                else
-                    i32.const 87
-                    i32.const -10
-                end
-                i32.const 100
-                i32.add
-                if
-                    i32.const 88
-                else
-                    i32.const 89
-                end
-                i32.const -14
-            )
-        )
-        "#, &AST{
-            root: 0,
-            nodes: vec![]
-        });
-    }
-    #[test]
-    fn test_ast_builder_break2() {
-
-        assert_correct_ast(r#"
-        (module
-                (memory 1)
-                (func (export "exported_func") (param i32) (result i32)
-                    loop
-                        i32.const 10
-                        local.get 0
-                        i32.add
-                        local.tee 0
-                        br_if 1
-                        i32.const 100
-                        loop
-                            i32.const 10
-                            local.get 0
-                            i32.add
-                            local.tee 0
-                            br 2
-                        end
-                    end
-                    local.get 0
-                )
-            )
-        "#, &AST{
-            root: 0,
-            nodes: vec![]
-        });
-    }
-
-    #[test]
-    fn test_ast_builder_break3() {
-
-        assert_correct_ast(r#"
-        (module
-                (memory 1)
-                (func (export "exported_func") (param i32) (result i32)
-                    loop
-                        i32.const 10
-                        local.get 0
-                        i32.add
-                        local.tee 0
-                        br_if 1
-                        i32.const 100
-                        loop
-                            i32.const 10
-                            local.get 0
-                            i32.add
-                            local.tee 0
-                            br_if 1
-                        end
-                    end
-                    local.get 0
-                )
-            )
-        "#, &AST{
-            root: 0,
-            nodes: vec![]
-        });
-    }
-
-    #[test]
-    fn test_ast_builder_break4() {
-
-        assert_correct_ast(r#"
-        (module
-                (memory 1)
-                (func (export "exported_func") (param i32) (result i32)
-                    loop
-                        i32.const 10
-                        local.get 0
-                        i32.add
-                        local.tee 0
-                        br_if 1
-                        i32.const 100
-                        loop
-                            i32.const 10
-                            local.get 0
-                            i32.add
-                            local.tee 0
-                            br_table 1 2
-                        end
-                    end
-                    local.get 0
-                )
-            )
-        "#, &AST{
-            root: 0,
-            nodes: vec![]
-        });
-    }
-    #[test]
-    fn test_ast_builder_break1() {
-
-        assert_correct_ast(r#"
-        (module
-                (memory 1)
-                (func (export "exported_func") (param i32) (result i32)
-                    loop
-                        i32.const 10
-                        local.get 0
-                        i32.add
-                        local.tee 0
-                        br_if 1
-                        i32.const 100
-                        br_if 1
-                    end
-                    local.get 0
-                )
-            )
-        "#, &AST{
-            root: 0,
-            nodes: vec![]
-        });
-    }
-    #[test]
-    fn test_ast_builder_if_else1() {
-
-        assert_correct_ast(r#"
-        (module
-                (memory 1)
-                (func (export "exported_func") (param i32) (result i32)
-
-                    local.get 0
-                    local.get 0
-                    i32.add
-                    i32.load
-                    if
-                        i32.const 100
-                    else
-                        i32.const 87
-                    end
-                    i32.const 100
-                    end
-                )
-            )
-        "#, &AST{
-            root: 0,
-            nodes: vec![]
-        });
-    }
-    #[test]
-    fn test_ast_builder_loop() {
-        assert_correct_ast(r#"
-        (module
-            (memory 1)
-            (func (export "exported_func") (param i32) (result i32)
-
-                loop
-                i32.const 1
-                local.get 0
-                i32.add
-                local.set 0
-            end
-            )
-        )
-        "#, &AST{
-            root: 0,
-            nodes: vec![]
-        });
-    }
-
-    #[test]
-    fn test_ast_builder_if_else_with_return() {
-        
-        assert_correct_ast(r#"
-        (module
-            (memory 1)
-            (func (export "exported_func") (param i32) (result i32)
-
-                local.get 0
-                local.get 0
-                i32.add
-                i32.load
-                if
-                    i32.const 100
-                else
-                    return
-                    i32.const 130
-                end
-            )
-        )
-        "#, &AST{
-            root: 0,
-            nodes: vec![]
-        });
-    }
-    #[test]
-    fn test_ast_builder_and_encode() {
-        let original = &wat::parse_str(
-            r#"
-        (module
-            (func (param i32) (result i32)
-
-                local.get 0
-                local.get 0
-                i32.add
-                i32.load
-                if
-                    i32.const 54
-                    if
-                        i32.const 55
-                        i32.const -55
-                    end
-                    if
-                        i32.const -10
-                        call 0
-                    else
-                        return
-                        i32.const 120
-                    end
-                    i32.const -10
-                else
-                    i32.const 87
-                end
-                i32.const 56
-                i32.add
-                loop
-                    i32.const 1
-                    local.get 0
-                    i32.add
-                    local.set 0
-                    loop
-                        local.get 0
-                        local.set 0
-                        br 1
-                        
-                    end
-                    loop
-                        i32.const 1
-                        local.get 0
-                        i32.add
-                        local.set 0
-                        loop
-                            local.get 0
-                            local.set 0
-                            br 1
-                        end
-                        br 1
-                    end
-
-                    br 1
-                end
-            
-            )
-        )
-        "#,
-        )
-        .unwrap();
-
-        let mut parser = Parser::new(0);
-        let mut consumed = 0;
-        loop {
-            let (payload, size) = match parser.parse(&original[consumed..], true).unwrap() {
-                wasmparser::Chunk::NeedMoreData(_) => {
-                    panic!("This should not happen")
-                }
-                wasmparser::Chunk::Parsed { consumed, payload } => (payload, consumed),
-            };
-
-            consumed += size;
-
-            match payload {
-                wasmparser::Payload::CodeSectionEntry(reader) => {
-                    let operators = reader
-                        .get_operators_reader()
-                        .unwrap()
-                        .into_iter_with_offsets()
-                        .collect::<wasmparser::Result<Vec<OperatorAndByteOffset>>>()
-                        .unwrap();
-
-                        
-                    let ast = ASTBuilder.build_ast(0, &operators);
-
-                    assert!(ast.is_ok());
-
-                    let mut module = Module::new();
-                    let mut code = CodeSection::new();
-                    let mut newfunc = Function::new(vec![]);
-
-                    let ast = ast.unwrap();
-                    ast.write_ast(&mut newfunc, &operators, &original);                    
-                    code.function(&newfunc);
-
-                    let mut types = TypeSection::new();
-                    let params = vec![ValType::I32];
-                    let results = vec![ValType::I32];
-                    types.function(params, results);
-                    module.section(&types);
-                    
-                    // Encode the function section.
-                    let mut functions = FunctionSection::new();
-                    let type_index = 0;
-                    functions.function(type_index);
-                    module.section(&functions);
-                    
-                    module.section(&code);
-
-                    let encoded = module.finish();
-                    let text = wasmprinter::print_bytes(encoded.clone()).unwrap();
-                    println!("{}", text);
-
-                    assert_eq!(&encoded, original); 
-
-                }
-                wasmparser::Payload::End => {
-                    break;
-                }
-                _ => {
-                    // Do nothing
-                }
-            }
-        }
+        Ok(parse_context.finish())
     }
 }

--- a/crates/wasm-mutate/src/mutators/codemotion/ir/mod.rs
+++ b/crates/wasm-mutate/src/mutators/codemotion/ir/mod.rs
@@ -32,6 +32,7 @@ pub trait AstWriter {
     }
 
     /// Default encoding for a loop node
+    /// 
     /// This function is called by the defaut implementation
     /// of the `write_loop` method
     ///
@@ -53,7 +54,8 @@ pub trait AstWriter {
         Ok(())
     }
 
-    /// Default encoding for a loop node
+    /// Default encoding for a block node
+    /// 
     /// This function is called by the defaut implementation
     /// of the `write_block` method
     ///
@@ -127,6 +129,7 @@ pub trait AstWriter {
     }
 
     /// Default encoding for an if-else node
+    /// 
     /// This function is called by the defaut implementation
     /// of the `write_if_else` method
     ///
@@ -158,6 +161,8 @@ pub trait AstWriter {
         Ok(())
     }
 
+    /// Encodes a code node. 
+    /// 
     /// Redefine this if your implementation mutates basic block constructions. For example, if your
     /// implementation replaces the basic block with an unreachable instruction, override
     /// this method. For the other nodes in the Wasm that your implementation is not
@@ -183,6 +188,7 @@ pub trait AstWriter {
     }
 
     /// Default encoding for code node
+    /// 
     /// This function is called by the defaut implementation
     /// of the `write_code` method
     ///
@@ -198,8 +204,9 @@ pub trait AstWriter {
         self.write_code(ast, nodeidx, range, newfunc, operators, input_wasm)
     }
 
-    /// Encoding discriminator for the Ast nodes, it calls
-    /// the corresponding methods depending on the node type
+    /// Encoding discriminator for the Ast nodes
+    /// 
+    /// It calls the corresponding methods depending on the node type
     ///
     fn write<'a>(
         &self,

--- a/crates/wasm-mutate/src/mutators/codemotion/ir/mod.rs
+++ b/crates/wasm-mutate/src/mutators/codemotion/ir/mod.rs
@@ -32,7 +32,7 @@ pub trait AstWriter {
     }
 
     /// Default encoding for a loop node
-    /// 
+    ///
     /// This function is called by the defaut implementation
     /// of the `write_loop` method
     ///
@@ -55,7 +55,7 @@ pub trait AstWriter {
     }
 
     /// Default encoding for a block node
-    /// 
+    ///
     /// This function is called by the defaut implementation
     /// of the `write_block` method
     ///
@@ -129,7 +129,7 @@ pub trait AstWriter {
     }
 
     /// Default encoding for an if-else node
-    /// 
+    ///
     /// This function is called by the defaut implementation
     /// of the `write_if_else` method
     ///
@@ -161,8 +161,8 @@ pub trait AstWriter {
         Ok(())
     }
 
-    /// Encodes a code node. 
-    /// 
+    /// Encodes a code node.
+    ///
     /// Redefine this if your implementation mutates basic block constructions. For example, if your
     /// implementation replaces the basic block with an unreachable instruction, override
     /// this method. For the other nodes in the Wasm that your implementation is not
@@ -188,7 +188,7 @@ pub trait AstWriter {
     }
 
     /// Default encoding for code node
-    /// 
+    ///
     /// This function is called by the defaut implementation
     /// of the `write_code` method
     ///
@@ -205,7 +205,7 @@ pub trait AstWriter {
     }
 
     /// Encoding discriminator for the Ast nodes
-    /// 
+    ///
     /// It calls the corresponding methods depending on the node type
     ///
     fn write<'a>(

--- a/crates/wasm-mutate/src/mutators/codemotion/ir/parse_context.rs
+++ b/crates/wasm-mutate/src/mutators/codemotion/ir/parse_context.rs
@@ -235,15 +235,15 @@ impl ParseContext {
     ///
     /// Returns a new Ast instance
     ///
-    pub fn finish(&mut self) -> Ast {
+    pub fn finish(mut self) -> Ast {
         let roots = self.get_current_parsing();
         let root_id = self.push_node_to_current_parsing(Node::Root(roots));
         Ast {
             root: root_id,
-            nodes: self.get_nodes(),
-            ifs: self.ifs.clone(),
-            loops: self.loops.clone(),
-            blocks: self.blocks.clone(),
+            nodes: self.nodes,
+            ifs: self.ifs,
+            loops: self.loops,
+            blocks: self.blocks,
         }
     }
 }

--- a/crates/wasm-mutate/src/mutators/codemotion/ir/parse_context.rs
+++ b/crates/wasm-mutate/src/mutators/codemotion/ir/parse_context.rs
@@ -1,0 +1,249 @@
+use wasmparser::{Range, TypeOrFuncType};
+
+#[derive(Debug, Default)]
+pub struct Ast {
+    // Index of the root node
+    root: usize,
+    // Nodes of the tree
+    nodes: Vec<Node>,
+    // indexes of ifs nodes
+    ifs: Vec<usize>,
+    // indexeds of loop nodes
+    loops: Vec<usize>,
+    // indexes of block nodes
+    blocks: Vec<usize>,
+}
+
+impl Ast {
+    /// Build a new empty Ast
+    ///
+    pub fn new(
+        root: usize,
+        nodes: Vec<Node>,
+        ifs: Vec<usize>,
+        loops: Vec<usize>,
+        blocks: Vec<usize>,
+    ) -> Self {
+        Ast {
+            root,
+            nodes,
+            ifs,
+            loops,
+            blocks,
+        }
+    }
+
+    /// Returns true if the Ast has if-else nodes
+    ///
+    pub fn has_if(&self) -> bool {
+        !self.ifs.is_empty()
+    }
+
+    /// Returns true if the Ast has loop nodes
+    ///
+    pub fn has_loop(&self) -> bool {
+        !self.loops.is_empty()
+    }
+
+    /// Returns true if the Ast has block nodes
+    ///
+    pub fn has_block(&self) -> bool {
+        !self.blocks.is_empty()
+    }
+
+    /// Returns the node indexes corresponding to if-else nodes
+    ///
+    pub fn get_ifs(&self) -> &[usize] {
+        &self.ifs
+    }
+
+    /// Returns the `Root` node index of the Ast
+    ///
+    pub fn get_root(&self) -> usize {
+        self.root
+    }
+
+    /// Returns all Ast nodes
+    ///
+    pub fn get_nodes(&self) -> Vec<Node> {
+        self.nodes.clone()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Node {
+    /// `if`/`else` node.
+    IfElse {
+        /// Then branch node indices.
+        consequent: Vec<usize>,
+        /// Else branch node indices.
+        alternative: Option<Vec<usize>>,
+        /// The block type for the branches.
+        ty: TypeOrFuncType,
+    },
+    /// Code node (pseudo basic block) (range of the operators in the input function)
+    Code { range: Range },
+    /// Loop node (pseudo basic block) (sorted children node indexes, type of the Loop node)
+    Loop(Vec<usize>, TypeOrFuncType),
+    /// Block node (pseudo basic block) (sorted children node indexes, type of the Block node)
+    Block(Vec<usize>, TypeOrFuncType),
+    /// Special node to wrap the root nodes of the Ast
+    Root(Vec<usize>),
+}
+
+#[derive(Debug)]
+pub(crate) enum State {
+    If,
+    Else,
+    Loop,
+    Block,
+    Root,
+}
+
+#[derive(Debug)]
+pub(crate) struct ParseContext {
+    current_parsing: Vec<usize>,
+    stack: Vec<Vec<usize>>,
+    frames: Vec<(State, Option<TypeOrFuncType>)>,
+    current_code_range: Range,
+    nodes: Vec<Node>,
+
+    ifs: Vec<usize>,
+    loops: Vec<usize>,
+    blocks: Vec<usize>,
+}
+
+impl Default for ParseContext {
+    fn default() -> Self {
+        ParseContext {
+            current_code_range: Range::new(0, 0),
+            current_parsing: Vec::new(),
+            stack: Vec::new(),
+            frames: Vec::new(),
+            nodes: Vec::new(),
+            ifs: Vec::new(),
+            loops: Vec::new(),
+            blocks: Vec::new(),
+        }
+    }
+}
+
+impl ParseContext {
+    /// Saves current parsed nodes in the stack
+    ///
+    pub fn push_state(&mut self) {
+        self.stack.push(self.current_parsing.clone());
+        self.current_parsing = vec![]
+    }
+
+    /// Pops nodes previously parsed, set them as the current parsing
+    /// and then returns a copy of the poped value
+    ///
+    pub fn pop_state(&mut self) -> crate::Result<Vec<usize>> {
+        match self.stack.pop() {
+            Some(new_state) => {
+                self.current_parsing = new_state.clone();
+                Ok(new_state)
+            }
+            None => Err(crate::Error::InvalidAstOperation(
+                "Parsing should not be empty".to_string(),
+            )),
+        }
+    }
+
+    /// Push a node to the current parsing
+    ///
+    pub fn push_node_to_current_parsing(&mut self, node: Node) -> usize {
+        let id = self.nodes.len();
+        self.nodes.push(node.clone());
+        self.current_parsing.push(id);
+
+        match node {
+            Node::IfElse {
+                consequent: _,
+                alternative: _,
+                ty: _,
+            } => self.ifs.push(id),
+            Node::Loop(_, _) => self.loops.push(id),
+            Node::Block(_, _) => self.blocks.push(id),
+            _ => {}
+        }
+        id
+    }
+
+    /// Push a new frame,
+    /// * `state` - `If`, `Else`, `Block`, or `Loop` frame type
+    /// * `ty` - Returning type of the frame
+    ///
+    pub fn push_frame(&mut self, state: State, ty: Option<TypeOrFuncType>) {
+        self.frames.push((state, ty))
+    }
+
+    /// Pop frame from the current parsing
+    ///
+    pub fn pop_frame(&mut self) -> crate::Result<(State, Option<TypeOrFuncType>)> {
+        match self.frames.pop() {
+            Some(e) => Ok(e),
+            None => Err(crate::Error::InvalidAstOperation(
+                "Missing parent frame".to_string(),
+            )),
+        }
+    }
+
+    /// Returns the nodes indexes already parsed in the current state
+    ///
+    pub fn get_current_parsing(&self) -> Vec<usize> {
+        self.current_parsing.clone()
+    }
+
+    /// Returns all parsed nodes since the creation of this `ParseContext`
+    /// inetance.
+    ///
+    pub fn get_nodes(&self) -> Vec<Node> {
+        self.nodes.clone()
+    }
+
+    /// Checks if the corrent code parsing has at least one instruction
+    ///
+    pub fn current_code_is_empty(&self) -> bool {
+        self.current_code_range.start == self.current_code_range.end
+    }
+
+    /// Pushes the current code parsing as a `Node::Code` instance
+    ///
+    pub fn push_current_code_as_node(&mut self) -> usize {
+        self.push_node_to_current_parsing(Node::Code {
+            range: self.current_code_range,
+        })
+    }
+
+    /// Resets the current code parsing
+    ///
+    pub fn reset_code_range_at(&mut self, idx: usize) {
+        self.current_code_range = Range::new(idx, idx);
+    }
+
+    /// Augmnents current code parsing to include the next instruction
+    /// in the Wasm code
+    ///
+    pub fn append_instruction_to_current_code(&mut self) {
+        self.current_code_range.end += 1;
+    }
+
+    /// Closes the parsing, creates a `Node::Root` node where the children are the current
+    /// parsed nodes in the current state.
+    ///
+    /// Returns a new Ast instance
+    ///
+    pub fn finish(&mut self) -> Ast {
+        let roots = self.get_current_parsing();
+        let root_id = self.push_node_to_current_parsing(Node::Root(roots));
+        Ast {
+            root: root_id,
+            nodes: self.get_nodes(),
+            ifs: self.ifs.clone(),
+            loops: self.loops.clone(),
+            blocks: self.blocks.clone(),
+        }
+    }
+}

--- a/crates/wasm-mutate/src/mutators/codemotion/mod.rs
+++ b/crates/wasm-mutate/src/mutators/codemotion/mod.rs
@@ -1,21 +1,124 @@
-use std::{borrow::BorrowMut, cell::RefCell, collections::HashMap, rc::Rc};
-
-use rand::{
-    Rng,
+use crate::{
+    module::map_type,
+    mutators::{
+        codemotion::{ir::AstBuilder, mutators::if_complement::IfComplementMutator},
+        OperatorAndByteOffset,
+    },
+    Error, Result,
 };
-use wasm_encoder::{Module};
-use wasmparser::{BinaryReaderError, CodeSectionReader, FunctionBody, Operator, Range};
-use crate::{ModuleInfo, Result, WasmMutate};
+use rand::{prelude::SliceRandom, Rng};
+use wasm_encoder::{CodeSection, Function, Module, ValType};
+use wasmparser::{CodeSectionReader, FunctionBody};
+
+use self::ir::parse_context::Ast;
 
 use super::Mutator;
+// Hack to show debug messages in tests
+#[cfg(not(test))]
+use log::debug;
+
+#[cfg(test)]
+use std::println as debug;
 
 mod ir;
+mod mutators;
 
 pub struct CodemotionMutator;
 
 impl CodemotionMutator {
-    
-    
+    fn copy_locals(&self, reader: FunctionBody) -> Result<Vec<(u32, ValType)>> {
+        // Create the new function
+        let mut localreader = reader.get_locals_reader()?;
+        // Get current locals and map to encoder types
+        let mut local_count = 0;
+        let current_locals = (0..localreader.get_count())
+            .map(|_| {
+                let (count, ty) = localreader.read().unwrap();
+                local_count += count;
+                (count, map_type(ty).unwrap())
+            })
+            .collect::<Vec<(u32, ValType)>>();
+
+        Ok(current_locals)
+    }
+
+    fn random_mutate(
+        &self,
+        config: &crate::WasmMutate,
+        rnd: &mut rand::prelude::SmallRng,
+        info: &crate::ModuleInfo,
+        mutators: &[Box<dyn AstMutator>],
+    ) -> crate::Result<(Function, u32)> {
+        let original_code_section = info.get_code_section();
+        let mut sectionreader = CodeSectionReader::new(original_code_section.data, 0)?;
+        let function_count = sectionreader.get_count();
+
+        // This split strategy will avoid very often mutating the first function
+        // and very rarely mutating the last function
+        let function_to_mutate = rnd.gen_range(0, function_count);
+        let all_readers = (0..function_count)
+            .map(|_| sectionreader.read().unwrap())
+            .collect::<Vec<FunctionBody>>();
+
+        for fidx in (function_to_mutate..function_count).chain(0..function_to_mutate) {
+            let reader = all_readers[fidx as usize];
+            let operatorreader = reader.get_operators_reader()?;
+
+            let operators = operatorreader
+                .into_iter_with_offsets()
+                .collect::<wasmparser::Result<Vec<OperatorAndByteOffset>>>()?;
+
+            // build Ast
+            let ast = AstBuilder.build_ast(&operators)?;
+            // filter mutators by those applicable
+            let filtered = mutators
+                .iter()
+                .filter(|m| m.can_mutate(config, info, &ast))
+                .collect::<Vec<_>>();
+            // If no mutator, just continue to the next function
+            if filtered.is_empty() {
+                continue;
+            }
+
+            match filtered.choose(rnd) {
+                Some(choosen_mutator) => {
+                    let newfunc = choosen_mutator.mutate(
+                        config,
+                        info,
+                        rnd,
+                        &ast,
+                        &self.copy_locals(reader)?,
+                        &operators,
+                        original_code_section.data,
+                    )?;
+                    return Ok((newfunc, fidx));
+                }
+                None => continue,
+            }
+        }
+
+        Err(Error::NoMutationsApplicable)
+    }
+}
+/// Trait to be implemented by all code motion mutators
+pub trait AstMutator {
+    fn mutate<'a>(
+        &self,
+        config: &'a crate::WasmMutate,
+        info: &crate::ModuleInfo,
+        rnd: &mut rand::prelude::SmallRng,
+        ast: &Ast,
+        locals: &[(u32, ValType)],
+        operators: &Vec<OperatorAndByteOffset>,
+        input_wasm: &'a [u8],
+    ) -> Result<Function>;
+
+    fn can_mutate<'a>(
+        &self,
+        config: &'a crate::WasmMutate,
+        info: &crate::ModuleInfo,
+        ast: &Ast,
+    ) -> bool;
 }
 
 /// Meta mutator for peephole
@@ -26,82 +129,208 @@ impl Mutator for CodemotionMutator {
         rnd: &mut rand::prelude::SmallRng,
         info: &crate::ModuleInfo,
     ) -> Result<Module> {
-        
-        /*
+        // Initialize mutators
+        let mutators: Vec<Box<dyn AstMutator>> = vec![
+            Box::new(IfComplementMutator), // Add the other here
+        ];
+
+        let (newfunc, function_to_mutate) = self.random_mutate(config, rnd, info, &mutators)?;
+
+        let mut codes = CodeSection::new();
         let code_section = info.get_code_section();
         let mut sectionreader = CodeSectionReader::new(code_section.data, 0)?;
-        let function_count = sectionreader.get_count();
 
-        // Split where to start looking for mutable function
-        // In theory random split will provide a mutable location faster
-        let function_to_mutate = rnd.gen_range(0, function_count);
-        let all_readers = (0..function_count)
-            .map(|fidx| sectionreader.read().unwrap())
-            .collect::<Vec<FunctionBody>>();
-
-        for fidx in (function_to_mutate..function_count).chain(0..function_to_mutate) {
-            let reader = all_readers[fidx as usize];
-            let operatorreader = reader.get_operators_reader()?;
-            let operatorsrange = Range::default(); // TODO change
-            let operators = operatorreader
-                .into_iter_with_offsets()
-                .collect::<wasmparser::Result<Vec<OperatorAndByteOffset>>>()?;
-            let operatorscount = operators.len();
-            let opcode_to_mutate = rnd.gen_range(0, operatorscount);
-
-            let bbs = self.collect_bbs(&operators)?;
-        } */
-
-        todo!();
+        for fidx in 0..info.function_count {
+            let reader = sectionreader.read()?;
+            if fidx == function_to_mutate {
+                debug!("Mutating function  idx {:?}", fidx);
+                codes.function(&newfunc);
+            } else {
+                codes.raw(&code_section.data[reader.range().start..reader.range().end]);
+            }
+        }
+        let module = info.replace_section(info.code.unwrap(), &codes);
+        Ok(module)
     }
 
-    fn can_mutate<'a>(
-        &self,
-        config: &'a crate::WasmMutate,
-        info: &crate::ModuleInfo,
-    ) -> bool {
+    fn can_mutate<'a>(&self, _: &'a crate::WasmMutate, info: &crate::ModuleInfo) -> bool {
         info.has_code() && info.function_count > 0
     }
 }
 
-
-
 #[cfg(test)]
 mod tests {
-    use crate::{WasmMutate, mutators::{Mutator,  peephole::PeepholeMutator}};
+    use crate::{
+        info::ModuleInfo,
+        mutators::{codemotion::CodemotionMutator, Mutator},
+        WasmMutate,
+    };
     use rand::{rngs::SmallRng, SeedableRng};
 
-    #[test]
-    fn test_code_motion_mutator() {
-       /*// From https://developer.mozilla.org/en-US/docs/WebAssembly/Text_format_to_wasm
-        let wat = r#"
-        (module
-            (func (export "exported_func") (result i32) (local i32 i32)
-                i32.const 42
-                i32.const 42
-                if 
-                    i32.const 50
-                    if 
-                        i32.const 45
-                    else
-                        i32.const 60
-                else
-                    i32.const 60
-            )
-        )
-        "#;
-
+    fn test_motion_mutator(original: &str, expected: &str, seed: u64) {
         let wasmmutate = WasmMutate::default();
-        let original = &wat::parse_str(wat).unwrap();
+        let original = &wat::parse_str(original).unwrap();
 
         let mutator = CodemotionMutator; // the string is empty
 
-        let mut info = wasmmutate.get_module_info(original).unwrap();
-        let can_mutate = mutator.can_mutate(&wasmmutate, &info).unwrap();
+        let mut info = ModuleInfo::new(original).unwrap();
+        let can_mutate = mutator.can_mutate(&wasmmutate, &info);
+
+        let mut rnd = SmallRng::seed_from_u64(seed);
 
         assert_eq!(can_mutate, true);
-        let mut rnd = SmallRng::seed_from_u64(0);
 
-        mutator.mutate(&wasmmutate, &mut rnd, &mut info);*/
+        let mutated = mutator.mutate(&wasmmutate, &mut rnd, &mut info).unwrap();
+
+        let mut validator = wasmparser::Validator::new();
+        let mutated_bytes = &mutated.finish();
+        let text = wasmprinter::print_bytes(mutated_bytes).unwrap();
+        println!("{}", text);
+        crate::validate(&mut validator, mutated_bytes);
+        let expected_bytes = &wat::parse_str(expected).unwrap();
+        let expectedtext = wasmprinter::print_bytes(expected_bytes).unwrap();
+        assert_eq!(expectedtext, text);
+    }
+
+    #[test]
+    fn test_if_swap() {
+        test_motion_mutator(
+            r#"
+        (module
+            (memory 1)
+            (func (export "exported_func") (param i32) (result i32)
+                (local i32 i32)
+                local.get 0
+                if (result i32)
+                    i32.const 50
+                else
+                    i32.const 41
+                end
+            )
+        )
+        "#,
+            r#"
+            (module
+                (type (;0;) (func (param i32) (result i32)))
+                (func (;0;) (type 0) (param i32) (result i32)
+                (local i32 i32)
+                  local.get 0
+                  i32.eqz
+                  if (result i32)  ;; label = @1
+                    i32.const 41
+                  else
+                    i32.const 50
+                  end)
+                (memory (;0;) 1)
+                (export "exported_func" (func 0)))
+        "#,
+            0,
+        );
+    }
+
+    #[test]
+    fn test_if_swap2() {
+        test_motion_mutator(
+            r#"
+        (module
+            (memory 1)
+            (func (export "exported_func") (param i32) (result i32)
+                local.get 0
+                local.get 0
+                i32.add
+                local.get 0
+                if 
+                    i32.const 150
+                    drop
+                else
+                    i32.const 200
+                    drop
+                end
+                if (result i32)
+                    i32.const 50
+                else
+                    i32.const 41
+                end
+            )
+        )
+        "#,
+            r#"
+            (module
+                (type (;0;) (func (param i32) (result i32)))
+                (func (;0;) (type 0) (param i32) (result i32)
+                  local.get 0
+                  local.get 0
+                  i32.add
+                  local.get 0
+                  if  ;; label = @1
+                    i32.const 150
+                    drop
+                  else
+                    i32.const 200
+                    drop
+                  end
+                  i32.eqz
+                  if (result i32)  ;; label = @1
+                    i32.const 41
+                  else
+                    i32.const 50
+                  end)
+                (memory (;0;) 1)
+                (export "exported_func" (func 0)))
+        "#,
+            1,
+        );
+    }
+
+    #[test]
+    fn test_if_swap3() {
+        test_motion_mutator(
+            r#"
+        (module
+            (memory 1)
+            (func (export "exported_func") (param i32) (result i32)
+                local.get 0
+                local.get 0
+                i32.add
+                local.get 0
+                if 
+                    i32.const 150
+                    drop
+                else
+                    i32.const 200
+                    drop
+                end
+                if (result i32)
+                    i32.const 50
+                end
+            )
+        )
+        "#,
+            r#"
+            (module
+                (type (;0;) (func (param i32) (result i32)))
+                (func (;0;) (type 0) (param i32) (result i32)
+                  local.get 0
+                  local.get 0
+                  i32.add
+                  local.get 0
+                  if  ;; label = @1
+                    i32.const 150
+                    drop
+                  else
+                    i32.const 200
+                    drop
+                  end
+                  i32.eqz
+                  if (result i32)  ;; label = @1
+                    unreachable
+                  else
+                    i32.const 50
+                  end)
+                (memory (;0;) 1)
+                (export "exported_func" (func 0)))
+        "#,
+            1,
+        );
     }
 }

--- a/crates/wasm-mutate/src/mutators/codemotion/mod.rs
+++ b/crates/wasm-mutate/src/mutators/codemotion/mod.rs
@@ -1,0 +1,107 @@
+use std::{borrow::BorrowMut, cell::RefCell, collections::HashMap, rc::Rc};
+
+use rand::{
+    Rng,
+};
+use wasm_encoder::{Module};
+use wasmparser::{BinaryReaderError, CodeSectionReader, FunctionBody, Operator, Range};
+use crate::{ModuleInfo, Result, WasmMutate};
+
+use super::Mutator;
+
+mod ir;
+
+pub struct CodemotionMutator;
+
+impl CodemotionMutator {
+    
+    
+}
+
+/// Meta mutator for peephole
+impl Mutator for CodemotionMutator {
+    fn mutate(
+        &self,
+        config: &crate::WasmMutate,
+        rnd: &mut rand::prelude::SmallRng,
+        info: &crate::ModuleInfo,
+    ) -> Result<Module> {
+        
+        /*
+        let code_section = info.get_code_section();
+        let mut sectionreader = CodeSectionReader::new(code_section.data, 0)?;
+        let function_count = sectionreader.get_count();
+
+        // Split where to start looking for mutable function
+        // In theory random split will provide a mutable location faster
+        let function_to_mutate = rnd.gen_range(0, function_count);
+        let all_readers = (0..function_count)
+            .map(|fidx| sectionreader.read().unwrap())
+            .collect::<Vec<FunctionBody>>();
+
+        for fidx in (function_to_mutate..function_count).chain(0..function_to_mutate) {
+            let reader = all_readers[fidx as usize];
+            let operatorreader = reader.get_operators_reader()?;
+            let operatorsrange = Range::default(); // TODO change
+            let operators = operatorreader
+                .into_iter_with_offsets()
+                .collect::<wasmparser::Result<Vec<OperatorAndByteOffset>>>()?;
+            let operatorscount = operators.len();
+            let opcode_to_mutate = rnd.gen_range(0, operatorscount);
+
+            let bbs = self.collect_bbs(&operators)?;
+        } */
+
+        todo!();
+    }
+
+    fn can_mutate<'a>(
+        &self,
+        config: &'a crate::WasmMutate,
+        info: &crate::ModuleInfo,
+    ) -> bool {
+        info.has_code() && info.function_count > 0
+    }
+}
+
+
+
+#[cfg(test)]
+mod tests {
+    use crate::{WasmMutate, mutators::{Mutator,  peephole::PeepholeMutator}};
+    use rand::{rngs::SmallRng, SeedableRng};
+
+    #[test]
+    fn test_code_motion_mutator() {
+       /*// From https://developer.mozilla.org/en-US/docs/WebAssembly/Text_format_to_wasm
+        let wat = r#"
+        (module
+            (func (export "exported_func") (result i32) (local i32 i32)
+                i32.const 42
+                i32.const 42
+                if 
+                    i32.const 50
+                    if 
+                        i32.const 45
+                    else
+                        i32.const 60
+                else
+                    i32.const 60
+            )
+        )
+        "#;
+
+        let wasmmutate = WasmMutate::default();
+        let original = &wat::parse_str(wat).unwrap();
+
+        let mutator = CodemotionMutator; // the string is empty
+
+        let mut info = wasmmutate.get_module_info(original).unwrap();
+        let can_mutate = mutator.can_mutate(&wasmmutate, &info).unwrap();
+
+        assert_eq!(can_mutate, true);
+        let mut rnd = SmallRng::seed_from_u64(0);
+
+        mutator.mutate(&wasmmutate, &mut rnd, &mut info);*/
+    }
+}

--- a/crates/wasm-mutate/src/mutators/codemotion/mutators/if_complement.rs
+++ b/crates/wasm-mutate/src/mutators/codemotion/mutators/if_complement.rs
@@ -1,0 +1,129 @@
+//! This mutator selects a random `if` construction in a function and swap its branches.
+//! Since this mutator preserves the original semantic of the input Wasm,
+//! before the mutated if structure is encoded, a "negation" of the previous operand
+//! in the stack is written. The "negation" is encoded with a `i32.eqz` operator.
+use rand::prelude::SliceRandom;
+use wasm_encoder::{Function, Instruction, ValType};
+
+use crate::{
+    module::map_block_type,
+    mutators::{
+        codemotion::{
+            ir::{parse_context::Ast, AstWriter},
+            AstMutator,
+        },
+        OperatorAndByteOffset,
+    },
+};
+
+pub struct IfComplementMutator;
+
+#[derive(Default)]
+struct IfComplementWriter {
+    if_to_mutate: usize,
+}
+
+impl IfComplementWriter {
+    /// Swap the then and alternative branches and negates the expected value for the "if" condition
+    fn write_complement<'a>(
+        &self,
+        ast: &Ast,
+        _: usize,
+        then: &[usize],
+        alternative: &Option<Vec<usize>>,
+        newfunc: &mut wasm_encoder::Function,
+        operators: &Vec<crate::mutators::OperatorAndByteOffset>,
+        input_wasm: &'a [u8],
+        ty: &wasmparser::TypeOrFuncType,
+    ) -> crate::Result<()> {
+        // negate the value on the stack
+        newfunc.instruction(&Instruction::I32Eqz);
+        newfunc.instruction(&Instruction::If(map_block_type(*ty)?));
+
+        // Swap, write alternative first
+        if let Some(alternative) = alternative {
+            for ch in alternative {
+                self.write(ast, *ch, newfunc, operators, input_wasm)?;
+            }
+        } else {
+            // Write an unreachable instruction
+            newfunc.instruction(&Instruction::Unreachable);
+        }
+        newfunc.instruction(&Instruction::Else);
+        for ch in then {
+            self.write(ast, *ch, newfunc, operators, input_wasm)?;
+        }
+        newfunc.instruction(&Instruction::End);
+
+        Ok(())
+    }
+}
+
+impl AstWriter for IfComplementWriter {
+    /// Replaces the default implementation of the if_else_writing
+    fn write_if_else<'a>(
+        &self,
+        ast: &Ast,
+        nodeidx: usize,
+        then: &[usize],
+        alternative: &Option<Vec<usize>>,
+        newfunc: &mut wasm_encoder::Function,
+        operators: &Vec<crate::mutators::OperatorAndByteOffset>,
+        input_wasm: &'a [u8],
+        ty: &wasmparser::TypeOrFuncType,
+    ) -> crate::Result<()> {
+        if self.if_to_mutate == nodeidx {
+            self.write_complement(
+                ast,
+                nodeidx,
+                then,
+                alternative,
+                newfunc,
+                operators,
+                input_wasm,
+                ty,
+            )?;
+        } else {
+            self.write_if_else_default(
+                ast,
+                nodeidx,
+                then,
+                alternative,
+                newfunc,
+                operators,
+                input_wasm,
+                ty,
+            )?;
+        }
+        Ok(())
+    }
+}
+
+impl AstMutator for IfComplementMutator {
+    fn can_mutate<'a>(&self, _: &'a crate::WasmMutate, _: &crate::ModuleInfo, ast: &Ast) -> bool {
+        ast.has_if()
+    }
+
+    fn mutate<'a>(
+        &self,
+        _: &'a crate::WasmMutate,
+        _: &crate::ModuleInfo,
+        rnd: &mut rand::prelude::SmallRng,
+        ast: &Ast,
+        locals: &[(u32, ValType)],
+        operators: &Vec<OperatorAndByteOffset>,
+        input_wasm: &'a [u8],
+    ) -> crate::Result<Function> {
+        // Select the if index
+        let mut newfunc = Function::new(locals.to_vec());
+        let if_index = ast
+            .get_ifs()
+            .choose(rnd)
+            .expect("This mutator should check first if the AST contains at least one if");
+        let writer = IfComplementWriter {
+            if_to_mutate: *if_index,
+        };
+        writer.write(ast, ast.get_root(), &mut newfunc, operators, input_wasm)?;
+        Ok(newfunc)
+    }
+}

--- a/crates/wasm-mutate/src/mutators/codemotion/mutators/mod.rs
+++ b/crates/wasm-mutate/src/mutators/codemotion/mutators/mod.rs
@@ -1,0 +1,1 @@
+pub mod if_complement;

--- a/crates/wasm-mutate/src/mutators/mod.rs
+++ b/crates/wasm-mutate/src/mutators/mod.rs
@@ -1,6 +1,7 @@
 //! Mutator trait
 use rand::prelude::SmallRng;
 use wasm_encoder::Module;
+use wasmparser::Operator;
 
 use super::Result;
 use crate::{ModuleInfo, WasmMutate};
@@ -24,11 +25,15 @@ pub trait Mutator {
     }
 }
 
+// Helper type to return operator and ofsset inside the byte stream
+pub type OperatorAndByteOffset<'a> = (Operator<'a>, usize);
+
 pub(crate) mod function_body_unreachable;
 pub(crate) mod peephole;
 pub(crate) mod remove_export;
 pub(crate) mod rename_export;
 pub(crate) mod snip_function;
+pub(crate) mod codemotion;
 
 #[cfg(test)]
 pub(crate) fn match_mutation(original: &str, mutator: &dyn Mutator, expected: &str) {

--- a/crates/wasm-mutate/src/mutators/mod.rs
+++ b/crates/wasm-mutate/src/mutators/mod.rs
@@ -25,15 +25,15 @@ pub trait Mutator {
     }
 }
 
-// Helper type to return operator and ofsset inside the byte stream
+/// Type helper to wrap operator and the byte offset in the code section of a Wasm module
 pub type OperatorAndByteOffset<'a> = (Operator<'a>, usize);
 
+pub(crate) mod codemotion;
 pub(crate) mod function_body_unreachable;
 pub(crate) mod peephole;
 pub(crate) mod remove_export;
 pub(crate) mod rename_export;
 pub(crate) mod snip_function;
-pub(crate) mod codemotion;
 
 #[cfg(test)]
 pub(crate) fn match_mutation(original: &str, mutator: &dyn Mutator, expected: &str) {

--- a/crates/wasm-mutate/src/mutators/peephole/dfg/mod.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/dfg/mod.rs
@@ -4,8 +4,8 @@ use wasmparser::{Operator, Range};
 
 use crate::{module::PrimitiveTypeInfo, ModuleInfo};
 
-use super::OperatorAndByteOffset;
 
+use crate::mutators::OperatorAndByteOffset;
 /// It executes a minimal symbolic evaluation of the stack to detect operands location in the code for certain operators
 /// For example, i.add operator should know who are its operands
 pub struct DFGBuilder {
@@ -763,8 +763,9 @@ impl std::fmt::Display for MiniDFG {
 
 #[cfg(test)]
 mod tests {
+    use crate::mutators::OperatorAndByteOffset;
     use super::DFGBuilder;
-    use crate::{module::PrimitiveTypeInfo, mutators::peephole::OperatorAndByteOffset, ModuleInfo};
+    use crate::{module::PrimitiveTypeInfo, ModuleInfo};
     use wasmparser::Parser;
 
     #[test]

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder.rs
@@ -2,20 +2,18 @@
 use std::cell::{Cell, RefCell};
 use std::{collections::HashMap, num::Wrapping};
 
+use crate::mutators::OperatorAndByteOffset;
 use egg::{Id, RecExpr};
 use rand::Rng;
 use wasm_encoder::{Function, Instruction, MemArg};
 use wasmparser::Operator;
-use crate::mutators::OperatorAndByteOffset;
 
 use crate::module::PrimitiveTypeInfo;
 use crate::mutators::peephole::dfg::StackType;
 use crate::mutators::peephole::{Lang, EG};
 use crate::{
     error::EitherType,
-    mutators::peephole::{
-        dfg::{BBlock, MiniDFG, StackEntry},
-    },
+    mutators::peephole::dfg::{BBlock, MiniDFG, StackEntry},
     ModuleInfo,
 };
 
@@ -185,7 +183,7 @@ impl Encoder {
                 | Lang::Add(operands) => {
                     update(
                         idx,
-                        get(idx).or(get(usize::from(operands[0]).clone())
+                        get(idx).or(get(usize::from(operands[0]))
                             .or(get(usize::from(operands[1])).clone())
                             .or(gettpe(Id::from(idx)))),
                     );

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder.rs
@@ -6,6 +6,7 @@ use egg::{Id, RecExpr};
 use rand::Rng;
 use wasm_encoder::{Function, Instruction, MemArg};
 use wasmparser::Operator;
+use crate::mutators::OperatorAndByteOffset;
 
 use crate::module::PrimitiveTypeInfo;
 use crate::mutators::peephole::dfg::StackType;
@@ -14,7 +15,6 @@ use crate::{
     error::EitherType,
     mutators::peephole::{
         dfg::{BBlock, MiniDFG, StackEntry},
-        OperatorAndByteOffset,
     },
     ModuleInfo,
 };

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/mod.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/mod.rs
@@ -250,7 +250,7 @@ mod tests {
                             &ModuleInfo::default(),
                             &operators,
                             &bb,
-                            &vec![PrimitiveTypeInfo::I32],
+                            &[PrimitiveTypeInfo::I32],
                         )
                         .unwrap();
 

--- a/crates/wasm-mutate/src/mutators/peephole/mod.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/mod.rs
@@ -25,7 +25,7 @@ static NUM_SUCCESSFUL_MUTATIONS: AtomicU64 = AtomicU64::new(0);
 
 use self::{dfg::DFGBuilder, eggsy::RandomExtractor};
 
-use super::Mutator;
+use super::{Mutator, OperatorAndByteOffset};
 
 pub mod dfg;
 pub mod eggsy;
@@ -37,8 +37,6 @@ type EG = egg::EGraph<Lang, PeepholeMutationAnalysis>;
 // Code mutator, function id, operator id
 type MutationContext = (Function, u32);
 
-// Helper type to return operator and ofsset inside the byte stream
-type OperatorAndByteOffset<'a> = (Operator<'a>, usize);
 impl PeepholeMutator {
     // Collect and unfold params and locals, [x, ty, y, ty2] -> [ty....ty, ty2...ty2]
     fn get_func_locals(

--- a/src/bin/wasm-mutate.rs
+++ b/src/bin/wasm-mutate.rs
@@ -33,6 +33,8 @@ use structopt::StructOpt;
 ///      supported by `wasm-mutate`.
 ///
 /// * 4: The input is not a valid Wasm module.
+///
+/// * 5: Constructing the Ast for code motion mutations fails
 #[derive(StructOpt)]
 struct Options {
     /// The input WebAssembly binary that will be mutated.
@@ -97,6 +99,7 @@ fn main() -> anyhow::Result<()> {
                 wasm_mutate::Error::NoMutationsApplicable => 2,
                 wasm_mutate::Error::UnsupportedType(_) => 3,
                 wasm_mutate::Error::Parse(_) => 4,
+                wasm_mutate::Error::InvalidAstOperation(_) => 5,
             };
             eprintln!("{}", e);
             std::process::exit(code);


### PR DESCRIPTION
Skeleton for code-motion mutators

- First code motion mutation implemented for if-else constructions: 
  - For a random if-else, inverts the expected stack value and  swaps the encoding for `then` and `alternative` branches

cc @fitzgen 