### PR TITLE
wasm-mutate: Further simplify DFG construction

### DIFF
--- a/crates/wasm-mutate/src/mutators/peephole.rs
+++ b/crates/wasm-mutate/src/mutators/peephole.rs
@@ -166,7 +166,7 @@ impl PeepholeMutator {
                     }
                     Some(basicblock) => basicblock,
                 };
-                let minidfg = dfg.get_dfg(config.info(), &operators, &basicblock, &locals);
+                let minidfg = dfg.get_dfg(config.info(), &operators, &basicblock);
 
                 let minidfg = match minidfg {
                     None => {


### PR DESCRIPTION
This commit is another pass at simplifying dfg construction, namely
removing redundant and unnecessary information. First the `operands`
field of each `StackEntry` is removed since it was already the same as
the `children()` accessor for the `Lang` item. Second the type
information for each node was actually incorrect in many cases but was
only used locally to determine whether a node should be pushed or not.
Instead of trying to keep track of precise type information (which isn't
necessary here) two functions are used instead: one for pushing the node
and one for not pushing the node.

Functionally this should be the same as before but each branch of `Lang`
should require less information about how it's translated ideally.