### PR TITLE
Introduce the `wasm-shrink` WebAssembly test case reducer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,13 @@ arbitrary = "1.0.0"
 env_logger = "0.8"
 flagset = "0.4"
 getopts = "0.2"
+is_executable = "1.0.1"
 log = "0.4"
 rayon = "1.0"
 structopt = "0.3.16"
+tempfile = "3.2.0"
 wasm-mutate = { path = "crates/wasm-mutate", features = ["structopt"] }
+wasm-shrink = { path = "crates/wasm-shrink", features = ["structopt"] }
 wasm-smith = { path = "crates/wasm-smith" }
 wasmparser = { path = "crates/wasmparser" }
 wasmparser-dump = { path = "crates/dump" }

--- a/crates/wasm-shrink/Cargo.toml
+++ b/crates/wasm-shrink/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
+categories = ["command-line-utilities", "development-tools", "development-tools::testing", "wasm"]
+description = "A WebAssembly test case shrinker"
+edition = "2021"
+keywords = ["reducer", "reduce", "bug", "crash"]
+license = "Apache-2.0 WITH LLVM-exception"
+readme = "./README.md"
+repository = "https://github.com/bytecodealliance/wasm-tools"
+name = "wasm-shrink"
+version = "0.1.0"
+
+[dependencies]
+anyhow = "1"
+log = "0.4"
+rand = { version = "0.8.4", features = ["small_rng"] }
+structopt = { version = "0.3.25", optional = true }
+wasm-mutate = { version = "0.1.0", path = "../wasm-mutate" }
+wasmparser = { version = "0.81", path = "../wasmparser" }
+
+[dev-dependencies]
+wasmprinter = { version = "0.2", path = "../wasmprinter" }
+wat = { version = "1", path = "../wat" }

