### PR TITLE
Begin adding support for components to `wast`

### DIFF
--- a/crates/wast/README.md
+++ b/crates/wast/README.md
@@ -29,6 +29,7 @@ types to parse anything that looks like a WebAssembly s-expression.
 
 * Need to parse a `*.wat` file?
 * Need to parse a `*.wast` file?
+* Need to parse a `*.cat` file?
 * Need to run test suite assertions from the official wasm test suite?
 * Want to write an extension do the WebAssembly text format?
 
@@ -38,12 +39,12 @@ interface if all you'd like to do is convert `*.wat` to `*.wasm`.
 
 ## Cargo features
 
-By default this crate enables and exports support necessary to parse `*.wat` and
-`*.wast` files, or in other words entire wasm modules. If you're using this
-crate, however, to parse simply an s-expression wasm-related format (like
-`*.witx` or `*.wit` perhaps) then you can disable the default set of features to
-only include a lexer, the parsing framework, and a few basic token-related
-parsers.
+By default this crate enables and exports support necessary to parse `*.wat`,
+`*.wast`, and `*.cat` files, or in other words entire wasm modules. If you're
+using this crate, however, to parse simply an s-expression wasm-related format
+(like `*.witx` or `*.wit` perhaps) then you can disable the default set of
+features to only include a lexer, the parsing framework, and a few basic
+token-related parsers.
 
 ```toml
 [dependencies]

--- a/crates/wast/src/ast/mod.rs
+++ b/crates/wast/src/ast/mod.rs
@@ -350,6 +350,7 @@ pub mod kw {
     custom_keyword!(catch);
     custom_keyword!(catch_all);
     custom_keyword!(code);
+    custom_keyword!(component);
     custom_keyword!(data);
     custom_keyword!(dataref);
     custom_keyword!(declare);

--- a/crates/wast/src/ast/mod.rs
+++ b/crates/wast/src/ast/mod.rs
@@ -62,7 +62,7 @@ macro_rules! custom_keyword {
         }
 
         impl $crate::parser::Peek for $name {
-            fn peek(cursor: $crate::parser::Cursor<'_>) -> bool {
+            fn peek(cursor: $crate::parser::Cursor<'_>) -> std::primitive::bool {
                 if let Some((kw, _rest)) = cursor.keyword() {
                     kw == $kw
                 } else {
@@ -349,6 +349,7 @@ pub mod kw {
     custom_keyword!(block);
     custom_keyword!(catch);
     custom_keyword!(catch_all);
+    custom_keyword!(char);
     custom_keyword!(code);
     custom_keyword!(component);
     custom_keyword!(data);
@@ -359,6 +360,7 @@ pub mod kw {
     custom_keyword!(elem);
     custom_keyword!(end);
     custom_keyword!(tag);
+    custom_keyword!(expected);
     custom_keyword!(export);
     custom_keyword!(r#extern = "extern");
     custom_keyword!(externref);
@@ -370,6 +372,9 @@ pub mod kw {
     custom_keyword!(f64x2);
     custom_keyword!(field);
     custom_keyword!(first);
+    custom_keyword!(float32);
+    custom_keyword!(float64);
+    custom_keyword!(flags);
     custom_keyword!(func);
     custom_keyword!(funcref);
     custom_keyword!(get);
@@ -390,38 +395,57 @@ pub mod kw {
     custom_keyword!(invoke);
     custom_keyword!(item);
     custom_keyword!(last);
+    custom_keyword!(list);
     custom_keyword!(local);
     custom_keyword!(memory);
     custom_keyword!(module);
     custom_keyword!(modulecode);
+    custom_keyword!(named);
     custom_keyword!(nan_arithmetic = "nan:arithmetic");
     custom_keyword!(nan_canonical = "nan:canonical");
     custom_keyword!(null);
     custom_keyword!(nullref);
     custom_keyword!(offset);
+    custom_keyword!(optional);
     custom_keyword!(outer);
     custom_keyword!(param);
     custom_keyword!(parent);
     custom_keyword!(passive);
     custom_keyword!(quote);
+    custom_keyword!(r#bool = "bool");
+    custom_keyword!(r#enum = "enum");
     custom_keyword!(r#else = "else");
     custom_keyword!(r#if = "if");
     custom_keyword!(r#loop = "loop");
     custom_keyword!(r#mut = "mut");
     custom_keyword!(r#type = "type");
     custom_keyword!(r#ref = "ref");
+    custom_keyword!(record);
     custom_keyword!(ref_func = "ref.func");
     custom_keyword!(ref_null = "ref.null");
     custom_keyword!(register);
     custom_keyword!(result);
     custom_keyword!(rtt);
+    custom_keyword!(s8);
+    custom_keyword!(s16);
+    custom_keyword!(s32);
+    custom_keyword!(s64);
     custom_keyword!(shared);
     custom_keyword!(start);
+    custom_keyword!(string);
     custom_keyword!(r#struct = "struct");
     custom_keyword!(table);
     custom_keyword!(then);
+    custom_keyword!(tuple);
     custom_keyword!(r#try = "try");
+    custom_keyword!(u8);
+    custom_keyword!(u16);
+    custom_keyword!(u32);
+    custom_keyword!(u64);
+    custom_keyword!(union);
     custom_keyword!(v128);
+    custom_keyword!(value);
+    custom_keyword!(variant);
 }
 
 /// Common annotations used to parse WebAssembly text files.

--- a/crates/wast/src/ast/types.rs
+++ b/crates/wast/src/ast/types.rs
@@ -4,7 +4,7 @@ use std::mem;
 
 /// The value types for a wasm module.
 #[allow(missing_docs)]
-#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum ValType<'a> {
     I32,
     I64,
@@ -13,6 +13,7 @@ pub enum ValType<'a> {
     V128,
     Ref(RefType<'a>),
     Rtt(Option<u32>, ast::Index<'a>),
+    InterType(InterType),
 }
 
 impl<'a> Parse<'a> for ValType<'a> {
@@ -45,6 +46,8 @@ impl<'a> Parse<'a> for ValType<'a> {
                     Err(l.error())
                 }
             })
+        } else if l.peek::<InterType>() {
+            Ok(ValType::InterType(parser.parse()?))
         } else {
             Err(l.error())
         }
@@ -63,6 +66,244 @@ impl<'a> Peek for ValType<'a> {
     }
     fn display() -> &'static str {
         "valtype"
+    }
+}
+
+/// An interface-types type.
+#[allow(missing_docs)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub enum InterType {
+    Bool,
+    S8,
+    U8,
+    S16,
+    U16,
+    S32,
+    U32,
+    S64,
+    U64,
+    Float32,
+    Float64,
+    Char,
+    String,
+    Record(Record),
+    Variant(Variant),
+    List(List),
+    Tuple(Tuple),
+    Flags(Flags),
+    Enum(Enum),
+    Union(Union),
+    Optional(Optional),
+    Expected(Expected),
+    Named(Named),
+}
+
+impl<'a> Parse<'a> for InterType {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        let mut l = parser.lookahead1();
+        if l.peek::<kw::r#bool>() {
+            parser.parse::<kw::r#bool>()?;
+            Ok(InterType::Bool)
+        } else if l.peek::<kw::r#bool>() {
+            parser.parse::<kw::r#bool>()?;
+            Ok(InterType::Bool)
+        } else if l.peek::<kw::s8>() {
+            parser.parse::<kw::s8>()?;
+            Ok(InterType::S8)
+        } else if l.peek::<kw::r#u8>() {
+            parser.parse::<kw::r#u8>()?;
+            Ok(InterType::U8)
+        } else if l.peek::<kw::s16>() {
+            parser.parse::<kw::s16>()?;
+            Ok(InterType::S16)
+        } else if l.peek::<kw::r#u16>() {
+            parser.parse::<kw::r#u16>()?;
+            Ok(InterType::U16)
+        } else if l.peek::<kw::s32>() {
+            parser.parse::<kw::s32>()?;
+            Ok(InterType::S32)
+        } else if l.peek::<kw::r#u32>() {
+            parser.parse::<kw::r#u32>()?;
+            Ok(InterType::U32)
+        } else if l.peek::<kw::s64>() {
+            parser.parse::<kw::s64>()?;
+            Ok(InterType::S64)
+        } else if l.peek::<kw::r#u64>() {
+            parser.parse::<kw::r#u64>()?;
+            Ok(InterType::U64)
+        } else if l.peek::<kw::float32>() {
+            parser.parse::<kw::float32>()?;
+            Ok(InterType::Float32)
+        } else if l.peek::<kw::float64>() {
+            parser.parse::<kw::float64>()?;
+            Ok(InterType::Float64)
+        } else if l.peek::<kw::r#char>() {
+            parser.parse::<kw::r#char>()?;
+            Ok(InterType::Char)
+        } else if l.peek::<kw::string>() {
+            parser.parse::<kw::string>()?;
+            Ok(InterType::String)
+        } else if l.peek::<kw::record>() {
+            let record = parser.parse::<Record>()?;
+            Ok(InterType::Record(record))
+        } else if l.peek::<kw::variant>() {
+            let variant = parser.parse::<Variant>()?;
+            Ok(InterType::Variant(variant))
+        } else if l.peek::<kw::tuple>() {
+            let tuple = parser.parse::<Tuple>()?;
+            Ok(InterType::Tuple(tuple))
+        } else if l.peek::<kw::flags>() {
+            let flags = parser.parse::<Flags>()?;
+            Ok(InterType::Flags(flags))
+        } else if l.peek::<kw::r#enum>() {
+            let r#enum = parser.parse::<Enum>()?;
+            Ok(InterType::Enum(r#enum))
+        } else if l.peek::<kw::union>() {
+            let union = parser.parse::<Union>()?;
+            Ok(InterType::Union(union))
+        } else if l.peek::<kw::optional>() {
+            let optional = parser.parse::<Optional>()?;
+            Ok(InterType::Optional(optional))
+        } else if l.peek::<kw::expected>() {
+            let expected = parser.parse::<Expected>()?;
+            Ok(InterType::Expected(expected))
+        } else if l.peek::<kw::named>() {
+            let named = parser.parse::<Named>()?;
+            Ok(InterType::Named(named))
+        } else {
+            Err(l.error())
+        }
+    }
+}
+
+impl Peek for InterType {
+    fn peek(cursor: Cursor<'_>) -> bool {
+        kw::r#bool::peek(cursor) ||
+                  kw::s8::peek(cursor) ||
+                  kw::r#u8::peek(cursor) ||
+                  kw::s16::peek(cursor) ||
+                  kw::r#u16::peek(cursor) ||
+                  kw::s32::peek(cursor) ||
+                  kw::r#u32::peek(cursor) ||
+                  kw::s64::peek(cursor) ||
+                  kw::r#u64::peek(cursor) ||
+                  kw::float32::peek(cursor) ||
+                  kw::float64::peek(cursor) ||
+                  kw::r#char::peek(cursor) ||
+                  kw::string::peek(cursor) ||
+                  kw::record::peek(cursor) ||
+                  kw::variant::peek(cursor) ||
+                  kw::list::peek(cursor) ||
+                  kw::tuple::peek(cursor) ||
+                  kw::flags::peek(cursor) ||
+                  kw::r#enum::peek(cursor) ||
+                  kw::union::peek(cursor) ||
+                  kw::optional::peek(cursor) ||
+                  kw::expected::peek(cursor) ||
+                  kw::named::peek(cursor)
+    }
+    fn display() -> &'static str {
+        "intertype"
+    }
+}
+
+/// An interface-types record, aka a struct.
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct Record { fields: Vec<(String, InterType)>, }
+
+impl<'a> Parse<'a> for Record {
+    fn parse(_parser: Parser<'a>) -> Result<Self> {
+        todo!("Parse for Record")
+    }
+}
+
+/// An interface-types variant, aka a discriminated union with named arms.
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct Variant { arms: Vec<(String, InterType)>, }
+
+impl<'a> Parse<'a> for Variant {
+    fn parse(_parser: Parser<'a>) -> Result<Self> {
+        todo!("Parse for Variant")
+    }
+}
+
+/// An interface-types list, aka a fixed-size array.
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct List { element: Box<InterType> }
+
+impl<'a> Parse<'a> for List {
+    fn parse(_parser: Parser<'a>) -> Result<Self> {
+        todo!("Parse for List")
+    }
+}
+
+/// An interface-types tuple, aka a record with anonymous fields.
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct Tuple { fields: Vec<InterType> }
+
+impl<'a> Parse<'a> for Tuple {
+    fn parse(_parser: Parser<'a>) -> Result<Self> {
+        todo!("Parse for Tuple")
+    }
+}
+
+/// An interface-types flags, aka a fixed-sized bitfield with named fields.
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct Flags { flag_names: Vec<String> }
+
+impl<'a> Parse<'a> for Flags {
+    fn parse(_parser: Parser<'a>) -> Result<Self> {
+        todo!("Parse for Flags")
+    }
+}
+
+/// An interface-types enum, aka a discriminated union with unit arms.
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct Enum { arms: Vec<String> }
+
+impl<'a> Parse<'a> for Enum {
+    fn parse(_parser: Parser<'a>) -> Result<Self> {
+        todo!("Parse for Enum")
+    }
+}
+
+/// An interface-types union, aka a discriminated union with anonymous arms.
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct Union { arms: Vec<InterType> }
+
+impl<'a> Parse<'a> for Union {
+    fn parse(_parser: Parser<'a>) -> Result<Self> {
+        todo!("Parse for Union")
+    }
+}
+
+/// An interface-types optional, aka an option.
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct Optional { element: Box<InterType> }
+
+impl<'a> Parse<'a> for Optional {
+    fn parse(_parser: Parser<'a>) -> Result<Self> {
+        todo!("Parse for Optional")
+    }
+}
+
+/// An interface-types expected, aka an result.
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct Expected { ok: Box<InterType>, err: Box<InterType> }
+
+impl<'a> Parse<'a> for Expected {
+    fn parse(_parser: Parser<'a>) -> Result<Self> {
+        todo!("Parse for Expected")
+    }
+}
+
+/// An interface-types named type, aka a newtype that adds a name.
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub struct Named { name: String, types: Box<InterType> }
+
+impl<'a> Parse<'a> for Named {
+    fn parse(_parser: Parser<'a>) -> Result<Self> {
+        todo!("Parse for Named")
     }
 }
 
@@ -262,7 +503,7 @@ impl<'a> Peek for RefType<'a> {
 
 /// The types of values that may be used in a struct or array.
 #[allow(missing_docs)]
-#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum StorageType<'a> {
     I8,
     I16,
@@ -287,7 +528,7 @@ impl<'a> Parse<'a> for StorageType<'a> {
 }
 
 /// Type for a `global` in a wasm module
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct GlobalType<'a> {
     /// The element type of this `global`
     pub ty: ValType<'a>,

--- a/crates/wast/src/binary.rs
+++ b/crates/wast/src/binary.rs
@@ -351,6 +351,9 @@ impl<'a> Encode for ValType<'a> {
             ValType::Ref(ty) => {
                 ty.encode(e);
             }
+            ValType::InterType(_ity) => {
+                todo!("Encode for InterType")
+            }
         }
     }
 }
@@ -780,7 +783,7 @@ impl Encode for Vec<Local<'_>> {
                     continue;
                 }
             }
-            locals_compressed.push((1, local.ty));
+            locals_compressed.push((1, local.ty.clone()));
         }
         locals_compressed.encode(e);
     }

--- a/crates/wast/src/resolve/deinline_import_export.rs
+++ b/crates/wast/src/resolve/deinline_import_export.rs
@@ -166,7 +166,7 @@ pub fn run(fields: &mut Vec<ModuleField>) {
                                 span: g.span,
                                 id: g.id,
                                 name: None,
-                                kind: ItemKind::Global(g.ty),
+                                kind: ItemKind::Global(g.ty.clone()),
                             },
                         });
                     }

--- a/crates/wast/src/resolve/names.rs
+++ b/crates/wast/src/resolve/names.rs
@@ -114,7 +114,7 @@ impl<'a> Resolver<'a> {
                 // `call_indirect`.
                 match &i.def {
                     TypeDef::Func(f) => {
-                        let params = f.params.iter().map(|p| p.2).collect();
+                        let params = f.params.iter().map(|p| p.2.clone()).collect();
                         let results = f.results.clone();
                         self.type_info.push(TypeInfo::Func { params, results });
                     }

--- a/crates/wast/src/resolve/types.rs
+++ b/crates/wast/src/resolve/types.rs
@@ -295,7 +295,7 @@ impl<'a> TypeReference<'a> for FunctionType<'a> {
     type Key = FuncKey<'a>;
 
     fn key(&self) -> Self::Key {
-        let params = self.params.iter().map(|p| p.2).collect();
+        let params = self.params.iter().map(|p| p.2.clone()).collect();
         let results = self.results.clone();
         (params, results)
     }
@@ -310,7 +310,7 @@ impl<'a> TypeKey<'a> for FuncKey<'a> {
 
     fn to_def(&self, _span: Span) -> TypeDef<'a> {
         TypeDef::Func(FunctionType {
-            params: self.0.iter().map(|t| (None, None, *t)).collect(),
+            params: self.0.iter().map(|t| (None, None, t.clone())).collect(),
             results: self.1.clone(),
         })
     }


### PR DESCRIPTION
This begins adding support for `*.cat` files, which are like `*.wat` files, but hold `(component ...)` s-expressions representing wasm components, following the AST design [here]. This has several `todo` markers left to be done, but has enough code to illustrate the high-level shape of this support: `Module` has an `is_component` field to indicate whether it was parsed from `(component ...)` versus `(module ...)` indicating a core-wasm component.

[here]: https://github.com/WebAssembly/component-model/blob/ast-and-binary/design/MVP/Explainer.md

This makes `ValType` non-`Copy`, as it can now contain interface types which can contain `Vec`s.

This doesn't yet contain any tests; I'll add tests as I implement the `todo`s.