### PR TITLE
wasm-mutate: Remove a hot vector creation found during fuzzing

### DIFF
--- a/crates/wasm-mutate/src/mutators/peephole/dfg.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/dfg.rs
@@ -191,22 +191,8 @@ impl MiniDFG {
     /// by cleaning spurious nodes
     pub fn get_expr(&self, at: usize) -> RecExpr<Lang> {
         let root = self.map[&at];
-        let enodes = self.entries[..=root]
-            .iter()
-            .map(|t| t.operator.clone())
-            .collect::<Vec<_>>();
-        let operands = self.entries[..=root]
-            .iter()
-            .map(|t| {
-                t.operator
-                    .children()
-                    .iter()
-                    .map(|i| Id::from(*i))
-                    .collect::<Vec<_>>()
-            })
-            .collect::<Vec<_>>();
-
-        build_expr(Id::from(root), &enodes, &operands)
+        let entries = &self.entries[..=root];
+        build_expr(Id::from(root), |id| &entries[usize::from(id)].operator)
     }
 }
 

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy.rs
@@ -110,7 +110,7 @@ where
         &self,
         eclass: Id,
         recexpr: &RefCell<RecExpr<L>>,
-        expression_builder: impl Fn(Id, &[L], &[Vec<Id>], &mut RecExpr<L>) -> Id,
+        expression_builder: impl for<'b> Fn(Id, &mut RecExpr<L>, &dyn Fn(Id) -> (&'b L, &'b [Id])) -> Id,
     ) -> crate::Result<Id> // return the random tree, TODO, improve the way the tree is returned
     {
         // A map from a node's id to its actual node data.
@@ -156,7 +156,9 @@ where
         }
         // Build the tree with the right language constructor
         let mut to_write_in = recexpr.borrow_mut();
-        let expr = expression_builder(Id::from(0), &id_to_node, &operands, &mut to_write_in);
+        let expr = expression_builder(Id::from(0), &mut to_write_in, &|id| {
+            (&id_to_node[usize::from(id)], &operands[usize::from(id)])
+        });
         Ok(expr)
     }
 }

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/expr_enumerator.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/expr_enumerator.rs
@@ -53,7 +53,7 @@ pub fn lazy_expand<'a>(
         let cf = AstSize;
         let extractor = RandomExtractor::new(&egraph, cf);
         let shorter = extractor
-            .extract_smallest(id, &recexpr, build_expr_inner)
+            .extract_smallest(id, &recexpr, |a, b, c| build_expr_inner(a, b, c))
             .unwrap();
 
         return Box::new(vec![shorter].into_iter());


### PR DESCRIPTION
This commit fixes a hot loop found during fuzzing which cause fuzzing to
time out. Previously allocated vectors are now replaced with closures to
avoid all of the allocations entirely. This is intended to purely
refactor how this functionality is expressed, no changes in behavior is
intended here.

Previously a fuzzer running in ~60s now runs in 3s.