### PR TITLE
wasm-mutate: Fix generating duplicate export names

### DIFF
--- a/crates/wasm-mutate/src/mutators/rename_export.rs
+++ b/crates/wasm-mutate/src/mutators/rename_export.rs
@@ -33,7 +33,11 @@ impl RenameExportMutator {
             if bytes.len() > self.max_name_size {
                 continue;
             }
-            return Ok(String::from_utf8(bytes).unwrap());
+            let ret = String::from_utf8(bytes).unwrap();
+            if config.info().export_names.contains(&ret) {
+                continue;
+            }
+            return Ok(ret);
         }
     }
 }

--- a/crates/wasm-mutate/src/mutators/rename_export.rs
+++ b/crates/wasm-mutate/src/mutators/rename_export.rs
@@ -20,6 +20,7 @@ impl RenameExportMutator {
     /// Copied and transformed from wasm-smith name generation
     fn limited_string(&self, config: &mut WasmMutate, original: &str) -> crate::Result<String> {
         loop {
+            config.consume_fuel(1)?;
             let mut bytes = original.as_bytes().to_vec();
             config.raw_mutate(&mut bytes, self.max_name_size)?;
 
@@ -34,7 +35,7 @@ impl RenameExportMutator {
                 continue;
             }
             let ret = String::from_utf8(bytes).unwrap();
-            if config.info().export_names.contains(&ret) {
+            if ret != original && config.info().export_names.contains(&ret) {
                 continue;
             }
             return Ok(ret);


### PR DESCRIPTION
This fixes an issue from #447 where the renaming export pass was
mistakenly generating a duplicate export name because I forgot to add a
check. The check is added here, however!