### PR TITLE
Implement encoding of wasm components. 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,6 @@ jobs:
       env:
         RUSTFLAGS: --cfg=wast_check_exhaustive
     - run: cargo test --manifest-path crates/wasmparser/Cargo.toml --features deterministic
-    - run: cargo test --manifest-path crates/wasm-encoder/Cargo.toml --features component-model
     - run: cargo build --manifest-path crates/wast/Cargo.toml --no-default-features
     - run: cargo build --manifest-path crates/wast/Cargo.toml --no-default-features --features wasm-module
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,7 @@ jobs:
       env:
         RUSTFLAGS: --cfg=wast_check_exhaustive
     - run: cargo test --manifest-path crates/wasmparser/Cargo.toml --features deterministic
+    - run: cargo test --manifest-path crates/wasm-encoder/Cargo.toml --features component-model
     - run: cargo build --manifest-path crates/wast/Cargo.toml --no-default-features
     - run: cargo build --manifest-path crates/wast/Cargo.toml --no-default-features --features wasm-module
 

--- a/crates/wasm-encoder/Cargo.toml
+++ b/crates/wasm-encoder/Cargo.toml
@@ -22,4 +22,7 @@ wasmparser = { path = "../wasmparser" }
 
 [features]
 default = []
+# The feature to support encoding of WebAssembly components.
+# Currently the component model spec is being worked on, so support is gated
+# behind this feature because the API may have substantial breaking changes.
 component-model = []

--- a/crates/wasm-encoder/Cargo.toml
+++ b/crates/wasm-encoder/Cargo.toml
@@ -19,3 +19,7 @@ leb128 = "0.2.4"
 anyhow = "1.0.38"
 tempfile = "3.2.0"
 wasmparser = { path = "../wasmparser" }
+
+[features]
+default = []
+component-model = []

--- a/crates/wasm-encoder/Cargo.toml
+++ b/crates/wasm-encoder/Cargo.toml
@@ -19,10 +19,3 @@ leb128 = "0.2.4"
 anyhow = "1.0.38"
 tempfile = "3.2.0"
 wasmparser = { path = "../wasmparser" }
-
-[features]
-default = []
-# The feature to support encoding of WebAssembly components.
-# Currently the component model spec is being worked on, so support is gated
-# behind this feature because the API may have substantial breaking changes.
-component-model = []

--- a/crates/wasm-encoder/Cargo.toml
+++ b/crates/wasm-encoder/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wasm-encoder"
 version = "0.8.0"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-encoder"
@@ -11,8 +11,6 @@ documentation = "https://docs.rs/wasm-encoder"
 description = """
 A low-level WebAssembly encoder.
 """
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 leb128 = "0.2.4"

--- a/crates/wasm-encoder/src/adapter/aliases.rs
+++ b/crates/wasm-encoder/src/adapter/aliases.rs
@@ -1,4 +1,4 @@
-use super::{ComponentSection, SectionId};
+use super::{AdapterModuleSection, SectionId};
 use crate::encoders;
 
 const ALIAS_KIND_INSTANCE_EXPORT: u8 = 0x00;
@@ -23,21 +23,21 @@ pub enum ExportKind {
     Global,
 }
 
-/// An encoder for the component alias section.
+/// An encoder for the adapter module alias section.
 ///
 /// # Example
 ///
 /// ```rust
-/// use wasm_encoder::component::{Component, AliasSection, ExportKind};
+/// use wasm_encoder::adapter::{AdapterModule, AliasSection, ExportKind};
 ///
 /// let mut aliases = AliasSection::new();
 /// aliases.outer_type(0, 2);
 /// aliases.instance_export(0, ExportKind::Function, "foo");
 ///
-/// let mut component = Component::new();
-/// component.section(&aliases);
+/// let mut module = AdapterModule::new();
+/// module.section(&aliases);
 ///
