### PR TITLE
Implement component parsing in `wasmparser`. 

### DIFF
--- a/crates/wasm-encoder/src/component.rs
+++ b/crates/wasm-encoder/src/component.rs
@@ -44,8 +44,9 @@ const TYPE_REF_ADAPTER_FUNCTION: u8 = 0x06;
 const CANONICAL_OPTION_UTF8: u8 = 0x00;
 const CANONICAL_OPTION_UTF16: u8 = 0x01;
 const CANONICAL_OPTION_COMPACT_UTF16: u8 = 0x02;
-const CANONICAL_OPTION_WITH_REALLOC: u8 = 0x03;
-const CANONICAL_OPTION_WITH_FREE: u8 = 0x04;
+const CANONICAL_OPTION_MEMORY: u8 = 0x03;
+const CANONICAL_OPTION_REALLOC: u8 = 0x04;
+const CANONICAL_OPTION_FREE: u8 = 0x05;
 
 /// A WebAssembly component section.
 ///
@@ -296,10 +297,12 @@ pub enum CanonicalOption {
     UTF16,
     /// The string types in the function signature are compact UTF-16 encoded.
     CompactUTF16,
+    /// Specifies the memory to use.
+    Memory(u32),
     /// Specifies the function to use to reallocate memory.
-    WithRealloc(u32),
+    Realloc(u32),
     /// Specifies the function to use to free memory.
-    WithFree(u32),
+    Free(u32),
 }
 
 impl CanonicalOption {
@@ -308,12 +311,16 @@ impl CanonicalOption {
             Self::UTF8 => bytes.push(CANONICAL_OPTION_UTF8),
             Self::UTF16 => bytes.push(CANONICAL_OPTION_UTF16),
             Self::CompactUTF16 => bytes.push(CANONICAL_OPTION_COMPACT_UTF16),
-            Self::WithRealloc(index) => {
-                bytes.push(CANONICAL_OPTION_WITH_REALLOC);
+            Self::Memory(index) => {
+                bytes.push(CANONICAL_OPTION_MEMORY);
                 bytes.extend(encoders::u32(*index));
             }
-            Self::WithFree(index) => {
-                bytes.push(CANONICAL_OPTION_WITH_FREE);
+            Self::Realloc(index) => {
+                bytes.push(CANONICAL_OPTION_REALLOC);
+                bytes.extend(encoders::u32(*index));
+            }
+            Self::Free(index) => {
+                bytes.push(CANONICAL_OPTION_FREE);
                 bytes.extend(encoders::u32(*index));
             }
         }

--- a/crates/wasm-encoder/src/component.rs
+++ b/crates/wasm-encoder/src/component.rs
@@ -7,6 +7,7 @@ use crate::{encoders, GlobalType, MemoryType, RawSection, Section, TableType};
 
 mod adapters;
 mod aliases;
+mod custom;
 mod exports;
 mod functions;
 mod imports;
@@ -16,6 +17,7 @@ mod types;
 
 pub use adapters::*;
 pub use aliases::*;
+pub use custom::*;
 pub use exports::*;
 pub use functions::*;
 pub use imports::*;

--- a/crates/wasm-encoder/src/component/custom.rs
+++ b/crates/wasm-encoder/src/component/custom.rs
@@ -1,0 +1,46 @@
+use super::{ComponentSection, SectionId};
+use crate::encoders;
+
+/// An encoder for the component custom section.
+///
+/// # Example
+///
+/// ```rust
+/// use wasm_encoder::component::{Component, CustomSection};
+///
+/// let mut component = Component::new();
+/// component.section(&CustomSection {
+///    name: "my_custom_section",
+///    data: &[0x01, 0x02, 0x03]
+/// });
+///
+/// let bytes = component.finish();
+/// ```
+#[derive(Clone, Debug, Default)]
+pub struct CustomSection<'a> {
+    /// The name of the custom section.
+    pub name: &'a str,
+    /// The custom section's data.
+    pub data: &'a [u8],
+}
+
+impl ComponentSection for CustomSection<'_> {
+    fn id(&self) -> u8 {
+        SectionId::Custom.into()
+    }
+
+    fn encode<S>(&self, sink: &mut S)
+    where
+        S: Extend<u8>,
+    {
+        let name_len = encoders::u32(u32::try_from(self.name.len()).unwrap());
+        let n = name_len.len();
+
+        sink.extend(
+            encoders::u32(u32::try_from(n + self.name.len() + self.data.len()).unwrap())
+                .chain(name_len)
+                .chain(self.name.as_bytes().iter().copied())
+                .chain(self.data.iter().copied()),
+        );
+    }
+}

--- a/crates/wasm-encoder/src/component/types.rs
+++ b/crates/wasm-encoder/src/component/types.rs
@@ -65,11 +65,9 @@ pub enum DefinitionKind {
     Global = 5,
 }
 
-/// Represents an index for an outer alias.
+/// Represents an index for an outer alias in instance and module type definitions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OuterAliasIndex {
-    /// The index is a module index.
-    Module(u32),
     /// The index is a type index.
     Type(u32),
 }
