### PR TITLE
wasm-smith: avoid exporting flagset types in public API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4"
 rayon = "1.0"
 structopt = "0.3.16"
 wasm-mutate = { path = "crates/wasm-mutate", features = ["structopt"] }
-wasm-smith = { path = "crates/wasm-smith" }
+wasm-smith = { path = "crates/wasm-smith", features = ["_internal_cli"] }
 wasmparser = { path = "crates/wasmparser" }
 wasmparser-dump = { path = "crates/dump" }
 wasmprinter = { path = "crates/wasmprinter" }

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -21,6 +21,7 @@ flagset = { version = "0.4", features = ["serde"] }
 leb128 = "0.2.4"
 wasm-encoder = { version = "0.8.0", path = "../wasm-encoder" }
 indexmap = "1.6"
+serde = { version = "1", features = ['derive'] }
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -17,11 +17,11 @@ harness = false
 
 [dependencies]
 arbitrary = { version = "1.0.0", features = ["derive"] }
-flagset = { version = "0.4", features = ["serde"] }
+flagset = "0.4"
 leb128 = "0.2.4"
 wasm-encoder = { version = "0.8.0", path = "../wasm-encoder" }
 indexmap = "1.6"
-serde = { version = "1", features = ['derive'] }
+serde = { version = "1", features = ['derive'], optional = true }
 
 [dev-dependencies]
 criterion = "0.3.3"
@@ -29,3 +29,6 @@ libfuzzer-sys = "0.4.0"
 rand = { version = "0.7.3", features = ["small_rng"] }
 wasmparser = { path = "../wasmparser" }
 wasmprinter = { path = "../wasmprinter" }
+
+[features]
+_internal_cli = ["serde", "flagset/serde"]

