### PR TITLE
wasm-mutate: `table.set` doesn't produce a value

### DIFF
--- a/crates/wasm-mutate/src/lib.rs
+++ b/crates/wasm-mutate/src/lib.rs
@@ -160,8 +160,17 @@ pub struct WasmMutate<'wasm> {
     preserve_semantics: bool,
 
     /// Fuel to control the time of the mutation.
-    #[cfg_attr(feature = "clap", clap(skip = Cell::new(u64::MAX)))]
+    #[cfg_attr(
+        feature = "clap",
+        clap(
+            short,
+            long,
+            default_value = "18446744073709551615", // u64::MAX
+            parse(try_from_str = parse_fuel),
+        )
+    )]
     fuel: Cell<u64>,
+
     /// Only perform size-reducing transformations on the Wasm module. This
     /// allows `wasm-mutate` to be used as a test case reducer.
     #[cfg_attr(feature = "clap", clap(long))]
@@ -177,6 +186,11 @@ pub struct WasmMutate<'wasm> {
 
     #[cfg_attr(feature = "clap", clap(skip = None))]
     info: Option<ModuleInfo<'wasm>>,
+}
+
+#[cfg(feature = "clap")]
+fn parse_fuel(s: &str) -> Result<Cell<u64>, String> {
+    s.parse::<u64>().map(Cell::new).map_err(|s| s.to_string())
 }
 
 impl Default for WasmMutate<'_> {

--- a/crates/wasm-mutate/src/mutators/peephole/dfg.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/dfg.rs
@@ -735,7 +735,7 @@ impl<'a> DFGBuilder {
                 Operator::TableSet { table } => {
                     let arg1 = Id::from(self.pop_operand(idx, false));
                     let arg2 = Id::from(self.pop_operand(idx, false));
-                    self.push_node(Lang::TableSet(*table, [arg2, arg1]), idx);
+                    self.empty_node(Lang::TableSet(*table, [arg2, arg1]), idx);
                 }
 
                 _ => {


### PR DESCRIPTION
So use `empty_node` rather than `push_node`.

Fixes https://github.com/bytecodealliance/wasm-tools/issues/499