### PR TITLE
wasm-mutate: Fix a copy/paste typo

### DIFF
--- a/crates/wasm-mutate/src/mutators/peephole/dfg.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/dfg.rs
@@ -724,7 +724,7 @@ impl<'a> DFGBuilder {
                     let a = Id::from(self.pop_operand(idx, false));
                     let b = Id::from(self.pop_operand(idx, false));
                     let c = Id::from(self.pop_operand(idx, false));
-                    self.empty_node(Lang::MemoryFill(*table, [c, b, a]), idx);
+                    self.empty_node(Lang::TableFill(*table, [c, b, a]), idx);
                 }
 
                 Operator::TableGet { table } => {


### PR DESCRIPTION
Avoids accidentally mapping `table.fill` instructions to `memory.fill`