### PR TITLE
wasm-mutate: simplify initializer const expressions

### DIFF
--- a/crates/wasm-mutate/src/info.rs
+++ b/crates/wasm-mutate/src/info.rs
@@ -387,6 +387,10 @@ impl<'a> ModuleInfo<'a> {
         self.imported_globals_count
     }
 
+    pub fn num_local_globals(&self) -> u32 {
+        self.global_types.len() as u32 - self.imported_globals_count
+    }
+
     pub fn num_tags(&self) -> u32 {
         self.tag_count
     }

--- a/crates/wasm-mutate/src/lib.rs
+++ b/crates/wasm-mutate/src/lib.rs
@@ -371,5 +371,5 @@ pub(crate) fn validate(validator: &mut wasmparser::Validator, bytes: &[u8]) {
         drop(std::fs::write("test.wat", &text));
     }
 
-    panic!("wasm failed to validate: {}", err);
+    panic!("wasm failed to validate: {} (written to test.wasm)", err);
 }

--- a/crates/wasm-mutate/src/lib.rs
+++ b/crates/wasm-mutate/src/lib.rs
@@ -19,9 +19,9 @@ pub use error::*;
 use crate::mutators::{
     add_function::AddFunctionMutator, add_type::AddTypeMutator, codemotion::CodemotionMutator,
     custom::RemoveCustomSection, function_body_unreachable::FunctionBodyUnreachable,
-    modify_data::ModifyDataMutator, peephole::PeepholeMutator, remove_export::RemoveExportMutator,
-    remove_item::RemoveItemMutator, rename_export::RenameExportMutator, snip_function::SnipMutator,
-    Item,
+    modify_data::ModifyDataMutator, modify_init_exprs::InitExpressionMutator,
+    peephole::PeepholeMutator, remove_export::RemoveExportMutator, remove_item::RemoveItemMutator,
+    rename_export::RenameExportMutator, snip_function::SnipMutator, Item,
 };
 use info::ModuleInfo;
 use mutators::Mutator;
@@ -285,6 +285,9 @@ impl<'wasm> WasmMutate<'wasm> {
                 },
                 AddFunctionMutator,
                 RemoveCustomSection,
+                InitExpressionMutator::Global,
+                InitExpressionMutator::ElementOffset,
+                InitExpressionMutator::ElementFunc,
                 RemoveItemMutator(Item::Function),
                 RemoveItemMutator(Item::Global),
                 RemoveItemMutator(Item::Memory),

--- a/crates/wasm-mutate/src/mutators.rs
+++ b/crates/wasm-mutate/src/mutators.rs
@@ -26,6 +26,7 @@ pub mod codemotion;
 pub mod custom;
 pub mod function_body_unreachable;
 pub mod modify_data;
+pub mod modify_init_exprs;
 pub mod peephole;
 pub mod remove_export;
 pub mod remove_item;

--- a/crates/wasm-mutate/src/mutators/modify_data.rs
+++ b/crates/wasm-mutate/src/mutators/modify_data.rs
@@ -1,4 +1,4 @@
-use super::translate::InitExprContext;
+use super::translate::InitExprKind;
 use super::Mutator;
 use crate::{Result, WasmMutate};
 