-/// let bytes = component.finish();
+/// let bytes = module.finish();
 /// ```
 #[derive(Clone, Debug, Default)]
 pub struct AliasSection {
@@ -46,7 +46,7 @@ pub struct AliasSection {
 }
 
 impl AliasSection {
-    /// Create a new component alias section encoder.
+    /// Create a new adapter module alias section encoder.
     pub fn new() -> Self {
         Self::default()
     }
@@ -92,7 +92,7 @@ impl AliasSection {
     }
 }
 
-impl ComponentSection for AliasSection {
+impl AdapterModuleSection for AliasSection {
     fn id(&self) -> u8 {
         SectionId::Alias.into()
     }

--- a/crates/wasm-encoder/src/adapter/exports.rs
+++ b/crates/wasm-encoder/src/adapter/exports.rs
@@ -1,0 +1,68 @@
+use super::{AdapterModuleSection, IndexRef, SectionId};
+use crate::encoders;
+
+/// An encoder for the adapter module export section.
+///
+/// # Example
+///
+/// ```rust
+/// use wasm_encoder::adapter::{AdapterModule, ExportSection, IndexRef};
+///
+/// // This assumes there is a function at index 0 to export
+/// let mut exports = ExportSection::new();
+/// exports.export("foo", IndexRef::Function(0));
+///
+/// let mut module = AdapterModule::new();
+/// module.section(&exports);
+///
+/// let bytes = module.finish();
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct ExportSection {
+    bytes: Vec<u8>,
+    num_added: u32,
+}
+
+impl ExportSection {
+    /// Create a new adapter module export section encoder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The number of exports in the section.
+    pub fn len(&self) -> u32 {
+        self.num_added
+    }
+
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.num_added == 0
+    }
+
+    /// Define an export in the export section.
+    pub fn export(&mut self, name: &str, index_ref: IndexRef) -> &mut Self {
+        self.bytes.extend(encoders::str(name));
+        index_ref.encode(&mut self.bytes);
+        self.num_added += 1;
+        self
+    }
+}
+
+impl AdapterModuleSection for ExportSection {
+    fn id(&self) -> u8 {
+        SectionId::Export.into()
+    }
+
+    fn encode<S>(&self, sink: &mut S)
+    where
+        S: Extend<u8>,
+    {
+        let num_added = encoders::u32(self.num_added);
+        let n = num_added.len();
+        sink.extend(
+            encoders::u32(u32::try_from(n + self.bytes.len()).unwrap())
+                .chain(num_added)
+                .chain(self.bytes.iter().copied()),
+        );
+    }
+}

--- a/crates/wasm-encoder/src/adapter/imports.rs
+++ b/crates/wasm-encoder/src/adapter/imports.rs
@@ -1,0 +1,74 @@
+use super::{AdapterModuleSection, SectionId, TypeRef};
+use crate::encoders;
+
+/// An encoder for the adapter module import section.
+///
+/// # Example
+///
+/// ```rust
+/// use wasm_encoder::{MemoryType, adapter::{AdapterModule, ImportSection}};
+///
+/// let mut imports = ImportSection::new();
+/// imports.import(
+///     "memory",
+///     MemoryType {
+///         minimum: 1,
+///         maximum: None,
+///         memory64: false,
+///     }
+/// );
+///
+/// let mut module = AdapterModule::new();
+/// module.section(&imports);
+///
+/// let bytes = module.finish();
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct ImportSection {
+    bytes: Vec<u8>,
+    num_added: u32,
+}
+
+impl ImportSection {
+    /// Create a new adapter module import section encoder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The number of imports in the section.
+    pub fn len(&self) -> u32 {
+        self.num_added
+    }
+
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.num_added == 0
+    }
+
+    /// Define an import in the import section.
+    pub fn import(&mut self, name: &str, ty: impl Into<TypeRef>) -> &mut Self {
+        self.bytes.extend(encoders::str(name));
+        ty.into().encode(&mut self.bytes);
+        self.num_added += 1;
+        self
+    }
+}
+
+impl AdapterModuleSection for ImportSection {
+    fn id(&self) -> u8 {
+        SectionId::Import.into()
+    }
+
+    fn encode<S>(&self, sink: &mut S)
+    where
+        S: Extend<u8>,
+    {
+        let num_added = encoders::u32(self.num_added);
+        let n = num_added.len();
+        sink.extend(
+            encoders::u32(u32::try_from(n + self.bytes.len()).unwrap())
+                .chain(num_added)
+                .chain(self.bytes.iter().copied()),
+        );
+    }
+}

--- a/crates/wasm-encoder/src/adapter/instances.rs
+++ b/crates/wasm-encoder/src/adapter/instances.rs
@@ -1,0 +1,110 @@
+use super::{AdapterModuleSection, IndexRef, SectionId};
+use crate::encoders;
+
+const INSTANCE_KIND_INSTANTIATION: u8 = 0x00;
+const INSTANCE_KIND_EXPORTS: u8 = 0x01;
+
+/// An encoder for the adapter module instance section.
+///
+/// # Example
+///
+/// ```rust
+/// use wasm_encoder::adapter::{AdapterModule, InstanceSection, IndexRef};
+///
+/// // This assumes there is a module with index 0, a function with index 0,
+/// // a module with index 2, and a global with index 0.
+/// let mut instances = InstanceSection::new();
+/// instances.instantiate(0, [
+///     ("x", IndexRef::Function(0)),
+///     ("", IndexRef::Module(2)),
+///     ("foo", IndexRef::Global(0)),
+/// ]);
+///
+/// let mut module = AdapterModule::new();
+/// module.section(&instances);
+///
+/// let bytes = module.finish();
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct InstanceSection {
+    bytes: Vec<u8>,
+    num_added: u32,
+}
+
+impl InstanceSection {
+    /// Create a new adapter module instance section encoder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The number of instances in the section.
+    pub fn len(&self) -> u32 {
+        self.num_added
+    }
+
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.num_added == 0
+    }
+
+    /// Define an instantiation of the given module with the given
+    /// arguments to the instantiation.
+    pub fn instantiate<'a, I>(&mut self, module: u32, args: I) -> &mut Self
+    where
+        I: IntoIterator<Item = (&'a str, IndexRef)>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        let args = args.into_iter();
+
+        self.bytes.push(INSTANCE_KIND_INSTANTIATION);
+        self.bytes.extend(encoders::u32(module));
+
+        self.bytes
+            .extend(encoders::u32(u32::try_from(args.len()).unwrap()));
+        for (name, index) in args {
+            self.bytes.extend(encoders::str(name));
+            index.encode(&mut self.bytes);
+        }
+
+        self
+    }
+
+    /// Define an instance by exporting the given exports.
+    pub fn exports<'a, E>(&mut self, exports: E) -> &mut Self
+    where
+        E: IntoIterator<Item = (&'a str, IndexRef)>,
+        E::IntoIter: ExactSizeIterator,
+    {
+        let exports = exports.into_iter();
+
+        self.bytes.push(INSTANCE_KIND_EXPORTS);
+
+        self.bytes
+            .extend(encoders::u32(u32::try_from(exports.len()).unwrap()));
+        for (name, index) in exports {
+            self.bytes.extend(encoders::str(name));
+            index.encode(&mut self.bytes);
+        }
+
+        self
+    }
+}
+
+impl AdapterModuleSection for InstanceSection {
+    fn id(&self) -> u8 {
+        SectionId::Instance.into()
+    }
+
+    fn encode<S>(&self, sink: &mut S)
+    where
+        S: Extend<u8>,
+    {
+        let num_added = encoders::u32(self.num_added);
+        let n = num_added.len();
+        sink.extend(
+            encoders::u32(u32::try_from(n + self.bytes.len()).unwrap())
+                .chain(num_added)
+                .chain(self.bytes.iter().copied()),
+        );
+    }
+}

--- a/crates/wasm-encoder/src/adapter/modules.rs
+++ b/crates/wasm-encoder/src/adapter/modules.rs
@@ -1,22 +1,21 @@
-use super::{Component, ComponentSection, SectionId};
-use crate::{adapter::AdapterModule, encoders, Module};
+use super::{AdapterModule, AdapterModuleSection, SectionId};
+use crate::{encoders, Module};
 
-/// An encoder for the component module section.
+/// An encoder for the adapter module `module` section.
 ///
 /// # Example
 ///
 /// ```rust
-/// use wasm_encoder::{Module, adapter::AdapterModule, component::{Component, ModuleSection}};
+/// use wasm_encoder::{Module, adapter::{AdapterModule, ModuleSection}};
 ///
 /// let mut modules = ModuleSection::new();
 /// modules.module(&Module::new());
 /// modules.adapter(&AdapterModule::new());
-/// modules.component(&Component::new());
 ///
-/// let mut component = Component::new();
-/// component.section(&modules);
+/// let mut module = AdapterModule::new();
+/// module.section(&modules);
 ///
-/// let bytes = component.finish();
+/// let bytes = module.finish();
 /// ```
 #[derive(Clone, Debug, Default)]
 pub struct ModuleSection {
@@ -25,7 +24,7 @@ pub struct ModuleSection {
 }
 
 impl ModuleSection {
-    /// Create a new component module section encoder.
+    /// Create a new adapter module `module` section encoder.
     pub fn new() -> Self {
         Self::default()
     }
@@ -59,19 +58,9 @@ impl ModuleSection {
         self.num_added += 1;
         self
     }
-
-    /// Writes a component into this module section.
-    pub fn component(&mut self, component: &Component) -> &mut Self {
-        self.bytes.extend(
-            encoders::u32(u32::try_from(component.bytes.len()).unwrap())
-                .chain(component.bytes.iter().copied()),
-        );
-        self.num_added += 1;
-        self
-    }
 }
 
-impl ComponentSection for ModuleSection {
+impl AdapterModuleSection for ModuleSection {
     fn id(&self) -> u8 {
         SectionId::Module.into()
     }

--- a/crates/wasm-encoder/src/adapter/types.rs
+++ b/crates/wasm-encoder/src/adapter/types.rs
@@ -1,0 +1,307 @@
+use super::{AdapterModuleSection, SectionId, TypeRef};
+use crate::{encoders, ValType};
+
+const TYPE_INSTANCE: u8 = 0x7f;
+const TYPE_MODULE: u8 = 0x7e;
+const TYPE_FUNCTION: u8 = 0x7d;
+
+const ALIAS_TYPE_INSTANCE_EXPORT: u8 = 0x00;
+const ALIAS_TYPE_OUTER: u8 = 0x01;
+
+const OUTER_ALIAS_MODULE: u8 = 0x01;
+const OUTER_ALIAS_TYPE: u8 = 0x06;
+
+const INSTANCE_TYPEDEF_TYPE: u8 = 0x01;
+const INSTANCE_TYPEDEF_ALIAS: u8 = 0x05;
+const INSTANCE_TYPEDEF_EXPORT: u8 = 0x06;
+
+const MODULE_TYPEDEF_TYPE: u8 = 0x01;
+const MODULE_TYPEDEF_ALIAS: u8 = 0x05;
+const MODULE_TYPEDEF_EXPORT: u8 = 0x06;
+const MODULE_TYPEDEF_IMPORT: u8 = 0x02;
+
+/// Represents a definition kind.
+///
+/// This is used in aliases to specify the kind of the definition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DefinitionKind {
+    /// The definition is an instance.
+    Instance = 0,
+    /// The definition is a module.
+    Module = 1,
+    /// The definition is a function.
+    Function = 2,
+    /// The definition is a table.
+    Table = 3,
+    /// The definition is a memory.
+    Memory = 4,
+    /// The definition is a global.
+    Global = 5,
+}
+
+/// Represents an index for an outer alias.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OuterAliasIndex {
+    /// The index is a module index.
+    Module(u32),
+    /// The index is a type index.
+    Type(u32),
+}
+
+impl OuterAliasIndex {
+    pub(crate) fn encode(&self, bytes: &mut Vec<u8>) {
+        match self {
+            Self::Module(index) => {
+                bytes.extend(encoders::u32(*index));
+                bytes.push(OUTER_ALIAS_MODULE);
+            }
+            Self::Type(index) => {
+                bytes.extend(encoders::u32(*index));
+                bytes.push(OUTER_ALIAS_TYPE);
+            }
+        }
+    }
+}
+
+/// Represents an instance type.
+#[derive(Debug, Clone, Default)]
+pub struct InstanceType {
+    bytes: Vec<u8>,
+    num_added: u32,
+}
+
+impl InstanceType {
+    /// Creates a new instance type.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Define a type in this instance type.
+    #[must_use = "the encoder must be used to encode the type"]
+    pub fn ty(&mut self) -> TypeEncoder {
+        self.bytes.push(INSTANCE_TYPEDEF_TYPE);
+        self.num_added += 1;
+        TypeEncoder(&mut self.bytes)
+    }
+
+    /// Defines an alias to an instance export in the instance type.
+    pub fn alias_instance_export(
+        &mut self,
+        instance: u32,
+        name: &str,
+        kind: DefinitionKind,
+    ) -> &mut Self {
+        self.bytes.push(INSTANCE_TYPEDEF_ALIAS);
+        self.bytes.push(ALIAS_TYPE_INSTANCE_EXPORT);
+        self.bytes.extend(encoders::u32(instance));
+        self.bytes.extend(encoders::str(name));
+        self.bytes.push(kind as u8);
+        self.num_added += 1;
+        self
+    }
+
+    /// Defines an alias to an outer module in the instance type.
+    pub fn alias_outer_module(&mut self, count: u32, index: OuterAliasIndex) -> &mut Self {
+        self.bytes.push(INSTANCE_TYPEDEF_ALIAS);
+        self.bytes.push(ALIAS_TYPE_OUTER);
+        self.bytes.extend(encoders::u32(count));
+        index.encode(&mut self.bytes);
+        self.num_added += 1;
+        self
+    }
+
+    /// Defines an export in the instance type.
+    pub fn export(&mut self, name: &str, ty: TypeRef) -> &mut Self {
+        self.bytes.push(INSTANCE_TYPEDEF_EXPORT);
+        self.bytes.extend(encoders::str(name));
+        ty.encode(&mut self.bytes);
+        self.num_added += 1;
+        self
+    }
+
+    pub(crate) fn encode(&self, bytes: &mut Vec<u8>) {
+        bytes.extend(encoders::u32(self.num_added));
+        bytes.extend(self.bytes.iter().copied());
+    }
+}
+
+/// Represents a module type.
+#[derive(Debug, Clone, Default)]
+pub struct ModuleType {
+    bytes: Vec<u8>,
+    num_added: u32,
+}
+
+impl ModuleType {
+    /// Creates a new module type.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Define a type in this module type.
+    #[must_use = "the encoder must be used to encode the type"]
+    pub fn ty(&mut self) -> TypeEncoder {
+        self.bytes.push(MODULE_TYPEDEF_TYPE);
+        self.num_added += 1;
+        TypeEncoder(&mut self.bytes)
+    }
+
+    /// Defines an alias to an instance export in the module type.
+    pub fn alias_instance_export(
+        &mut self,
+        instance: u32,
+        name: &str,
+        kind: DefinitionKind,
+    ) -> &mut Self {
+        self.bytes.push(MODULE_TYPEDEF_ALIAS);
+        self.bytes.push(ALIAS_TYPE_INSTANCE_EXPORT);
+        self.bytes.extend(encoders::u32(instance));
+        self.bytes.extend(encoders::str(name));
+        self.bytes.push(kind as u8);
+        self.num_added += 1;
+        self
+    }
+
+    /// Defines an alias to an outer module in the module type.
+    pub fn alias_outer_module(&mut self, count: u32, index: OuterAliasIndex) -> &mut Self {
+        self.bytes.push(MODULE_TYPEDEF_ALIAS);
+        self.bytes.push(ALIAS_TYPE_OUTER);
+        self.bytes.extend(encoders::u32(count));
+        index.encode(&mut self.bytes);
+        self.num_added += 1;
+        self
+    }
+
+    /// Defines an export in the module type.
+    pub fn export(&mut self, name: &str, ty: TypeRef) -> &mut Self {
+        self.bytes.push(MODULE_TYPEDEF_EXPORT);
+        self.bytes.extend(encoders::str(name));
+        ty.encode(&mut self.bytes);
+        self.num_added += 1;
+        self
+    }
+
+    /// Defines an import in the module type.
+    pub fn import(&mut self, name: &str, ty: TypeRef) -> &mut Self {
+        self.bytes.push(MODULE_TYPEDEF_IMPORT);
+        self.bytes.extend(encoders::str(name));
+        ty.encode(&mut self.bytes);
+        self.num_added += 1;
+        self
+    }
+
+    pub(crate) fn encode(&self, bytes: &mut Vec<u8>) {
+        bytes.extend(encoders::u32(self.num_added));
+        bytes.extend(self.bytes.iter().copied());
+    }
+}
+
+/// Used to encode types.
+#[derive(Debug)]
+pub struct TypeEncoder<'a>(&'a mut Vec<u8>);
+
+impl<'a> TypeEncoder<'a> {
+    /// Define an instance type.
+    pub fn instance(self, ty: &InstanceType) {
+        self.0.push(TYPE_INSTANCE);
+        ty.encode(self.0);
+    }
+
+    /// Define a module type.
+    pub fn module(self, ty: &ModuleType) {
+        self.0.push(TYPE_MODULE);
+        ty.encode(self.0);
+    }
+
+    /// Define a function type.
+    pub fn function(self, params: &[ValType], results: &[ValType]) {
+        self.0.push(TYPE_FUNCTION);
+        self.0
+            .extend(encoders::u32(u32::try_from(params.len()).unwrap()));
+        self.0.extend(params.iter().map(|p| u8::from(*p)));
+        self.0
+            .extend(encoders::u32(u32::try_from(results.len()).unwrap()));
+        self.0.extend(results.iter().map(|r| u8::from(*r)));
+    }
+}
+
+/// An encoder for the adapter module type section.
+///
+/// # Example
+///
+/// ```rust
+/// use wasm_encoder::adapter::{AdapterModule, TypeSection};
+///
+/// let mut types = TypeSection::new();
+/// types.function(&[], &[]);
+///
+/// let mut module = AdapterModule::new();
+/// module.section(&types);
+///
+/// let bytes = module.finish();
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct TypeSection {
+    bytes: Vec<u8>,
+    num_added: u32,
+}
+
+impl TypeSection {
+    /// Create a new module adapter type section encoder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The number of types in the section.
+    pub fn len(&self) -> u32 {
+        self.num_added
+    }
+
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.num_added == 0
+    }
+
+    /// Define an instance type in this type section.
+    pub fn instance(&mut self, ty: &InstanceType) -> &mut Self {
+        let encoder = TypeEncoder(&mut self.bytes);
+        encoder.instance(ty);
+        self.num_added += 1;
+        self
+    }
+
+    /// Define a module type in this type section.
+    pub fn module(&mut self, ty: &ModuleType) -> &mut Self {
+        let encoder = TypeEncoder(&mut self.bytes);
+        encoder.module(ty);
+        self.num_added += 1;
+        self
+    }
+
+    /// Define a function type in this type section.
+    pub fn function(&mut self, params: &[ValType], results: &[ValType]) -> &mut Self {
+        let encoder = TypeEncoder(&mut self.bytes);
+        encoder.function(params, results);
+        self.num_added += 1;
+        self
+    }
+}
+
+impl AdapterModuleSection for TypeSection {
+    fn id(&self) -> u8 {
+        SectionId::Type.into()
+    }
+
+    fn encode<S>(&self, sink: &mut S)
+    where
+        S: Extend<u8>,
+    {
+        let num_added = encoders::u32(self.num_added);
+        let n = num_added.len();
+        sink.extend(
+            encoders::u32(u32::try_from(n + self.bytes.len()).unwrap())
+                .chain(num_added)
+                .chain(self.bytes.iter().copied()),
+        );
+    }
+}

