### PR TITLE
Decrease iterations performed in `mutate` target

### DIFF
--- a/fuzz/fuzz_targets/mutate.rs
+++ b/fuzz/fuzz_targets/mutate.rs
@@ -74,7 +74,7 @@ fuzz_target!(|bytes: &[u8]| {
     features.relaxed_simd = config.relaxed_simd_enabled;
     features.module_linking = config.module_linking_enabled;
 
-    for (i, mutated_wasm) in iterator.take(100).enumerate() {
+    for (i, mutated_wasm) in iterator.take(10).enumerate() {
         let mutated_wasm = match mutated_wasm {
             Ok(w) => w,
             Err(e) => match e.kind() {


### PR DESCRIPTION
Parsing and validation is excessively slow [1] in `wasmparser` right now
so we can't support a 20ms budget for each validation in the `mutate`
target with 100 mutations. To work around this for now decrease the
number of iterations to 10.

[1]: https://github.com/bytecodealliance/wasm-tools/issues/188#issuecomment-1060875636