### PR TITLE
`wasm-smith`: `SwarmConfig` should enable bulk memory if enabling reference types

### DIFF
--- a/crates/wasm-smith/src/config.rs
+++ b/crates/wasm-smith/src/config.rs
@@ -428,7 +428,7 @@ impl<'a> Arbitrary<'a> for SwarmConfig {
             max_tables,
             max_memory_pages: u.arbitrary()?,
             min_uleb_size: u.int_in_range(0..=5)?,
-            bulk_memory_enabled: u.arbitrary()?,
+            bulk_memory_enabled: reference_types_enabled || u.arbitrary()?,
             reference_types_enabled,
             max_aliases: u.int_in_range(0..=MAX_MAXIMUM)?,
             max_nesting_depth: u.int_in_range(0..=10)?,

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -1426,7 +1426,7 @@ impl Validator {
                 }
                 ElementKind::Passive | ElementKind::Declared => {
                     if !me.features.bulk_memory {
-                        return me.create_error("reference types must be enabled");
+                        return me.create_error("bulk memory must be enabled");
                     }
                 }
             }


### PR DESCRIPTION
The reference types proposal depends on the bulk memory proposal.

This fixes #409 because we enable/disable wasm feature validation based on what the `SwarmConfig` has enabled or disabled.

@cfallin mind giving this a quick review?

cc @Jacarte 

Fix #409 