### PR TITLE
Add primitive support for v128/funcref/externref in wasm-mutate

### DIFF
--- a/crates/wasm-mutate/src/module/mod.rs
+++ b/crates/wasm-mutate/src/module/mod.rs
@@ -57,13 +57,13 @@ impl TryFrom<TypeDef<'_>> for TypeInfo {
                 params: ft
                     .params
                     .iter()
-                    .map(|&t| PrimitiveTypeInfo::try_from(t).unwrap())
-                    .collect(),
+                    .map(|&t| PrimitiveTypeInfo::try_from(t))
+                    .collect::<Result<Vec<_>, _>>()?,
                 returns: ft
                     .returns
                     .iter()
-                    .map(|&t| PrimitiveTypeInfo::try_from(t).unwrap())
-                    .collect(),
+                    .map(|&t| PrimitiveTypeInfo::try_from(t))
+                    .collect::<Result<Vec<_>, _>>()?,
             })),
             _ => Err(super::Error::UnsupportedType(EitherType::TypeDef(format!(
                 "{:?}",

--- a/crates/wasm-mutate/src/module/mod.rs
+++ b/crates/wasm-mutate/src/module/mod.rs
@@ -11,6 +11,9 @@ pub enum PrimitiveTypeInfo {
     I64,
     F32,
     F64,
+    V128,
+    FuncRef,
+    ExternRef,
     Empty,
 }
 
@@ -36,6 +39,9 @@ impl TryFrom<Type> for PrimitiveTypeInfo {
             wasmparser::Type::I64 => Ok(PrimitiveTypeInfo::I64),
             wasmparser::Type::F32 => Ok(PrimitiveTypeInfo::F32),
             wasmparser::Type::F64 => Ok(PrimitiveTypeInfo::F64),
+            wasmparser::Type::V128 => Ok(PrimitiveTypeInfo::V128),
+            wasmparser::Type::FuncRef => Ok(PrimitiveTypeInfo::FuncRef),
+            wasmparser::Type::ExternRef => Ok(PrimitiveTypeInfo::ExternRef),
             Type::EmptyBlockType => Ok(PrimitiveTypeInfo::Empty),
             _ => Err(super::Error::UnsupportedType(EitherType::Type(value))),
         }
@@ -73,6 +79,9 @@ pub fn map_type(tpe: Type) -> super::Result<ValType> {
         Type::I64 => Ok(ValType::I64),
         Type::F32 => Ok(ValType::F32),
         Type::F64 => Ok(ValType::F64),
+        Type::V128 => Ok(ValType::V128),
+        Type::FuncRef => Ok(ValType::FuncRef),
+        Type::ExternRef => Ok(ValType::ExternRef),
         _ => Err(super::Error::UnsupportedType(EitherType::Type(tpe))),
     }
 }

--- a/crates/wasm-mutate/src/mutators/snip_function.rs
+++ b/crates/wasm-mutate/src/mutators/snip_function.rs
@@ -5,7 +5,7 @@ use crate::module::{PrimitiveTypeInfo, TypeInfo};
 use crate::{ModuleInfo, Result, WasmMutate};
 use rand::prelude::SmallRng;
 use rand::Rng;
-use wasm_encoder::{CodeSection, Function, Instruction, Module};
+use wasm_encoder::{CodeSection, Function, Instruction, Module, ValType};
 use wasmparser::CodeSectionReader;
 
 /// Mutator that replaces the body of a function with an empty body
@@ -45,7 +45,16 @@ impl Mutator for SnipMutator {
                                 PrimitiveTypeInfo::F64 => {
                                     f.instruction(&Instruction::F64Const(0.0));
                                 }
-                                _ => {
+                                PrimitiveTypeInfo::V128 => {
+                                    f.instruction(&Instruction::V128Const(0));
+                                }
+                                PrimitiveTypeInfo::FuncRef => {
+                                    f.instruction(&Instruction::RefNull(ValType::FuncRef));
+                                }
+                                PrimitiveTypeInfo::ExternRef => {
+                                    f.instruction(&Instruction::RefNull(ValType::ExternRef));
+                                }
+                                PrimitiveTypeInfo::Empty => {
                                     // Do nothing
                                 }
                             });

--- a/fuzz/fuzz_targets/mutate.rs
+++ b/fuzz/fuzz_targets/mutate.rs
@@ -14,11 +14,9 @@ fuzz_target!(|bytes: &[u8]| {
     // use with `wasm-mutate`.
 
     let mut seed = 0;
-    let (wasm, _config) = match wasm_tools_fuzz::generate_valid_module(bytes, |config, u| {
+    let (wasm, config) = match wasm_tools_fuzz::generate_valid_module(bytes, |config, u| {
         config.module_linking_enabled = false;
         config.exceptions_enabled = false;
-        config.simd_enabled = false;
-        config.reference_types_enabled = false;
         config.memory64_enabled = false;
         config.max_memories = 1;
         seed = u.arbitrary()?;
@@ -71,7 +69,9 @@ fuzz_target!(|bytes: &[u8]| {
 
     // The mutated Wasm should still be valid, since the input Wasm was valid.
 
-    let features = WasmFeatures::default();
+    let mut features = WasmFeatures::default();
+    features.simd = config.simd_enabled;
+    features.relaxed_simd = config.relaxed_simd_enabled;
     let mut validator = wasmparser::Validator::new();
     validator.wasm_features(features);
 


### PR DESCRIPTION
This only adds a few type definitions and mappings, but it at least gets
the input module ingested. Since none of the new instructions are added
here to wasm-mutate the mutations supported are pretty limited, but
otherwise it helps reducing code from other functions.