### PR TITLE
wasmparser: minimize diff for no_std support mirrors

### DIFF
--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -13,10 +13,10 @@
  * limitations under the License.
  */
 
+use alloc::{boxed::Box, format, vec::Vec};
 use core::convert::TryInto;
 use core::fmt;
 use core::str;
-use alloc::{vec::Vec, format, boxed::Box};
 
 use crate::limits::*;
 

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -13,9 +13,10 @@
  * limitations under the License.
  */
 
-use std::convert::TryInto;
-use std::fmt;
-use std::str;
+use core::convert::TryInto;
+use core::fmt;
+use core::str;
+use alloc::{vec::Vec, format, boxed::Box};
 
 use crate::limits::*;
 
@@ -1080,7 +1081,7 @@ impl<'a> BinaryReader<'a> {
         } else {
             self.position = position;
             let idx = self.read_var_s33()?;
-            if idx < 0 || idx > (std::u32::MAX as i64) {
+            if idx < 0 || idx > (core::u32::MAX as i64) {
                 return Err(BinaryReaderError::new("invalid function type", position));
             }
             Ok(TypeOrFuncType::FuncType(idx as u32))

--- a/crates/wasmparser/src/lib.rs
+++ b/crates/wasmparser/src/lib.rs
@@ -23,6 +23,8 @@
 //! this is not the right library for you. You could however, build such
 //! a data-structure using this library.
 
+extern crate alloc;
+
 pub use crate::binary_reader::BinaryReader;
 pub use crate::binary_reader::Range;
 

--- a/crates/wasmparser/src/module_resources.rs
+++ b/crates/wasmparser/src/module_resources.rs
@@ -14,7 +14,7 @@
  */
 
 use crate::{FuncType, GlobalType, MemoryType, TableType, Type};
-use std::ops::Range;
+use core::ops::Range;
 
 /// Types that qualify as Wasm function types for validation purposes.
 pub trait WasmFuncType {
@@ -261,7 +261,7 @@ where
     }
 }
 
-impl<T> WasmModuleResources for std::sync::Arc<T>
+impl<T> WasmModuleResources for alloc::sync::Arc<T>
 where
     T: WasmModuleResources,
 {

--- a/crates/wasmparser/src/operators_validator.rs
+++ b/crates/wasmparser/src/operators_validator.rs
@@ -25,7 +25,7 @@
 use crate::limits::MAX_WASM_FUNCTION_LOCALS;
 use crate::primitives::{MemoryImmediate, Operator, SIMDLaneIndex, Type, TypeOrFuncType};
 use crate::{BinaryReaderError, Result, WasmFeatures, WasmFuncType, WasmModuleResources};
-use alloc::{format, string::String, vec::Vec, vec};
+use alloc::{format, string::String, vec, vec::Vec};
 
 /// A wrapper around a `BinaryReaderError` where the inner error's offset is a
 /// temporary placeholder value. This can be converted into a proper

--- a/crates/wasmparser/src/operators_validator.rs
+++ b/crates/wasmparser/src/operators_validator.rs
@@ -25,6 +25,7 @@
 use crate::limits::MAX_WASM_FUNCTION_LOCALS;
 use crate::primitives::{MemoryImmediate, Operator, SIMDLaneIndex, Type, TypeOrFuncType};
 use crate::{BinaryReaderError, Result, WasmFeatures, WasmFuncType, WasmModuleResources};
+use alloc::{format, string::String, vec::Vec, vec};
 
 /// A wrapper around a `BinaryReaderError` where the inner error's offset is a
 /// temporary placeholder value. This can be converted into a proper
@@ -49,7 +50,7 @@ macro_rules! bail_op_err {
 impl OperatorValidatorError {
     /// Create a new `OperatorValidatorError` with a placeholder offset.
     pub(crate) fn new(message: impl Into<String>) -> Self {
-        let offset = std::usize::MAX;
+        let offset = core::usize::MAX;
         let e = BinaryReaderError::new(message, offset);
         OperatorValidatorError(e)
     }
@@ -57,13 +58,13 @@ impl OperatorValidatorError {
     /// Convert this `OperatorValidatorError` into a `BinaryReaderError` by
     /// supplying an actual offset to replace the internal placeholder offset.
     pub(crate) fn set_offset(mut self, offset: usize) -> BinaryReaderError {
-        debug_assert_eq!(self.0.inner.offset, std::usize::MAX);
+        debug_assert_eq!(self.0.inner.offset, core::usize::MAX);
         self.0.inner.offset = offset;
         self.0
     }
 }
 
-type OperatorValidatorResult<T> = std::result::Result<T, OperatorValidatorError>;
+type OperatorValidatorResult<T> = core::result::Result<T, OperatorValidatorError>;
 
 pub(crate) struct OperatorValidator {
     // The total number of locals that this function contains

--- a/crates/wasmparser/src/parser.rs
+++ b/crates/wasmparser/src/parser.rs
@@ -4,10 +4,10 @@ use crate::{BinaryReader, BinaryReaderError, FunctionBody, Range, Result};
 use crate::{DataSectionReader, ElementSectionReader, ExportSectionReader};
 use crate::{FunctionSectionReader, ImportSectionReader, TypeSectionReader};
 use crate::{GlobalSectionReader, MemorySectionReader, TableSectionReader};
+use alloc::{format, vec::Vec};
 use core::convert::TryInto;
 use core::fmt;
 use core::iter;
-use alloc::{format, vec::Vec};
 
 /// An incremental parser of a binary WebAssembly module.
 ///

--- a/crates/wasmparser/src/parser.rs
+++ b/crates/wasmparser/src/parser.rs
@@ -4,9 +4,10 @@ use crate::{BinaryReader, BinaryReaderError, FunctionBody, Range, Result};
 use crate::{DataSectionReader, ElementSectionReader, ExportSectionReader};
 use crate::{FunctionSectionReader, ImportSectionReader, TypeSectionReader};
 use crate::{GlobalSectionReader, MemorySectionReader, TableSectionReader};
-use std::convert::TryInto;
-use std::fmt;
-use std::iter;
+use core::convert::TryInto;
+use core::fmt;
+use core::iter;
+use alloc::{format, vec::Vec};
 
 /// An incremental parser of a binary WebAssembly module.
 ///

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -14,8 +14,9 @@
  */
 
 use std::error::Error;
-use std::fmt;
-use std::result;
+use core::fmt;
+use core::result;
+use alloc::{boxed::Box, string::String};
 
 #[derive(Debug, Clone)]
 pub struct BinaryReaderError {

--- a/crates/wasmparser/src/primitives.rs
+++ b/crates/wasmparser/src/primitives.rs
@@ -13,10 +13,10 @@
  * limitations under the License.
  */
 
-use std::error::Error;
+use alloc::{boxed::Box, string::String};
 use core::fmt;
 use core::result;
-use alloc::{boxed::Box, string::String};
+use std::error::Error;
 
 #[derive(Debug, Clone)]
 pub struct BinaryReaderError {

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -21,9 +21,8 @@ use crate::{BinaryReaderError, GlobalType, MemoryType, Range, Result, TableType,
 use crate::{DataKind, ElementItem, ElementKind, InitExpr, Instance, Operator};
 use crate::{FuncType, SectionReader, SectionWithLimitedItems};
 use crate::{FunctionBody, Parser, Payload};
-use std::collections::{HashMap, HashSet};
-use std::mem;
-use std::sync::Arc;
+use alloc::{vec::Vec, string::String, format, sync::Arc, collections::{BTreeMap, BTreeSet}};
+use core::mem;
 
 /// Test whether the given buffer contains a valid WebAssembly module,
 /// analogous to [`WebAssembly.validate`][js] in the JS API.
@@ -144,7 +143,7 @@ struct ModuleState {
     tags: Vec<usize>,            // pointer into `validator.types`
     submodules: Vec<usize>,      // pointer into `validator.types`
     instances: Vec<usize>,       // pointer into `validator.types`
-    function_references: HashSet<u32>,
+    function_references: BTreeSet<u32>,
 
     // This is populated when we hit the export section
     exports: NameSet,
@@ -266,14 +265,14 @@ impl TypeDef {
 struct ModuleType {
     imports_size: u32,
     exports_size: u32,
-    imports: HashMap<String, EntityType>,
-    exports: HashMap<String, EntityType>,
+    imports: BTreeMap<String, EntityType>,
+    exports: BTreeMap<String, EntityType>,
 }
 
 #[derive(Default)]
 struct InstanceType {
     type_size: u32,
-    exports: HashMap<String, EntityType>,
+    exports: BTreeMap<String, EntityType>,
 }
 
 #[derive(Clone)]
@@ -765,7 +764,7 @@ impl Validator {
         // Clear the list of implicit imports after the import section is
         // finished since later import sections cannot append further to the
         // pseudo-instances defined in this import section.
-        self.cur.state.assert_mut().imports.implicit.drain();
+        self.cur.state.assert_mut().imports.implicit.clear();
         Ok(())
     }
 
@@ -1116,8 +1115,8 @@ impl Validator {
 
     fn check_type_sets_match(
         &self,
-        a: &HashMap<String, EntityType>,
-        b: &HashMap<String, EntityType>,
+        a: &BTreeMap<String, EntityType>,
+        b: &BTreeMap<String, EntityType>,
         desc: &str,
     ) -> Result<()> {
         for (name, b) in b {
@@ -1777,8 +1776,8 @@ impl WasmModuleResources for ValidatorResources {
 }
 
 mod arc {
-    use std::ops::Deref;
-    use std::sync::Arc;
+    use core::ops::Deref;
+    use alloc::sync::Arc;
 
     pub struct MaybeOwned<T> {
         owned: bool,
@@ -1829,8 +1828,8 @@ mod arc {
 /// single-level import of an instance, and that mapping happens here.
 #[derive(Default)]
 struct NameSet {
-    set: HashMap<String, EntityType>,
-    implicit: HashSet<String>,
+    set: BTreeMap<String, EntityType>,
+    implicit: BTreeSet<String>,
     type_size: u32,
 }
 
@@ -2056,7 +2055,7 @@ impl<T> SnapshotList<T> {
     }
 }
 
-impl<T> std::ops::Index<usize> for SnapshotList<T> {
+impl<T> core::ops::Index<usize> for SnapshotList<T> {
     type Output = T;
 
     fn index(&self, index: usize) -> &T {
@@ -2064,7 +2063,7 @@ impl<T> std::ops::Index<usize> for SnapshotList<T> {
     }
 }
 
-impl<T> std::ops::IndexMut<usize> for SnapshotList<T> {
+impl<T> core::ops::IndexMut<usize> for SnapshotList<T> {
     fn index_mut(&mut self, index: usize) -> &mut T {
         self.get_mut(index).unwrap()
     }

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -21,7 +21,13 @@ use crate::{BinaryReaderError, GlobalType, MemoryType, Range, Result, TableType,
 use crate::{DataKind, ElementItem, ElementKind, InitExpr, Instance, Operator};
 use crate::{FuncType, SectionReader, SectionWithLimitedItems};
 use crate::{FunctionBody, Parser, Payload};
-use alloc::{vec::Vec, string::String, format, sync::Arc, collections::{BTreeMap, BTreeSet}};
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    format,
+    string::String,
+    sync::Arc,
+    vec::Vec,
+};
 use core::mem;
 
 /// Test whether the given buffer contains a valid WebAssembly module,
@@ -1776,8 +1782,8 @@ impl WasmModuleResources for ValidatorResources {
 }
 
 mod arc {
-    use core::ops::Deref;
     use alloc::sync::Arc;
+    use core::ops::Deref;
 
     pub struct MaybeOwned<T> {
         owned: bool,


### PR DESCRIPTION
This PR does **_not_** introduce `no_std` support to the `wasmparser` crate.
Instead it just simplifies the process of supporting a `no_std` mirror of the `wasmparser` crate by minimizing the required diff.

This also replaces `Hash{Map,Set}` usage in the `wasmparser` validator with `BTree{Map,Set}` since those are not attackable in `no_std` environments. I saw absolutely no difference in the benchmarks. Using `BTree{Map,Set}` also leads to more deterministic runtime behavior in general.

@alexcrichton Many projects would love to use this high quality and battle tested Wasm parsing and validation crate in a `no_std` environment so I thought about a solution that fits those projects while not putting a burden on the maintainers (you). This PR just minimizes the diff needed to add trivial `no_std` support to `wasmparser` but does not actually introduce `no_std` support. With this PR it will become very easy to maintain a `no_std` fork of `wasmparser ` and keep it in sync. I'd be happy to know how you feel about this idea.

Link to `no_std` `wasmparser` fork: https://crates.io/crates/wasmparser-nostd