### PR TITLE
wasm-mutate: avoid mutating empty code sections

### DIFF
--- a/crates/wasm-mutate/src/info.rs
+++ b/crates/wasm-mutate/src/info.rs
@@ -230,6 +230,17 @@ impl<'a> ModuleInfo<'a> {
         Ok(info)
     }
 
+    pub fn has_nonempty_code(&self) -> bool {
+        if let Some(section) = self.code {
+            let section_data = self.raw_sections[section].data;
+            wasmparser::CodeSectionReader::new(section_data, 0)
+                .map(|r| r.get_count() != 0)
+                .unwrap_or(false)
+        } else {
+            false
+        }
+    }
+
     pub fn has_code(&self) -> bool {
         self.code != None
     }

--- a/crates/wasm-mutate/src/mutators/function_body_unreachable.rs
+++ b/crates/wasm-mutate/src/mutators/function_body_unreachable.rs
@@ -51,13 +51,14 @@ impl Mutator for FunctionBodyUnreachable {
     }
 
     fn can_mutate<'a>(&self, config: &'a WasmMutate) -> bool {
-        !config.preserve_semantics && config.info().has_code()
+        !config.preserve_semantics && config.info().has_nonempty_code()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::FunctionBodyUnreachable;
+    use crate::mutators::Mutator;
 
     #[test]
     fn test_code_unreachable_mutator() {
@@ -84,5 +85,13 @@ mod tests {
                   i64.const 42)  (func (;2;) (type 1) (result i32)    unreachable)
                 (export "exported_func" (func 2)))"#,
         );
+    }
+
+    #[test]
+    fn test_fn_body_unreachable_empty_code_section() {
+        let wasm = b"\x00\x61\x73\x6d\x01\x00\x00\x00\x0a\x02\x00\x0b";
+        let mut config = crate::WasmMutate::default();
+        config.setup(wasm).unwrap();
+        assert_eq!(FunctionBodyUnreachable.can_mutate(&config), false);
     }
 }

--- a/crates/wasm-mutate/src/mutators/snip_function.rs
+++ b/crates/wasm-mutate/src/mutators/snip_function.rs
@@ -87,13 +87,14 @@ impl Mutator for SnipMutator {
     }
 
     fn can_mutate<'a>(&self, config: &'a WasmMutate) -> bool {
-        !config.preserve_semantics && config.info().has_code()
+        !config.preserve_semantics && config.info().has_nonempty_code()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::SnipMutator;
+    use crate::mutators::Mutator;
 
     #[test]
     fn test_code_snip_mutator() {
@@ -114,5 +115,13 @@ mod tests {
         )
         "#,
         );
+    }
+
+    #[test]
+    fn test_snip_function_empty_code_section() {
+        let wasm = b"\x00\x61\x73\x6d\x01\x00\x00\x00\x0a\x02\x00\x0b";
+        let mut config = crate::WasmMutate::default();
+        config.setup(wasm).unwrap();
+        assert_eq!(SnipMutator.can_mutate(&config), false);
     }
 }


### PR DESCRIPTION
The `Rng::gen_range`, which both `SnipMutator` and
`FunctionBodyUnreachable` mutators utilize to pick a function to mutate,
has a panicking failure mode when the range provided to it is empty.

This failure mode may be triggered if the mutation ends up removing all
of the functions, thus leaving an empty code section.

One could argue that removing the section as it becomes empty would be a
cleaner fix for this particular problem. Being able to verify operation
of the predicate when fed modules with empty sections is an important
feature that should be preserved.