### PR TITLE
Add initial memory64 and multi-memory support to wasm-mutate

### DIFF
--- a/crates/wasm-mutate/src/lib.rs
+++ b/crates/wasm-mutate/src/lib.rs
@@ -375,7 +375,13 @@ impl<'wasm> WasmMutate<'wasm> {
 }
 
 #[cfg(test)]
-pub(crate) fn validate(validator: &mut wasmparser::Validator, bytes: &[u8]) {
+pub(crate) fn validate(bytes: &[u8]) {
+    let mut validator = wasmparser::Validator::new();
+    validator.wasm_features(wasmparser::WasmFeatures {
+        memory64: true,
+        multi_memory: true,
+        ..Default::default()
+    });
     let err = match validator.validate_all(bytes) {
         Ok(()) => return,
         Err(e) => e,

--- a/crates/wasm-mutate/src/mutators.rs
+++ b/crates/wasm-mutate/src/mutators.rs
@@ -120,7 +120,6 @@ impl WasmMutate<'_> {
         T: Mutator + Clone,
     {
         use crate::ErrorKind;
-        use wasmparser::WasmFeatures;
 
         drop(env_logger::try_init());
 
@@ -153,12 +152,7 @@ impl WasmMutate<'_> {
 
             let mutation_bytes = mutation.finish();
 
-            let mut validator = wasmparser::Validator::new();
-            validator.wasm_features(WasmFeatures {
-                multi_memory: true,
-                ..WasmFeatures::default()
-            });
-            crate::validate(&mut validator, &mutation_bytes);
+            crate::validate(&mutation_bytes);
 
             // If it fails, it is probably an invalid
             // reformatting expected

--- a/crates/wasm-mutate/src/mutators/codemotion.rs
+++ b/crates/wasm-mutate/src/mutators/codemotion.rs
@@ -77,7 +77,8 @@ impl CodemotionMutator {
         for fidx in (function_to_mutate..function_count).chain(0..function_to_mutate) {
             config.consume_fuel(1)?;
             let reader = all_readers[fidx as usize];
-            let operatorreader = reader.get_operators_reader()?;
+            let mut operatorreader = reader.get_operators_reader()?;
+            operatorreader.allow_memarg64(true);
 
             let operators = operatorreader
                 .into_iter_with_offsets()

--- a/crates/wasm-mutate/src/mutators/peephole.rs
+++ b/crates/wasm-mutate/src/mutators/peephole.rs
@@ -139,7 +139,8 @@ impl PeepholeMutator {
             }
 
             let reader = readers[function_to_mutate as usize];
-            let operatorreader = reader.get_operators_reader()?;
+            let mut operatorreader = reader.get_operators_reader()?;
+            operatorreader.allow_memarg64(true);
             let mut localsreader = reader.get_locals_reader()?;
             let operators = operatorreader
                 .into_iter_with_offsets()
@@ -540,8 +541,7 @@ macro_rules! match_code_mutation {
         }
         modu.section(&codesection);
         let mutated = modu.finish();
-        let mut validator = wasmparser::Validator::new();
-        crate::validate(&mut validator, &mutated);
+        crate::validate(&mutated);
 
         let text = wasmprinter::print_bytes(mutated).unwrap();
 
@@ -940,10 +940,9 @@ mod tests {
         for mutated in mutator.mutate_with_rules(&mut wasmmutate, &rules).unwrap() {
             let module = mutated.unwrap();
 
-            let mut validator = wasmparser::Validator::new();
             let mutated_bytes = &module.finish();
             let _text = wasmprinter::print_bytes(mutated_bytes).unwrap();
-            crate::validate(&mut validator, mutated_bytes);
+            crate::validate(mutated_bytes);
         }
     }
 

--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -966,7 +966,9 @@ pub fn code(t: &mut dyn Translator, body: FunctionBody<'_>, s: &mut CodeSection)
         .collect::<Result<Vec<_>>>()?;
     let mut func = Function::new(locals);
 
-    for op in body.get_operators_reader()? {
+    let mut reader = body.get_operators_reader()?;
+    reader.allow_memarg64(true);
+    for op in reader {
         let op = op?;
         func.instruction(&t.translate_op(&op)?);
     }

--- a/fuzz/fuzz_targets/mutate.rs
+++ b/fuzz/fuzz_targets/mutate.rs
@@ -17,8 +17,6 @@ fuzz_target!(|bytes: &[u8]| {
     let (wasm, config) = match wasm_tools_fuzz::generate_valid_module(bytes, |config, u| {
         config.module_linking_enabled = false;
         config.exceptions_enabled = false;
-        config.memory64_enabled = false;
-        config.max_memories = 1;
         seed = u.arbitrary()?;
         Ok(())
     }) {
@@ -73,6 +71,8 @@ fuzz_target!(|bytes: &[u8]| {
     let mut features = WasmFeatures::default();
     features.relaxed_simd = config.relaxed_simd_enabled;
     features.module_linking = config.module_linking_enabled;
+    features.multi_memory = config.max_memories > 1;
+    features.memory64 = config.memory64_enabled;
 
     for (i, mutated_wasm) in iterator.take(10).enumerate() {
         let mutated_wasm = match mutated_wasm {


### PR DESCRIPTION
This fixes at least one issue I was encountering on #511 where I forgot
that the modules were using memory64 which meant that the
`allow_memarg64` method needed to be enabled to enable parsing 64-bit
offsets in memargs. This also touches up a few other locations to
support memory64 and multi-memory, enabling fuzzing as well. This gets
the exact test case on #511 to reduce much further in the shape of the
outer module (e.g. elements, imports, etc all removed), although the
function itself causing the issue is still not being reduced.