### PR TITLE
Add support for the extended-consts wasm proposal

### DIFF
--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -218,6 +218,7 @@ fn validate_benchmark(c: &mut Criterion) {
             tail_call: true,
             multi_memory: true,
             memory64: true,
+            extended_const: true,
             deterministic_only: false,
         });
         return ret;

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -1239,6 +1239,7 @@ impl Validator {
             self.offset = offset;
             let op = ops.read()?;
             match &op {
+                // These are always valid in const expressions.
                 Operator::I32Const { .. }
                 | Operator::I64Const { .. }
                 | Operator::F32Const { .. }
@@ -1247,6 +1248,7 @@ impl Validator {
                 | Operator::V128Const { .. }
                 | Operator::End => {}
 
+                // These are valid const expressions when the extended-const proposal is enabled.
                 Operator::I32Add
                 | Operator::I32Sub
                 | Operator::I32Mul
@@ -1255,6 +1257,7 @@ impl Validator {
                 | Operator::I64Mul
                     if self.features.extended_const => {}
 
+                // `global.get` is a valid const expression for imported, immutable globals.
                 Operator::GlobalGet { global_index } => {
                     let global = self.get_global(*global_index)?;
                     if *global_index >= self.cur.state.num_imported_globals {

--- a/crates/wasmparser/src/validator/func.rs
+++ b/crates/wasmparser/src/validator/func.rs
@@ -31,7 +31,7 @@ impl<T: WasmModuleResources> FuncValidator<T> {
         features: &WasmFeatures,
     ) -> Result<FuncValidator<T>> {
         Ok(FuncValidator {
-            validator: OperatorValidator::new(ty, offset, features, &resources)?,
+            validator: OperatorValidator::new_func(ty, offset, features, &resources)?,
             resources,
         })
     }

--- a/crates/wast/src/ast/expr.rs
+++ b/crates/wast/src/ast/expr.rs
@@ -15,7 +15,11 @@ pub struct Expression<'a> {
 
 impl<'a> Parse<'a> for Expression<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
-        ExpressionParser::default().parse(parser)
+        let mut exprs = ExpressionParser::default();
+        exprs.parse(parser)?;
+        Ok(Expression {
+            instrs: exprs.instrs.into(),
+        })
     }
 }
 
@@ -96,7 +100,7 @@ enum Try<'a> {
 }
 
 impl<'a> ExpressionParser<'a> {
-    fn parse(mut self, parser: Parser<'a>) -> Result<Expression<'a>> {
+    fn parse(&mut self, parser: Parser<'a>) -> Result<()> {
         // Here we parse instructions in a loop, and we do not recursively
         // invoke this parse function to avoid blowing the stack on
         // deeply-recursive parses.
@@ -207,9 +211,7 @@ impl<'a> ExpressionParser<'a> {
             }
         }
 
-        Ok(Expression {
-            instrs: self.instrs.into(),
-        })
+        Ok(())
     }
 
     /// Parses either `(`, `)`, or nothing.

--- a/crates/wast/src/ast/table.rs
+++ b/crates/wast/src/ast/table.rs
@@ -206,9 +206,18 @@ impl<'a> ElemPayload<'a> {
         }
         let mut exprs = Vec::new();
         while !parser.is_empty() {
-            let expr = parser.parens(|p| {
-                p.parse::<Option<kw::item>>()?;
-                p.parse()
+            let expr = parser.parens(|parser| {
+                if parser.peek::<kw::item>() {
+                    parser.parse::<kw::item>()?;
+                    parser.parse()
+                } else {
+                    // Without `item` this is "sugar" for a single-instruction
+                    // expression.
+                    let insn = parser.parse()?;
+                    Ok(ast::Expression {
+                        instrs: [insn].into(),
+                    })
+                }
             })?;
             exprs.push(expr);
         }

--- a/fuzz/fuzz_targets/validate.rs
+++ b/fuzz/fuzz_targets/validate.rs
@@ -26,6 +26,7 @@ fuzz_target!(|data: &[u8]| {
         memory64: (byte2 & 0b0000_0010) != 0,
         exceptions: (byte2 & 0b0000_0100) != 0,
         relaxed_simd: (byte2 & 0b0000_1000) != 0,
+        extended_const: (byte2 & 0b0001_0000) != 0,
     });
 
     drop(validator.validate_all(&data[2..]));

--- a/src/bin/wasm-validate-rs.rs
+++ b/src/bin/wasm-validate-rs.rs
@@ -35,6 +35,9 @@ const FEATURES: &[(&str, &str, fn(&mut WasmFeatures) -> &mut bool)] = &[
         |f| &mut f.exceptions,
     ),
     ("memory64", "wasm memory64 feature", |f| &mut f.memory64),
+    ("extended-const", "wasm extended-const feature", |f| {
+        &mut f.extended_const
+    }),
 ];
 
 fn main() -> Result<()> {

--- a/tests/local/invalid-funcref-in-data-segment.wast
+++ b/tests/local/invalid-funcref-in-data-segment.wast
@@ -2,5 +2,13 @@
   (module
     (memory 0)
     (func $f)
+    (elem declare $f)
     (data (ref.func $f) ""))
   "type mismatch")
+
+(assert_invalid
+  (module
+    (memory 0)
+    (func $f)
+    (data (ref.func $f) ""))
+  "undeclared function reference")

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -557,6 +557,7 @@ impl TestState {
             multi_value: true,
             multi_memory: true,
             memory64: true,
+            extended_const: true,
         };
         for part in test.iter().filter_map(|t| t.to_str()) {
             match part {
@@ -590,6 +591,7 @@ impl TestState {
                     features.bulk_memory = true;
                 }
                 "module-linking" => features.module_linking = true,
+                "extended-const" => features.extended_const = true,
                 _ => {}
             }
         }


### PR DESCRIPTION
This commit updates the upstream testsuite that we test against and at
the same time implements a new proposal added to the suite, the
extended-const proposal. This proposal adds a few more instructions that
are valid in an init-expr context such as global initialization
expressions.

The internal changes to implement this new proposal are to use an
`OperatorsValidator` in its full glory when validating a global or
element initialization expression. This means that we get all the new
operators supported for free, and an allow-list is checked beforehand
for init-expressions to ensure only valid "const" instructions are
allowed.

This also necessitated some tweaks to parsing and printing of
more-than-one-instruction expressions which are accounted for here as
well.