### PR TITLE
wasmparser: no functype blocks without multi-value

### DIFF
--- a/crates/wasmparser/src/operators_validator.rs
+++ b/crates/wasmparser/src/operators_validator.rs
@@ -484,24 +484,14 @@ impl OperatorValidator {
                 self.check_reference_types_enabled()
             }
             TypeOrFuncType::Type(Type::V128) => self.check_simd_enabled(),
-            TypeOrFuncType::FuncType(idx) => {
-                let ty = func_type_at(&resources, idx)?;
-                if !self.features.multi_value {
-                    if ty.len_outputs() > 1 {
-                        return Err(OperatorValidatorError::new(
-                            "blocks, loops, and ifs may only return at most one \
-                             value when multi-value is not enabled",
-                        ));
-                    }
-                    if ty.len_inputs() > 0 {
-                        return Err(OperatorValidatorError::new(
-                            "blocks, loops, and ifs accept no parameters \
-                             when multi-value is not enabled",
-                        ));
-                    }
-                }
-                Ok(())
+            TypeOrFuncType::FuncType(_) if !self.features.multi_value => {
+                return Err(OperatorValidatorError::new(
+                    "blocks, loops, and ifs may only produce a resulttype when multi-value is not \
+                    enabled",
+                ));
             }
+
+            TypeOrFuncType::FuncType(idx) => func_type_at(&resources, idx).map(|_| ()),
             _ => Err(OperatorValidatorError::new("invalid block return type")),
         }
     }

--- a/tests/local/missing-features/multi-value-function-block-type.wast
+++ b/tests/local/missing-features/multi-value-function-block-type.wast
@@ -1,0 +1,20 @@
+(assert_invalid
+  (module binary
+    "\00\61\73\6d"
+    "\01\00\00\00"
+    "\01\05"
+    "\01"
+    "\60\00\01\7f"
+    "\03\02"
+    "\01"
+    "\00"
+    "\0a\09"
+    "\01"
+    "\07"
+    "\00"
+    "\02\00"
+    "\41\00"
+    "\0b"
+    "\0b"
+  )
+  "blocks, loops, and ifs may only produce a resulttype when multi-value is not enabled")

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -566,6 +566,7 @@ impl TestState {
                     features = WasmFeatures::default();
                     features.simd = false;
                     features.reference_types = false;
+                    features.multi_value = false;
                 }
                 "threads" => {
                     features.threads = true;


### PR DESCRIPTION
Block types have been generalzed from `resulttype := valtype?` to
`functype` with the integration of the multi-value proposal. Before then
producing a wasm with functype-typed blocks would constitute a malformed
WASM.

This adjusts wasmparser to reject blocks with functype results unless
multi-value is enabled. This also results in somewhat worse error
message, however.