### PR TITLE
More attempts to simplify the `Lang` enum in `wasm-mutate`

### DIFF
--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/analysis.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/analysis.rs
@@ -262,8 +262,8 @@ impl PeepholeMutationAnalysis {
 
     /// Returns the function type based on the index of the function type
     /// `types[functions[idx]]`
-    pub fn get_functype_idx(&self, idx: usize) -> &TypeInfo {
-        let functpeindex = self.function_map[idx] as usize;
+    pub fn get_functype_idx(&self, idx: u32) -> &TypeInfo {
+        let functpeindex = self.function_map[idx as usize] as usize;
         &self.types_map[functpeindex]
     }
 }

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder/expr2wasm.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder/expr2wasm.rs
@@ -2,13 +2,13 @@
 
 use crate::{
     module::PrimitiveTypeInfo,
-    mutators::peephole::{eggsy::encoder::TraversalEvent, Lang, EG},
+    mutators::peephole::{eggsy::encoder::TraversalEvent, Lang, MemArg, EG},
     Error, Result, WasmMutate,
 };
 use egg::{Id, Language, RecExpr};
 use rand::Rng;
 use std::num::Wrapping;
-use wasm_encoder::{Function, Instruction, MemArg};
+use wasm_encoder::{Function, Instruction};
 
 /// Some custom nodes might need special resource allocation outside the
 /// function. Fore xample, if a new global is needed is should be added outside
@@ -115,201 +115,47 @@ pub fn expr2wasm(
                     Lang::Drop(_) => {
                         newfunc.instruction(&Instruction::Drop);
                     }
-                    Lang::I32Load {
-                        align,
-                        mem,
-                        static_offset,
-                        offset: _,
-                    } => {
-                        let memarg = MemArg {
-                            offset: *static_offset,
-                            align: *align as u32,
-                            memory_index: *mem,
-                        };
-
-                        newfunc.instruction(&Instruction::I32Load(memarg));
+                    Lang::I32Load(memarg, _) => {
+                        newfunc.instruction(&Instruction::I32Load(memarg.into()));
                     }
-                    Lang::I64Load {
-                        align,
-                        mem,
-                        static_offset,
-                        offset: _,
-                    } => {
-                        let memarg = MemArg {
-                            offset: *static_offset,
-                            align: *align as u32,
-                            memory_index: *mem,
-                        };
-
-                        newfunc.instruction(&Instruction::I64Load(memarg));
+                    Lang::I64Load(memarg, _) => {
+                        newfunc.instruction(&Instruction::I64Load(memarg.into()));
                     }
-                    Lang::F32Load {
-                        align,
-                        mem,
-                        static_offset,
-                        offset: _,
-                    } => {
-                        let memarg = MemArg {
-                            offset: *static_offset,
-                            align: *align as u32,
-                            memory_index: *mem,
-                        };
-
-                        newfunc.instruction(&Instruction::F32Load(memarg));
+                    Lang::F32Load(memarg, _) => {
+                        newfunc.instruction(&Instruction::F32Load(memarg.into()));
                     }
-                    Lang::F64Load {
-                        align,
-                        mem,
-                        static_offset,
-                        offset: _,
-                    } => {
-                        let memarg = MemArg {
-                            offset: *static_offset,
-                            align: *align as u32,
-                            memory_index: *mem,
-                        };
-
-                        newfunc.instruction(&Instruction::F64Load(memarg));
+                    Lang::F64Load(memarg, _) => {
+                        newfunc.instruction(&Instruction::F64Load(memarg.into()));
                     }
-                    Lang::I32Load8S {
-                        align,
-                        mem,
-                        static_offset,
-                        offset: _,
-                    } => {
-                        let memarg = MemArg {
-                            offset: *static_offset,
-                            align: *align as u32,
-                            memory_index: *mem,
-                        };
-
-                        newfunc.instruction(&Instruction::I32Load8_S(memarg));
+                    Lang::I32Load8U(memarg, _) => {
+                        newfunc.instruction(&Instruction::I32Load8_U(memarg.into()));
                     }
-                    Lang::I32Load8U {
-                        align,
-                        mem,
-                        static_offset,
-                        offset: _,
-                    } => {
-                        let memarg = MemArg {
-                            offset: *static_offset,
-                            align: *align as u32,
-                            memory_index: *mem,
-                        };
-
-                        newfunc.instruction(&Instruction::I32Load8_U(memarg));
+                    Lang::I32Load8S(memarg, _) => {
+                        newfunc.instruction(&Instruction::I32Load8_S(memarg.into()));
                     }
-                    Lang::I32Load16S {
-                        align,
-                        mem,
-                        static_offset,
-                        offset: _,
-                    } => {
-                        let memarg = MemArg {
-                            offset: *static_offset,
-                            align: *align as u32,
-                            memory_index: *mem,
-                        };
-
-                        newfunc.instruction(&Instruction::I32Load16_S(memarg));
+                    Lang::I32Load16U(memarg, _) => {
+                        newfunc.instruction(&Instruction::I32Load16_U(memarg.into()));
                     }
-                    Lang::I32Load16U {
-                        align,
-                        mem,
-                        static_offset,
-                        offset: _,
-                    } => {
-                        let memarg = MemArg {
-                            offset: *static_offset,
-                            align: *align as u32,
-                            memory_index: *mem,
-                        };
-
-                        newfunc.instruction(&Instruction::I32Load16_U(memarg));
+                    Lang::I32Load16S(memarg, _) => {
+                        newfunc.instruction(&Instruction::I32Load16_S(memarg.into()));
                     }
-                    Lang::I64Load8S {
-                        align,
-                        mem,
-                        static_offset,
-                        offset: _,
-                    } => {
-                        let memarg = MemArg {
-                            offset: *static_offset,
-                            align: *align as u32,
-                            memory_index: *mem,
-                        };
-
-                        newfunc.instruction(&Instruction::I64Load8_S(memarg));
+                    Lang::I64Load8U(memarg, _) => {
+                        newfunc.instruction(&Instruction::I64Load8_U(memarg.into()));
                     }
-                    Lang::I64Load8U {
-                        align,
-                        mem,
-                        static_offset,
-                        offset: _,
-                    } => {
-                        let memarg = MemArg {
-                            offset: *static_offset,
-                            align: *align as u32,
-                            memory_index: *mem,
-                        };
-
-                        newfunc.instruction(&Instruction::I64Load8_U(memarg));
+                    Lang::I64Load8S(memarg, _) => {
+                        newfunc.instruction(&Instruction::I64Load8_S(memarg.into()));
                     }
-                    Lang::I64Load16S {
-                        align,
-                        mem,
-                        static_offset,
-                        offset: _,
-                    } => {
-                        let memarg = MemArg {
-                            offset: *static_offset,
-                            align: *align as u32,
-                            memory_index: *mem,
-                        };
-
-                        newfunc.instruction(&Instruction::I64Load16_S(memarg));
+                    Lang::I64Load16U(memarg, _) => {
+                        newfunc.instruction(&Instruction::I64Load16_U(memarg.into()));
                     }
-                    Lang::I64Load16U {
-                        align,
-                        mem,
-                        static_offset,
-                        offset: _,
-                    } => {
-                        let memarg = MemArg {
-                            offset: *static_offset,
-                            align: *align as u32,
-                            memory_index: *mem,
-                        };
-
-                        newfunc.instruction(&Instruction::I64Load16_U(memarg));
+                    Lang::I64Load16S(memarg, _) => {
+                        newfunc.instruction(&Instruction::I64Load16_S(memarg.into()));
                     }
-                    Lang::I64Load32S {
-                        align,
-                        mem,
-                        static_offset,
-                        offset: _,
-                    } => {
-                        let memarg = MemArg {
-                            offset: *static_offset,
-                            align: *align as u32,
-                            memory_index: *mem,
-                        };
-
-                        newfunc.instruction(&Instruction::I64Load32_S(memarg));
+                    Lang::I64Load32U(memarg, _) => {
+                        newfunc.instruction(&Instruction::I64Load32_U(memarg.into()));
                     }
-                    Lang::I64Load32U {
-                        align,
-                        mem,
-                        static_offset,
-                        offset: _,
-                    } => {
-                        let memarg = MemArg {
-                            offset: *static_offset,
-                            align: *align as u32,
-                            memory_index: *mem,
-                        };
-
-                        newfunc.instruction(&Instruction::I64Load32_U(memarg));
+                    Lang::I64Load32S(memarg, _) => {
+                        newfunc.instruction(&Instruction::I64Load32_S(memarg.into()));
                     }
                     Lang::RandI32 => {
                         newfunc.instruction(&Instruction::I32Const(config.rng().gen()));
@@ -777,131 +623,32 @@ pub fn expr2wasm(
                     Lang::F64Ge(_) => {
                         newfunc.instruction(&Instruction::F64Ge);
                     }
-                    Lang::I32Store {
-                        align,
-                        mem,
-                        static_offset,
-                        value_and_offset: _,
-                    } => {
-                        let memarg = MemArg {
-                            offset: *static_offset,
-                            align: *align as u32,
-                            memory_index: *mem,
-                        };
-
-                        newfunc.instruction(&Instruction::I32Store(memarg));
+                    Lang::I32Store(memarg, _) => {
+                        newfunc.instruction(&Instruction::I32Store(memarg.into()));
                     }
-                    Lang::I64Store {
-                        align,
-                        mem,
-                        static_offset,
-                        value_and_offset: _,
-                    } => {
-                        let memarg = MemArg {
-                            offset: *static_offset,
-                            align: *align as u32,
-                            memory_index: *mem,
-                        };
-
-                        newfunc.instruction(&Instruction::I64Store(memarg));
+                    Lang::I64Store(memarg, _) => {
+                        newfunc.instruction(&Instruction::I64Store(memarg.into()));
                     }
-                    Lang::F32Store {
-                        align,
-                        mem,
-                        static_offset,
-                        value_and_offset: _,
-                    } => {
-                        let memarg = MemArg {
-                            offset: *static_offset,
-                            align: *align as u32,
-                            memory_index: *mem,
-                        };
-
-                        newfunc.instruction(&Instruction::F32Store(memarg));
+                    Lang::F32Store(memarg, _) => {
+                        newfunc.instruction(&Instruction::F32Store(memarg.into()));
                     }
-                    Lang::F64Store {
-                        align,
-                        mem,
-                        static_offset,
-                        value_and_offset: _,
-                    } => {
-                        let memarg = MemArg {
-                            offset: *static_offset,
-                            align: *align as u32,
-                            memory_index: *mem,
-                        };
-
-                        newfunc.instruction(&Instruction::F64Store(memarg));
+                    Lang::F64Store(memarg, _) => {
+                        newfunc.instruction(&Instruction::F64Store(memarg.into()));
                     }
-                    Lang::I32Store8 {
-                        align,
-                        mem,
-                        static_offset,
-                        value_and_offset: _,
-                    } => {
-                        let memarg = MemArg {
-                            offset: *static_offset,
-                            align: *align as u32,
-                            memory_index: *mem,
-                        };
-
-                        newfunc.instruction(&Instruction::I32Store8(memarg));
+                    Lang::I32Store8(memarg, _) => {
+                        newfunc.instruction(&Instruction::I32Store8(memarg.into()));
                     }
-                    Lang::I32Store16 {
-                        align,
-                        mem,
-                        static_offset,
-                        value_and_offset: _,
-                    } => {
-                        let memarg = MemArg {
-                            offset: *static_offset,
-                            align: *align as u32,
-                            memory_index: *mem,
-                        };
-
-                        newfunc.instruction(&Instruction::I32Store16(memarg));
+                    Lang::I32Store16(memarg, _) => {
+                        newfunc.instruction(&Instruction::I32Store16(memarg.into()));
                     }
-                    Lang::I64Store8 {
-                        align,
-                        mem,
-                        static_offset,
-                        value_and_offset: _,
-                    } => {
-                        let memarg = MemArg {
-                            offset: *static_offset,
-                            align: *align as u32,
-                            memory_index: *mem,
-                        };
-
-                        newfunc.instruction(&Instruction::I64Store8(memarg));
+                    Lang::I64Store8(memarg, _) => {
+                        newfunc.instruction(&Instruction::I64Store8(memarg.into()));
                     }
-                    Lang::I64Store16 {
-                        align,
-                        mem,
-                        static_offset,
-                        value_and_offset: _,
-                    } => {
-                        let memarg = MemArg {
-                            offset: *static_offset,
-                            align: *align as u32,
-                            memory_index: *mem,
-                        };
-
-                        newfunc.instruction(&Instruction::I64Store16(memarg));
+                    Lang::I64Store16(memarg, _) => {
+                        newfunc.instruction(&Instruction::I64Store16(memarg.into()));
                     }
-                    Lang::I64Store32 {
-                        align,
-                        mem,
-                        static_offset,
-                        value_and_offset: _,
-                    } => {
-                        let memarg = MemArg {
-                            offset: *static_offset,
-                            align: *align as u32,
-                            memory_index: *mem,
-                        };
-
-                        newfunc.instruction(&Instruction::I64Store32(memarg));
+                    Lang::I64Store32(memarg, _) => {
+                        newfunc.instruction(&Instruction::I64Store32(memarg.into()));
                     }
                     Lang::Nop => {
                         newfunc.instruction(&Instruction::Nop);
@@ -912,10 +659,10 @@ pub fn expr2wasm(
                     Lang::Select(_) => {
                         newfunc.instruction(&Instruction::Select);
                     }
-                    Lang::MemoryGrow { mem, .. } => {
+                    Lang::MemoryGrow(mem, _) => {
                         newfunc.instruction(&Instruction::MemoryGrow(*mem));
                     }
-                    Lang::MemorySize { mem, .. } => {
+                    Lang::MemorySize(mem) => {
                         newfunc.instruction(&Instruction::MemorySize(*mem));
                     }
                     Lang::I32UseGlobal(_) => {
@@ -972,4 +719,14 @@ pub fn expr2wasm(
         }
     }
     Ok(resources)
+}
+
+impl From<&MemArg> for wasm_encoder::MemArg {
+    fn from(arg: &MemArg) -> wasm_encoder::MemArg {
+        wasm_encoder::MemArg {
+            offset: arg.static_offset,
+            align: arg.align.into(),
+            memory_index: arg.mem,
+        }
+    }
 }

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/expr_enumerator.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/expr_enumerator.rs
@@ -220,15 +220,15 @@ mod tests {
     #[test]
     fn test_rec_iterator() {
         let rules: &[Rewrite<Lang, PeepholeMutationAnalysis>] = &[
-            rewrite!("rule";  "?x" => "(i32.add ?x 0_i32)"),
+            rewrite!("rule";  "?x" => "(i32.add ?x i32.const.0)"),
             rewrite!("rule2";  "(i32.add ?y ?x)" => "(i32.add ?x ?y)"),
-            rewrite!("rule2";  "0_i32" => "(i32.sub 500_i32 500_i32)"),
+            rewrite!("rule2";  "i32.const.0" => "(i32.sub i32.const.50 i32.const.500)"),
             //rewrite!("rule3";  "?x" => "(i32.mul ?x 1_i32)"),
             //rewrite!("rule4";  "0_i32" => "(i32.unfold 0_i32)"),
             //rewrite!("rule5";  "1_i32" => "(i32.unfold 1_i32)"),
         ];
 
-        let expr = "(i32.add 100_i32 200_i32)";
+        let expr = "(i32.add i32.const.100 i32.const.200)";
 
         let analysis = PeepholeMutationAnalysis::new(vec![], vec![], vec![], vec![]);
         let runner = Runner::<Lang, PeepholeMutationAnalysis, ()>::new(analysis)

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
@@ -1,1751 +1,691 @@
 //! Nodes for intermediate representation of Wasm operators
 //!
 use egg::Id;
-use std::fmt::Display;
+use std::convert::TryInto;
+use std::fmt::{self, Display};
 use std::str::FromStr;
 
-/// Each "mutable" operator of Wasm is defined here plus articial operators with a
-/// a custom behavior.
+/// This is a macro used to define the `Lang` enum.
 ///
-/// You can define custom operators by adding a variant to this enum. Notice
-/// that custom operator nodes can only be created from rewriting rules and not
-/// form the direct translation of the Wasm binary. After you add a custom node,
-/// you need to also implement its parsing from a `string` and its encoding to
-/// Wasm. Let's assume for example that we want to implement a custom node that
-/// insert three `nop` operators when it is written back to Wasm.
+/// The goal of this macro is to synthesize an implementation of the
+/// `egg::Language` trait which involves parsing strings, displaying operands,
+/// determining whether operands are equal, and getting the child nodes of
+/// operands. The macro here attempts to synthesize all these operations purely
+/// from the structure of each variant. Some more details are below on the
+/// definition of `enum Lang`.
 ///
-/// * We firsts need to define the custom node ```ThreeNops``` as a variant of
-///   the [Lang] enum.
-/// * Then, we modify the `children`, `children_mut` and `from_op_str` methods
-/// the `impl egg::Language for Lang` as follows.
-///   ```ignore
-///    fn children(&self) -> &[Id] {
-///         ...
-///         Lang::ThreeNops => &[], // This variant has no children
-///         ...
-///    }
-///
-///    fn children_mut (&self) -> &[Id] {
-///         ...
-///         Lang::ThreeNops => &mut [], // This variant has no children
-///         ...
-///    }
-///
-///    fn from_op_str(op_str: &str, children: Vec<Id>) -> Result<Self, String> {
-///         ...
-///         "three_nops" => Ok(Lang::ThreeNops)
-///         ...
-///    }
-///
-///   ```
-/// * The custom node needs to translated to Wasm. To do so, you need to modify
-///   the `expr2wasm` function somehow as follow
-///   ```ignore
-///   Lang::ThreeNops  => {
-///     newfunc.instruction(&Instruction::Nop);
-///     newfunc.instruction(&Instruction::Nop);
-///     newfunc.instruction(&Instruction::Nop);
-///   }
-///   ```
-/// * The final step is to use this node in a rewriting rule. Inside the
-///   [`rules.rs`]() file
-///   ```ignore
-///   rewrite!("three-nops";  "?x" => "(container ?x three_nops)"),
-///   ```
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
-pub enum Lang {
-    // binops integers
-    /// i32.add operator
-    I32Add([Id; 2]),
-    /// i64.add operator
-    I64Add([Id; 2]),
-    /// i32.sub  operator
-    I32Sub([Id; 2]),
-    /// i64.sub  operator
-    I64Sub([Id; 2]),
-    /// i32.mul  operator
-    I32Mul([Id; 2]),
-    /// i64.mul  operator
-    I64Mul([Id; 2]),
-    /// i32.and  operator
-    I32And([Id; 2]),
-    /// i64.and  operator
-    I64And([Id; 2]),
-    /// i32.or  operator
-    I32Or([Id; 2]),
-    /// i64.or  operator
-    I64Or([Id; 2]),
-    /// i32.xor  operator
-    I32Xor([Id; 2]),
-    /// i64.xor  operator
-    I64Xor([Id; 2]),
-    /// i32.shl  operator
-    I32Shl([Id; 2]),
-    /// i64.shl  operator
-    I64Shl([Id; 2]),
-    /// i32.shru  operator
-    I32ShrU([Id; 2]),
-    /// i64.shru  operator
-    I64ShrU([Id; 2]),
-    /// i32.divu  operator
-    I32DivU([Id; 2]),
-    /// i64.divu  operator
-    I64DivU([Id; 2]),
-    /// i32.divs  operator
-    I32DivS([Id; 2]),
-    /// i64.divs  operator
-    I64DivS([Id; 2]),
-    /// i32.shrs  operator
-    I32ShrS([Id; 2]),
-    /// i64.shrs  operator
-    I64ShrS([Id; 2]),
-    /// i32.rotr  operator
-    I32RotR([Id; 2]),
-    /// i64.rotr  operator
-    I64RotR([Id; 2]),
-    /// i32.rotl  operator
-    I32RotL([Id; 2]),
-    /// i64.rotl  operator
-    I64RotL([Id; 2]),
-    /// i32.rems  operator
-    I32RemS([Id; 2]),
-    /// i64.rems  operator
-    I64RemS([Id; 2]),
-    /// i32.remu  operator
-    I32RemU([Id; 2]),
-    /// i64.remu  operator
-    I64RemU([Id; 2]),
-    /// i32.eq  operator
-    I32Eq([Id; 2]),
-    /// i64.eq  operator
-    I64Eq([Id; 2]),
-    /// i32.ne  operator
-    I32Ne([Id; 2]),
-    /// i64.ne  operator
-    I64Ne([Id; 2]),
-    /// i32.lts  operator
-    I32LtS([Id; 2]),
-    /// i64.lts  operator
-    I64LtS([Id; 2]),
-    /// i32.ltu  operator
-    I32LtU([Id; 2]),
-    /// i64.ltu  operator
-    I64LtU([Id; 2]),
-    /// i32.gts  operator
-    I32GtS([Id; 2]),
-    /// i64.gts  operator
-    I64GtS([Id; 2]),
-    /// i32.gtu  operator
-    I32GtU([Id; 2]),
-    /// i64.gtu  operator
-    I64GtU([Id; 2]),
-    /// i32.les  operator
-    I32LeS([Id; 2]),
-    /// i64.les  operator
-    I64LeS([Id; 2]),
-    /// i32.leu  operator
-    I32LeU([Id; 2]),
-    /// i64.leu  operator
-    I64LeU([Id; 2]),
-    /// i32.ges  operator
-    I32GeS([Id; 2]),
-    /// i64.ges  operator
-    I64GeS([Id; 2]),
-    /// i32.geu  operator
-    I32GeU([Id; 2]),
-    /// i64.geu  operator
-    I64GeU([Id; 2]),
-    // binops floats
-    /// f32.add  operator
-    F32Add([Id; 2]),
-    /// f64.add  operator
-    F64Add([Id; 2]),
-    /// f32.sub  operator
-    F32Sub([Id; 2]),
-    /// f64.sub  operator
-    F64Sub([Id; 2]),
-    /// f32.mul  operator
-    F32Mul([Id; 2]),
-    /// f64.mul  operator
-    F64Mul([Id; 2]),
-    /// f32.div  operator
-    F32Div([Id; 2]),
-    /// f64.div  operator
-    F64Div([Id; 2]),
-    /// f32.min  operator
-    F32Min([Id; 2]),
-    /// f64.min  operator
-    F64Min([Id; 2]),
-    /// f32.max  operator
-    F32Max([Id; 2]),
-    /// f64.max  operator
-    F64Max([Id; 2]),
-    /// f32.copysign  operator
-    F32Copysign([Id; 2]),
-    /// f64.copysign  operator
-    F64Copysign([Id; 2]),
-    // frelops
-    /// f32.eq  operator
-    F32Eq([Id; 2]),
-    /// f64.eq  operator
-    F64Eq([Id; 2]),
-    /// f32.ne  operator
-    F32Ne([Id; 2]),
-    /// f64.ne  operator
-    F64Ne([Id; 2]),
-    /// f32.lt  operator
-    F32Lt([Id; 2]),
-    /// f64.lt  operator
-    F64Lt([Id; 2]),
-    /// f32.gt  operator
-    F32Gt([Id; 2]),
-    /// f64.gt  operator
-    F64Gt([Id; 2]),
-    /// f32.le  operator
-    F32Le([Id; 2]),
-    /// f64.le  operator
-    F64Le([Id; 2]),
-    /// f32.ge  operator
-    F32Ge([Id; 2]),
-    /// f64.ge  operator
-    F64Ge([Id; 2]),
-    // unops integers
-    /// i32.eqz  operator
-    I32Eqz([Id; 1]),
-    /// i64.eqz  operator
-    I64Eqz([Id; 1]),
-
-    /// i32.popcnt  operator
-    I32Popcnt([Id; 1]),
-    /// i64.popcnt  operator
-    I64Popcnt([Id; 1]),
-    /// i32.clz  operator
-    I32Clz([Id; 1]),
-    /// i32.ctz  operator
-    I32Ctz([Id; 1]),
-    /// i64.ctz  operator
-    I64Ctz([Id; 1]),
-    /// i64.clz  operator
-    I64Clz([Id; 1]),
-
-    // unops floats
-    /// f32.abs  operator
-    F32Abs([Id; 1]),
-    /// f64.abs  operator
-    F64Abs([Id; 1]),
-    /// f32.neg  operator
-    F32Neg([Id; 1]),
-    /// f64.neg  operator
-    F64Neg([Id; 1]),
-    /// f32.sqrt  operator
-    F32Sqrt([Id; 1]),
-    /// f64.sqrt  operator
-    F64Sqrt([Id; 1]),
-    /// f32.ceil  operator
-    F32Ceil([Id; 1]),
-    /// f64.ceil  operator
-    F64Ceil([Id; 1]),
-    /// f32.floor  operator
-    F32Floor([Id; 1]),
-    /// f64.floor  operator
-    F64Floor([Id; 1]),
-    /// f32.trunc  operator
-    F32Trunc([Id; 1]),
-    /// f64.trunc  operator
-    F64Trunc([Id; 1]),
-    /// f32.nearest  operator
-    F32Nearest([Id; 1]),
-    /// f64.nearest  operator
-    F64Nearest([Id; 1]),
-
-    // Locals
-    // Idx and value
-    /// local.tee operator
-    LocalTee(u32, Id),
-    // Idx and value
-    /// local.set operator
-    LocalSet(u32, Id),
-    /// local.get operator
-    LocalGet(u32),
-
-    // Globals
-    // Idx and value
-    /// global.set operator
-    GlobalSet(u32, Id),
-    /// global.get operator
-    GlobalGet(u32),
-    // conversion operators
-    /// i32.wrap_i64 operator
-    Wrap([Id; 1]),
-
-    // conversion
-    /// i32.extend.8s operator
-    I32Extend8S([Id; 1]),
-    /// i64.extend.8s operator
-    I64Extend8S([Id; 1]),
-    /// i32.extend.16s operator
-    I32Extend16S([Id; 1]),
-    /// i64.extend.16s operator
-    I64Extend16S([Id; 1]),
-    /// i64.extend.32s operator
-    I64Extend32S([Id; 1]),
-    /// i64.extendi.32s operator
-    I64ExtendI32S([Id; 1]),
-    /// i64.extendi.32u operator
-    I64ExtendI32U([Id; 1]),
-    /// i32.truncf.32s operator
-    I32TruncF32S([Id; 1]),
-    /// i32.truncf.32u operator
-    I32TruncF32U([Id; 1]),
-    /// i32.truncf.64s operator
-    I32TruncF64S([Id; 1]),
-    /// i32.truncf.64u operator
-    I32TruncF64U([Id; 1]),
-    /// i64.truncf.32s operator
-    I64TruncF32S([Id; 1]),
-    /// i64.truncf.32u operator
-    I64TruncF32U([Id; 1]),
-    /// i64.truncf.64s operator
-    I64TruncF64S([Id; 1]),
-    /// i64.truncf.64u operator
-    I64TruncF64U([Id; 1]),
-    /// f32.converti.32s operator
-    F32ConvertI32S([Id; 1]),
-    /// f32.converti.32u operator
-    F32ConvertI32U([Id; 1]),
-    /// f32.converti.64s operator
-    F32ConvertI64S([Id; 1]),
-    /// f32.converti.64u operator
-    F32ConvertI64U([Id; 1]),
-    /// f32.demote.f64 operator
-    F32DemoteF64([Id; 1]),
-    /// f64.converti.32s operator
-    F64ConvertI32S([Id; 1]),
-    /// f64.converti.32u operator
-    F64ConvertI32U([Id; 1]),
-    /// f64.converti.64s operator
-    F64ConvertI64S([Id; 1]),
-    /// f64.converti.64u operator
-    F64ConvertI64U([Id; 1]),
-    /// f64.promote.f32 operator
-    F64PromoteF32([Id; 1]),
-    /// i32.reinterpret.f32 operator
-    I32ReinterpretF32([Id; 1]),
-    /// i64.reinterpret.f64 operator
-    I64ReinterpretF64([Id; 1]),
-    /// f32.reinterpret.i32 operator
-    F32ReinterpretI32([Id; 1]),
-    /// f64.reinterpret.i64 operator
-    F64ReinterpretI64([Id; 1]),
-    /// i32.truncsatf.32s operator
-    I32TruncSatF32S([Id; 1]),
-    /// i32.truncsatf.32u operator
-    I32TruncSatF32U([Id; 1]),
-    /// i32.truncsatf.64s operator
-    I32TruncSatF64S([Id; 1]),
-    /// i32.truncsatf.64u operator
-    I32TruncSatF64U([Id; 1]),
-    /// i64.truncsatf.32s operator
-    I64TruncSatF32S([Id; 1]),
-    /// i64.truncsatf.32u operator
-    I64TruncSatF32U([Id; 1]),
-    /// i64.truncsatf.64s operator
-    I64TruncSatF64S([Id; 1]),
-    /// i64.truncsatf.64u operator
-    I64TruncSatF64U([Id; 1]),
-
-    // The u32 argument should be the function index
-    /// call operator node
-    Call(usize, Vec<Id>),
-    /// drop operator
-    Drop([Id; 1]),
-    /// nop operator
-    Nop,
-    // Memory operations
-    // loads
-    /// i32.load operator
-    I32Load {
-        /// Inmediate static offset of the store operator
-        static_offset: u64,
-        /// Inmediate align value of the store operator
-        align: u8,
-        /// Inmediate mem value of the store operator
-        mem: u32,
-        /// Dynamic offset node id
-        offset: Id,
-    },
-    /// i64.load operator
-    I64Load {
-        /// Inmediate static offset of the store operator
-        static_offset: u64,
-        /// Inmediate align value of the store operator
-        align: u8,
-        /// Inmediate mem value of the store operator
-        mem: u32,
-        /// Dynamic offset node id
-        offset: Id,
-    },
-    /// f32.load operator
-    F32Load {
-        /// Inmediate static offset of the store operator
-        static_offset: u64,
-        /// Inmediate align value of the store operator
-        align: u8,
-        /// Inmediate mem value of the store operator
-        mem: u32,
-        /// Dynamic offset node id
-        offset: Id,
-    },
-    /// f64.load operator
-    F64Load {
-        /// Inmediate static offset of the store operator
-        static_offset: u64,
-        /// Inmediate align value of the store operator
-        align: u8,
-        /// Inmediate mem value of the store operator
-        mem: u32,
-        /// Dynamic offset node id
-        offset: Id,
-    },
-    /// i32.load8_s operator
-    I32Load8S {
-        /// Inmediate static offset of the store operator
-        static_offset: u64,
-        /// Inmediate align value of the store operator
-        align: u8,
-        /// Inmediate mem value of the store operator
-        mem: u32,
-        /// Dynamic offset node id
-        offset: Id,
-    },
-    /// i32.load8_u operator
-    I32Load8U {
-        /// Inmediate static offset of the store operator
-        static_offset: u64,
-        /// Inmediate align value of the store operator
-        align: u8,
-        /// Inmediate mem value of the store operator
-        mem: u32,
-        /// Dynamic offset node id
-        offset: Id,
-    },
-    /// i32.load16_s operator
-    I32Load16S {
-        /// Inmediate static offset of the store operator
-        static_offset: u64,
-        /// Inmediate align value of the store operator
-        align: u8,
-        /// Inmediate mem value of the store operator
-        mem: u32,
-        /// Dynamic offset node id
-        offset: Id,
-    },
-    /// i32.load16_u operator
-    I32Load16U {
-        /// Inmediate static offset of the store operator
-        static_offset: u64,
-        /// Inmediate align value of the store operator
-        align: u8,
-        /// Inmediate mem value of the store operator
-        mem: u32,
-        /// Dynamic offset node id
-        offset: Id,
-    },
-    /// i64.load8_s operator
-    I64Load8S {
-        /// Inmediate static offset of the store operator
-        static_offset: u64,
-        /// Inmediate align value of the store operator
-        align: u8,
-        /// Inmediate mem value of the store operator
-        mem: u32,
-        /// Dynamic offset node id
-        offset: Id,
-    },
-    /// i64.load8_u operator
-    I64Load8U {
-        /// Inmediate static offset of the store operator
-        static_offset: u64,
-        /// Inmediate align value of the store operator
-        align: u8,
-        /// Inmediate mem value of the store operator
-        mem: u32,
-        /// Dynamic offset node id
-        offset: Id,
-    },
-    /// i64.load16_s operator
-    I64Load16S {
-        /// Inmediate static offset of the store operator
-        static_offset: u64,
-        /// Inmediate align value of the store operator
-        align: u8,
-        /// Inmediate mem value of the store operator
-        mem: u32,
-        /// Dynamic offset node id
-        offset: Id,
-    },
-    /// i64.load16_u operator
-    I64Load16U {
-        /// Inmediate static offset of the store operator
-        static_offset: u64,
-        /// Inmediate align value of the store operator
-        align: u8,
-        /// Inmediate mem value of the store operator
-        mem: u32,
-        /// Dynamic offset node id
-        offset: Id,
-    },
-    /// i64.load32_s operator
-    I64Load32S {
-        /// Inmediate static offset of the store operator
-        static_offset: u64,
-        /// Inmediate align value of the store operator
-        align: u8,
-        /// Inmediate mem value of the store operator
-        mem: u32,
-        /// Dynamic offset node id
-        offset: Id,
-    },
-    /// i64.load32_u operator
-    I64Load32U {
-        /// Inmediate static offset of the store operator
-        static_offset: u64,
-        /// Inmediate align value of the store operator
-        align: u8,
-        /// Inmediate mem value of the store operator
-        mem: u32,
-        /// Dynamic offset node id
-        offset: Id,
-    },
-
-    /// i32.store operator
-    I32Store {
-        /// Inmediate static offset of the store operator
-        static_offset: u64,
-        /// Inmediate align value of the store operator
-        align: u8,
-        /// Inmediate mem value of the store operator
-        mem: u32,
-        /// Value and dynamic offset node Ids
-        value_and_offset: [Id; 2],
-    },
-    /// i64.store operator
-    I64Store {
-        /// Inmediate static offset of the store operator
-        static_offset: u64,
-        /// Inmediate align value of the store operator
-        align: u8,
-        /// Inmediate mem value of the store operator
-        mem: u32,
-        /// Value and dynamic offset node Ids
-        value_and_offset: [Id; 2],
-    },
-    /// f32.store operator
-    F32Store {
-        /// Inmediate static offset of the store operator
-        static_offset: u64,
-        /// Inmediate align value of the store operator
-        align: u8,
-        /// Inmediate mem value of the store operator
-        mem: u32,
-        /// Value and dynamic offset node Ids
-        value_and_offset: [Id; 2],
-    },
-    /// f64.store operator
-    F64Store {
-        /// Inmediate static offset of the store operator
-        static_offset: u64,
-        /// Inmediate align value of the store operator
-        align: u8,
-        /// Inmediate mem value of the store operator
-        mem: u32,
-        /// Value and dynamic offset node Ids
-        value_and_offset: [Id; 2],
-    },
-    /// i32.store8 operator
-    I32Store8 {
-        /// Inmediate static offset of the store operator
-        static_offset: u64,
-        /// Inmediate align value of the store operator
-        align: u8,
-        /// Inmediate mem value of the store operator
-        mem: u32,
-        /// Value and dynamic offset node Ids
-        value_and_offset: [Id; 2],
-    },
-    /// i32.store16 operator
-    I32Store16 {
-        /// Inmediate static offset of the store operator
-        static_offset: u64,
-        /// Inmediate align value of the store operator
-        align: u8,
-        /// Inmediate mem value of the store operator
-        mem: u32,
-        /// Value and dynamic offset node Ids
-        value_and_offset: [Id; 2],
-    },
-    /// i64.store8 operator
-    I64Store8 {
-        /// Inmediate static offset of the store operator
-        static_offset: u64,
-        /// Inmediate align value of the store operator
-        align: u8,
-        /// Inmediate mem value of the store operator
-        mem: u32,
-        /// Value and dynamic offset node Ids
-        value_and_offset: [Id; 2],
-    },
-    /// i64.store16 operator
-    I64Store16 {
-        /// Inmediate static offset of the store operator
-        static_offset: u64,
-        /// Inmediate align value of the store operator
-        align: u8,
-        /// Inmediate mem value of the store operator
-        mem: u32,
-        /// Value and dynamic offset node Ids
-        value_and_offset: [Id; 2],
-    },
-    /// i32.store32 operator
-    I64Store32 {
-        /// Inmediate static offset of the store operator
-        static_offset: u64,
-        /// Inmediate align value of the store operator
-        align: u8,
-        /// Inmediate mem value of the store operator
-        mem: u32,
-        /// Value and dynamic offset node Ids
-        value_and_offset: [Id; 2],
-    },
-    /// Select operator
-    Select([Id; 3]),
-    /// Memory grow operator
-    MemoryGrow {
-        /// immediate mem value
-        mem: u32,
-        /// immediate mem byte value
-        mem_byte: u8,
-        /// by node idx
-        by: Id,
-    },
-    /// Memory size operator
-    MemorySize {
-        /// immediate mem value
-        mem: u32,
-        /// immediate mem byte
-        mem_byte: u8,
-    },
-
-    /// Add custom or others operator nodes below
-
-    /// Custom mutation operations and instructions
-    ///
-    /// This operation represent a random i32 integer
-    RandI32,
-    /// This operation represent a random i64 integer
-    RandI64,
-
-    /// This instructions is used to define unknown operands, for example when the value can come from the join of several basic blocks in a dfg
-    Undef,
-    /// Takes one i32 constant operand and turn it into a sum of two random numbers whihch sum is the operand `i32.const x = i32.const r + i32.const (x - r) `
-    UnfoldI32(Id),
-    /// Takes one i64 constant operand and turn it into a sum of two random numbers whihch sum is the operand `i64.const x = i64.const r + i64.const (x - r) `
-    UnfoldI64(Id),
-
-    /// Propsoed custom mutator from issue #391, use-of-global
-    I32UseGlobal(Id),
-    /// Propsoed custom mutator from issue #391, use-of-global
-    I64UseGlobal(Id),
-    /// Propsoed custom mutator from issue #391, use-of-global
-    F32UseGlobal(Id),
-    /// Propsoed custom mutator from issue #391, use-of-global
-    F64UseGlobal(Id),
-
-    /// Just a wrapper of multiple nodes, when encoding to Wasm it is written as
-    /// nothing. Its only responsibility is to express stack-neutral operations.
-    ///
-    /// For example, let's assume we want to insert a nop operation after or
-    /// before another node (or both). `container` allows us to do this with the
-    /// following rewrites:
-    ///
-    /// * Before: `?x => (container nop ?x)`
-    /// * After: `?x => (container ?x nop)`
-    /// * Before and after: `?x => (container nop ?x nop)`
-    /// * Stack-nuetral insertion: `?x => (container (drop i32.rand) ?x) `
-    Container(Vec<Id>),
-
-    // End of custom mutation operations and instructions
-    /// I32 constant node
-    I32(i32),
-    /// I64 constant node
-    I64(i64),
-    // Save bits
-    /// F32 constant node
-    F32(u32),
-    /// F64 constant node
-    F64(u64),
-}
-
-impl Display for Lang {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Lang::LocalSet(idx, _) => f.write_str(&format!("local.set.{}", idx)),
-            Lang::LocalTee(idx, _) => f.write_str(&format!("local.tee.{}", idx)),
-            Lang::I32(val) => f.write_str(&format!("{}_i32", val)),
-            Lang::I64(val) => f.write_str(&format!("{}_i64", val)),
-            Lang::F32(v) => f.write_str(&format!("{}_f32", *v)),
-            Lang::F64(v) => f.write_str(&format!("{}_f64", *v)),
-            Lang::I32Add(_) => f.write_str("i32.add"),
-            Lang::I64Add(_) => f.write_str("i64.add"),
-            Lang::I32Sub(_) => f.write_str("i32.sub"),
-            Lang::I64Sub(_) => f.write_str("i64.sub"),
-            Lang::I32Mul(_) => f.write_str("i32.mul"),
-            Lang::I64Mul(_) => f.write_str("i64.mul"),
-            Lang::I32And(_) => f.write_str("i32.and"),
-            Lang::I64And(_) => f.write_str("i64.and"),
-            Lang::I32Or(_) => f.write_str("i32.or"),
-            Lang::I64Or(_) => f.write_str("i64.or"),
-            Lang::I32Xor(_) => f.write_str("i32.xor"),
-            Lang::I64Xor(_) => f.write_str("i64.xor"),
-            Lang::I32Shl(_) => f.write_str("i32.shl"),
-            Lang::I64Shl(_) => f.write_str("i64.shl"),
-            Lang::I32ShrU(_) => f.write_str("i32.shr_u"),
-            Lang::I64ShrU(_) => f.write_str("i64.shr_u"),
-            Lang::I32DivU(_) => f.write_str("i32.div_u"),
-            Lang::I64DivU(_) => f.write_str("i64.div_u"),
-            Lang::I32DivS(_) => f.write_str("i32.div_s"),
-            Lang::I64DivS(_) => f.write_str("i64.div_s"),
-            Lang::I32ShrS(_) => f.write_str("i32.shr_s"),
-            Lang::I64ShrS(_) => f.write_str("i64.shr_s"),
-            Lang::I32RotR(_) => f.write_str("i32.rotr"),
-            Lang::I64RotR(_) => f.write_str("i64.rotr"),
-            Lang::I32RotL(_) => f.write_str("i32.rotl"),
-            Lang::I64RotL(_) => f.write_str("i64.rotl"),
-            Lang::I32RemS(_) => f.write_str("i32.rem_s"),
-            Lang::I64RemS(_) => f.write_str("i64.rem_s"),
-            Lang::I32RemU(_) => f.write_str("i32.rem_u"),
-            Lang::I64RemU(_) => f.write_str("i64.rem_u"),
-            Lang::I32Eqz(_) => f.write_str("i32.eqz"),
-            Lang::I64Eqz(_) => f.write_str("i64.eqz"),
-            Lang::I32Eq(_) => f.write_str("i32.eq"),
-            Lang::I64Eq(_) => f.write_str("i64.eq"),
-            Lang::I32Ne(_) => f.write_str("i32.ne"),
-            Lang::I64Ne(_) => f.write_str("i64.ne"),
-            Lang::I32LtS(_) => f.write_str("i32.lt_s"),
-            Lang::I64LtS(_) => f.write_str("i64.lt_s"),
-            Lang::I32LtU(_) => f.write_str("i32.lt_u"),
-            Lang::I64LtU(_) => f.write_str("i64.lt_u"),
-            Lang::I32GtS(_) => f.write_str("i32.gt_s"),
-            Lang::I64GtS(_) => f.write_str("i64.gt_s"),
-            Lang::I32GtU(_) => f.write_str("i32.gt_u"),
-            Lang::I64GtU(_) => f.write_str("i64.gt_u"),
-            Lang::I32LeS(_) => f.write_str("i32.le_s"),
-            Lang::I64LeS(_) => f.write_str("i64.le_s"),
-            Lang::I32LeU(_) => f.write_str("i32.le_u"),
-            Lang::I64LeU(_) => f.write_str("i64.le_u"),
-            Lang::I32GeS(_) => f.write_str("i32.ge_s"),
-            Lang::I64GeS(_) => f.write_str("i64.ge_s"),
-            Lang::I32GeU(_) => f.write_str("i32.ge_u"),
-            Lang::I64GeU(_) => f.write_str("i64.ge_u"),
-            Lang::I32Popcnt(_) => f.write_str("i32.popcnt"),
-            Lang::I64Popcnt(_) => f.write_str("i64.popcnt"),
-            Lang::F32Add(_) => f.write_str("f32.add"),
-            Lang::F64Add(_) => f.write_str("f64.add"),
-            Lang::F32Sub(_) => f.write_str("f32.sub"),
-            Lang::F64Sub(_) => f.write_str("f64.sub"),
-            Lang::F32Mul(_) => f.write_str("f32.mul"),
-            Lang::F64Mul(_) => f.write_str("f64.mul"),
-            Lang::F32Div(_) => f.write_str("f32.div"),
-            Lang::F64Div(_) => f.write_str("f64.div"),
-            Lang::F32Min(_) => f.write_str("f32.min"),
-            Lang::F64Min(_) => f.write_str("f64.min"),
-            Lang::F32Max(_) => f.write_str("f32.max"),
-            Lang::F64Max(_) => f.write_str("f64.max"),
-            Lang::F32Copysign(_) => f.write_str("f32.copysign"),
-            Lang::F64Copysign(_) => f.write_str("f64.copysign"),
-            Lang::F32Eq(_) => f.write_str("f32.eq"),
-            Lang::F64Eq(_) => f.write_str("f64.eq"),
-            Lang::F32Ne(_) => f.write_str("f32.ne"),
-            Lang::F64Ne(_) => f.write_str("f64.ne"),
-            Lang::F32Lt(_) => f.write_str("f32.lt"),
-            Lang::F64Lt(_) => f.write_str("f64.lt"),
-            Lang::F32Gt(_) => f.write_str("f32.gt"),
-            Lang::F64Gt(_) => f.write_str("f64.gt"),
-            Lang::F32Le(_) => f.write_str("f32.le"),
-            Lang::F64Le(_) => f.write_str("f64.le"),
-            Lang::F32Ge(_) => f.write_str("f32.ge"),
-            Lang::F64Ge(_) => f.write_str("f64.ge"),
-            Lang::I32Clz(_) => f.write_str("i32.clz"),
-            Lang::I32Ctz(_) => f.write_str("i32.ctz"),
-            Lang::I64Ctz(_) => f.write_str("i64.ctz"),
-            Lang::I64Clz(_) => f.write_str("i64.clz"),
-            Lang::F32Abs(_) => f.write_str("f32.abs"),
-            Lang::F64Abs(_) => f.write_str("f64.abs"),
-            Lang::F32Neg(_) => f.write_str("f32.neg"),
-            Lang::F64Neg(_) => f.write_str("f64.neg"),
-            Lang::F32Sqrt(_) => f.write_str("f32.sqrt"),
-            Lang::F64Sqrt(_) => f.write_str("f64.sqrt"),
-            Lang::F32Ceil(_) => f.write_str("f32.ceil"),
-            Lang::F64Ceil(_) => f.write_str("f64.ceil"),
-            Lang::F32Floor(_) => f.write_str("f32.floor"),
-            Lang::F64Floor(_) => f.write_str("f64.floor"),
-            Lang::F32Trunc(_) => f.write_str("f32.trunc"),
-            Lang::F64Trunc(_) => f.write_str("f64.trunc"),
-            Lang::F32Nearest(_) => f.write_str("f32.nearest"),
-            Lang::F64Nearest(_) => f.write_str("f64.nearest"),
-            Lang::LocalGet(idx) => f.write_str(&format!("local.get.{}", idx)),
-            Lang::GlobalGet(idx) => f.write_str(&format!("global.get.{}", idx)),
-            Lang::GlobalSet(idx, _) => f.write_str(&format!("global.set.{}", idx)),
-            Lang::Wrap(_) => f.write_str("wrap"),
-            Lang::I32Extend8S(_) => f.write_str("i32.extend8_s"),
-            Lang::I64Extend8S(_) => f.write_str("i64.extend8_s"),
-            Lang::I32Extend16S(_) => f.write_str("i32.extend16_s"),
-            Lang::I64Extend16S(_) => f.write_str("i64.extend16_s"),
-            Lang::I64Extend32S(_) => f.write_str("i64.extend32_s"),
-            Lang::I64ExtendI32S(_) => f.write_str("i64.extendi32_s"),
-            Lang::I64ExtendI32U(_) => f.write_str("i64.extendi32_u"),
-            Lang::I32TruncF32S(_) => f.write_str("i32.truncf32_s"),
-            Lang::I32TruncF32U(_) => f.write_str("i32.truncf32_u"),
-            Lang::I32TruncF64S(_) => f.write_str("i32.truncf64_s"),
-            Lang::I32TruncF64U(_) => f.write_str("i32.truncf64_u"),
-            Lang::I64TruncF32S(_) => f.write_str("i64.truncf32_s"),
-            Lang::I64TruncF32U(_) => f.write_str("i64.truncf32_u"),
-            Lang::I64TruncF64S(_) => f.write_str("i64.truncf64_s"),
-            Lang::I64TruncF64U(_) => f.write_str("i64.truncf64_u"),
-            Lang::F32ConvertI32S(_) => f.write_str("f32.converti32_s"),
-            Lang::F32ConvertI32U(_) => f.write_str("f32.converti32_u"),
-            Lang::F32ConvertI64S(_) => f.write_str("f32.converti64_s"),
-            Lang::F32ConvertI64U(_) => f.write_str("f32.converti64_u"),
-            Lang::F32DemoteF64(_) => f.write_str("f32.demotef64"),
-            Lang::F64ConvertI32S(_) => f.write_str("f64.converti32_s"),
-            Lang::F64ConvertI32U(_) => f.write_str("f64.converti32_u"),
-            Lang::F64ConvertI64S(_) => f.write_str("f64.converti64_s"),
-            Lang::F64ConvertI64U(_) => f.write_str("f64.converti64_u"),
-            Lang::F64PromoteF32(_) => f.write_str("f64.promotef32"),
-            Lang::I32ReinterpretF32(_) => f.write_str("i32.reinterpretf32"),
-            Lang::I64ReinterpretF64(_) => f.write_str("i64.reinterpretf64"),
-            Lang::F32ReinterpretI32(_) => f.write_str("f32.reinterpreti32"),
-            Lang::F64ReinterpretI64(_) => f.write_str("f64.reinterpreti64"),
-            Lang::I32TruncSatF32S(_) => f.write_str("i32.truncsatf32_s"),
-            Lang::I32TruncSatF32U(_) => f.write_str("i32.truncsatf32_u"),
-            Lang::I32TruncSatF64S(_) => f.write_str("i32.truncsatf64_s"),
-            Lang::I32TruncSatF64U(_) => f.write_str("i32.truncsatf64_u"),
-            Lang::I64TruncSatF32S(_) => f.write_str("i64.truncsatf32_s"),
-            Lang::I64TruncSatF32U(_) => f.write_str("i64.truncsatf32_u"),
-            Lang::I64TruncSatF64S(_) => f.write_str("i64.truncsatf64_s"),
-            Lang::I64TruncSatF64U(_) => f.write_str("i64.truncsatf64_u"),
-            Lang::Call(idx, _) => f.write_str(&format!("call.{}", idx)),
-            Lang::Drop(_) => f.write_str("drop"),
-            Lang::I32Load {
-                static_offset,
-                align,
-                mem,
-                offset: _,
-            } => f.write_str(&format!("i32.load.{}.{}.{}", static_offset, align, mem)),
-            Lang::I64Load {
-                static_offset,
-                align,
-                mem,
-                offset: _,
-            } => f.write_str(&format!("i64.load.{}.{}.{}", static_offset, align, mem)),
-            Lang::F32Load {
-                static_offset,
-                align,
-                mem,
-                offset: _,
-            } => f.write_str(&format!("f32.load.{}.{}.{}", static_offset, align, mem)),
-            Lang::F64Load {
-                static_offset,
-                align,
-                mem,
-                offset: _,
-            } => f.write_str(&format!("f64.load.{}.{}.{}", static_offset, align, mem)),
-            Lang::I32Load8S {
-                static_offset,
-                align,
-                mem,
-                offset: _,
-            } => f.write_str(&format!("i32.load8s.{}.{}.{}", static_offset, align, mem)),
-            Lang::I32Load8U {
-                static_offset,
-                align,
-                mem,
-                offset: _,
-            } => f.write_str(&format!("i32.load8u.{}.{}.{}", static_offset, align, mem)),
-            Lang::I32Load16S {
-                static_offset,
-                align,
-                mem,
-                offset: _,
-            } => f.write_str(&format!("i32.load16s.{}.{}.{}", static_offset, align, mem)),
-            Lang::I32Load16U {
-                static_offset,
-                align,
-                mem,
-                offset: _,
-            } => f.write_str(&format!("i32.load16u.{}.{}.{}", static_offset, align, mem)),
-            Lang::I64Load8S {
-                static_offset,
-                align,
-                mem,
-                offset: _,
-            } => f.write_str(&format!("i64.load8s.{}.{}.{}", static_offset, align, mem)),
-            Lang::I64Load8U {
-                static_offset,
-                align,
-                mem,
-                offset: _,
-            } => f.write_str(&format!("i64.load8u.{}.{}.{}", static_offset, align, mem)),
-            Lang::I64Load16S {
-                static_offset,
-                align,
-                mem,
-                offset: _,
-            } => f.write_str(&format!("i64.load16s.{}.{}.{}", static_offset, align, mem)),
-            Lang::I64Load16U {
-                static_offset,
-                align,
-                mem,
-                offset: _,
-            } => f.write_str(&format!("i64.load16u.{}.{}.{}", static_offset, align, mem)),
-            Lang::I64Load32S {
-                static_offset,
-                align,
-                mem,
-                offset: _,
-            } => f.write_str(&format!("i64.load32s.{}.{}.{}", static_offset, align, mem)),
-            Lang::I64Load32U {
-                static_offset,
-                align,
-                mem,
-                offset: _,
-            } => f.write_str(&format!("i64.load32u.{}.{}.{}", static_offset, align, mem)),
-            Lang::I32Store {
-                static_offset,
-                align,
-                mem,
-                value_and_offset: _,
-            } => f.write_str(&format!("i32.store.{}.{}.{}", static_offset, align, mem)),
-            Lang::I64Store {
-                static_offset,
-                align,
-                mem,
-                value_and_offset: _,
-            } => f.write_str(&format!("i64.store.{}.{}.{}", static_offset, align, mem)),
-            Lang::F32Store {
-                static_offset,
-                align,
-                mem,
-                value_and_offset: _,
-            } => f.write_str(&format!("f32.store.{}.{}.{}", static_offset, align, mem)),
-            Lang::F64Store {
-                static_offset,
-                align,
-                mem,
-                value_and_offset: _,
-            } => f.write_str(&format!("f64.store.{}.{}.{}", static_offset, align, mem)),
-            Lang::I32Store8 {
-                static_offset,
-                align,
-                mem,
-                value_and_offset: _,
-            } => f.write_str(&format!("i32.store8.{}.{}.{}", static_offset, align, mem)),
-            Lang::I32Store16 {
-                static_offset,
-                align,
-                mem,
-                value_and_offset: _,
-            } => f.write_str(&format!("i32.store16.{}.{}.{}", static_offset, align, mem)),
-            Lang::I64Store8 {
-                static_offset,
-                align,
-                mem,
-                value_and_offset: _,
-            } => f.write_str(&format!("i64.store8.{}.{}.{}", static_offset, align, mem)),
-            Lang::I64Store16 {
-                static_offset,
-                align,
-                mem,
-                value_and_offset: _,
-            } => f.write_str(&format!("i64.store16.{}.{}.{}", static_offset, align, mem)),
-            Lang::I64Store32 {
-                static_offset,
-                align,
-                mem,
-                value_and_offset: _,
-            } => f.write_str(&format!("i64.store32.{}.{}.{}", static_offset, align, mem)),
-
-            Lang::RandI32 => f.write_str("i32.rand"),
-            Lang::RandI64 => f.write_str("i64.rand"),
-            Lang::Undef => f.write_str("undef"),
-            Lang::UnfoldI32(_) => f.write_str("i32.unfold"),
-            Lang::UnfoldI64(_) => f.write_str("i64.unfold"),
-            Lang::Nop => f.write_str("nop"),
-            Lang::Container(_) => f.write_str("container"),
-            Lang::Select(_) => f.write_str("select"),
-            Lang::MemoryGrow { mem, mem_byte, .. } => {
-                f.write_str(&format!("memory.grow.{}.{}", mem, mem_byte))
-            }
-            Lang::MemorySize { mem, mem_byte } => {
-                f.write_str(&format!("memory.size.{}.{}", mem, mem_byte))
-            }
-            Lang::I32UseGlobal(_) => f.write_str("i32.use_of_global"),
-            Lang::I64UseGlobal(_) => f.write_str("i64.use_of_global"),
-            Lang::F32UseGlobal(_) => f.write_str("f32.use_of_global"),
-            Lang::F64UseGlobal(_) => f.write_str("f64.use_of_global"),
-        }
-    }
-}
-
-impl Lang {
-    /// Parse type annotated integers in the form
-    /// $i_(i32|i64)
-    fn parse_integer(op_str: &str) -> Result<Self, String> {
-        // Check for type annotation in the tail
-        if op_str.len() < 4 {
-            return Err(format!("Missing type annotation for integer {}", op_str));
-        }
-
-        let n = &op_str[..op_str.len() - 4];
-        let tail = &op_str[op_str.len() - 4..];
-
-        match tail {
-            "_i32" => Ok(Lang::I32(
-                i32::from_str(n).expect("Invalid integer parsing radix 10"),
-            )),
-            "_i64" => Ok(Lang::I64(
-                i64::from_str(n).expect("Invalid integer parsing radix 10"),
-            )),
-            // Notice that the rewriting rules should be written in the integer representation of the float bits
-            "_f32" => Ok(Lang::F32(u32::from_str(n).expect("Invalid float parsing"))),
-            "_f64" => Ok(Lang::F64(u64::from_str(n).expect("Invalid float parsing"))),
-            // Add other types here
-            _ => Err(format!("Invalid type annotation for {:?}", op_str)),
-        }
-    }
-
-    /// Parses index operations written in the textual form
-    /// local.(get|set|tee).$i
-    /// global.(get|set).$i
-    fn parse_index_op(op_str: &str, children: &Vec<Id>) -> Result<Self, String> {
-        let splat = op_str.split('.');
-        let ops = splat.collect::<Vec<_>>();
-        if ops.len() != 3 {
-            return Err(format!("Invalid index based operation {}", op_str));
-        }
-
-        // In theory indices can have eclasses as well
-        // If we want to have index-change-like mutators
-        let i = u32::from_str(ops[2]).unwrap();
-        match &ops[..2] {
-            ["local", "get"] => Ok(Lang::LocalGet(i)),
-            ["local", "set"] => Ok(Lang::LocalSet(i, children[0])),
-            ["local", "tee"] => Ok(Lang::LocalTee(i, children[0])),
-            ["global", "get"] => Ok(Lang::GlobalGet(i)),
-            ["global", "set"] => Ok(Lang::GlobalSet(i, children[0])),
-            _ => Err(format!("Invalid index based operation {:?}", op_str)),
-        }
-    }
-
-    /// Parses index mem operations written in the textual form
-    /// `(i32|i64|...).(store|load).$static_offset.$align.$mem`.
-    fn parse_mem_op(op_str: &str, children: &Vec<Id>) -> Result<Self, String> {
-        let splat = op_str.split('.');
-        let ops = splat.collect::<Vec<_>>();
-        if ops.len() != 5 {
-            return Err(format!("Invalid mem operation operation {}", op_str));
-        }
-
-        let static_offset = u64::from_str(ops[2]).unwrap();
-        let align = u8::from_str(ops[3]).unwrap();
-        let mem = u32::from_str(ops[4]).unwrap();
-
-        match &ops[..2] {
-            ["i32", "load"] => Ok(Lang::I32Load {
-                static_offset,
-                align,
-                mem,
-                offset: children[0],
-            }),
-            ["i64", "load"] => Ok(Lang::I64Load {
-                static_offset,
-                align,
-                mem,
-                offset: children[0],
-            }),
-            ["f32", "load"] => Ok(Lang::F32Load {
-                static_offset,
-                align,
-                mem,
-                offset: children[0],
-            }),
-            ["f64", "load"] => Ok(Lang::F64Load {
-                static_offset,
-                align,
-                mem,
-                offset: children[0],
-            }),
-            ["i32", "load8s"] => Ok(Lang::I32Load8S {
-                static_offset,
-                align,
-                mem,
-                offset: children[0],
-            }),
-            ["i32", "load8u"] => Ok(Lang::I32Load8U {
-                static_offset,
-                align,
-                mem,
-                offset: children[0],
-            }),
-            ["i32", "load16s"] => Ok(Lang::I32Load16S {
-                static_offset,
-                align,
-                mem,
-                offset: children[0],
-            }),
-            ["i32", "load16u"] => Ok(Lang::I32Load16U {
-                static_offset,
-                align,
-                mem,
-                offset: children[0],
-            }),
-            ["i64", "load8s"] => Ok(Lang::I64Load8S {
-                static_offset,
-                align,
-                mem,
-                offset: children[0],
-            }),
-            ["i64", "load8u"] => Ok(Lang::I64Load8U {
-                static_offset,
-                align,
-                mem,
-                offset: children[0],
-            }),
-            ["i64", "load16s"] => Ok(Lang::I64Load16S {
-                static_offset,
-                align,
-                mem,
-                offset: children[0],
-            }),
-            ["i64", "load16u"] => Ok(Lang::I64Load16U {
-                static_offset,
-                align,
-                mem,
-                offset: children[0],
-            }),
-            ["i64", "load32s"] => Ok(Lang::I64Load32S {
-                static_offset,
-                align,
-                mem,
-                offset: children[0],
-            }),
-            ["i64", "load32u"] => Ok(Lang::I64Load32U {
-                static_offset,
-                align,
-                mem,
-                offset: children[0],
-            }),
-            ["i32", "store"] => Ok(Lang::I32Store {
-                static_offset,
-                align,
-                mem,
-                value_and_offset: [children[1], children[0]],
-            }),
-            ["i64", "store"] => Ok(Lang::I64Store {
-                static_offset,
-                align,
-                mem,
-                value_and_offset: [children[1], children[0]],
-            }),
-            ["f32", "store"] => Ok(Lang::F32Store {
-                static_offset,
-                align,
-                mem,
-                value_and_offset: [children[1], children[0]],
-            }),
-            ["f64", "store"] => Ok(Lang::F64Store {
-                static_offset,
-                align,
-                mem,
-                value_and_offset: [children[1], children[0]],
-            }),
-            ["i32", "store8"] => Ok(Lang::I32Store8 {
-                static_offset,
-                align,
-                mem,
-                value_and_offset: [children[1], children[0]],
-            }),
-            ["i32", "store16"] => Ok(Lang::I32Store16 {
-                static_offset,
-                align,
-                mem,
-                value_and_offset: [children[1], children[0]],
-            }),
-            ["i64", "store8"] => Ok(Lang::I64Store8 {
-                static_offset,
-                align,
-                mem,
-                value_and_offset: [children[1], children[0]],
-            }),
-            ["i64", "store16"] => Ok(Lang::I64Store16 {
-                static_offset,
-                align,
-                mem,
-                value_and_offset: [children[1], children[0]],
-            }),
-            ["i64", "store32"] => Ok(Lang::I64Store32 {
-                static_offset,
-                align,
-                mem,
-                value_and_offset: [children[1], children[0]],
-            }),
-            _ => Err(format!("Invalid index based operation {:?}", op_str)),
-        }
-    }
-
-    /// Parses call operators: `call.$i`
-    fn parse_call(op_str: &str, children: &Vec<Id>) -> Result<Self, String> {
-        let splat = op_str.split('.');
-        let ops = splat.collect::<Vec<_>>();
-        if ops.len() != 2 {
-            return Err(format!("Invalid call operation {}", op_str));
-        }
-        let index = usize::from_str(ops[1]).expect("Invlid function index");
-
-        match ops[0] {
-            "call" => Ok(Lang::Call(index, children.clone())),
-            _ => Err(format!("Invalid call operation {:?}", op_str)),
-        }
-    }
-
-    /// Parses memory grow or size operator: `memory.(grow|size).$mem.$membyte`
-    fn parse_memory_sg(op_str: &str, children: &Vec<Id>) -> Result<Self, String> {
-        let splat = op_str.split('.');
-        let ops = splat.collect::<Vec<_>>();
-        if ops.len() != 4 {
-            return Err(format!("Invalid memory (grow|size) operator {}", op_str));
-        }
-
-        // In theory indices can have eclasses as well
-        // If we want to have index-change-like mutators
-        let mem = u32::from_str(ops[2]).unwrap();
-        let mem_byte = u8::from_str(ops[3]).unwrap();
-        match &ops[..2] {
-            ["memory", "grow"] => Ok(Lang::MemoryGrow {
-                mem,
-                mem_byte,
-                by: children[0],
-            }),
-            ["memory", "size"] => Ok(Lang::MemorySize { mem, mem_byte }),
-            _ => Err(format!("Invalid index based operation {:?}", op_str)),
-        }
-    }
-}
-
-macro_rules! get_children {
+/// It's recommended to probably gloss over this macro. Ideally you can follow
+/// the pattern of all other existing variants and ignore this. If you can't
+/// ignore this macro I can apologize in advance because it's a pretty gnarly
+/// macro. While it seems to work it's "macro soup" incarnate.
+macro_rules! lang {
     (
-        expr: $e:expr,
-        from_ref: $from_ref:ident,
-    ) => {
-        match $e {
-            // binops
-            Lang::I64Add(operands)
-            | Lang::I32Sub(operands)
-            | Lang::I64Sub(operands)
-            | Lang::I32Mul(operands)
-            | Lang::I64Mul(operands)
-            | Lang::I32And(operands)
-            | Lang::I64And(operands)
-            | Lang::I32Or(operands)
-            | Lang::I64Or(operands)
-            | Lang::I32Xor(operands)
-            | Lang::I64Xor(operands)
-            | Lang::I32Shl(operands)
-            | Lang::I64Shl(operands)
-            | Lang::I32ShrU(operands)
-            | Lang::I64ShrU(operands)
-            | Lang::I32DivU(operands)
-            | Lang::I64DivU(operands)
-            | Lang::I32DivS(operands)
-            | Lang::I64DivS(operands)
-            | Lang::I32ShrS(operands)
-            | Lang::I64ShrS(operands)
-            | Lang::I32RotR(operands)
-            | Lang::I64RotR(operands)
-            | Lang::I32RotL(operands)
-            | Lang::I64RotL(operands)
-            | Lang::I32RemS(operands)
-            | Lang::I64RemS(operands)
-            | Lang::I32RemU(operands)
-            | Lang::I64RemU(operands)
-            | Lang::I32Eq(operands)
-            | Lang::I64Eq(operands)
-            | Lang::I32Ne(operands)
-            | Lang::I64Ne(operands)
-            | Lang::I32LtS(operands)
-            | Lang::I64LtS(operands)
-            | Lang::I32LtU(operands)
-            | Lang::I64LtU(operands)
-            | Lang::I32GtS(operands)
-            | Lang::I64GtS(operands)
-            | Lang::I32GtU(operands)
-            | Lang::I64GtU(operands)
-            | Lang::I32LeS(operands)
-            | Lang::I64LeS(operands)
-            | Lang::I32LeU(operands)
-            | Lang::I64LeU(operands)
-            | Lang::I32GeS(operands)
-            | Lang::I64GeS(operands)
-            | Lang::I32GeU(operands)
-            | Lang::I64GeU(operands)
-            | Lang::I32Add(operands)
-            | Lang::F32Add(operands)
-            | Lang::F64Add(operands)
-            | Lang::F32Sub(operands)
-            | Lang::F64Sub(operands)
-            | Lang::F32Mul(operands)
-            | Lang::F64Mul(operands)
-            | Lang::F32Div(operands)
-            | Lang::F64Div(operands)
-            | Lang::F32Min(operands)
-            | Lang::F64Min(operands)
-            | Lang::F32Max(operands)
-            | Lang::F64Max(operands)
-            | Lang::F32Copysign(operands)
-            | Lang::F64Copysign(operands)
-            | Lang::F32Eq(operands)
-            | Lang::F64Eq(operands)
-            | Lang::F32Ne(operands)
-            | Lang::F64Ne(operands)
-            | Lang::F32Lt(operands)
-            | Lang::F64Lt(operands)
-            | Lang::F32Gt(operands)
-            | Lang::F64Gt(operands)
-            | Lang::F32Le(operands)
-            | Lang::F64Le(operands)
-            | Lang::F32Ge(operands)
-            | Lang::F64Ge(operands) => operands,
-            // unops
-            Lang::Drop(operands)
-            | Lang::I32Extend8S(operands)
-            | Lang::I64Extend8S(operands)
-            | Lang::I32Extend16S(operands)
-            | Lang::I64Extend16S(operands)
-            | Lang::I64Extend32S(operands)
-            | Lang::I64ExtendI32S(operands)
-            | Lang::I64ExtendI32U(operands)
-            | Lang::I64Popcnt(operands)
-            | Lang::I32Eqz(operands)
-            | Lang::I64Eqz(operands)
-            | Lang::I32Popcnt(operands)
-            | Lang::I32Clz(operands)
-            | Lang::I32Ctz(operands)
-            | Lang::I64Ctz(operands)
-            | Lang::I64Clz(operands)
-            | Lang::F32Abs(operands)
-            | Lang::F64Abs(operands)
-            | Lang::F32Neg(operands)
-            | Lang::F64Neg(operands)
-            | Lang::F32Sqrt(operands)
-            | Lang::F64Sqrt(operands)
-            | Lang::F32Ceil(operands)
-            | Lang::F64Ceil(operands)
-            | Lang::F32Floor(operands)
-            | Lang::F64Floor(operands)
-            | Lang::F32Trunc(operands)
-            | Lang::F64Trunc(operands)
-            | Lang::F32Nearest(operands)
-            | Lang::F64Nearest(operands)
-            | Lang::I32TruncF32S(operands)
-            | Lang::I32TruncF32U(operands)
-            | Lang::I32TruncF64S(operands)
-            | Lang::I32TruncF64U(operands)
-            | Lang::I64TruncF32S(operands)
-            | Lang::I64TruncF32U(operands)
-            | Lang::I64TruncF64S(operands)
-            | Lang::I64TruncF64U(operands)
-            | Lang::F32ConvertI32S(operands)
-            | Lang::F32ConvertI32U(operands)
-            | Lang::F32ConvertI64S(operands)
-            | Lang::F32ConvertI64U(operands)
-            | Lang::F32DemoteF64(operands)
-            | Lang::F64ConvertI32S(operands)
-            | Lang::F64ConvertI32U(operands)
-            | Lang::F64ConvertI64S(operands)
-            | Lang::F64ConvertI64U(operands)
-            | Lang::F64PromoteF32(operands)
-            | Lang::I32ReinterpretF32(operands)
-            | Lang::I64ReinterpretF64(operands)
-            | Lang::F32ReinterpretI32(operands)
-            | Lang::F64ReinterpretI64(operands)
-            | Lang::I32TruncSatF32S(operands)
-            | Lang::I32TruncSatF32U(operands)
-            | Lang::I32TruncSatF64S(operands)
-            | Lang::I32TruncSatF64U(operands)
-            | Lang::I64TruncSatF32S(operands)
-            | Lang::I64TruncSatF32U(operands)
-            | Lang::I64TruncSatF64S(operands)
-            | Lang::I64TruncSatF64U(operands) => operands,
-            Lang::GlobalSet(_, val) | Lang::LocalTee(_, val) => std::slice::$from_ref(val),
-            Lang::LocalSet(_, val) => std::slice::$from_ref(val),
-            Lang::LocalGet(_) => &mut [],
-            Lang::GlobalGet(_) => &mut [],
-            Lang::Wrap(operands) => operands,
-            Lang::Call(_, operands) => operands,
-            Lang::I32Load {
-                offset,
-                static_offset: _,
-                align: _,
-                mem: _,
-            }
-            | Lang::I64Load {
-                offset,
-                static_offset: _,
-                align: _,
-                mem: _,
-            }
-            | Lang::F32Load {
-                static_offset: _,
-                align: _,
-                mem: _,
-                offset,
-            }
-            | Lang::F64Load {
-                static_offset: _,
-                align: _,
-                mem: _,
-                offset,
-            }
-            | Lang::I32Load8S {
-                static_offset: _,
-                align: _,
-                mem: _,
-                offset,
-            }
-            | Lang::I32Load8U {
-                static_offset: _,
-                align: _,
-                mem: _,
-                offset,
-            }
-            | Lang::I32Load16S {
-                static_offset: _,
-                align: _,
-                mem: _,
-                offset,
-            }
-            | Lang::I32Load16U {
-                static_offset: _,
-                align: _,
-                mem: _,
-                offset,
-            }
-            | Lang::I64Load8S {
-                static_offset: _,
-                align: _,
-                mem: _,
-                offset,
-            }
-            | Lang::I64Load8U {
-                static_offset: _,
-                align: _,
-                mem: _,
-                offset,
-            }
-            | Lang::I64Load16S {
-                static_offset: _,
-                align: _,
-                mem: _,
-                offset,
-            }
-            | Lang::I64Load16U {
-                static_offset: _,
-                align: _,
-                mem: _,
-                offset,
-            }
-            | Lang::I64Load32S {
-                static_offset: _,
-                align: _,
-                mem: _,
-                offset,
-            }
-            | Lang::I64Load32U {
-                static_offset: _,
-                align: _,
-                mem: _,
-                offset,
-            } => std::slice::$from_ref(offset),
-            Lang::I32Store {
-                value_and_offset,
-                static_offset: _,
-                align: _,
-                mem: _,
-            }
-            | Lang::I64Store {
-                value_and_offset,
-                static_offset: _,
-                align: _,
-                mem: _,
-            }
-            | Lang::F32Store {
-                value_and_offset,
-                static_offset: _,
-                align: _,
-                mem: _,
-            }
-            | Lang::F64Store {
-                value_and_offset,
-                static_offset: _,
-                align: _,
-                mem: _,
-            }
-            | Lang::I32Store8 {
-                value_and_offset,
-                static_offset: _,
-                align: _,
-                mem: _,
-            }
-            | Lang::I32Store16 {
-                value_and_offset,
-                static_offset: _,
-                align: _,
-                mem: _,
-            }
-            | Lang::I64Store8 {
-                value_and_offset,
-                static_offset: _,
-                align: _,
-                mem: _,
-            }
-            | Lang::I64Store16 {
-                value_and_offset,
-                static_offset: _,
-                align: _,
-                mem: _,
-            }
-            | Lang::I64Store32 {
-                value_and_offset,
-                static_offset: _,
-                align: _,
-                mem: _,
-            } => value_and_offset,
-            Lang::RandI32 => &mut [],
-            Lang::RandI64 => &mut [],
-            Lang::Undef => &mut [],
-            Lang::UnfoldI32(operand) | Lang::UnfoldI64(operand) => std::slice::$from_ref(operand),
-            Lang::I32(_) => &mut [],
-            Lang::I64(_) => &mut [],
-            Lang::F32(_) => &mut [],
-            Lang::F64(_) => &mut [],
-            Lang::Nop => &mut [],
-            Lang::Container(operands) => operands,
-            Lang::Select(operands) => operands,
-            Lang::MemoryGrow { by, .. } => std::slice::$from_ref(by),
-            Lang::MemorySize { .. } => &mut [],
-            Lang::I32UseGlobal(arg)
-            | Lang::I64UseGlobal(arg)
-            | Lang::F32UseGlobal(arg)
-            | Lang::F64UseGlobal(arg) => std::slice::$from_ref(arg),
+        $(#[$attr:meta])*
+        pub enum $lang:ident {
+            $(
+                $(#[$docs:meta])*
+                $case:ident $(($($inner:tt)*))? = $name:tt,
+            )*
         }
-    }
+    ) => {
+        $(#[$attr])*
+        pub enum $lang {
+            $(
+                $(#[$docs])*
+                $case $(($($inner)*))?,
+            )*
+        }
+
+        impl Display for $lang {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                match self {
+                    $(
+                        lang!(@first _x $lang::$case $(($($inner)*))?) => {
+                            lang!(@fmt f _x $name $($($inner)*)?)
+                        }
+                    )*
+                }
+            }
+        }
+
+        impl egg::Language for Lang {
+            fn matches(&self, other: &Self) -> bool {
+                match (self, other) {
+                    $(
+                        (
+                            lang!(@first _x $lang::$case $(($($inner)*))?),
+                            lang!(@first _y $lang::$case $(($($inner)*))?),
+                        ) => lang!(@matches _x _y $($($inner)*)?),
+                    )*
+
+                    _ => false,
+                }
+            }
+
+            fn children(&self) -> &[Id] {
+                match self {
+                    $(
+                        lang!(@last _x $lang::$case $(($($inner)*))?) => {
+                            lang!(@children _x $($($inner)*)?)
+                        }
+                    )*
+                }
+            }
+
+            fn children_mut(&mut self) -> &mut [Id] {
+                match self {
+                    $(
+                        lang!(@last _x $lang::$case $(($($inner)*))?) => {
+                            lang!(@children_mut _x $($($inner)*)?)
+                        }
+                    )*
+                }
+            }
+
+            fn display_op(&self) -> &dyn std::fmt::Display {
+                self
+            }
+
+            fn from_op_str(op_str: &str, children: Vec<Id>) -> Result<Self, String> {
+                $(
+                    lang!(@from_op_str op_str children $name $lang::$case $(($($inner)*))?);
+                )*
+                Err(format!("invalid token {:?}", op_str))
+            }
+        }
+    };
+
+    // Helper to generate a match-pattern that extracts the first variant as
+    // $x, and with no types it matches nothing.
+    (@first $x:ident $lang:ident :: $case:ident) => ($lang::$case);
+    (@first $x:ident $lang:ident :: $case:ident ($($t:tt)* )) => ($lang::$case($x, ..));
+
+    // Same as above, but matches the last variant. Note that for variants
+    // with one type this will return that binding.
+    (@last $x:ident $lang:ident :: $case:ident) => ($lang::$case);
+    (@last $x:ident $lang:ident :: $case:ident ($($t:tt)* )) => ($lang::$case(.., $x));
+
+    // Implementation of `children` and `children_mut`
+    //
+    // These largely delegate the `Children` trait to perform the actual
+    // slicing, but only if the last argument of the binding (which is input
+    // via `$x` here) looks like a child.
+    (@children $x:ident $($t:tt)*) => (
+        lang!(@if_last_is_child ($($t)*) { Children::as_slice($x) } else { &[] })
+    );
+    (@children_mut $x:ident $($t:tt)*) => (
+        lang!(@if_last_is_child ($($t)*) { Children::as_slice_mut($x) } else { &mut [] })
+    );
+
+    // Implementation of `display_op`
+
+    (@fmt $fmt:ident $payload:ident $opname:tt) => ($fmt.write_str($opname));
+    (@fmt $fmt:ident $payload:ident $opname:tt $($t:tt)*) => (
+        lang!(@if_first_is_child ($($t)*) {
+            // If the first type argument is a child then this variant has no
+            // payload so our string representation is simply the operation.
+            $fmt.write_str($opname)
+        } else {
+            // ... otherwise if the first type, `$payload`, isn't a child then
+            // it's part of the static payload and is included after the
+            // operand with a `.`
+            write!($fmt, "{}.{}", $opname, $payload)
+        })
+    );
+
+    // Implementation of `matches`
+
+    // special case for empty variants
+    (@matches $x:ident $y:ident) => (true);
+    // If the first element, which is bound by x/y, is a child then no equality
+    // check is necessary, otherwise equality is performed.
+    (@matches $x:ident $y:ident $($t:tt)*) => (
+        lang!(@if_first_is_child ($($t)*) { true } else { $x == $y })
+    );
+
+    // Macro selection to condition on whether the last element of the tuple is
+    // a list of children or not.
+
+    // 2 types? Conventionally the last is always a list of children
+    (@if_last_is_child ($t1:ty, $t2:ty) { $($t:tt)* } else { $($f:tt)* }) => ($($t)*);
+    // 1 type? Well if the first looks like a list of children then it's a child
+    (@if_last_is_child ([Id; $n:tt]) { $($t:tt)* } else { $($f:tt)* }) => ($($t)*);
+    (@if_last_is_child (Vec<Id>) { $($t:tt)* } else { $($f:tt)* }) => ($($t)*);
+    (@if_last_is_child (Id) { $($t:tt)* } else { $($f:tt)* }) => ($($t)*);
+    // ... otherwise all other types and 0 types the last type isn't a child
+    (@if_last_is_child ($($ty:tt)*) { $($t:tt)* } else { $($f:tt)* }) => ($($f)*);
+
+    // Macro selection to condition on whether the first element of the tuple is
+    // a list of children or not.
+
+    // 2 types? Conventionally the first is never a child
+    (@if_first_is_child ($t1:ty, $t2:ty) { $($t:tt)* } else { $($f:tt)* }) => ($($f)*);
+    // 1 type? Check to see if the first looks like a child or not
+    (@if_first_is_child ([Id; $n:tt]) { $($t:tt)* } else { $($f:tt)* }) => ($($t)*);
+    (@if_first_is_child (Vec<Id>) { $($t:tt)* } else { $($f:tt)* }) => ($($t)*);
+    (@if_first_is_child (Id) { $($t:tt)* } else { $($f:tt)* }) => ($($t)*);
+    // ... otherwise all other types or 0 types don't have a child as tthe first type
+    (@if_first_is_child ($($ty:tt)*) { $($t:tt)* } else { $($f:tt)* }) => ($($f)*);
+
+    // Implementation of `from_op_str`.
+
+    // Special case for no payload. The `$op` must match exactly and
+    // `$children` must be empty.
+    (@from_op_str $op:ident $children:ident $name:tt $lang:ident :: $case:ident) => ({
+        if $op == $name {
+            if $children.len() != 0 {
+                return Err(format!("expected zero children"))
+            }
+            return Ok($lang::$case);
+        }
+    });
+
+    (@from_op_str $op:ident $children:ident $name:tt $lang:ident::$case:ident($($t:tt)*)) => (
+        lang!(@if_first_is_child ($($t)*) {
+            // If the first type is a child, then there's no payload and we
+            // simply match `$op` to `$name` and fallibly convert the list of
+            // children to the correct type.
+            if $op == $name {
+                return Ok($lang::$case(Children::from($children)?))
+            }
+        } else {
+            // Otherwise if the first type isn't a child, and this isn't an
+            // empty variant handled above, our operator has a payload. Look
+            // to see whether this is the correct operator by stripping the
+            // prefix.
+            if let Some(suffix) = $op.strip_prefix(concat!($name, ".")) {
+                lang!(@if_last_is_child ($($t)*) {{
+                    // If the last part of this type is a child list then the
+                    // first part parses `suffix` and children goes into the
+                    // list of children.
+                    return Ok($lang::$case(
+                        match suffix.parse() {
+                            Ok(e) => e,
+                            Err(e) => return Err(e.to_string()),
+                        },
+                        Children::from($children)?,
+                    ));
+                }} else {{
+                    // If the last type isn't a child list then it means this
+                    // node has no children. Verify as such and then parse the
+                    // suffix for the static information.
+                    if $children.len() != 0 {
+                        return Err(format!("expected zero children"))
+                    }
+                    return Ok($lang::$case(
+                        match suffix.parse() {
+                            Ok(e) => e,
+                            Err(e) => return Err(e.to_string()),
+                        },
+                    ));
+                }})
+            }
+        })
+    );
 }
 
-impl egg::Language for Lang {
-    fn matches(&self, other: &Self) -> bool {
-        let mut me = self.clone();
-        let mut other = other.clone();
-        for slot in me.children_mut().iter_mut().chain(other.children_mut()) {
-            *slot = 0.into();
-        }
-        me == other
-    }
+lang! {
+    /// Each "mutable" operator of Wasm is defined here plus articial operators
+    /// with a a custom behavior.
+    ///
+    /// As a note this enum is actually defined by the `lang!` macro above. The
+    /// definition here is intended to look similar to the generated
+    /// definition, but some conventions must be upheld for now:
+    ///
+    /// * Variants must either be `A`, `A(B)`, or `A(B, C)`.
+    /// * For `A(B)` then `B` can either be a "list" of children or static
+    ///   information.
+    /// * For `A(B, C)`, if specified `C` must be a "list" of children.
+    ///
+    /// The "list" of children can be either `Id`, `[Id; N]`, or `Vec<Id>`. When
+    /// `B` is not a list of children it must implement both `Display` and
+    /// `FromStr`.
+    ///
+    /// You can define custom operators by adding a variant to this enum.
+    /// Notice that custom operator nodes can only be created from rewriting
+    /// rules and not form the direct translation of the Wasm binary. Let's
+    /// assume for example that we want to implement a custom node that insert
+    /// three `nop` operators when it is written back to Wasm.
+    ///
+    /// * We firsts need to define the custom node ```ThreeNops``` as a variant of
+    ///   the [Lang] enum.
+    ///   ```ignore
+    ///   ThreeNops = "three.nops",
+    ///   ```
+    /// * The custom node needs to translated to Wasm. To do so, you need to modify
+    ///   the `expr2wasm` function somehow as follow
+    ///   ```ignore
+    ///   Lang::ThreeNops => {
+    ///     newfunc.instruction(&Instruction::Nop);
+    ///     newfunc.instruction(&Instruction::Nop);
+    ///     newfunc.instruction(&Instruction::Nop);
+    ///   }
+    ///   ```
+    /// * The final step is to use this node in a rewriting rule. Inside the
+    ///   [`rules.rs`]() file
+    ///   ```ignore
+    ///   rewrite!("three-nops";  "?x" => "(container ?x three_nops)"),
+    ///   ```
+    ///
+    /// Most other details about the `Lang` should be generated from the enum
+    /// variant definition and you can otherwise be guided by various compiler
+    /// errors.
+    #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+    pub enum Lang {
+        // binops integers
+        /// i32.add operator
+        I32Add([Id; 2]) = "i32.add",
+        /// i64.add operator
+        I64Add([Id; 2]) = "i64.add",
+        /// i32.sub  operator
+        I32Sub([Id; 2]) = "i32.sub",
+        /// i64.sub  operator
+        I64Sub([Id; 2]) = "i64.sub",
+        /// i32.mul  operator
+        I32Mul([Id; 2]) = "i32.mul",
+        /// i64.mul  operator
+        I64Mul([Id; 2]) = "i64.mul",
+        /// i32.and  operator
+        I32And([Id; 2]) = "i32.and",
+        /// i64.and  operator
+        I64And([Id; 2]) = "i64.and",
+        /// i32.or  operator
+        I32Or([Id; 2]) = "i32.or",
+        /// i64.or  operator
+        I64Or([Id; 2]) = "i64.or",
+        /// i32.xor  operator
+        I32Xor([Id; 2]) = "i32.xor",
+        /// i64.xor  operator
+        I64Xor([Id; 2]) = "i64.xor",
+        /// i32.shl  operator
+        I32Shl([Id; 2]) = "i32.shl",
+        /// i64.shl  operator
+        I64Shl([Id; 2]) = "i64.shl",
+        /// i32.shru  operator
+        I32ShrU([Id; 2]) = "i32.shr_u",
+        /// i64.shru  operator
+        I64ShrU([Id; 2]) = "i64.shr_u",
+        /// i32.divu  operator
+        I32DivU([Id; 2]) = "i32.div_u",
+        /// i64.divu  operator
+        I64DivU([Id; 2]) = "i64.div_u",
+        /// i32.divs  operator
+        I32DivS([Id; 2]) = "i32.div_s",
+        /// i64.divs  operator
+        I64DivS([Id; 2]) = "i64.div_s",
+        /// i32.shrs  operator
+        I32ShrS([Id; 2]) = "i32.shr_s",
+        /// i64.shrs  operator
+        I64ShrS([Id; 2]) = "i64.shr_s",
+        /// i32.rotr  operator
+        I32RotR([Id; 2]) = "i32.rotr",
+        /// i64.rotr  operator
+        I64RotR([Id; 2]) = "i64.rotr",
+        /// i32.rotl  operator
+        I32RotL([Id; 2]) = "i32.rotl",
+        /// i64.rotl  operator
+        I64RotL([Id; 2]) = "i64.rotl",
+        /// i32.rems  operator
+        I32RemS([Id; 2]) = "i32.rem_s",
+        /// i64.rems  operator
+        I64RemS([Id; 2]) = "i64.rem_s",
+        /// i32.remu  operator
+        I32RemU([Id; 2]) = "i32.rem_u",
+        /// i64.remu  operator
+        I64RemU([Id; 2]) = "i64.rem_u",
+        /// i32.eq  operator
+        I32Eq([Id; 2]) = "i32.eq",
+        /// i64.eq  operator
+        I64Eq([Id; 2]) = "i64.eq",
+        /// i32.ne  operator
+        I32Ne([Id; 2]) = "i32.ne",
+        /// i64.ne  operator
+        I64Ne([Id; 2]) = "i64.ne",
+        /// i32.lts  operator
+        I32LtS([Id; 2]) = "i32.lt_s",
+        /// i64.lts  operator
+        I64LtS([Id; 2]) = "i64.lt_s",
+        /// i32.ltu  operator
+        I32LtU([Id; 2]) = "i32.lt_u",
+        /// i64.ltu  operator
+        I64LtU([Id; 2]) = "i64.lt_u",
+        /// i32.gts  operator
+        I32GtS([Id; 2]) = "i32.gt_s",
+        /// i64.gts  operator
+        I64GtS([Id; 2]) = "i64.gt_s",
+        /// i32.gtu  operator
+        I32GtU([Id; 2]) = "i32.gt_u",
+        /// i64.gtu  operator
+        I64GtU([Id; 2]) = "i64.gt_u",
+        /// i32.les  operator
+        I32LeS([Id; 2]) = "i32.le_s",
+        /// i64.les  operator
+        I64LeS([Id; 2]) = "i64.le_s",
+        /// i32.leu  operator
+        I32LeU([Id; 2]) = "i32.le_u",
+        /// i64.leu  operator
+        I64LeU([Id; 2]) = "i64.le_u",
+        /// i32.ges  operator
+        I32GeS([Id; 2]) = "i32.ge_s",
+        /// i64.ges  operator
+        I64GeS([Id; 2]) = "i64.ge_s",
+        /// i32.geu  operator
+        I32GeU([Id; 2]) = "i32.ge_u",
+        /// i64.geu  operator
+        I64GeU([Id; 2]) = "i64.ge_u",
+        // binops floats
+        /// f32.add  operator
+        F32Add([Id; 2]) = "f32.add",
+        /// f64.add  operator
+        F64Add([Id; 2]) = "f64.add",
+        /// f32.sub  operator
+        F32Sub([Id; 2]) = "f32.sub",
+        /// f64.sub  operator
+        F64Sub([Id; 2]) = "f64.sub",
+        /// f32.mul  operator
+        F32Mul([Id; 2]) = "f32.mul",
+        /// f64.mul  operator
+        F64Mul([Id; 2]) = "f64.mul",
+        /// f32.div  operator
+        F32Div([Id; 2]) = "f32.div",
+        /// f64.div  operator
+        F64Div([Id; 2]) = "f64.div",
+        /// f32.min  operator
+        F32Min([Id; 2]) = "f32.min",
+        /// f64.min  operator
+        F64Min([Id; 2]) = "f64.min",
+        /// f32.max  operator
+        F32Max([Id; 2]) = "f32.max",
+        /// f64.max  operator
+        F64Max([Id; 2]) = "f64.max",
+        /// f32.copysign  operator
+        F32Copysign([Id; 2]) = "f32.copysign",
+        /// f64.copysign  operator
+        F64Copysign([Id; 2]) = "f64.copysign",
+        // frelops
+        /// f32.eq  operator
+        F32Eq([Id; 2]) = "f32.eq",
+        /// f64.eq  operator
+        F64Eq([Id; 2]) = "f64.eq",
+        /// f32.ne  operator
+        F32Ne([Id; 2]) = "f32.ne",
+        /// f64.ne  operator
+        F64Ne([Id; 2]) = "f64.ne",
+        /// f32.lt  operator
+        F32Lt([Id; 2]) = "f32.lt",
+        /// f64.lt  operator
+        F64Lt([Id; 2]) = "f64.lt",
+        /// f32.gt  operator
+        F32Gt([Id; 2]) = "f32.gt",
+        /// f64.gt  operator
+        F64Gt([Id; 2]) = "f64.gt",
+        /// f32.le  operator
+        F32Le([Id; 2]) = "f32.le",
+        /// f64.le  operator
+        F64Le([Id; 2]) = "f64.le",
+        /// f32.ge  operator
+        F32Ge([Id; 2]) = "f32.ge",
+        /// f64.ge  operator
+        F64Ge([Id; 2]) = "f64.ge",
+        // unops integers
+        /// i32.eqz  operator
+        I32Eqz([Id; 1]) = "i32.eqz",
+        /// i64.eqz  operator
+        I64Eqz([Id; 1]) = "i64.eqz",
 
-    fn children(&self) -> &[Id] {
-        get_children! {
-            expr: self,
-            from_ref: from_ref,
-        }
-    }
+        /// i32.popcnt  operator
+        I32Popcnt([Id; 1]) = "i32.popcnt",
+        /// i64.popcnt  operator
+        I64Popcnt([Id; 1]) = "i64.popcnt",
+        /// i32.clz  operator
+        I32Clz([Id; 1]) = "i32.clz",
+        /// i32.ctz  operator
+        I32Ctz([Id; 1]) = "i32.ctz",
+        /// i64.ctz  operator
+        I64Ctz([Id; 1]) = "i64.ctz",
+        /// i64.clz  operator
+        I64Clz([Id; 1]) = "i64.clz",
 
-    fn children_mut(&mut self) -> &mut [Id] {
-        get_children! {
-            expr: self,
-            from_ref: from_mut,
-        }
-    }
+        // unops floats
+        /// f32.abs  operator
+        F32Abs([Id; 1]) = "f32.abs",
+        /// f64.abs  operator
+        F64Abs([Id; 1]) = "f64.abs",
+        /// f32.neg  operator
+        F32Neg([Id; 1]) = "f32.neg",
+        /// f64.neg  operator
+        F64Neg([Id; 1]) = "f64.neg",
+        /// f32.sqrt  operator
+        F32Sqrt([Id; 1]) = "f32.sqrt",
+        /// f64.sqrt  operator
+        F64Sqrt([Id; 1]) = "f64.sqrt",
+        /// f32.ceil  operator
+        F32Ceil([Id; 1]) = "f32.ceil",
+        /// f64.ceil  operator
+        F64Ceil([Id; 1]) = "f64.ceil",
+        /// f32.floor  operator
+        F32Floor([Id; 1]) = "f32.floor",
+        /// f64.floor  operator
+        F64Floor([Id; 1]) = "f64.floor",
+        /// f32.trunc  operator
+        F32Trunc([Id; 1]) = "f32.trunc",
+        /// f64.trunc  operator
+        F64Trunc([Id; 1]) = "f64.trunc",
+        /// f32.nearest  operator
+        F32Nearest([Id; 1]) = "f32.nearest",
+        /// f64.nearest  operator
+        F64Nearest([Id; 1]) = "f64.nearest",
 
-    fn display_op(&self) -> &dyn std::fmt::Display {
-        self
-    }
+        // Locals
+        // Idx and value
+        /// local.tee operator
+        LocalTee(u32, Id) = "local.tee",
+        // Idx and value
+        /// local.set operator
+        LocalSet(u32, Id) = "local.set",
+        /// local.get operator
+        LocalGet(u32) = "local.get",
 
-    fn from_op_str(op_str: &str, children: Vec<Id>) -> Result<Self, String> {
-        match op_str {
-            // binops
-            "i32.add" => Ok(Lang::I32Add([children[0], children[1]])),
-            "i64.add" => Ok(Lang::I64Add([children[0], children[1]])),
-            "i32.sub" => Ok(Lang::I32Sub([children[0], children[1]])),
-            "i64.sub" => Ok(Lang::I64Sub([children[0], children[1]])),
-            "i32.mul" => Ok(Lang::I32Mul([children[0], children[1]])),
-            "i64.mul" => Ok(Lang::I64Mul([children[0], children[1]])),
-            "i32.and" => Ok(Lang::I32And([children[0], children[1]])),
-            "i64.and" => Ok(Lang::I64And([children[0], children[1]])),
-            "i32.or" => Ok(Lang::I32Or([children[0], children[1]])),
-            "i64.or" => Ok(Lang::I64Or([children[0], children[1]])),
-            "i32.xor" => Ok(Lang::I32Xor([children[0], children[1]])),
-            "i64.xor" => Ok(Lang::I64Xor([children[0], children[1]])),
-            "i32.shl" => Ok(Lang::I32Shl([children[0], children[1]])),
-            "i64.shl" => Ok(Lang::I64Shl([children[0], children[1]])),
-            "i32.shr_u" => Ok(Lang::I32ShrU([children[0], children[1]])),
-            "i64.shr_u" => Ok(Lang::I64ShrU([children[0], children[1]])),
-            "i32.div_u" => Ok(Lang::I32DivU([children[0], children[1]])),
-            "i64.div_u" => Ok(Lang::I64DivU([children[0], children[1]])),
-            "i32.div_s" => Ok(Lang::I32DivS([children[0], children[1]])),
-            "i64.div_s" => Ok(Lang::I64DivS([children[0], children[1]])),
-            "i32.shr_s" => Ok(Lang::I32ShrS([children[0], children[1]])),
-            "i64.shr_s" => Ok(Lang::I64ShrS([children[0], children[1]])),
-            "i32.rotr" => Ok(Lang::I32RotR([children[0], children[1]])),
-            "i64.rotr" => Ok(Lang::I64RotR([children[0], children[1]])),
-            "i32.rotl" => Ok(Lang::I32RotL([children[0], children[1]])),
-            "i64.rotl" => Ok(Lang::I64RotL([children[0], children[1]])),
-            "i32.rem_s" => Ok(Lang::I32RemS([children[0], children[1]])),
-            "i64.rem_s" => Ok(Lang::I64RemS([children[0], children[1]])),
-            "i32.rem_u" => Ok(Lang::I32RemU([children[0], children[1]])),
-            "i64.rem_u" => Ok(Lang::I64RemU([children[0], children[1]])),
-            "i32.eq" => Ok(Lang::I32Eq([children[0], children[1]])),
-            "i64.eq" => Ok(Lang::I64Eq([children[0], children[1]])),
-            "i32.ne" => Ok(Lang::I32Ne([children[0], children[1]])),
-            "i64.ne" => Ok(Lang::I64Ne([children[0], children[1]])),
-            "i32.lt_s" => Ok(Lang::I32LtS([children[0], children[1]])),
-            "i64.lt_s" => Ok(Lang::I64LtS([children[0], children[1]])),
-            "i32.lt_u" => Ok(Lang::I32LtU([children[0], children[1]])),
-            "i64.lt_u" => Ok(Lang::I64LtU([children[0], children[1]])),
-            "i32.gt_s" => Ok(Lang::I32GtS([children[0], children[1]])),
-            "i64.gt_s" => Ok(Lang::I64GtS([children[0], children[1]])),
-            "i32.gt_u" => Ok(Lang::I32GtU([children[0], children[1]])),
-            "i64.gt_u" => Ok(Lang::I64GtU([children[0], children[1]])),
-            "i32.le_s" => Ok(Lang::I32LeS([children[0], children[1]])),
-            "i64.le_s" => Ok(Lang::I64LeS([children[0], children[1]])),
-            "i32.le_u" => Ok(Lang::I32LeU([children[0], children[1]])),
-            "i64.le_u" => Ok(Lang::I64LeU([children[0], children[1]])),
-            "i32.ge_s" => Ok(Lang::I32GeS([children[0], children[1]])),
-            "i64.ge_s" => Ok(Lang::I64GeS([children[0], children[1]])),
-            "i32.ge_u" => Ok(Lang::I32GeU([children[0], children[1]])),
-            "i64.ge_u" => Ok(Lang::I64GeU([children[0], children[1]])),
-            // binops floats
-            "f32.add" => Ok(Lang::F32Add([children[0], children[1]])),
-            "f64.add" => Ok(Lang::F64Add([children[0], children[1]])),
-            "f32.sub" => Ok(Lang::F32Sub([children[0], children[1]])),
-            "f64.sub" => Ok(Lang::F64Sub([children[0], children[1]])),
-            "f32.mul" => Ok(Lang::F32Mul([children[0], children[1]])),
-            "f64.mul" => Ok(Lang::F64Mul([children[0], children[1]])),
-            "f32.div" => Ok(Lang::F32Div([children[0], children[1]])),
-            "f64.div" => Ok(Lang::F64Div([children[0], children[1]])),
-            "f32.min" => Ok(Lang::F32Min([children[0], children[1]])),
-            "f64.min" => Ok(Lang::F64Min([children[0], children[1]])),
-            "f32.max" => Ok(Lang::F32Max([children[0], children[1]])),
-            "f64.max" => Ok(Lang::F64Max([children[0], children[1]])),
-            "f32.copysign" => Ok(Lang::F32Copysign([children[0], children[1]])),
-            "f64.copysign" => Ok(Lang::F64Copysign([children[0], children[1]])),
-            // frelops
-            "f32.eq" => Ok(Lang::F32Eq([children[0], children[1]])),
-            "f64.eq" => Ok(Lang::F64Eq([children[0], children[1]])),
-            "f32.ne" => Ok(Lang::F32Ne([children[0], children[1]])),
-            "f64.ne" => Ok(Lang::F64Ne([children[0], children[1]])),
-            "f32.lt" => Ok(Lang::F32Lt([children[0], children[1]])),
-            "f64.lt" => Ok(Lang::F64Lt([children[0], children[1]])),
-            "f32.gt" => Ok(Lang::F32Gt([children[0], children[1]])),
-            "f64.gt" => Ok(Lang::F64Gt([children[0], children[1]])),
-            "f32.le" => Ok(Lang::F32Le([children[0], children[1]])),
-            "f64.le" => Ok(Lang::F64Le([children[0], children[1]])),
-            "f32.ge" => Ok(Lang::F32Ge([children[0], children[1]])),
-            "f64.ge" => Ok(Lang::F64Ge([children[0], children[1]])),
-            //unop
-            "i64.eqz" => Ok(Lang::I64Eqz([children[0]])),
-            "i32.eqz" => Ok(Lang::I32Eqz([children[0]])),
+        // Globals
+        // Idx and value
+        /// global.set operator
+        GlobalSet(u32, Id) = "global.set",
+        /// global.get operator
+        GlobalGet(u32) = "global.get",
 
-            "i32.popcnt" => Ok(Lang::I32Popcnt([children[0]])),
-            "i64.popcnt" => Ok(Lang::I64Popcnt([children[0]])),
-            "i32.clz" => Ok(Lang::I32Clz([children[0]])),
-            "i32.ctz" => Ok(Lang::I32Ctz([children[0]])),
-            "i64.ctz" => Ok(Lang::I64Ctz([children[0]])),
-            "i64.clz" => Ok(Lang::I64Clz([children[0]])),
+        // conversion operators
+        /// i32.wrap_i64 operator
+        Wrap([Id; 1]) = "wrap",
 
-            // unops floats
-            "f32.abs" => Ok(Lang::F32Abs([children[0]])),
-            "f64.abs" => Ok(Lang::F64Abs([children[0]])),
-            "f32.neg" => Ok(Lang::F32Neg([children[0]])),
-            "f64.neg" => Ok(Lang::F64Neg([children[0]])),
-            "f32.sqrt" => Ok(Lang::F32Sqrt([children[0]])),
-            "f64.sqrt" => Ok(Lang::F64Sqrt([children[0]])),
-            "f32.ceil" => Ok(Lang::F32Ceil([children[0]])),
-            "f64.ceil" => Ok(Lang::F64Ceil([children[0]])),
-            "f32.floor" => Ok(Lang::F32Floor([children[0]])),
-            "f64.floor" => Ok(Lang::F64Floor([children[0]])),
-            "f32.trunc" => Ok(Lang::F32Trunc([children[0]])),
-            "f64.trunc" => Ok(Lang::F64Trunc([children[0]])),
-            "f32.nearest" => Ok(Lang::F32Nearest([children[0]])),
-            "f64.nearest" => Ok(Lang::F64Nearest([children[0]])),
-            // more conversion
-            "i32.extend8_s" => Ok(Lang::I32Extend8S([children[0]])),
-            "i64.extend8_s" => Ok(Lang::I64Extend8S([children[0]])),
-            "i32.extend16_s" => Ok(Lang::I32Extend16S([children[0]])),
-            "i64.extend16_s" => Ok(Lang::I64Extend16S([children[0]])),
-            "i64.extend32_s" => Ok(Lang::I64Extend32S([children[0]])),
-            "i64.extendi32_s" => Ok(Lang::I64ExtendI32S([children[0]])),
-            "i64.extendi32_u" => Ok(Lang::I64ExtendI32U([children[0]])),
-            "wrap" => Ok(Lang::Wrap([children[0]])),
-            "i32.truncf32_s" => Ok(Lang::I32TruncF32S([children[0]])),
-            "i32.truncf32_u" => Ok(Lang::I32TruncF32U([children[0]])),
-            "i32.truncf64_s" => Ok(Lang::I32TruncF64S([children[0]])),
-            "i32.truncf64_u" => Ok(Lang::I32TruncF64U([children[0]])),
-            "i64.truncf32_s" => Ok(Lang::I64TruncF32S([children[0]])),
-            "i64.truncf32_u" => Ok(Lang::I64TruncF32U([children[0]])),
-            "i64.truncf64_s" => Ok(Lang::I64TruncF64S([children[0]])),
-            "i64.truncf64_u" => Ok(Lang::I64TruncF64U([children[0]])),
-            "f32.converti32_s" => Ok(Lang::F32ConvertI32S([children[0]])),
-            "f32.converti32_u" => Ok(Lang::F32ConvertI32U([children[0]])),
-            "f32.converti64_s" => Ok(Lang::F32ConvertI64S([children[0]])),
-            "f32.converti64_u" => Ok(Lang::F32ConvertI64U([children[0]])),
-            "f32.demotef64" => Ok(Lang::F32DemoteF64([children[0]])),
-            "f64.converti32_s" => Ok(Lang::F64ConvertI32S([children[0]])),
-            "f64.converti32_u" => Ok(Lang::F64ConvertI32U([children[0]])),
-            "f64.converti64_s" => Ok(Lang::F64ConvertI64S([children[0]])),
-            "f64.converti64_u" => Ok(Lang::F64ConvertI64U([children[0]])),
-            "f64.promotef32" => Ok(Lang::F64PromoteF32([children[0]])),
-            "i32.reinterpretf32" => Ok(Lang::I32ReinterpretF32([children[0]])),
-            "i64.reinterpretf64" => Ok(Lang::I64ReinterpretF64([children[0]])),
-            "f32.reinterpreti32" => Ok(Lang::F32ReinterpretI32([children[0]])),
-            "f64.reinterpreti64" => Ok(Lang::F64ReinterpretI64([children[0]])),
-            "i32.truncsatf32_s" => Ok(Lang::I32TruncSatF32S([children[0]])),
-            "i32.truncsatf32_u" => Ok(Lang::I32TruncSatF32U([children[0]])),
-            "i32.truncsatf64_s" => Ok(Lang::I32TruncSatF64S([children[0]])),
-            "i32.truncsatf64_u" => Ok(Lang::I32TruncSatF64U([children[0]])),
-            "i64.truncsatf32_s" => Ok(Lang::I64TruncSatF32S([children[0]])),
-            "i64.truncsatf32_u" => Ok(Lang::I64TruncSatF32U([children[0]])),
-            "i64.truncsatf64_s" => Ok(Lang::I64TruncSatF64S([children[0]])),
-            "i64.truncsatf64_u" => Ok(Lang::I64TruncSatF64U([children[0]])),
-            // Special nodes :)
-            "i32.unfold" => Ok(Lang::UnfoldI32(children[0])),
-            "i64.unfold" => Ok(Lang::UnfoldI64(children[0])),
-            "i32.rand" => Ok(Lang::RandI32),
-            "i64.rand" => Ok(Lang::RandI64),
-            "undef" => Ok(Lang::Undef),
-            "drop" => Ok(Lang::Drop([children[0]])),
-            "nop" => Ok(Lang::Nop),
-            "container" => Ok(Lang::Container(children)),
-            "select" => Ok(Lang::Select([children[0], children[1], children[2]])),
-            "i32.use_of_global" => Ok(Lang::I32UseGlobal(children[0])),
-            "i64.use_of_global" => Ok(Lang::I64UseGlobal(children[0])),
-            "f32.use_of_global" => Ok(Lang::F32UseGlobal(children[0])),
-            "f64.use_of_global" => Ok(Lang::F64UseGlobal(children[0])),
-            _ => Lang::parse_call(op_str, &children)
-                .or(Lang::parse_memory_sg(op_str, &children))
-                .or(Lang::parse_mem_op(op_str, &children))
-                .or(Lang::parse_index_op(op_str, &children))
-                .or(Lang::parse_integer(op_str))
-                .or(Err(format!("Invalid token {:?}", op_str))),
-        }
+        // conversion
+        /// i32.extend.8s operator
+        I32Extend8S([Id; 1]) = "i32.extend8_s",
+        /// i64.extend.8s operator
+        I64Extend8S([Id; 1]) = "i64.extend8_s",
+        /// i32.extend.16s operator
+        I32Extend16S([Id; 1]) = "i32.extend16_s",
+        /// i64.extend.16s operator
+        I64Extend16S([Id; 1]) = "i64.extend16_s",
+        /// i64.extend.32s operator
+        I64Extend32S([Id; 1]) = "i64.extend32_s",
+        /// i64.extendi.32s operator
+        I64ExtendI32S([Id; 1]) = "i64.extend_i32_s",
+        /// i64.extendi.32u operator
+        I64ExtendI32U([Id; 1]) = "i64.extend_i32_u",
+        /// i32.truncf.32s operator
+        I32TruncF32S([Id; 1]) = "i32.trunc_f32_s",
+        /// i32.truncf.32u operator
+        I32TruncF32U([Id; 1]) = "i32.trunc_f32_u",
+        /// i32.truncf.64s operator
+        I32TruncF64S([Id; 1]) = "i32.trunc_f64_s",
+        /// i32.truncf.64u operator
+        I32TruncF64U([Id; 1]) = "i32.trunc_f64_u",
+        /// i64.truncf.32s operator
+        I64TruncF32S([Id; 1]) = "i64.trunc_f32_s",
+        /// i64.truncf.32u operator
+        I64TruncF32U([Id; 1]) = "i64.trunc_f32_u",
+        /// i64.truncf.64s operator
+        I64TruncF64S([Id; 1]) = "i64.trunc_f64_s",
+        /// i64.truncf.64u operator
+        I64TruncF64U([Id; 1]) = "i64.trunc_f64_u",
+        /// f32.converti.32s operator
+        F32ConvertI32S([Id; 1]) = "f32.convert_i32_s",
+        /// f32.converti.32u operator
+        F32ConvertI32U([Id; 1]) = "f32.convert_i32_u",
+        /// f32.converti.64s operator
+        F32ConvertI64S([Id; 1]) = "f32.convert_i64_s",
+        /// f32.converti.64u operator
+        F32ConvertI64U([Id; 1]) = "f32.convert_i64_u",
+        /// f32.demote.f64 operator
+        F32DemoteF64([Id; 1]) = "f32.demote_f64",
+        /// f64.converti.32s operator
+        F64ConvertI32S([Id; 1]) = "f64.convert_i32_s",
+        /// f64.converti.32u operator
+        F64ConvertI32U([Id; 1]) = "f64.convert_i32_u",
+        /// f64.converti.64s operator
+        F64ConvertI64S([Id; 1]) = "f64.convert_i64_s",
+        /// f64.converti.64u operator
+        F64ConvertI64U([Id; 1]) = "f64.convert_i64_u",
+        /// f64.promote.f32 operator
+        F64PromoteF32([Id; 1]) = "f64.promote_f32",
+        /// i32.reinterpret.f32 operator
+        I32ReinterpretF32([Id; 1]) = "i32.reinterpret_f32",
+        /// i64.reinterpret.f64 operator
+        I64ReinterpretF64([Id; 1]) = "i64.reinterpret_f64",
+        /// f32.reinterpret.i32 operator
+        F32ReinterpretI32([Id; 1]) = "f32.reinterpret_i32",
+        /// f64.reinterpret.i64 operator
+        F64ReinterpretI64([Id; 1]) = "f64.reinterpret_i64",
+        /// i32.truncsatf.32s operator
+        I32TruncSatF32S([Id; 1]) = "i32.trunc_sat_f32_s",
+        /// i32.truncsatf.32u operator
+        I32TruncSatF32U([Id; 1]) = "i32.trunc_sat_f32_u",
+        /// i32.truncsatf.64s operator
+        I32TruncSatF64S([Id; 1]) = "i32.trunc_sat_f64_s",
+        /// i32.truncsatf.64u operator
+        I32TruncSatF64U([Id; 1]) = "i32.trunc_sat_f64_u",
+        /// i64.truncsatf.32s operator
+        I64TruncSatF32S([Id; 1]) = "i64.trunc_sat_f32_s",
+        /// i64.truncsatf.32u operator
+        I64TruncSatF32U([Id; 1]) = "i64.trunc_sat_f32_u",
+        /// i64.truncsatf.64s operator
+        I64TruncSatF64S([Id; 1]) = "i64.trunc_sat_f64_s",
+        /// i64.truncsatf.64u operator
+        I64TruncSatF64U([Id; 1]) = "i64.trunc_sat_f64_u",
+
+        // The u32 argument should be the function index
+        /// call operator node
+        Call(u32, Vec<Id>) = "call",
+        /// drop operator
+        Drop([Id; 1]) = "drop",
+        /// nop operator
+        Nop = "nop",
+
+        // Memory operations
+        // loads
+        /// i32.load operator
+        I32Load(MemArg, Id) = "i32.load",
+        /// i64.load operator
+        I64Load(MemArg, Id) = "i64.load",
+        /// f32.load operator
+        F32Load(MemArg, Id) = "f32.load",
+        /// f64.load operator
+        F64Load(MemArg, Id) = "f64.load",
+        /// i32.load8_s operator
+        I32Load8S(MemArg, Id) = "i32.load8_s",
+        /// i32.load8_u operator
+        I32Load8U(MemArg, Id) = "i32.load8_u",
+        /// i32.load16_s operator
+        I32Load16S(MemArg, Id) = "i32.load16_s",
+        /// i32.load16_u operator
+        I32Load16U(MemArg, Id) = "i32.load16_u",
+        /// i64.load8_s operator
+        I64Load8S(MemArg, Id) = "i64.load8_s",
+        /// i64.load8_u operator
+        I64Load8U(MemArg, Id) = "i64.load8_u",
+        /// i64.load16_s operator
+        I64Load16S(MemArg, Id) = "i64.load16_s",
+        /// i64.load16_u operator
+        I64Load16U(MemArg, Id) = "i64.load16_u",
+        /// i64.load32_s operator
+        I64Load32S(MemArg, Id) = "i64.load32_s",
+        /// i64.load32_u operator
+        I64Load32U(MemArg, Id) = "i64.load32_u",
+
+        /// i32.store operator
+        I32Store(MemArg, [Id; 2]) = "i32.store",
+        /// i64.store operator
+        I64Store(MemArg, [Id; 2]) = "i64.store",
+        /// f32.store operator
+        F32Store(MemArg, [Id; 2]) = "f32.store",
+        /// f64.store operator
+        F64Store(MemArg, [Id; 2]) = "f64.store",
+        /// i32.store8 operator
+        I32Store8(MemArg, [Id; 2]) = "i32.store8",
+        /// i32.store16 operator
+        I32Store16(MemArg, [Id; 2]) = "i32.store16",
+        /// i64.store8 operator
+        I64Store8(MemArg, [Id; 2]) = "i64.store8",
+        /// i64.store16 operator
+        I64Store16(MemArg, [Id; 2]) = "i64.store16",
+        /// i64.store32 operator
+        I64Store32(MemArg, [Id; 2]) = "i64.store32",
+
+        /// Select operator
+        Select([Id; 3]) = "select",
+        /// Memory grow operator
+        MemoryGrow(u32, Id) = "memory.grow",
+        /// Memory size operator
+        MemorySize(u32) = "memory.size",
+
+        /// Add custom or others operator nodes below
+
+        /// Custom mutation operations and instructions
+        ///
+        /// This operation represent a random i32 integer
+        RandI32 = "i32.rand",
+        /// This operation represent a random i64 integer
+        RandI64 = "i64.rand",
+
+        /// This instructions is used to define unknown operands, for example when the value can come from the join of several basic blocks in a dfg
+        Undef = "undef",
+        /// Takes one i32 constant operand and turn it into a sum of two random numbers whihch sum is the operand `i32.const x = i32.const r + i32.const (x - r) `
+        UnfoldI32(Id) = "i32.unfold",
+        /// Takes one i64 constant operand and turn it into a sum of two random numbers whihch sum is the operand `i64.const x = i64.const r + i64.const (x - r) `
+        UnfoldI64(Id) = "i64.unfold",
+
+        /// Propsoed custom mutator from issue #391, use-of-global
+        I32UseGlobal(Id) = "i32.use_of_global",
+        /// Propsoed custom mutator from issue #391, use-of-global
+        I64UseGlobal(Id) = "i64.use_of_global",
+        /// Propsoed custom mutator from issue #391, use-of-global
+        F32UseGlobal(Id) = "f32.use_of_global",
+        /// Propsoed custom mutator from issue #391, use-of-global
+        F64UseGlobal(Id) = "f64.use_of_global",
+
+        /// Just a wrapper of multiple nodes, when encoding to Wasm it is written as
+        /// nothing. Its only responsibility is to express stack-neutral operations.
+        ///
+        /// For example, let's assume we want to insert a nop operation after or
+        /// before another node (or both). `container` allows us to do this with the
+        /// following rewrites:
+        ///
+        /// * Before: `?x => (container nop ?x)`
+        /// * After: `?x => (container ?x nop)`
+        /// * Before and after: `?x => (container nop ?x nop)`
+        /// * Stack-nuetral insertion: `?x => (container (drop i32.rand) ?x) `
+        Container(Vec<Id>) = "container",
+
+        // End of custom mutation operations and instructions
+        /// I32 constant node
+        I32(i32) = "i32.const",
+        /// I64 constant node
+        I64(i64) = "i64.const",
+        // Save bits
+        /// F32 constant node
+        F32(u32) = "f32.const",
+        /// F64 constant node
+        F64(u64) = "f64.const",
     }
 }
 
@@ -1755,11 +695,108 @@ impl Default for Lang {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct MemArg {
+    /// Inmediate static offset of the store operator
+    pub static_offset: u64,
+    /// Inmediate align value of the store operator
+    pub align: u8,
+    /// Inmediate mem value of the store operator
+    pub mem: u32,
+}
+
+impl fmt::Display for MemArg {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.static_offset, self.align, self.mem)
+    }
+}
+
+impl FromStr for MemArg {
+    type Err = String;
+    fn from_str(s: &str) -> Result<MemArg, String> {
+        let mut parts = s.split('.');
+        let static_offset = parts
+            .next()
+            .ok_or_else(|| format!("expected more static instr info"))?
+            .parse::<u64>()
+            .map_err(|e| e.to_string())?;
+        let align = parts
+            .next()
+            .ok_or_else(|| format!("expected more static instr info"))?
+            .parse::<u8>()
+            .map_err(|e| e.to_string())?;
+        let mem = parts
+            .next()
+            .ok_or_else(|| format!("expected more static instr info"))?
+            .parse::<u32>()
+            .map_err(|e| e.to_string())?;
+
+        if parts.next().is_some() {
+            return Err(format!("too much info after instruction"));
+        }
+
+        Ok(MemArg {
+            static_offset,
+            align,
+            mem,
+        })
+    }
+}
+
+trait Children: Sized {
+    fn from(list: Vec<Id>) -> Result<Self, String>;
+    fn as_slice(&self) -> &[Id];
+    fn as_slice_mut(&mut self) -> &mut [Id];
+}
+
+impl Children for Id {
+    fn from(mut list: Vec<Id>) -> Result<Id, String> {
+        if list.len() != 1 {
+            Err(format!("expected one child node, got {}", list.len()))
+        } else {
+            Ok(list.remove(0))
+        }
+    }
+    fn as_slice(&self) -> &[Id] {
+        std::slice::from_ref(self)
+    }
+    fn as_slice_mut(&mut self) -> &mut [Id] {
+        std::slice::from_mut(self)
+    }
+}
+
+impl<const N: usize> Children for [Id; N] {
+    fn from(list: Vec<Id>) -> Result<Self, String> {
+        if let Ok(result) = list.try_into() {
+            Ok(result)
+        } else {
+            Err(format!("expected {} child nodes", N))
+        }
+    }
+    fn as_slice(&self) -> &[Id] {
+        self
+    }
+    fn as_slice_mut(&mut self) -> &mut [Id] {
+        self
+    }
+}
+
+impl Children for Vec<Id> {
+    fn from(list: Vec<Id>) -> Result<Self, String> {
+        Ok(list)
+    }
+    fn as_slice(&self) -> &[Id] {
+        self
+    }
+    fn as_slice_mut(&mut self) -> &mut [Id] {
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::{Lang, MemArg};
     use egg::{Id, Language};
-
-    use crate::mutators::peephole::eggsy::lang::Lang;
 
     #[test]
     fn test_parsing2() {
@@ -1775,18 +812,22 @@ mod tests {
                 Lang::GlobalSet(1, Id::from(1)),
             ],
             [
-                Lang::I32Load {
-                    mem: 1,
-                    align: 0,
-                    static_offset: 120,
-                    offset: Id::from(0),
-                },
-                Lang::I32Load {
-                    mem: 1,
-                    align: 0,
-                    static_offset: 0,
-                    offset: Id::from(0),
-                },
+                Lang::I32Load(
+                    MemArg {
+                        mem: 1,
+                        align: 0,
+                        static_offset: 120,
+                    },
+                    Id::from(0),
+                ),
+                Lang::I32Load(
+                    MemArg {
+                        mem: 1,
+                        align: 0,
+                        static_offset: 0,
+                    },
+                    Id::from(0),
+                ),
             ],
             [Lang::LocalGet(0), Lang::LocalGet(1)],
         ];

--- a/crates/wasm-mutate/src/mutators/peephole/rules.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/rules.rs
@@ -23,38 +23,38 @@ impl PeepholeMutator {
         if config.reduce {
             // NB: these only go one way when we are reducing.
             rules.extend(vec![
-                rewrite!("i32.or--1"; "(i32.or ?x -1_i32)" => "-1_i32"),
-                rewrite!("i64.or--1"; "(i64.or ?x -1_i64)" => "-1_i64"),
+                rewrite!("i32.or--1"; "(i32.or ?x i32.const.-1)" => "i32.const.-1"),
+                rewrite!("i64.or--1"; "(i64.or ?x -i64.const.1)" => "-i64.const.1"),
                 rewrite!("i32.or-x-x"; "(i32.or ?x ?x)" => "?x"),
                 rewrite!("i64.or-x-x"; "(i64.or ?x ?x)" => "?x"),
                 rewrite!("i32.and-x-x"; "(i32.and ?x ?x)" => "?x"),
                 rewrite!("i64.and-x-x"; "(i64.and ?x ?x)" => "?x"),
                 rewrite!("select-same-branches"; "(select ?y ?y ?x)" => "?y"),
-                rewrite!("i32.sub-0"; "(i32.sub ?x 0_i32)" => "?x"),
-                rewrite!("i64.sub-0"; "(i64.sub ?x 0_i64)" => "?x"),
-                rewrite!("i32.mul-x-1"; "(i32.mul ?x 1_i32)" => "?x"),
-                rewrite!("i64.mul-x-1"; "(i64.mul ?x 1_i64)" => "?x"),
-                rewrite!("f32.mul-x-1"; "(f32.mul ?x 1_f32)" => "?x"),
-                rewrite!("f64.mul-x-1"; "(f64.mul ?x 1_f64)" => "?x"),
-                rewrite!("i32.add-x-0"; "(i32.add ?x 0_i32)" => "?x"),
-                rewrite!("i64.add-x-0"; "(i64.add ?x 0_i64)" => "?x"),
-                rewrite!("f32-add-x-0"; "(f32.add ?x 0_f32)" => "?x"),
-                rewrite!("f64.add-x-0"; "(f64.add ?x 0_f64)" => "?x"),
-                rewrite!("i32.xor-x-0"; "(i32.xor ?x 0_i32)" => "?x"),
-                rewrite!("i64.xor-x-0"; "(i64.xor ?x 0_i64)" => "?x"),
-                rewrite!("i32.eq-x-0"; "(i32.eq ?x 0_i32)" => "(i32.eqz ?x)"),
-                rewrite!("i64.eq-x-0"; "(i64.eq ?x 0_i64)" => "(i64.eqz ?x)"),
-                rewrite!("i32.shl-by-0"; "(i32.shl ?x 0_i32)" => "?x"),
-                rewrite!("i64.shl-by-0"; "(i64.shl ?x 0_i64)" => "?x"),
-                rewrite!("i32.shr_u-by-0"; "(i32.shr_u ?x 0_i32)" => "?x"),
-                rewrite!("i64.shr_u-by-0"; "(i64.shr_u ?x 0_i64)" => "?x"),
-                rewrite!("i32.shr_s-by-0"; "(i32.shr_s ?x 0_i32)" => "?x"),
-                rewrite!("i64.shr_s-by-0"; "(i64.shr_s ?x 0_i64)" => "?x"),
+                rewrite!("i32.sub-0"; "(i32.sub ?x i32.const.0)" => "?x"),
+                rewrite!("i64.sub-0"; "(i64.sub ?x i64.const.0)" => "?x"),
+                rewrite!("i32.mul-x-1"; "(i32.mul ?x i32.const.1)" => "?x"),
+                rewrite!("i64.mul-x-1"; "(i64.mul ?x i64.const.1)" => "?x"),
+                rewrite!("f32.mul-x-1"; "(f32.mul ?x f32.const.1)" => "?x"),
+                rewrite!("f64.mul-x-1"; "(f64.mul ?x f64.const.1)" => "?x"),
+                rewrite!("i32.add-x-0"; "(i32.add ?x i32.const.0)" => "?x"),
+                rewrite!("i64.add-x-0"; "(i64.add ?x i64.const.0)" => "?x"),
+                rewrite!("f32-add-x-0"; "(f32.add ?x f32.const.0)" => "?x"),
+                rewrite!("f64.add-x-0"; "(f64.add ?x f64.const.0)" => "?x"),
+                rewrite!("i32.xor-x-0"; "(i32.xor ?x i32.const.0)" => "?x"),
+                rewrite!("i64.xor-x-0"; "(i64.xor ?x i64.const.0)" => "?x"),
+                rewrite!("i32.eq-x-0"; "(i32.eq ?x i32.const.0)" => "(i32.eqz ?x)"),
+                rewrite!("i64.eq-x-0"; "(i64.eq ?x i64.const.0)" => "(i64.eqz ?x)"),
+                rewrite!("i32.shl-by-0"; "(i32.shl ?x i32.const.0)" => "?x"),
+                rewrite!("i64.shl-by-0"; "(i64.shl ?x i64.const.0)" => "?x"),
+                rewrite!("i32.shr_u-by-0"; "(i32.shr_u ?x i32.const.0)" => "?x"),
+                rewrite!("i64.shr_u-by-0"; "(i64.shr_u ?x i64.const.0)" => "?x"),
+                rewrite!("i32.shr_s-by-0"; "(i32.shr_s ?x i32.const.0)" => "?x"),
+                rewrite!("i64.shr_s-by-0"; "(i64.shr_s ?x i64.const.0)" => "?x"),
             ]);
         } else {
             rules.extend(vec![
-                rewrite!("i32.or--1"; "(i32.or ?x -1_i32)" => "-1_i32"),
-                rewrite!("i64.or--1"; "(i64.or ?x -1_i64)" => "-1_i64"),
+                rewrite!("i32.or--1"; "(i32.or ?x i32.const.-1)" => "i32.const.-1"),
+                rewrite!("i64.or--1"; "(i64.or ?x i64.const.-1)" => "i64.const.-1"),
             ]);
 
             rules.extend(rewrite!(
@@ -83,110 +83,110 @@ impl PeepholeMutator {
 
             rules.extend(rewrite!(
                 "i32.sub-0";
-                "(i32.sub ?x 0_i32)" <=> "?x"
+                "(i32.sub ?x i32.const.0)" <=> "?x"
                     if self.is_type("?x", PrimitiveTypeInfo::I32)
             ));
             rules.extend(rewrite!(
                 "i64.sub-0";
-                "(i64.sub ?x 0_i64)" <=> "?x"
+                "(i64.sub ?x i64.const.0)" <=> "?x"
                     if self.is_type("?x", PrimitiveTypeInfo::I64)
             ));
 
             rules.extend(rewrite!(
                 "i32.mul-x-1";
-                "?x" <=> "(i32.mul ?x 1_i32)"
+                "?x" <=> "(i32.mul ?x i32.const.1)"
                     if self.is_type("?x", PrimitiveTypeInfo::I32)
             ));
             rules.extend(rewrite!(
                 "i64.mul-x-1";
-                "?x" <=> "(i64.mul ?x 1_i64)"
+                "?x" <=> "(i64.mul ?x i64.const.1)"
                     if self.is_type("?x", PrimitiveTypeInfo::I64)
             ));
 
             rules.extend(rewrite!(
                 "f32.mul-x-1";
-                "?x" <=> "(f32.mul ?x 1_f32)"
+                "?x" <=> "(f32.mul ?x f32.const.1)"
                     if self.is_type("?x", PrimitiveTypeInfo::F32)
             ));
             rules.extend(rewrite!(
                 "f64.mul-x-1";
-                "?x" <=> "(f64.mul ?x 1_f64)"
+                "?x" <=> "(f64.mul ?x f64.const.1)"
                     if self.is_type("?x", PrimitiveTypeInfo::F64)
             ));
 
             rules.extend(rewrite!(
                 "i32.add-x-0";
-                "?x" <=> "(i32.add ?x 0_i32)"
+                "?x" <=> "(i32.add ?x i32.const.0)"
                     if self.is_type("?x", PrimitiveTypeInfo::I32)
             ));
             rules.extend(rewrite!(
                 "i64.add-x-0";
-                "?x" <=> "(i64.add ?x 0_i64)"
+                "?x" <=> "(i64.add ?x i64.const.0)"
                     if self.is_type("?x", PrimitiveTypeInfo::I64)
             ));
             rules.extend(rewrite!(
                 "f32-add-x-0";
-                "?x" <=> "(f32.add ?x 0_f32)"
+                "?x" <=> "(f32.add ?x f32.const.0)"
                     if self.is_type("?x", PrimitiveTypeInfo::F32)
             ));
             rules.extend(rewrite!(
                 "f64.add-x-0";
-                "?x" <=> "(f64.add ?x 0_f64)"
+                "?x" <=> "(f64.add ?x f64.const.0)"
                     if self.is_type("?x", PrimitiveTypeInfo::F64)
             ));
 
             rules.extend(rewrite!(
                 "i32.xor-x-0";
-                "?x" <=> "(i32.xor ?x 0_i32)"
+                "?x" <=> "(i32.xor ?x i32.const.0)"
                     if self.is_type("?x", PrimitiveTypeInfo::I32)
             ));
             rules.extend(rewrite!(
                 "i64.xor-x-0";
-                "?x" <=> "(i64.xor ?x 0_i64)"
+                "?x" <=> "(i64.xor ?x i64.const.0)"
                     if self.is_type("?x", PrimitiveTypeInfo::I64)
             ));
 
             rules.extend(rewrite!(
                 "i32.eq-x-0";
-                "(i32.eq ?x 0_i32)" <=> "(i32.eqz ?x)"
+                "(i32.eq ?x i32.const.0)" <=> "(i32.eqz ?x)"
                     if self.is_type("?x", PrimitiveTypeInfo::I32)
             ));
             rules.extend(rewrite!(
                 "i64.eq-x-0";
-                "(i64.eq ?x 0_i64)" <=> "(i64.eqz ?x)"
+                "(i64.eq ?x i64.const.0)" <=> "(i64.eqz ?x)"
                     if self.is_type("?x", PrimitiveTypeInfo::I64)
             ));
 
             rules.extend(rewrite!(
                 "i32.shl-by-0";
-                "(i32.shl ?x 0_i32)" <=> "?x"
+                "(i32.shl ?x i32.const.0)" <=> "?x"
                     if self.is_type("?x", PrimitiveTypeInfo::I32)
             ));
             rules.extend(rewrite!(
                 "i64.shl-by-0";
-                "(i64.shl ?x 0_i64)" <=> "?x"
+                "(i64.shl ?x i64.const.0)" <=> "?x"
                     if self.is_type("?x", PrimitiveTypeInfo::I64)
             ));
 
             rules.extend(rewrite!(
                 "i32.shr_u-by-0";
-                "(i32.shr_u ?x 0_i32)" <=> "?x"
+                "(i32.shr_u ?x i32.const.0)" <=> "?x"
                     if self.is_type("?x", PrimitiveTypeInfo::I32)
             ));
             rules.extend(rewrite!(
                 "i64.shr_u-by-0";
-                "(i64.shr_u ?x 0_i64)" <=> "?x"
+                "(i64.shr_u ?x i64.const.0)" <=> "?x"
                     if self.is_type("?x", PrimitiveTypeInfo::I64)
             ));
 
             rules.extend(rewrite!(
                 "i32.shr_s-by-0";
-                "(i32.shr_s ?x 0_i32)" <=> "?x"
+                "(i32.shr_s ?x i32.const.0)" <=> "?x"
                     if self.is_type("?x", PrimitiveTypeInfo::I32)
             ));
             rules.extend(rewrite!(
                 "i64.shr_s-by-0";
-                "(i64.shr_s ?x 0_i64)" <=> "?x"
+                "(i64.shr_s ?x i64.const.0)" <=> "?x"
                     if self.is_type("?x", PrimitiveTypeInfo::I64)
             ));
         }
@@ -279,12 +279,24 @@ impl PeepholeMutator {
 
         // Undoing `x * 2 ==> x << 1` strength reduction, etc...
         if !config.reduce {
-            rules.extend(rewrite!("i32.mul-by-2"; "(i32.shl ?x 1_i32)" <=> "(i32.mul ?x 2_i32)"));
-            rules.extend(rewrite!("i64.mul-by-2"; "(i64.shl ?x 1_i64)" <=> "(i64.mul ?x 2_i64)"));
-            rules.extend(rewrite!("i32.mul-by-4"; "(i32.shl ?x 2_i32)" <=> "(i32.mul ?x 4_i32)"));
-            rules.extend(rewrite!("i64.mul-by-4"; "(i64.shl ?x 2_i64)" <=> "(i64.mul ?x 4_i64)"));
-            rules.extend(rewrite!("i32.mul-by-8"; "(i32.shl ?x 3_i32)" <=> "(i32.mul ?x 8_i32)"));
-            rules.extend(rewrite!("i64.mul-by-8"; "(i64.shl ?x 3_i64)" <=> "(i64.mul ?x 8_i64)"));
+            rules.extend(
+                rewrite!("i32.mul-by-2"; "(i32.shl ?x i32.const.1)" <=> "(i32.mul ?x i32.const.2)"),
+            );
+            rules.extend(
+                rewrite!("i64.mul-by-2"; "(i64.shl ?x i64.const.1)" <=> "(i64.mul ?x i64.const.2)"),
+            );
+            rules.extend(
+                rewrite!("i32.mul-by-4"; "(i32.shl ?x i32.const.2)" <=> "(i32.mul ?x i32.const.4)"),
+            );
+            rules.extend(
+                rewrite!("i64.mul-by-4"; "(i64.shl ?x i64.const.2)" <=> "(i64.mul ?x i64.const.4)"),
+            );
+            rules.extend(
+                rewrite!("i32.mul-by-8"; "(i32.shl ?x i32.const.3)" <=> "(i32.mul ?x i32.const.8)"),
+            );
+            rules.extend(
+                rewrite!("i64.mul-by-8"; "(i64.shl ?x i64.const.3)" <=> "(i64.mul ?x i64.const.8)"),
+            );
         }
 
         // Invert a `select` condition and swap its consequent and alternative.
@@ -296,8 +308,8 @@ impl PeepholeMutator {
 
         // Convert `x + x` into `x * 2`.
         if !config.reduce {
-            rules.extend(rewrite!("i32.add-x-x"; "(i32.add ?x ?x)" <=> "(i32.mul ?x 2_i32)"));
-            rules.extend(rewrite!("i64.add-x-x"; "(i64.add ?x ?x)" <=> "(i64.mul ?x 2_i64)"));
+            rules.extend(rewrite!("i32.add-x-x"; "(i32.add ?x ?x)" <=> "(i32.mul ?x i32.const.2)"));
+            rules.extend(rewrite!("i64.add-x-x"; "(i64.add ?x ?x)" <=> "(i64.mul ?x i64.const.2)"));
         }
 
         // Mess with dropped subexpressions.
@@ -315,12 +327,12 @@ impl PeepholeMutator {
                 ),
                 rewrite!(
                     "f32.drop-x";
-                    "(drop ?x)" => "(drop 0_f32)"
+                    "(drop ?x)" => "(drop f32.const.0)"
                         if self.is_type("?x", PrimitiveTypeInfo::F32)
                 ),
                 rewrite!(
                     "f64.drop-x";
-                    "(drop ?x)" => "(drop 0_f32)"
+                    "(drop ?x)" => "(drop f32.const.0)"
                         if self.is_type("?x", PrimitiveTypeInfo::F64)
                 ),
             ]);
@@ -395,22 +407,22 @@ impl PeepholeMutator {
             rules.extend(vec![
                 rewrite!(
                     "replace-with-i32-1";
-                    "?x" => "1_i32"
+                    "?x" => "i32.const.1"
                         if self.is_type("?x", PrimitiveTypeInfo::I32)
                 ),
                 rewrite!(
                     "replace-with-i64-1";
-                    "?x" => "1_i64"
+                    "?x" => "i64.const.1"
                         if self.is_type("?x", PrimitiveTypeInfo::I64)
                 ),
                 rewrite!(
                     "replace-with-i32-0";
-                    "?x" => "0_i32"
+                    "?x" => "i32.const.0"
                         if self.is_type("?x", PrimitiveTypeInfo::I32)
                 ),
                 rewrite!(
                     "replace-with-i64-0";
-                    "?x" => "0_i64"
+                    "?x" => "i64.const.0"
                         if self.is_type("?x", PrimitiveTypeInfo::I64)
                 ),
                 rewrite!(
@@ -429,94 +441,94 @@ impl PeepholeMutator {
                 // `x <=> x + 1`
                 rules.extend(rewrite!(
                     "i32.add-1";
-                    "?x" <=> "(i32.add ?x 1_i32)"
+                    "?x" <=> "(i32.add ?x i32.const.1)"
                         if self.is_type("?x", PrimitiveTypeInfo::I32)
                 ));
                 rules.extend(rewrite!(
                     "i64.add-1";
-                    "?x" <=> "(i64.add ?x 1_i64)"
+                    "?x" <=> "(i64.add ?x i64.const.1)"
                         if self.is_type("?x", PrimitiveTypeInfo::I64)
                 ));
 
                 // `x <=> x - 1`
                 rules.extend(rewrite!(
                     "i32.sub-1";
-                    "?x" <=> "(i32.sub ?x 1_i32)"
+                    "?x" <=> "(i32.sub ?x i32.const.1)"
                         if self.is_type("?x", PrimitiveTypeInfo::I32)
                 ));
                 rules.extend(rewrite!(
                     "i64.sub-1";
-                    "?x" <=> "(i64.sub ?x 1_i64)"
+                    "?x" <=> "(i64.sub ?x i64.const.1)"
                         if self.is_type("?x", PrimitiveTypeInfo::I64)
                 ));
 
                 // `x <=> x & 1`
                 rules.extend(rewrite!(
                     "i32.and-1";
-                    "?x" <=> "(i32.and ?x 1_i32)"
+                    "?x" <=> "(i32.and ?x i32.const.1)"
                         if self.is_type("?x", PrimitiveTypeInfo::I32)
                 ));
                 rules.extend(rewrite!(
                     "i64.and-1";
-                    "?x" <=> "(i64.and ?x 1_i64)"
+                    "?x" <=> "(i64.and ?x i64.const.1)"
                         if self.is_type("?x", PrimitiveTypeInfo::I64)
                 ));
 
                 // `x <=> x | 1`
                 rules.extend(rewrite!(
                     "i32.or-1";
-                    "?x" <=> "(i32.or ?x 1_i32)"
+                    "?x" <=> "(i32.or ?x i32.const.1)"
                         if self.is_type("?x", PrimitiveTypeInfo::I32)
                 ));
                 rules.extend(rewrite!(
                     "i64.or-1";
-                    "?x" <=> "(i64.or ?x 1_i64)"
+                    "?x" <=> "(i64.or ?x i64.const.1)"
                         if self.is_type("?x", PrimitiveTypeInfo::I64)
                 ));
 
                 // `x <=> x ^ 1`
                 rules.extend(rewrite!(
                     "i32.xor-1";
-                    "?x" <=> "(i32.xor ?x 1_i32)"
+                    "?x" <=> "(i32.xor ?x i32.const.1)"
                         if self.is_type("?x", PrimitiveTypeInfo::I32)
                 ));
                 rules.extend(rewrite!(
                     "i64.xor-1";
-                    "?x" <=> "(i64.xor ?x 1_i64)"
+                    "?x" <=> "(i64.xor ?x i64.const.1)"
                         if self.is_type("?x", PrimitiveTypeInfo::I64)
                 ));
 
                 // `x <=> x << 1`
                 rules.extend(rewrite!(
                     "i32.shl-1";
-                    "?x" <=> "(i32.shl ?x 1_i32)"
+                    "?x" <=> "(i32.shl ?x i32.const.1)"
                         if self.is_type("?x", PrimitiveTypeInfo::I32)
                 ));
                 rules.extend(rewrite!(
                     "i64.shl-1";
-                    "?x" <=> "(i64.shl ?x 1_i64)"
+                    "?x" <=> "(i64.shl ?x i64.const.1)"
                         if self.is_type("?x", PrimitiveTypeInfo::I64)
                 ));
 
                 // `x <=> x >> 1`
                 rules.extend(rewrite!(
                     "i32.shr_u-1";
-                    "?x" <=> "(i32.shr_u ?x 1_i32)"
+                    "?x" <=> "(i32.shr_u ?x i32.const.1)"
                         if self.is_type("?x", PrimitiveTypeInfo::I32)
                 ));
                 rules.extend(rewrite!(
                     "i64.shr_u-1";
-                    "?x" <=> "(i64.shr_u ?x 1_i64)"
+                    "?x" <=> "(i64.shr_u ?x i64.const.1)"
                         if self.is_type("?x", PrimitiveTypeInfo::I64)
                 ));
                 rules.extend(rewrite!(
                     "i32.shr_s-1";
-                    "?x" <=> "(i32.shr_s ?x 1_i32)"
+                    "?x" <=> "(i32.shr_s ?x i32.const.1)"
                         if self.is_type("?x", PrimitiveTypeInfo::I32)
                 ));
                 rules.extend(rewrite!(
                     "i64.shr_s-1";
-                    "?x" <=> "(i64.shr_s ?x 1_i64)"
+                    "?x" <=> "(i64.shr_s ?x i64.const.1)"
                         if self.is_type("?x", PrimitiveTypeInfo::I64)
                 ));
             }

--- a/crates/wasm-mutate/src/mutators/peephole/rules.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/rules.rs
@@ -24,7 +24,7 @@ impl PeepholeMutator {
             // NB: these only go one way when we are reducing.
             rules.extend(vec![
                 rewrite!("i32.or--1"; "(i32.or ?x i32.const.-1)" => "i32.const.-1"),
-                rewrite!("i64.or--1"; "(i64.or ?x -i64.const.1)" => "-i64.const.1"),
+                rewrite!("i64.or--1"; "(i64.or ?x i64.const.-1)" => "i64.const.-1"),
                 rewrite!("i32.or-x-x"; "(i32.or ?x ?x)" => "?x"),
                 rewrite!("i64.or-x-x"; "(i64.or ?x ?x)" => "?x"),
                 rewrite!("i32.and-x-x"; "(i32.and ?x ?x)" => "?x"),


### PR DESCRIPTION
This PR contains yet-more-attempts to simplify the definition of `Lang`. As mentioned before the end-goal is to greatly simplify the addition of new operations to make it as easy as possible to add new operands and such as they become implemented in the rest of the tooling here. No functional change is expected as a result of this commit, but the internals have changed quite a lot.

The first commit here are some pretty straightforward refactorings, but the second is the real meat. I think the first is relatively uncontroversial but the second aggressively optimizes for "define things once" to the end of "well if you can't read macros sorry but this is now all gobbledygook to you". I've got some more details in the commit messages.

Overall I feel that this strikes the right balance. I don't expect that the macro will change all that much over time, and this greatly simplifies the parsing/stringification of operands.