### PR TITLE
wasm-smith: Connect `SwarmConfig::max_type_size` to its `Config` implementation

### DIFF
--- a/crates/wasm-smith/src/config.rs
+++ b/crates/wasm-smith/src/config.rs
@@ -638,6 +638,10 @@ impl Config for SwarmConfig {
         self.memory64_enabled
     }
 
+    fn max_type_size(&self) -> u32 {
+        self.max_type_size
+    }
+
     fn canonicalize_nans(&self) -> bool {
         self.canonicalize_nans
     }


### PR DESCRIPTION
The `SwarmConfig::max_type_size` field was otherwise never used.