### PR TITLE
wasm-mutate: tell peephole about float and ref const replacements

### DIFF
--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/analysis.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/analysis.rs
@@ -116,6 +116,8 @@ impl PeepholeMutationAnalysis {
             Lang::I64Load { .. } => Ok(PrimitiveTypeInfo::I64),
             Lang::RandI32 => Ok(PrimitiveTypeInfo::I32),
             Lang::RandI64 => Ok(PrimitiveTypeInfo::I64),
+            Lang::RandF32 => Ok(PrimitiveTypeInfo::F32),
+            Lang::RandF64 => Ok(PrimitiveTypeInfo::F64),
             Lang::Undef => Ok(PrimitiveTypeInfo::Empty),
             Lang::UnfoldI32(_) => Ok(PrimitiveTypeInfo::I32),
             Lang::UnfoldI64(_) => Ok(PrimitiveTypeInfo::I64),

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/analysis.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/analysis.rs
@@ -1,6 +1,9 @@
 use crate::{
     module::{PrimitiveTypeInfo, TypeInfo},
-    mutators::peephole::{eggsy::Lang, EG},
+    mutators::peephole::{
+        eggsy::{lang::RefType, Lang},
+        EG,
+    },
     Error, ModuleInfo,
 };
 use egg::{Analysis, EGraph, Id};
@@ -270,6 +273,8 @@ impl PeepholeMutationAnalysis {
             Lang::I64UseGlobal(_) => Ok(PrimitiveTypeInfo::I64),
             Lang::F32UseGlobal(_) => Ok(PrimitiveTypeInfo::F32),
             Lang::F64UseGlobal(_) => Ok(PrimitiveTypeInfo::F64),
+            Lang::RefNull(RefType::Func) => Ok(PrimitiveTypeInfo::FuncRef),
+            Lang::RefNull(RefType::Extern) => Ok(PrimitiveTypeInfo::ExternRef),
         }
     }
 }

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder/expr2wasm.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder/expr2wasm.rs
@@ -772,6 +772,9 @@ pub fn expr2wasm(
                         newfunc.instruction(&Instruction::GlobalGet(global_idx));
                         global_idx += 1;
                     }
+                    &Lang::RefNull(valtype) => {
+                        newfunc.instruction(&Instruction::RefNull(valtype.into()));
+                    }
                 }
             }
         }

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder/expr2wasm.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder/expr2wasm.rs
@@ -163,6 +163,16 @@ pub fn expr2wasm(
                     Lang::RandI64 => {
                         newfunc.instruction(&Instruction::I64Const(config.rng().gen()));
                     }
+                    Lang::RandF32 => {
+                        newfunc.instruction(&Instruction::F32Const(f32::from_bits(
+                            config.rng().gen(),
+                        )));
+                    }
+                    Lang::RandF64 => {
+                        newfunc.instruction(&Instruction::F64Const(f64::from_bits(
+                            config.rng().gen(),
+                        )));
+                    }
                     Lang::Undef => { /* Do nothig */ }
                     Lang::UnfoldI32(value) => {
                         let child = &nodes[usize::from(*value)];

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
@@ -656,10 +656,14 @@ lang! {
 
         /// Custom mutation operations and instructions
         ///
-        /// This operation represent a random i32 integer
+        /// This operation represents a random i32 integer
         RandI32 = "i32.rand",
-        /// This operation represent a random i64 integer
+        /// This operation represents a random i64 integer
         RandI64 = "i64.rand",
+        /// This operation represents a random f32
+        RandF32 = "f32.rand",
+        /// This operation represents a random f64
+        RandF64 = "f64.rand",
 
         /// This instructions is used to define unknown operands, for example when the value can come from the join of several basic blocks in a dfg
         Undef = "undef",

--- a/crates/wasm-mutate/src/mutators/peephole/rules.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/rules.rs
@@ -465,6 +465,16 @@ impl PeepholeMutator {
                     "?x" => "f64.rand"
                         if self.is_type("?x", PrimitiveTypeInfo::F64)
                 ),
+                rewrite!(
+                    "replace-with-ref-null-func";
+                    "?x" => "ref.null.func"
+                        if self.is_type("?x", PrimitiveTypeInfo::FuncRef)
+                ),
+                rewrite!(
+                    "replace-with-ref-null-extern";
+                    "?x" => "ref.null.extern"
+                        if self.is_type("?x", PrimitiveTypeInfo::ExternRef)
+                ),
             ]);
 
             if !config.reduce {

--- a/crates/wasm-mutate/src/mutators/peephole/rules.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/rules.rs
@@ -416,6 +416,16 @@ impl PeepholeMutator {
                         if self.is_type("?x", PrimitiveTypeInfo::I64)
                 ),
                 rewrite!(
+                    "replace-with-f32-1.0";
+                    "?x" => "f32.const.1065353216"
+                        if self.is_type("?x", PrimitiveTypeInfo::F32)
+                ),
+                rewrite!(
+                    "replace-with-f64-1.0";
+                    "?x" => "f64.const.4607182418800017408"
+                        if self.is_type("?x", PrimitiveTypeInfo::F64)
+                ),
+                rewrite!(
                     "replace-with-i32-0";
                     "?x" => "i32.const.0"
                         if self.is_type("?x", PrimitiveTypeInfo::I32)
@@ -426,6 +436,16 @@ impl PeepholeMutator {
                         if self.is_type("?x", PrimitiveTypeInfo::I64)
                 ),
                 rewrite!(
+                    "replace-with-f32-0";
+                    "?x" => "f32.const.0"
+                        if self.is_type("?x", PrimitiveTypeInfo::F32)
+                ),
+                rewrite!(
+                    "replace-with-f64-0";
+                    "?x" => "f64.const.0"
+                        if self.is_type("?x", PrimitiveTypeInfo::F64)
+                ),
+                rewrite!(
                     "replace-with-i32.rand";
                     "?x" => "i32.rand"
                         if self.is_type("?x", PrimitiveTypeInfo::I32)
@@ -434,6 +454,16 @@ impl PeepholeMutator {
                     "replace-with-i64.rand";
                     "?x" => "i64.rand"
                         if self.is_type("?x", PrimitiveTypeInfo::I64)
+                ),
+                rewrite!(
+                    "replace-with-f32.rand";
+                    "?x" => "f32.rand"
+                        if self.is_type("?x", PrimitiveTypeInfo::F32)
+                ),
+                rewrite!(
+                    "replace-with-f64.rand";
+                    "?x" => "f64.rand"
+                        if self.is_type("?x", PrimitiveTypeInfo::F64)
                 ),
             ]);
 


### PR DESCRIPTION
Some time ago I was reducing a test case that utilized floating point numbers and eventually managed to reduce the test case further by hand by replacing all sorts of floating point operations, primarily those dealing with function locals, with their `*.const` versions.

Much like the #469, in many cases these rules are prone to producing WASM that's equivalent or larger byte-wise even if it sets up for more opportunities for further reduction.