### PR TITLE
wasmparser: remove enforcement that `into` instances must export a memory.

### DIFF
--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -485,16 +485,6 @@ impl ComponentState {
             Some(idx) => {
                 let into_ty = self.module_instance_at(idx, types, offset)?;
 
-                match into_ty.exports.get("memory") {
-                    Some(EntityType::Memory(_)) => {}
-                    _ => {
-                        return Err(BinaryReaderError::new(
-                            "instance specified by `into` option does not export a memory named `memory`",
-                            offset,
-                        ));
-                    }
-                }
-
                 check_into_func(
                     into_ty,
                     "canonical_abi_realloc",


### PR DESCRIPTION
Currently, the component model validator requires that an instance pointed at
by the `into` canonical option export a memory named `memory`.

However, we have a chicken-and-the-egg problem when lowering imported
functions: the functions' `into` options must point at an instance, but we
don't have the instance yet because we're lowering the functions that the inner
core module will be importing.

To work around this problem, a small "shim" instance is used that has a
`funcref` table pointing at the canonical ABI functions expected by the `into`
option. The table gets populated after the inner core module gets instantiated.

Thus the `into` options for lowering imported functions point at this shim
instance rather than the actual core module's instance for the component.

As the shim instance can't export the same memory as the actual core module,
this validation enforcement prevents this from working.