### PR TITLE
Remove named compound types from `wasm-encoder`.

### DIFF
--- a/crates/wasm-encoder/src/types.rs
+++ b/crates/wasm-encoder/src/types.rs
@@ -12,7 +12,6 @@ const COMPOUND_INTERFACE_TYPE_ENUM: u8 = 0x6c;
 const COMPOUND_INTERFACE_TYPE_UNION: u8 = 0x6b;
 const COMPOUND_INTERFACE_TYPE_OPTIONAL: u8 = 0x6a;
 const COMPOUND_INTERFACE_TYPE_EXPECTED: u8 = 0x69;
-const COMPOUND_INTERFACE_TYPE_NAMED: u8 = 0x68;
 
 const INTERFACE_TYPE_UNIT: u8 = 0x7f;
 const INTERFACE_TYPE_BOOL: u8 = 0x7e;
@@ -535,13 +534,6 @@ impl CompoundTypeEncoder<'_> {
         self.0.push(COMPOUND_INTERFACE_TYPE_EXPECTED);
         ok.encode(self.0);
         error.encode(self.0);
-    }
-
-    /// Define a named type.
-    pub fn named(self, name: &str, ty: InterfaceType) {
-        self.0.push(COMPOUND_INTERFACE_TYPE_NAMED);
-        self.0.extend(encoders::str(name));
-        ty.encode(self.0);
     }
 }
 


### PR DESCRIPTION
A recent component model spec change has removed named compound types.

That same change also added the ability to export types with a name as a
replacement for named compound types.

However, I'm waiting on more clarification for exported types in the grammar
before implementing.

For now, we can at least remove named compound types.