### PR TITLE
Allow exporting of component function types.

### DIFF
--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -808,7 +808,7 @@ impl ComponentState {
                 ComponentEntityType::Value(*self.value_at(*idx, offset)?)
             }
             crate::ComponentExportKind::Type(idx) => {
-                ComponentEntityType::Type(self.interface_type_at(*idx, types, offset)?)
+                ComponentEntityType::Type(self.type_at(*idx, offset)?)
             }
         })
     }
@@ -1436,7 +1436,7 @@ impl ComponentState {
                 crate::ComponentExportKind::Type(idx) => {
                     insert_export(
                         export.name,
-                        ComponentEntityType::Type(self.interface_type_at(idx, types, offset)?),
+                        ComponentEntityType::Type(self.type_at(idx, offset)?),
                         &mut inst_exports,
                         offset,
                     )?;


### PR DESCRIPTION
This PR allows the exporting of component function types in the validator.

See [this discussion](https://github.com/WebAssembly/component-model/pull/6#discussion_r815185164) as to why it's needed.

Marking this as a draft until the request spec change is incorporated.