### PR TITLE
mutate: Add support for `v128.load{32,64}_zero`

### DIFF
--- a/crates/wasm-mutate/src/mutators/peephole/dfg.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/dfg.rs
@@ -783,6 +783,8 @@ impl<'a> DFGBuilder {
                 Operator::V128Load64Splat { memarg } => {
                     self.load(idx, memarg, Lang::V128Load64Splat)
                 }
+                Operator::V128Load32Zero { memarg } => self.load(idx, memarg, Lang::V128Load32Zero),
+                Operator::V128Load64Zero { memarg } => self.load(idx, memarg, Lang::V128Load64Zero),
                 Operator::V128Store { memarg } => self.store(idx, memarg, Lang::V128Store),
                 Operator::V128Load8Lane { memarg, lane } => {
                     self.load_lane(idx, memarg, lane, Lang::V128Load8Lane)

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/analysis.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/analysis.rs
@@ -298,6 +298,8 @@ impl PeepholeMutationAnalysis {
             Lang::V128Load16Splat(..) => Ok(PrimitiveTypeInfo::V128),
             Lang::V128Load32Splat(..) => Ok(PrimitiveTypeInfo::V128),
             Lang::V128Load64Splat(..) => Ok(PrimitiveTypeInfo::V128),
+            Lang::V128Load32Zero(..) => Ok(PrimitiveTypeInfo::V128),
+            Lang::V128Load64Zero(..) => Ok(PrimitiveTypeInfo::V128),
             Lang::V128Store(..) => Ok(PrimitiveTypeInfo::Empty),
             Lang::V128Load8Lane(..) => Ok(PrimitiveTypeInfo::V128),
             Lang::V128Load16Lane(..) => Ok(PrimitiveTypeInfo::V128),

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder/expr2wasm.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder/expr2wasm.rs
@@ -465,6 +465,16 @@ pub fn expr2wasm(
                             memarg: memarg.into(),
                         });
                     }
+                    Lang::V128Load32Zero(memarg, _) => {
+                        newfunc.instruction(&Instruction::V128Load32Zero {
+                            memarg: memarg.into(),
+                        });
+                    }
+                    Lang::V128Load64Zero(memarg, _) => {
+                        newfunc.instruction(&Instruction::V128Load64Zero {
+                            memarg: memarg.into(),
+                        });
+                    }
                     Lang::V128Store(memarg, _) => {
                         newfunc.instruction(&Instruction::V128Store {
                             memarg: memarg.into(),

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
@@ -665,6 +665,8 @@ lang! {
         V128Load16Splat(MemArg, Id) = "v128.load16_splat",
         V128Load32Splat(MemArg, Id) = "v128.load32_splat",
         V128Load64Splat(MemArg, Id) = "v128.load64_splat",
+        V128Load32Zero(MemArg, Id) = "v128.load32_zero",
+        V128Load64Zero(MemArg, Id) = "v128.load64_zero",
         V128Store(MemArg, [Id; 2]) = "v128.store",
         V128Load8Lane(MemArgLane, [Id; 2]) = "v128.load8_lane",
         V128Load16Lane(MemArgLane, [Id; 2]) = "v128.load16_lane",


### PR DESCRIPTION
I accidentally missed these instructions in #513