### PR TITLE
Fix always encoding empty component function section.

### DIFF
--- a/crates/wasm-encoder/src/component/functions.rs
+++ b/crates/wasm-encoder/src/component/functions.rs
@@ -88,6 +88,7 @@ impl ComponentFunctionSection {
         }
         self.bytes.extend(encoders::u32(type_index));
         self.bytes.extend(encoders::u32(func_index));
+        self.num_added += 1;
         self
     }
 
@@ -105,6 +106,7 @@ impl ComponentFunctionSection {
             option.encode(&mut self.bytes);
         }
         self.bytes.extend(encoders::u32(func_index));
+        self.num_added += 1;
         self
     }
 }


### PR DESCRIPTION
The `lift` and `lower` methods on `ComponentFunctionSection` were failing to
increment the internal count of items that were added, resulting in always
encoding a zero for the item count.