### PR TITLE
mutate: Fix `i16x8.q15mulr_sat_s`

### DIFF
--- a/crates/wasm-mutate/src/mutators/peephole/dfg.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/dfg.rs
@@ -939,7 +939,7 @@ impl<'a> DFGBuilder {
                 }
                 Operator::I16x8Abs => self.unop(idx, Lang::I16x8Abs),
                 Operator::I16x8Neg => self.unop(idx, Lang::I16x8Neg),
-                Operator::I16x8Q15MulrSatS => self.unop(idx, Lang::I16x8Q15MulrSatS),
+                Operator::I16x8Q15MulrSatS => self.binop(idx, Lang::I16x8Q15MulrSatS),
                 Operator::I16x8AllTrue => self.unop(idx, Lang::I16x8AllTrue),
                 Operator::I16x8Bitmask => self.unop(idx, Lang::I16x8Bitmask),
                 Operator::I16x8NarrowI32x4S => self.binop(idx, Lang::I16x8NarrowI32x4S),

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
@@ -771,7 +771,7 @@ lang! {
         I16x8ExtAddPairwiseI8x16U([Id; 1]) = "i16x8.extadd_pairwise_i8x16_u",
         I16x8Abs([Id; 1]) = "i16x8.abs",
         I16x8Neg([Id; 1]) = "i16x8.neg",
-        I16x8Q15MulrSatS([Id; 1]) = "i16x8.q15mulr_sat_s",
+        I16x8Q15MulrSatS([Id; 2]) = "i16x8.q15mulr_sat_s",
         I16x8AllTrue([Id; 1]) = "i16x8.all_true",
         I16x8Bitmask([Id; 1]) = "i16x8.bitmask",
         I16x8NarrowI32x4S([Id; 2]) = "i16x8.narrow_i32x4_s",


### PR DESCRIPTION
This was accidentally classified as a unary operation when it is in fact
a binary operation.