@@ -77,10 +75,6 @@ pub enum OuterAliasIndex {
 impl OuterAliasIndex {
     pub(crate) fn encode(&self, bytes: &mut Vec<u8>) {
         match self {
-            Self::Module(index) => {
-                bytes.extend(encoders::u32(*index));
-                bytes.push(ALIAS_KIND_OUTER_MODULE);
-            }
             Self::Type(index) => {
                 bytes.extend(encoders::u32(*index));
                 bytes.push(ALIAS_KIND_OUTER_TYPE);

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -37,8 +37,6 @@ fn is_name_prefix(name: &str, prefix: &'static str) -> bool {
 }
 
 const WASM_MAGIC_NUMBER: &[u8; 4] = b"\0asm";
-const WASM_EXPERIMENTAL_VERSION: u32 = 0xd;
-const WASM_SUPPORTED_VERSION: u32 = 0x1;
 
 /// Bytecode range in the WebAssembly module.
 #[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -1864,7 +1862,7 @@ impl<'a> BinaryReader<'a> {
         })
     }
 
-    pub(crate) fn read_file_header(&mut self) -> Result<u32> {
+    pub(crate) fn read_module_version(&mut self) -> Result<u32> {
         let magic_number = self.read_bytes(4)?;
         if magic_number != WASM_MAGIC_NUMBER {
             return Err(BinaryReaderError::new(
@@ -1872,14 +1870,8 @@ impl<'a> BinaryReader<'a> {
                 self.original_position() - 4,
             ));
         }
-        let version = self.read_u32()?;
-        if version != WASM_SUPPORTED_VERSION && version != WASM_EXPERIMENTAL_VERSION {
-            return Err(BinaryReaderError::new(
-                "Bad version number",
-                self.original_position() - 4,
-            ));
-        }
-        Ok(version)
+
+        self.read_u32()
     }
 
     pub(crate) fn read_name_type(&mut self) -> Result<NameType> {

--- a/crates/wasmparser/src/component.rs
+++ b/crates/wasmparser/src/component.rs
@@ -1,0 +1,877 @@
+//! Module for parsing WebAssembly components.
+
+use crate::{
+    parser::{delimited, subreader, usize_to_u64},
+    BinaryReader, BinaryReaderError, Range, Result, WASM_MODULE_VERSION,
+};
+use std::fmt;
+use std::iter;
+
+mod adapters;
+mod aliases;
+mod exports;
+mod functions;
+mod imports;
+mod instances;
+mod types;
+
+pub use self::adapters::*;
+pub use self::aliases::*;
+pub use self::exports::*;
+pub use self::functions::*;
+pub use self::imports::*;
+pub use self::instances::*;
+pub use self::types::*;
+
+// The currently supported version in a component's header.
+const WASM_COMPONENT_VERSION: u32 = 0x0002000a;
+
+const SECTION_CUSTOM: u8 = 0x00;
+const SECTION_TYPE: u8 = 0x01;
+const SECTION_IMPORT: u8 = 0x02;
+const SECTION_MODULE: u8 = 0x03;
+const SECTION_INSTANCE: u8 = 0x04;
+const SECTION_ALIAS: u8 = 0x05;
+const SECTION_EXPORT: u8 = 0x06;
+const SECTION_FUNCTION: u8 = 0x07;
+const SECTION_ADAPTER_FUNCTION: u8 = 0x08;
+
+const INDEX_REF_INSTANCE: u32 = 0x00;
+const INDEX_REF_MODULE: u32 = 0x01;
+const INDEX_REF_FUNCTION: u32 = 0x02;
+const INDEX_REF_TABLE: u32 = 0x03;
+const INDEX_REF_MEMORY: u32 = 0x04;
+const INDEX_REF_GLOBAL: u32 = 0x05;
+const INDEX_REF_ADAPTER_FUNCTION: u32 = 0x06;
+
+/// Parses an entire section resident in memory into a `Payload`.
+///
+/// Requires that `len` bytes are resident in `reader` and uses `ctor`/`variant`
+/// to construct the section to return.
+fn section<'a, T>(
+    reader: &mut BinaryReader<'a>,
+    len: u32,
+    ctor: fn(&'a [u8], usize) -> Result<T>,
+    variant: fn(T) -> Payload<'a>,
+) -> Result<Payload<'a>> {
+    let offset = reader.original_position();
+    let payload = reader.read_bytes(len as usize)?;
+    // clear the hint for "need this many more bytes" here because we already
+    // read all the bytes, so it's not possible to read more bytes if this
+    // fails.
+    let reader = ctor(payload, offset).map_err(BinaryReaderError::clear_hint)?;
+    Ok(variant(reader))
+}
+
+/// Represents a reference to an index in a WebAssembly component section.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub enum IndexRef {
+    /// The reference is to an instance in the instance section.
+    Instance(u32),
+    /// The reference is to a module in the module section.
+    Module(u32),
+    /// The reference is to a function in the function section.
+    Function(u32),
+    /// The reference is to a table in the table section.
+    Table(u32),
+    /// The reference is to a memory in the memory section.
+    Memory(u32),
+    /// The reference is to a global in the global section.
+    Global(u32),
+    /// The reference is to an adapter function in the adapter function section.
+    AdapterFunction(u32),
+}
+
+impl IndexRef {
+    fn new(reader: &mut BinaryReader) -> Result<Self> {
+        Ok(match reader.read_u8()? {
+            INDEX_REF_INSTANCE => IndexRef::Instance(reader.read_var_u32()?),
+            INDEX_REF_MODULE => IndexRef::Module(reader.read_var_u32()?),
+            INDEX_REF_FUNCTION => IndexRef::Function(reader.read_var_u32()?),
+            INDEX_REF_TABLE => IndexRef::Table(reader.read_var_u32()?),
+            INDEX_REF_MEMORY => IndexRef::Memory(reader.read_var_u32()?),
+            INDEX_REF_GLOBAL => IndexRef::Global(reader.read_var_u32()?),
+            INDEX_REF_ADAPTER_FUNCTION => IndexRef::AdapterFunction(reader.read_var_u32()?),
+            x => {
+                return Err(BinaryReaderError::new(
+                    format!("invalid byte (0x{:x}) in index reference", x),
+                    reader.original_position() - 1,
+                ))
+            }
+        })
+    }
+}
+
+/// An incremental parser of a binary WebAssembly component.
+///
+/// This type is intended to be used to incrementally parse a WebAssembly component
+/// as bytes become available for the component. This can also be used to parse
+/// components that are already entirely resident within memory.
+///
+/// This primary function for a parser is the [`Parser::parse`] function which
+/// will incrementally consume input. You can also use the [`Parser::parse_all`]
+/// function to parse a component that is entirely resident in memory.
+#[derive(Debug, Copy, Clone)]
+pub struct Parser {
+    state: State,
+    offset: u64,
+    max_size: u64,
+}
+
+impl Parser {
+    /// Creates a new component parser.
+    ///
+    /// Reports errors and ranges relative to `offset` provided, where `offset`
+    /// is some logical offset within the input stream that we're parsing.
+    pub fn new(offset: u64) -> Self {
+        Self::new_with_max_size(offset, u64::max_value())
+    }
+
+    pub(crate) fn new_with_max_size(offset: u64, max_size: u64) -> Self {
+        Self {
+            state: State::Header,
+            offset,
+            max_size,
+        }
+    }
+
+    /// Attempts to parse a chunk of data.
+    ///
+    /// This method will attempt to parse the next incremental portion of a
+    /// WebAssembly binary. Data available for the component is provided as `data`,
+    /// and the data can be incomplete if more data has yet to arrive for the
+    /// component. The `eof` flag indicates whether `data` represents all possible
+    /// data for the component and no more data will ever be received.
+    ///
+    /// There are two ways parsing can succeed with this method:
+    ///
+    /// * `Chunk::NeedMoreData` - this indicates that there is not enough bytes
+    ///   in `data` to parse a chunk of this component. The caller needs to wait
+    ///   for more data to be available in this situation before calling this
+    ///   method again. It is guaranteed that this is only returned if `eof` is
+    ///   `false`.
+    ///
+    /// * `Chunk::Parsed` - this indicates that a chunk of the input was
+    ///   successfully parsed. The payload is available in this variant of what
+    ///   was parsed, and this also indicates how many bytes of `data` was
+    ///   consumed. It's expected that the caller will not provide these bytes
+    ///   back to the [`Parser`] again.
+    ///
+    /// Note that all `Chunk` return values are connected, with a lifetime, to
+    /// the input buffer. Each parsed chunk borrows the input buffer and is a
+    /// view into it for successfully parsed chunks.
+    ///
+    /// It is expected that you'll call this method until `Payload::End` is
+    /// reached, at which point you're guaranteed that the component has completely
+    /// parsed. Note that complete parsing, for the top-level WebAssembly component,
+    /// implies that `data` is empty and `eof` is `true`.
+    ///
+    /// # Errors
+    ///
+    /// Parse errors are returned as an `Err`. Errors can happen when the
+    /// structure of the component is unexpected, or if sections are too large for
+    /// example. Note that errors are not returned for malformed *contents* of
+    /// sections here. Sections are generally not individually parsed and each
+    /// returned [`Payload`] needs to be iterated over further to detect all
+    /// errors.
+    ///
+    /// # Examples
+    ///
+    /// An example of reading a WebAssembly component file from a stream (`std::io::Read`)
+    /// and incrementally parsing it.
+    ///
+    /// ```
+    /// use std::io::Read;
+    /// use anyhow::Result;
+    /// use wasmparser::component::{Parser, SubParser, Chunk, Payload};
+    ///
+    /// fn parse(mut reader: impl Read) -> Result<()> {
+    ///     let mut buf = Vec::new();
+    ///     // Start with a component parser at the top-level
+    ///     let mut parser = SubParser::Component(Parser::new(0));
+    ///     let mut eof = false;
+    ///     let mut stack = Vec::new();
+    ///
+    ///     loop {
+    ///         let (hint, payload) = match &mut parser {
+    ///             SubParser::Module(parser) => match parser.parse(&buf, eof)? {
+    ///                 wasmparser::Chunk::NeedMoreData(hint) => (Some(hint), None),
+    ///                 wasmparser::Chunk::Parsed { payload, consumed } => (None, Some((Payload::SubmodulePayload(payload), consumed))),
+    ///             },
+    ///             SubParser::Component(parser) => match parser.parse(&buf, eof)? {
+    ///                 Chunk::NeedMoreData(hint) => (Some(hint), None),
+    ///                 Chunk::Parsed { payload, consumed } => (None, Some((payload, consumed))),
+    ///             },
+    ///         };
+    ///
+    ///         if let Some(hint) = hint {
+    ///             assert!(!eof); // otherwise an error would be returned
+    ///
+    ///             // Use the hint to preallocate more space, then read
+    ///             // some more data into our buffer.
+    ///             //
+    ///             // Note that the buffer management here is not ideal,
+    ///             // but it's compact enough to fit in an example!
+    ///             let len = buf.len();
+    ///             buf.extend((0..hint).map(|_| 0u8));
+    ///             let n = reader.read(&mut buf[len..])?;
+    ///             buf.truncate(len + n);
+    ///             eof = n == 0;
+    ///             continue;
+    ///         }
+    ///         let (payload, consumed) = payload.unwrap();
+    ///         match payload {
+    ///             // Each of these would be handled individually as necessary
+    ///             Payload::Version { .. } => { /* ... */ }
+    ///             Payload::TypeSection(_) => { /* ... */ }
+    ///             Payload::ImportSection(_) => { /* ... */ }
+    ///             Payload::InstanceSection(_) => { /* ... */ }
+    ///             Payload::AliasSection(_) => { /* ... */ }
+    ///             Payload::ExportSection(_) => { /* ... */ }
+    ///             Payload::FunctionSection(_) => { /* ... */ }
+    ///             Payload::AdapterFunctionSection(_) => { /* ... */ }
+    ///             // When parsing nested components/modules we need to switch which
+    ///             // `Parser` we're using.
+    ///             Payload::ModuleSectionStart { .. } => { /* ... */ }
+    ///             Payload::ModuleSectionEntry { subparser, .. } => {
+    ///                 stack.push(parser);
+    ///                 parser = subparser;
+    ///             }
+    ///             Payload::SubmodulePayload(payload) => {
+    ///                // This is a payload from a submodule being parsed.
+    ///             }
+    ///             Payload::CustomSection { name, .. } => { /* ... */ }
+    ///             // most likely you'd return an error here
+    ///             Payload::UnknownSection { id, .. } => { /* ... */ }
+    ///             // Once we've reached the end of a component we either resume
+    ///             // at the parent component or we break out of the loop because
+    ///             // we're done.
+    ///             Payload::End => {
+    ///                 if let Some(parent_parser) = stack.pop() {
+    ///                     parser = parent_parser;
+    ///                 } else {
+    ///                     break;
+    ///                 }
+    ///             }
+    ///         }
+    ///
+    ///         // once we're done processing the payload we can forget the
+    ///         // original.
+    ///         buf.drain(..consumed);
+    ///     }
+    ///
+    ///     Ok(())
+    /// }
+    ///
+    /// # parse(&b"\0asm\x0a\0\x02\0"[..]).unwrap();
+    /// ```
+    pub fn parse<'a>(&mut self, data: &'a [u8], eof: bool) -> Result<Chunk<'a>> {
+        let (data, eof) = if usize_to_u64(data.len()) > self.max_size {
+            (&data[..(self.max_size as usize)], true)
+        } else {
+            (data, eof)
+        };
+        let mut reader = BinaryReader::new_with_offset(data, self.offset as usize);
+        match self.parse_reader(&mut reader, eof) {
+            Ok(payload) => {
+                // Be sure to update our offset with how far we got in the
+                // reader
+                self.offset += usize_to_u64(reader.position);
+                self.max_size -= usize_to_u64(reader.position);
+                Ok(Chunk::Parsed {
+                    consumed: reader.position,
+                    payload,
+                })
+            }
+            Err(e) => {
+                // If we're at EOF then there's no way we can recover from any
+                // error, so continue to propagate it.
+                if eof {
+                    return Err(e);
+                }
+
+                // If our error doesn't look like it can be resolved with more
+                // data being pulled down, then propagate it, otherwise switch
+                // the error to "feed me please"
+                match e.inner.needed_hint {
+                    Some(hint) => Ok(Chunk::NeedMoreData(usize_to_u64(hint))),
+                    None => Err(e),
+                }
+            }
+        }
+    }
+
+    fn parse_reader<'a>(
+        &mut self,
+        reader: &mut BinaryReader<'a>,
+        eof: bool,
+    ) -> Result<Payload<'a>> {
+        match self.state {
+            State::Header => {
+                let start = reader.original_position();
+                let version = reader.read_module_version()?;
+                if version != WASM_COMPONENT_VERSION {
+                    return Err(BinaryReaderError::new(
+                        format!(
+                            "WebAssembly component version `{}` is not supported",
+                            version
+                        ),
+                        reader.original_position() - 4,
+                    ));
+                }
+                self.state = State::SectionStart;
+                Ok(Payload::Version {
+                    version,
+                    range: Range {
+                        start,
+                        end: reader.original_position(),
+                    },
+                })
+            }
+            State::SectionStart => {
+                // If we're at eof and there are no bytes in our buffer, then
+                // that means we reached the end of the component file since it's
+                // just a bunch of sections concatenated after the component's
+                // header.
+                if eof && reader.bytes_remaining() == 0 {
+                    return Ok(Payload::End);
+                }
+
+                let id = reader.read_var_u7()? as u8;
+                let len_pos = reader.position;
+                let mut len = reader.read_var_u32()?;
+
+                // Test to make sure that this section actually fits within
+                // `Parser::max_size`. This doesn't matter for top-level components
+                // but it is required for nested component/modules to correctly ensure
+                // that all sections live entirely within their section of the
+                // original file.
+                let section_overflow = self
+                    .max_size
+                    .checked_sub(usize_to_u64(reader.position))
+                    .and_then(|s| s.checked_sub(len.into()))
+                    .is_none();
+                if section_overflow {
+                    return Err(BinaryReaderError::new("section too large", len_pos));
+                }
+
+                match id {
+                    SECTION_CUSTOM => {
+                        let start = reader.original_position();
+                        let range = Range {
+                            start,
+                            end: reader.original_position() + len as usize,
+                        };
+                        let mut content = subreader(reader, len)?;
+                        // Note that if this fails we can't read any more bytes,
+                        // so clear the "we'd succeed if we got this many more
+                        // bytes" because we can't recover from "eof" at this point.
+                        let name = content
+                            .read_string()
+                            .map_err(BinaryReaderError::clear_hint)?;
+                        Ok(Payload::CustomSection {
+                            name,
+                            data_offset: content.original_position(),
+                            data: content.remaining_buffer(),
+                            range,
+                        })
+                    }
+                    SECTION_TYPE => {
+                        section(reader, len, TypeSectionReader::new, Payload::TypeSection)
+                    }
+                    SECTION_IMPORT => section(
+                        reader,
+                        len,
+                        ImportSectionReader::new,
+                        Payload::ImportSection,
+                    ),
+                    SECTION_MODULE => {
+                        let start = reader.original_position();
+                        let count = delimited(reader, &mut len, |r| r.read_var_u32())?;
+                        let range = Range {
+                            start,
+                            end: reader.original_position() + len as usize,
+                        };
+                        self.state = State::ModuleSection {
+                            remaining: count,
+                            len,
+                        };
+                        Ok(Payload::ModuleSectionStart {
+                            count,
+                            range,
+                            size: len,
+                        })
+                    }
+                    SECTION_INSTANCE => section(
+                        reader,
+                        len,
+                        InstanceSectionReader::new,
+                        Payload::InstanceSection,
+                    ),
+                    SECTION_ALIAS => {
+                        section(reader, len, AliasSectionReader::new, Payload::AliasSection)
+                    }
+                    SECTION_EXPORT => section(
+                        reader,
+                        len,
+                        ExportSectionReader::new,
+                        Payload::ExportSection,
+                    ),
+                    SECTION_FUNCTION => section(
+                        reader,
+                        len,
+                        FunctionSectionReader::new,
+                        Payload::FunctionSection,
+                    ),
+                    SECTION_ADAPTER_FUNCTION => section(
+                        reader,
+                        len,
+                        AdapterFunctionSectionReader::new,
+                        Payload::AdapterFunctionSection,
+                    ),
+                    id => {
+                        let offset = reader.original_position();
+                        let contents = reader.read_bytes(len as usize)?;
+                        let range = Range {
+                            start: offset,
+                            end: offset + len as usize,
+                        };
+                        Ok(Payload::UnknownSection {
+                            id,
+                            contents,
+                            range,
+                        })
+                    }
+                }
+            }
+            State::ModuleSection {
+                remaining: 0,
+                len: 0,
+            } => {
+                self.state = State::SectionStart;
+                self.parse_reader(reader, eof)
+            }
+            // ... otherwise trailing bytes with no remaining entries in these
+            // sections indicates an error.
+            State::ModuleSection { remaining: 0, len } => {
+                debug_assert!(len > 0);
+                Err(BinaryReaderError::new(
+                    "trailing bytes at end of section",
+                    reader.original_position(),
+                ))
+            }
+            State::ModuleSection { remaining, mut len } => {
+                let size = delimited(reader, &mut len, |r| r.read_var_u32())?;
+                match len.checked_sub(size) {
+                    Some(i) => len = i,
+                    None => {
+                        return Err(BinaryReaderError::new(
+                            "Unexpected EOF",
+                            reader.original_position(),
+                        ));
+                    }
+                }
+                let subparser = {
+                    // We need to peek at the entry's header to see if it is a component or module
+                    let mut reader = reader.clone();
+                    match reader.read_module_version()? {
+                        WASM_MODULE_VERSION => SubParser::Module(crate::Parser::new_with_max_size(
+                            usize_to_u64(reader.original_position()),
+                            size.into(),
+                        )),
+                        WASM_COMPONENT_VERSION => SubParser::Component(Parser::new_with_max_size(
+                            usize_to_u64(reader.original_position()),
+                            size.into(),
+                        )),
+                        version => {
+                            return Err(BinaryReaderError::new(
+                                format!(
+                                    "Module section entry has unsupported version `{}`",
+                                    version
+                                ),
+                                reader.original_position() - 4,
+                            ));
+                        }
+                    }
+                };
+
+                self.state = State::ModuleSection {
+                    remaining: remaining - 1,
+                    len,
+                };
+                let range = Range {
+                    start: reader.original_position(),
+                    end: reader.original_position() + size as usize,
+                };
+                self.max_size -= u64::from(size);
+                self.offset += u64::from(size);
+                Ok(Payload::ModuleSectionEntry { subparser, range })
+            }
+        }
+    }
+
+    /// Convenience function that can be used to parse a component that is entirely
+    /// resident in memory.
+    ///
+    /// This function will parse the `data` provided as a WebAssembly component,
+    /// assuming that `data` represents the entire WebAssembly component.
+    ///
+    /// Note that when this function yields `ModuleSectionEntry`
+    /// no action needs to be taken with the returned sub-parser. The sub-parser will be
+    /// automatically switched to internally and more payloads will continue to
+    /// be returned.
+    pub fn parse_all(self, mut data: &[u8]) -> impl Iterator<Item = Result<Payload>> {
+        let mut stack = Vec::new();
+        let mut cur = SubParser::Component(self);
+        let mut done = false;
+        iter::from_fn(move || {
+            if done {
+                return None;
+            }
+
+            let payload = match &mut cur {
+                SubParser::Module(parser) => match parser.parse(data, true) {
+                    Ok(crate::Chunk::NeedMoreData(_)) => unreachable!(),
+                    Ok(crate::Chunk::Parsed { payload, consumed }) => {
+                        data = &data[consumed..];
+
+                        // Eventually core WebAssembly modules won't support submodules
+                        // Until then, just return an error when encountered
+                        if let crate::Payload::ModuleSectionStart { range, .. } = &payload {
+                            return Some(Err(BinaryReaderError::new(
+                                "WebAssembly modules may not contain submodules",
+                                range.start,
+                            )));
+                        }
+
+                        Payload::SubmodulePayload(payload)
+                    }
+                    Err(e) => return Some(Err(e)),
+                },
+                SubParser::Component(parser) => match parser.parse(data, true) {
+                    Ok(Chunk::NeedMoreData(_)) => unreachable!(),
+                    Ok(Chunk::Parsed { payload, consumed }) => {
+                        data = &data[consumed..];
+                        payload
+                    }
+                    Err(e) => return Some(Err(e)),
+                },
+            };
+
+            match &payload {
+                // If a module ends then we either finished the current
+                // module or, if there's a parent, we switch back to
+                // resuming parsing the parent.
+                Payload::End => match stack.pop() {
+                    Some(p) => cur = p,
+                    None => done = true,
+                },
+
+                // When we enter a nested component/module then we need to update our
+                // current parser, saving off the previous state.
+                //
+                // Afterwards we turn the loop again to recurse in parsing the
+                // nested component/module.
+                Payload::ModuleSectionEntry {
+                    subparser,
+                    range: _,
+                } => {
+                    stack.push(cur);
+                    cur = *subparser;
+                }
+
+                _ => {}
+            }
+
+            Some(Ok(payload))
+        })
+    }
+
+    /// Skip parsing the component's module section entirely.
+    ///
+    /// This function can be used to indicate, after receiving
+    /// `ModuleSectionStart`, that the section will not be parsed.
+    ///
+    /// The caller will be responsible for skipping `size` bytes (found in the
+    /// `ModuleSectionStart` payload). Bytes should only be fed into `parse`
+    /// after the `size` bytes have been skipped.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if the parser is not in a state where it's
+    /// parsing the module section.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use wasmparser::{Result, Range, SectionReader, component::{Parser, Chunk, Payload}};
+    ///
+    /// fn objdump_headers(mut bytes: &[u8]) -> Result<()> {
+    ///     let mut parser = Parser::new(0);
+    ///     loop {
+    ///         let payload = match parser.parse(bytes, true)? {
+    ///             Chunk::Parsed { consumed, payload } => {
+    ///                 bytes = &bytes[consumed..];
+    ///                 payload
+    ///             }
+    ///             // this state isn't possible with `eof = true`
+    ///             Chunk::NeedMoreData(_) => unreachable!(),
+    ///         };
+    ///         match payload {
+    ///             Payload::TypeSection(s) => print_range("type section", &s.range()),
+    ///             // .. other sections
+    ///
+    ///             // Print the range of the module section we see, but don't
+    ///             // actually iterate over each individual module.
+    ///             Payload::ModuleSectionStart { range, size, .. } => {
+    ///                 print_range("module section", &range);
+    ///                 parser.skip_section();
+    ///                 bytes = &bytes[size as usize..];
+    ///             }
+    ///             Payload::End => break,
+    ///             _ => {}
+    ///         }
+    ///     }
+    ///     Ok(())
+    /// }
+    ///
+    /// fn print_range(section: &str, range: &Range) {
+    ///     println!("{:>40}: {:#010x} - {:#010x}", section, range.start, range.end);
+    /// }
+    /// ```
+    pub fn skip_section(&mut self) {
+        let skip = match self.state {
+            State::ModuleSection { remaining: _, len } => len,
+            _ => panic!("wrong state to call `skip_section`"),
+        };
+        self.offset += u64::from(skip);
+        self.max_size -= u64::from(skip);
+        self.state = State::SectionStart;
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+enum State {
+    /// The header is being parsed.
+    Header,
+    /// The start of a section is being parsed.
+    SectionStart,
+    /// The module section is being incrementally parsed.
+    ModuleSection { remaining: u32, len: u32 },
+}
+
+/// A successful return payload from [`Parser::parse`].
+///
+/// On success one of two possible values can be returned, either that more data
+/// is needed to continue parsing or a chunk of the input was parsed, indicating
+/// how much of it was parsed.
+#[derive(Debug)]
+pub enum Chunk<'a> {
+    /// This can be returned at any time and indicates that more data is needed
+    /// to proceed with parsing. Zero bytes were consumed from the input to
+    /// [`Parser::parse`]. The `usize` value here is a hint as to how many more
+    /// bytes are needed to continue parsing.
+    NeedMoreData(u64),
+
+    /// A chunk was successfully parsed.
+    Parsed {
+        /// This many bytes of the `data` input to [`Parser::parse`] were
+        /// consumed to produce `payload`.
+        consumed: usize,
+        /// The value that we actually parsed.
+        payload: Payload<'a>,
+    },
+}
+
+/// Values that can be parsed from a WebAssembly component.
+///
+/// This enumeration is all possible chunks of pieces that can be parsed by a
+/// [`Parser`] from a binary WebAssembly component. Note that for many sections the
+/// entire section is parsed all at once, whereas other functions, like the module
+/// section, are parsed incrementally.
+///
+/// Note that payloads, when returned, do not indicate that the component is
+/// valid. For example when you receive a `Payload::TypeSection` the type
+/// section itself has not yet actually been parsed. The reader returned will be
+/// able to parse it, but you'll have to actually iterate the reader to do the
+/// full parse. Each payload returned is intended to be a *window* into the
+/// original `data` passed to [`Parser::parse`] which can be further processed
+/// if necessary.
+pub enum Payload<'a> {
+    /// Indicates the header of a WebAssembly component.
+    ///
+    /// This header also indicates the version number that was parsed, which is
+    /// currently always 2.
+    Version {
+        /// The version number found
+        version: u32,
+        /// The range of bytes that were parsed to consume the header of the
+        /// component. Note that this range is relative to the start of the byte
+        /// stream.
+        range: Range,
+    },
+
+    /// A custom section was found.
+    CustomSection {
+        /// The name of the custom section.
+        name: &'a str,
+        /// The offset, relative to the start of the original component, that the
+        /// `data` payload for this custom section starts at.
+        data_offset: usize,
+        /// The actual contents of the custom section.
+        data: &'a [u8],
+        /// The range of bytes that specify this whole custom section (including
+        /// both the name of this custom section and its data) specified in
+        /// offsets relative to the start of the byte stream.
+        range: Range,
+    },
+
+    /// A type section was received, and the provided reader can be used to
+    /// parse the contents of the type section.
+    TypeSection(TypeSectionReader<'a>),
+
+    /// An import section was received, and the provided reader can be used to
+    /// parse the contents of the import section.
+    ImportSection(ImportSectionReader<'a>),
+
+    /// Indicator of the start of a component's modules section.
+    ///
+    /// It is guaranteed that the next `count` payloads will be of type
+    /// `ModuleSectionEntry`.
+    ModuleSectionStart {
+        /// The number of inline component or modules in this section.
+        count: u32,
+        /// The range of bytes that represent this section, specified in
+        /// offsets relative to the start of the byte stream.
+        range: Range,
+        /// The size, in bytes, of the remaining contents of this section.
+        size: u32,
+    },
+
+    /// An entry of the module section was parsed.
+    ///
+    /// This variant is special in that it returns a `SubParser`. Upon
+    /// receiving a `ModuleSectionEntry` it is expected that the returned
+    /// `SubParser` will be used instead of the parent `Parser` until the parse has
+    /// finished. You'll need to feed data into the `SubParser` returned until it
+    /// returns `Payload::End`. After that you'll switch back to the parent
+    /// parser to resume parsing the rest of the module section.
+    ModuleSectionEntry {
+        /// The subparser to use for parsing the module section entry.
+        subparser: SubParser,
+        /// The range of bytes, relative to the start of the input stream, of
+        /// the bytes containing this module entry.
+        range: Range,
+    },
+
+    /// A submodule payload was parsed when using `Parse::parse_all`.
+    ///
+    /// Submodule payloads are returned when a submodule is being parsed
+    /// from a component's module section.
+    ///
+    /// This variant is only ever returned from calls to `Parse::parse_all`.
+    SubmodulePayload(crate::Payload<'a>),
+
+    /// An instance section was received, and the provided reader can be used to
+    /// parse the contents of the instance section.
+    InstanceSection(InstanceSectionReader<'a>),
+
+    /// An alias section was received, and the provided reader can be used to
+    /// parse the contents of the alias section.
+    AliasSection(AliasSectionReader<'a>),
+
+    /// An export section was received, and the provided reader can be used to
+    /// parse the contents of the export section.
+    ExportSection(ExportSectionReader<'a>),
+
+    /// A function section was received, and the provided reader can be used to
+    /// parse the contents of the function section.
+    FunctionSection(FunctionSectionReader<'a>),
+
+    /// An adapter function section was received, and the provided reader can be used to
+    /// parse the contents of the adapter function section.
+    AdapterFunctionSection(AdapterFunctionSectionReader<'a>),
+
+    /// An unknown section was found.
+    ///
+    /// This variant is returned for all unknown sections in a component file. This
+    /// likely wants to be interpreted as an error by consumers of the parser,
+    /// but this can also be used to parse sections unknown to wasmparser at
+    /// this time.
+    UnknownSection {
+        /// The 8-bit identifier for this section.
+        id: u8,
+        /// The contents of this section.
+        contents: &'a [u8],
+        /// The range of bytes, relative to the start of the original data
+        /// stream, that the contents of this section reside in.
+        range: Range,
+    },
+
+    /// The end of the WebAssembly component was reached.
+    End,
+}
+
+impl fmt::Debug for Payload<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Payload::Version { version, range } => f
+                .debug_struct("Version")
+                .field("version", version)
+                .field("range", range)
+                .finish(),
+            Payload::CustomSection {
+                name,
+                data_offset,
+                data: _,
+                range,
+            } => f
+                .debug_struct("CustomSection")
+                .field("name", name)
+                .field("data_offset", data_offset)
+                .field("range", range)
+                .field("data", &"...")
+                .finish(),
+            Payload::TypeSection(_) => f.debug_tuple("TypeSection").field(&"...").finish(),
+            Payload::ImportSection(_) => f.debug_tuple("ImportSection").field(&"...").finish(),
+            Payload::ModuleSectionStart { count, range, size } => f
+                .debug_struct("ModuleSectionStart")
+                .field("count", count)
+                .field("range", range)
+                .field("size", size)
+                .finish(),
+            Payload::ModuleSectionEntry {
+                subparser: _,
+                range,
+            } => f
+                .debug_struct("ModuleSectionEntry")
+                .field("range", range)
+                .finish(),
+            Payload::SubmodulePayload(p) => p.fmt(f),
+            Payload::InstanceSection(_) => f.debug_tuple("InstanceSection").field(&"...").finish(),
+            Payload::AliasSection(_) => f.debug_tuple("AliasSection").field(&"...").finish(),
+            Payload::ExportSection(_) => f.debug_tuple("ExportSection").field(&"...").finish(),
+            Payload::FunctionSection(_) => f.debug_tuple("FunctionSection").field(&"...").finish(),
+            Payload::AdapterFunctionSection(_) => f
+                .debug_tuple("AdapterFunctionSection")
+                .field(&"...")
+                .finish(),
+            Payload::UnknownSection { id, range, .. } => f
+                .debug_struct("UnknownSection")
+                .field("id", id)
+                .field("range", range)
+                .finish(),
+            Payload::End => f.write_str("End"),
+        }
+    }
+}
+
+/// Represents the possible sub-parsers that can be returned while
+/// parsing a WebAssembly component's module section.
+#[derive(Debug, Clone, Copy)]
+pub enum SubParser {
+    /// The subparser for a WebAssembly module.
+    Module(crate::Parser),
+    /// The subparser for a WebAssembly component.
+    Component(Parser),
+}

--- a/crates/wasmparser/src/component.rs
+++ b/crates/wasmparser/src/component.rs
@@ -111,7 +111,7 @@ impl IndexRef {
 /// This primary function for a parser is the [`Parser::parse`] function which
 /// will incrementally consume input. You can also use the [`Parser::parse_all`]
 /// function to parse a component that is entirely resident in memory.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct Parser {
     state: State,
     offset: u64,
@@ -576,8 +576,8 @@ impl Parser {
                     subparser,
                     range: _,
                 } => {
-                    stack.push(cur);
-                    cur = *subparser;
+                    stack.push(cur.clone());
+                    cur = subparser.clone();
                 }
 
                 _ => {}
@@ -650,7 +650,7 @@ impl Parser {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 enum State {
     /// The header is being parsed.
     Header,
@@ -868,7 +868,7 @@ impl fmt::Debug for Payload<'_> {
 
 /// Represents the possible sub-parsers that can be returned while
 /// parsing a WebAssembly component's module section.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub enum SubParser {
     /// The subparser for a WebAssembly module.
     Module(crate::Parser),

--- a/crates/wasmparser/src/component/adapters.rs
+++ b/crates/wasmparser/src/component/adapters.rs
@@ -1,0 +1,170 @@
+use super::CanonicalOption;
+use crate::{
+    BinaryReader, Range, Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems,
+};
+
+/// Represents an adapter function in the component adapter function section.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdapterFunction {
+    /// The index of the adapter function's type.
+    pub ty: u32,
+    /// The index of the function being lifted.
+    pub function: u32,
+    /// The options for the adapter function.
+    pub options: Box<[CanonicalOption]>,
+}
+
+impl AdapterFunction {
+    fn new(reader: &mut BinaryReader) -> Result<Self> {
+        Ok(Self {
+            ty: reader.read_var_u32()?,
+            function: reader.read_var_u32()?,
+            options: (0..reader.read_var_u32()?)
+                .map(|_| CanonicalOption::new(reader))
+                .collect::<Result<_>>()?,
+        })
+    }
+}
+
+/// The function section reader for a WebAssembly component.
+#[derive(Clone)]
+pub struct AdapterFunctionSectionReader<'a> {
+    reader: BinaryReader<'a>,
+    count: u32,
+}
+
+impl<'a> AdapterFunctionSectionReader<'a> {
+    /// Creates a new function section reader for the given data and initial offset.
+    pub fn new(data: &'a [u8], offset: usize) -> Result<Self> {
+        let mut reader = BinaryReader::new_with_offset(data, offset);
+        let count = reader.read_var_u32()?;
+        Ok(Self { reader, count })
+    }
+
+    /// Gets the original position of the reader.
+    pub fn original_position(&self) -> usize {
+        self.reader.original_position()
+    }
+
+    /// Gets the number of adapter functions in the section.
+    pub fn len(&self) -> u32 {
+        self.count
+    }
+
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+
+    /// Reads adapter functions from the adapter function section.
+    ///
+    /// # Examples
+    /// ```
+    /// use wasmparser::component::AdapterFunctionSectionReader;
+    /// # let data: &[u8] = &[0x1, 0x0, 0x1, 0x0];
+    /// let functions = AdapterFunctionSectionReader::new(data, 0).unwrap();
+    /// for function in functions {
+    ///     let function = function.expect("function");
+    ///     println!("{:?}", function);
+    /// }
+    /// ```
+    pub fn read(&mut self) -> Result<AdapterFunction> {
+        AdapterFunction::new(&mut self.reader)
+    }
+}
+
+impl<'a> SectionReader for AdapterFunctionSectionReader<'a> {
+    type Item = AdapterFunction;
+
+    fn read(&mut self) -> Result<Self::Item> {
+        AdapterFunctionSectionReader::read(self)
+    }
+
+    fn eof(&self) -> bool {
+        self.reader.eof()
+    }
+
+    fn original_position(&self) -> usize {
+        AdapterFunctionSectionReader::original_position(self)
+    }
+
+    fn range(&self) -> Range {
+        self.reader.range()
+    }
+}
+
+impl<'a> SectionWithLimitedItems for AdapterFunctionSectionReader<'a> {
+    fn get_count(&self) -> u32 {
+        AdapterFunctionSectionReader::len(self)
+    }
+}
+
+impl<'a> IntoIterator for AdapterFunctionSectionReader<'a> {
+    type Item = Result<AdapterFunction>;
+    type IntoIter = SectionIteratorLimited<AdapterFunctionSectionReader<'a>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        SectionIteratorLimited::new(self)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::component::{
+        CANONICAL_OPTION_COMPACT_UTF16, CANONICAL_OPTION_FREE, CANONICAL_OPTION_MEMORY,
+        CANONICAL_OPTION_REALLOC, CANONICAL_OPTION_UTF16, CANONICAL_OPTION_UTF8,
+    };
+
+    use super::*;
+    use anyhow::Result;
+
+    #[test]
+    fn it_parses_an_empty_section() -> Result<()> {
+        let data: &[u8] = &[0];
+        let reader = AdapterFunctionSectionReader::new(data, 0)?;
+        assert!(reader.eof());
+        assert_eq!(reader.len(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn it_parses_adapter_functions() -> Result<()> {
+        let data: &[u8] = &[
+            1,
+            0,
+            1,
+            6,
+            CANONICAL_OPTION_UTF8 as u8,
+            CANONICAL_OPTION_UTF16 as u8,
+            CANONICAL_OPTION_COMPACT_UTF16 as u8,
+            CANONICAL_OPTION_MEMORY as u8,
+            2,
+            CANONICAL_OPTION_REALLOC as u8,
+            3,
+            CANONICAL_OPTION_FREE as u8,
+            4,
+        ];
+        let reader = AdapterFunctionSectionReader::new(data, 0)?;
+        assert!(!reader.eof());
+        assert_eq!(reader.len(), 1);
+
+        let functions: Vec<_> = reader.into_iter().collect::<crate::Result<_>>()?;
+        assert_eq!(
+            functions,
+            [AdapterFunction {
+                ty: 0,
+                function: 1,
+                options: [
+                    CanonicalOption::UTF8,
+                    CanonicalOption::UTF16,
+                    CanonicalOption::CompactUTF16,
+                    CanonicalOption::Memory(2),
+                    CanonicalOption::Realloc(3),
+                    CanonicalOption::Free(4)
+                ]
+                .into(),
+            },]
+        );
+        Ok(())
+    }
+}

--- a/crates/wasmparser/src/component/aliases.rs
+++ b/crates/wasmparser/src/component/aliases.rs
@@ -1,0 +1,351 @@
+use crate::{
+    BinaryReader, BinaryReaderError, Range, Result, SectionIteratorLimited, SectionReader,
+    SectionWithLimitedItems,
+};
+
+const ALIAS_KIND_INSTANCE: u32 = 0x00;
+pub(crate) const ALIAS_KIND_OUTER: u32 = 0x01;
+pub(crate) const ALIAS_KIND_OUTER_MODULE: u32 = 0x01;
+pub(crate) const ALIAS_KIND_OUTER_TYPE: u32 = 0x06;
+
+const ALIAS_EXPORT_KIND_INSTANCE: u32 = 0x0;
+const ALIAS_EXPORT_KIND_MODULE: u32 = 0x1;
+const ALIAS_EXPORT_KIND_FUNCTION: u32 = 0x2;
+const ALIAS_EXPORT_KIND_TABLE: u32 = 0x3;
+const ALIAS_EXPORT_KIND_MEMORY: u32 = 0x4;
+const ALIAS_EXPORT_KIND_GLOBAL: u32 = 0x5;
+const ALIAS_EXPORT_KIND_ADAPTER_FUNCTION: u32 = 0x6;
+
+/// Represents the expected export kind for an alias.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExportKind {
+    /// The alias is to an instance.
+    Instance,
+    /// The alias is to a module.
+    Module,
+    /// The alias is to a function.
+    Function,
+    /// The alias is to a table.
+    Table,
+    /// The alias is to a memory.
+    Memory,
+    /// The alias is to a global.
+    Global,
+    /// The alias is to an adapter function.
+    AdapterFunction,
+}
+
+impl ExportKind {
+    fn new(reader: &mut BinaryReader) -> Result<Self> {
+        Ok(match reader.read_u8()? {
+            ALIAS_EXPORT_KIND_INSTANCE => ExportKind::Instance,
+            ALIAS_EXPORT_KIND_MODULE => ExportKind::Module,
+            ALIAS_EXPORT_KIND_FUNCTION => ExportKind::Function,
+            ALIAS_EXPORT_KIND_TABLE => ExportKind::Table,
+            ALIAS_EXPORT_KIND_MEMORY => ExportKind::Memory,
+            ALIAS_EXPORT_KIND_GLOBAL => ExportKind::Global,
+            ALIAS_EXPORT_KIND_ADAPTER_FUNCTION => ExportKind::AdapterFunction,
+            x => {
+                return Err(BinaryReaderError::new(
+                    format!("invalid byte (0x{:x}) in alias export kind", x),
+                    reader.original_position() - 1,
+                ))
+            }
+        })
+    }
+}
+
+/// Represents an alias in the component alias section.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Alias<'a> {
+    /// The alias is to an instance export.
+    Instance {
+        /// The index of the instance being aliased.
+        index: u32,
+        /// The name of the export being aliased.
+        name: &'a str,
+        /// The export kind.
+        kind: ExportKind,
+    },
+    /// The alias is to an outer module type.
+    OuterType {
+        /// The outward count from the current module (count 0).
+        count: u32,
+        /// The type index within the outer module.
+        index: u32,
+    },
+    OuterModule {
+        /// The outward count from the current module (count 0).
+        count: u32,
+        /// The type index within the outer module.
+        index: u32,
+    },
+}
+
+impl<'a> Alias<'a> {
+    fn new(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        Ok(match reader.read_u8()? {
+            ALIAS_KIND_INSTANCE => Self::Instance {
+                index: reader.read_var_u32()?,
+                name: reader.read_string()?,
+                kind: ExportKind::new(reader)?,
+            },
+            ALIAS_KIND_OUTER => {
+                let count = reader.read_var_u32()?;
+                let index = reader.read_var_u32()?;
+                match reader.read_u8()? {
+                    ALIAS_KIND_OUTER_MODULE => Alias::OuterModule { count, index },
+                    ALIAS_KIND_OUTER_TYPE => Alias::OuterType { count, index },
+                    x => {
+                        return Err(BinaryReaderError::new(
+                            format!("invalid byte (0x{:x}) in outer alias kind", x),
+                            reader.original_position() - 1,
+                        ))
+                    }
+                }
+            }
+            x => {
+                return Err(BinaryReaderError::new(
+                    format!("invalid byte (0x{:x}) in alias kind", x),
+                    reader.original_position() - 1,
+                ))
+            }
+        })
+    }
+}
+
+/// The alias section reader for a WebAssembly component.
+#[derive(Clone)]
+pub struct AliasSectionReader<'a> {
+    reader: BinaryReader<'a>,
+    count: u32,
+}
+
+impl<'a> AliasSectionReader<'a> {
+    /// Creates a new alias section reader for the given data and initial offset.
+    pub fn new(data: &'a [u8], offset: usize) -> Result<Self> {
+        let mut reader = BinaryReader::new_with_offset(data, offset);
+        let count = reader.read_var_u32()?;
+        Ok(Self { reader, count })
+    }
+
+    /// Gets the original position of the reader.
+    pub fn original_position(&self) -> usize {
+        self.reader.original_position()
+    }
+
+    /// Gets the number of aliases in the section.
+    pub fn len(&self) -> u32 {
+        self.count
+    }
+
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+
+    /// Reads aliases from the alias section.
+    ///
+    /// # Examples
+    /// ```
+    /// use wasmparser::component::AliasSectionReader;
+    /// # let data: &[u8] = &[0x1, 0x0, 0x0, 0x3, b'f', b'o', b'o', 0x2];
+    /// let aliases = AliasSectionReader::new(data, 0).unwrap();
+    /// for alias in aliases {
+    ///     let alias = alias.expect("alias");
+    ///     println!("{:?}", alias);
+    /// }
+    /// ```
+    pub fn read(&mut self) -> Result<Alias<'a>> {
+        Alias::new(&mut self.reader)
+    }
+}
+
+impl<'a> SectionReader for AliasSectionReader<'a> {
+    type Item = Alias<'a>;
+
+    fn read(&mut self) -> Result<Self::Item> {
+        AliasSectionReader::read(self)
+    }
+
+    fn eof(&self) -> bool {
+        self.reader.eof()
+    }
+
+    fn original_position(&self) -> usize {
+        AliasSectionReader::original_position(self)
+    }
+
+    fn range(&self) -> Range {
+        self.reader.range()
+    }
+}
+
+impl<'a> SectionWithLimitedItems for AliasSectionReader<'a> {
+    fn get_count(&self) -> u32 {
+        AliasSectionReader::len(self)
+    }
+}
+
+impl<'a> IntoIterator for AliasSectionReader<'a> {
+    type Item = Result<Alias<'a>>;
+    type IntoIter = SectionIteratorLimited<AliasSectionReader<'a>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        SectionIteratorLimited::new(self)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use anyhow::Result;
+
+    #[test]
+    fn it_parses_an_empty_section() -> Result<()> {
+        let data: &[u8] = &[0];
+        let reader = AliasSectionReader::new(data, 0)?;
+        assert!(reader.eof());
+        assert_eq!(reader.len(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn it_parses_an_instance_aliases() -> Result<()> {
+        let data: &[u8] = &[
+            7,
+            ALIAS_KIND_INSTANCE as u8,
+            0,
+            1,
+            b'a',
+            ALIAS_EXPORT_KIND_INSTANCE as u8,
+            ALIAS_KIND_INSTANCE as u8,
+            1,
+            1,
+            b'b',
+            ALIAS_EXPORT_KIND_MODULE as u8,
+            ALIAS_KIND_INSTANCE as u8,
+            2,
+            1,
+            b'c',
+            ALIAS_EXPORT_KIND_FUNCTION as u8,
+            ALIAS_KIND_INSTANCE as u8,
+            3,
+            1,
+            b'd',
+            ALIAS_EXPORT_KIND_TABLE as u8,
+            ALIAS_KIND_INSTANCE as u8,
+            4,
+            1,
+            b'e',
+            ALIAS_EXPORT_KIND_MEMORY as u8,
+            ALIAS_KIND_INSTANCE as u8,
+            5,
+            1,
+            b'f',
+            ALIAS_EXPORT_KIND_GLOBAL as u8,
+            ALIAS_KIND_INSTANCE as u8,
+            6,
+            1,
+            b'g',
+            ALIAS_EXPORT_KIND_ADAPTER_FUNCTION as u8,
+        ];
+        let reader = AliasSectionReader::new(data, 0)?;
+        assert!(!reader.eof());
+        assert_eq!(reader.len(), 7);
+
+        let aliases: Vec<_> = reader.into_iter().collect::<crate::Result<_>>()?;
+
+        assert_eq!(
+            aliases,
+            [
+                Alias::Instance {
+                    index: 0,
+                    name: "a".into(),
+                    kind: ExportKind::Instance,
+                },
+                Alias::Instance {
+                    index: 1,
+                    name: "b".into(),
+                    kind: ExportKind::Module,
+                },
+                Alias::Instance {
+                    index: 2,
+                    name: "c".into(),
+                    kind: ExportKind::Function,
+                },
+                Alias::Instance {
+                    index: 3,
+                    name: "d".into(),
+                    kind: ExportKind::Table,
+                },
+                Alias::Instance {
+                    index: 4,
+                    name: "e".into(),
+                    kind: ExportKind::Memory,
+                },
+                Alias::Instance {
+                    index: 5,
+                    name: "f".into(),
+                    kind: ExportKind::Global,
+                },
+                Alias::Instance {
+                    index: 6,
+                    name: "g".into(),
+                    kind: ExportKind::AdapterFunction,
+                },
+            ]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn it_parses_an_outer_module_alias() -> Result<()> {
+        let data: &[u8] = &[
+            1,
+            ALIAS_KIND_OUTER as u8,
+            3,
+            101,
+            ALIAS_KIND_OUTER_MODULE as u8,
+        ];
+        let reader = AliasSectionReader::new(data, 0)?;
+        assert!(!reader.eof());
+        assert_eq!(reader.len(), 1);
+
+        let aliases: Vec<_> = reader.into_iter().collect::<crate::Result<_>>()?;
+
+        assert_eq!(
+            aliases,
+            [Alias::OuterModule {
+                count: 3,
+                index: 101
+            }]
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn it_parses_an_outer_type_alias() -> Result<()> {
+        let data: &[u8] = &[
+            1,
+            ALIAS_KIND_OUTER as u8,
+            3,
+            101,
+            ALIAS_KIND_OUTER_TYPE as u8,
+        ];
+        let reader = AliasSectionReader::new(data, 0)?;
+        assert!(!reader.eof());
+        assert_eq!(reader.len(), 1);
+
+        let aliases: Vec<_> = reader.into_iter().collect::<crate::Result<_>>()?;
+
+        assert_eq!(
+            aliases,
+            [Alias::OuterType {
+                count: 3,
+                index: 101
+            }]
+        );
+        Ok(())
+    }
+}

--- a/crates/wasmparser/src/component/exports.rs
+++ b/crates/wasmparser/src/component/exports.rs
@@ -1,0 +1,200 @@
+use super::IndexRef;
+use crate::{
+    BinaryReader, Range, Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems,
+};
+
+/// Represents an export in the component export section.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct Export<'a> {
+    /// The name of the export.
+    pub name: &'a str,
+    /// The index of the item being exported.
+    pub index: IndexRef,
+}
+
+impl<'a> Export<'a> {
+    fn new(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        Ok(Self {
+            name: reader.read_string()?,
+            index: IndexRef::new(reader)?,
+        })
+    }
+}
+
+/// The export section reader for a WebAssembly component.
+#[derive(Clone)]
+pub struct ExportSectionReader<'a> {
+    reader: BinaryReader<'a>,
+    count: u32,
+}
+
+impl<'a> ExportSectionReader<'a> {
+    /// Creates a new export section reader for the given data and initial offset.
+    pub fn new(data: &'a [u8], offset: usize) -> Result<Self> {
+        let mut reader = BinaryReader::new_with_offset(data, offset);
+        let count = reader.read_var_u32()?;
+        Ok(Self { reader, count })
+    }
+
+    /// Gets the original position of the reader.
+    pub fn original_position(&self) -> usize {
+        self.reader.original_position()
+    }
+
+    /// Gets the number of exports in the section.
+    pub fn len(&self) -> u32 {
+        self.count
+    }
+
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+
+    /// Reads exports from the export section.
+    ///
+    /// # Examples
+    /// ```
+    /// use wasmparser::component::ExportSectionReader;
+    /// # let data: &[u8] = &[0x1, 0x3, b'f', b'o', b'o', 0x2, 0x1];
+    /// let exports = ExportSectionReader::new(data, 0).unwrap();
+    /// for export in exports {
+    ///     let export = export.expect("export");
+    ///     println!("{:?}", export);
+    /// }
+    /// ```
+    pub fn read(&mut self) -> Result<Export<'a>> {
+        Export::new(&mut self.reader)
+    }
+}
+
+impl<'a> SectionReader for ExportSectionReader<'a> {
+    type Item = Export<'a>;
+
+    fn read(&mut self) -> Result<Self::Item> {
+        ExportSectionReader::read(self)
+    }
+
+    fn eof(&self) -> bool {
+        self.reader.eof()
+    }
+
+    fn original_position(&self) -> usize {
+        ExportSectionReader::original_position(self)
+    }
+
+    fn range(&self) -> Range {
+        self.reader.range()
+    }
+}
+
+impl<'a> SectionWithLimitedItems for ExportSectionReader<'a> {
+    fn get_count(&self) -> u32 {
+        ExportSectionReader::len(self)
+    }
+}
+
+impl<'a> IntoIterator for ExportSectionReader<'a> {
+    type Item = Result<Export<'a>>;
+    type IntoIter = SectionIteratorLimited<ExportSectionReader<'a>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        SectionIteratorLimited::new(self)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::component::{
+        INDEX_REF_ADAPTER_FUNCTION, INDEX_REF_FUNCTION, INDEX_REF_GLOBAL, INDEX_REF_INSTANCE,
+        INDEX_REF_MEMORY, INDEX_REF_MODULE, INDEX_REF_TABLE,
+    };
+    use anyhow::Result;
+
+    #[test]
+    fn it_parses_an_empty_section() -> Result<()> {
+        let data: &[u8] = &[0];
+        let reader = ExportSectionReader::new(data, 0)?;
+        assert!(reader.eof());
+        assert_eq!(reader.len(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn it_parses_exports() -> Result<()> {
+        let data: &[u8] = &[
+            7,
+            1,
+            b'a',
+            INDEX_REF_INSTANCE as u8,
+            0,
+            1,
+            b'b',
+            INDEX_REF_MODULE as u8,
+            1,
+            1,
+            b'c',
+            INDEX_REF_FUNCTION as u8,
+            2,
+            1,
+            b'd',
+            INDEX_REF_TABLE as u8,
+            3,
+            1,
+            b'e',
+            INDEX_REF_MEMORY as u8,
+            4,
+            1,
+            b'f',
+            INDEX_REF_GLOBAL as u8,
+            5,
+            1,
+            b'g',
+            INDEX_REF_ADAPTER_FUNCTION as u8,
+            6,
+        ];
+
+        let reader = ExportSectionReader::new(data, 0)?;
+        assert!(!reader.eof());
+        assert_eq!(reader.len(), 7);
+
+        let exports: Vec<_> = reader.into_iter().collect::<crate::Result<_>>()?;
+
+        assert_eq!(
+            exports,
+            &[
+                Export {
+                    name: "a",
+                    index: IndexRef::Instance(0)
+                },
+                Export {
+                    name: "b",
+                    index: IndexRef::Module(1)
+                },
+                Export {
+                    name: "c",
+                    index: IndexRef::Function(2)
+                },
+                Export {
+                    name: "d",
+                    index: IndexRef::Table(3)
+                },
+                Export {
+                    name: "e",
+                    index: IndexRef::Memory(4)
+                },
+                Export {
+                    name: "f",
+                    index: IndexRef::Global(5)
+                },
+                Export {
+                    name: "g",
+                    index: IndexRef::AdapterFunction(6)
+                },
+            ]
+        );
+
+        Ok(())
+    }
+}

--- a/crates/wasmparser/src/component/functions.rs
+++ b/crates/wasmparser/src/component/functions.rs
@@ -1,0 +1,208 @@
+use crate::{
+    BinaryReader, BinaryReaderError, Range, Result, SectionIteratorLimited, SectionReader,
+    SectionWithLimitedItems,
+};
+
+pub(crate) const CANONICAL_OPTION_UTF8: u32 = 0x00;
+pub(crate) const CANONICAL_OPTION_UTF16: u32 = 0x01;
+pub(crate) const CANONICAL_OPTION_COMPACT_UTF16: u32 = 0x02;
+pub(crate) const CANONICAL_OPTION_MEMORY: u32 = 0x03;
+pub(crate) const CANONICAL_OPTION_REALLOC: u32 = 0x04;
+pub(crate) const CANONICAL_OPTION_FREE: u32 = 0x05;
+
+/// Represents options for functions and adapter functions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CanonicalOption {
+    /// The string types in the function signature are UTF-8 encoded.
+    UTF8,
+    /// The string types in the function signature are UTF-16 encoded.
+    UTF16,
+    /// The string types in the function signature are compact UTF-16 encoded.
+    CompactUTF16,
+    /// Specifies the memory to use.
+    Memory(u32),
+    /// Specifies the function to use to reallocate memory.
+    Realloc(u32),
+    /// Specifies the function to use to free memory.
+    Free(u32),
+}
+
+impl CanonicalOption {
+    pub(crate) fn new(reader: &mut BinaryReader) -> Result<Self> {
+        Ok(match reader.read_u8()? {
+            CANONICAL_OPTION_UTF8 => Self::UTF8,
+            CANONICAL_OPTION_UTF16 => Self::UTF16,
+            CANONICAL_OPTION_COMPACT_UTF16 => Self::CompactUTF16,
+            CANONICAL_OPTION_MEMORY => Self::Memory(reader.read_var_u32()?),
+            CANONICAL_OPTION_REALLOC => Self::Realloc(reader.read_var_u32()?),
+            CANONICAL_OPTION_FREE => Self::Free(reader.read_var_u32()?),
+            x => {
+                return Err(BinaryReaderError::new(
+                    format!("invalid byte (0x{:x}) in canonical option", x),
+                    reader.original_position() - 1,
+                ))
+            }
+        })
+    }
+}
+
+/// Represents a function in the component function section.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Function {
+    /// The index of the function's type.
+    pub ty: u32,
+    /// The index of the adapter function being lowered.
+    pub adapter: u32,
+    /// The options for the function.
+    pub options: Box<[CanonicalOption]>,
+}
+
+impl Function {
+    fn new(reader: &mut BinaryReader) -> Result<Self> {
+        Ok(Self {
+            ty: reader.read_var_u32()?,
+            adapter: reader.read_var_u32()?,
+            options: (0..reader.read_var_u32()?)
+                .map(|_| CanonicalOption::new(reader))
+                .collect::<Result<_>>()?,
+        })
+    }
+}
+
+/// The function section reader for a WebAssembly component.
+#[derive(Clone)]
+pub struct FunctionSectionReader<'a> {
+    reader: BinaryReader<'a>,
+    count: u32,
+}
+
+impl<'a> FunctionSectionReader<'a> {
+    /// Creates a new function section reader for the given data and initial offset.
+    pub fn new(data: &'a [u8], offset: usize) -> Result<Self> {
+        let mut reader = BinaryReader::new_with_offset(data, offset);
+        let count = reader.read_var_u32()?;
+        Ok(Self { reader, count })
+    }
+
+    /// Gets the original position of the reader.
+    pub fn original_position(&self) -> usize {
+        self.reader.original_position()
+    }
+
+    /// Gets the number of functions in the section.
+    pub fn len(&self) -> u32 {
+        self.count
+    }
+
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+
+    /// Reads functions from the function section.
+    ///
+    /// # Examples
+    /// ```
+    /// use wasmparser::component::FunctionSectionReader;
+    /// # let data: &[u8] = &[0x1, 0x0, 0x1, 0x0];
+    /// let functions = FunctionSectionReader::new(data, 0).unwrap();
+    /// for function in functions {
+    ///     let function = function.expect("function");
+    ///     println!("{:?}", function);
+    /// }
+    /// ```
+    pub fn read(&mut self) -> Result<Function> {
+        Function::new(&mut self.reader)
+    }
+}
+
+impl<'a> SectionReader for FunctionSectionReader<'a> {
+    type Item = Function;
+
+    fn read(&mut self) -> Result<Self::Item> {
+        FunctionSectionReader::read(self)
+    }
+
+    fn eof(&self) -> bool {
+        self.reader.eof()
+    }
+
+    fn original_position(&self) -> usize {
+        FunctionSectionReader::original_position(self)
+    }
+
+    fn range(&self) -> Range {
+        self.reader.range()
+    }
+}
+
+impl<'a> SectionWithLimitedItems for FunctionSectionReader<'a> {
+    fn get_count(&self) -> u32 {
+        FunctionSectionReader::len(self)
+    }
+}
+
+impl<'a> IntoIterator for FunctionSectionReader<'a> {
+    type Item = Result<Function>;
+    type IntoIter = SectionIteratorLimited<FunctionSectionReader<'a>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        SectionIteratorLimited::new(self)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use anyhow::Result;
+
+    #[test]
+    fn it_parses_an_empty_section() -> Result<()> {
+        let data: &[u8] = &[0];
+        let reader = FunctionSectionReader::new(data, 0)?;
+        assert!(reader.eof());
+        assert_eq!(reader.len(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn it_parses_functions() -> Result<()> {
+        let data: &[u8] = &[
+            1,
+            0,
+            1,
+            6,
+            CANONICAL_OPTION_UTF8 as u8,
+            CANONICAL_OPTION_UTF16 as u8,
+            CANONICAL_OPTION_COMPACT_UTF16 as u8,
+            CANONICAL_OPTION_MEMORY as u8,
+            2,
+            CANONICAL_OPTION_REALLOC as u8,
+            3,
+            CANONICAL_OPTION_FREE as u8,
+            4,
+        ];
+        let reader = FunctionSectionReader::new(data, 0)?;
+        assert!(!reader.eof());
+        assert_eq!(reader.len(), 1);
+
+        let functions: Vec<_> = reader.into_iter().collect::<crate::Result<_>>()?;
+        assert_eq!(
+            functions,
+            [Function {
+                ty: 0,
+                adapter: 1,
+                options: [
+                    CanonicalOption::UTF8,
+                    CanonicalOption::UTF16,
+                    CanonicalOption::CompactUTF16,
+                    CanonicalOption::Memory(2),
+                    CanonicalOption::Realloc(3),
+                    CanonicalOption::Free(4)
+                ]
+                .into(),
+            },]
+        );
+        Ok(())
+    }
+}

--- a/crates/wasmparser/src/component/imports.rs
+++ b/crates/wasmparser/src/component/imports.rs
@@ -1,0 +1,221 @@
+use crate::{
+    component::TypeRef, BinaryReader, Range, Result, SectionIteratorLimited, SectionReader,
+    SectionWithLimitedItems,
+};
+
+/// Represents an import in the component import section.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct Import<'a> {
+    /// The name of the import.
+    pub name: &'a str,
+    /// The type of the import.
+    pub ty: TypeRef,
+}
+
+impl<'a> Import<'a> {
+    fn new(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        Ok(Self {
+            name: reader.read_string()?,
+            ty: TypeRef::new(reader)?,
+        })
+    }
+}
+
+/// The import section reader for a WebAssembly component.
+#[derive(Clone)]
+pub struct ImportSectionReader<'a> {
+    reader: BinaryReader<'a>,
+    count: u32,
+}
+
+impl<'a> ImportSectionReader<'a> {
+    /// Creates a new import section reader for the given data and initial offset.
+    pub fn new(data: &'a [u8], offset: usize) -> Result<Self> {
+        let mut reader = BinaryReader::new_with_offset(data, offset);
+        let count = reader.read_var_u32()?;
+        Ok(Self { reader, count })
+    }
+
+    /// Gets the original position of the reader.
+    pub fn original_position(&self) -> usize {
+        self.reader.original_position()
+    }
+
+    /// Gets the number of imports in the section.
+    pub fn len(&self) -> u32 {
+        self.count
+    }
+
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+
+    /// Reads imports from the import section.
+    ///
+    /// # Examples
+    /// ```
+    /// use wasmparser::component::ImportSectionReader;
+    /// # let data: &[u8] = &[0x1, 0x3, b'f', b'o', b'o', 0x2, 0x1];
+    /// let imports = ImportSectionReader::new(data, 0).unwrap();
+    /// for import in imports {
+    ///     let import = import.expect("import");
+    ///     println!("{:?}", import);
+    /// }
+    /// ```
+    pub fn read(&mut self) -> Result<Import<'a>> {
+        Import::new(&mut self.reader)
+    }
+}
+
+impl<'a> SectionReader for ImportSectionReader<'a> {
+    type Item = Import<'a>;
+
+    fn read(&mut self) -> Result<Self::Item> {
+        ImportSectionReader::read(self)
+    }
+
+    fn eof(&self) -> bool {
+        self.reader.eof()
+    }
+
+    fn original_position(&self) -> usize {
+        ImportSectionReader::original_position(self)
+    }
+
+    fn range(&self) -> Range {
+        self.reader.range()
+    }
+}
+
+impl<'a> SectionWithLimitedItems for ImportSectionReader<'a> {
+    fn get_count(&self) -> u32 {
+        ImportSectionReader::len(self)
+    }
+}
+
+impl<'a> IntoIterator for ImportSectionReader<'a> {
+    type Item = Result<Import<'a>>;
+    type IntoIter = SectionIteratorLimited<ImportSectionReader<'a>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        SectionIteratorLimited::new(self)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        component::{
+            TYPE_REF_ADAPTER_FUNCTION, TYPE_REF_FUNCTION, TYPE_REF_GLOBAL, TYPE_REF_INSTANCE,
+            TYPE_REF_MEMORY, TYPE_REF_MODULE, TYPE_REF_TABLE,
+        },
+        GlobalType, MemoryType, TableType, Type,
+    };
+    use anyhow::Result;
+
+    #[test]
+    fn it_parses_an_empty_section() -> Result<()> {
+        let data: &[u8] = &[0];
+        let reader = ImportSectionReader::new(data, 0)?;
+        assert!(reader.eof());
+        assert_eq!(reader.len(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn it_parses_imports() -> Result<()> {
+        let data: &[u8] = &[
+            7,
+            1,
+            b'a',
+            TYPE_REF_INSTANCE as u8,
+            0,
+            1,
+            b'b',
+            TYPE_REF_MODULE as u8,
+            1,
+            1,
+            b'c',
+            TYPE_REF_FUNCTION as u8,
+            2,
+            1,
+            b'd',
+            TYPE_REF_TABLE as u8,
+            0x7f, // i32
+            0x1,  // has max
+            0x0,  // min
+            0x10, // max
+            1,
+            b'e',
+            TYPE_REF_MEMORY as u8,
+            0x1,  // flags (has max)
+            0x0,  // min
+            0x10, // max
+            1,
+            b'f',
+            TYPE_REF_GLOBAL as u8,
+            0x7e, // i64
+            0x1,  // mutable
+            1,
+            b'g',
+            TYPE_REF_ADAPTER_FUNCTION as u8,
+            3,
+        ];
+
+        let reader = ImportSectionReader::new(data, 0)?;
+        assert!(!reader.eof());
+        assert_eq!(reader.len(), 7);
+
+        let imports: Vec<_> = reader.into_iter().collect::<crate::Result<_>>()?;
+
+        assert_eq!(
+            imports,
+            &[
+                Import {
+                    name: "a",
+                    ty: TypeRef::Instance(0)
+                },
+                Import {
+                    name: "b",
+                    ty: TypeRef::Module(1)
+                },
+                Import {
+                    name: "c",
+                    ty: TypeRef::Function(2)
+                },
+                Import {
+                    name: "d",
+                    ty: TypeRef::Table(TableType {
+                        element_type: Type::I32,
+                        initial: 0,
+                        maximum: Some(16)
+                    })
+                },
+                Import {
+                    name: "e",
+                    ty: TypeRef::Memory(MemoryType {
+                        initial: 0,
+                        maximum: Some(16),
+                        shared: false,
+                        memory64: false,
+                    })
+                },
+                Import {
+                    name: "f",
+                    ty: TypeRef::Global(GlobalType {
+                        content_type: Type::I64,
+                        mutable: true,
+                    })
+                },
+                Import {
+                    name: "g",
+                    ty: TypeRef::AdapterFunction(3)
+                }
+            ]
+        );
+
+        Ok(())
+    }
+}

--- a/crates/wasmparser/src/component/instances.rs
+++ b/crates/wasmparser/src/component/instances.rs
@@ -1,0 +1,285 @@
+use super::IndexRef;
+use crate::{
+    BinaryReader, BinaryReaderError, Range, Result, SectionIteratorLimited, SectionReader,
+    SectionWithLimitedItems,
+};
+
+const INSTANCE_KIND_INSTANTIATION: u32 = 0x00;
+const INSTANCE_KIND_EXPORTED: u32 = 0x01;
+
+/// Represents an instance in the component instance section.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Instance<'a> {
+    /// The instance is the result of instantiating a module.
+    Instantiation {
+        /// The index of the module being instantiated.
+        module: u32,
+        /// The imports to instantiate the module with.
+        imports: Box<[(&'a str, IndexRef)]>,
+    },
+    /// The instance is the result of exporting local items.
+    Exported(Box<[(&'a str, IndexRef)]>),
+}
+
+impl<'a> Instance<'a> {
+    fn new(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        Ok(match reader.read_u8()? {
+            INSTANCE_KIND_INSTANTIATION => Instance::Instantiation {
+                module: reader.read_var_u32()?,
+                imports: (0..reader.read_var_u32()?)
+                    .map(|_| Ok((reader.read_string()?, IndexRef::new(reader)?)))
+                    .collect::<Result<_>>()?,
+            },
+            INSTANCE_KIND_EXPORTED => Instance::Exported(
+                (0..reader.read_var_u32()?)
+                    .map(|_| Ok((reader.read_string()?, IndexRef::new(reader)?)))
+                    .collect::<Result<_>>()?,
+            ),
+            x => {
+                return Err(BinaryReaderError::new(
+                    format!("invalid byte (0x{:x}) in instance kind", x),
+                    reader.original_position() - 1,
+                ))
+            }
+        })
+    }
+}
+
+/// The instance section reader for a WebAssembly component.
+#[derive(Clone)]
+pub struct InstanceSectionReader<'a> {
+    reader: BinaryReader<'a>,
+    count: u32,
+}
+
+impl<'a> InstanceSectionReader<'a> {
+    /// Creates a new instance section reader for the given data and initial offset.
+    pub fn new(data: &'a [u8], offset: usize) -> Result<Self> {
+        let mut reader = BinaryReader::new_with_offset(data, offset);
+        let count = reader.read_var_u32()?;
+        Ok(Self { reader, count })
+    }
+
+    /// Gets the original position of the reader.
+    pub fn original_position(&self) -> usize {
+        self.reader.original_position()
+    }
+
+    /// Gets the number of instances in the section.
+    pub fn len(&self) -> u32 {
+        self.count
+    }
+
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+
+    /// Reads instances from the instance section.
+    ///
+    /// # Examples
+    /// ```
+    /// use wasmparser::component::InstanceSectionReader;
+    /// # let data: &[u8] = &[0x1, 0x0, 0x0, 0x1, 0x3, b'f', b'o', b'o', 0x2, 0x1];
+    /// let instances = InstanceSectionReader::new(data, 0).unwrap();
+    /// for instance in instances {
+    ///     let instance = instance.expect("instance");
+    ///     println!("{:?}", instance);
+    /// }
+    /// ```
+    pub fn read(&mut self) -> Result<Instance<'a>> {
+        Instance::new(&mut self.reader)
+    }
+}
+
+impl<'a> SectionReader for InstanceSectionReader<'a> {
+    type Item = Instance<'a>;
+
+    fn read(&mut self) -> Result<Self::Item> {
+        InstanceSectionReader::read(self)
+    }
+
+    fn eof(&self) -> bool {
+        self.reader.eof()
+    }
+
+    fn original_position(&self) -> usize {
+        InstanceSectionReader::original_position(self)
+    }
+
+    fn range(&self) -> Range {
+        self.reader.range()
+    }
+}
+
+impl<'a> SectionWithLimitedItems for InstanceSectionReader<'a> {
+    fn get_count(&self) -> u32 {
+        InstanceSectionReader::len(self)
+    }
+}
+
+impl<'a> IntoIterator for InstanceSectionReader<'a> {
+    type Item = Result<Instance<'a>>;
+    type IntoIter = SectionIteratorLimited<InstanceSectionReader<'a>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        SectionIteratorLimited::new(self)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::component::{
+        INDEX_REF_ADAPTER_FUNCTION, INDEX_REF_FUNCTION, INDEX_REF_GLOBAL, INDEX_REF_INSTANCE,
+        INDEX_REF_MEMORY, INDEX_REF_MODULE, INDEX_REF_TABLE,
+    };
+    use anyhow::Result;
+
+    #[test]
+    fn it_parses_an_empty_section() -> Result<()> {
+        let data: &[u8] = &[0];
+        let reader = InstanceSectionReader::new(data, 0)?;
+        assert!(reader.eof());
+        assert_eq!(reader.len(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn it_parses_an_instantiation() -> Result<()> {
+        let data: &[u8] = &[
+            1,
+            INSTANCE_KIND_INSTANTIATION as u8,
+            101,
+            7,
+            3,
+            b'f',
+            b'o',
+            b'o',
+            INDEX_REF_INSTANCE as u8,
+            0,
+            3,
+            b'b',
+            b'a',
+            b'r',
+            INDEX_REF_MODULE as u8,
+            1,
+            3,
+            b'b',
+            b'a',
+            b'z',
+            INDEX_REF_FUNCTION as u8,
+            2,
+            3,
+            b'j',
+            b'a',
+            b'm',
+            INDEX_REF_TABLE as u8,
+            3,
+            1,
+            b'a',
+            INDEX_REF_MEMORY as u8,
+            4,
+            1,
+            b'b',
+            INDEX_REF_GLOBAL as u8,
+            5,
+            1,
+            b'c',
+            INDEX_REF_ADAPTER_FUNCTION as u8,
+            6,
+        ];
+        let reader = InstanceSectionReader::new(data, 0)?;
+        assert!(!reader.eof());
+        assert_eq!(reader.len(), 1);
+
+        let instances: Vec<_> = reader.into_iter().collect::<crate::Result<_>>()?;
+
+        assert_eq!(
+            instances,
+            [Instance::Instantiation {
+                module: 101,
+                imports: [
+                    ("foo", IndexRef::Instance(0)),
+                    ("bar", IndexRef::Module(1)),
+                    ("baz", IndexRef::Function(2)),
+                    ("jam", IndexRef::Table(3)),
+                    ("a", IndexRef::Memory(4)),
+                    ("b", IndexRef::Global(5)),
+                    ("c", IndexRef::AdapterFunction(6)),
+                ]
+                .into()
+            }]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn it_parses_an_export() -> Result<()> {
+        let data: &[u8] = &[
+            1,
+            INSTANCE_KIND_EXPORTED as u8,
+            7,
+            3,
+            b'f',
+            b'o',
+            b'o',
+            INDEX_REF_INSTANCE as u8,
+            0,
+            3,
+            b'b',
+            b'a',
+            b'r',
+            INDEX_REF_MODULE as u8,
+            1,
+            3,
+            b'b',
+            b'a',
+            b'z',
+            INDEX_REF_FUNCTION as u8,
+            2,
+            3,
+            b'j',
+            b'a',
+            b'm',
+            INDEX_REF_TABLE as u8,
+            3,
+            1,
+            b'a',
+            INDEX_REF_MEMORY as u8,
+            4,
+            1,
+            b'b',
+            INDEX_REF_GLOBAL as u8,
+            5,
+            1,
+            b'c',
+            INDEX_REF_ADAPTER_FUNCTION as u8,
+            6,
+        ];
+        let reader = InstanceSectionReader::new(data, 0)?;
+        assert!(!reader.eof());
+        assert_eq!(reader.len(), 1);
+
+        let instances: Vec<_> = reader.into_iter().collect::<crate::Result<_>>()?;
+
+        assert_eq!(
+            instances,
+            [Instance::Exported(
+                [
+                    ("foo", IndexRef::Instance(0)),
+                    ("bar", IndexRef::Module(1)),
+                    ("baz", IndexRef::Function(2)),
+                    ("jam", IndexRef::Table(3)),
+                    ("a", IndexRef::Memory(4)),
+                    ("b", IndexRef::Global(5)),
+                    ("c", IndexRef::AdapterFunction(6)),
+                ]
+                .into()
+            )]
+        );
+
+        Ok(())
+    }
+}

--- a/crates/wasmparser/src/component/types.rs
+++ b/crates/wasmparser/src/component/types.rs
@@ -1,0 +1,1003 @@
+use crate::{
+    BinaryReader, BinaryReaderError, FuncType, GlobalType, MemoryType, Range, Result,
+    SectionIteratorLimited, SectionReader, SectionWithLimitedItems, TableType,
+};
+
+use super::{ALIAS_KIND_OUTER, ALIAS_KIND_OUTER_MODULE, ALIAS_KIND_OUTER_TYPE};
+
+const TYPE_INSTANCE: u32 = 0x7f;
+const TYPE_MODULE: u32 = 0x7e;
+const TYPE_FUNCTION: u32 = 0x7d;
+const TYPE_ADAPTER_FUNCTION: u32 = 0x7c;
+
+const COMPOUND_TYPE_LIST: u32 = 0x7b;
+const COMPOUND_TYPE_RECORD: u32 = 0x7a;
+const COMPOUND_TYPE_VARIANT: u32 = 0x79;
+const COMPOUND_TYPE_TUPLE: u32 = 0x78;
+const COMPOUND_TYPE_FLAGS: u32 = 0x77;
+const COMPOUND_TYPE_ENUM: u32 = 0x76;
+const COMPOUND_TYPE_UNION: u32 = 0x75;
+const COMPOUND_TYPE_OPTIONAL: u32 = 0x74;
+const COMPOUND_TYPE_EXPECTED: u32 = 0x73;
+const COMPOUND_TYPE_NAMED: u32 = 0x72;
+
+const INTERFACE_TYPE_BOOL: u32 = 0x71;
+const INTERFACE_TYPE_S8: u32 = 0x70;
+const INTERFACE_TYPE_U8: u32 = 0x6f;
+const INTERFACE_TYPE_S16: u32 = 0x6e;
+const INTERFACE_TYPE_U16: u32 = 0x6d;
+const INTERFACE_TYPE_S32: u32 = 0x6c;
+const INTERFACE_TYPE_U32: u32 = 0x6b;
+const INTERFACE_TYPE_S64: u32 = 0x6a;
+const INTERFACE_TYPE_U64: u32 = 0x69;
+const INTERFACE_TYPE_F32: u32 = 0x68;
+const INTERFACE_TYPE_F64: u32 = 0x67;
+const INTERFACE_TYPE_CHAR: u32 = 0x66;
+const INTERFACE_TYPE_STRING: u32 = 0x65;
+
+const INSTANCE_TYPEDEF_TYPE: u32 = 0x01;
+const INSTANCE_TYPEDEF_ALIAS: u32 = 0x05;
+const INSTANCE_TYPEDEF_EXPORT: u32 = 0x06;
+
+const MODULE_TYPEDEF_TYPE: u32 = 0x01;
+const MODULE_TYPEDEF_ALIAS: u32 = 0x05;
+const MODULE_TYPEDEF_EXPORT: u32 = 0x06;
+const MODULE_TYPEDEF_IMPORT: u32 = 0x02;
+
+pub(crate) const TYPE_REF_INSTANCE: u32 = 0x00;
+pub(crate) const TYPE_REF_MODULE: u32 = 0x01;
+pub(crate) const TYPE_REF_FUNCTION: u32 = 0x02;
+pub(crate) const TYPE_REF_TABLE: u32 = 0x03;
+pub(crate) const TYPE_REF_MEMORY: u32 = 0x04;
+pub(crate) const TYPE_REF_GLOBAL: u32 = 0x05;
+pub(crate) const TYPE_REF_ADAPTER_FUNCTION: u32 = 0x06;
+
+/// Represents a reference to a type definition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TypeRef {
+    /// The definition is an instance.
+    ///
+    /// The value is an index in the types index space.
+    Instance(u32),
+    /// The definition is a module.
+    ///
+    /// The value is an index in the types index space.
+    Module(u32),
+    /// The definition is a core wasm function.
+    ///
+    /// The value is an index in the types index space.
+    Function(u32),
+    /// The definition is a core wasm table.
+    Table(TableType),
+    /// The definition is a core wasm memory.
+    Memory(MemoryType),
+    /// The definition is a core wasm global.
+    Global(GlobalType),
+    /// The definition is an adapter function.
+    ///
+    /// The value is an index in the types index space.
+    AdapterFunction(u32),
+}
+
+impl TypeRef {
+    pub(crate) fn new(reader: &mut BinaryReader) -> Result<Self> {
+        Ok(match reader.read_u8()? {
+            TYPE_REF_INSTANCE => TypeRef::Instance(reader.read_var_u32()?),
+            TYPE_REF_MODULE => TypeRef::Module(reader.read_var_u32()?),
+            TYPE_REF_FUNCTION => TypeRef::Function(reader.read_var_u32()?),
+            TYPE_REF_TABLE => TypeRef::Table(reader.read_table_type()?),
+            TYPE_REF_MEMORY => TypeRef::Memory(reader.read_memory_type()?),
+            TYPE_REF_GLOBAL => TypeRef::Global(reader.read_global_type()?),
+            TYPE_REF_ADAPTER_FUNCTION => TypeRef::AdapterFunction(reader.read_var_u32()?),
+            x => {
+                return Err(BinaryReaderError::new(
+                    format!("invalid byte (0x{:x}) in type reference", x),
+                    reader.original_position() - 1,
+                ))
+            }
+        })
+    }
+}
+
+/// Represents an index for an outer alias.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OuterAliasIndex {
+    /// The index is a module index.
+    Module(u32),
+    /// The index is a type index.
+    Type(u32),
+}
+
+impl OuterAliasIndex {
+    fn new(reader: &mut BinaryReader) -> Result<Self> {
+        let index = reader.read_var_u32()?;
+        Ok(match reader.read_u8()? {
+            ALIAS_KIND_OUTER_MODULE => Self::Module(index),
+            ALIAS_KIND_OUTER_TYPE => Self::Type(index),
+            _ => {
+                return Err(BinaryReaderError::new(
+                    "expected a module or type alias for instance type definition",
+                    reader.original_position() - 1,
+                ))
+            }
+        })
+    }
+}
+
+/// Represents an instance type definition.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InstanceTypeDef<'a> {
+    /// The instance type definition is for a type.
+    Type(TypeDef<'a>),
+    /// The instance type definition is for an outer alias.
+    Alias {
+        /// The enclosing module count, starting at zero for current module.
+        count: u32,
+        /// The outer index being aliased.
+        index: OuterAliasIndex,
+    },
+    /// The instance type definition is for an instance export.
+    Export {
+        /// The export's name.
+        name: &'a str,
+        /// The export's type.
+        ty: TypeRef,
+    },
+}
+
+impl<'a> InstanceTypeDef<'a> {
+    fn new(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        Ok(match reader.read_u8()? {
+            INSTANCE_TYPEDEF_TYPE => Self::Type(TypeDef::new(reader)?),
+            INSTANCE_TYPEDEF_ALIAS => match reader.read_u8()? {
+                ALIAS_KIND_OUTER => Self::Alias {
+                    count: reader.read_var_u32()?,
+                    index: OuterAliasIndex::new(reader)?,
+                },
+                x => {
+                    return Err(BinaryReaderError::new(
+                        format!("unexpected alias kind (0x{:x}) encountered in instance type definition", x),
+                        reader.original_position() - 1,
+                    ));
+                }
+            },
+            INSTANCE_TYPEDEF_EXPORT => Self::Export {
+                name: reader.read_string()?,
+                ty: TypeRef::new(reader)?,
+            },
+            x => {
+                return Err(BinaryReaderError::new(
+                    format!(
+                        "unexpected kind (0x{:x}) encountered in instance type definition",
+                        x
+                    ),
+                    reader.original_position() - 1,
+                ));
+            }
+        })
+    }
+}
+
+/// Represents a module type definition.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ModuleTypeDef<'a> {
+    /// The module type definition is for a type.
+    Type(TypeDef<'a>),
+    /// The module type definition is for an outer alias.
+    Alias {
+        /// The enclosing module count, starting at zero for current module.
+        count: u32,
+        /// The outer index being aliased.
+        index: OuterAliasIndex,
+    },
+    /// The module type definition is for an export.
+    Export {
+        /// The export's name.
+        name: &'a str,
+        /// The export's type.
+        ty: TypeRef,
+    },
+    /// The module type definition is for an import.
+    Import {
+        /// The import's name.
+        name: &'a str,
+        /// The import's type.
+        ty: TypeRef,
+    },
+}
+
+impl<'a> ModuleTypeDef<'a> {
+    fn new(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        Ok(match reader.read_u8()? {
+            MODULE_TYPEDEF_TYPE => Self::Type(TypeDef::new(reader)?),
+            MODULE_TYPEDEF_ALIAS => match reader.read_u8()? {
+                ALIAS_KIND_OUTER => Self::Alias {
+                    count: reader.read_var_u32()?,
+                    index: OuterAliasIndex::new(reader)?,
+                },
+                _ => {
+                    return Err(BinaryReaderError::new(
+                        "expected an outer alias for module type definition",
+                        reader.original_position() - 1,
+                    ));
+                }
+            },
+            MODULE_TYPEDEF_EXPORT => Self::Export {
+                name: reader.read_string()?,
+                ty: TypeRef::new(reader)?,
+            },
+            MODULE_TYPEDEF_IMPORT => Self::Import {
+                name: reader.read_string()?,
+                ty: TypeRef::new(reader)?,
+            },
+            _ => {
+                return Err(BinaryReaderError::new(
+                    "invalid module type definition",
+                    reader.original_position() - 1,
+                ))
+            }
+        })
+    }
+}
+
+/// Represents an interface type.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InterfaceType {
+    /// The type is a boolean.
+    Bool,
+    /// The type is a signed 8-bit integer.
+    S8,
+    /// The type is an unsigned 8-bit integer.
+    U8,
+    /// The type is a signed 16-bit integer.
+    S16,
+    /// The type is an unsigned 16-bit integer.
+    U16,
+    /// The type is a signed 32-bit integer.
+    S32,
+    /// The type is an unsigned 32-bit integer.
+    U32,
+    /// The type is a signed 64-bit integer.
+    S64,
+    /// The type is an unsigned 64-bit integer.
+    U64,
+    /// The type is a 32-bit floating point number.
+    F32,
+    /// The type is a 64-bit floating point number.
+    F64,
+    /// The type is a Unicode character.
+    Char,
+    /// The type is a string.
+    String,
+    /// The type is a compound interface type.
+    ///
+    /// The value is a type index to a compound type.
+    Compound(u32),
+}
+
+impl InterfaceType {
+    fn new(reader: &mut BinaryReader) -> Result<Self> {
+        Ok(match reader.read_var_u32()? {
+            INTERFACE_TYPE_BOOL => Self::Bool,
+            INTERFACE_TYPE_S8 => Self::S8,
+            INTERFACE_TYPE_U8 => Self::U8,
+            INTERFACE_TYPE_S16 => Self::S16,
+            INTERFACE_TYPE_U16 => Self::U16,
+            INTERFACE_TYPE_S32 => Self::S32,
+            INTERFACE_TYPE_U32 => Self::U32,
+            INTERFACE_TYPE_S64 => Self::S64,
+            INTERFACE_TYPE_U64 => Self::U64,
+            INTERFACE_TYPE_F32 => Self::F32,
+            INTERFACE_TYPE_F64 => Self::F64,
+            INTERFACE_TYPE_CHAR => Self::Char,
+            INTERFACE_TYPE_STRING => Self::String,
+            i => Self::Compound(i),
+        })
+    }
+
+    fn maybe(reader: &mut BinaryReader) -> Result<Option<Self>> {
+        Ok(match reader.read_u8()? {
+            0 => None,
+            1 => Some(Self::new(reader)?),
+            x => {
+                return Err(BinaryReaderError::new(
+                    format!("invalid byte (0x{:x}) in type definition", x),
+                    reader.original_position() - 1,
+                ))
+            }
+        })
+    }
+}
+
+/// Represents a compound interface type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CompoundType<'a> {
+    /// The type is a list of the given interface type.
+    List(InterfaceType),
+    /// The type is a record with the given fields.
+    Record(Box<[(&'a str, InterfaceType)]>),
+    /// The type is a variant with the given cases.
+    Variant(Box<[(&'a str, Option<InterfaceType>)]>),
+    /// The type is a tuple of the given interface types.
+    Tuple(Box<[InterfaceType]>),
+    /// The type is flags with the given names.
+    Flags(Box<[&'a str]>),
+    /// The type is an enum with the given tags.
+    Enum(Box<[&'a str]>),
+    /// The type is a union of the given interface types.
+    Union(Box<[InterfaceType]>),
+    /// The type is an optional of the given interface type.
+    Optional(InterfaceType),
+    /// The type is an expected type.
+    Expected {
+        /// The type returned for success.
+        ok: Option<InterfaceType>,
+        /// The type returned for failure.
+        error: Option<InterfaceType>,
+    },
+    /// The type is a named type.
+    Named {
+        /// The name of the type.
+        name: &'a str,
+        /// The interface type being named.
+        ty: InterfaceType,
+    },
+}
+
+impl<'a> CompoundType<'a> {
+    fn new(leading: u32, reader: &mut BinaryReader<'a>) -> Result<Self> {
+        Ok(match leading {
+            COMPOUND_TYPE_LIST => CompoundType::List(InterfaceType::new(reader)?),
+            COMPOUND_TYPE_RECORD => CompoundType::Record(
+                (0..reader.read_var_u32()?)
+                    .map(|_| {
+                        let name = reader.read_string()?;
+                        let ty = InterfaceType::new(reader)?;
+                        Ok((name, ty))
+                    })
+                    .collect::<Result<_>>()?,
+            ),
+            COMPOUND_TYPE_VARIANT => CompoundType::Variant(
+                (0..reader.read_var_u32()?)
+                    .map(|_| {
+                        let name = reader.read_string()?;
+                        let ty = InterfaceType::maybe(reader)?;
+                        Ok((name, ty))
+                    })
+                    .collect::<Result<_>>()?,
+            ),
+            COMPOUND_TYPE_TUPLE => CompoundType::Tuple(
+                (0..reader.read_var_u32()?)
+                    .map(|_| InterfaceType::new(reader))
+                    .collect::<Result<_>>()?,
+            ),
+            COMPOUND_TYPE_FLAGS => CompoundType::Flags(
+                (0..reader.read_var_u32()?)
+                    .map(|_| reader.read_string())
+                    .collect::<Result<_>>()?,
+            ),
+            COMPOUND_TYPE_ENUM => CompoundType::Enum(
+                (0..reader.read_var_u32()?)
+                    .map(|_| reader.read_string())
+                    .collect::<Result<_>>()?,
+            ),
+            COMPOUND_TYPE_UNION => CompoundType::Union(
+                (0..reader.read_var_u32()?)
+                    .map(|_| InterfaceType::new(reader))
+                    .collect::<Result<_>>()?,
+            ),
+            COMPOUND_TYPE_OPTIONAL => CompoundType::Optional(InterfaceType::new(reader)?),
+            COMPOUND_TYPE_EXPECTED => CompoundType::Expected {
+                ok: InterfaceType::maybe(reader)?,
+                error: InterfaceType::maybe(reader)?,
+            },
+            COMPOUND_TYPE_NAMED => CompoundType::Named {
+                name: reader.read_string()?,
+                ty: InterfaceType::new(reader)?,
+            },
+            x => {
+                return Err(BinaryReaderError::new(
+                    format!("invalid leading byte (0x{:x}) in type definition", x),
+                    reader.original_position() - 1,
+                ))
+            }
+        })
+    }
+}
+
+/// Represents a name-type pair.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NameTypePair<'a> {
+    /// The optional name.
+    pub name: Option<&'a str>,
+    /// The type.
+    pub ty: InterfaceType,
+}
+
+/// Represents a type definition in the types section.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TypeDef<'a> {
+    /// The type is an instance.
+    Instance(Box<[InstanceTypeDef<'a>]>),
+    /// The type is a module.
+    Module(Box<[ModuleTypeDef<'a>]>),
+    /// The type is a core WebAssembly function.
+    Function(FuncType),
+    /// The type is a function adapter.
+    AdapterFunction {
+        /// The function's parameter types.
+        params: Box<[NameTypePair<'a>]>,
+        /// The function's result types.
+        results: Box<[NameTypePair<'a>]>,
+    },
+    /// The type is a compound interface type.
+    Compound(CompoundType<'a>),
+}
+
+impl<'a> TypeDef<'a> {
+    fn new(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        Ok(match reader.read_u8()? {
+            TYPE_INSTANCE => TypeDef::Instance(
+                (0..reader.read_var_u32()?)
+                    .map(|_| InstanceTypeDef::new(reader))
+                    .collect::<Result<_>>()?,
+            ),
+            TYPE_MODULE => TypeDef::Module(
+                (0..reader.read_var_u32()?)
+                    .map(|_| ModuleTypeDef::new(reader))
+                    .collect::<Result<_>>()?,
+            ),
+            TYPE_FUNCTION => TypeDef::Function(reader.read_func_type()?),
+            TYPE_ADAPTER_FUNCTION => TypeDef::AdapterFunction {
+                params: Self::maybe_named_types(reader)?,
+                results: Self::maybe_named_types(reader)?,
+            },
+            // All other supported leading bytes should be compound types
+            leading => TypeDef::Compound(CompoundType::new(leading, reader)?),
+        })
+    }
+
+    fn maybe_named_types(reader: &mut BinaryReader<'a>) -> Result<Box<[NameTypePair<'a>]>> {
+        Ok(match reader.read_u8()? {
+            0 => (0..reader.read_var_u32()?)
+                .map(|_| {
+                    Ok(NameTypePair {
+                        name: None,
+                        ty: InterfaceType::new(reader)?,
+                    })
+                })
+                .collect::<Result<_>>()?,
+            1 => (0..reader.read_var_u32()?)
+                .map(|_| {
+                    Ok(NameTypePair {
+                        name: Some(reader.read_string()?),
+                        ty: InterfaceType::new(reader)?,
+                    })
+                })
+                .collect::<Result<_>>()?,
+            x => {
+                return Err(BinaryReaderError::new(
+                    format!("invalid byte (0x{:x}) in type definition", x),
+                    reader.original_position() - 1,
+                ))
+            }
+        })
+    }
+}
+
+/// The type section reader for a WebAssembly component.
+#[derive(Clone)]
+pub struct TypeSectionReader<'a> {
+    reader: BinaryReader<'a>,
+    count: u32,
+}
+
+impl<'a> TypeSectionReader<'a> {
+    /// Creates a new type section reader for the given data and initial offset.
+    pub fn new(data: &'a [u8], offset: usize) -> Result<Self> {
+        let mut reader = BinaryReader::new_with_offset(data, offset);
+        let count = reader.read_var_u32()?;
+        Ok(Self { reader, count })
+    }
+
+    /// Gets the original position of the reader.
+    pub fn original_position(&self) -> usize {
+        self.reader.original_position()
+    }
+
+    /// Gets the number of types in the section.
+    pub fn len(&self) -> u32 {
+        self.count
+    }
+
+    /// Determines if the section is empty.
+    pub fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+
+    /// Reads types from the type section.
+    ///
+    /// # Examples
+    /// ```
+    /// use wasmparser::component::TypeSectionReader;
+    /// # let data: &[u8] = &[0x01, 0x7b, 0x65];
+    /// let types = TypeSectionReader::new(data, 0).unwrap();
+    /// for ty in types {
+    ///     let ty = ty.expect("type");
+    ///     println!("{:?}", ty);
+    /// }
+    /// ```
+    pub fn read(&mut self) -> Result<TypeDef<'a>> {
+        TypeDef::new(&mut self.reader)
+    }
+}
+
+impl<'a> SectionReader for TypeSectionReader<'a> {
+    type Item = TypeDef<'a>;
+
+    fn read(&mut self) -> Result<Self::Item> {
+        TypeSectionReader::read(self)
+    }
+
+    fn eof(&self) -> bool {
+        self.reader.eof()
+    }
+
+    fn original_position(&self) -> usize {
+        TypeSectionReader::original_position(self)
+    }
+
+    fn range(&self) -> Range {
+        self.reader.range()
+    }
+}
+
+impl<'a> SectionWithLimitedItems for TypeSectionReader<'a> {
+    fn get_count(&self) -> u32 {
+        TypeSectionReader::len(self)
+    }
+}
+
+impl<'a> IntoIterator for TypeSectionReader<'a> {
+    type Item = Result<TypeDef<'a>>;
+    type IntoIter = SectionIteratorLimited<TypeSectionReader<'a>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        SectionIteratorLimited::new(self)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::Type;
+    use anyhow::Result;
+
+    #[test]
+    fn it_parses_an_empty_section() -> Result<()> {
+        let data: &[u8] = &[0];
+        let reader = TypeSectionReader::new(data, 0)?;
+        assert!(reader.eof());
+        assert_eq!(reader.len(), 0);
+        Ok(())
+    }
+
+    #[test]
+    fn it_parses_an_instance_definition() -> Result<()> {
+        let data: &[u8] = &[
+            1,
+            TYPE_INSTANCE as u8,
+            3,
+            INSTANCE_TYPEDEF_TYPE as u8,
+            COMPOUND_TYPE_LIST as u8,
+            INTERFACE_TYPE_STRING as u8,
+            INSTANCE_TYPEDEF_ALIAS as u8,
+            ALIAS_KIND_OUTER as u8,
+            6,
+            101,
+            ALIAS_KIND_OUTER_MODULE as u8,
+            INSTANCE_TYPEDEF_EXPORT as u8,
+            3,
+            b'f',
+            b'o',
+            b'o',
+            TYPE_REF_FUNCTION as u8,
+            7,
+        ];
+        let mut reader = TypeSectionReader::new(data, 0)?;
+        assert!(!reader.eof());
+        assert_eq!(reader.len(), 1);
+
+        match reader.read()? {
+            TypeDef::Instance(defs) => {
+                assert_eq!(defs.len(), 3);
+                assert_eq!(
+                    defs[0],
+                    InstanceTypeDef::Type(TypeDef::Compound(CompoundType::List(
+                        InterfaceType::String
+                    )))
+                );
+                assert_eq!(
+                    defs[1],
+                    InstanceTypeDef::Alias {
+                        count: 6,
+                        index: OuterAliasIndex::Module(101)
+                    }
+                );
+                assert_eq!(
+                    defs[2],
+                    InstanceTypeDef::Export {
+                        name: "foo",
+                        ty: TypeRef::Function(7)
+                    }
+                );
+            }
+            _ => panic!("unexpected type"),
+        }
+
+        assert!(reader.eof());
+        Ok(())
+    }
+
+    #[test]
+    fn it_parses_a_module_definition() -> Result<()> {
+        let data: &[u8] = &[
+            1,
+            TYPE_MODULE as u8,
+            4,
+            MODULE_TYPEDEF_TYPE as u8,
+            COMPOUND_TYPE_OPTIONAL as u8,
+            INTERFACE_TYPE_STRING as u8,
+            MODULE_TYPEDEF_ALIAS as u8,
+            ALIAS_KIND_OUTER as u8,
+            10,
+            42,
+            ALIAS_KIND_OUTER_TYPE as u8,
+            MODULE_TYPEDEF_EXPORT as u8,
+            3,
+            b'f',
+            b'o',
+            b'o',
+            TYPE_REF_FUNCTION as u8,
+            7,
+            MODULE_TYPEDEF_IMPORT as u8,
+            3,
+            b'b',
+            b'a',
+            b'r',
+            TYPE_REF_FUNCTION as u8,
+            8,
+        ];
+        let mut reader = TypeSectionReader::new(data, 0)?;
+        assert!(!reader.eof());
+        assert_eq!(reader.len(), 1);
+
+        match reader.read()? {
+            TypeDef::Module(defs) => {
+                assert_eq!(defs.len(), 4);
+                assert_eq!(
+                    defs[0],
+                    ModuleTypeDef::Type(TypeDef::Compound(CompoundType::Optional(
+                        InterfaceType::String
+                    )))
+                );
+                assert_eq!(
+                    defs[1],
+                    ModuleTypeDef::Alias {
+                        count: 10,
+                        index: OuterAliasIndex::Type(42)
+                    }
+                );
+                assert_eq!(
+                    defs[2],
+                    ModuleTypeDef::Export {
+                        name: "foo",
+                        ty: TypeRef::Function(7)
+                    }
+                );
+                assert_eq!(
+                    defs[3],
+                    ModuleTypeDef::Import {
+                        name: "bar",
+                        ty: TypeRef::Function(8)
+                    }
+                )
+            }
+            _ => panic!("unexpected type"),
+        }
+
+        assert!(reader.eof());
+        Ok(())
+    }
+
+    #[test]
+    fn it_parses_a_func_type() -> Result<()> {
+        let data: &[u8] = &[
+            1,
+            TYPE_FUNCTION as u8,
+            4,
+            0x7f, // i32
+            0x7e, // i64
+            0x7d, // f32
+            0x7c, // f64
+            2,
+            0x7e, // i64
+            0x7f, // i32
+        ];
+        let mut reader = TypeSectionReader::new(data, 0)?;
+        assert!(!reader.eof());
+        assert_eq!(reader.len(), 1);
+
+        match reader.read()? {
+            TypeDef::Function(ty) => {
+                assert_eq!(*ty.params, [Type::I32, Type::I64, Type::F32, Type::F64]);
+                assert_eq!(*ty.returns, [Type::I64, Type::I32]);
+            }
+            _ => panic!("unexpected type"),
+        }
+
+        assert!(reader.eof());
+        Ok(())
+    }
+
+    #[test]
+    fn it_parses_a_nameless_adapter_func_type() -> Result<()> {
+        let data: &[u8] = &[
+            0x01,
+            TYPE_ADAPTER_FUNCTION as u8,
+            0,
+            4,
+            INTERFACE_TYPE_STRING as u8,
+            INTERFACE_TYPE_BOOL as u8,
+            INTERFACE_TYPE_S64 as u8,
+            INTERFACE_TYPE_CHAR as u8,
+            0,
+            2,
+            INTERFACE_TYPE_F64 as u8,
+            INTERFACE_TYPE_S16 as u8,
+        ];
+        let mut reader = TypeSectionReader::new(data, 0)?;
+        assert!(!reader.eof());
+        assert_eq!(reader.len(), 1);
+
+        match reader.read()? {
+            TypeDef::AdapterFunction { params, results } => {
+                assert_eq!(
+                    *params,
+                    [
+                        NameTypePair {
+                            name: None,
+                            ty: InterfaceType::String
+                        },
+                        NameTypePair {
+                            name: None,
+                            ty: InterfaceType::Bool
+                        },
+                        NameTypePair {
+                            name: None,
+                            ty: InterfaceType::S64
+                        },
+                        NameTypePair {
+                            name: None,
+                            ty: InterfaceType::Char
+                        }
+                    ]
+                );
+                assert_eq!(
+                    *results,
+                    [
+                        NameTypePair {
+                            name: None,
+                            ty: InterfaceType::F64
+                        },
+                        NameTypePair {
+                            name: None,
+                            ty: InterfaceType::S16
+                        }
+                    ]
+                );
+            }
+            _ => panic!("unexpected type"),
+        }
+
+        assert!(reader.eof());
+        Ok(())
+    }
+
+    #[test]
+    fn it_parses_a_named_adapter_func_type() -> Result<()> {
+        let data: &[u8] = &[
+            0x01,
+            TYPE_ADAPTER_FUNCTION as u8,
+            1,
+            4,
+            3,
+            b'a',
+            b'b',
+            b'c',
+            INTERFACE_TYPE_STRING as u8,
+            1,
+            b'd',
+            INTERFACE_TYPE_S16 as u8,
+            2,
+            b'e',
+            b'f',
+            INTERFACE_TYPE_S32 as u8,
+            4,
+            b'g',
+            b'h',
+            b'i',
+            b'j',
+            INTERFACE_TYPE_U8 as u8,
+            1,
+            2,
+            3,
+            b'k',
+            b'l',
+            b'm',
+            INTERFACE_TYPE_F32 as u8,
+            1,
+            b'n',
+            INTERFACE_TYPE_S8 as u8,
+        ];
+        let mut reader = TypeSectionReader::new(data, 0)?;
+        assert!(!reader.eof());
+        assert_eq!(reader.len(), 1);
+
+        match reader.read()? {
+            TypeDef::AdapterFunction { params, results } => {
+                assert_eq!(
+                    *params,
+                    [
+                        NameTypePair {
+                            name: Some("abc"),
+                            ty: InterfaceType::String
+                        },
+                        NameTypePair {
+                            name: Some("d"),
+                            ty: InterfaceType::S16
+                        },
+                        NameTypePair {
+                            name: Some("ef"),
+                            ty: InterfaceType::S32
+                        },
+                        NameTypePair {
+                            name: Some("ghij"),
+                            ty: InterfaceType::U8
+                        },
+                    ]
+                );
+                assert_eq!(
+                    *results,
+                    [
+                        NameTypePair {
+                            name: Some("klm"),
+                            ty: InterfaceType::F32
+                        },
+                        NameTypePair {
+                            name: Some("n"),
+                            ty: InterfaceType::S8
+                        },
+                    ]
+                );
+            }
+            _ => panic!("unexpected type"),
+        }
+
+        assert!(reader.eof());
+        Ok(())
+    }
+
+    #[test]
+    fn it_parses_compound_types() -> Result<()> {
+        let data: &[u8] = &[
+            10,
+            COMPOUND_TYPE_LIST as u8,
+            INTERFACE_TYPE_STRING as u8,
+            COMPOUND_TYPE_RECORD as u8,
+            2,
+            3,
+            b'f',
+            b'o',
+            b'o',
+            INTERFACE_TYPE_S8 as u8,
+            3,
+            b'b',
+            b'a',
+            b'r',
+            INTERFACE_TYPE_U8 as u8,
+            COMPOUND_TYPE_VARIANT as u8,
+            2,
+            3,
+            b'b',
+            b'a',
+            b'z',
+            0,
+            3,
+            b'j',
+            b'a',
+            b'm',
+            1,
+            INTERFACE_TYPE_STRING as u8,
+            COMPOUND_TYPE_TUPLE as u8,
+            4,
+            INTERFACE_TYPE_CHAR as u8,
+            INTERFACE_TYPE_STRING as u8,
+            INTERFACE_TYPE_S16 as u8,
+            INTERFACE_TYPE_S32 as u8,
+            COMPOUND_TYPE_FLAGS as u8,
+            3,
+            1,
+            b'a',
+            1,
+            b'b',
+            1,
+            b'c',
+            COMPOUND_TYPE_ENUM as u8,
+            3,
+            1,
+            b'd',
+            1,
+            b'e',
+            1,
+            b'f',
+            COMPOUND_TYPE_UNION as u8,
+            2,
+            INTERFACE_TYPE_CHAR as u8,
+            INTERFACE_TYPE_STRING as u8,
+            COMPOUND_TYPE_OPTIONAL as u8,
+            INTERFACE_TYPE_BOOL as u8,
+            COMPOUND_TYPE_EXPECTED as u8,
+            0,
+            1,
+            INTERFACE_TYPE_STRING as u8,
+            COMPOUND_TYPE_NAMED as u8,
+            3,
+            b'f',
+            b'o',
+            b'o',
+            INTERFACE_TYPE_S8 as u8,
+        ];
+        let reader = TypeSectionReader::new(data, 0)?;
+        assert!(!reader.eof());
+        assert_eq!(reader.len(), 10);
+
+        let types: Vec<_> = reader.into_iter().collect::<crate::Result<_>>()?;
+        assert_eq!(
+            types,
+            [
+                TypeDef::Compound(CompoundType::List(InterfaceType::String)),
+                TypeDef::Compound(CompoundType::Record(
+                    [("foo", InterfaceType::S8), ("bar", InterfaceType::U8)].into()
+                )),
+                TypeDef::Compound(CompoundType::Variant(
+                    [("baz", None), ("jam", Some(InterfaceType::String))].into()
+                )),
+                TypeDef::Compound(CompoundType::Tuple(
+                    [
+                        InterfaceType::Char,
+                        InterfaceType::String,
+                        InterfaceType::S16,
+                        InterfaceType::S32,
+                    ]
+                    .into()
+                )),
+                TypeDef::Compound(CompoundType::Flags(["a", "b", "c"].into())),
+                TypeDef::Compound(CompoundType::Enum(["d", "e", "f"].into())),
+                TypeDef::Compound(CompoundType::Union(
+                    [InterfaceType::Char, InterfaceType::String].into()
+                )),
+                TypeDef::Compound(CompoundType::Optional(InterfaceType::Bool)),
+                TypeDef::Compound(CompoundType::Expected {
+                    ok: None,
+                    error: Some(InterfaceType::String)
+                }),
+                TypeDef::Compound(CompoundType::Named {
+                    name: "foo",
+                    ty: InterfaceType::S8
+                }),
+            ]
+        );
+        Ok(())
+    }
+}

--- a/crates/wasmparser/src/lib.rs
+++ b/crates/wasmparser/src/lib.rs
@@ -33,6 +33,7 @@ pub use crate::readers::*;
 pub use crate::validator::*;
 
 mod binary_reader;
+pub mod component;
 mod limits;
 mod module_resources;
 mod operators_validator;

--- a/crates/wasmparser/src/operators_validator.rs
+++ b/crates/wasmparser/src/operators_validator.rs
@@ -19,7 +19,7 @@
 //
 // That algorithm is followed pretty closely here, namely `push_operand`,
 // `pop_operand`, `push_ctrl`, and `pop_ctrl`. If anything here is a bit
-// confusing it's recomended to read over that section to see how it maps to
+// confusing it's recommended to read over that section to see how it maps to
 // the various methods here.
 
 use crate::limits::MAX_WASM_FUNCTION_LOCALS;
@@ -199,7 +199,7 @@ impl OperatorValidator {
             }
             // If `Ok` is returned we found the index exactly, or if `Err` is
             // returned the position is the one which is the least index
-            // greater thatn `idx`, which is still the type of `idx` according
+            // greater than `idx`, which is still the type of `idx` according
             // to our "compressed" representation. In both cases we access the
             // list at index `i`.
             Ok(i) | Err(i) => Ok(self.locals[i].1),
@@ -359,7 +359,7 @@ impl OperatorValidator {
         }
     }
 
-    /// Validates a `memarg for alignment and such (also the memory it
+    /// Validates a `memarg` for alignment and such (also the memory it
     /// references), and returns the type of index used to address the memory.
     fn check_memarg(
         &self,

--- a/crates/wasmparser/src/parser.rs
+++ b/crates/wasmparser/src/parser.rs
@@ -20,14 +20,14 @@ pub(crate) const WASM_MODULE_VERSION: u32 = 0x1;
 /// This primary function for a parser is the [`Parser::parse`] function which
 /// will incrementally consume input. You can also use the [`Parser::parse_all`]
 /// function to parse a module that is entirely resident in memory.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct Parser {
     state: State,
     offset: u64,
     max_size: u64,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 enum State {
     ModuleHeader,
     SectionStart,
@@ -741,8 +741,8 @@ impl Parser {
                 // Afterwards we turn the loop again to recurse in parsing the
                 // nested module.
                 Payload::ModuleSectionEntry { parser, range: _ } => {
-                    stack.push(cur);
-                    cur = *parser;
+                    stack.push(cur.clone());
+                    cur = parser.clone();
                 }
 
                 _ => {}

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -25,6 +25,13 @@ pub struct BinaryReaderError {
     pub(crate) inner: Box<BinaryReaderErrorInner>,
 }
 
+impl BinaryReaderError {
+    pub(crate) fn clear_hint(mut self) -> Self {
+        self.inner.needed_hint = None;
+        self
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct BinaryReaderErrorInner {
     pub(crate) message: String,

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -388,7 +388,7 @@ impl Validator {
             UnknownSection { id, range, .. } => self.unknown_section(*id, range)?,
             ModuleSectionEntry { parser, .. } => {
                 self.module_section_entry();
-                return Ok(ValidPayload::Submodule(parser.clone()));
+                return Ok(ValidPayload::Submodule(*parser));
             }
         }
         Ok(ValidPayload::Ok)

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -388,7 +388,7 @@ impl Validator {
             UnknownSection { id, range, .. } => self.unknown_section(*id, range)?,
             ModuleSectionEntry { parser, .. } => {
                 self.module_section_entry();
-                return Ok(ValidPayload::Submodule(*parser));
+                return Ok(ValidPayload::Submodule(parser.clone()));
             }
         }
         Ok(ValidPayload::Ok)


### PR DESCRIPTION
This PR implements WebAssembly component parsing in `wasmparser` per the in-progress component model proposal.

Similar to the wasm module parser, `component::Parser` is implemented to
incrementally parse the sections of a WebAssembly component.

This PR also fixes `wasm-encoder` parsing of canonical options to fit the
current component model spec and adds encoding of custom sections for WebAssembly components.

The changes to `wasmparser` do not yet include a validator for WebAssembly components; that will be coming soon.