--- a/crates/wasm-smith/src/code_builder.rs
+++ b/crates/wasm-smith/src/code_builder.rs
@@ -23,6 +23,7 @@ macro_rules! instructions {
             fn(&mut Unstructured<'_>, &Module, &mut CodeBuilder) -> Result<Instruction>
         > {
             builder.allocs.options.clear();
+            let allowed_instructions = module.config.allowed_instructions();
             let mut cost = 0;
             // Unroll the loop that checks whether each instruction is valid in
             // the current context and, if it is valid, pushes it onto our
@@ -33,7 +34,7 @@ macro_rules! instructions {
             $(
                 let predicate: Option<fn(&Module, &mut CodeBuilder) -> bool> = $predicate;
                 if predicate.map_or(true, |f| f(module, builder))
-                    && module.config.allowed_instructions().0.contains($instruction_kind) {
+                    && allowed_instructions.contains($instruction_kind) {
                     builder.allocs.options.push(($generator_fn, cost));
                     cost += 1000 $(- $cost)?;
                 }

--- a/crates/wasm-smith/src/code_builder.rs
+++ b/crates/wasm-smith/src/code_builder.rs
@@ -33,7 +33,7 @@ macro_rules! instructions {
             $(
                 let predicate: Option<fn(&Module, &mut CodeBuilder) -> bool> = $predicate;
                 if predicate.map_or(true, |f| f(module, builder))
-                    && module.config.allowed_instructions().contains($instruction_kind) {
+                    && module.config.allowed_instructions().0.contains($instruction_kind) {
                     builder.allocs.options.push(($generator_fn, cost));
                     cost += 1000 $(- $cost)?;
                 }

--- a/crates/wasm-smith/src/config.rs
+++ b/crates/wasm-smith/src/config.rs
@@ -1,6 +1,6 @@
 //! Configuring the shape of generated Wasm modules.
 
-use crate::InstructionKind;
+use crate::InstructionKinds;
 use arbitrary::{Arbitrary, Result, Unstructured};
 use flagset::FlagSet;
 
@@ -325,6 +325,14 @@ pub trait Config: 'static + std::fmt::Debug {
     /// Returns the kinds of instructions allowed in the generated wasm
     /// programs.
     ///
+    /// To configure which kinds of instructions are allowed, override with:
+    ///
+    /// ```ignore
+    /// fn allowed_instructions(&self) -> InstructionKinds {
+    ///    InstructionKinds::new(InstructionKind::Numeric | InstructionKind::Memory)
+    /// }
+    /// ```
+    ///
     /// The categories of instructions match the categories used by the
     /// [WebAssembly
     /// specification](https://webassembly.github.io/spec/core/syntax/instructions.html);
@@ -333,8 +341,8 @@ pub trait Config: 'static + std::fmt::Debug {
     /// == true` but `allowed_instruction_kinds()` does not include vector
     /// instructions, the generated programs will not include these instructions
     /// but could contain vector types.
-    fn allowed_instructions(&self) -> FlagSet<InstructionKind> {
-        FlagSet::full()
+    fn allowed_instructions(&self) -> InstructionKinds {
+        InstructionKinds::new(FlagSet::full())
     }
 }
 

--- a/crates/wasm-smith/src/config.rs
+++ b/crates/wasm-smith/src/config.rs
@@ -2,7 +2,6 @@
 
 use crate::InstructionKinds;
 use arbitrary::{Arbitrary, Result, Unstructured};
-use flagset::FlagSet;
 
 /// Configuration for a generated module.
 ///
@@ -325,24 +324,16 @@ pub trait Config: 'static + std::fmt::Debug {
     /// Returns the kinds of instructions allowed in the generated wasm
     /// programs.
     ///
-    /// To configure which kinds of instructions are allowed, override with:
-    ///
-    /// ```ignore
-    /// fn allowed_instructions(&self) -> InstructionKinds {
-    ///    InstructionKinds::new(InstructionKind::Numeric | InstructionKind::Memory)
-    /// }
-    /// ```
-    ///
     /// The categories of instructions match the categories used by the
     /// [WebAssembly
     /// specification](https://webassembly.github.io/spec/core/syntax/instructions.html);
     /// e.g., numeric, vector, control, memory, etc. Note that modifying this
     /// setting is separate from the proposal flags; that is, if `simd_enabled()
-    /// == true` but `allowed_instruction_kinds()` does not include vector
+    /// == true` but `allowed_instruction()` does not include vector
     /// instructions, the generated programs will not include these instructions
     /// but could contain vector types.
     fn allowed_instructions(&self) -> InstructionKinds {
-        InstructionKinds::new(FlagSet::full())
+        InstructionKinds::all()
     }
 }
 

--- a/crates/wasm-smith/src/lib.rs
+++ b/crates/wasm-smith/src/lib.rs
@@ -75,6 +75,7 @@ mod terminate;
 use crate::code_builder::CodeBuilderAllocations;
 use arbitrary::{Arbitrary, Result, Unstructured};
 use flagset::{flags, FlagSet};
+#[cfg(feature = "_internal_cli")]
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 use std::convert::TryFrom;
@@ -2498,7 +2499,7 @@ flags! {
     /// Enumerate the categories of instructions defined in the [WebAssembly
     /// specification](https://webassembly.github.io/spec/core/syntax/instructions.html).
     #[allow(missing_docs)]
-    #[derive(Deserialize)]
+    #[cfg_attr(feature = "_internal_cli", derive(Deserialize))]
     pub enum InstructionKind: u16 {
         Numeric,
         Vector,

--- a/crates/wasm-smith/src/lib.rs
+++ b/crates/wasm-smith/src/lib.rs
@@ -75,8 +75,6 @@ mod terminate;
 use crate::code_builder::CodeBuilderAllocations;
 use arbitrary::{Arbitrary, Result, Unstructured};
 use flagset::{flags, FlagSet};
-#[cfg(feature = "_internal_cli")]
-use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
 use std::convert::TryFrom;
 use std::marker;
@@ -2499,7 +2497,7 @@ flags! {
     /// Enumerate the categories of instructions defined in the [WebAssembly
     /// specification](https://webassembly.github.io/spec/core/syntax/instructions.html).
     #[allow(missing_docs)]
-    #[cfg_attr(feature = "_internal_cli", derive(Deserialize))]
+    #[cfg_attr(feature = "_internal_cli", derive(serde::Deserialize))]
     pub enum InstructionKind: u16 {
         Numeric,
         Vector,

--- a/crates/wasm-smith/src/lib.rs
+++ b/crates/wasm-smith/src/lib.rs
@@ -81,7 +81,7 @@ use std::convert::TryFrom;
 use std::marker;
 use std::ops::Range;
 use std::rc::Rc;
-use std::str::{self};
+use std::str::{self, FromStr};
 use wasm_encoder::{BlockType, Export, GlobalType, ItemKind, MemoryType, TableType, ValType};
 
 pub use config::{Config, DefaultConfig, SwarmConfig};
@@ -2463,14 +2463,31 @@ struct Outer {
 /// emit. Usage:
 /// ```
 /// # use wasm_smith::{InstructionKinds, InstructionKind};
-/// InstructionKinds::new(InstructionKind::Numeric | InstructionKind::Memory);
+/// let kinds = InstructionKinds::new([InstructionKind::Numeric, InstructionKind::Memory]);
+/// assert!(kinds.contains(InstructionKind::Memory));
 /// ```
-#[derive(Clone, Copy, Debug, Default, Deserialize)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct InstructionKinds(pub(crate) FlagSet<InstructionKind>);
 impl InstructionKinds {
     /// Create a new container.
-    pub fn new(kinds: impl Into<FlagSet<InstructionKind>>) -> Self {
-        Self(kinds.into())
+    pub fn new<'a>(kinds: impl IntoIterator<Item = &'a InstructionKind>) -> Self {
+        Self(kinds.into_iter().fold(FlagSet::default(), |ks, k| ks | *k))
+    }
+
+    /// Include all [InstructionKind]s.
+    pub fn all() -> Self {
+        Self(FlagSet::full())
+    }
+
+    /// Include no [InstructionKind]s.
+    pub fn none() -> Self {
+        Self(FlagSet::default())
+    }
+
+    /// Check if the [InstructionKind] is contained in this set.
+    #[inline]
+    pub fn contains(&self, kind: InstructionKind) -> bool {
+        self.0.contains(kind)
     }
 }
 
@@ -2478,6 +2495,7 @@ flags! {
     /// Enumerate the categories of instructions defined in the [WebAssembly
     /// specification](https://webassembly.github.io/spec/core/syntax/instructions.html).
     #[allow(missing_docs)]
+    #[derive(Deserialize)]
     pub enum InstructionKind: u16 {
         Numeric,
         Vector,
@@ -2490,23 +2508,19 @@ flags! {
     }
 }
 
-/// Parse a comma-separated list of instruction kinds into a `FlagSet`.
-pub fn parse_instruction_kinds(s: &str) -> std::result::Result<InstructionKinds, String> {
-    let mut kinds = InstructionKinds::default();
-    for s in s.split(",") {
-        let matched = match s.to_lowercase().as_str() {
-            "numeric" => InstructionKind::Numeric,
-            "vector" => InstructionKind::Vector,
-            "reference" => InstructionKind::Reference,
-            "parametric" => InstructionKind::Parametric,
-            "variable" => InstructionKind::Variable,
-            "table" => InstructionKind::Table,
-            "memory" => InstructionKind::Memory,
-            "control" => InstructionKind::Control,
-            _ => return Err(format!("unknown instruction kind: {}", s)),
-        };
-        kinds.0 |= matched;
+impl FromStr for InstructionKind {
+    type Err = String;
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "numeric" => Ok(InstructionKind::Numeric),
+            "vector" => Ok(InstructionKind::Vector),
+            "reference" => Ok(InstructionKind::Reference),
+            "parametric" => Ok(InstructionKind::Parametric),
+            "variable" => Ok(InstructionKind::Variable),
+            "table" => Ok(InstructionKind::Table),
+            "memory" => Ok(InstructionKind::Memory),
+            "control" => Ok(InstructionKind::Control),
+            _ => Err(format!("unknown instruction kind: {}", s)),
+        }
     }
-    println!("Parsed kinds: {:?}", kinds);
-    Ok(kinds)
 }

--- a/crates/wasm-smith/src/lib.rs
+++ b/crates/wasm-smith/src/lib.rs
@@ -2460,7 +2460,10 @@ struct Outer {
 }
 
 /// A container for the kinds of instructions that wasm-smith is allowed to
-/// emit. Usage:
+/// emit.
+///
+/// # Example
+///
 /// ```
 /// # use wasm_smith::{InstructionKinds, InstructionKind};
 /// let kinds = InstructionKinds::new(&[InstructionKind::Numeric, InstructionKind::Memory]);

--- a/crates/wasm-smith/src/lib.rs
+++ b/crates/wasm-smith/src/lib.rs
@@ -2463,15 +2463,15 @@ struct Outer {
 /// emit. Usage:
 /// ```
 /// # use wasm_smith::{InstructionKinds, InstructionKind};
-/// let kinds = InstructionKinds::new([InstructionKind::Numeric, InstructionKind::Memory]);
+/// let kinds = InstructionKinds::new(&[InstructionKind::Numeric, InstructionKind::Memory]);
 /// assert!(kinds.contains(InstructionKind::Memory));
 /// ```
 #[derive(Clone, Copy, Debug, Default)]
 pub struct InstructionKinds(pub(crate) FlagSet<InstructionKind>);
 impl InstructionKinds {
     /// Create a new container.
-    pub fn new<'a>(kinds: impl IntoIterator<Item = &'a InstructionKind>) -> Self {
-        Self(kinds.into_iter().fold(FlagSet::default(), |ks, k| ks | *k))
+    pub fn new(kinds: &[InstructionKind]) -> Self {
+        Self(kinds.iter().fold(FlagSet::default(), |ks, k| ks | *k))
     }
 
     /// Include all [InstructionKind]s.

--- a/src/bin/wasm-smith.rs
+++ b/src/bin/wasm-smith.rs
@@ -5,7 +5,7 @@ use std::io::{stdin, stdout, Read, Write};
 use std::path::PathBuf;
 use std::process;
 use structopt::StructOpt;
-use wasm_smith::{parse_instruction_kinds, InstructionKinds, MaybeInvalidModule, Module};
+use wasm_smith::{InstructionKind, InstructionKinds, MaybeInvalidModule, Module};
 
 /// A WebAssembly test case generator.
 ///
@@ -169,8 +169,8 @@ struct Config {
     /// reference, parametric, variable, table, memory, control. Specify
     /// multiple kinds with a comma-separated list: e.g.,
     /// `--allowed-instructions numeric,control,parametric`
-    #[structopt(long = "allowed-instructions", parse(try_from_str = parse_instruction_kinds))]
-    allowed_instructions: Option<InstructionKinds>,
+    #[structopt(long = "allowed-instructions", use_delimiter = true)]
+    allowed_instructions: Option<Vec<InstructionKind>>,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -305,7 +305,6 @@ impl wasm_smith::Config for CliAndJsonConfig {
         (max_nesting_depth, usize, 1000),
         (max_type_size, u32, 1000),
         (canonicalize_nans, bool, false),
-        (allowed_instructions, InstructionKinds, InstructionKinds::default()),
     }
 
     fn max_memory_pages(&self, _is_64: bool) -> u64 {
@@ -313,5 +312,17 @@ impl wasm_smith::Config for CliAndJsonConfig {
             .max_memory_pages
             .or(self.json.max_memory_pages)
             .unwrap_or(65536)
+    }
+
+    fn allowed_instructions(&self) -> InstructionKinds {
+        match self
+            .cli
+            .allowed_instructions
+            .as_ref()
+            .or(self.json.allowed_instructions.as_ref())
+        {
+            Some(ks) => InstructionKinds::new(ks),
+            None => InstructionKinds::all(),
+        }
     }
 }

--- a/src/bin/wasm-smith.rs
+++ b/src/bin/wasm-smith.rs
@@ -1,12 +1,11 @@
 use anyhow::Context;
 use arbitrary::Arbitrary;
-use flagset::FlagSet;
 use std::fs;
 use std::io::{stdin, stdout, Read, Write};
 use std::path::PathBuf;
 use std::process;
 use structopt::StructOpt;
-use wasm_smith::{parse_instruction_kinds, InstructionKind, MaybeInvalidModule, Module};
+use wasm_smith::{parse_instruction_kinds, InstructionKinds, MaybeInvalidModule, Module};
 
 /// A WebAssembly test case generator.
 ///
@@ -171,7 +170,7 @@ struct Config {
     /// multiple kinds with a comma-separated list: e.g.,
     /// `--allowed-instructions numeric,control,parametric`
     #[structopt(long = "allowed-instructions", parse(try_from_str = parse_instruction_kinds))]
-    allowed_instructions: Option<FlagSet<InstructionKind>>,
+    allowed_instructions: Option<InstructionKinds>,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -306,7 +305,7 @@ impl wasm_smith::Config for CliAndJsonConfig {
         (max_nesting_depth, usize, 1000),
         (max_type_size, u32, 1000),
         (canonicalize_nans, bool, false),
-        (allowed_instructions, FlagSet<InstructionKind>, FlagSet::default()),
+        (allowed_instructions, InstructionKinds, InstructionKinds::default()),
     }
 
     fn max_memory_pages(&self, _is_64: bool) -> u64 {


### PR DESCRIPTION
In #400, the `FlagSet` type from the `flagset` crate was publicly
exposed by the `Config` trait. This forced users (me) to import
`flagset` anywhere `wasm-smith` was being configured. To avoid this,
`FlagSet` is wrapped in a container structure--`InstructionKinds`.