### PR TITLE
wasmprinter: fix component formatting.

### DIFF
--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -2932,7 +2932,7 @@ impl Printer {
     }
 
     fn print_module_arg(&mut self, state: &State, arg: &ModuleArg) -> Result<()> {
-        self.start_group("import ");
+        self.start_group("with ");
         self.print_str(arg.name)?;
         self.result.push(' ');
         match arg.kind {
@@ -2947,7 +2947,7 @@ impl Printer {
     }
 
     fn print_component_arg(&mut self, state: &State, arg: &ComponentArg) -> Result<()> {
-        self.start_group("import ");
+        self.start_group("with ");
         self.print_str(arg.name)?;
         self.result.push(' ');
         self.print_component_export_kind(state, &arg.kind)?;

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -2786,6 +2786,7 @@ impl Printer {
             self.newline();
             self.start_group("func ");
             self.print_name(&state.function_names, state.functions.len() as u32)?;
+            self.result.push(' ');
 
             match func? {
                 ComponentFunction::Lift {
@@ -2798,6 +2799,7 @@ impl Printer {
                     self.print_idx(&state.type_names, type_index)?;
                     self.end_group();
                     self.print_canonical_options(state, &options)?;
+                    self.result.push(' ');
                     self.start_group("func ");
                     self.print_idx(&state.function_names, func_index)?;
                     self.end_group();
@@ -2807,8 +2809,9 @@ impl Printer {
                     func_index,
                     options,
                 } => {
-                    self.start_group("canon.lower ");
+                    self.start_group("canon.lower");
                     self.print_canonical_options(state, &options)?;
+                    self.result.push(' ');
                     self.start_group("func ");
                     self.print_idx(&state.function_names, func_index)?;
                     self.end_group();
@@ -3102,6 +3105,8 @@ impl Printer {
                 state.tags += 1;
             }
         }
+
+        self.end_group(); // alias export
 
         Ok(())
     }

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -350,10 +350,25 @@ impl Printer {
                         Encoding::Module => {
                             states.push(State::new(Encoding::Module));
                             self.start_group("module");
+
+                            if states.len() > 1 {
+                                let parent = &states[states.len() - 2];
+                                self.result.push(' ');
+                                self.print_name(&parent.module_names, parent.modules)?;
+                            }
                         }
                         Encoding::Component => {
                             states.push(State::new(Encoding::Component));
                             self.start_group("component");
+
+                            if states.len() > 1 {
+                                let parent = &states[states.len() - 2];
+                                self.result.push(' ');
+                                self.print_name(
+                                    &parent.component_names,
+                                    parent.components.len() as u32,
+                                )?;
+                            }
                         }
                     }
 


### PR DESCRIPTION
This PR fixes a failure to end a group for `alias export` and also some
spacing around how component functions are printed.

It also fixes printing the index of a nested component or module from the parent's index space.