### PR TITLE
Optimize `*.wat` parsing

### DIFF
--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -15,6 +15,7 @@ Customizable Rust parsers for the WebAssembly Text formats WAT and WAST
 [dependencies]
 leb128 = "0.2"
 unicode-width = "0.1.9"
+memchr = "2.4.1"
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/crates/wast/src/lexer.rs
+++ b/crates/wast/src/lexer.rs
@@ -226,13 +226,6 @@ pub enum FloatVal<'a> {
     },
 }
 
-// https://webassembly.github.io/spec/core/text/lexical.html#white-space
-macro_rules! ws_chars {
-    () => {
-        b' ' | b'\n' | b'\r' | b'\t'
-    };
-}
-
 // https://webassembly.github.io/spec/core/text/values.html#text-idchar
 macro_rules! idchars {
     () => {
@@ -371,7 +364,8 @@ impl<'a> Lexer<'a> {
                 })))));
             }
 
-            ws_chars!() => Ok(Some(Token::Whitespace(self.split_ws()))),
+            // https://webassembly.github.io/spec/core/text/lexical.html#white-space
+            b' ' | b'\n' | b'\r' | b'\t' => Ok(Some(Token::Whitespace(self.split_ws()))),
 
             c @ idchars!() => {
                 let reserved = self.split_while(|b| match b {

--- a/crates/wast/tests/parse-fail/string12.wat.err
+++ b/crates/wast/tests/parse-fail/string12.wat.err
@@ -1,5 +1,5 @@
 invalid unicode scalar value 0xffffffff
-     --> tests/parse-fail/string12.wat:1:3
+     --> tests/parse-fail/string12.wat:1:12
       |
     1 | "\u{ffffffff}"
-      |   ^
+      |            ^


### PR DESCRIPTION
This commit attempts to resolve at least some slowness in text parsing
for wasm. With some profiling the main source of slowdown for parsing
the text format appeared to be the actual utf-8 decoding of the source,
apparent because the source was iterated over `char`-by-`char`. This
decoding led to lots of branch-y code even for simple operations such as
skipping whitespace.

The change in this commit is to change the lexer of the text format to
working with `&[u8]` internally instead of `CharIndices`. This means
that the lexer will utf-8 decode as little as possible from now on and
only reading `char` values as necessary for lexing operations such as
strings. Otherwise the text format is primarily ASCII and doesn't need
to go into the realm of utf-8 decoding. Also note that the lexer still
operates over `&str` at the API-level since wasm source text is required
to be valid utf-8.

For parsing a wasm-smith-generated-module this cause the entire
`wat2wasm` operation to be 40% faster. The vast majority of the
remaining time is still spent in lexing, almost exclusively in skipping
whitespace (since heavily nested blocks lead to lots of whitespace).
Unfortunately I don't really know of an easy way to optimize skipping of
whitespace, but at least the problem is quite tractable where the goal
is to find the first-non-whitespace-byte in a list of bytes, so this
should be ripe for optimization in the future.