--- a/crates/wasm-encoder/src/aliases.rs
+++ b/crates/wasm-encoder/src/aliases.rs
@@ -29,11 +29,8 @@ pub struct AliasSection {
 
 impl AliasSection {
     /// Construct a new alias section encoder.
-    pub fn new() -> AliasSection {
-        AliasSection {
-            bytes: vec![],
-            num_added: 0,
-        }
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// How many aliases have been defined inside this section so far?

--- a/crates/wasm-encoder/src/aliases.rs
+++ b/crates/wasm-encoder/src/aliases.rs
@@ -21,7 +21,7 @@ use super::*;
 ///
 /// let wasm_bytes = module.finish();
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct AliasSection {
     bytes: Vec<u8>,
     num_added: u32,
@@ -39,6 +39,11 @@ impl AliasSection {
     /// How many aliases have been defined inside this section so far?
     pub fn len(&self) -> u32 {
         self.num_added
+    }
+
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.num_added == 0
     }
 
     /// Define an alias that references the export of a defined instance.

--- a/crates/wasm-encoder/src/code.rs
+++ b/crates/wasm-encoder/src/code.rs
@@ -49,6 +49,11 @@ impl CodeSection {
         self.num_added
     }
 
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.num_added == 0
+    }
+
     /// Write a function body into this code section.
     pub fn function(&mut self, func: &Function) -> &mut Self {
         func.encode(&mut self.bytes);

--- a/crates/wasm-encoder/src/code.rs
+++ b/crates/wasm-encoder/src/code.rs
@@ -40,8 +40,8 @@ pub struct CodeSection {
 
 impl CodeSection {
     /// Create a new code section encoder.
-    pub fn new() -> CodeSection {
-        CodeSection::default()
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// How many function bodies have been defined inside this section so far?

--- a/crates/wasm-encoder/src/component.rs
+++ b/crates/wasm-encoder/src/component.rs
@@ -1,0 +1,371 @@
+//! The module for encoding a WebAssembly component.
+//!
+//! This is an implementation of the in-progress [component
+//! model proposal](https://github.com/WebAssembly/component-model/).
+
+use crate::{encoders, GlobalType, MemoryType, RawSection, Section, TableType};
+
+mod adapters;
+mod aliases;
+mod exports;
+mod functions;
+mod imports;
+mod instances;
+mod modules;
+mod types;
+
+pub use adapters::*;
+pub use aliases::*;
+pub use exports::*;
+pub use functions::*;
+pub use imports::*;
+pub use instances::*;
+pub use modules::*;
+pub use types::*;
+
+const INDEX_REF_INSTANCE: u8 = 0x00;
+const INDEX_REF_MODULE: u8 = 0x01;
+const INDEX_REF_FUNCTION: u8 = 0x02;
+const INDEX_REF_TABLE: u8 = 0x03;
+const INDEX_REF_MEMORY: u8 = 0x04;
+const INDEX_REF_GLOBAL: u8 = 0x05;
+
+const TYPE_REF_INSTANCE: u8 = 0x00;
+const TYPE_REF_MODULE: u8 = 0x01;
+const TYPE_REF_FUNCTION: u8 = 0x02;
+const TYPE_REF_TABLE: u8 = 0x03;
+const TYPE_REF_MEMORY: u8 = 0x04;
+const TYPE_REF_GLOBAL: u8 = 0x05;
+const TYPE_REF_ADAPTER_FUNCTION: u8 = 0x06;
+
+const CANONICAL_OPTION_UTF8: u8 = 0x01;
+const CANONICAL_OPTION_UTF16: u8 = 0x02;
+const CANONICAL_OPTION_COMPACT_UTF16: u8 = 0x03;
+const CANONICAL_OPTION_WITH_REALLOC: u8 = 0x04;
+const CANONICAL_OPTION_WITH_FREE: u8 = 0x05;
+
+/// A WebAssembly component section.
+///
+/// This trait marks sections that can be written to a `Component`.
+///
+/// Various builders defined in this crate already implement this trait, but you
+/// can also implement it yourself for your own custom section builders, or use
+/// `RawSection` to use a bunch of raw bytes as a section.
+pub trait ComponentSection {
+    /// This section's id.
+    ///
+    /// See `SectionId` for known section ids.
+    fn id(&self) -> u8;
+
+    /// Write this section's data and data length prefix into the given sink.
+    fn encode<S>(&self, sink: &mut S)
+    where
+        S: Extend<u8>;
+}
+
+impl ComponentSection for RawSection<'_> {
+    fn id(&self) -> u8 {
+        self.id
+    }
+
+    fn encode<S>(&self, sink: &mut S)
+    where
+        S: Extend<u8>,
+    {
+        <Self as Section>::encode(self, sink);
+    }
+}
+
+/// A Wasm adapter module that is being encoded.
+#[derive(Clone, Debug)]
+pub struct AdapterModule {
+    bytes: Vec<u8>,
+}
+
+impl AdapterModule {
+    /// Begin writing a new `AdapterModule`.
+    pub fn new() -> Self {
+        Self {
+            bytes: vec![
+                0x00, 0x61, 0x73, 0x6D, // magic (`\0asm`)
+                0x0a, 0x00, 0x01, 0x00, // version
+            ],
+        }
+    }
+
+    /// Finish writing this adapter module and extract ownership of the encoded bytes.
+    pub fn finish(self) -> Vec<u8> {
+        self.bytes
+    }
+
+    /// Write a section into this adapter module.
+    pub fn section(&mut self, section: &impl ComponentSection) -> &mut Self {
+        self.bytes.push(section.id());
+        section.encode(&mut self.bytes);
+        self
+    }
+}
+
+impl Default for AdapterModule {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A Wasm component that is being encoded.
+#[derive(Clone, Debug)]
+pub struct Component {
+    bytes: Vec<u8>,
+}
+
+impl Component {
+    /// Begin writing a new `Component`.
+    pub fn new() -> Self {
+        Self {
+            bytes: vec![
+                0x00, 0x61, 0x73, 0x6D, // magic (`\0asm`)
+                0x0a, 0x00, 0x02, 0x00, // version
+            ],
+        }
+    }
+
+    /// Finish writing this component and extract ownership of the encoded bytes.
+    pub fn finish(self) -> Vec<u8> {
+        self.bytes
+    }
+
+    /// Write a section into this component.
+    pub fn section(&mut self, section: &impl ComponentSection) -> &mut Self {
+        self.bytes.push(section.id());
+        section.encode(&mut self.bytes);
+        self
+    }
+}
+
+impl Default for Component {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Known component section IDs.
+///
+/// Useful for implementing the `ComponentSection` trait, or for setting
+/// `RawSection::id`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[repr(u8)]
+pub enum SectionId {
+    /// The section is a custom section.
+    Custom = 0,
+    /// The section is a type section.
+    Type = 1,
+    /// The section is an import section.
+    Import = 2,
+    /// The section is a module section.
+    Module = 3,
+    /// The section is an instance section.
+    Instance = 4,
+    /// The section is an alias section.
+    Alias = 5,
+    /// The section is an export section.
+    Export = 6,
+    /// THe section is a function section.
+    Function = 7,
+    /// The section is an adapter function section.
+    AdapterFunction = 8,
+}
+
+impl From<SectionId> for u8 {
+    #[inline]
+    fn from(id: SectionId) -> u8 {
+        id as u8
+    }
+}
+
+/// Represents a reference to an index in a WebAssembly section.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub enum IndexRef {
+    /// The reference is to an instance in the instance section.
+    Instance(u32),
+    /// The reference is to a module in the module section.
+    Module(u32),
+    /// The reference is to a function in the function section.
+    Function(u32),
+    /// The reference is to a table in the table section.
+    Table(u32),
+    /// The reference is to a memory in the memory section.
+    Memory(u32),
+    /// The reference is to a global in the global section.
+    Global(u32),
+}
+
+impl IndexRef {
+    pub(crate) fn encode(&self, bytes: &mut Vec<u8>) {
+        match self {
+            IndexRef::Instance(index) => {
+                bytes.push(INDEX_REF_INSTANCE);
+                bytes.extend(encoders::u32(*index));
+            }
+            IndexRef::Module(index) => {
+                bytes.push(INDEX_REF_MODULE);
+                bytes.extend(encoders::u32(*index));
+            }
+            IndexRef::Function(index) => {
+                bytes.push(INDEX_REF_FUNCTION);
+                bytes.extend(encoders::u32(*index));
+            }
+            IndexRef::Table(index) => {
+                bytes.push(INDEX_REF_TABLE);
+                bytes.extend(encoders::u32(*index));
+            }
+            IndexRef::Memory(index) => {
+                bytes.push(INDEX_REF_MEMORY);
+                bytes.extend(encoders::u32(*index));
+            }
+            IndexRef::Global(index) => {
+                bytes.push(INDEX_REF_GLOBAL);
+                bytes.extend(encoders::u32(*index));
+            }
+        }
+    }
+}
+
+/// Represents a reference to a type definition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TypeRef {
+    /// The definition is an instance.
+    ///
+    /// The value is an index in the types index space.
+    /// The index must be to an instance type.
+    Instance(u32),
+    /// The definition is a module.
+    ///
+    /// The value is an index in the types index space.
+    /// The index must be to a module type.
+    Module(u32),
+    /// The definition is a core wasm function.
+    ///
+    /// The value is an index in the types index space.
+    /// The index must be to a function type.
+    Function(u32),
+    /// The definition is a core wasm table.
+    Table(TableType),
+    /// The definition is a core wasm memory.
+    Memory(MemoryType),
+    /// The definition is a core wasm global.
+    Global(GlobalType),
+    /// The definition is an adapter function.
+    ///
+    /// The value is an index in the types index space.
+    /// The index must be to an adapter function type.
+    AdapterFunction(u32),
+}
+
+impl TypeRef {
+    pub(crate) fn encode(&self, bytes: &mut Vec<u8>) {
+        match self {
+            Self::Instance(index) => {
+                bytes.push(TYPE_REF_INSTANCE);
+                bytes.extend(encoders::u32(*index));
+            }
+            Self::Module(index) => {
+                bytes.push(TYPE_REF_MODULE);
+                bytes.extend(encoders::u32(*index));
+            }
+            Self::Function(index) => {
+                bytes.push(TYPE_REF_FUNCTION);
+                bytes.extend(encoders::u32(*index));
+            }
+            Self::Table(ty) => {
+                bytes.push(TYPE_REF_TABLE);
+                ty.encode(bytes);
+            }
+            Self::Memory(ty) => {
+                bytes.push(TYPE_REF_MEMORY);
+                ty.encode(bytes);
+            }
+            Self::Global(ty) => {
+                bytes.push(TYPE_REF_GLOBAL);
+                ty.encode(bytes);
+            }
+            Self::AdapterFunction(index) => {
+                bytes.push(TYPE_REF_ADAPTER_FUNCTION);
+                bytes.extend(encoders::u32(*index));
+            }
+        }
+    }
+}
+
+impl From<TableType> for TypeRef {
+    fn from(t: TableType) -> Self {
+        Self::Table(t)
+    }
+}
+
+impl From<MemoryType> for TypeRef {
+    fn from(t: MemoryType) -> Self {
+        Self::Memory(t)
+    }
+}
+
+impl From<GlobalType> for TypeRef {
+    fn from(t: GlobalType) -> Self {
+        Self::Global(t)
+    }
+}
+
+/// Represents options for canonical functions and adapter functions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CanonicalOption {
+    /// The string types in the function signature are UTF-8 encoded.
+    UTF8,
+    /// The string types in the function signature are UTF-16 encoded.
+    UTF16,
+    /// The string types in the function signature are compact UTF-16 encoded.
+    CompactUTF16,
+    /// Specifies the function to use to reallocate memory.
+    WithRealloc(u32),
+    /// Specifies the function to use to free memory.
+    WithFree(u32),
+}
+
+impl CanonicalOption {
+    pub(crate) fn encode(&self, bytes: &mut Vec<u8>) {
+        match self {
+            Self::UTF8 => bytes.push(CANONICAL_OPTION_UTF8),
+            Self::UTF16 => bytes.push(CANONICAL_OPTION_UTF16),
+            Self::CompactUTF16 => bytes.push(CANONICAL_OPTION_COMPACT_UTF16),
+            Self::WithRealloc(index) => {
+                bytes.push(CANONICAL_OPTION_WITH_REALLOC);
+                bytes.extend(encoders::u32(*index));
+            }
+            Self::WithFree(index) => {
+                bytes.push(CANONICAL_OPTION_WITH_FREE);
+                bytes.extend(encoders::u32(*index));
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn it_encodes_an_empty_component() {
+        let bytes = Component::new().finish();
+        assert_eq!(
+            bytes,
+            [0x00, 'a' as u8, 's' as u8, 'm' as u8, 0x0a, 0x00, 0x02, 0x00]
+        );
+    }
+
+    #[test]
+    fn it_encodes_an_adapter_module() {
+        let bytes = AdapterModule::new().finish();
+        assert_eq!(
+            bytes,
+            [0x00, 'a' as u8, 's' as u8, 'm' as u8, 0x0a, 0x00, 0x01, 0x00]
+        );
+    }
+}

--- a/crates/wasm-encoder/src/component.rs
+++ b/crates/wasm-encoder/src/component.rs
@@ -38,11 +38,11 @@ const TYPE_REF_MEMORY: u8 = 0x04;
 const TYPE_REF_GLOBAL: u8 = 0x05;
 const TYPE_REF_ADAPTER_FUNCTION: u8 = 0x06;
 
-const CANONICAL_OPTION_UTF8: u8 = 0x01;
-const CANONICAL_OPTION_UTF16: u8 = 0x02;
-const CANONICAL_OPTION_COMPACT_UTF16: u8 = 0x03;
-const CANONICAL_OPTION_WITH_REALLOC: u8 = 0x04;
-const CANONICAL_OPTION_WITH_FREE: u8 = 0x05;
+const CANONICAL_OPTION_UTF8: u8 = 0x00;
+const CANONICAL_OPTION_UTF16: u8 = 0x01;
+const CANONICAL_OPTION_COMPACT_UTF16: u8 = 0x02;
+const CANONICAL_OPTION_WITH_REALLOC: u8 = 0x03;
+const CANONICAL_OPTION_WITH_FREE: u8 = 0x04;
 
 /// A WebAssembly component section.
 ///
@@ -169,7 +169,7 @@ pub enum SectionId {
     Alias = 5,
     /// The section is an export section.
     Export = 6,
-    /// THe section is a function section.
+    /// The section is a function section.
     Function = 7,
     /// The section is an adapter function section.
     AdapterFunction = 8,

--- a/crates/wasm-encoder/src/component/adapters.rs
+++ b/crates/wasm-encoder/src/component/adapters.rs
@@ -1,0 +1,82 @@
+use super::{CanonicalOption, ComponentSection, SectionId};
+use crate::encoders;
+
+/// An encoder for the component adapter function section.
+///
+/// # Example
+///
+/// ```rust
+/// use wasm_encoder::component::{Component, AdapterFunctionSection, CanonicalOption};
+///
+/// // This assumes there is an adapter function type with
+/// // index 0 and a target function with index 0.
+/// let mut adapters = AdapterFunctionSection::new();
+/// adapters.adapter(0, &[CanonicalOption::UTF8], 0);
+///
+/// let mut component = Component::new();
+/// component.section(&adapters);
+///
+/// let bytes = component.finish();
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct AdapterFunctionSection {
+    bytes: Vec<u8>,
+    num_added: u32,
+}
+
+impl AdapterFunctionSection {
+    /// Create a new component adapter function section encoder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The number of adapter functions in the section.
+    pub fn len(&self) -> u32 {
+        self.num_added
+    }
+
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.num_added == 0
+    }
+
+    /// Define an adapter function in the adapter function section.
+    ///
+    /// `type_index` must be to an adapter function type.
+    /// `target_index` must be to a function.
+    pub fn adapter(
+        &mut self,
+        type_index: u32,
+        options: &[CanonicalOption],
+        target_index: u32,
+    ) -> &mut Self {
+        self.bytes.extend(encoders::u32(type_index));
+        self.bytes.push(0x00); // This byte is a placeholder for future cases.
+        self.bytes
+            .extend(encoders::u32(u32::try_from(options.len()).unwrap()));
+        for option in options {
+            option.encode(&mut self.bytes);
+        }
+        self.bytes.extend(encoders::u32(target_index));
+        self
+    }
+}
+
+impl ComponentSection for AdapterFunctionSection {
+    fn id(&self) -> u8 {
+        SectionId::AdapterFunction.into()
+    }
+
+    fn encode<S>(&self, sink: &mut S)
+    where
+        S: Extend<u8>,
+    {
+        let num_added = encoders::u32(self.num_added);
+        let n = num_added.len();
+        sink.extend(
+            encoders::u32(u32::try_from(n + self.bytes.len()).unwrap())
+                .chain(num_added)
+                .chain(self.bytes.iter().copied()),
+        );
+    }
+}

--- a/crates/wasm-encoder/src/component/aliases.rs
+++ b/crates/wasm-encoder/src/component/aliases.rs
@@ -1,0 +1,112 @@
+use super::{ComponentSection, SectionId};
+use crate::encoders;
+
+const ALIAS_KIND_INSTANCE_EXPORT: u8 = 0x00;
+const ALIAS_KIND_OUTER: u8 = 0x01;
+const ALIAS_KIND_OUTER_MODULE: u8 = 0x01;
+const ALIAS_KIND_OUTER_TYPE: u8 = 0x06;
+
+/// Represents the expected export kind for an alias.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExportKind {
+    /// The alias is to an instance.
+    Instance,
+    /// The alias is to a module.
+    Module,
+    /// The alias is to a function.
+    Function,
+    /// The alias is to a table.
+    Table,
+    /// The alias is to a memory.
+    Memory,
+    /// The alias is to a global.
+    Global,
+}
+
+/// An encoder for the component alias section.
+///
+/// # Example
+///
+/// ```rust
+/// use wasm_encoder::component::{Component, AliasSection, ExportKind};
+///
+/// let mut aliases = AliasSection::new();
+/// aliases.outer_type(0, 2);
+/// aliases.instance_export(0, ExportKind::Function, "foo");
+///
+/// let mut component = Component::new();
+/// component.section(&aliases);
+///
+/// let bytes = component.finish();
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct AliasSection {
+    bytes: Vec<u8>,
+    num_added: u32,
+}
+
+impl AliasSection {
+    /// Create a new component alias section encoder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The number of aliases in the section.
+    pub fn len(&self) -> u32 {
+        self.num_added
+    }
+
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.num_added == 0
+    }
+
+    /// Define an alias that references the export of a defined instance.
+    pub fn instance_export(&mut self, instance: u32, kind: ExportKind, name: &str) -> &mut Self {
+        self.bytes.push(ALIAS_KIND_INSTANCE_EXPORT);
+        self.bytes.extend(encoders::u32(instance));
+        self.bytes.extend(encoders::str(name));
+        self.bytes.push(kind as u8);
+        self.num_added += 1;
+        self
+    }
+
+    /// Define an alias that references an outer module's type.
+    pub fn outer_type(&mut self, count: u32, ty: u32) -> &mut Self {
+        self.bytes.push(ALIAS_KIND_OUTER);
+        self.bytes.extend(encoders::u32(count));
+        self.bytes.extend(encoders::u32(ty));
+        self.bytes.push(ALIAS_KIND_OUTER_TYPE);
+        self.num_added += 1;
+        self
+    }
+
+    /// Define an alias that references an outer module's module.
+    pub fn outer_module(&mut self, count: u32, module: u32) -> &mut Self {
+        self.bytes.push(ALIAS_KIND_OUTER);
+        self.bytes.extend(encoders::u32(count));
+        self.bytes.extend(encoders::u32(module));
+        self.bytes.push(ALIAS_KIND_OUTER_MODULE);
+        self.num_added += 1;
+        self
+    }
+}
+
+impl ComponentSection for AliasSection {
+    fn id(&self) -> u8 {
+        SectionId::Alias.into()
+    }
+
+    fn encode<S>(&self, sink: &mut S)
+    where
+        S: Extend<u8>,
+    {
+        let num_added = encoders::u32(self.num_added);
+        let n = num_added.len();
+        sink.extend(
+            encoders::u32(u32::try_from(n + self.bytes.len()).unwrap())
+                .chain(num_added)
+                .chain(self.bytes.iter().copied()),
+        );
+    }
+}

--- a/crates/wasm-encoder/src/component/exports.rs
+++ b/crates/wasm-encoder/src/component/exports.rs
@@ -1,0 +1,68 @@
+use super::{ComponentSection, IndexRef, SectionId};
+use crate::encoders;
+
+/// An encoder for the component export section.
+///
+/// # Example
+///
+/// ```rust
+/// use wasm_encoder::component::{Component, ExportSection, IndexRef};
+///
+/// // This assumes there is a function at index 0 to export
+/// let mut exports = ExportSection::new();
+/// exports.export("foo", IndexRef::Function(0));
+///
+/// let mut component = Component::new();
+/// component.section(&exports);
+///
+/// let bytes = component.finish();
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct ExportSection {
+    bytes: Vec<u8>,
+    num_added: u32,
+}
+
+impl ExportSection {
+    /// Create a new component export section encoder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The number of exports in the section.
+    pub fn len(&self) -> u32 {
+        self.num_added
+    }
+
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.num_added == 0
+    }
+
+    /// Define an export in the export section.
+    pub fn export(&mut self, name: &str, index_ref: IndexRef) -> &mut Self {
+        self.bytes.extend(encoders::str(name));
+        index_ref.encode(&mut self.bytes);
+        self.num_added += 1;
+        self
+    }
+}
+
+impl ComponentSection for ExportSection {
+    fn id(&self) -> u8 {
+        SectionId::Export.into()
+    }
+
+    fn encode<S>(&self, sink: &mut S)
+    where
+        S: Extend<u8>,
+    {
+        let num_added = encoders::u32(self.num_added);
+        let n = num_added.len();
+        sink.extend(
+            encoders::u32(u32::try_from(n + self.bytes.len()).unwrap())
+                .chain(num_added)
+                .chain(self.bytes.iter().copied()),
+        );
+    }
+}

--- a/crates/wasm-encoder/src/component/functions.rs
+++ b/crates/wasm-encoder/src/component/functions.rs
@@ -1,0 +1,82 @@
+use super::{CanonicalOption, ComponentSection, SectionId};
+use crate::encoders;
+
+/// An encoder for the component function section.
+///
+/// # Example
+///
+/// ```rust
+/// use wasm_encoder::component::{Component, FunctionSection, CanonicalOption};
+///
+/// // This assumes there is a function type with
+/// // index 0 and a target adapter function with index 0.
+/// let mut functions = FunctionSection::new();
+/// functions.function(0, &[CanonicalOption::UTF8], 0);
+///
+/// let mut component = Component::new();
+/// component.section(&functions);
+///
+/// let bytes = component.finish();
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct FunctionSection {
+    bytes: Vec<u8>,
+    num_added: u32,
+}
+
+impl FunctionSection {
+    /// Create a new component function section encoder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The number of functions in the section.
+    pub fn len(&self) -> u32 {
+        self.num_added
+    }
+
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.num_added == 0
+    }
+
+    /// Define a function in the function section.
+    ///
+    /// `type_index` must be to a function type.
+    /// `target_index` must be to an adapter function.
+    pub fn function(
+        &mut self,
+        type_index: u32,
+        options: &[CanonicalOption],
+        target_index: u32,
+    ) -> &mut Self {
+        self.bytes.extend(encoders::u32(type_index));
+        self.bytes.push(0x00); // This byte is a placeholder for future cases.
+        self.bytes
+            .extend(encoders::u32(u32::try_from(options.len()).unwrap()));
+        for option in options {
+            option.encode(&mut self.bytes);
+        }
+        self.bytes.extend(encoders::u32(target_index));
+        self
+    }
+}
+
+impl ComponentSection for FunctionSection {
+    fn id(&self) -> u8 {
+        SectionId::Function.into()
+    }
+
+    fn encode<S>(&self, sink: &mut S)
+    where
+        S: Extend<u8>,
+    {
+        let num_added = encoders::u32(self.num_added);
+        let n = num_added.len();
+        sink.extend(
+            encoders::u32(u32::try_from(n + self.bytes.len()).unwrap())
+                .chain(num_added)
+                .chain(self.bytes.iter().copied()),
+        );
+    }
+}

--- a/crates/wasm-encoder/src/component/imports.rs
+++ b/crates/wasm-encoder/src/component/imports.rs
@@ -1,0 +1,74 @@
+use super::{ComponentSection, SectionId, TypeRef};
+use crate::encoders;
+
+/// An encoder for the component import section.
+///
+/// # Example
+///
+/// ```rust
+/// use wasm_encoder::{MemoryType, component::{Component, ImportSection}};
+///
+/// let mut imports = ImportSection::new();
+/// imports.import(
+///     "memory",
+///     MemoryType {
+///         minimum: 1,
+///         maximum: None,
+///         memory64: false,
+///     }
+/// );
+///
+/// let mut component = Component::new();
+/// component.section(&imports);
+///
+/// let bytes = component.finish();
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct ImportSection {
+    bytes: Vec<u8>,
+    num_added: u32,
+}
+
+impl ImportSection {
+    /// Create a new component import section encoder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The number of imports in the section.
+    pub fn len(&self) -> u32 {
+        self.num_added
+    }
+
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.num_added == 0
+    }
+
+    /// Define an import in the import section.
+    pub fn import(&mut self, name: &str, ty: impl Into<TypeRef>) -> &mut Self {
+        self.bytes.extend(encoders::str(name));
+        ty.into().encode(&mut self.bytes);
+        self.num_added += 1;
+        self
+    }
+}
+
+impl ComponentSection for ImportSection {
+    fn id(&self) -> u8 {
+        SectionId::Import.into()
+    }
+
+    fn encode<S>(&self, sink: &mut S)
+    where
+        S: Extend<u8>,
+    {
+        let num_added = encoders::u32(self.num_added);
+        let n = num_added.len();
+        sink.extend(
+            encoders::u32(u32::try_from(n + self.bytes.len()).unwrap())
+                .chain(num_added)
+                .chain(self.bytes.iter().copied()),
+        );
+    }
+}

--- a/crates/wasm-encoder/src/component/instances.rs
+++ b/crates/wasm-encoder/src/component/instances.rs
@@ -1,0 +1,110 @@
+use super::{ComponentSection, IndexRef, SectionId};
+use crate::encoders;
+
+const INSTANCE_KIND_INSTANTIATION: u8 = 0x00;
+const INSTANCE_KIND_EXPORTS: u8 = 0x01;
+
+/// An encoder for the component instance section.
+///
+/// # Example
+///
+/// ```rust
+/// use wasm_encoder::component::{Component, InstanceSection, IndexRef};
+///
+/// // This assumes there is a module with index 0, a function with index 0,
+/// // a module with index 2, and a global with index 0.
+/// let mut instances = InstanceSection::new();
+/// instances.instantiate(0, [
+///     ("x", IndexRef::Function(0)),
+///     ("", IndexRef::Module(2)),
+///     ("foo", IndexRef::Global(0)),
+/// ]);
+///
+/// let mut component = Component::new();
+/// component.section(&instances);
+///
+/// let bytes = component.finish();
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct InstanceSection {
+    bytes: Vec<u8>,
+    num_added: u32,
+}
+
+impl InstanceSection {
+    /// Create a new component instance section encoder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The number of instances in the section.
+    pub fn len(&self) -> u32 {
+        self.num_added
+    }
+
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.num_added == 0
+    }
+
+    /// Define an instantiation of the given module with the given
+    /// arguments to the instantiation.
+    pub fn instantiate<'a, I>(&mut self, module: u32, args: I) -> &mut Self
+    where
+        I: IntoIterator<Item = (&'a str, IndexRef)>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        let args = args.into_iter();
+
+        self.bytes.push(INSTANCE_KIND_INSTANTIATION);
+        self.bytes.extend(encoders::u32(module));
+
+        self.bytes
+            .extend(encoders::u32(u32::try_from(args.len()).unwrap()));
+        for (name, index) in args {
+            self.bytes.extend(encoders::str(name));
+            index.encode(&mut self.bytes);
+        }
+
+        self
+    }
+
+    /// Define an instance by exporting the given exports.
+    pub fn exports<'a, E>(&mut self, exports: E) -> &mut Self
+    where
+        E: IntoIterator<Item = (&'a str, IndexRef)>,
+        E::IntoIter: ExactSizeIterator,
+    {
+        let exports = exports.into_iter();
+
+        self.bytes.push(INSTANCE_KIND_EXPORTS);
+
+        self.bytes
+            .extend(encoders::u32(u32::try_from(exports.len()).unwrap()));
+        for (name, index) in exports {
+            self.bytes.extend(encoders::str(name));
+            index.encode(&mut self.bytes);
+        }
+
+        self
+    }
+}
+
+impl ComponentSection for InstanceSection {
+    fn id(&self) -> u8 {
+        SectionId::Instance.into()
+    }
+
+    fn encode<S>(&self, sink: &mut S)
+    where
+        S: Extend<u8>,
+    {
+        let num_added = encoders::u32(self.num_added);
+        let n = num_added.len();
+        sink.extend(
+            encoders::u32(u32::try_from(n + self.bytes.len()).unwrap())
+                .chain(num_added)
+                .chain(self.bytes.iter().copied()),
+        );
+    }
+}

--- a/crates/wasm-encoder/src/component/modules.rs
+++ b/crates/wasm-encoder/src/component/modules.rs
@@ -1,0 +1,80 @@
+use super::{AdapterModule, ComponentSection, SectionId};
+use crate::{encoders, Module};
+
+/// An encoder for the component module section.
+///
+/// # Example
+///
+/// ```rust
+/// use wasm_encoder::{Module, component::{Component, ModuleSection}};
+///
+/// let mut modules = ModuleSection::new();
+/// modules.module(&Module::new());
+/// modules.module(&Module::new());
+///
+/// let mut component = Component::new();
+/// component.section(&modules);
+///
+/// let bytes = component.finish();
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct ModuleSection {
+    bytes: Vec<u8>,
+    num_added: u32,
+}
+
+impl ModuleSection {
+    /// Create a new component module section encoder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The number of modules in the section.
+    pub fn len(&self) -> u32 {
+        self.num_added
+    }
+
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.num_added == 0
+    }
+
+    /// Writes a module into this module section.
+    pub fn module(&mut self, module: &Module) -> &mut Self {
+        self.bytes.extend(
+            encoders::u32(u32::try_from(module.bytes.len()).unwrap())
+                .chain(module.bytes.iter().copied()),
+        );
+        self.num_added += 1;
+        self
+    }
+
+    /// Writes an adapter module into this module section.
+    pub fn adapter_module(&mut self, module: &AdapterModule) -> &mut Self {
+        self.bytes.extend(
+            encoders::u32(u32::try_from(module.bytes.len()).unwrap())
+                .chain(module.bytes.iter().copied()),
+        );
+        self.num_added += 1;
+        self
+    }
+}
+
+impl ComponentSection for ModuleSection {
+    fn id(&self) -> u8 {
+        SectionId::Module.into()
+    }
+
+    fn encode<S>(&self, sink: &mut S)
+    where
+        S: Extend<u8>,
+    {
+        let num_added = encoders::u32(self.num_added);
+        let n = num_added.len();
+        sink.extend(
+            encoders::u32(u32::try_from(n + self.bytes.len()).unwrap())
+                .chain(num_added)
+                .chain(self.bytes.iter().copied()),
+        );
+    }
+}

--- a/crates/wasm-encoder/src/component/types.rs
+++ b/crates/wasm-encoder/src/component/types.rs
@@ -1,0 +1,574 @@
+use super::{ComponentSection, SectionId, TypeRef};
+use crate::{encoders, ValType};
+
+const TYPE_INSTANCE: u8 = 0x7f;
+const TYPE_MODULE: u8 = 0x7e;
+const TYPE_FUNCTION: u8 = 0x7d;
+const TYPE_ADAPTER_FUNCTION: u8 = 0x7c;
+
+const COMPOUND_INTERFACE_TYPE_LIST: u8 = 0x7b;
+const COMPOUND_INTERFACE_TYPE_RECORD: u8 = 0x7a;
+const COMPOUND_INTERFACE_TYPE_VARIANT: u8 = 0x79;
+const COMPOUND_INTERFACE_TYPE_TUPLE: u8 = 0x78;
+const COMPOUND_INTERFACE_TYPE_FLAGS: u8 = 0x77;
+const COMPOUND_INTERFACE_TYPE_ENUM: u8 = 0x76;
+const COMPOUND_INTERFACE_TYPE_UNION: u8 = 0x75;
+const COMPOUND_INTERFACE_TYPE_OPTIONAL: u8 = 0x74;
+const COMPOUND_INTERFACE_TYPE_EXPECTED: u8 = 0x73;
+const COMPOUND_INTERFACE_TYPE_NAMED: u8 = 0x72;
+
+const EXPECTED_OK: u8 = 0x00;
+const EXPECTED_OK_ERR: u8 = 0x01;
+
+const INTERFACE_TYPE_BOOL: u8 = 0x71;
+const INTERFACE_TYPE_S8: u8 = 0x70;
+const INTERFACE_TYPE_U8: u8 = 0x6f;
+const INTERFACE_TYPE_S16: u8 = 0x6e;
+const INTERFACE_TYPE_U16: u8 = 0x6d;
+const INTERFACE_TYPE_S32: u8 = 0x6c;
+const INTERFACE_TYPE_U32: u8 = 0x6b;
+const INTERFACE_TYPE_S64: u8 = 0x6a;
+const INTERFACE_TYPE_U64: u8 = 0x69;
+const INTERFACE_TYPE_F32: u8 = 0x68;
+const INTERFACE_TYPE_F64: u8 = 0x67;
+const INTERFACE_TYPE_CHAR: u8 = 0x66;
+const INTERFACE_TYPE_STRING: u8 = 0x65;
+const INTERFACE_TYPE_UNIT: u8 = 0x64;
+
+const INSTANCE_DEFINITION_KIND: u8 = 0x00;
+const MODULE_DEFINITION_KIND: u8 = 0x01;
+const FUNCTION_DEFINITION_KIND: u8 = 0x02;
+const TABLE_DEFINITION_KIND: u8 = 0x03;
+const MEMORY_DEFINITION_KIND: u8 = 0x04;
+const GLOBAL_DEFINITION_KIND: u8 = 0x05;
+
+const ALIAS_TYPE_INSTANCE_EXPORT: u8 = 0x00;
+const ALIAS_TYPE_OUTER: u8 = 0x01;
+
+const OUTER_ALIAS_MODULE: u8 = 0x01;
+const OUTER_ALIAS_TYPE: u8 = 0x06;
+
+const INSTANCE_TYPEDEF_TYPE: u8 = 0x01;
+const INSTANCE_TYPEDEF_ALIAS: u8 = 0x05;
+const INSTANCE_TYPEDEF_EXPORT: u8 = 0x06;
+
+const MODULE_TYPEDEF_TYPE: u8 = 0x01;
+const MODULE_TYPEDEF_ALIAS: u8 = 0x05;
+const MODULE_TYPEDEF_EXPORT: u8 = 0x06;
+const MODULE_TYPEDEF_IMPORT: u8 = 0x02;
+
+/// Represents a definition kind.
+///
+/// This is used in aliases to specify the kind of the definition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DefinitionKind {
+    /// The definition is an instance.
+    Instance,
+    /// The definition is a module.
+    Module,
+    /// The definition is a function.
+    Function,
+    /// The definition is a table.
+    Table,
+    /// The definition is a memory.
+    Memory,
+    /// The definition is a global.
+    Global,
+}
+
+impl DefinitionKind {
+    pub(crate) fn encode(&self, bytes: &mut Vec<u8>) {
+        match self {
+            Self::Instance => bytes.push(INSTANCE_DEFINITION_KIND),
+            Self::Module => bytes.push(MODULE_DEFINITION_KIND),
+            Self::Function => bytes.push(FUNCTION_DEFINITION_KIND),
+            Self::Table => bytes.push(TABLE_DEFINITION_KIND),
+            Self::Memory => bytes.push(MEMORY_DEFINITION_KIND),
+            Self::Global => bytes.push(GLOBAL_DEFINITION_KIND),
+        }
+    }
+}
+
+/// Represents an index for an outer alias.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OuterAliasIndex {
+    /// The index is a module index.
+    Module(u32),
+    /// The index is a type index.
+    Type(u32),
+}
+
+impl OuterAliasIndex {
+    pub(crate) fn encode(&self, bytes: &mut Vec<u8>) {
+        match self {
+            Self::Module(index) => {
+                bytes.extend(encoders::u32(*index));
+                bytes.push(OUTER_ALIAS_MODULE);
+            }
+            Self::Type(index) => {
+                bytes.extend(encoders::u32(*index));
+                bytes.push(OUTER_ALIAS_TYPE);
+            }
+        }
+    }
+}
+
+/// Represents an alias.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Alias<'a> {
+    /// The alias is to an instance export.
+    InstanceExport {
+        /// The index of the instance being aliased.
+        instance: u32,
+        /// The name of the export.
+        name: &'a str,
+        /// The kind of the definition being aliased.
+        kind: DefinitionKind,
+    },
+    /// The alias is to an index in an outer module.
+    Outer {
+        /// The count of the outer module.
+        ///
+        /// The count starts at 0 which denotes the current module.
+        count: u32,
+        /// The index from the outer module's index space being aliased.
+        index: OuterAliasIndex,
+    },
+}
+
+impl Alias<'_> {
+    pub(crate) fn encode(&self, bytes: &mut Vec<u8>) {
+        match self {
+            Self::InstanceExport {
+                instance,
+                name,
+                kind,
+            } => {
+                bytes.push(ALIAS_TYPE_INSTANCE_EXPORT);
+                bytes.extend(encoders::u32(*instance));
+                bytes.extend(encoders::str(name));
+                kind.encode(bytes);
+            }
+            Self::Outer { count, index } => {
+                bytes.push(ALIAS_TYPE_OUTER);
+                bytes.extend(encoders::u32(*count));
+                index.encode(bytes);
+            }
+        }
+    }
+}
+
+/// Represents a named interface type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NamedInterfaceType<'a> {
+    name: &'a str,
+    ty: InterfaceType,
+}
+
+impl NamedInterfaceType<'_> {
+    pub(crate) fn encode(&self, bytes: &mut Vec<u8>) {
+        bytes.extend(encoders::str(self.name));
+        self.ty.encode(bytes);
+    }
+}
+
+/// Represents results of an adapter function.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdapterFunctionResults<'a> {
+    /// The adapter function returns zero results.
+    None,
+    /// The adapter function returns one unnamed result.
+    Single(InterfaceType),
+    /// The function returns multiple named results.
+    ///
+    /// The length of the slice must be greater than one.
+    Multiple(&'a [NamedInterfaceType<'a>]),
+}
+
+impl AdapterFunctionResults<'_> {
+    pub(crate) fn encode(&self, bytes: &mut Vec<u8>) {
+        match self {
+            Self::None => bytes.push(0x00),
+            Self::Single(ty) => {
+                bytes.push(0x01);
+                ty.encode(bytes);
+            }
+            Self::Multiple(types) => {
+                assert!(types.len() > 1);
+                bytes.extend(encoders::u32(types.len() as u32));
+                for ty in *types {
+                    ty.encode(bytes);
+                }
+            }
+        }
+    }
+}
+
+/// Represents a type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Type<'a> {
+    /// The type is an instance.
+    Instance(&'a [InstanceTypeDef<'a>]),
+    /// The type is a module.
+    Module(&'a [ModuleTypeDef<'a>]),
+    /// The type is a core wasm function.
+    Function {
+        /// The parameters of the function.
+        params: &'a [ValType],
+        /// The results of the function.
+        results: &'a [ValType],
+    },
+    /// The type is an adapter function.
+    AdapterFunction {
+        /// The parameters of the function.
+        params: &'a [NamedInterfaceType<'a>],
+        /// The results of the function.
+        results: AdapterFunctionResults<'a>,
+    },
+    /// The type is a compound interface type.
+    CompoundInterfaceType(CompoundInterfaceType<'a>),
+}
+
+impl Type<'_> {
+    pub(crate) fn encode(&self, bytes: &mut Vec<u8>) {
+        match self {
+            Self::Instance(defs) => {
+                bytes.push(TYPE_INSTANCE);
+                bytes.extend(encoders::u32(u32::try_from(defs.len()).unwrap()));
+                for def in *defs {
+                    def.encode(bytes);
+                }
+            }
+            Self::Module(defs) => {
+                bytes.push(TYPE_MODULE);
+                bytes.extend(encoders::u32(u32::try_from(defs.len()).unwrap()));
+                for def in *defs {
+                    def.encode(bytes);
+                }
+            }
+            Self::Function { params, results } => {
+                bytes.push(TYPE_FUNCTION);
+
+                bytes.extend(encoders::u32(u32::try_from(params.len()).unwrap()));
+                bytes.extend(params.iter().map(|ty| u8::from(*ty)));
+
+                bytes.extend(encoders::u32(u32::try_from(results.len()).unwrap()));
+                bytes.extend(results.iter().map(|ty| u8::from(*ty)));
+            }
+            Self::AdapterFunction { params, results } => {
+                bytes.push(TYPE_ADAPTER_FUNCTION);
+
+                bytes.extend(encoders::u32(u32::try_from(params.len()).unwrap()));
+                for param in *params {
+                    param.encode(bytes);
+                }
+
+                results.encode(bytes);
+            }
+            Self::CompoundInterfaceType(ty) => {
+                ty.encode(bytes);
+            }
+        }
+    }
+}
+
+/// Represents an instance type definition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstanceTypeDef<'a> {
+    /// The definition is for a type.
+    Type(Type<'a>),
+    /// The definition is for an alias.
+    Alias(Alias<'a>),
+    /// The definition is for an export.
+    Export(&'a str, TypeRef),
+}
+
+impl InstanceTypeDef<'_> {
+    pub(crate) fn encode(&self, bytes: &mut Vec<u8>) {
+        match self {
+            Self::Type(ty) => {
+                bytes.push(INSTANCE_TYPEDEF_TYPE);
+                ty.encode(bytes)
+            }
+            Self::Alias(alias) => {
+                bytes.push(INSTANCE_TYPEDEF_ALIAS);
+                alias.encode(bytes);
+            }
+            Self::Export(name, ty) => {
+                bytes.push(INSTANCE_TYPEDEF_EXPORT);
+                bytes.extend(encoders::str(name));
+                ty.encode(bytes);
+            }
+        }
+    }
+}
+
+/// Represents a module type definition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModuleTypeDef<'a> {
+    /// The definition is for a type.
+    Type(Type<'a>),
+    /// The definition is for an alias.
+    Alias(Alias<'a>),
+    /// The definition is for an export.
+    Export(&'a str, TypeRef),
+    /// The definition is for an import.
+    Import(&'a str, TypeRef),
+}
+
+impl ModuleTypeDef<'_> {
+    pub(crate) fn encode(&self, bytes: &mut Vec<u8>) {
+        match self {
+            Self::Type(ty) => {
+                bytes.push(MODULE_TYPEDEF_TYPE);
+                ty.encode(bytes)
+            }
+            Self::Alias(alias) => {
+                bytes.push(MODULE_TYPEDEF_ALIAS);
+                alias.encode(bytes);
+            }
+            Self::Export(name, ty) => {
+                bytes.push(MODULE_TYPEDEF_EXPORT);
+                bytes.extend(encoders::str(name));
+                ty.encode(bytes);
+            }
+            Self::Import(name, ty) => {
+                bytes.push(MODULE_TYPEDEF_IMPORT);
+                bytes.extend(encoders::str(name));
+                ty.encode(bytes);
+            }
+        }
+    }
+}
+
+/// Represents an interface type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InterfaceType {
+    /// The type is a boolean.
+    Bool,
+    /// The type is a signed 8-bit integer.
+    S8,
+    /// The type is an unsigned 8-bit integer.
+    U8,
+    /// The type is a signed 16-bit integer.
+    S16,
+    /// The type is an unsigned 16-bit integer.
+    U16,
+    /// The type is a signed 32-bit integer.
+    S32,
+    /// The type is an unsigned 32-bit integer.
+    U32,
+    /// The type is a signed 64-bit integer.
+    S64,
+    /// The type is an unsigned 64-bit integer.
+    U64,
+    /// The type is a 32-bit floating point number.
+    F32,
+    /// The type is a 64-bit floating point number.
+    F64,
+    /// The type is a Unicode character.
+    Char,
+    /// The type is a string.
+    String,
+    /// The type is the unit type.
+    Unit,
+    /// The type is a compound interface type.
+    ///
+    /// The value is a type index to a compound type.
+    Compound(u32),
+}
+
+impl InterfaceType {
+    pub(crate) fn encode(&self, bytes: &mut Vec<u8>) {
+        match self {
+            Self::Bool => bytes.push(INTERFACE_TYPE_BOOL),
+            Self::S8 => bytes.push(INTERFACE_TYPE_S8),
+            Self::U8 => bytes.push(INTERFACE_TYPE_U8),
+            Self::S16 => bytes.push(INTERFACE_TYPE_S16),
+            Self::U16 => bytes.push(INTERFACE_TYPE_U16),
+            Self::S32 => bytes.push(INTERFACE_TYPE_S32),
+            Self::U32 => bytes.push(INTERFACE_TYPE_U32),
+            Self::S64 => bytes.push(INTERFACE_TYPE_S64),
+            Self::U64 => bytes.push(INTERFACE_TYPE_U64),
+            Self::F32 => bytes.push(INTERFACE_TYPE_F32),
+            Self::F64 => bytes.push(INTERFACE_TYPE_F64),
+            Self::Char => bytes.push(INTERFACE_TYPE_CHAR),
+            Self::String => bytes.push(INTERFACE_TYPE_STRING),
+            Self::Unit => bytes.push(INTERFACE_TYPE_UNIT),
+            Self::Compound(index) => bytes.extend(encoders::u32(*index)),
+        }
+    }
+}
+
+/// Represents a compound interface type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompoundInterfaceType<'a> {
+    /// A list interface type.
+    List(InterfaceType),
+    /// A record interface type.
+    Record(&'a [(&'a str, InterfaceType)]),
+    /// A variant interface type.
+    Variant(&'a [(&'a str, InterfaceType)]),
+    /// A tuple interface type.
+    Tuple(&'a [InterfaceType]),
+    /// A flags interface type.
+    Flags(&'a [&'a str]),
+    /// An enumeration interface type.
+    Enum(&'a [&'a str]),
+    /// A union interface type.
+    Union(&'a [InterfaceType]),
+    /// An optional interface type.
+    Optional(InterfaceType),
+    /// An expected interface type.
+    ///
+    /// If `error` is `None`, then the error type is unit.
+    Expected {
+        /// The type representing success.
+        ok: InterfaceType,
+        /// The type representing failure.
+        error: Option<InterfaceType>,
+    },
+    /// A named interface type.
+    ///
+    /// Named types are either part of a type's declaration (i.e. a record)
+    /// or may be a type alias.
+    Named(NamedInterfaceType<'a>),
+}
+
+impl CompoundInterfaceType<'_> {
+    pub(crate) fn encode(&self, bytes: &mut Vec<u8>) {
+        match self {
+            Self::List(ty) => {
+                bytes.push(COMPOUND_INTERFACE_TYPE_LIST);
+                ty.encode(bytes);
+            }
+            Self::Record(fields) => {
+                bytes.push(COMPOUND_INTERFACE_TYPE_RECORD);
+                bytes.extend(encoders::u32(u32::try_from(fields.len()).unwrap()));
+                for (name, ty) in *fields {
+                    bytes.extend(encoders::str(name));
+                    ty.encode(bytes);
+                }
+            }
+            Self::Variant(cases) => {
+                bytes.push(COMPOUND_INTERFACE_TYPE_VARIANT);
+                bytes.extend(encoders::u32(u32::try_from(cases.len()).unwrap()));
+                for (name, ty) in *cases {
+                    bytes.extend(encoders::str(name));
+                    ty.encode(bytes);
+                }
+            }
+            Self::Tuple(types) => {
+                bytes.push(COMPOUND_INTERFACE_TYPE_TUPLE);
+                bytes.extend(encoders::u32(u32::try_from(types.len()).unwrap()));
+                for ty in *types {
+                    ty.encode(bytes);
+                }
+            }
+            Self::Flags(names) => {
+                bytes.push(COMPOUND_INTERFACE_TYPE_FLAGS);
+                bytes.extend(encoders::u32(u32::try_from(names.len()).unwrap()));
+                for name in *names {
+                    bytes.extend(encoders::str(name));
+                }
+            }
+            Self::Enum(tags) => {
+                bytes.push(COMPOUND_INTERFACE_TYPE_ENUM);
+                bytes.extend(encoders::u32(u32::try_from(tags.len()).unwrap()));
+                for tag in *tags {
+                    bytes.extend(encoders::str(tag));
+                }
+            }
+            Self::Union(types) => {
+                bytes.push(COMPOUND_INTERFACE_TYPE_UNION);
+                bytes.extend(encoders::u32(u32::try_from(types.len()).unwrap()));
+                for ty in *types {
+                    ty.encode(bytes);
+                }
+            }
+            Self::Optional(ty) => {
+                bytes.push(COMPOUND_INTERFACE_TYPE_OPTIONAL);
+                ty.encode(bytes);
+            }
+            Self::Expected { ok, error } => {
+                bytes.push(COMPOUND_INTERFACE_TYPE_EXPECTED);
+                if let Some(error) = error {
+                    bytes.push(EXPECTED_OK_ERR);
+                    ok.encode(bytes);
+                    error.encode(bytes);
+                } else {
+                    bytes.push(EXPECTED_OK);
+                    ok.encode(bytes);
+                }
+            }
+            Self::Named(named) => {
+                bytes.push(COMPOUND_INTERFACE_TYPE_NAMED);
+                named.encode(bytes);
+            }
+        }
+    }
+}
+
+/// An encoder for the component type section.
+///
+/// # Example
+///
+/// ```rust
+/// use wasm_encoder::component::{Component, TypeSection, Type};
+///
+/// let mut types = TypeSection::new();
+/// types.ty(Type::Function { params: &[], results: &[] });
+///
+/// let mut component = Component::new();
+/// component.section(&types);
+///
+/// let bytes = component.finish();
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct TypeSection {
+    bytes: Vec<u8>,
+    num_added: u32,
+}
+
+impl TypeSection {
+    /// Create a new component type section encoder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The number of types in the section.
+    pub fn len(&self) -> u32 {
+        self.num_added
+    }
+
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.num_added == 0
+    }
+
+    /// Define a type in the type section.
+    pub fn ty(&mut self, ty: Type) -> &mut Self {
+        ty.encode(&mut self.bytes);
+        self.num_added += 1;
+        self
+    }
+}
+
+impl ComponentSection for TypeSection {
+    fn id(&self) -> u8 {
+        SectionId::Type.into()
+    }
+
+    fn encode<S>(&self, sink: &mut S)
+    where
+        S: Extend<u8>,
+    {
+        let num_added = encoders::u32(self.num_added);
+        let n = num_added.len();
+        sink.extend(
+            encoders::u32(u32::try_from(n + self.bytes.len()).unwrap())
+                .chain(num_added)
+                .chain(self.bytes.iter().copied()),
+        );
+    }
+}

