### PR TITLE
Clamp the maximum nested printing level in wasmprinter

### DIFF
--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -16,6 +16,7 @@ use std::path::Path;
 use wasmparser::*;
 
 const MAX_LOCALS: u32 = 50000;
+const MAX_NESTING_TO_PRINT: u32 = 50;
 
 /// Reads a WebAssembly `file` from the filesystem and then prints it into an
 /// in-memory `String`.
@@ -741,7 +742,11 @@ impl Printer {
 
     fn newline(&mut self) {
         self.result.push_str("\n");
-        for _ in 0..self.nesting {
+
+        // Clamp the maximum nesting size that we print at something somewhat
+        // reasonable to avoid generating hundreds of megabytes of whitespace
+        // for small-ish modules that have deep-ish nesting.
+        for _ in 0..self.nesting.min(MAX_NESTING_TO_PRINT) {
             self.result.push_str("  ");
         }
     }


### PR DESCRIPTION
Occasionally I've seen timeouts on oss-fuzz related to printing
small-ish wasm modules that have very deeply nested blocks. Each level
of nesting increases the size of subsequent lines for later blocks,
meaning that it's pretty easy to generate a small wasm module (<1M)
which generates hundreds of megabytes of textual output (>200M). This
limit is intended to be a small stopgap against that by clamping the
maximum nesting level to a reasonable-ish value that ideally shouldn't
be hit in practice but may still show up from time to time. This doesn't
actually affect the interpretation of the textual output, only the
representation.