### PR TITLE
wasmparser: Improve FuncType

### DIFF
--- a/crates/wasm-mutate/src/module.rs
+++ b/crates/wasm-mutate/src/module.rs
@@ -53,12 +53,12 @@ impl TryFrom<TypeDef<'_>> for TypeInfo {
         match value {
             TypeDef::Func(ft) => Ok(TypeInfo::Func(FuncInfo {
                 params: ft
-                    .params
+                    .params()
                     .iter()
                     .map(|&t| PrimitiveTypeInfo::from(t))
                     .collect(),
                 returns: ft
-                    .returns
+                    .returns()
                     .iter()
                     .map(|&t| PrimitiveTypeInfo::from(t))
                     .collect(),

--- a/crates/wasm-mutate/src/mutators/remove_item.rs
+++ b/crates/wasm-mutate/src/mutators/remove_item.rs
@@ -454,11 +454,11 @@ impl RemoveItem {
         match ty {
             TypeDef::Func(f) => {
                 s.function(
-                    f.params
+                    f.params()
                         .iter()
                         .map(|t| self.translate_type(t))
                         .collect::<Result<Vec<_>>>()?,
-                    f.returns
+                    f.returns()
                         .iter()
                         .map(|t| self.translate_type(t))
                         .collect::<Result<Vec<_>>>()?,

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -236,10 +236,7 @@ impl<'a> BinaryReader<'a> {
         for _ in 0..returns_len {
             returns.push(self.read_type()?);
         }
-        Ok(FuncType {
-            params: params.into_boxed_slice(),
-            returns: returns.into_boxed_slice(),
-        })
+        Ok(FuncType::new(params, returns))
     }
 
     pub(crate) fn read_module_type(&mut self) -> Result<ModuleType<'a>> {

--- a/crates/wasmparser/src/module_resources.rs
+++ b/crates/wasmparser/src/module_resources.rs
@@ -310,18 +310,18 @@ where
 
 impl WasmFuncType for FuncType {
     fn len_inputs(&self) -> usize {
-        self.params.len()
+        self.params().len()
     }
 
     fn len_outputs(&self) -> usize {
-        self.returns.len()
+        self.returns().len()
     }
 
     fn input_at(&self, at: u32) -> Option<Type> {
-        self.params.get(at as usize).copied()
+        self.params().get(at as usize).copied()
     }
 
     fn output_at(&self, at: u32) -> Option<Type> {
-        self.returns.get(at as usize).copied()
+        self.returns().get(at as usize).copied()
     }
 }

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -200,17 +200,16 @@ impl Debug for FuncType {
 
 impl FuncType {
     /// Creates a new function type.
-    pub fn new<I, O>(inputs: I, outputs: O) -> Self
+    pub fn new<I, O>(params: I, results: O) -> Self
     where
         I: IntoIterator<Item = Type>,
         O: IntoIterator<Item = Type>,
-        I::IntoIter: ExactSizeIterator,
     {
-        let inputs = inputs.into_iter();
-        let len_params = inputs.len();
-        let inputs_outputs = inputs.chain(outputs).collect::<Vec<_>>().into_boxed_slice();
+        let mut params_results = params.into_iter().collect::<Vec<_>>();
+        let len_params = params_results.len();
+        params_results.extend(results);
         Self {
-            params_results: inputs_outputs,
+            params_results: params_results.into_boxed_slice(),
             len_params,
         }
     }

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -223,11 +223,6 @@ impl FuncType {
     pub fn returns(&self) -> &[Type] {
         &self.params_results[self.len_params..]
     }
-
-    /// Returns the pair of parameter and result types of the function type.
-    pub fn params_returns(&self) -> (&[Type], &[Type]) {
-        self.params_results.split_at(self.len_params)
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -15,6 +15,7 @@
 
 use std::error::Error;
 use std::fmt;
+use std::fmt::Debug;
 use std::result;
 
 #[derive(Debug, Clone)]
@@ -169,10 +170,65 @@ pub enum TypeDef<'a> {
     Module(ModuleType<'a>),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+/// A function type containing the function parameter and result types.
+///
+/// # Note
+///
+/// The parameters and results are ordered and merged in a single
+/// allocation starting with parameter types in order and following
+/// with the result types in order.
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct FuncType {
-    pub params: Box<[Type]>,
-    pub returns: Box<[Type]>,
+    /// The ordered and merged parameters and results of the function type.
+    params_results: Box<[Type]>,
+    /// The number of inputs.
+    ///
+    /// The `len_params` field denotes how many inputs there are in
+    /// the head of the vector. The rest of the allocation is made up
+    /// of result types.
+    len_params: usize,
+}
+
+impl Debug for FuncType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FuncType")
+            .field("params", &self.params())
+            .field("returns", &self.returns())
+            .finish()
+    }
+}
+
+impl FuncType {
+    /// Creates a new function type.
+    pub fn new<I, O>(inputs: I, outputs: O) -> Self
+    where
+        I: IntoIterator<Item = Type>,
+        O: IntoIterator<Item = Type>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        let inputs = inputs.into_iter();
+        let len_params = inputs.len();
+        let inputs_outputs = inputs.chain(outputs).collect::<Vec<_>>().into_boxed_slice();
+        Self {
+            params_results: inputs_outputs,
+            len_params,
+        }
+    }
+
+    /// Returns the parameter types of the function type.
+    pub fn params(&self) -> &[Type] {
+        &self.params_results[..self.len_params]
+    }
+
+    /// Returns the result types of the function type.
+    pub fn returns(&self) -> &[Type] {
+        &self.params_results[self.len_params..]
+    }
+
+    /// Returns the pair of parameter and result types of the function type.
+    pub fn params_returns(&self) -> (&[Type], &[Type]) {
+        self.params_results.split_at(self.len_params)
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -575,10 +575,10 @@ impl Validator {
     fn type_def(&mut self, def: crate::TypeDef<'_>) -> Result<()> {
         let def = match def {
             crate::TypeDef::Func(t) => {
-                for ty in t.params.iter().chain(t.returns.iter()) {
+                for ty in t.params().iter().chain(t.returns().iter()) {
                     self.value_type(*ty)?;
                 }
-                if t.returns.len() > 1 && !self.features.multi_value {
+                if t.returns().len() > 1 && !self.features.multi_value {
                     return self
                         .create_error("invalid result arity: func type returns multiple values");
                 }
@@ -735,7 +735,7 @@ impl Validator {
             return self.create_error("exceptions proposal not enabled");
         }
         let ty = self.func_type_at(ty.type_index)?;
-        if ty.returns.len() > 0 {
+        if ty.returns().len() > 0 {
             return self.create_error("invalid exception type: non-empty tag result type");
         }
         Ok(())
@@ -1395,7 +1395,7 @@ impl Validator {
         self.offset = range.start;
         self.update_order(Order::Start)?;
         let ty = self.get_func_type(func)?;
-        if !ty.params.is_empty() || !ty.returns.is_empty() {
+        if !ty.params().is_empty() || !ty.returns().is_empty() {
             return self.create_error("invalid start function type");
         }
         Ok(())
@@ -1949,7 +1949,7 @@ impl EntityType {
             | EntityType::Module(i)
             | EntityType::Instance(i)
             | EntityType::Tag(i) => match &list[*i] {
-                TypeDef::Func(f) => 1 + (f.params.len() + f.returns.len()) as u32,
+                TypeDef::Func(f) => 1 + (f.params().len() + f.returns().len()) as u32,
                 TypeDef::Module(m) => m.imports_size + m.exports_size,
                 TypeDef::Instance(i) => i.type_size,
             },

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -392,7 +392,7 @@ impl Printer {
     /// Returns the number of parameters, useful for local index calculations
     /// later.
     fn print_functype(&mut self, ty: &FuncType, names_for: Option<u32>) -> Result<u32> {
-        if ty.params.len() > 0 {
+        if ty.params().len() > 0 {
             self.result.push_str(" ");
         }
 
@@ -400,7 +400,7 @@ impl Printer {
         // Note that named parameters must be alone in a `param` block, so
         // we need to be careful to terminate previous param blocks and open
         // a new one if that's the case with a named parameter.
-        for (i, param) in ty.params.iter().enumerate() {
+        for (i, param) in ty.params().iter().enumerate() {
             let local_names = &self.state.local_names;
             let name = names_for.and_then(|n| local_names.get(&(n, i as u32)));
             params.start_local(name, &mut self.result);
@@ -408,15 +408,15 @@ impl Printer {
             params.end_local(&mut self.result);
         }
         params.finish(&mut self.result);
-        if ty.returns.len() > 0 {
+        if ty.returns().len() > 0 {
             self.result.push_str(" (result");
-            for result in ty.returns.iter() {
+            for result in ty.returns().iter() {
                 self.result.push_str(" ");
                 self.print_valtype(*result)?;
             }
             self.result.push_str(")");
         }
-        Ok(ty.params.len() as u32)
+        Ok(ty.params().len() as u32)
     }
 
     fn print_valtype(&mut self, ty: Type) -> Result<()> {


### PR DESCRIPTION
This reduces the number of separate allocations per FuncType instance by 1.
Also this adds some public API and hides the implementation details.
Other crates of the workspace have been adjusted.
The `Debug` implementation has been adjusted to output the same output as before.

The same optimization could be applied to Wasmtime's `FuncType`, too.