### PR TITLE
wasmparser: Improve FuncType

### DIFF
--- a/crates/dump/Cargo.toml
+++ b/crates/dump/Cargo.toml
@@ -9,4 +9,8 @@ description = "Utility to dump debug information about the wasm binary format"
 
 [dependencies]
 anyhow = "1"
-wasmparser = { path = "../wasmparser", version = "0.82.0" }
+wasmparser = { path = "../wasmparser", version = "0.82.0", default-features = false, features = [] }
+
+[features]
+default = ["std"]
+std = ["wasmparser/std"]

--- a/crates/wasm-mutate/src/module.rs
+++ b/crates/wasm-mutate/src/module.rs
@@ -53,12 +53,12 @@ impl TryFrom<TypeDef<'_>> for TypeInfo {
         match value {
             TypeDef::Func(ft) => Ok(TypeInfo::Func(FuncInfo {
                 params: ft
-                    .params
+                    .params()
                     .iter()
                     .map(|&t| PrimitiveTypeInfo::from(t))
                     .collect(),
                 returns: ft
-                    .returns
+                    .returns()
                     .iter()
                     .map(|&t| PrimitiveTypeInfo::from(t))
                     .collect(),

--- a/crates/wasm-mutate/src/mutators/remove_item.rs
+++ b/crates/wasm-mutate/src/mutators/remove_item.rs
@@ -454,11 +454,11 @@ impl RemoveItem {
         match ty {
             TypeDef::Func(f) => {
                 s.function(
-                    f.params
+                    f.params()
                         .iter()
                         .map(|t| self.translate_type(t))
                         .collect::<Result<Vec<_>>>()?,
-                    f.returns
+                    f.returns()
                         .iter()
                         .map(|t| self.translate_type(t))
                         .collect::<Result<Vec<_>>>()?,

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -12,7 +12,7 @@ A simple event-driven library for parsing WebAssembly binary files.
 edition = "2018"
 
 [dependencies]
-no-std-compat = { version = "0.4.1", default-features = false, features = ["compat_hash", "compat_sync", "alloc"] }
+no-std-compat = { version = "0.4.1", default-features = false, features = ["compat_sync", "alloc"] }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -11,6 +11,9 @@ A simple event-driven library for parsing WebAssembly binary files.
 """
 edition = "2018"
 
+[dependencies]
+no-std-compat = { version = "0.4.1", default-features = false, features = ["compat_hash", "compat_sync", "alloc"] }
+
 [dev-dependencies]
 anyhow = "1.0"
 criterion = "0.3"
@@ -25,7 +28,17 @@ name = "benchmark"
 harness = false
 
 [features]
+default = ["std"]
+# Enables the crate to use the Rust standard library.
+#
+# Disabling it allows to use the crate in environments without support
+# for the Rust standard library.
+#
+# Enabled by default.
+std = ["no-std-compat/std"]
 # The "deterministic" feature supports only Wasm code with "deterministic" execution
 # across any hardware. This feature is very critical for many Blockchain infrastructures
 # that rely on deterministic executions of smart contracts across different hardwares.
+#
+# Disabled by default.
 deterministic = []

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -21,7 +21,7 @@ getopts = "0.2"
 wat = { path = "../wat" }
 wast = { path = "../wast" }
 rayon = "1.3"
-wasmparser-dump = { path = "../dump" }
+wasmparser-dump = { path = "../dump", default-features = false }
 
 [[bench]]
 name = "benchmark"
@@ -35,7 +35,7 @@ default = ["std"]
 # for the Rust standard library.
 #
 # Enabled by default.
-std = ["no-std-compat/std"]
+std = ["no-std-compat/std", "wasmparser-dump/std"]
 # The "deterministic" feature supports only Wasm code with "deterministic" execution
 # across any hardware. This feature is very critical for many Blockchain infrastructures
 # that rely on deterministic executions of smart contracts across different hardwares.

--- a/crates/wasmparser/README.md
+++ b/crates/wasmparser/README.md
@@ -1,3 +1,9 @@
+> This is a fork of the `wasmparser` crate by the
+> [Bytecode Alliance](https://bytecodealliance.org/)
+> with the sole purpose to add `no_std` support.
+>
+> This crate will be deprecated as soon as `wasmparser` crate itself supports `no_std`.
+
 # The WebAssembly binary file decoder in Rust
 
 **A [Bytecode Alliance](https://bytecodealliance.org/) project**

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -237,10 +237,7 @@ impl<'a> BinaryReader<'a> {
         for _ in 0..returns_len {
             returns.push(self.read_type()?);
         }
-        Ok(FuncType {
-            params: params.into_boxed_slice(),
-            returns: returns.into_boxed_slice(),
-        })
+        Ok(FuncType::new(params, returns))
     }
 
     pub(crate) fn read_module_type(&mut self) -> Result<ModuleType<'a>> {

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -15,6 +15,7 @@
 
 use std::convert::TryInto;
 use std::fmt;
+use std::prelude::v1::*;
 use std::str;
 
 use crate::limits::*;

--- a/crates/wasmparser/src/lib.rs
+++ b/crates/wasmparser/src/lib.rs
@@ -23,6 +23,10 @@
 //! this is not the right library for you. You could however, build such
 //! a data-structure using this library.
 
+#![no_std]
+
+extern crate no_std_compat as std;
+
 pub use crate::binary_reader::BinaryReader;
 pub use crate::binary_reader::Range;
 

--- a/crates/wasmparser/src/module_resources.rs
+++ b/crates/wasmparser/src/module_resources.rs
@@ -310,18 +310,18 @@ where
 
 impl WasmFuncType for FuncType {
     fn len_inputs(&self) -> usize {
-        self.params.len()
+        self.params().len()
     }
 
     fn len_outputs(&self) -> usize {
-        self.returns.len()
+        self.returns().len()
     }
 
     fn input_at(&self, at: u32) -> Option<Type> {
-        self.params.get(at as usize).copied()
+        self.params().get(at as usize).copied()
     }
 
     fn output_at(&self, at: u32) -> Option<Type> {
-        self.returns.get(at as usize).copied()
+        self.returns().get(at as usize).copied()
     }
 }

--- a/crates/wasmparser/src/operators_validator.rs
+++ b/crates/wasmparser/src/operators_validator.rs
@@ -25,6 +25,7 @@
 use crate::limits::MAX_WASM_FUNCTION_LOCALS;
 use crate::primitives::{MemoryImmediate, Operator, SIMDLaneIndex, Type, TypeOrFuncType};
 use crate::{BinaryReaderError, Result, WasmFeatures, WasmFuncType, WasmModuleResources};
+use std::prelude::v1::*;
 
 /// A wrapper around a `BinaryReaderError` where the inner error's offset is a
 /// temporary placeholder value. This can be converted into a proper

--- a/crates/wasmparser/src/parser.rs
+++ b/crates/wasmparser/src/parser.rs
@@ -7,6 +7,7 @@ use crate::{GlobalSectionReader, MemorySectionReader, TableSectionReader};
 use std::convert::TryInto;
 use std::fmt;
 use std::iter;
+use std::prelude::v1::*;
 
 /// An incremental parser of a binary WebAssembly module.
 ///

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -17,6 +17,7 @@
 use std::error::Error;
 
 use std::fmt;
+use std::fmt::Debug;
 use std::prelude::v1::*;
 use std::result;
 
@@ -180,7 +181,7 @@ pub enum TypeDef<'a> {
 /// The parameters and results are ordered and merged in a single
 /// allocation starting with parameter types in order and following
 /// with the result types in order.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct FuncType {
     /// The ordered and merged parameters and results of the function type.
     params_results: Box<[Type]>,
@@ -190,6 +191,15 @@ pub struct FuncType {
     /// the head of the vector. The rest of the allocation is made up
     /// of result types.
     len_params: usize,
+}
+
+impl Debug for FuncType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FuncType")
+            .field("params", &self.params())
+            .field("returns", &self.returns())
+            .finish()
+    }
 }
 
 impl FuncType {

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -13,7 +13,9 @@
  * limitations under the License.
  */
 
+#[cfg(feature = "std")]
 use std::error::Error;
+
 use std::fmt;
 use std::prelude::v1::*;
 use std::result;
@@ -35,6 +37,7 @@ pub(crate) struct BinaryReaderErrorInner {
 
 pub type Result<T, E = BinaryReaderError> = result::Result<T, E>;
 
+#[cfg(feature = "std")]
 impl Error for BinaryReaderError {}
 
 impl fmt::Display for BinaryReaderError {

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -15,6 +15,7 @@
 
 use std::error::Error;
 use std::fmt;
+use std::prelude::v1::*;
 use std::result;
 
 #[derive(Debug, Clone)]

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -24,6 +24,7 @@ use crate::{FunctionBody, Parser, Payload};
 use std::collections::{HashMap, HashSet};
 use std::mem;
 use std::sync::Arc;
+use std::prelude::v1::*;
 
 /// Test whether the given buffer contains a valid WebAssembly module,
 /// analogous to [`WebAssembly.validate`][js] in the JS API.

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -581,10 +581,10 @@ impl Validator {
     fn type_def(&mut self, def: crate::TypeDef<'_>) -> Result<()> {
         let def = match def {
             crate::TypeDef::Func(t) => {
-                for ty in t.params.iter().chain(t.returns.iter()) {
+                for ty in t.params().iter().chain(t.returns().iter()) {
                     self.value_type(*ty)?;
                 }
-                if t.returns.len() > 1 && !self.features.multi_value {
+                if t.returns().len() > 1 && !self.features.multi_value {
                     return self
                         .create_error("invalid result arity: func type returns multiple values");
                 }
@@ -741,7 +741,7 @@ impl Validator {
             return self.create_error("exceptions proposal not enabled");
         }
         let ty = self.func_type_at(ty.type_index)?;
-        if ty.returns.len() > 0 {
+        if ty.returns().len() > 0 {
             return self.create_error("invalid exception type: non-empty tag result type");
         }
         Ok(())
@@ -1401,7 +1401,7 @@ impl Validator {
         self.offset = range.start;
         self.update_order(Order::Start)?;
         let ty = self.get_func_type(func)?;
-        if !ty.params.is_empty() || !ty.returns.is_empty() {
+        if !ty.params().is_empty() || !ty.returns().is_empty() {
             return self.create_error("invalid start function type");
         }
         Ok(())
@@ -1955,7 +1955,7 @@ impl EntityType {
             | EntityType::Module(i)
             | EntityType::Instance(i)
             | EntityType::Tag(i) => match &list[*i] {
-                TypeDef::Func(f) => 1 + (f.params.len() + f.returns.len()) as u32,
+                TypeDef::Func(f) => 1 + (f.params().len() + f.returns().len()) as u32,
                 TypeDef::Module(m) => m.imports_size + m.exports_size,
                 TypeDef::Instance(i) => i.type_size,
             },

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -392,7 +392,7 @@ impl Printer {
     /// Returns the number of parameters, useful for local index calculations
     /// later.
     fn print_functype(&mut self, ty: &FuncType, names_for: Option<u32>) -> Result<u32> {
-        if ty.params.len() > 0 {
+        if ty.params().len() > 0 {
             self.result.push_str(" ");
         }
 
@@ -400,7 +400,7 @@ impl Printer {
         // Note that named parameters must be alone in a `param` block, so
         // we need to be careful to terminate previous param blocks and open
         // a new one if that's the case with a named parameter.
-        for (i, param) in ty.params.iter().enumerate() {
+        for (i, param) in ty.params().iter().enumerate() {
             let local_names = &self.state.local_names;
             let name = names_for.and_then(|n| local_names.get(&(n, i as u32)));
             params.start_local(name, &mut self.result);
@@ -408,15 +408,15 @@ impl Printer {
             params.end_local(&mut self.result);
         }
         params.finish(&mut self.result);
-        if ty.returns.len() > 0 {
+        if ty.returns().len() > 0 {
             self.result.push_str(" (result");
-            for result in ty.returns.iter() {
+            for result in ty.returns().iter() {
                 self.result.push_str(" ");
                 self.print_valtype(*result)?;
             }
             self.result.push_str(")");
         }
-        Ok(ty.params.len() as u32)
+        Ok(ty.params().len() as u32)
     }
 
     fn print_valtype(&mut self, ty: Type) -> Result<()> {


### PR DESCRIPTION
This reduces the number of separate allocations per FuncType instance by 1.
Also this adds some public API and hides the implementation details.
Other crates of the workspace have been adjusted.
The `Debug` implementation has been adjusted to output the same output as before.