### PR TITLE
wasm-mutate: construct DFG for `v128.*` arithmetic operations

### DIFF
--- a/crates/wasm-mutate/src/mutators/peephole/dfg.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/dfg.rs
@@ -598,6 +598,14 @@ impl<'a> DFGBuilder {
                 Operator::I64Rotl => self.binop(idx, Lang::I64RotL),
                 Operator::I64Rotr => self.binop(idx, Lang::I64RotR),
 
+                Operator::V128Not => self.unop(idx, Lang::V128Not),
+                Operator::V128And => self.binop(idx, Lang::V128And),
+                Operator::V128AndNot => self.binop(idx, Lang::V128AndNot),
+                Operator::V128Or => self.binop(idx, Lang::V128Or),
+                Operator::V128Xor => self.binop(idx, Lang::V128Xor),
+                Operator::V128AnyTrue => self.unop(idx, Lang::V128AnyTrue),
+                Operator::V128Bitselect => self.ternop(idx, Lang::V128Bitselect),
+
                 Operator::Drop => {
                     let arg = self.pop_operand(idx, false);
                     self.empty_node(Lang::Drop([Id::from(arg)]), idx);
@@ -1124,6 +1132,19 @@ impl<'a> DFGBuilder {
         assert_ne!(leftidx, rightidx);
 
         self.push_node(op([Id::from(rightidx), Id::from(leftidx)]), idx);
+    }
+
+    fn ternop(&mut self, idx: usize, op: fn([Id; 3]) -> Lang) {
+        let c = self.pop_operand(idx, false);
+        let b = self.pop_operand(idx, false);
+        let a = self.pop_operand(idx, false);
+
+        // The operands should not be the same.
+        assert_ne!(a, b);
+        assert_ne!(a, c);
+        assert_ne!(b, c);
+
+        self.push_node(op([Id::from(a), Id::from(b), Id::from(c)]), idx);
     }
 
     fn store(

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/analysis.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/analysis.rs
@@ -299,6 +299,13 @@ impl PeepholeMutationAnalysis {
             Lang::V128Store16Lane(..) => Ok(PrimitiveTypeInfo::Empty),
             Lang::V128Store32Lane(..) => Ok(PrimitiveTypeInfo::Empty),
             Lang::V128Store64Lane(..) => Ok(PrimitiveTypeInfo::Empty),
+            Lang::V128Not(..) => Ok(PrimitiveTypeInfo::V128),
+            Lang::V128And(..) => Ok(PrimitiveTypeInfo::V128),
+            Lang::V128AndNot(..) => Ok(PrimitiveTypeInfo::V128),
+            Lang::V128Or(..) => Ok(PrimitiveTypeInfo::V128),
+            Lang::V128Xor(..) => Ok(PrimitiveTypeInfo::V128),
+            Lang::V128Bitselect(..) => Ok(PrimitiveTypeInfo::V128),
+            Lang::V128AnyTrue(..) => Ok(PrimitiveTypeInfo::I32),
 
             Lang::I8x16ExtractLaneS(..) => Ok(PrimitiveTypeInfo::I32),
             Lang::I8x16ExtractLaneU(..) => Ok(PrimitiveTypeInfo::I32),

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder/expr2wasm.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder/expr2wasm.rs
@@ -410,6 +410,14 @@ pub fn expr2wasm(
                     Lang::RefFunc(idx) => insn(Instruction::RefFunc(*idx)),
                     Lang::RefIsNull(_) => insn(Instruction::RefIsNull),
 
+                    Lang::V128Not(_) => insn(Instruction::V128Not),
+                    Lang::V128And(_) => insn(Instruction::V128And),
+                    Lang::V128AndNot(_) => insn(Instruction::V128AndNot),
+                    Lang::V128Or(_) => insn(Instruction::V128Or),
+                    Lang::V128Xor(_) => insn(Instruction::V128Xor),
+                    Lang::V128AnyTrue(_) => insn(Instruction::V128AnyTrue),
+                    Lang::V128Bitselect(_) => insn(Instruction::V128Bitselect),
+
                     Lang::V128Load(memarg, _) => {
                         newfunc.instruction(&Instruction::V128Load {
                             memarg: memarg.into(),

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
@@ -403,6 +403,27 @@ lang! {
         F32Copysign([Id; 2]) = "f32.copysign",
         /// f64.copysign  operator
         F64Copysign([Id; 2]) = "f64.copysign",
+
+        // unops v128
+        /// v128.not operator
+        V128Not([Id; 1]) = "v128.not",
+        /// v128.any_true operator
+        V128AnyTrue([Id; 1]) = "v128.any_true",
+
+        // binops v128
+        /// v128.bitselect operator
+        V128And([Id; 2]) = "v128.and",
+        /// v128.and_not operator
+        V128AndNot([Id; 2]) = "v128.and_not",
+        /// v128.or operator
+        V128Or([Id; 2]) = "v128.or",
+        /// v128.xor operator
+        V128Xor([Id; 2]) = "v128.xor",
+
+        // ternary ops v128
+        /// v128.bitselect operator
+        V128Bitselect([Id; 3]) = "v128.bitselect",
+
         // frelops
         /// f32.eq  operator
         F32Eq([Id; 2]) = "f32.eq",
@@ -428,6 +449,7 @@ lang! {
         F32Ge([Id; 2]) = "f32.ge",
         /// f64.ge  operator
         F64Ge([Id; 2]) = "f64.ge",
+
         // unops integers
         /// i32.eqz  operator
         I32Eqz([Id; 1]) = "i32.eqz",


### PR DESCRIPTION
Part of #511