### PR TITLE
Make sure `parse_all` stops on Errors

### DIFF
--- a/crates/wasmparser/src/parser.rs
+++ b/crates/wasmparser/src/parser.rs
@@ -700,7 +700,10 @@ impl Parser {
             }
             let payload = match cur.parse(data, true) {
                 // Propagate all errors
-                Err(e) => return Some(Err(e)),
+                Err(e) => {
+                    done = true;
+                    return Some(Err(e));
+                }
 
                 // This isn't possible because `eof` is always true.
                 Ok(Chunk::NeedMoreData(_)) => unreachable!(),
@@ -995,6 +998,14 @@ mod tests {
                 payload: Payload::Version { num: 1, .. },
             }),
         );
+    }
+
+    #[test]
+    fn header_iter() {
+        for _ in Parser::default().parse_all(&[]) {}
+        for _ in Parser::default().parse_all(b"\0") {}
+        for _ in Parser::default().parse_all(b"\0asm") {}
+        for _ in Parser::default().parse_all(b"\0asm\x01\x01\x01\x01") {}
     }
 
     fn parser_after_header() -> Parser {


### PR DESCRIPTION
All uses of `Parser::parse_all` in the code immediately propagate errors
and thus stop iteration. However the Iterator interface does not mandate
this, and not handling the inner `Result` at all can way too easily lead
to infinite loops.

I found this while fuzzing `symbolic` that internally uses `wasmparser`: https://github.com/getsentry/symbolic/pull/500

I see this crate does have some fuzz tests as well, but it would seem that this condition is never checked for? I can add something to verify this to the fuzz target here as well.