### PR TITLE
Temporarily pin nightly version in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
             rust: beta
           - build: nightly
             os: ubuntu-latest
-            rust: nightly
+            rust: nightly-2021-12-10
           - build: macos
             os: macos-latest
             rust: stable


### PR DESCRIPTION
The `rustix` crate fails to build on the current nightly, so let's pin
while that's sorted out.