### PR TITLE
wasm-mutate: Clean up the DFG some more

### DIFF
--- a/crates/wasm-mutate/src/mutators/peephole/dfg.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/dfg.rs
@@ -18,10 +18,17 @@ use super::eggsy::encoder::rebuild::build_expr;
 ///
 /// For example, the `i32.add` operator should know who are its operands
 pub struct DFGBuilder {
+    /// Current color of the state of the world. This is incremented any time
+    /// the Wasm mutates state, for example makes a function call or writes to
+    /// memory. We generally only apply mutations to expressions where all
+    /// subexpressions have the same color as the root expression. This helps us
+    /// avoid incorrectly reordering side-effectful operations.
+    color: u32,
+
     stack: Vec<usize>,
     dfg_map: Vec<StackEntry>,
-    operatormap: HashMap<usize, usize>,
-    parents: Vec<i32>,
+    operator_index_to_entry_index: HashMap<usize, usize>,
+    parents: Vec<Option<usize>>,
 }
 
 /// Basic block of a Wasm's function defined as a range of operators in the Wasm
@@ -62,7 +69,7 @@ pub struct MiniDFG {
     /// For each stack entry we keep the parental relation, the ith value is the index of
     /// the ith instruction's parent instruction.
     /// We write each stack entry having no parent, i.e. a root in the dfg
-    pub parents: Vec<i32>,
+    pub parents: Vec<Option<usize>>,
 }
 
 impl MiniDFG {
@@ -105,27 +112,26 @@ impl MiniDFG {
     /// For an example, see the implementation of the `pretty_print_default` method.
     pub fn pretty_print(&self, entryformatter: &dyn Fn(&StackEntry) -> String) -> String {
         let mut builder = String::from("");
-
         builder.push_str("DFG forest\n");
 
-        // To get ansi colors
-        fn get_color(color: u32) -> &'static str {
+        fn get_ansi_term_color(color: u32) -> &'static str {
             match color {
-                0 => "\u{001b}[31m",    // red
-                1 => "\u{001b}[32m",    // green
-                2 => "\u{001b}[33m",    // yellow
-                3 => "\u{001b}[34m",    // blue
-                4 => "\u{001b}[35m",    // magenta
-                5 => "\u{001b}[36m",    // cyan
-                6 => "\u{001b}[37;1m",  // bright white
-                7 => "\u{001b}[32;1m",  // bright green
-                8 => "\u{001b}[33;1m",  // bright yellow
-                9 => "\u{001b}[36;1m",  // bright cyan
-                10 => "\u{001b}[35;1m", // bright magenta
-                11 => "\u{001b}[31;1m", // bright red
-                _ => "\u{001b}[0m",     // reset color (terminal default)
+                0 => "\u{001b}[31m",             // red
+                1 => "\u{001b}[32m",             // green
+                2 => "\u{001b}[33m",             // yellow
+                3 => "\u{001b}[34m",             // blue
+                4 => "\u{001b}[35m",             // magenta
+                5 => "\u{001b}[36m",             // cyan
+                6 => "\u{001b}[37;1m",           // bright white
+                7 => "\u{001b}[32;1m",           // bright green
+                8 => "\u{001b}[33;1m",           // bright yellow
+                9 => "\u{001b}[36;1m",           // bright cyan
+                10 => "\u{001b}[35;1m",          // bright magenta
+                UNDEF_COLOR => "\u{001b}[31;1m", // bright red
+                _ => "\u{001b}[0m",              // reset color (terminal default)
             }
         }
+
         fn write_child(
             minidfg: &MiniDFG,
             entryidx: usize,
@@ -136,7 +142,7 @@ impl MiniDFG {
         ) {
             let entry = &minidfg.entries[entryidx];
             builder.push_str(&(&preffix).to_string());
-            let color = get_color(entry.color);
+            let color = get_ansi_term_color(entry.color);
             builder.push_str(
                 format!(
                     "{}({})(at {}) {:?}\u{001b}[0m\n",
@@ -175,9 +181,10 @@ impl MiniDFG {
                 }
             }
         }
-        // Get roots
-        for (entryidx, idx) in self.parents.iter().enumerate() {
-            if *idx == -1 {
+
+        // Print the roots.
+        for (entryidx, parent) in self.parents.iter().enumerate() {
+            if parent.is_none() {
                 write_child(self, entryidx, "", entryformatter, "", &mut builder);
             }
         }
@@ -202,13 +209,16 @@ impl MiniDFG {
     }
 }
 
+const UNDEF_COLOR: u32 = u32::MAX;
+
 impl<'a> DFGBuilder {
     /// Returns a new DFG builder
     pub fn new() -> Self {
         DFGBuilder {
+            color: 0,
             stack: Vec::new(),
             dfg_map: Vec::new(),
-            operatormap: HashMap::new(),
+            operator_index_to_entry_index: HashMap::new(),
             parents: Vec::new(),
         }
     }
@@ -278,60 +288,79 @@ impl<'a> DFGBuilder {
         operator: Lang,
         operator_idx: usize,
         operands: Vec<usize>,
-        color: u32,
         return_type: PrimitiveTypeInfo,
     ) -> usize {
         let entry_idx = self.dfg_map.len();
+
         let push_to_stack = if let PrimitiveTypeInfo::Empty = return_type {
             // Avoid to push empty values on to the stack
             false
         } else {
             true
         };
-        let newnode = StackEntry {
+
+        // Add the parent links for this node's operands.
+        for id in &operands {
+            debug_assert!(self.parents[*id].is_none());
+            self.parents[*id] = Some(entry_idx);
+        }
+
+        let new_node = StackEntry {
             operator,
             operands,
             return_type,
             entry_idx,
-            color,
+            color: self.color,
             operator_idx,
         };
 
-        self.operatormap.insert(operator_idx, entry_idx);
+        self.operator_index_to_entry_index
+            .insert(operator_idx, entry_idx);
+
         if push_to_stack {
             self.stack.push(entry_idx)
         }
+
         // Add the data flow link
-        self.dfg_map.push(newnode);
-        self.parents.push(-1);
+        self.dfg_map.push(new_node);
+        self.parents.push(None);
+
         entry_idx
     }
 
-    fn pop_operand(&mut self, operator_idx: usize, insertindfg: bool) -> usize {
+    fn pop_operand(&mut self, operator_idx: usize, insert_in_dfg: bool) -> usize {
         self.stack
             .pop()
             .or_else(|| {
-                // Since this represents the same for all
-                // Create 0 element as Unknown
                 let entry_idx = self.dfg_map.len();
+
                 let leaf = StackEntry {
                     operator: Lang::Undef,
                     operands: vec![],
                     // Check if this can be inferred from the operator
                     return_type: PrimitiveTypeInfo::Empty,
                     entry_idx,
-                    color: 0, // 0 color is undefined
+                    color: UNDEF_COLOR,
                     operator_idx,
-                }; // Means not reachable
-                if insertindfg {
-                    self.operatormap.insert(operator_idx, entry_idx);
+                };
+
+                if insert_in_dfg {
+                    self.operator_index_to_entry_index
+                        .insert(operator_idx, entry_idx);
                 }
-                // Add the data flow link
+
+                // Add the data flow link. No parent yet.
                 self.dfg_map.push(leaf);
-                self.parents.push(-1); // no parent yet
+                self.parents.push(None);
+
                 Some(entry_idx)
             })
             .unwrap()
+    }
+
+    fn new_color(&mut self) {
+        self.color += 1;
+        assert!(self.color < UNDEF_COLOR);
     }
 
     /// This method should build lane dfg information
@@ -348,10 +377,9 @@ impl<'a> DFGBuilder {
         basicblock: &BBlock,
         locals: &[PrimitiveTypeInfo],
     ) -> Option<MiniDFG> {
-        let mut color = 1; // start with color 1 since 0 is undef
-                           // Create a DFG from the BB
-                           // Start from the first operator and simulate the stack...
-                           // If an operator is missing in the stack then it probably comes from a previous BB
+        // Create a DFG from the BB. Start from the first operator and simulate
+        // the stack. If an operator is missing in the stack then it probably
+        // comes from a previous BB.
 
         for idx in basicblock.range.start..basicblock.range.end {
             // We dont care about the jump
@@ -376,26 +404,21 @@ impl<'a> DFGBuilder {
                             // reverse operands
                             operands.reverse();
                             // Add this as a new operator
-                            let fidx = self.push_node(
+                            self.push_node(
                                 Lang::Call(
                                     *function_index as usize,
                                     operands.iter().map(|i| Id::from(*i)).collect::<Vec<_>>(),
                                 ),
                                 idx,
                                 operands.clone(),
-                                color,
                                 if tpe.returns.is_empty() {
                                     PrimitiveTypeInfo::Empty
                                 } else {
                                     tpe.returns[0].clone()
                                 },
                             );
-                            // Set the parents for the operands
-                            for id in &operands {
-                                self.parents[*id] = fidx as i32;
-                            }
-                            // Change the color
-                            color += 1;
+
+                            self.new_color();
                         }
                     }
                 }
@@ -404,7 +427,6 @@ impl<'a> DFGBuilder {
                         Lang::LocalGet(*local_index),
                         idx,
                         vec![],
-                        color,
                         locals[*local_index as usize].clone(),
                     );
                 }
@@ -413,209 +435,161 @@ impl<'a> DFGBuilder {
                         Lang::GlobalGet(*global_index),
                         idx,
                         vec![],
-                        color,
                         info.global_types[*global_index as usize].clone(),
                     );
                 }
                 Operator::GlobalSet { global_index } => {
                     let child = self.pop_operand(idx, true);
-
-                    let idx = self.push_node(
+                    self.push_node(
                         Lang::GlobalSet(*global_index, Id::from(child)),
                         idx,
                         vec![child],
-                        color,
                         PrimitiveTypeInfo::Empty,
                     );
-
-                    self.parents[child] = idx as i32;
-                    // Augnment the color since the next operations could be inconsistent
-                    color += 1;
+                    self.new_color();
                 }
                 Operator::I32Const { value } => {
-                    self.push_node(
-                        Lang::I32(*value),
-                        idx,
-                        vec![],
-                        color,
-                        PrimitiveTypeInfo::I32,
-                    );
+                    self.push_node(Lang::I32(*value), idx, vec![], PrimitiveTypeInfo::I32);
                 }
                 Operator::I64Const { value } => {
-                    self.push_node(
-                        Lang::I64(*value),
-                        idx,
-                        vec![],
-                        color,
-                        PrimitiveTypeInfo::I64,
-                    );
+                    self.push_node(Lang::I64(*value), idx, vec![], PrimitiveTypeInfo::I64);
                 }
                 Operator::F32Const { value } => {
-                    self.push_node(
-                        Lang::F32(value.bits()),
-                        idx,
-                        vec![],
-                        color,
-                        PrimitiveTypeInfo::I32,
-                    );
+                    self.push_node(Lang::F32(value.bits()), idx, vec![], PrimitiveTypeInfo::I32);
                 }
                 Operator::F64Const { value } => {
-                    self.push_node(
-                        Lang::F64(value.bits()),
-                        idx,
-                        vec![],
-                        color,
-                        PrimitiveTypeInfo::I64,
-                    );
+                    self.push_node(Lang::F64(value.bits()), idx, vec![], PrimitiveTypeInfo::I64);
                 }
                 Operator::LocalSet { local_index } => {
-                    // It needs the offset arg
-                    let child = self.pop_operand(idx, true);
-
-                    let idx = self.push_node(
-                        Lang::LocalSet(*local_index, Id::from(child)),
+                    let val = self.pop_operand(idx, true);
+                    self.push_node(
+                        Lang::LocalSet(*local_index, Id::from(val)),
                         idx,
-                        vec![child],
-                        color,
+                        vec![val],
                         PrimitiveTypeInfo::Empty,
                     );
-                    self.parents[child] = idx as i32;
-                    // Augnment the color since the next operations could be inconsistent
-                    color += 1;
+                    self.new_color();
                 }
                 Operator::LocalTee { local_index } => {
-                    // It needs the offset arg
-                    let child = self.pop_operand(idx, true);
-
-                    let idx = self.push_node(
-                        Lang::LocalTee(*local_index, Id::from(child)),
+                    let val = self.pop_operand(idx, true);
+                    self.push_node(
+                        Lang::LocalTee(*local_index, Id::from(val)),
                         idx,
-                        vec![child],
-                        color,
+                        vec![val],
                         locals[*local_index as usize].clone(),
                     );
-                    self.parents[child] = idx as i32;
-                    // Augnment the color since the next operations could be inconsistent
-                    color += 1;
+                    self.new_color();
                 }
 
                 Operator::I32Store { memarg } => {
-                    self.binop_cb(idx, color, Empty, |offset, value| Lang::I32Store {
+                    self.binop_cb(idx, Empty, |offset, value| Lang::I32Store {
                         value_and_offset: [offset, value],
                         static_offset: memarg.offset,
                         align: memarg.align,
                         mem: memarg.memory,
                     });
-                    color += 1;
+                    self.new_color();
                 }
                 Operator::I64Store { memarg } => {
-                    self.binop_cb(idx, color, Empty, |offset, value| Lang::I64Store {
+                    self.binop_cb(idx, Empty, |offset, value| Lang::I64Store {
                         value_and_offset: [offset, value],
                         static_offset: memarg.offset,
                         align: memarg.align,
                         mem: memarg.memory,
                     });
-                    color += 1;
+                    self.new_color();
                 }
                 Operator::F32Store { memarg } => {
-                    self.binop_cb(idx, color, Empty, |offset, value| Lang::F32Store {
+                    self.binop_cb(idx, Empty, |offset, value| Lang::F32Store {
                         value_and_offset: [offset, value],
                         static_offset: memarg.offset,
                         align: memarg.align,
                         mem: memarg.memory,
                     });
-                    color += 1;
+                    self.new_color();
                 }
                 Operator::F64Store { memarg } => {
-                    self.binop_cb(idx, color, Empty, |offset, value| Lang::F64Store {
+                    self.binop_cb(idx, Empty, |offset, value| Lang::F64Store {
                         value_and_offset: [offset, value],
                         static_offset: memarg.offset,
                         align: memarg.align,
                         mem: memarg.memory,
                     });
-                    color += 1;
+                    self.new_color();
                 }
                 Operator::I32Store8 { memarg } => {
-                    self.binop_cb(idx, color, Empty, |offset, value| Lang::I32Store8 {
+                    self.binop_cb(idx, Empty, |offset, value| Lang::I32Store8 {
                         value_and_offset: [offset, value],
                         static_offset: memarg.offset,
                         align: memarg.align,
                         mem: memarg.memory,
                     });
-                    color += 1;
+                    self.new_color();
                 }
                 Operator::I32Store16 { memarg } => {
-                    self.binop_cb(idx, color, Empty, |offset, value| Lang::I32Store16 {
+                    self.binop_cb(idx, Empty, |offset, value| Lang::I32Store16 {
                         value_and_offset: [offset, value],
                         static_offset: memarg.offset,
                         align: memarg.align,
                         mem: memarg.memory,
                     });
-                    color += 1;
+                    self.new_color();
                 }
                 Operator::I64Store8 { memarg } => {
-                    self.binop_cb(idx, color, Empty, |offset, value| Lang::I64Store8 {
+                    self.binop_cb(idx, Empty, |offset, value| Lang::I64Store8 {
                         value_and_offset: [offset, value],
                         static_offset: memarg.offset,
                         align: memarg.align,
                         mem: memarg.memory,
                     });
-                    color += 1;
+                    self.new_color();
                 }
                 Operator::I64Store16 { memarg } => {
-                    self.binop_cb(idx, color, Empty, |offset, value| Lang::I64Store16 {
+                    self.binop_cb(idx, Empty, |offset, value| Lang::I64Store16 {
                         value_and_offset: [offset, value],
                         static_offset: memarg.offset,
                         align: memarg.align,
                         mem: memarg.memory,
                     });
-                    color += 1;
+                    self.new_color();
                 }
                 Operator::I64Store32 { memarg } => {
-                    self.binop_cb(idx, color, Empty, |offset, value| Lang::I64Store32 {
+                    self.binop_cb(idx, Empty, |offset, value| Lang::I64Store32 {
                         value_and_offset: [offset, value],
                         static_offset: memarg.offset,
                         align: memarg.align,
                         mem: memarg.memory,
                     });
-                    color += 1;
+                    self.new_color();
                 }
 
                 // All memory loads
-                Operator::I32Load { memarg } => {
-                    self.unop_cb(idx, color, I32, |offset| Lang::I32Load {
-                        offset,
-                        static_offset: memarg.offset,
-                        align: memarg.align,
-                        mem: memarg.memory,
-                    })
-                }
-                Operator::I64Load { memarg } => {
-                    self.unop_cb(idx, color, I64, |offset| Lang::I64Load {
-                        offset,
-                        static_offset: memarg.offset,
-                        align: memarg.align,
-                        mem: memarg.memory,
-                    })
-                }
-                Operator::F32Load { memarg } => {
-                    self.unop_cb(idx, color, F32, |offset| Lang::F32Load {
-                        offset,
-                        static_offset: memarg.offset,
-                        align: memarg.align,
-                        mem: memarg.memory,
-                    })
-                }
-                Operator::F64Load { memarg } => {
-                    self.unop_cb(idx, color, F64, |offset| Lang::F64Load {
-                        offset,
-                        static_offset: memarg.offset,
-                        align: memarg.align,
-                        mem: memarg.memory,
-                    })
-                }
+                Operator::I32Load { memarg } => self.unop_cb(idx, I32, |offset| Lang::I32Load {
+                    offset,
+                    static_offset: memarg.offset,
+                    align: memarg.align,
+                    mem: memarg.memory,
+                }),
+                Operator::I64Load { memarg } => self.unop_cb(idx, I64, |offset| Lang::I64Load {
+                    offset,
+                    static_offset: memarg.offset,
+                    align: memarg.align,
+                    mem: memarg.memory,
+                }),
+                Operator::F32Load { memarg } => self.unop_cb(idx, F32, |offset| Lang::F32Load {
+                    offset,
+                    static_offset: memarg.offset,
+                    align: memarg.align,
+                    mem: memarg.memory,
+                }),
+                Operator::F64Load { memarg } => self.unop_cb(idx, F64, |offset| Lang::F64Load {
+                    offset,
+                    static_offset: memarg.offset,
+                    align: memarg.align,
+                    mem: memarg.memory,
+                }),
                 Operator::I32Load8S { memarg } => {
-                    self.unop_cb(idx, color, I32, |offset| Lang::I32Load8S {
+                    self.unop_cb(idx, I32, |offset| Lang::I32Load8S {
                         offset,
                         static_offset: memarg.offset,
                         align: memarg.align,
@@ -623,7 +597,7 @@ impl<'a> DFGBuilder {
                     })
                 }
                 Operator::I32Load8U { memarg } => {
-                    self.unop_cb(idx, color, I32, |offset| Lang::I32Load8U {
+                    self.unop_cb(idx, I32, |offset| Lang::I32Load8U {
                         offset,
                         static_offset: memarg.offset,
                         align: memarg.align,
@@ -631,7 +605,7 @@ impl<'a> DFGBuilder {
                     })
                 }
                 Operator::I32Load16S { memarg } => {
-                    self.unop_cb(idx, color, I32, |offset| Lang::I32Load16S {
+                    self.unop_cb(idx, I32, |offset| Lang::I32Load16S {
                         offset,
                         static_offset: memarg.offset,
                         align: memarg.align,
@@ -639,7 +613,7 @@ impl<'a> DFGBuilder {
                     })
                 }
                 Operator::I32Load16U { memarg } => {
-                    self.unop_cb(idx, color, I32, |offset| Lang::I32Load16U {
+                    self.unop_cb(idx, I32, |offset| Lang::I32Load16U {
                         offset,
                         static_offset: memarg.offset,
                         align: memarg.align,
@@ -647,7 +621,7 @@ impl<'a> DFGBuilder {
                     })
                 }
                 Operator::I64Load8S { memarg } => {
-                    self.unop_cb(idx, color, I64, |offset| Lang::I64Load8S {
+                    self.unop_cb(idx, I64, |offset| Lang::I64Load8S {
                         offset,
                         static_offset: memarg.offset,
                         align: memarg.align,
@@ -655,7 +629,7 @@ impl<'a> DFGBuilder {
                     })
                 }
                 Operator::I64Load8U { memarg } => {
-                    self.unop_cb(idx, color, I64, |offset| Lang::I64Load8U {
+                    self.unop_cb(idx, I64, |offset| Lang::I64Load8U {
                         offset,
                         static_offset: memarg.offset,
                         align: memarg.align,
@@ -663,7 +637,7 @@ impl<'a> DFGBuilder {
                     })
                 }
                 Operator::I64Load16S { memarg } => {
-                    self.unop_cb(idx, color, I64, |offset| Lang::I64Load16S {
+                    self.unop_cb(idx, I64, |offset| Lang::I64Load16S {
                         offset,
                         static_offset: memarg.offset,
                         align: memarg.align,
@@ -671,7 +645,7 @@ impl<'a> DFGBuilder {
                     })
                 }
                 Operator::I64Load16U { memarg } => {
-                    self.unop_cb(idx, color, I64, |offset| Lang::I64Load16U {
+                    self.unop_cb(idx, I64, |offset| Lang::I64Load16U {
                         offset,
                         static_offset: memarg.offset,
                         align: memarg.align,
@@ -679,7 +653,7 @@ impl<'a> DFGBuilder {
                     })
                 }
                 Operator::I64Load32S { memarg } => {
-                    self.unop_cb(idx, color, I64, |offset| Lang::I64Load32S {
+                    self.unop_cb(idx, I64, |offset| Lang::I64Load32S {
                         offset,
                         static_offset: memarg.offset,
                         align: memarg.align,
@@ -687,7 +661,7 @@ impl<'a> DFGBuilder {
                     })
                 }
                 Operator::I64Load32U { memarg } => {
-                    self.unop_cb(idx, color, I64, |offset| Lang::I64Load32U {
+                    self.unop_cb(idx, I64, |offset| Lang::I64Load32U {
                         offset,
                         static_offset: memarg.offset,
                         align: memarg.align,
@@ -695,163 +669,162 @@ impl<'a> DFGBuilder {
                     })
                 }
 
-                Operator::I32Eqz => self.unop(idx, color, Lang::I32Eqz, I32),
-                Operator::I64Eqz => self.unop(idx, color, Lang::I64Eqz, I32),
+                Operator::I32Eqz => self.unop(idx, Lang::I32Eqz, I32),
+                Operator::I64Eqz => self.unop(idx, Lang::I64Eqz, I32),
 
-                Operator::F32Eq => self.binop(idx, color, Lang::F32Eq, I32),
-                Operator::F32Ne => self.binop(idx, color, Lang::F32Ne, I32),
-                Operator::F32Lt => self.binop(idx, color, Lang::F32Lt, I32),
-                Operator::F32Gt => self.binop(idx, color, Lang::F32Gt, I32),
-                Operator::F32Le => self.binop(idx, color, Lang::F32Le, I32),
-                Operator::F32Ge => self.binop(idx, color, Lang::F32Ge, I32),
+                Operator::F32Eq => self.binop(idx, Lang::F32Eq, I32),
+                Operator::F32Ne => self.binop(idx, Lang::F32Ne, I32),
+                Operator::F32Lt => self.binop(idx, Lang::F32Lt, I32),
+                Operator::F32Gt => self.binop(idx, Lang::F32Gt, I32),
+                Operator::F32Le => self.binop(idx, Lang::F32Le, I32),
+                Operator::F32Ge => self.binop(idx, Lang::F32Ge, I32),
 
-                Operator::F64Eq => self.binop(idx, color, Lang::F64Eq, I32),
-                Operator::F64Ne => self.binop(idx, color, Lang::F64Ne, I32),
-                Operator::F64Lt => self.binop(idx, color, Lang::F64Lt, I32),
-                Operator::F64Gt => self.binop(idx, color, Lang::F64Gt, I32),
-                Operator::F64Le => self.binop(idx, color, Lang::F64Le, I32),
-                Operator::F64Ge => self.binop(idx, color, Lang::F64Ge, I32),
+                Operator::F64Eq => self.binop(idx, Lang::F64Eq, I32),
+                Operator::F64Ne => self.binop(idx, Lang::F64Ne, I32),
+                Operator::F64Lt => self.binop(idx, Lang::F64Lt, I32),
+                Operator::F64Gt => self.binop(idx, Lang::F64Gt, I32),
+                Operator::F64Le => self.binop(idx, Lang::F64Le, I32),
+                Operator::F64Ge => self.binop(idx, Lang::F64Ge, I32),
 
-                Operator::I32Clz => self.unop(idx, color, Lang::I32Clz, I32),
-                Operator::I32Ctz => self.unop(idx, color, Lang::I32Ctz, I32),
-                Operator::I64Clz => self.unop(idx, color, Lang::I64Clz, I64),
-                Operator::I64Ctz => self.unop(idx, color, Lang::I64Ctz, I64),
+                Operator::I32Clz => self.unop(idx, Lang::I32Clz, I32),
+                Operator::I32Ctz => self.unop(idx, Lang::I32Ctz, I32),
+                Operator::I64Clz => self.unop(idx, Lang::I64Clz, I64),
+                Operator::I64Ctz => self.unop(idx, Lang::I64Ctz, I64),
 
-                Operator::F32Abs => self.unop(idx, color, Lang::F32Abs, F32),
-                Operator::F32Neg => self.unop(idx, color, Lang::F32Neg, F32),
-                Operator::F32Ceil => self.unop(idx, color, Lang::F32Ceil, F32),
-                Operator::F32Floor => self.unop(idx, color, Lang::F32Floor, F32),
-                Operator::F32Trunc => self.unop(idx, color, Lang::F32Trunc, F32),
-                Operator::F32Nearest => self.unop(idx, color, Lang::F32Nearest, F32),
-                Operator::F32Sqrt => self.unop(idx, color, Lang::F32Sqrt, F32),
-                Operator::F32Add => self.binop(idx, color, Lang::F32Add, F32),
-                Operator::F32Sub => self.binop(idx, color, Lang::F32Sub, F32),
-                Operator::F32Mul => self.binop(idx, color, Lang::F32Mul, F32),
-                Operator::F32Div => self.binop(idx, color, Lang::F32Div, F32),
-                Operator::F32Min => self.binop(idx, color, Lang::F32Min, F32),
-                Operator::F32Max => self.binop(idx, color, Lang::F32Max, F32),
-                Operator::F32Copysign => self.binop(idx, color, Lang::F32Copysign, F32),
+                Operator::F32Abs => self.unop(idx, Lang::F32Abs, F32),
+                Operator::F32Neg => self.unop(idx, Lang::F32Neg, F32),
+                Operator::F32Ceil => self.unop(idx, Lang::F32Ceil, F32),
+                Operator::F32Floor => self.unop(idx, Lang::F32Floor, F32),
+                Operator::F32Trunc => self.unop(idx, Lang::F32Trunc, F32),
+                Operator::F32Nearest => self.unop(idx, Lang::F32Nearest, F32),
+                Operator::F32Sqrt => self.unop(idx, Lang::F32Sqrt, F32),
+                Operator::F32Add => self.binop(idx, Lang::F32Add, F32),
+                Operator::F32Sub => self.binop(idx, Lang::F32Sub, F32),
+                Operator::F32Mul => self.binop(idx, Lang::F32Mul, F32),
+                Operator::F32Div => self.binop(idx, Lang::F32Div, F32),
+                Operator::F32Min => self.binop(idx, Lang::F32Min, F32),
+                Operator::F32Max => self.binop(idx, Lang::F32Max, F32),
+                Operator::F32Copysign => self.binop(idx, Lang::F32Copysign, F32),
 
-                Operator::F64Abs => self.unop(idx, color, Lang::F64Abs, F64),
-                Operator::F64Neg => self.unop(idx, color, Lang::F64Neg, F64),
-                Operator::F64Ceil => self.unop(idx, color, Lang::F64Ceil, F64),
-                Operator::F64Floor => self.unop(idx, color, Lang::F64Floor, F64),
-                Operator::F64Trunc => self.unop(idx, color, Lang::F64Trunc, F64),
-                Operator::F64Nearest => self.unop(idx, color, Lang::F64Nearest, F64),
-                Operator::F64Sqrt => self.unop(idx, color, Lang::F64Sqrt, F64),
-                Operator::F64Add => self.binop(idx, color, Lang::F64Add, F64),
-                Operator::F64Sub => self.binop(idx, color, Lang::F64Sub, F64),
-                Operator::F64Mul => self.binop(idx, color, Lang::F64Mul, F64),
-                Operator::F64Div => self.binop(idx, color, Lang::F64Div, F64),
-                Operator::F64Min => self.binop(idx, color, Lang::F64Min, F64),
-                Operator::F64Max => self.binop(idx, color, Lang::F64Max, F64),
-                Operator::F64Copysign => self.binop(idx, color, Lang::F64Copysign, F64),
+                Operator::F64Abs => self.unop(idx, Lang::F64Abs, F64),
+                Operator::F64Neg => self.unop(idx, Lang::F64Neg, F64),
+                Operator::F64Ceil => self.unop(idx, Lang::F64Ceil, F64),
+                Operator::F64Floor => self.unop(idx, Lang::F64Floor, F64),
+                Operator::F64Trunc => self.unop(idx, Lang::F64Trunc, F64),
+                Operator::F64Nearest => self.unop(idx, Lang::F64Nearest, F64),
+                Operator::F64Sqrt => self.unop(idx, Lang::F64Sqrt, F64),
+                Operator::F64Add => self.binop(idx, Lang::F64Add, F64),
+                Operator::F64Sub => self.binop(idx, Lang::F64Sub, F64),
+                Operator::F64Mul => self.binop(idx, Lang::F64Mul, F64),
+                Operator::F64Div => self.binop(idx, Lang::F64Div, F64),
+                Operator::F64Min => self.binop(idx, Lang::F64Min, F64),
+                Operator::F64Max => self.binop(idx, Lang::F64Max, F64),
+                Operator::F64Copysign => self.binop(idx, Lang::F64Copysign, F64),
 
-                Operator::I32TruncF32S => self.unop(idx, color, Lang::I32TruncF32S, I32),
-                Operator::I32TruncF32U => self.unop(idx, color, Lang::I32TruncF32U, I32),
-                Operator::I32TruncF64S => self.unop(idx, color, Lang::I32TruncF64S, I32),
-                Operator::I32TruncF64U => self.unop(idx, color, Lang::I32TruncF64U, I32),
-                Operator::I64TruncF32S => self.unop(idx, color, Lang::I64TruncF32S, I64),
-                Operator::I64TruncF32U => self.unop(idx, color, Lang::I64TruncF32U, I64),
-                Operator::I64TruncF64S => self.unop(idx, color, Lang::I64TruncF64S, I64),
-                Operator::I64TruncF64U => self.unop(idx, color, Lang::I64TruncF64U, I64),
-                Operator::F32ConvertI32S => self.unop(idx, color, Lang::F32ConvertI32S, F32),
-                Operator::F32ConvertI32U => self.unop(idx, color, Lang::F32ConvertI32U, F32),
-                Operator::F32ConvertI64S => self.unop(idx, color, Lang::F32ConvertI64S, F32),
-                Operator::F32ConvertI64U => self.unop(idx, color, Lang::F32ConvertI64U, F32),
-                Operator::F64ConvertI32S => self.unop(idx, color, Lang::F64ConvertI32S, F64),
-                Operator::F64ConvertI32U => self.unop(idx, color, Lang::F64ConvertI32U, F64),
-                Operator::F64ConvertI64S => self.unop(idx, color, Lang::F64ConvertI64S, F64),
-                Operator::F64ConvertI64U => self.unop(idx, color, Lang::F64ConvertI64U, F64),
-                Operator::F64PromoteF32 => self.unop(idx, color, Lang::F64PromoteF32, F64),
-                Operator::F32DemoteF64 => self.unop(idx, color, Lang::F32DemoteF64, F32),
-                Operator::I32ReinterpretF32 => self.unop(idx, color, Lang::I32ReinterpretF32, I32),
-                Operator::I64ReinterpretF64 => self.unop(idx, color, Lang::I64ReinterpretF64, I64),
-                Operator::F32ReinterpretI32 => self.unop(idx, color, Lang::F32ReinterpretI32, F32),
-                Operator::F64ReinterpretI64 => self.unop(idx, color, Lang::F64ReinterpretI64, F64),
-                Operator::I32TruncSatF32S => self.unop(idx, color, Lang::I32TruncSatF32S, I32),
-                Operator::I32TruncSatF32U => self.unop(idx, color, Lang::I32TruncSatF32U, I32),
-                Operator::I32TruncSatF64S => self.unop(idx, color, Lang::I32TruncSatF64S, I32),
-                Operator::I32TruncSatF64U => self.unop(idx, color, Lang::I32TruncSatF64U, I32),
-                Operator::I64TruncSatF32S => self.unop(idx, color, Lang::I64TruncSatF32S, I64),
-                Operator::I64TruncSatF32U => self.unop(idx, color, Lang::I64TruncSatF32U, I64),
-                Operator::I64TruncSatF64S => self.unop(idx, color, Lang::I64TruncSatF64S, I64),
-                Operator::I64TruncSatF64U => self.unop(idx, color, Lang::I64TruncSatF64U, I64),
+                Operator::I32TruncF32S => self.unop(idx, Lang::I32TruncF32S, I32),
+                Operator::I32TruncF32U => self.unop(idx, Lang::I32TruncF32U, I32),
+                Operator::I32TruncF64S => self.unop(idx, Lang::I32TruncF64S, I32),
+                Operator::I32TruncF64U => self.unop(idx, Lang::I32TruncF64U, I32),
+                Operator::I64TruncF32S => self.unop(idx, Lang::I64TruncF32S, I64),
+                Operator::I64TruncF32U => self.unop(idx, Lang::I64TruncF32U, I64),
+                Operator::I64TruncF64S => self.unop(idx, Lang::I64TruncF64S, I64),
+                Operator::I64TruncF64U => self.unop(idx, Lang::I64TruncF64U, I64),
+                Operator::F32ConvertI32S => self.unop(idx, Lang::F32ConvertI32S, F32),
+                Operator::F32ConvertI32U => self.unop(idx, Lang::F32ConvertI32U, F32),
+                Operator::F32ConvertI64S => self.unop(idx, Lang::F32ConvertI64S, F32),
+                Operator::F32ConvertI64U => self.unop(idx, Lang::F32ConvertI64U, F32),
+                Operator::F64ConvertI32S => self.unop(idx, Lang::F64ConvertI32S, F64),
+                Operator::F64ConvertI32U => self.unop(idx, Lang::F64ConvertI32U, F64),
+                Operator::F64ConvertI64S => self.unop(idx, Lang::F64ConvertI64S, F64),
+                Operator::F64ConvertI64U => self.unop(idx, Lang::F64ConvertI64U, F64),
+                Operator::F64PromoteF32 => self.unop(idx, Lang::F64PromoteF32, F64),
+                Operator::F32DemoteF64 => self.unop(idx, Lang::F32DemoteF64, F32),
+                Operator::I32ReinterpretF32 => self.unop(idx, Lang::I32ReinterpretF32, I32),
+                Operator::I64ReinterpretF64 => self.unop(idx, Lang::I64ReinterpretF64, I64),
+                Operator::F32ReinterpretI32 => self.unop(idx, Lang::F32ReinterpretI32, F32),
+                Operator::F64ReinterpretI64 => self.unop(idx, Lang::F64ReinterpretI64, F64),
+                Operator::I32TruncSatF32S => self.unop(idx, Lang::I32TruncSatF32S, I32),
+                Operator::I32TruncSatF32U => self.unop(idx, Lang::I32TruncSatF32U, I32),
+                Operator::I32TruncSatF64S => self.unop(idx, Lang::I32TruncSatF64S, I32),
+                Operator::I32TruncSatF64U => self.unop(idx, Lang::I32TruncSatF64U, I32),
+                Operator::I64TruncSatF32S => self.unop(idx, Lang::I64TruncSatF32S, I64),
+                Operator::I64TruncSatF32U => self.unop(idx, Lang::I64TruncSatF32U, I64),
+                Operator::I64TruncSatF64S => self.unop(idx, Lang::I64TruncSatF64S, I64),
+                Operator::I64TruncSatF64U => self.unop(idx, Lang::I64TruncSatF64U, I64),
 
-                Operator::I32Add => self.binop(idx, color, Lang::I32Add, I32),
-                Operator::I32Sub => self.binop(idx, color, Lang::I32Sub, I32),
-                Operator::I32Eq => self.binop(idx, color, Lang::I32Eq, I32),
-                Operator::I32Ne => self.binop(idx, color, Lang::I32Ne, I32),
-                Operator::I32LtS => self.binop(idx, color, Lang::I32LtS, I32),
-                Operator::I32LtU => self.binop(idx, color, Lang::I32LtU, I32),
-                Operator::I32GtS => self.binop(idx, color, Lang::I32GtS, I32),
-                Operator::I32GtU => self.binop(idx, color, Lang::I32GtU, I32),
-                Operator::I32LeS => self.binop(idx, color, Lang::I32LeS, I32),
-                Operator::I32LeU => self.binop(idx, color, Lang::I32LeU, I32),
-                Operator::I32GeS => self.binop(idx, color, Lang::I32GeS, I32),
-                Operator::I32GeU => self.binop(idx, color, Lang::I32GeU, I32),
-                Operator::I32Mul => self.binop(idx, color, Lang::I32Mul, I32),
-                Operator::I32DivS => self.binop(idx, color, Lang::I32DivS, I32),
-                Operator::I32DivU => self.binop(idx, color, Lang::I32DivU, I32),
-                Operator::I32RemS => self.binop(idx, color, Lang::I32RemS, I32),
-                Operator::I32RemU => self.binop(idx, color, Lang::I32RemU, I32),
-                Operator::I32Shl => self.binop(idx, color, Lang::I32Shl, I32),
-                Operator::I32ShrS => self.binop(idx, color, Lang::I32ShrS, I32),
-                Operator::I32ShrU => self.binop(idx, color, Lang::I32ShrU, I32),
-                Operator::I32Xor => self.binop(idx, color, Lang::I32Xor, I32),
-                Operator::I32Or => self.binop(idx, color, Lang::I32Or, I32),
-                Operator::I32And => self.binop(idx, color, Lang::I32And, I32),
-                Operator::I32Rotl => self.binop(idx, color, Lang::I32RotL, I32),
-                Operator::I32Rotr => self.binop(idx, color, Lang::I32RotR, I32),
+                Operator::I32Add => self.binop(idx, Lang::I32Add, I32),
+                Operator::I32Sub => self.binop(idx, Lang::I32Sub, I32),
+                Operator::I32Eq => self.binop(idx, Lang::I32Eq, I32),
+                Operator::I32Ne => self.binop(idx, Lang::I32Ne, I32),
+                Operator::I32LtS => self.binop(idx, Lang::I32LtS, I32),
+                Operator::I32LtU => self.binop(idx, Lang::I32LtU, I32),
+                Operator::I32GtS => self.binop(idx, Lang::I32GtS, I32),
+                Operator::I32GtU => self.binop(idx, Lang::I32GtU, I32),
+                Operator::I32LeS => self.binop(idx, Lang::I32LeS, I32),
+                Operator::I32LeU => self.binop(idx, Lang::I32LeU, I32),
+                Operator::I32GeS => self.binop(idx, Lang::I32GeS, I32),
+                Operator::I32GeU => self.binop(idx, Lang::I32GeU, I32),
+                Operator::I32Mul => self.binop(idx, Lang::I32Mul, I32),
+                Operator::I32DivS => self.binop(idx, Lang::I32DivS, I32),
+                Operator::I32DivU => self.binop(idx, Lang::I32DivU, I32),
+                Operator::I32RemS => self.binop(idx, Lang::I32RemS, I32),
+                Operator::I32RemU => self.binop(idx, Lang::I32RemU, I32),
+                Operator::I32Shl => self.binop(idx, Lang::I32Shl, I32),
+                Operator::I32ShrS => self.binop(idx, Lang::I32ShrS, I32),
+                Operator::I32ShrU => self.binop(idx, Lang::I32ShrU, I32),
+                Operator::I32Xor => self.binop(idx, Lang::I32Xor, I32),
+                Operator::I32Or => self.binop(idx, Lang::I32Or, I32),
+                Operator::I32And => self.binop(idx, Lang::I32And, I32),
+                Operator::I32Rotl => self.binop(idx, Lang::I32RotL, I32),
+                Operator::I32Rotr => self.binop(idx, Lang::I32RotR, I32),
 
-                Operator::I64Add => self.binop(idx, color, Lang::I64Add, I64),
-                Operator::I64Sub => self.binop(idx, color, Lang::I64Sub, I64),
-                Operator::I64Eq => self.binop(idx, color, Lang::I64Eq, I64),
-                Operator::I64Ne => self.binop(idx, color, Lang::I64Ne, I64),
-                Operator::I64LtS => self.binop(idx, color, Lang::I64LtS, I64),
-                Operator::I64LtU => self.binop(idx, color, Lang::I64LtU, I64),
-                Operator::I64GtS => self.binop(idx, color, Lang::I64GtS, I64),
-                Operator::I64GtU => self.binop(idx, color, Lang::I64GtU, I64),
-                Operator::I64LeS => self.binop(idx, color, Lang::I64LeS, I64),
-                Operator::I64LeU => self.binop(idx, color, Lang::I64LeU, I64),
-                Operator::I64GeS => self.binop(idx, color, Lang::I64GeS, I64),
-                Operator::I64GeU => self.binop(idx, color, Lang::I64GeU, I64),
-                Operator::I64Mul => self.binop(idx, color, Lang::I64Mul, I64),
-                Operator::I64DivS => self.binop(idx, color, Lang::I64DivS, I64),
-                Operator::I64DivU => self.binop(idx, color, Lang::I64DivU, I64),
-                Operator::I64RemS => self.binop(idx, color, Lang::I64RemS, I64),
-                Operator::I64RemU => self.binop(idx, color, Lang::I64RemU, I64),
-                Operator::I64Shl => self.binop(idx, color, Lang::I64Shl, I64),
-                Operator::I64ShrS => self.binop(idx, color, Lang::I64ShrS, I64),
-                Operator::I64ShrU => self.binop(idx, color, Lang::I64ShrU, I64),
-                Operator::I64Xor => self.binop(idx, color, Lang::I64Xor, I64),
-                Operator::I64Or => self.binop(idx, color, Lang::I64Or, I64),
-                Operator::I64And => self.binop(idx, color, Lang::I64And, I64),
-                Operator::I64Rotl => self.binop(idx, color, Lang::I64RotL, I64),
-                Operator::I64Rotr => self.binop(idx, color, Lang::I64RotR, I64),
+                Operator::I64Add => self.binop(idx, Lang::I64Add, I64),
+                Operator::I64Sub => self.binop(idx, Lang::I64Sub, I64),
+                Operator::I64Eq => self.binop(idx, Lang::I64Eq, I64),
+                Operator::I64Ne => self.binop(idx, Lang::I64Ne, I64),
+                Operator::I64LtS => self.binop(idx, Lang::I64LtS, I64),
+                Operator::I64LtU => self.binop(idx, Lang::I64LtU, I64),
+                Operator::I64GtS => self.binop(idx, Lang::I64GtS, I64),
+                Operator::I64GtU => self.binop(idx, Lang::I64GtU, I64),
+                Operator::I64LeS => self.binop(idx, Lang::I64LeS, I64),
+                Operator::I64LeU => self.binop(idx, Lang::I64LeU, I64),
+                Operator::I64GeS => self.binop(idx, Lang::I64GeS, I64),
+                Operator::I64GeU => self.binop(idx, Lang::I64GeU, I64),
+                Operator::I64Mul => self.binop(idx, Lang::I64Mul, I64),
+                Operator::I64DivS => self.binop(idx, Lang::I64DivS, I64),
+                Operator::I64DivU => self.binop(idx, Lang::I64DivU, I64),
+                Operator::I64RemS => self.binop(idx, Lang::I64RemS, I64),
+                Operator::I64RemU => self.binop(idx, Lang::I64RemU, I64),
+                Operator::I64Shl => self.binop(idx, Lang::I64Shl, I64),
+                Operator::I64ShrS => self.binop(idx, Lang::I64ShrS, I64),
+                Operator::I64ShrU => self.binop(idx, Lang::I64ShrU, I64),
+                Operator::I64Xor => self.binop(idx, Lang::I64Xor, I64),
+                Operator::I64Or => self.binop(idx, Lang::I64Or, I64),
+                Operator::I64And => self.binop(idx, Lang::I64And, I64),
+                Operator::I64Rotl => self.binop(idx, Lang::I64RotL, I64),
+                Operator::I64Rotr => self.binop(idx, Lang::I64RotR, I64),
 
-                Operator::Drop => self.unop(idx, color, Lang::Drop, Empty),
+                Operator::Drop => self.unop(idx, Lang::Drop, Empty),
 
                 // conversion between integers
-                Operator::I32WrapI64 => self.unop(idx, color, Lang::Wrap, I32),
-                Operator::I32Extend8S => self.unop(idx, color, Lang::I32Extend8S, I32),
-                Operator::I32Extend16S => self.unop(idx, color, Lang::I32Extend16S, I32),
+                Operator::I32WrapI64 => self.unop(idx, Lang::Wrap, I32),
+                Operator::I32Extend8S => self.unop(idx, Lang::I32Extend8S, I32),
+                Operator::I32Extend16S => self.unop(idx, Lang::I32Extend16S, I32),
 
-                Operator::I64Extend8S => self.unop(idx, color, Lang::I64Extend8S, I64),
-                Operator::I64Extend16S => self.unop(idx, color, Lang::I64Extend16S, I64),
-                Operator::I64Extend32S => self.unop(idx, color, Lang::I64Extend32S, I64),
-                Operator::I64ExtendI32S => self.unop(idx, color, Lang::I64ExtendI32S, I64),
-                Operator::I64ExtendI32U => self.unop(idx, color, Lang::I64ExtendI32U, I64),
+                Operator::I64Extend8S => self.unop(idx, Lang::I64Extend8S, I64),
+                Operator::I64Extend16S => self.unop(idx, Lang::I64Extend16S, I64),
+                Operator::I64Extend32S => self.unop(idx, Lang::I64Extend32S, I64),
+                Operator::I64ExtendI32S => self.unop(idx, Lang::I64ExtendI32S, I64),
+                Operator::I64ExtendI32U => self.unop(idx, Lang::I64ExtendI32U, I64),
 
-                Operator::I32Popcnt => self.unop(idx, color, Lang::I32Popcnt, I32),
-                Operator::I64Popcnt => self.unop(idx, color, Lang::I64Popcnt, I64),
+                Operator::I32Popcnt => self.unop(idx, Lang::I32Popcnt, I32),
+                Operator::I64Popcnt => self.unop(idx, Lang::I64Popcnt, I64),
 
                 Operator::Select => {
                     let condition = self.pop_operand(idx, false);
                     let alternative = self.pop_operand(idx, false);
                     let consequent = self.pop_operand(idx, false);
-
-                    let idx = self.push_node(
+                    self.push_node(
                         Lang::Select([
                             Id::from(condition),
                             Id::from(consequent),
@@ -859,18 +832,12 @@ impl<'a> DFGBuilder {
                         ]),
                         idx,
                         vec![condition, consequent, alternative],
-                        color,
                         PrimitiveTypeInfo::I32,
                     );
-
-                    self.parents[condition] = idx as i32;
-                    self.parents[consequent] = idx as i32;
-                    self.parents[alternative] = idx as i32;
                 }
                 Operator::MemoryGrow { mem, mem_byte } => {
                     let arg = self.pop_operand(idx, false);
-
-                    let idx = self.push_node(
+                    self.push_node(
                         Lang::MemoryGrow {
                             mem: *mem,
                             mem_byte: *mem_byte,
@@ -878,11 +845,8 @@ impl<'a> DFGBuilder {
                         },
                         idx,
                         vec![arg],
-                        color,
                         PrimitiveTypeInfo::I32,
                     );
-
-                    self.parents[arg] = idx as i32;
                 }
                 Operator::MemorySize { mem, mem_byte } => {
                     let _idx = self.push_node(
@@ -892,7 +856,6 @@ impl<'a> DFGBuilder {
                         },
                         idx,
                         vec![],
-                        color,
                         PrimitiveTypeInfo::I32,
                     );
                 }
@@ -905,48 +868,37 @@ impl<'a> DFGBuilder {
 
         Some(MiniDFG {
             entries: self.dfg_map.clone(),
-            map: self.operatormap.clone(),
+            map: self.operator_index_to_entry_index.clone(),
             parents: self.parents.clone(),
         })
     }
 
-    fn unop(&mut self, idx: usize, color: u32, op: fn([Id; 1]) -> Lang, ty: PrimitiveTypeInfo) {
-        self.unop_cb(idx, color, ty, |id| op([id]))
+    fn unop(&mut self, idx: usize, op: fn([Id; 1]) -> Lang, ty: PrimitiveTypeInfo) {
+        self.unop_cb(idx, ty, |id| op([id]))
     }
 
-    fn unop_cb(&mut self, idx: usize, color: u32, ty: PrimitiveTypeInfo, op: impl Fn(Id) -> Lang) {
+    fn unop_cb(&mut self, idx: usize, ty: PrimitiveTypeInfo, op: impl Fn(Id) -> Lang) {
         let arg = self.pop_operand(idx, false);
-        let idx = self.push_node(op(Id::from(arg)), idx, vec![arg], color, ty);
-        self.parents[arg] = idx as i32;
+        self.push_node(op(Id::from(arg)), idx, vec![arg], ty);
     }
 
-    fn binop(&mut self, idx: usize, color: u32, op: fn([Id; 2]) -> Lang, ty: PrimitiveTypeInfo) {
-        self.binop_cb(idx, color, ty, |a, b| op([a, b]))
+    fn binop(&mut self, idx: usize, op: fn([Id; 2]) -> Lang, ty: PrimitiveTypeInfo) {
+        self.binop_cb(idx, ty, |a, b| op([a, b]))
     }
 
-    fn binop_cb(
-        &mut self,
-        idx: usize,
-        color: u32,
-        ty: PrimitiveTypeInfo,
-        op: impl Fn(Id, Id) -> Lang,
-    ) {
+    fn binop_cb(&mut self, idx: usize, ty: PrimitiveTypeInfo, op: impl Fn(Id, Id) -> Lang) {
         let leftidx = self.pop_operand(idx, false);
         let rightidx = self.pop_operand(idx, false);
 
         // The operands should not be the same
         assert_ne!(leftidx, rightidx);
 
-        let idx = self.push_node(
+        self.push_node(
             op(Id::from(rightidx), Id::from(leftidx)),
             idx,
             vec![rightidx, leftidx],
-            color,
             ty,
         );
-
-        self.parents[leftidx] = idx as i32;
-        self.parents[rightidx] = idx as i32;
     }
 }
 

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder.rs
@@ -46,9 +46,9 @@ impl Encoder {
         // The edges of the stackentries are always backward in the array, so, it consistent to
         // do the writing in reverse
         let mut resource_request = vec![];
-        for (entryidx, parentidx) in dfg.parents.iter().enumerate() {
+        for (entryidx, parent) in dfg.parents.iter().enumerate() {
             // It is a root, write then
-            if *parentidx == -1 {
+            if parent.is_none() {
                 let entry = &dfg.entries[entryidx];
                 let to_encode = if entry.operator_idx == insertion_point {
                     expr.clone()


### PR DESCRIPTION
* A few variables and fields renamed to be more idiomatic Rust style.

* Made `color` a member of `DFGBuilder` so that we don't have to pipe it through
  everywhere.

* Made `push_node` update the parent link in the DFG for the pushed node's
  operands so that we don't have to manually do that everywhere we call
  `push_node`.

* Used `Option<usize>` instead of `i32`-with-negative-one-meaning-none for
  parent links' representation.