### PR TITLE
Update component encoding for spec changes.

### DIFF
--- a/crates/wasm-encoder/src/component.rs
+++ b/crates/wasm-encoder/src/component.rs
@@ -29,6 +29,7 @@ const INDEX_REF_FUNCTION: u8 = 0x02;
 const INDEX_REF_TABLE: u8 = 0x03;
 const INDEX_REF_MEMORY: u8 = 0x04;
 const INDEX_REF_GLOBAL: u8 = 0x05;
+const INDEX_REF_ADAPTER_FUNCTION: u8 = 0x06;
 
 const TYPE_REF_INSTANCE: u8 = 0x00;
 const TYPE_REF_MODULE: u8 = 0x01;
@@ -161,6 +162,8 @@ pub enum IndexRef {
     Memory(u32),
     /// The reference is to a global in the global section.
     Global(u32),
+    /// The reference is to an adapter function in the adapter function section.
+    AdapterFunction(u32),
 }
 
 impl IndexRef {
@@ -188,6 +191,10 @@ impl IndexRef {
             }
             IndexRef::Global(index) => {
                 bytes.push(INDEX_REF_GLOBAL);
+                bytes.extend(encoders::u32(*index));
+            }
+            IndexRef::AdapterFunction(index) => {
+                bytes.push(INDEX_REF_ADAPTER_FUNCTION);
                 bytes.extend(encoders::u32(*index));
             }
         }

--- a/crates/wasm-encoder/src/component/aliases.rs
+++ b/crates/wasm-encoder/src/component/aliases.rs
@@ -10,17 +10,19 @@ pub(crate) const ALIAS_KIND_OUTER_TYPE: u8 = 0x06;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ExportKind {
     /// The alias is to an instance.
-    Instance,
+    Instance = 0x00,
     /// The alias is to a module.
-    Module,
+    Module = 0x01,
     /// The alias is to a function.
-    Function,
+    Function = 0x02,
     /// The alias is to a table.
-    Table,
+    Table = 0x03,
     /// The alias is to a memory.
-    Memory,
+    Memory = 0x04,
     /// The alias is to a global.
-    Global,
+    Global = 0x05,
+    /// The alias is to an adapter function.
+    AdapterFunction = 0x06,
 }
 
 /// An encoder for the component alias section.


### PR DESCRIPTION
This PR updates component encoding in `wasm-encoder` based on some recent
updates to the component model spec:

* Index references can be to adapter functions.
* Aliases can be made to adapter functions from instance exports.
* Adapter function type definitions have results that are either all named or
  all unnamed.