--- a/crates/wasm-shrink/README.md
+++ b/crates/wasm-shrink/README.md
@@ -1,0 +1,137 @@
+# `wasm-shrink`
+
+**A WebAssembly test case shrinker.**
+
+[![](https://docs.rs/wasm-shrink/badge.svg)](https://docs.rs/wasm-shrink/)
+[![](https://img.shields.io/crates/v/wasm-shrink.svg)](https://crates.io/crates/wasm-shrink)
+[![](https://img.shields.io/crates/d/wasm-shrink.svg)](https://crates.io/crates/wasm-shrink)
+
+* [About](#about)
+* [Usage](#usage)
+  * [Install](#install)
+  * [Writing a Predicate Script](#writing-a-predicate-script)
+  * [Run](#run)
+* [Embed as a Library](#embed-as-a-library)
+
+## About
+
+`wasm-shrink` is a test case shrinker for WebAssembly. It shrinks a Wasm file
+while preserving an interesting property (such as triggering a bug in your Wasm
+compiler).
+
+## Usage
+
+### Install
+
+```
+$ cargo install --git https://github.com/bytecodealliance/wasm-tools.git
+```
+
+### Writing a Predicate Script
+
+The predicate script tells `wasm-shrink` whether a Wasm file is "interesting" or
+not, i.e. whether the Wasm file triggers the bug you are trying to isolate.
+
+The interface between `wasm-shrink` and a predicate script is simple:
+
+* The predicate script is given a Wasm file as its first and only argument.
+
+* The predicate script must exit with a zero status code if the Wasm file is
+  interesting and a non-zero status code otherwise.
+
+The predicate script must not depend on the current working directory nor that
+only one predicate script process is running at any given time.
+
+Here is an example predicate script that could be used to track down a panic in
+Wasmtime that includes the panic message "assertion failed: invalid stack map":
+
+```bash
+#!/usr/bin/env bash
+
+# Exit the script if any subcommand fails.
+set -e
+
+# The Wasm file is given as the first and only argument to the script.
+WASM=$1
+
+# Run the Wasm in Wasmtime and `grep` for our target bug's panic
+# message.
+wasmtime run $WASM 2>&1 | grep --quiet 'assertion failed: invalid stack map'
+```
+
+Note that passing `grep` the `--quiet` flag makes it avoid its usual
+match-printing behavior and exit with status code zero if there is *any* match
+and non-zero if there is *not* any match. This is useful for predicate scripts.
+
+### Run
+
+To run `wasm-shrink` pass it the predicate and the initial test case:
+
+```bash
+$ wasm-shrink predicate.sh test-case.wasm -o shrunken.wasm
+```
+
+The shrunken Wasm file will be written to `shrunken.wasm` in this case, but if
+the `-o` flag is not given an output name is generated based on the initial test
+case's name.
+
+You can see all options by passing `--help`:
+
+```bash
+$ wasm-shrink --help
+```
+
+## Embed as a Library
+
+`wasm-shrink` is not only a command-line tool, it also defines a library to
+allow programmatic usage.
+
+First, add a dependency to your `Cargo.toml`:
+
+```toml
+[dependencies]
+wasm-shrink = "0.1.0"
+```
+
+Then use the `wasm_shrink::WasmShrink` builder to configure and run a shrinking
+task:
+
+```rust
+use wasm_shrink::WasmShrink;
+
+// Get the Wasm you want to shrink from somewhere.
+let my_input_wasm: Vec<u8> = todo!();
+
+// Configure the shrinking task.
+let shrink = WasmShrink::default()
+    // Give up on shrinking after 999 failed attempts to shrink a given
+    // Wasm test case any further.
+    .attempts(999);
+
+// Run the configured shrinking task.
+let info = shrink.run(
+    my_input_wasm,
+
+    // Predicate.
+    &mut |wasm| {
+        let is_interesting: bool = todo!(
+            "check for whether the given Wasm is interesting"
+        );
+        Ok(is_interesting)
+    },
+
+    // Callback called each time we find a new smallest interesting
+    // Wasm.
+    &mut |new_smallest| {
+        // Optionally do something with the new smallest Wasm.
+        Ok(())
+    },
+)?;
+
+// Get the shrunken Wasm and other information about the completed shrink
+// task from the returned `ShrinkInfo`.
+let shrunken_wasm = info.output;
+```
+
+For more details, see [the documentation on
+`docs.rs`](https://docs.rs/wasm-shrink/).

--- a/crates/wasm-shrink/src/lib.rs
+++ b/crates/wasm-shrink/src/lib.rs
@@ -1,0 +1,303 @@
+//! Shrink a Wasm file while maintaining a property of interest (such as
+//! triggering a compiler bug).
+//!
+//! See the [`WasmShrink`][WasmShrink] type for details.
+
+use anyhow::{Context, Result};
+use rand::{rngs::SmallRng, Rng, SeedableRng};
+use wasm_mutate::WasmMutate;
+
+#[rustfmt::skip]
+static EMPTY_WASM: &'static [u8] = &[
+    // Magic.
+    0x00, b'a', b's', b'm',
+    // Version.
+    0x01, 0x00, 0x00, 0x00,
+];
+
+#[cfg_attr(
+    not(feature = "structopt"),
+    doc = r###"
+Shrink a Wasm file while maintaining a property of interest (such as
+triggering a compiler bug).
+
+# Example
+
+```
+use wasm_shrink::WasmShrink;
+
+# fn foo() -> anyhow::Result<()> {
+// Get the Wasm you want to shrink from somewhere.
+let my_input_wasm: Vec<u8> = todo!();
+
+// Configure the shrinking task.
+let shrink = WasmShrink::default()
+    // Give up on shrinking after 999 failed attempts to shrink a given
+    // Wasm test case any further.
+    .attempts(999);
+
+// Run the configured shrinking task.
+let info = shrink.run(
+    my_input_wasm,
+    // Predicate.
+    &mut |wasm| {
+        let is_interesting: bool = todo!(
+            "check for whether the given Wasm is interesting"
+        );
+        Ok(is_interesting)
+    },
+    // Callback called each time we find a new smallest interesting
+    // Wasm.
+    &mut |new_smallest| {
+        // Optionally do something with the new smallest Wasm.
+        Ok(())
+    },
+)?;
+
+// Get the shrunken Wasm and other information about the completed shrink
+// task from the returned `ShrinkInfo`.
+let shrunken_wasm = info.output;
+# Ok(()) }
+```
+"###
+)]
+#[cfg_attr(feature = "structopt", derive(structopt::StructOpt))]
+pub struct WasmShrink {
+    /// The number of shrink attempts to try before considering a Wasm module as
+    /// small as it will ever get.
+    #[cfg_attr(feature = "structopt", structopt(short, long, default_value = "1000"))]
+    attempts: u32,
+
+    /// Allow shrinking the input down to an empty Wasm module.
+    ///
+    /// This is usually not desired and typically reflects a bug in the
+    /// predicate script.
+    #[cfg_attr(feature = "structopt", structopt(long))]
+    allow_empty: bool,
+
+    /// The RNG seed for choosing which size-reducing mutation to attempt next.
+    #[cfg_attr(feature = "structopt", structopt(short, long, default_value = "42"))]
+    seed: u64,
+}
+
+impl Default for WasmShrink {
+    fn default() -> Self {
+        WasmShrink {
+            attempts: 1000,
+            allow_empty: false,
+            seed: 42,
+        }
+    }
+}
+
+impl WasmShrink {
+    /// Set the number of shrink attempts to try before considering a Wasm
+    /// module as small as it will ever get.
+    pub fn attempts(mut self, attempts: u32) -> WasmShrink {
+        self.attempts = attempts;
+        self
+    }
+
+    /// Is it okay to shrink the input down to an empty Wasm module?
+    ///
+    /// This is usually not desired and typically reflects a bug in the
+    /// predicate.
+    pub fn allow_empty(mut self, allow_empty: bool) -> WasmShrink {
+        self.allow_empty = allow_empty;
+        self
+    }
+
+    /// Set the RNG seed for choosing which size-reducing mutation to attempt
+    /// next.
+    pub fn seed(mut self, seed: u64) -> WasmShrink {
+        self.seed = seed;
+        self
+    }
+
+    /// Run this configured Wasm shrinking task.
+    ///
+    /// The `predicate` function is called on each candidate Wasm to determine
+    /// whether the Wasm is interesting or not. Returning `true` means that it
+    /// is interesting, `false` means that it is not.
+    ///
+    /// The `on_new_smallest` function is called whenever we find a new smallest
+    /// interesting Wasm.
+    ///
+    /// Returns information and metrics about the shrink task, such as the
+    /// shrunken Wasm's output file path, the size of the input Wasm, the size
+    /// of the output Wasm, etc.
+    pub fn run<P, I, S>(
+        self,
+        input: Vec<u8>,
+        mut predicate: P,
+        mut on_new_smallest: S,
+    ) -> Result<ShrinkInfo>
+    where
+        P: FnMut(&[u8]) -> Result<I>,
+        I: IsInteresting,
+        S: FnMut(&[u8]) -> Result<()>,
+    {
+        let input_size = input.len() as u64;
+
+        // Prerequisites for the input Wasm.
+        self.validate_wasm(&input)
+            .context("The input is not valid Wasm.")?;
+
+        // First double check that the input Wasm passes the predicate.
+        //
+        // It is fairly common to accidentally write a predicate script that
+        // doesn't consider the input Wasm interesting. Better to surface this
+        // user error as quick as possible than to make them wait until we've
+        // exhausted all the ways we could shrink it further.
+        let result = predicate(&input)?;
+        anyhow::ensure!(
+            result.is_interesting(),
+            "The predicate does not consider the input Wasm interesting: {}",
+            result
+        );
+
+        // The smallest Wasm that passes the predicate.
+        let mut best = input;
+
+        let mut new_best = |old_best: &mut Vec<u8>, new: Vec<u8>| -> Result<()> {
+            debug_assert!(
+                new.len() < old_best.len() || (new == EMPTY_WASM && *old_best == EMPTY_WASM)
+            );
+            on_new_smallest(&new)?;
+            *old_best = new;
+            Ok(())
+        };
+
+        // Next try running the predicate on an empty Wasm module.
+        //
+        // It is fairly common to accidentally write a predicate script that
+        // considers the empty module interesting, and we might as well check
+        // for it eagerly, rather than make the user wait forever until we
+        // finally to reduce the whole Wasm module to nothing.
+        let result = predicate(EMPTY_WASM)?;
+        if result.is_interesting() {
+            if self.allow_empty {
+                new_best(&mut best, EMPTY_WASM.to_vec())?;
+                return Ok(ShrinkInfo {
+                    input_size,
+                    output_size: best.len() as u64,
+                    output: best,
+                });
+            } else {
+                anyhow::bail!(
+                    "The predicate considers the empty Wasm module \
+                     interesting, which is usually not desired and \
+                     is a symptom of a bug in the predicate:\n\
+                     \n\
+                     {}",
+                    result
+                );
+            }
+        }
+
+        // Now we perform the main search. Keep trying to find smaller and
+        // interesting variants of the current smallest interesting Wasm file
+        // until we run out of attempts and get stuck.
+
+        let mut rng = SmallRng::seed_from_u64(self.seed);
+
+        loop {
+            let mut new_smallest = None;
+
+            'attempts: for _ in 0..self.attempts {
+                let mut mutate = WasmMutate::default();
+                mutate.reduce(true).seed(rng.gen());
+
+                let mutations = match mutate.run(&best) {
+                    Ok(m) => m,
+                    Err(_) => {
+                        // This mutation failed, but another randomly chosen
+                        // mutation might succeed, so keep attempting.
+                        continue;
+                    }
+                };
+
+                for mutated_wasm in mutations.filter_map(|w| w.ok()) {
+                    log::debug!("Testing candidate of size {}", mutated_wasm.len());
+
+                    // TODO: This "shouldn't" happen when we set
+                    // `.reduce(true)` on `WasmMutate`, but it does. This
+                    // should turn into a `debug_assert!` once we fix
+                    // `wasm-mutate`.
+                    if mutated_wasm.len() >= best.len() {
+                        continue;
+                    }
+
+                    if predicate(&mutated_wasm)?.is_interesting() {
+                        new_smallest = Some(mutated_wasm);
+                        break 'attempts;
+                    }
+                }
+            }
+
+            match new_smallest {
+                // We've exhausted our attempt budget for shrinking this Wasm
+                // any further.
+                None => break,
+
+                // We found a new smallest Wasm module, try reducing it further.
+                Some(w) => new_best(&mut best, w)?,
+            }
+        }
+
+        Ok(ShrinkInfo {
+            input_size,
+            output_size: best.len() as u64,
+            output: best,
+        })
+    }
+
+    fn validate_wasm(&self, wasm: &[u8]) -> Result<()> {
+        let mut validator = wasmparser::Validator::new();
+        validator.wasm_features(wasmparser::WasmFeatures {
+            // TODO: we should have CLI flags for each Wasm proposal.
+            reference_types: true,
+            multi_value: true,
+            bulk_memory: true,
+            module_linking: false,
+            simd: true,
+            threads: true,
+            tail_call: true,
+            multi_memory: true,
+            exceptions: true,
+            memory64: true,
+            relaxed_simd: true,
+            extended_const: true,
+
+            // We'll never enable this here.
+            deterministic_only: false,
+        });
+
+        validator.validate_all(wasm)?;
+        Ok(())
+    }
+}
+
+/// A type that describes whether a Wasm is interesting or not.
+pub trait IsInteresting: std::fmt::Display {
+    /// Was the Wasm interesting?
+    fn is_interesting(&self) -> bool;
+}
+
+impl IsInteresting for bool {
+    fn is_interesting(&self) -> bool {
+        *self
+    }
+}
+
+/// Information about a completed shrinking run.
+pub struct ShrinkInfo {
+    /// The original size of the input Wasm.
+    pub input_size: u64,
+
+    /// The final size of the output, shrunken Wasm.
+    pub output_size: u64,
+
+    /// The final, shrunken Wasm.
+    pub output: Vec<u8>,
+}

--- a/crates/wasm-shrink/tests/tests.rs
+++ b/crates/wasm-shrink/tests/tests.rs
@@ -1,0 +1,61 @@
+use anyhow::Result;
+use wasm_shrink::WasmShrink;
+
+fn wasm() -> Vec<u8> {
+    wat::parse_str(
+        r#"
+            (module
+                (table 1 funcref)
+                (memory 1)
+                (func $a (param i32 i32) (result i32)
+                    local.get 0
+                    local.get 1
+                    i32.add
+                )
+                (func (export "f") (param i32 i32) (result i32)
+                    local.get 0
+                    local.get 1
+                    call $a
+                )
+            )
+        "#,
+    )
+    .unwrap()
+}
+
+#[test]
+fn shrink_to_empty_is_error() -> Result<()> {
+    let result = WasmShrink::default().run(wasm(), |_| Ok(true), |_| Ok(()));
+    assert!(result.is_err());
+    let err_msg = result.err().unwrap().to_string();
+    assert!(dbg!(err_msg).contains("empty Wasm module"));
+    Ok(())
+}
+
+#[test]
+fn shrink_to_empty_allowed() -> Result<()> {
+    WasmShrink::default()
+        .allow_empty(true)
+        .run(wasm(), |_| Ok(true), |_| Ok(()))?;
+    Ok(())
+}
+
+#[test]
+fn smoke_test() -> Result<()> {
+    let info = WasmShrink::default().attempts(100).run(
+        wasm(),
+        |wasm| {
+            let wat = wasmprinter::print_bytes(&wasm)?;
+            Ok(wat.contains("local.get"))
+        },
+        |_| Ok(()),
+    )?;
+
+    assert!(info.input_size > info.output_size);
+
+    let wat = wasmprinter::print_bytes(&info.output)?;
+    assert!(wat.contains("local.get"));
+
+    wasmparser::validate(&info.output)?;
+    Ok(())
+}

--- a/src/bin/wasm-shrink.rs
+++ b/src/bin/wasm-shrink.rs
@@ -1,0 +1,205 @@
+use anyhow::{Context, Result};
+use is_executable::IsExecutable;
+use std::path::{Path, PathBuf};
+use structopt::StructOpt;
+use wasm_shrink::{IsInteresting, WasmShrink};
+
+/// Shrink a Wasm file while maintaining a property of interest (such as triggering
+/// a compiler bug).
+///
+/// ## Example
+///
+/// Given that
+///
+///  * `crasher.wasm` is a Wasm file that triggers a crash in your Wasm compiler
+///    when you try to compile it, and
+///
+///  * `compile.sh` is a script that exits with code zero if its first
+///    command-line argument triggers a crash in your Wasm compiler, and exits
+///    with a non-zero code otherwise.
+///
+/// then you can shrink `crasher.wasm` into a smaller Wasm file that still triggers
+/// the crash and save it at `shrunken.wasm` with the following command:
+///
+/// $ wasm-shrink compile.sh crasher.wasm -o shrunken.wasm
+#[derive(StructOpt)]
+struct Options {
+    /// The output file path to write the shrunken Wasm file to.
+    ///
+    /// By default, a file path based on the input will be generated.
+    #[structopt(short, long)]
+    output: Option<PathBuf>,
+
+    #[structopt(flatten)]
+    shrink: WasmShrink,
+
+    /// The interestingness predicate script.
+    predicate: PathBuf,
+
+    /// The input Wasm.
+    input: PathBuf,
+}
+
+fn main() -> Result<()> {
+    env_logger::init();
+
+    let options = Options::from_args();
+
+    // Prerequisites for the predicate.
+    anyhow::ensure!(
+        options.predicate.is_file(),
+        "The predicate script '{}' does not exist.",
+        options.predicate.display()
+    );
+    anyhow::ensure!(
+        options.predicate.is_executable(),
+        "The predicate script '{}' is not executable.",
+        options.predicate.display()
+    );
+
+    let input = wat::parse_file(&options.input).with_context(|| {
+        format!(
+            "Failed to read input Wasm file: {}",
+            options.input.display()
+        )
+    })?;
+    let initial_size = input.len();
+
+    let output = options
+        .output
+        .clone()
+        .unwrap_or_else(|| options.input.with_extension("shrunken.wasm"));
+    log::info!("Will write shrunken Wasm file to: {}", output.display());
+
+    let predicate = make_predicate(&options.predicate);
+
+    let on_new_smallest = |new_smallest: &[u8]| {
+        // Write the Wasm to a temp file and then move that to the output path
+        // as a second, atomic step. This ensures that the output is always a
+        // valid, interesting, shrunken Wasm file, even in the presence of the
+        // user doing `Ctrl-C`.
+        let tmp = tempfile::NamedTempFile::new().context("Failed to create a temporary file")?;
+        std::fs::write(tmp.path(), new_smallest)
+            .with_context(|| format!("Failed to write to file: {}", tmp.path().display()))?;
+        std::fs::rename(tmp.path(), &output).with_context(|| {
+            format!(
+                "Failed to rename {} to {}",
+                tmp.path().display(),
+                output.display()
+            )
+        })?;
+
+        println!(
+            "{} bytes ({:.02}% smaller)",
+            new_smallest.len(),
+            (100.0 - (new_smallest.len() as f64 / initial_size as f64 * 100.0))
+        );
+
+        // Now write the WAT disassembly as well.
+        match wasmprinter::print_bytes(new_smallest) {
+            Err(e) => {
+                // Ignore disassembly errors, since this isn't critical for
+                // shrinking.
+                log::warn!("Error disassembling the shrunken Wasm into WAT: {}", e);
+            }
+            Ok(wat) => {
+                let wat_path = output.with_extension("wat");
+                log::info!("Writing WAT disassembly to {}", wat_path.display());
+                std::fs::write(&wat_path, wat).with_context(|| {
+                    format!("Failed to write WAT disassembly to {}", wat_path.display())
+                })?;
+            }
+        }
+
+        Ok(())
+    };
+
+    let shrunken = options.shrink.run(input, predicate, on_new_smallest)?;
+
+    let wat = wasmprinter::print_bytes(&shrunken.output)
+        .unwrap_or_else(|e| format!("<error disassembling WAT: {}>", e));
+
+    println!(
+        "\n\
+         {} :: {} bytes ({:.02}% smaller)\n\
+         ================================================================================\n\
+         {}\n\
+         ================================================================================",
+        output.display(),
+        shrunken.output.len(),
+        100.0 - (shrunken.output.len() as f64 / initial_size as f64 * 100.0),
+        wat.trim(),
+    );
+
+    Ok(())
+}
+
+struct OutputIsInteresting(std::process::Output);
+
+impl std::fmt::Display for OutputIsInteresting {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "predicate script exit status: {}\n\
+             \n\
+             === predicate script stdout ===\n\
+             {}\n\
+             ===============================\n\
+             \n\
+             === predicate script stderr ===\n\
+             {}\n\
+             ===============================",
+            self.0.status,
+            String::from_utf8_lossy(&self.0.stdout),
+            String::from_utf8_lossy(&self.0.stderr),
+        )
+    }
+}
+
+impl IsInteresting for OutputIsInteresting {
+    fn is_interesting(&self) -> bool {
+        // `code` is `None` when a signal killed the child process on
+        // unix. Treat that as a non-zero exit code.
+        let code = self.0.status.code().unwrap_or(1);
+        code == 0
+    }
+}
+
+fn make_predicate<'a>(
+    predicate_script: &'a Path,
+) -> impl FnMut(&[u8]) -> Result<OutputIsInteresting> + 'a {
+    move |wasm| {
+        let tmp = tempfile::NamedTempFile::new().context("Failed to create a temporary file.")?;
+        std::fs::write(tmp.path(), wasm).with_context(|| {
+            format!(
+                "Failed to write to temporary file: {}",
+                tmp.path().display()
+            )
+        })?;
+
+        let output = std::process::Command::new(&predicate_script)
+            .arg(tmp.path())
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .output()
+            .with_context(|| {
+                format!(
+                    "Failed to run predicate script '{}'",
+                    predicate_script.display()
+                )
+            })?;
+
+        log::trace!("predicate script exit status: {}", output.status);
+        log::trace!(
+            "predicate script stdout:\n{}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+        log::trace!(
+            "predicate script stderr:\n{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        Ok(OutputIsInteresting(output))
+    }
+}


### PR DESCRIPTION
`wasm-shrink` is a test case shrinker for WebAssembly. It shrinks a Wasm file while preserving an interesting property (such as triggering a bug in your Wasm compiler).

cc @Jacarte 