### PR TITLE
fuzz: Enable more validation feature in the mutate fuzzer

### DIFF
--- a/fuzz/fuzz_targets/mutate.rs
+++ b/fuzz/fuzz_targets/mutate.rs
@@ -62,12 +62,17 @@ fuzz_target!(|bytes: &[u8]| {
         }
     };
 
+    // Note that on-by-default features in wasmparser are not disabled here if
+    // the feature was disabled in `config` when the module was generated. For
+    // example if the input module doesn't have simd then wasm-mutate may
+    // produce a module that uses simd, which is ok and expected.
+    //
+    // Otherwise only forward some off-by-default features which are affected by
+    // wasm-smith's generation of modules and wasm-mutate otherwise won't add
+    // itself if it doesn't already exist.
     let mut features = WasmFeatures::default();
-    features.simd = config.simd_enabled;
     features.relaxed_simd = config.relaxed_simd_enabled;
-    features.reference_types = config.reference_types_enabled;
     features.module_linking = config.module_linking_enabled;
-    features.bulk_memory = config.bulk_memory_enabled;
 
     for (i, mutated_wasm) in iterator.take(100).enumerate() {
         let mutated_wasm = match mutated_wasm {


### PR DESCRIPTION
It's possible for wasm-mutate to take a module without simd enabled, for
example, and add simd features into it such as a type with `v128` or
similar. This means that the features for validation cannot be based
entirely on the input but rather some features need to be
unconditionally enabled (those that `wasm-mutate` could add at any
time).