### PR TITLE
wasm-smith: support smithing pre-multi-value wasm

### DIFF
--- a/crates/wasm-smith/src/code_builder.rs
+++ b/crates/wasm-smith/src/code_builder.rs
@@ -806,13 +806,13 @@ impl CodeBuilder<'_> {
             Box::new(|_| Ok(BlockType::Empty)),
             Box::new(|u| Ok(BlockType::Result(module.arbitrary_valtype(u)?))),
         ];
-
-        for (i, ty) in module.func_types() {
-            if self.types_on_stack(&ty.params) {
-                options.push(Box::new(move |_| Ok(BlockType::FunctionType(i as u32))));
+        if module.config.multi_value_enabled() {
+            for (i, ty) in module.func_types() {
+                if self.types_on_stack(&ty.params) {
+                    options.push(Box::new(move |_| Ok(BlockType::FunctionType(i as u32))));
+                }
             }
         }
-
         let f = u.choose(&options)?;
         f(u)
     }

--- a/crates/wasm-smith/src/config.rs
+++ b/crates/wasm-smith/src/config.rs
@@ -237,31 +237,41 @@ pub trait Config: 'static + std::fmt::Debug {
     }
 
     /// Determines whether the bulk memory proposal is enabled for generating
-    /// insructions. Defaults to `false`.
+    /// insructions.
+    ///
+    /// Defaults to `false`.
     fn bulk_memory_enabled(&self) -> bool {
         false
     }
 
     /// Determines whether the reference types proposal is enabled for
-    /// generating insructions. Defaults to `false`.
+    /// generating insructions.
+    ///
+    /// Defaults to `false`.
     fn reference_types_enabled(&self) -> bool {
         false
     }
 
     /// Determines whether the SIMD proposal is enabled for
-    /// generating insructions. Defaults to `false`.
+    /// generating insructions.
+    ///
+    /// Defaults to `false`.
     fn simd_enabled(&self) -> bool {
         false
     }
 
     /// Determines whether the Relaxed SIMD proposal is enabled for
-    /// generating insructions. Defaults to `false`.
+    /// generating insructions.
+    ///
+    /// Defaults to `false`.
     fn relaxed_simd_enabled(&self) -> bool {
         false
     }
 
     /// Determines whether the exception-handling proposal is enabled for
-    /// generating insructions. Defaults to `false`.
+    /// generating insructions.
+    ///
+    /// Defaults to `false`.
     fn exceptions_enabled(&self) -> bool {
         false
     }
@@ -271,6 +281,13 @@ pub trait Config: 'static + std::fmt::Debug {
     /// Defaults to `false`.
     fn module_linking_enabled(&self) -> bool {
         false
+    }
+
+    /// Determines whether the multi-value results are enabled.
+    ///
+    /// Defaults to `true`.
+    fn multi_value_enabled(&self) -> bool {
+        true
     }
 
     /// Determines whether a `start` export may be included. Defaults to `true`.
