### PR TITLE
Prepare the root `wasm-tools` crate for publication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,15 @@
 [package]
 name = "wasm-tools"
-version = "0.1.0"
+version = "1.0.0"
 authors = ["The Wasmtime Project Developers"]
 edition = "2018"
-publish = false
+description = "CLI tools for interoperating with WebAssembly files"
+license = "Apache-2.0 WITH LLVM-exception"
+documentation = "https://github.com/bytecodealliance/wasm-tools"
+categories = ["wasm"]
+keywords = ["webassembly", "wasm"]
+repository = "https://github.com/bytecodealliance/wasm-totols"
+readme = "README.md"
 
 [workspace]
 members = ['fuzz', 'crates/wasm-encoder', 'crates/fuzz-stats', 'crates/wasm-mutate-stats']

--- a/README.md
+++ b/README.md
@@ -8,12 +8,59 @@
   </p>
 </div>
 
+# Installation
+
+This project can be installed and compiled from source with this Cargo command:
+
+```
+$ cargo install wasm-tools
+```
+
+Installation can be confirmed with:
+
+```
+$ wasm-tools --version
+```
+
+Subcommands can be explored with:
+
+```
+$ wasm-tools help
+```
+
 # Tools included
 
-This project is intended to house a number of tools related to the low-level
-workings of WebAssembly. The top-level crate here ties everything together but
-isn't currently intended for general use. Instead you probably want to take a
-look at the sub-crates:
+The `wasm-tools` binary internally contains a number of subcommands for working
+with wasm modules. Many subcommands also come with Rust crates that can be use
+programmatically as well:
+
+| Tool | Crate | Description |
+|------|------|------------|
+| `wasm-tools validate` | [wasmparser] | Validate a WebAssembly file |
+| `wasm-tools parser` | [wat] and [wast] | Translate the WebAssembly text format to binary |
+| `wasm-tools print` | [wasmprinter] | Translate the WebAssembly binary format to text |
+| `wasm-tools smith` | [wasm-smith] | Generate a "random" valid WebAssembly module |
+| `wasm-tools mutate` | [wasm-mutate] | Mutate an input wasm file into a new valid wasm file |
+| `wasm-tools shrink` | [wasm-shrink] | Shrink a wasm file while preserving a predicate |
+| `wasm-tools dump` |   | Print debugging information about the binary format |
+| `wasm-tools objdump` |   | Print debugging information about section headers |
+
+[wasmparser]: https://crates.io/crates/wasmparser
+[wat]: https://crates.io/crates/wat
+[wast]: https://crates.io/crates/wast
+[wasmprinter]: https://crates.io/crates/wasmprinter
+[wasm-smith]: https://crates.io/crates/wasm-smith
+[wasm-mutate]: https://crates.io/crates/wasm-mutate
+[wasm-shrink]: https://crates.io/crates/wasm-shrink
+
+The `wasm-tools` CLI is primarily intended to be a debugging aid. The various
+subcommands all have `--help` explainer texts to describe more about their
+functionality as well.
+
+# Libraries
+
+As mentioned above many of the tools of the `wasm-tools` CLI have libraries
+implemented in this repository as well. These libraries are:
 
 * [**`wasmparser`**](crates/wasmparser) - a library to parse WebAssembly binaries
 * [**`wat`**](crates/wat) - a library to parse the WebAssembly text format
@@ -25,6 +72,9 @@ look at the sub-crates:
 * [**`wasm-smith`**](crates/wasm-smith) - a WebAssembly test case generator
 * [**`wasm-encoder`**](crates/wasm-encoder) - a crate to generate a binary
   WebAssembly module
+
+It's recommended to use the libraries directly rather than the CLI tooling when
+embedding into a separate project.
 
 # License
 

--- a/crates/wasm-mutate/Cargo.toml
+++ b/crates/wasm-mutate/Cargo.toml
@@ -2,6 +2,9 @@
 name = "wasm-mutate"
 version = "0.1.0"
 edition = "2018"
+license = "Apache-2.0 WITH LLVM-exception"
+repository = "https://github.com/bytecodealliance/wasm-tools"
+description = "A WebAssembly test case mutator"
 
 [dependencies]
 structopt = { optional = true, version = "0.3" }


### PR DESCRIPTION
It's about that time nowadays, so this fills in a bit of `Cargo.toml`
and spruces up the `README.md` slightly.