--- a/crates/wasm-encoder/src/component/types.rs
+++ b/crates/wasm-encoder/src/component/types.rs
@@ -30,7 +30,6 @@ const INTERFACE_TYPE_F32: u8 = 0x68;
 const INTERFACE_TYPE_F64: u8 = 0x67;
 const INTERFACE_TYPE_CHAR: u8 = 0x66;
 const INTERFACE_TYPE_STRING: u8 = 0x65;
-const INTERFACE_TYPE_UNIT: u8 = 0x64;
 
 const ALIAS_TYPE_INSTANCE_EXPORT: u8 = 0x00;
 const ALIAS_TYPE_OUTER: u8 = 0x01;
@@ -347,8 +346,6 @@ pub enum InterfaceType {
     Char,
     /// The type is a string.
     String,
-    /// The type is the unit type.
-    Unit,
     /// The type is a compound interface type.
     ///
     /// The value is a type index to a compound type.
@@ -371,7 +368,6 @@ impl InterfaceType {
             Self::F64 => bytes.push(INTERFACE_TYPE_F64),
             Self::Char => bytes.push(INTERFACE_TYPE_CHAR),
             Self::String => bytes.push(INTERFACE_TYPE_STRING),
-            Self::Unit => bytes.push(INTERFACE_TYPE_UNIT),
             Self::Compound(index) => bytes.extend(encoders::u32(*index)),
         }
     }

