### PR TITLE
More component model fixes

### DIFF
--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -789,7 +789,7 @@ impl ComponentState {
                         }
                     };
 
-                    if !a.is_subtype_of(b) {
+                    if !a.is_subtype_of(b, types) {
                         return Err(BinaryReaderError::new(
                             format!(
                                 "{} type mismatch for module instantiation argument `{}::{}`",

--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -190,7 +190,8 @@ impl ComponentState {
         types: &mut TypeList,
         offset: usize,
     ) -> Result<()> {
-        let ty = self.function_type_at(func_index, types, offset)?;
+        let ty = types[self.component_function_at(func_index, types, offset)?]
+            .unwrap_component_func_type();
 
         self.check_options(&options, ty, types, offset)?;
 

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -2886,8 +2886,9 @@ impl Printer {
                         .push(InstanceIndexType::Component(state.component(index)?));
                 }
                 Instance::ModuleFromExports(exports) => {
-                    self.result.push_str(" core ");
+                    self.result.push_str(" core");
                     for export in exports.iter() {
+                        self.result.push(' ');
                         self.print_export(state, export)?;
                     }
 


### PR DESCRIPTION
Fixes three bugs:

* in `wasmparser`: lowering a component function was checking the type index space instead of the function index space for `func_index`.

* in `wasmprinter`: no space between `export` output in "core instance from exports" printing.

* in `wasmparser`: function/tag subtype checking was comparing internal type ids (i.e. indexes into the global type list) instead of the expected function types.