@@ -398,6 +415,7 @@ pub struct SwarmConfig {
     pub memory_offset_choices: (u32, u32, u32),
     pub memory_max_size_required: bool,
     pub simd_enabled: bool,
+    pub multi_value_enabled: bool,
     pub relaxed_simd_enabled: bool,
     pub exceptions_enabled: bool,
     pub allow_start_export: bool,
@@ -430,6 +448,7 @@ impl<'a> Arbitrary<'a> for SwarmConfig {
             bulk_memory_enabled: reference_types_enabled || u.arbitrary()?,
             reference_types_enabled,
             simd_enabled: u.arbitrary()?,
+            multi_value_enabled: u.arbitrary()?,
             max_aliases: u.int_in_range(0..=MAX_MAXIMUM)?,
             max_nesting_depth: u.int_in_range(0..=10)?,
 
@@ -597,6 +616,10 @@ impl Config for SwarmConfig {
 
     fn exceptions_enabled(&self) -> bool {
         self.exceptions_enabled
+    }
+
+    fn multi_value_enabled(&self) -> bool {
+        self.multi_value_enabled
     }
 
     fn allow_start_export(&self) -> bool {

--- a/crates/wasm-smith/src/lib.rs
+++ b/crates/wasm-smith/src/lib.rs
@@ -585,7 +585,12 @@ impl Module {
             params.push(self.arbitrary_valtype(u)?);
             Ok(true)
         })?;
-        arbitrary_loop(u, 0, 20, |u| {
+        let max_results = if self.config.multi_value_enabled() {
+            20
+        } else {
+            1
+        };
+        arbitrary_loop(u, 0, max_results, |u| {
             results.push(self.arbitrary_valtype(u)?);
             Ok(true)
         })?;

--- a/crates/wasm-smith/tests/tests.rs
+++ b/crates/wasm-smith/tests/tests.rs
@@ -16,7 +16,7 @@ fn wasm_features() -> WasmFeatures {
 #[test]
 fn smoke_test_module() {
     let mut rng = SmallRng::seed_from_u64(0);
-    let mut buf = vec![0; 1024];
+    let mut buf = vec![0; 2048];
     for _ in 0..1024 {
         rng.fill_bytes(&mut buf);
         let u = Unstructured::new(&buf);
@@ -33,7 +33,7 @@ fn smoke_test_module() {
 #[test]
 fn smoke_test_ensure_termination() {
     let mut rng = SmallRng::seed_from_u64(0);
-    let mut buf = vec![0; 1024];
+    let mut buf = vec![0; 2048];
     for _ in 0..1024 {
         rng.fill_bytes(&mut buf);
         let u = Unstructured::new(&buf);
@@ -51,7 +51,7 @@ fn smoke_test_ensure_termination() {
 #[test]
 fn smoke_test_swarm_config() {
     let mut rng = SmallRng::seed_from_u64(0);
-    let mut buf = vec![0; 1024];
+    let mut buf = vec![0; 2048];
     for _ in 0..1024 {
         rng.fill_bytes(&mut buf);
         let u = Unstructured::new(&buf);
@@ -62,6 +62,27 @@ fn smoke_test_swarm_config() {
             let mut validator = Validator::new();
             let mut features = wasm_features();
             features.module_linking = module.config().module_linking_enabled();
+            validator.wasm_features(features);
+            validate(&mut validator, &wasm_bytes);
+        }
+    }
+}
+
+#[test]
+fn multi_value_disabled() {
+    let mut rng = SmallRng::seed_from_u64(42);
+    let mut buf = vec![0; 2048];
+    for i in 0..10 {
+        rng.fill_bytes(&mut buf);
+        let mut u = Unstructured::new(&buf);
+        let mut cfg = SwarmConfig::arbitrary(&mut u).unwrap();
+        cfg.multi_value_enabled = false;
+        if let Ok(module) = Module::new(cfg, &mut u) {
+            let wasm_bytes = module.to_bytes();
+            let mut validator = Validator::new();
+            let mut features = wasm_features();
+            features.module_linking = module.config().module_linking_enabled();
+            features.multi_value = false;
             validator.wasm_features(features);
             validate(&mut validator, &wasm_bytes);
         }

--- a/fuzz/fuzz_targets/validate-valid-module.rs
+++ b/fuzz/fuzz_targets/validate-valid-module.rs
@@ -14,7 +14,7 @@ fuzz_target!(|m: &[u8]| {
     // validation.
     let mut validator = wasmparser::Validator::new();
     validator.wasm_features(wasmparser::WasmFeatures {
-        multi_value: true,
+        multi_value: config.multi_value_enabled,
         multi_memory: config.max_memories > 1,
         bulk_memory: true,
         reference_types: true,


### PR DESCRIPTION
Some of the VMs and embedders target WASM before the multi-value
specification has been merged. This enables them to fuzz and test more
precisely, without necessarily wasting time exploring branches where
multi-value WASM turns up.

Fixes #463