### PR TITLE
Fix UB in MaybeOwned by deriving the &mut T from a raw pointer, not a &T

### DIFF
--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -1791,7 +1791,7 @@ mod arc {
                 return None;
             }
             debug_assert!(Arc::get_mut(&mut self.arc).is_some());
-            Some(unsafe { &mut *(&*self.arc as *const T as *mut T) })
+            Some(unsafe { &mut *(Arc::as_ptr(&self.arc) as *mut T) })
         }
 
         pub fn assert_mut(&mut self) -> &mut T {


### PR DESCRIPTION
The previous implementation converts a `&T` to a `&mut T` by casting through raw pointers, which is UB. Miri can detect this with
`MIRIFLAGS=-Zmiri-tag-raw-pointers`, though the `wasmparser` crate itself doesn't have the test coverage to hit it. I became aware of this code because it is hit in the test suites of `wasm-bindgen-wasm-interpreter` and `cranelift-wasm`.

As this is only one of two uses of `unsafe` in this project, I don't think it's worth adding Miri to CI. The test suite for this whole workspace is pretty complex and uses a number of things which Miri is very slow at running or doesn't support at all.

I tried replacing this with an all-safe implementation, and saw a 1-3% performance hit on the benchmarks.