### PR TITLE
FIX: relop type propagation

### DIFF
--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder.rs
@@ -336,8 +336,6 @@ impl Encoder {
         }
 
         let r = &*types.borrow();
-        println!("typs {:?}", r);
-        println!("typs {:?}", nodes);
         Ok(r.clone())
     }
 

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder.rs
@@ -144,19 +144,27 @@ impl Encoder {
                     let child = get(usize::from(operands[0])).clone();
                     update(idx, child);
                 }
-                Lang::Eqz(_)
-                | Lang::LtS(_)
-                | Lang::LtU(_)
-                | Lang::GtS(_)
-                | Lang::GtU(_)
-                | Lang::LeS(_)
-                | Lang::LeU(_)
-                | Lang::GeS(_)
-                | Lang::Eq(_)
-                | Lang::Ne(_)
-                | Lang::GeU(_) => {
+                Lang::Eqz(_) => {
+                    update(idx, Some(PrimitiveTypeInfo::I32));
+                }
+                Lang::LtS(operands)
+                | Lang::LtU(operands)
+                | Lang::GtS(operands)
+                | Lang::GtU(operands)
+                | Lang::LeS(operands)
+                | Lang::LeU(operands)
+                | Lang::GeS(operands)
+                | Lang::Eq(operands)
+                | Lang::Ne(operands)
+                | Lang::GeU(operands) => {
                     // It always return i32
                     update(idx, Some(PrimitiveTypeInfo::I32));
+                    // Both children should have the same type
+                    let ty = get(usize::from(operands[0]).clone())
+                        .or(get(usize::from(operands[1])).clone());
+                    // Set the type for the children
+                    update(usize::from(operands[0]), ty.clone());
+                    update(usize::from(operands[1]), ty);
                 }
                 Lang::Drop => {
                     update(idx, Some(PrimitiveTypeInfo::Empty));
@@ -328,6 +336,8 @@ impl Encoder {
         }
 
         let r = &*types.borrow();
+        println!("typs {:?}", r);
+        println!("typs {:?}", nodes);
         Ok(r.clone())
     }
 

--- a/crates/wasm-mutate/src/mutators/peephole/mod.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/mod.rs
@@ -1152,6 +1152,41 @@ mod tests {
     }
 
     #[test]
+    fn test_peep_cv5() {
+        let rules: &[Rewrite<super::Lang, PeepholeMutationAnalysis>] =
+            &[rewrite!("cv4";  "?x" => "(and ?x ?x)")];
+
+        test_peephole_mutator(
+            r#"
+                (module
+                    (type (;0;) (func (result i32)))
+                    (func (;0;) (type 0) (result i32)
+                    i32.const -1
+                    i64.extend_i32_u
+                    i64.const -1
+                    i64.ge_s)
+                    (data (;0;) ""))
+            "#,
+            rules,
+            r#"
+                        (module
+                            (type (;0;) (func (result i32)))
+                            (func (;0;) (type 0) (result i32)
+                            i32.const -1
+                            i64.extend_i32_u
+                            i64.const -1
+                            i64.ge_s
+                            i32.const -1
+                            i64.extend_i32_u
+                            i64.const -1
+                            i64.ge_s
+                            i32.and)
+                            (data (;0;) ""))
+                    "#,
+            1,
+        );
+    }
+    #[test]
     fn test_peep_idem3() {
         let rules: &[Rewrite<super::Lang, PeepholeMutationAnalysis>] =
             &[rewrite!("idempotent-3";  "?x" => "(add ?x 0)")];


### PR DESCRIPTION
Fixes #385

During type propagation to assign a type to children nodes of `irelop` operands was missing. 

cc @fitzgen and @alexcrichton 