--- a/crates/wasm-encoder/src/data.rs
+++ b/crates/wasm-encoder/src/data.rs
@@ -63,8 +63,8 @@ pub enum DataSegmentMode<'a> {
 
 impl DataSection {
     /// Create a new data section encoder.
-    pub fn new() -> DataSection {
-        DataSection::default()
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// How many segments have been defined inside this section so far?

--- a/crates/wasm-encoder/src/data.rs
+++ b/crates/wasm-encoder/src/data.rs
@@ -72,6 +72,11 @@ impl DataSection {
         self.num_added
     }
 
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.num_added == 0
+    }
+
     /// Define an active data segment.
     pub fn segment<D>(&mut self, segment: DataSegment<D>) -> &mut Self
     where
@@ -111,12 +116,7 @@ impl DataSection {
     }
 
     /// Define an active data segment.
-    pub fn active<'a, D>(
-        &mut self,
-        memory_index: u32,
-        offset: &Instruction<'a>,
-        data: D,
-    ) -> &mut Self
+    pub fn active<D>(&mut self, memory_index: u32, offset: &Instruction, data: D) -> &mut Self
     where
         D: IntoIterator<Item = u8>,
         D::IntoIter: ExactSizeIterator,
@@ -133,7 +133,7 @@ impl DataSection {
     /// Define a passive data segment.
     ///
     /// Passive data segments are part of the bulk memory proposal.
-    pub fn passive<'a, D>(&mut self, data: D) -> &mut Self
+    pub fn passive<D>(&mut self, data: D) -> &mut Self
     where
         D: IntoIterator<Item = u8>,
         D::IntoIter: ExactSizeIterator,

--- a/crates/wasm-encoder/src/elements.rs
+++ b/crates/wasm-encoder/src/elements.rs
@@ -102,6 +102,11 @@ impl ElementSection {
         self.num_added
     }
 
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.num_added == 0
+    }
+
     /// Define an element segment.
     pub fn segment<'a>(&mut self, segment: ElementSegment<'a>) -> &mut Self {
         let expr_bit = match segment.elements {
@@ -113,7 +118,7 @@ impl ElementSection {
                 table: None,
                 offset,
             } => {
-                self.bytes.extend(encoders::u32(0x00 | expr_bit));
+                self.bytes.extend(encoders::u32(/* 0x00 | */ expr_bit));
                 offset.encode(&mut self.bytes);
                 Instruction::End.encode(&mut self.bytes);
             }

--- a/crates/wasm-encoder/src/elements.rs
+++ b/crates/wasm-encoder/src/elements.rs
@@ -118,7 +118,7 @@ impl ElementSection {
                 table: None,
                 offset,
             } => {
-                self.bytes.extend(encoders::u32(/* 0x00 | */ expr_bit));
+                self.bytes.extend(encoders::u32(0x00 | expr_bit));
                 offset.encode(&mut self.bytes);
                 Instruction::End.encode(&mut self.bytes);
             }

--- a/crates/wasm-encoder/src/elements.rs
+++ b/crates/wasm-encoder/src/elements.rs
@@ -93,8 +93,8 @@ pub struct ElementSegment<'a> {
 
 impl ElementSection {
     /// Create a new element section encoder.
-    pub fn new() -> ElementSection {
-        ElementSection::default()
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// How many segments have been defined inside this section so far?

--- a/crates/wasm-encoder/src/encoders.rs
+++ b/crates/wasm-encoder/src/encoders.rs
@@ -15,7 +15,7 @@ pub fn u32(n: u32) -> impl ExactSizeIterator<Item = u8> {
 /// Encode a `u64` as a ULEB128.
 pub fn u64(n: u64) -> impl ExactSizeIterator<Item = u8> {
     let mut buf = [0; 10];
-    let n = leb128::write::unsigned(&mut &mut buf[..], n.into()).unwrap();
+    let n = leb128::write::unsigned(&mut &mut buf[..], n).unwrap();
     <_>::into_iter(buf).take(n)
 }
 
@@ -65,6 +65,6 @@ pub fn s64(x: i64) -> impl ExactSizeIterator<Item = u8> {
 }
 
 /// Encode a length-prefixed UTF-8 string.
-pub fn str<'a>(s: &'a str) -> impl Iterator<Item = u8> + 'a {
+pub fn str(s: &'_ str) -> impl Iterator<Item = u8> + '_ {
     u32(u32::try_from(s.len()).unwrap()).chain(s.as_bytes().iter().copied())
 }

--- a/crates/wasm-encoder/src/exports.rs
+++ b/crates/wasm-encoder/src/exports.rs
@@ -34,8 +34,8 @@ pub struct ExportSection {
 
 impl ExportSection {
     /// Create a new export section encoder.
-    pub fn new() -> ExportSection {
-        ExportSection::default()
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// How many exports have been defined inside this section so far?

--- a/crates/wasm-encoder/src/exports.rs
+++ b/crates/wasm-encoder/src/exports.rs
@@ -43,6 +43,11 @@ impl ExportSection {
         self.num_added
     }
 
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.num_added == 0
+    }
+
     /// Define an export.
     pub fn export(&mut self, name: &str, export: Export) -> &mut Self {
         self.bytes.extend(encoders::str(name));

--- a/crates/wasm-encoder/src/functions.rs
+++ b/crates/wasm-encoder/src/functions.rs
@@ -28,8 +28,8 @@ pub struct FunctionSection {
 
 impl FunctionSection {
     /// Construct a new function section encoder.
-    pub fn new() -> FunctionSection {
-        FunctionSection::default()
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// How many functions have been defined inside this section so far?

--- a/crates/wasm-encoder/src/functions.rs
+++ b/crates/wasm-encoder/src/functions.rs
@@ -37,6 +37,11 @@ impl FunctionSection {
         self.num_added
     }
 
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.num_added == 0
+    }
+
     /// Define a function that uses the given type.
     pub fn function(&mut self, type_index: u32) -> &mut Self {
         self.bytes.extend(encoders::u32(type_index));

--- a/crates/wasm-encoder/src/globals.rs
+++ b/crates/wasm-encoder/src/globals.rs
@@ -29,8 +29,8 @@ pub struct GlobalSection {
 
 impl GlobalSection {
     /// Create a new global section encoder.
-    pub fn new() -> GlobalSection {
-        GlobalSection::default()
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// How many globals have been defined inside this section so far?

--- a/crates/wasm-encoder/src/globals.rs
+++ b/crates/wasm-encoder/src/globals.rs
@@ -38,6 +38,11 @@ impl GlobalSection {
         self.num_added
     }
 
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.num_added == 0
+    }
+
     /// Define a global.
     pub fn global(&mut self, global_type: GlobalType, init_expr: &Instruction<'_>) -> &mut Self {
         global_type.encode(&mut self.bytes);

--- a/crates/wasm-encoder/src/imports.rs
+++ b/crates/wasm-encoder/src/imports.rs
@@ -41,6 +41,11 @@ impl ImportSection {
         self.num_added
     }
 
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.num_added == 0
+    }
+
     /// Define an import.
     pub fn import(
         &mut self,

--- a/crates/wasm-encoder/src/imports.rs
+++ b/crates/wasm-encoder/src/imports.rs
@@ -32,8 +32,8 @@ pub struct ImportSection {
 
 impl ImportSection {
     /// Construct a new import section encoder.
-    pub fn new() -> ImportSection {
-        ImportSection::default()
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// How many imports have been defined inside this section so far?

--- a/crates/wasm-encoder/src/instances.rs
+++ b/crates/wasm-encoder/src/instances.rs
@@ -32,11 +32,8 @@ pub struct InstanceSection {
 
 impl InstanceSection {
     /// Construct a new instance section encoder.
-    pub fn new() -> InstanceSection {
-        InstanceSection {
-            bytes: vec![],
-            num_added: 0,
-        }
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// How many instances have been defined inside this section so far?

--- a/crates/wasm-encoder/src/instances.rs
+++ b/crates/wasm-encoder/src/instances.rs
@@ -24,7 +24,7 @@ use super::*;
 ///
 /// let wasm_bytes = module.finish();
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct InstanceSection {
     bytes: Vec<u8>,
     num_added: u32,
@@ -42,6 +42,11 @@ impl InstanceSection {
     /// How many instances have been defined inside this section so far?
     pub fn len(&self) -> u32 {
         self.num_added
+    }
+
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.num_added == 0
     }
 
     /// Define an instantiation of the given module with the given items as

--- a/crates/wasm-encoder/src/lib.rs
+++ b/crates/wasm-encoder/src/lib.rs
@@ -201,6 +201,12 @@ impl Module {
     }
 }
 
+impl Default for Module {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Known section IDs.
 ///
 /// Useful for implementing the `Section` trait, or for setting

--- a/crates/wasm-encoder/src/lib.rs
+++ b/crates/wasm-encoder/src/lib.rs
@@ -108,11 +108,8 @@ pub use tables::*;
 pub use tags::*;
 pub use types::*;
 
-//#[cfg(feature = "component-model")]
 pub mod adapter;
-//#[cfg(feature = "component-model")]
 pub mod component;
-
 pub mod encoders;
 
 use std::convert::TryFrom;

--- a/crates/wasm-encoder/src/lib.rs
+++ b/crates/wasm-encoder/src/lib.rs
@@ -108,6 +108,9 @@ pub use tables::*;
 pub use tags::*;
 pub use types::*;
 
+#[cfg(feature = "component-model")]
+pub mod component;
+
 pub mod encoders;
 
 use std::convert::TryFrom;

--- a/crates/wasm-encoder/src/lib.rs
+++ b/crates/wasm-encoder/src/lib.rs
@@ -108,7 +108,9 @@ pub use tables::*;
 pub use tags::*;
 pub use types::*;
 
-#[cfg(feature = "component-model")]
+//#[cfg(feature = "component-model")]
+pub mod adapter;
+//#[cfg(feature = "component-model")]
 pub mod component;
 
 pub mod encoders;

--- a/crates/wasm-encoder/src/linking.rs
+++ b/crates/wasm-encoder/src/linking.rs
@@ -44,7 +44,7 @@ pub struct LinkingSection {
 impl LinkingSection {
     /// Construct a new encoder for the linking custom section.
     pub fn new() -> Self {
-        LinkingSection { bytes: vec![] }
+        Self::default()
     }
 
     // TODO: `fn segment_info` for the `WASM_SEGMENT_INFO` linking subsection.

--- a/crates/wasm-encoder/src/linking.rs
+++ b/crates/wasm-encoder/src/linking.rs
@@ -36,7 +36,7 @@ use std::convert::TryInto;
 /// module.section(&linking);
 /// let wasm_bytes = module.finish();
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct LinkingSection {
     bytes: Vec<u8>,
 }
@@ -97,7 +97,7 @@ const WASM_SYMBOL_TABLE: u8 = 8;
 /// A subsection of the [linking custom section][crate::LinkingSection] that
 /// provides extra information about the symbols present in this Wasm object
 /// file.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct SymbolTable {
     bytes: Vec<u8>,
     num_added: u32,

--- a/crates/wasm-encoder/src/memories.rs
+++ b/crates/wasm-encoder/src/memories.rs
@@ -27,8 +27,8 @@ pub struct MemorySection {
 
 impl MemorySection {
     /// Create a new memory section encoder.
-    pub fn new() -> MemorySection {
-        MemorySection::default()
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// How many memories have been defined inside this section so far?

--- a/crates/wasm-encoder/src/memories.rs
+++ b/crates/wasm-encoder/src/memories.rs
@@ -36,6 +36,11 @@ impl MemorySection {
         self.num_added
     }
 
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.num_added == 0
+    }
+
     /// Define a memory.
     pub fn memory(&mut self, memory_type: MemoryType) -> &mut Self {
         memory_type.encode(&mut self.bytes);
@@ -64,7 +69,7 @@ impl Section for MemorySection {
 }
 
 /// A memory's type.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct MemoryType {
     /// Minimum size, in pages, of this memory
     pub minimum: u64,

--- a/crates/wasm-encoder/src/modules.rs
+++ b/crates/wasm-encoder/src/modules.rs
@@ -21,7 +21,7 @@ use super::*;
 ///
 /// let wasm_bytes = module.finish();
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct ModuleSection {
     bytes: Vec<u8>,
     num_added: u32,
@@ -39,6 +39,11 @@ impl ModuleSection {
     /// How many modules have been defined inside this section so far?
     pub fn len(&self) -> u32 {
         self.num_added
+    }
+
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.num_added == 0
     }
 
     /// Writes a module into this module code section.

--- a/crates/wasm-encoder/src/modules.rs
+++ b/crates/wasm-encoder/src/modules.rs
@@ -29,11 +29,8 @@ pub struct ModuleSection {
 
 impl ModuleSection {
     /// Create a new code section encoder.
-    pub fn new() -> ModuleSection {
-        ModuleSection {
-            bytes: vec![],
-            num_added: 0,
-        }
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// How many modules have been defined inside this section so far?

--- a/crates/wasm-encoder/src/names.rs
+++ b/crates/wasm-encoder/src/names.rs
@@ -46,8 +46,8 @@ enum Subsection {
 
 impl NameSection {
     /// Creates a new blank `name` custom section.
-    pub fn new() -> NameSection {
-        NameSection { bytes: vec![] }
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Appends a module name subsection to this section.

--- a/crates/wasm-encoder/src/names.rs
+++ b/crates/wasm-encoder/src/names.rs
@@ -21,7 +21,7 @@ use super::*;
 ///
 /// let wasm_bytes = module.finish();
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct NameSection {
     bytes: Vec<u8>,
 }
@@ -178,7 +178,7 @@ impl Section for NameSection {
 ///
 /// This is used in conjunction with [`NameSection::functions`] and simlar
 /// methods.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct NameMap {
     bytes: Vec<u8>,
     count: u32,
@@ -221,7 +221,7 @@ impl NameMap {
 /// [`NameMap`] which has one level of indirection.
 ///
 /// This naming map is used with [`NameSection::locals`], for example.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct IndirectNameMap {
     bytes: Vec<u8>,
     count: u32,

--- a/crates/wasm-encoder/src/tables.rs
+++ b/crates/wasm-encoder/src/tables.rs
@@ -27,8 +27,8 @@ pub struct TableSection {
 
 impl TableSection {
     /// Construct a new table section encoder.
-    pub fn new() -> TableSection {
-        TableSection::default()
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// How many tables have been defined inside this section so far?

--- a/crates/wasm-encoder/src/tables.rs
+++ b/crates/wasm-encoder/src/tables.rs
@@ -36,6 +36,11 @@ impl TableSection {
         self.num_added
     }
 
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.num_added == 0
+    }
+
     /// Define a table.
     pub fn table(&mut self, table_type: TableType) -> &mut Self {
         table_type.encode(&mut self.bytes);
@@ -64,7 +69,7 @@ impl Section for TableSection {
 }
 
 /// A table's type.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TableType {
     /// The table's element type.
     pub element_type: ValType,

--- a/crates/wasm-encoder/src/tags.rs
+++ b/crates/wasm-encoder/src/tags.rs
@@ -36,6 +36,11 @@ impl TagSection {
         self.num_added
     }
 
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.num_added == 0
+    }
+
     /// Define a tag.
     pub fn tag(&mut self, tag_type: TagType) -> &mut Self {
         tag_type.encode(&mut self.bytes);

--- a/crates/wasm-encoder/src/tags.rs
+++ b/crates/wasm-encoder/src/tags.rs
@@ -27,8 +27,8 @@ pub struct TagSection {
 
 impl TagSection {
     /// Create a new tag section encoder.
-    pub fn new() -> TagSection {
-        TagSection::default()
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// How many tags have been defined inside this section so far?

--- a/crates/wasm-encoder/src/types.rs
+++ b/crates/wasm-encoder/src/types.rs
@@ -35,6 +35,11 @@ impl TypeSection {
         self.num_added
     }
 
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.num_added == 0
+    }
+
     /// Define a function type.
     pub fn function<P, R>(&mut self, params: P, results: R) -> &mut Self
     where
@@ -50,11 +55,11 @@ impl TypeSection {
 
         self.bytes
             .extend(encoders::u32(u32::try_from(params.len()).unwrap()));
-        self.bytes.extend(params.map(|ty| u8::from(ty)));
+        self.bytes.extend(params.map(u8::from));
 
         self.bytes
             .extend(encoders::u32(u32::try_from(results.len()).unwrap()));
-        self.bytes.extend(results.map(|ty| u8::from(ty)));
+        self.bytes.extend(results.map(u8::from));
 
         self.num_added += 1;
         self

--- a/crates/wasm-encoder/src/types.rs
+++ b/crates/wasm-encoder/src/types.rs
@@ -26,8 +26,8 @@ pub struct TypeSection {
 
 impl TypeSection {
     /// Create a new type section encoder.
-    pub fn new() -> TypeSection {
-        TypeSection::default()
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// How many types have been defined inside this section so far?


### PR DESCRIPTION
This PR implements encoders for adapter modules and components.

The encoders added here are in accordance with the (very much)
in-progress [wasm component model proposal](https://github.com/WebAssembly/interface-types/blob/component-rebase/design/proposals/interface-types/Binary.md).

It is expected that this will be updated when the component model proposal
changes.