### PR TITLE
Reexport `ValidatorResources` from wasmparser

### DIFF
--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -51,6 +51,7 @@ mod operators;
 pub mod types;
 
 use self::component::*;
+pub use self::core::ValidatorResources;
 use self::core::*;
 use self::types::{TypeList, Types};
 pub use func::FuncValidator;


### PR DESCRIPTION
I think this was forgotten in recent refactorings, nothing major here
though