### PR TITLE
wasmparser: Apply clippy suggestions + add clippy CI job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install Rust
       run: rustup update stable && rustup default stable && rustup component add clippy
-    - run: cargo clippy -- -D warnings
+    - run: cargo clippy --package wasmparser -- -D warnings
 
   rustfmt:
     name: Rustfmt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,15 +68,6 @@ jobs:
     - run: cargo build --manifest-path crates/wast/Cargo.toml --no-default-features
     - run: cargo build --manifest-path crates/wast/Cargo.toml --no-default-features --features wasm-module
 
-  clippy:
-    name: Clippy
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install Rust
-      run: rustup update stable && rustup default stable && rustup component add clippy
-    - run: cargo clippy --package wasmparser -- -D warnings
-
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,15 @@ jobs:
     - run: cargo build --manifest-path crates/wast/Cargo.toml --no-default-features
     - run: cargo build --manifest-path crates/wast/Cargo.toml --no-default-features --features wasm-module
 
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Rust
+      run: rustup update stable && rustup default stable && rustup component add clippy
+    - run: cargo clippy -- -D warnings
+
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -1553,7 +1553,7 @@ impl<'a> BinaryReader<'a> {
                 value: self.read_v128()?,
             },
             0x0d => {
-                let mut lanes = [0 as SIMDLaneIndex; 16];
+                let mut lanes: [SIMDLaneIndex; 16] = [0; 16];
                 for lane in &mut lanes {
                     *lane = self.read_lane_index(32)?
                 }
@@ -1982,7 +1982,7 @@ impl<'a> BrTable<'a> {
     ///     assert_eq!(targets, [1, 2]);
     /// }
     /// ```
-    pub fn targets<'b>(&'b self) -> impl Iterator<Item = Result<u32>> + 'b {
+    pub fn targets(&self) -> impl Iterator<Item = Result<u32>> + '_ {
         let mut reader = self.reader.clone();
         (0..self.cnt).map(move |i| {
             let label = reader.read_var_u32()?;

--- a/crates/wasmparser/src/parser.rs
+++ b/crates/wasmparser/src/parser.rs
@@ -690,10 +690,7 @@ impl Parser {
     /// no action needs to be taken with the returned parser. The parser will be
     /// automatically switched to internally and more payloads will continue to
     /// get returned.
-    pub fn parse_all(
-        self,
-        mut data: &[u8],
-    ) -> impl Iterator<Item = Result<Payload>> {
+    pub fn parse_all(self, mut data: &[u8]) -> impl Iterator<Item = Result<Payload>> {
         let mut stack = Vec::new();
         let mut cur = self;
         let mut done = false;

--- a/crates/wasmparser/src/parser.rs
+++ b/crates/wasmparser/src/parser.rs
@@ -690,10 +690,10 @@ impl Parser {
     /// no action needs to be taken with the returned parser. The parser will be
     /// automatically switched to internally and more payloads will continue to
     /// get returned.
-    pub fn parse_all<'a>(
+    pub fn parse_all(
         self,
-        mut data: &'a [u8],
-    ) -> impl Iterator<Item = Result<Payload<'a>>> + 'a {
+        mut data: &[u8],
+    ) -> impl Iterator<Item = Result<Payload>> {
         let mut stack = Vec::new();
         let mut cur = self;
         let mut done = false;

--- a/crates/wasmparser/src/readers/linking_section.rs
+++ b/crates/wasmparser/src/readers/linking_section.rs
@@ -42,7 +42,7 @@ impl<'a> LinkingSectionReader<'a> {
     where
         'a: 'b,
     {
-        Ok(self.reader.read_linking_type()?)
+        self.reader.read_linking_type()
     }
 }
 

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -1791,7 +1791,17 @@ mod arc {
                 return None;
             }
             debug_assert!(Arc::get_mut(&mut self.arc).is_some());
-            Some(self.assert_mut())
+            Some(
+                // # Safety
+                //
+                // This operation is safe since the API asserts that
+                // `self.owned` is only ever `true` if there is just
+                // one owner of the `Arc`.
+                // As soon as `Arc::get_mut_unchecked` we should
+                // make use of it instead.
+                #[allow(clippy::cast_ref_to_mut)]
+                unsafe { &mut *(&*self.arc as *const T as *mut T) }
+            )
         }
 
         pub fn assert_mut(&mut self) -> &mut T {

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -1800,7 +1800,9 @@ mod arc {
                 // As soon as `Arc::get_mut_unchecked` we should
                 // make use of it instead.
                 #[allow(clippy::cast_ref_to_mut)]
-                unsafe { &mut *(&*self.arc as *const T as *mut T) }
+                unsafe {
+                    &mut *(&*self.arc as *const T as *mut T)
+                },
             )
         }
 

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -1791,19 +1791,7 @@ mod arc {
                 return None;
             }
             debug_assert!(Arc::get_mut(&mut self.arc).is_some());
-            Some(
-                // # Safety
-                //
-                // This operation is safe since the API asserts that
-                // `self.owned` is only ever `true` if there is just
-                // one owner of the `Arc`.
-                // As soon as `Arc::get_mut_unchecked` we should
-                // make use of it instead.
-                #[allow(clippy::cast_ref_to_mut)]
-                unsafe {
-                    &mut *(&*self.arc as *const T as *mut T)
-                },
-            )
+            Some(unsafe { &mut *(&*self.arc as *const T as *mut T) })
         }
 
         pub fn assert_mut(&mut self) -> &mut T {


### PR DESCRIPTION
This PR adds a `clippy` CI job for `wasmparser` that can be extended to other crates of this workspace in later PRs.
Also the PR applies all `clippy` suggestions to the `wasmparser` crate.