### PR TITLE
wasm-mutate: remove dead code

### DIFF
--- a/crates/wasm-mutate/src/mutators/codemotion/ir/parse_context.rs
+++ b/crates/wasm-mutate/src/mutators/codemotion/ir/parse_context.rs
@@ -222,13 +222,6 @@ impl ParseContext {
         self.current_parsing.clone()
     }
 
-    /// Returns all parsed nodes since the creation of this `ParseContext`
-    /// inetance.
-    ///
-    pub fn get_nodes(&self) -> Vec<Node> {
-        self.nodes.clone()
-    }
-
     /// Checks if the corrent code parsing has at least one instruction
     ///
     pub fn current_code_is_empty(&self) -> bool {


### PR DESCRIPTION
Rust was emitting warnings because `get_nodes` was unused.