### PR TITLE
FIX: enode matching

### DIFF
--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
@@ -310,7 +310,6 @@ pub enum Lang {
         mem: u32,
         value_and_offset: [Id; 2],
     },
-    //Select([Id; 3]),
     // TODO add the others
 
     // Custom mutation operations and instructions
@@ -329,7 +328,6 @@ pub enum Lang {
     */
     UnfoldI32(Id),
     UnfoldI64(Id),
-
     /*
         Just a wrapper of multiple nodes, when encoding to Wasm it is written as nothing
         Its only responsability is to add stack neutral operations (if semantic equivalence is set)
@@ -592,7 +590,7 @@ impl Display for Lang {
                 align,
                 mem,
                 value_and_offset: _,
-            } => f.write_str(&format!("i32.store.{}.{}.{}", static_offset, align, mem)),
+            } => f.write_str(&format!("i64.store.{}.{}.{}", static_offset, align, mem)),
             Lang::F32Store {
                 static_offset,
                 align,
@@ -667,12 +665,8 @@ impl Lang {
                 i64::from_str(n).expect("Invalid integer parsing radix 10"),
             )),
             // Notice that the rewriting rules should be written in the integer representation of the float bits
-            "_f32" => Ok(Lang::F32(
-                u32::from_str(n).expect("Invalid integer parsing radix 10"),
-            )),
-            "_f64" => Ok(Lang::F64(
-                u64::from_str(n).expect("Invalid integer parsing radix 10"),
-            )),
+            "_f32" => Ok(Lang::F32(u32::from_str(n).expect("Invalid float parsing"))),
+            "_f64" => Ok(Lang::F64(u64::from_str(n).expect("Invalid float parsing"))),
             // Add other types here
             _ => Err(format!("Invalid type annotation for {:?}", op_str)),
         }
@@ -878,9 +872,91 @@ impl Lang {
     }
 }
 
+// To match memory like nodes by its inmediates
+macro_rules! match_mem {
+    ($l:ident, $self: ident, $other: ident) => {
+        if let (
+            Lang::$l {
+                static_offset,
+                align,
+                mem,
+                ..
+            },
+            Lang::$l {
+                static_offset: static_offset2,
+                align: align2,
+                mem: mem2,
+                ..
+            },
+        ) = ($self, $other)
+        {
+            return ::std::mem::discriminant($self) == ::std::mem::discriminant($other)
+                && static_offset == static_offset2
+                && align == align2
+                && mem == mem2;
+        }
+    };
+}
+
 impl egg::Language for Lang {
     fn matches(&self, other: &Self) -> bool {
-        ::std::mem::discriminant(self) == ::std::mem::discriminant(other)
+        match_mem!(I32Load, self, other);
+        match_mem!(I64Load, self, other);
+        match_mem!(F32Load, self, other);
+        match_mem!(F64Load, self, other);
+        match_mem!(I32Load8S, self, other);
+        match_mem!(I32Load8U, self, other);
+        match_mem!(I32Load16S, self, other);
+        match_mem!(I32Load16U, self, other);
+        match_mem!(I64Load8S, self, other);
+        match_mem!(I64Load8U, self, other);
+        match_mem!(I64Load16S, self, other);
+        match_mem!(I64Load16U, self, other);
+        match_mem!(I64Load32S, self, other);
+        match_mem!(I64Load32U, self, other);
+        match_mem!(I32Store, self, other);
+        match_mem!(I64Store, self, other);
+        match_mem!(F32Store, self, other);
+        match_mem!(F64Store, self, other);
+        match_mem!(I32Store8, self, other);
+        match_mem!(I32Store16, self, other);
+        match_mem!(I64Store8, self, other);
+        match_mem!(I64Store16, self, other);
+        match_mem!(I64Store32, self, other);
+
+        match (self, other) {
+            (Lang::I32(v), Lang::I32(v2)) => {
+                ::std::mem::discriminant(self) == ::std::mem::discriminant(other) && v == v2
+            }
+            (Lang::I64(v), Lang::I64(v2)) => {
+                ::std::mem::discriminant(self) == ::std::mem::discriminant(other) && v == v2
+            }
+            (Lang::F32(v), Lang::F32(v2)) => {
+                ::std::mem::discriminant(self) == ::std::mem::discriminant(other) && v == v2
+            }
+            (Lang::F64(v), Lang::F64(v2)) => {
+                ::std::mem::discriminant(self) == ::std::mem::discriminant(other) && v == v2
+            }
+            (Lang::GlobalGet(v), Lang::GlobalGet(v2)) => {
+                ::std::mem::discriminant(self) == ::std::mem::discriminant(other) && v == v2
+            }
+            (Lang::LocalGet(v), Lang::LocalGet(v2)) => {
+                ::std::mem::discriminant(self) == ::std::mem::discriminant(other) && v == v2
+            }
+            (Lang::GlobalSet(v, _), Lang::GlobalSet(v2, _))
+            | (Lang::LocalSet(v, _), Lang::LocalSet(v2, _))
+            | (Lang::LocalTee(v, _), Lang::LocalTee(v2, _)) => {
+                ::std::mem::discriminant(self) == ::std::mem::discriminant(other) && v == v2
+            }
+            (Lang::Call(v, _), Lang::Call(v2, _)) => {
+                ::std::mem::discriminant(self) == ::std::mem::discriminant(other) && v == v2
+            }
+            (Lang::Container(v), Lang::Container(v2)) => {
+                ::std::mem::discriminant(self) == ::std::mem::discriminant(other)
+                    && v.len() == v2.len()
+            }
+            _ => ::std::mem::discriminant(self) == ::std::mem::discriminant(other),
+        }
     }
 
     fn children(&self) -> &[Id] {
@@ -1475,7 +1551,6 @@ impl egg::Language for Lang {
             Lang::F64(_) => &mut [],
             Lang::Nop => &mut [],
             Lang::Container(operands) => operands,
-            //Lang::Select(operands) => operands,
         }
     }
 
@@ -1708,5 +1783,48 @@ impl egg::Language for Lang {
 impl Default for Lang {
     fn default() -> Self {
         Lang::Undef
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::RefCell, collections::HashMap, str::FromStr};
+
+    use egg::{rewrite, AstSize, Id, Language, RecExpr, Rewrite, Runner};
+    use rand::{prelude::SmallRng, SeedableRng};
+
+    use crate::mutators::peephole::eggsy::{analysis::PeepholeMutationAnalysis, lang::Lang};
+
+    #[test]
+    fn test_parsing() {
+        let a = "0_i32";
+
+        let parse = RecExpr::<Lang>::from_str(a).unwrap();
+    }
+
+    #[test]
+    fn test_parsing2() {
+        let pairs = vec![
+            [Lang::GlobalGet(0), Lang::GlobalGet(1)],
+            [
+                Lang::LocalSet(0, Id::from(0)),
+                Lang::LocalSet(1, Id::from(1)),
+            ],
+            [Lang::LocalGet(0), Lang::LocalGet(1)],
+            [
+                Lang::GlobalSet(0, Id::from(0)),
+                Lang::GlobalSet(1, Id::from(1)),
+            ],
+            [Lang::LocalGet(0), Lang::LocalGet(1)],
+        ];
+        for [l, r] in pairs {
+            println!(
+                "l {:?}, r {:?} matches ({}), it should be false",
+                l,
+                r,
+                l.matches(&r)
+            );
+            assert_eq!(l.matches(&r), false);
+        }
     }
 }

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
@@ -890,8 +890,7 @@ macro_rules! match_mem {
             },
         ) = ($self, $other)
         {
-            return ::std::mem::discriminant($self) == ::std::mem::discriminant($other)
-                && static_offset == static_offset2
+            return static_offset == static_offset2
                 && align == align2
                 && mem == mem2;
         }
@@ -925,35 +924,25 @@ impl egg::Language for Lang {
         match_mem!(I64Store32, self, other);
 
         match (self, other) {
-            (Lang::I32(v), Lang::I32(v2)) => {
-                ::std::mem::discriminant(self) == ::std::mem::discriminant(other) && v == v2
+            (Lang::I32(v), Lang::I32(v2)) => { v == v2
             }
-            (Lang::I64(v), Lang::I64(v2)) => {
-                ::std::mem::discriminant(self) == ::std::mem::discriminant(other) && v == v2
+            (Lang::I64(v), Lang::I64(v2)) => { v == v2
             }
-            (Lang::F32(v), Lang::F32(v2)) => {
-                ::std::mem::discriminant(self) == ::std::mem::discriminant(other) && v == v2
+            (Lang::F32(v), Lang::F32(v2)) => { v == v2
             }
-            (Lang::F64(v), Lang::F64(v2)) => {
-                ::std::mem::discriminant(self) == ::std::mem::discriminant(other) && v == v2
+            (Lang::F64(v), Lang::F64(v2)) => { v == v2
             }
-            (Lang::GlobalGet(v), Lang::GlobalGet(v2)) => {
-                ::std::mem::discriminant(self) == ::std::mem::discriminant(other) && v == v2
+            (Lang::GlobalGet(v), Lang::GlobalGet(v2)) => {v == v2
             }
-            (Lang::LocalGet(v), Lang::LocalGet(v2)) => {
-                ::std::mem::discriminant(self) == ::std::mem::discriminant(other) && v == v2
+            (Lang::LocalGet(v), Lang::LocalGet(v2)) => {v == v2
             }
             (Lang::GlobalSet(v, _), Lang::GlobalSet(v2, _))
             | (Lang::LocalSet(v, _), Lang::LocalSet(v2, _))
-            | (Lang::LocalTee(v, _), Lang::LocalTee(v2, _)) => {
-                ::std::mem::discriminant(self) == ::std::mem::discriminant(other) && v == v2
+            | (Lang::LocalTee(v, _), Lang::LocalTee(v2, _)) => { v == v2
             }
-            (Lang::Call(v, _), Lang::Call(v2, _)) => {
-                ::std::mem::discriminant(self) == ::std::mem::discriminant(other) && v == v2
+            (Lang::Call(v, _), Lang::Call(v2, _)) => {v == v2
             }
-            (Lang::Container(v), Lang::Container(v2)) => {
-                ::std::mem::discriminant(self) == ::std::mem::discriminant(other)
-                    && v.len() == v2.len()
+            (Lang::Container(v), Lang::Container(v2)) => {v.len() == v2.len()
             }
             _ => ::std::mem::discriminant(self) == ::std::mem::discriminant(other),
         }

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
@@ -890,9 +890,7 @@ macro_rules! match_mem {
             },
         ) = ($self, $other)
         {
-            return static_offset == static_offset2
-                && align == align2
-                && mem == mem2;
+            return static_offset == static_offset2 && align == align2 && mem == mem2;
         }
     };
 }
@@ -924,26 +922,17 @@ impl egg::Language for Lang {
         match_mem!(I64Store32, self, other);
 
         match (self, other) {
-            (Lang::I32(v), Lang::I32(v2)) => { v == v2
-            }
-            (Lang::I64(v), Lang::I64(v2)) => { v == v2
-            }
-            (Lang::F32(v), Lang::F32(v2)) => { v == v2
-            }
-            (Lang::F64(v), Lang::F64(v2)) => { v == v2
-            }
-            (Lang::GlobalGet(v), Lang::GlobalGet(v2)) => {v == v2
-            }
-            (Lang::LocalGet(v), Lang::LocalGet(v2)) => {v == v2
-            }
+            (Lang::I32(v), Lang::I32(v2)) => v == v2,
+            (Lang::I64(v), Lang::I64(v2)) => v == v2,
+            (Lang::F32(v), Lang::F32(v2)) => v == v2,
+            (Lang::F64(v), Lang::F64(v2)) => v == v2,
+            (Lang::GlobalGet(v), Lang::GlobalGet(v2)) => v == v2,
+            (Lang::LocalGet(v), Lang::LocalGet(v2)) => v == v2,
             (Lang::GlobalSet(v, _), Lang::GlobalSet(v2, _))
             | (Lang::LocalSet(v, _), Lang::LocalSet(v2, _))
-            | (Lang::LocalTee(v, _), Lang::LocalTee(v2, _)) => { v == v2
-            }
-            (Lang::Call(v, _), Lang::Call(v2, _)) => {v == v2
-            }
-            (Lang::Container(v), Lang::Container(v2)) => {v.len() == v2.len()
-            }
+            | (Lang::LocalTee(v, _), Lang::LocalTee(v2, _)) => v == v2,
+            (Lang::Call(v, _), Lang::Call(v2, _)) => v == v2,
+            (Lang::Container(v), Lang::Container(v2)) => v.len() == v2.len(),
             _ => ::std::mem::discriminant(self) == ::std::mem::discriminant(other),
         }
     }

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
@@ -1815,15 +1815,23 @@ mod tests {
                 Lang::GlobalSet(0, Id::from(0)),
                 Lang::GlobalSet(1, Id::from(1)),
             ],
+            [
+                Lang::I32Load {
+                    mem: 1,
+                    align: 0,
+                    static_offset: 120,
+                    offset: Id::from(0),
+                },
+                Lang::I32Load {
+                    mem: 1,
+                    align: 0,
+                    static_offset: 0,
+                    offset: Id::from(0),
+                },
+            ],
             [Lang::LocalGet(0), Lang::LocalGet(1)],
         ];
         for [l, r] in pairs {
-            println!(
-                "l {:?}, r {:?} matches ({}), it should be false",
-                l,
-                r,
-                l.matches(&r)
-            );
             assert_eq!(l.matches(&r), false);
         }
     }

--- a/crates/wasm-mutate/src/mutators/peephole/mod.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/mod.rs
@@ -1291,7 +1291,7 @@ mod tests {
     #[test]
     fn test_peep_floats1() {
         let rules: &[Rewrite<super::Lang, PeepholeMutationAnalysis>] =
-            &[rewrite!("rule";  "1_f32" => "0_f32" )];
+            &[rewrite!("rule";  "1065353216_f32" => "0_f32" )];
 
         test_peephole_mutator(
             r#"


### PR DESCRIPTION
The matching process during the construction of the enodes was incorrect. It was matching only the `enum` discriminant and this leads to match two any constants as the same enode. The same for immediate having oeprators.

cc @fitzgen 