@@ -38,7 +38,7 @@ impl Mutator for ModifyDataMutator {
                     offset = DefaultTranslator.translate_init_expr(
                         init_expr,
                         &wasmparser::Type::I32,
-                        InitExprContext::DataOffset,
+                        InitExprKind::DataOffset,
                     )?;
                     DataSegmentMode::Active {
                         memory_index: *memory_index,

--- a/crates/wasm-mutate/src/mutators/modify_data.rs
+++ b/crates/wasm-mutate/src/mutators/modify_data.rs
@@ -1,3 +1,4 @@
+use super::translate::InitExprContext;
 use super::Mutator;
 use crate::{Result, WasmMutate};
 
@@ -34,7 +35,11 @@ impl Mutator for ModifyDataMutator {
                     memory_index,
                     init_expr,
                 } => {
-                    offset = DefaultTranslator.translate_init_expr(init_expr)?;
+                    offset = DefaultTranslator.translate_init_expr(
+                        init_expr,
+                        &wasmparser::Type::I32,
+                        InitExprContext::DataOffset,
+                    )?;
                     DataSegmentMode::Active {
                         memory_index: *memory_index,
                         offset: &offset,

--- a/crates/wasm-mutate/src/mutators/modify_init_exprs.rs
+++ b/crates/wasm-mutate/src/mutators/modify_init_exprs.rs
@@ -1,0 +1,190 @@
+//! This mutator modifies the constant initializer expressions between various valid forms in
+//! entities which require constant initializers.
+
+use crate::mutators::translate::{self, InitExprContext, Item, Translator};
+use crate::{Error, Mutator, Result};
+
+use rand::Rng;
+use wasm_encoder::{ElementSection, GlobalSection, Instruction};
+use wasmparser::{ElementSectionReader, GlobalSectionReader, InitExpr, Operator, Type};
+
+#[derive(Copy, Clone)]
+pub enum InitExpressionMutator {
+    Global,
+    ElementOffset,
+    ElementFunc,
+}
+
+struct InitTranslator {
+    new_value: u128,
+    skip_inits: u32,
+    context: InitExprContext,
+}
+
+impl Translator for InitTranslator {
+    fn as_obj(&mut self) -> &mut dyn Translator {
+        self
+    }
+
+    fn remap(&mut self, item: Item, idx: u32) -> Result<u32> {
+        match (self.context, item) {
+            // Element's function items can either be presented to `Translator` via `remap` here or
+            // via expressions (the function below). The API here is insufficiently flexible to
+            // produce null funcrefs so at least lets try pointing at the lowest numbered function
+            // instead.
+            //
+            // TODO: may make sense to actually generate the functions pointed at more randomly.
+            (InitExprContext::ElementFunction, Item::Function) => {
+                if self.skip_inits != 0 {
+                    self.skip_inits -= 1;
+                    Ok(idx)
+                } else {
+                    log::trace!("... replacing referenced function index with 0");
+                    self.skip_inits = u32::MAX;
+                    Ok(0)
+                }
+            }
+            _ => Ok(idx),
+        }
+    }
+
+    fn translate_init_expr(
+        &mut self,
+        e: &InitExpr<'_>,
+        ty: &Type,
+        ctx: InitExprContext,
+    ) -> Result<Instruction<'static>> {
+        use {Instruction as I, Type as T};
+        if ctx != self.context {
+            return translate::init_expr(self.as_obj(), e);
+        } else if self.skip_inits != 0 {
+            self.skip_inits -= 1;
+            return translate::init_expr(self.as_obj(), e);
+        }
+        let mut reader = e.get_operators_reader();
+        let op = reader.read()?;
+        // Don't mutate further if the expressions are already their most reduced form.
+        let simplest = match op {
+            Operator::RefNull { .. }
+            | Operator::I32Const { value: 0 | 1 }
+            | Operator::I64Const { value: 0 | 1 } => true,
+            Operator::F32Const { value } => value.bits() == 0,
+            Operator::F64Const { value } => value.bits() == 0,
+            Operator::V128Const { value } => value.i128() == 0,
+            _ => false,
+        };
+        if simplest {
+            return Err(Error::no_mutations_applicable());
+        }
+        let new_op = match ty {
+            T::I32 => I::I32Const(self.new_value as u32 as _),
+            T::I64 => I::I64Const(self.new_value as u64 as _),
+            T::F32 => I::F32Const(f32::from_bits(self.new_value as u32)),
+            T::F64 => I::F64Const(f64::from_bits(self.new_value as u64)),
+            T::V128 => I::V128Const(self.new_value as i128),
+            T::FuncRef => I::RefNull(wasm_encoder::ValType::FuncRef),
+            T::ExternRef => I::RefNull(wasm_encoder::ValType::ExternRef),
+            T::ExnRef | T::Func | T::EmptyBlockType => return Err(Error::no_mutations_applicable()),
+        };
+        log::trace!("... replacing original expression with {:?}", new_op);
+        // We applied a change. Don't apply any more during this translation/mutation.
+        self.skip_inits = u32::MAX;
+        Ok(new_op)
+    }
+}
+
+impl Mutator for InitExpressionMutator {
+    fn mutate<'a>(
+        self,
+        config: &'a mut crate::WasmMutate,
+    ) -> crate::Result<Box<dyn Iterator<Item = crate::Result<wasm_encoder::Module>> + 'a>> {
+        let mut translator = InitTranslator {
+            new_value: 0,
+            skip_inits: 0,
+            context: match self {
+                Self::Global => InitExprContext::Global,
+                Self::ElementOffset => InitExprContext::ElementOffset,
+                Self::ElementFunc => InitExprContext::ElementFunction,
+            },
+        };
+        match self {
+            Self::Global => {
+                let num_total = config.info().num_local_globals();
+                translator.new_value = match config.rng().gen::<u8>() {
+                    0..=99 => 0,
+                    100..=199 => 1,
+                    200.. => config.rng().gen::<u128>(),
+                };
+                let mutate_idx = config.rng().gen_range(0..num_total);
+                let info = config.info();
+                let section = info.globals.ok_or(Error::no_mutations_applicable())?;
+                let mut new_section = GlobalSection::new();
+                let mut reader = GlobalSectionReader::new(info.raw_sections[section].data, 0)?;
+                for idx in 0..reader.get_count() {
+                    config.consume_fuel(1)?;
+                    let start = reader.original_position();
+                    let global = reader.read()?;
+                    let end = reader.original_position();
+                    if idx == mutate_idx {
+                        log::trace!("Modifying global at index {}...", idx);
+                        translator.translate_global(global, &mut new_section)?;
+                    } else {
+                        new_section.raw(&info.raw_sections[section].data[start..end]);
+                    }
+                }
+                Ok(Box::new(std::iter::once(Ok(
+                    info.replace_section(section, &new_section)
+                ))))
+            }
+            Self::ElementOffset | Self::ElementFunc => {
+                let num_total = config.info().num_elements();
+                let mutate_idx = config.rng().gen_range(0..num_total);
+                let section = config
+                    .info()
+                    .elements
+                    .ok_or(Error::no_mutations_applicable())?;
+                let mut new_section = ElementSection::new();
+                let mut reader =
+                    ElementSectionReader::new(config.info().raw_sections[section].data, 0)?;
+                for idx in 0..reader.get_count() {
+                    config.consume_fuel(1)?;
+                    let start = reader.original_position();
+                    let element = reader.read()?;
+                    let end = reader.original_position();
+                    if idx == mutate_idx {
+                        if let Self::ElementFunc = self {
+                            // Pick a specific element item to mutate. We do this through an option
+                            // to skip a specific number of activations of the Translator methods.
+                            let item_count = element.items.get_items_reader()?.get_count();
+                            if item_count > 0 {
+                                translator.skip_inits = config.rng().gen_range(0..item_count);
+                            } else {
+                                return Err(Error::no_mutations_applicable());
+                            }
+                        }
+                        log::trace!(
+                            "Modifying {} element's {:?}({})...",
+                            idx,
+                            translator.context,
+                            translator.skip_inits
+                        );
+                        translator.translate_element(element, &mut new_section)?;
+                    } else {
+                        new_section.raw(&config.info().raw_sections[section].data[start..end]);
+                    }
+                }
+                Ok(Box::new(std::iter::once(Ok(config
+                    .info()
+                    .replace_section(section, &new_section)))))
+            }
+        }
+    }
+
+    fn can_mutate(&self, config: &crate::WasmMutate) -> bool {
+        !config.preserve_semantics
+            && match self {
+                Self::Global => config.info().num_local_globals() > 0,
+                Self::ElementOffset | Self::ElementFunc => config.info().num_elements() > 0,
+            }
+    }
+}

--- a/crates/wasm-mutate/src/mutators/modify_init_exprs.rs
+++ b/crates/wasm-mutate/src/mutators/modify_init_exprs.rs
@@ -1,7 +1,7 @@
 //! This mutator modifies the constant initializer expressions between various valid forms in
 //! entities which require constant initializers.
 
-use crate::mutators::translate::{self, InitExprContext, Item, Translator};
+use crate::mutators::translate::{self, InitExprKind, Item, Translator};
 use crate::{Error, Mutator, Result};
 
 use rand::Rng;
@@ -15,80 +15,134 @@ pub enum InitExpressionMutator {
     ElementFunc,
 }
 
-struct InitTranslator {
-    new_value: u128,
+struct InitTranslator<'cfg, 'wasm> {
+    config: &'cfg mut crate::WasmMutate<'wasm>,
     skip_inits: u32,
-    context: InitExprContext,
+    kind: InitExprKind,
 }
 
-impl Translator for InitTranslator {
+impl<'cfg, 'wasm> InitTranslator<'cfg, 'wasm> {
+    /// Reduces the expression skip counter by 1 and indicates whether the current expression
+    /// should be processed.
+    ///
+    /// If current expression ought to be modified, this function will return `true`.
+    fn should_process(&mut self) -> bool {
+        // NB: by wrapping the counter here we ensure that we usually apply just one transformation
+        // during a walk of a WASM module, because we'd need to skip u32::MAX initializers once we
+        // apply the first transformation.
+        let (new_counter, was_zero) = self.skip_inits.overflowing_sub(1);
+        self.skip_inits = new_counter;
+        was_zero
+    }
+}
+
+impl<'cfg, 'wasm> Translator for InitTranslator<'cfg, 'wasm> {
     fn as_obj(&mut self) -> &mut dyn Translator {
         self
     }
 
+    /// Handle `elem`s with values of the `ElementItem::Func` kind. This function will not be
+    /// called for values of the `ElementItem::Expr` kind.
     fn remap(&mut self, item: Item, idx: u32) -> Result<u32> {
-        match (self.context, item) {
-            // Element's function items can either be presented to `Translator` via `remap` here or
-            // via expressions (the function below). The API here is insufficiently flexible to
-            // produce null funcrefs so at least lets try pointing at the lowest numbered function
-            // instead.
-            //
-            // TODO: may make sense to actually generate the functions pointed at more randomly.
-            (InitExprContext::ElementFunction, Item::Function) => {
-                if self.skip_inits != 0 {
-                    self.skip_inits -= 1;
-                    Ok(idx)
-                } else {
-                    log::trace!("... replacing referenced function index with 0");
-                    self.skip_inits = u32::MAX;
-                    Ok(0)
-                }
+        Ok(match (self.kind, item) {
+            (InitExprKind::ElementFunction, Item::Function) if self.should_process() => {
+                log::trace!("... replacing referenced function index with 0");
+                // FIXME: generate random function indices when `!config.reduce`.
+                0
             }
-            _ => Ok(idx),
-        }
+            _ => idx,
+        })
     }
 
+    /// Handle `global` initalizers and `elem`s with values of the `ElementItem::Expr` kind.
+    ///
+    /// This function will not be called for `elem` values of the `ElementItem::Func` kind.
     fn translate_init_expr(
         &mut self,
         e: &InitExpr<'_>,
         ty: &Type,
-        ctx: InitExprContext,
+        kind: InitExprKind,
     ) -> Result<Instruction<'static>> {
-        use {Instruction as I, Type as T};
-        if ctx != self.context {
-            return translate::init_expr(self.as_obj(), e);
-        } else if self.skip_inits != 0 {
-            self.skip_inits -= 1;
+        use {Instruction as I, Operator as O, Type as T};
+        if kind != self.kind || !self.should_process() {
             return translate::init_expr(self.as_obj(), e);
         }
         let mut reader = e.get_operators_reader();
         let op = reader.read()?;
         // Don't mutate further if the expressions are already their most reduced form.
-        let simplest = match op {
-            Operator::RefNull { .. }
-            | Operator::I32Const { value: 0 | 1 }
-            | Operator::I64Const { value: 0 | 1 } => true,
-            Operator::F32Const { value } => value.bits() == 0,
-            Operator::F64Const { value } => value.bits() == 0,
-            Operator::V128Const { value } => value.i128() == 0,
+        let is_simplest = match op {
+            O::RefNull { .. } | O::I32Const { value: 0 | 1 } | O::I64Const { value: 0 | 1 } => true,
+            O::F32Const { value } => value.bits() == 0,
+            O::F64Const { value } => value.bits() == 0,
+            O::V128Const { value } => value.i128() == 0,
             _ => false,
         };
-        if simplest {
+        if self.config.reduce && is_simplest {
             return Err(Error::no_mutations_applicable());
         }
-        let new_op = match ty {
-            T::I32 => I::I32Const(self.new_value as u32 as _),
-            T::I64 => I::I64Const(self.new_value as u64 as _),
-            T::F32 => I::F32Const(f32::from_bits(self.new_value as u32)),
-            T::F64 => I::F64Const(f64::from_bits(self.new_value as u64)),
-            T::V128 => I::V128Const(self.new_value as i128),
-            T::FuncRef => I::RefNull(wasm_encoder::ValType::FuncRef),
-            T::ExternRef => I::RefNull(wasm_encoder::ValType::ExternRef),
-            T::ExnRef | T::Func | T::EmptyBlockType => return Err(Error::no_mutations_applicable()),
+
+        let new_op = if self.config.reduce {
+            // For globals give a 25% chance to produce a const with 0 value (arguably the simplest
+            // representation) to give a chance to quickly discover this final reduction if it is
+            // in fact applicable.
+            //
+            // For element offsets always generate `i32.const 0` (effectively removing the offset)
+            // as other values may not necessarily be valid (e.g. maximum table size is limited)
+            let is_element_offset = matches!(kind, InitExprKind::ElementOffset);
+            let should_zero = is_element_offset || self.config.rng().gen::<u8>() & 0b11 == 0;
+            match ty {
+                T::I32 if should_zero => I::I32Const(0),
+                T::I64 if should_zero => I::I64Const(0),
+                T::V128 if should_zero => I::V128Const(0),
+                T::F32 if should_zero => I::F32Const(0.0),
+                T::F64 if should_zero => I::F64Const(0.0),
+                T::I32 => {
+                    if let O::I32Const { value } = op {
+                        I::I32Const(self.config.rng().gen_range(0..value))
+                    } else {
+                        I::I32Const(self.config.rng().gen())
+                    }
+                }
+                T::I64 => {
+                    if let O::I64Const { value } = op {
+                        I::I64Const(self.config.rng().gen_range(0..value))
+                    } else {
+                        I::I64Const(self.config.rng().gen())
+                    }
+                }
+                T::V128 => {
+                    if let O::V128Const { value } = op {
+                        I::V128Const(self.config.rng().gen_range(0..value.i128() as u128) as i128)
+                    } else {
+                        I::V128Const(self.config.rng().gen())
+                    }
+                }
+                T::F32 => {
+                    if let O::F32Const { value } = op {
+                        I::F32Const(f32::from_bits(value.bits()) / 2.0)
+                    } else {
+                        I::F32Const(f32::from_bits(self.config.rng().gen()))
+                    }
+                }
+                T::F64 => {
+                    if let O::F64Const { value } = op {
+                        I::F64Const(f64::from_bits(value.bits()) / 2.0)
+                    } else {
+                        I::F64Const(f64::from_bits(self.config.rng().gen()))
+                    }
+                }
+                T::FuncRef => I::RefNull(wasm_encoder::ValType::FuncRef),
+                T::ExternRef => I::RefNull(wasm_encoder::ValType::ExternRef),
+                T::ExnRef | T::Func | T::EmptyBlockType => {
+                    return Err(Error::no_mutations_applicable())
+                }
+            }
+        } else {
+            // FIXME: implement non-reducing mutations for constant expressions.
+            return Err(Error::no_mutations_applicable());
         };
+
         log::trace!("... replacing original expression with {:?}", new_op);
-        // We applied a change. Don't apply any more during this translation/mutation.
-        self.skip_inits = u32::MAX;
         Ok(new_op)
     }
 }
@@ -98,30 +152,27 @@ impl Mutator for InitExpressionMutator {
         self,
         config: &'a mut crate::WasmMutate,
     ) -> crate::Result<Box<dyn Iterator<Item = crate::Result<wasm_encoder::Module>> + 'a>> {
-        let mut translator = InitTranslator {
-            new_value: 0,
-            skip_inits: 0,
-            context: match self {
-                Self::Global => InitExprContext::Global,
-                Self::ElementOffset => InitExprContext::ElementOffset,
-                Self::ElementFunc => InitExprContext::ElementFunction,
-            },
+        let translator_kind = match self {
+            Self::Global => InitExprKind::Global,
+            Self::ElementOffset => InitExprKind::ElementOffset,
+            Self::ElementFunc => InitExprKind::ElementFunction,
         };
+        let skip_err = Error::no_mutations_applicable();
         match self {
             Self::Global => {
                 let num_total = config.info().num_local_globals();
-                translator.new_value = match config.rng().gen::<u8>() {
-                    0..=99 => 0,
-                    100..=199 => 1,
-                    200.. => config.rng().gen::<u128>(),
-                };
                 let mutate_idx = config.rng().gen_range(0..num_total);
-                let info = config.info();
-                let section = info.globals.ok_or(Error::no_mutations_applicable())?;
+                let section = config.info().globals.ok_or(skip_err)?;
                 let mut new_section = GlobalSection::new();
-                let mut reader = GlobalSectionReader::new(info.raw_sections[section].data, 0)?;
+                let mut reader =
+                    GlobalSectionReader::new(config.info().raw_sections[section].data, 0)?;
+                let mut translator = InitTranslator {
+                    config,
+                    skip_inits: 0,
+                    kind: translator_kind,
+                };
                 for idx in 0..reader.get_count() {
-                    config.consume_fuel(1)?;
+                    translator.config.consume_fuel(1)?;
                     let start = reader.original_position();
                     let global = reader.read()?;
                     let end = reader.original_position();
@@ -129,25 +180,27 @@ impl Mutator for InitExpressionMutator {
                         log::trace!("Modifying global at index {}...", idx);
                         translator.translate_global(global, &mut new_section)?;
                     } else {
-                        new_section.raw(&info.raw_sections[section].data[start..end]);
+                        let old_section = &translator.config.info().raw_sections[section];
+                        new_section.raw(&old_section.data[start..end]);
                     }
                 }
-                Ok(Box::new(std::iter::once(Ok(
-                    info.replace_section(section, &new_section)
-                ))))
+                let new_module = config.info().replace_section(section, &new_section);
+                Ok(Box::new(std::iter::once(Ok(new_module))))
             }
             Self::ElementOffset | Self::ElementFunc => {
                 let num_total = config.info().num_elements();
                 let mutate_idx = config.rng().gen_range(0..num_total);
-                let section = config
-                    .info()
-                    .elements
-                    .ok_or(Error::no_mutations_applicable())?;
+                let section = config.info().elements.ok_or(skip_err)?;
                 let mut new_section = ElementSection::new();
                 let mut reader =
                     ElementSectionReader::new(config.info().raw_sections[section].data, 0)?;
+                let mut translator = InitTranslator {
+                    config,
+                    skip_inits: 0,
+                    kind: translator_kind,
+                };
                 for idx in 0..reader.get_count() {
-                    config.consume_fuel(1)?;
+                    translator.config.consume_fuel(1)?;
                     let start = reader.original_position();
                     let element = reader.read()?;
                     let end = reader.original_position();
@@ -157,7 +210,8 @@ impl Mutator for InitExpressionMutator {
                             // to skip a specific number of activations of the Translator methods.
                             let item_count = element.items.get_items_reader()?.get_count();
                             if item_count > 0 {
-                                translator.skip_inits = config.rng().gen_range(0..item_count);
+                                let skip = translator.config.rng().gen_range(0..item_count);
+                                translator.skip_inits = skip
                             } else {
                                 return Err(Error::no_mutations_applicable());
                             }
@@ -165,26 +219,116 @@ impl Mutator for InitExpressionMutator {
                         log::trace!(
                             "Modifying {} element's {:?}({})...",
                             idx,
-                            translator.context,
+                            translator_kind,
                             translator.skip_inits
                         );
                         translator.translate_element(element, &mut new_section)?;
                     } else {
-                        new_section.raw(&config.info().raw_sections[section].data[start..end]);
+                        let old_section = &translator.config.info().raw_sections[section];
+                        new_section.raw(&old_section.data[start..end]);
                     }
                 }
-                Ok(Box::new(std::iter::once(Ok(config
-                    .info()
-                    .replace_section(section, &new_section)))))
+                let new_module = config.info().replace_section(section, &new_section);
+                Ok(Box::new(std::iter::once(Ok(new_module))))
             }
         }
     }
 
     fn can_mutate(&self, config: &crate::WasmMutate) -> bool {
-        !config.preserve_semantics
-            && match self {
-                Self::Global => config.info().num_local_globals() > 0,
-                Self::ElementOffset | Self::ElementFunc => config.info().num_elements() > 0,
-            }
+        // the implementation here can only reduce for now,
+        // but could be extended to mutate arbitrarily.
+        if !config.reduce {
+            return false;
+        }
+
+        let any_data = match self {
+            Self::Global => config.info().num_local_globals() > 0,
+            Self::ElementOffset | Self::ElementFunc => config.info().num_elements() > 0,
+        };
+        !config.preserve_semantics && any_data
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    fn match_reduction<T>(original: &str, mutator: T, expected: &str)
+    where
+        T: crate::Mutator + Clone,
+    {
+        let mut config = crate::WasmMutate::default();
+        config.reduce = true;
+        config.match_mutation(original, mutator, expected)
+    }
+
+    #[test]
+    fn reduce_global_const_i32() {
+        match_reduction(
+            "(module (global i32 (i32.const 42)))",
+            super::InitExpressionMutator::Global,
+            "(module (global i32 (i32.const 0)))",
+        );
+        match_reduction(
+            "(module (global i32 (i32.const 10)))",
+            super::InitExpressionMutator::Global,
+            "(module (global i32 (i32.const 5)))",
+        );
+    }
+
+    #[test]
+    fn reduce_global_xref() {
+        match_reduction(
+            r#"(module (import "m" "g" (global i32)) (global i32 (global.get 0)))"#,
+            super::InitExpressionMutator::Global,
+            r#"(module (import "m" "g" (global i32)) (global i32 (i32.const 0)))"#,
+        );
+    }
+
+    #[test]
+    fn reduce_global_const_f32() {
+        match_reduction(
+            r#"(module (global f32 (f32.const 2.0)))"#,
+            super::InitExpressionMutator::Global,
+            r#"(module (global f32 (f32.const 1.0)))"#,
+        );
+        match_reduction(
+            r#"(module (global f32 (f32.const 2.0)))"#,
+            super::InitExpressionMutator::Global,
+            r#"(module (global f32 (f32.const 0.0)))"#,
+        );
+    }
+
+    #[test]
+    fn reduce_elem_funcref() {
+        match_reduction(
+            r#"(module (table 0 funcref) (elem $a $b) (func $a) (func $b))"#,
+            super::InitExpressionMutator::ElementFunc,
+            r#"(module (table 0 funcref) (elem $a $a) (func $a) (func $b))"#,
+        );
+    }
+
+    #[test]
+    fn reduce_elem_expr() {
+        match_reduction(
+            r#"(module (table 0 funcref) (elem funcref (ref.func 0)) (func $a))"#,
+            super::InitExpressionMutator::ElementFunc,
+            r#"(module (table 0 funcref) (elem funcref (ref.null func)) (func $a))"#,
+        );
+    }
+
+    #[test]
+    fn reduce_elem_base() {
+        match_reduction(
+            r#"(module
+                (import "m" "g" (global i32))
+                (table 0 funcref)
+                (func $f)
+                (elem (offset (global.get 0)) $f))"#,
+            super::InitExpressionMutator::ElementOffset,
+            r#"(module
+                (import "m" "g" (global i32))
+                (table 0 funcref)
+                (func $f)
+                (elem (offset (i32.const 0)) $f))"#,
+        );
     }
 }


### PR DESCRIPTION
This can replace WASM such as:

     (elem (global.get 0) func)
     => (elem (i32.const 0) func)

or

    (global funcref (func $f))
    => (global funcref (ref.null))

which then can lead to further reduction opportunities such as removing
entities no longer referenced. That said, today this doesn't always help
wasm-shrink, since some of these reductions have the same encoded
byte-length, and therefore `wasm-shrink` decides the arguably simpler
result is not actually interesting for further consideration…

For that reason I'm marking this as a draft and I guess the intent I've here
is to kick off a discussion on whether there is a better metric for wasm-shrink
to use during reduction.

In particular a question I have is why `wasm-shrink` doesn't blindly trust that
`wasm-mutate` will produce a “simpler” wasm after every step. Sure, I imagine a 
`Mutator` could forget to check for `config.reduce` and actually fail to produce
an objectively simpler WASM at times, but ultimately even in presence of such a 
bug the mistake would most likely be undone by some other invocation of some 
`Mutator`. Not to mention wasm-smith itself could remember the smallest wasm 
file it has seen and present that to the user, even if it wasn't the exact same
as the working state at the end of the reduction process.