### PR TITLE
Another round of small wasm-mutate changes

### DIFF
--- a/crates/wasm-mutate/src/mutators/peephole.rs
+++ b/crates/wasm-mutate/src/mutators/peephole.rs
@@ -247,21 +247,28 @@ impl PeepholeMutator {
                 // At this point we spent some resource calculating basic block,
                 // and constructing the egraph
                 config.consume_fuel(1)?;
-                let iterator = if config.reduce {
+
+                // If reduction mode is requested then yield back the smallest
+                // graph to start off with. For reduction cases that are
+                // specifically trying to find an interesting test case though
+                // the first reduction may not be interesting, so continue to
+                // chain up the lazy expansions afterwards like we always do.
+                let iter = if config.reduce {
                     let mut extractor = egg::Extractor::new(&egraph, egg::AstSize);
                     let (_best_cost, best_expr) = extractor.find_best(root);
-                    Box::new(std::iter::once(best_expr))
+                    Some(best_expr).into_iter()
                 } else {
-                    lazy_expand_aux(
-                        root,
-                        egraph.clone(),
-                        self.max_tree_depth,
-                        config.rng().gen(),
-                    )
+                    None.into_iter()
                 };
+                let iter = iter.chain(lazy_expand_aux(
+                    root,
+                    egraph.clone(),
+                    self.max_tree_depth,
+                    config.rng().gen(),
+                ));
 
                 // Filter expression equal to the original one
-                let iterator = iterator
+                let iterator = iter
                     .filter(move |expr| !expr.to_string().eq(&startcmp.to_string()))
                     .map(move |expr| {
                         log::trace!("Yielding expression:\n{}", expr.pretty(60));

--- a/crates/wasm-mutate/src/mutators/peephole.rs
+++ b/crates/wasm-mutate/src/mutators/peephole.rs
@@ -166,7 +166,7 @@ impl PeepholeMutator {
                 if count == operatorscount {
                     break;
                 }
-                let mut dfg = DFGBuilder::new();
+                let mut dfg = DFGBuilder::new(config);
                 let basicblock = dfg.get_bb_from_operator(opcode_to_mutate, &operators);
 
                 let basicblock = match basicblock {

--- a/crates/wasm-mutate/src/mutators/peephole/dfg.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/dfg.rs
@@ -1235,7 +1235,7 @@ impl From<&wasmparser::MemoryImmediate> for MemArg {
 mod tests {
     use super::DFGBuilder;
     use crate::mutators::OperatorAndByteOffset;
-    use crate::ModuleInfo;
+    use crate::{ModuleInfo, WasmMutate};
     use wasmparser::Parser;
 
     #[test]
@@ -1270,6 +1270,7 @@ mod tests {
         )
         .unwrap();
 
+        let config = WasmMutate::default();
         let mut parser = Parser::new(0);
         let mut consumed = 0;
         loop {
@@ -1291,7 +1292,7 @@ mod tests {
                         .collect::<wasmparser::Result<Vec<OperatorAndByteOffset>>>()
                         .unwrap();
 
-                    let roots = DFGBuilder::new().get_bb_from_operator(5, &operators);
+                    let roots = DFGBuilder::new(&config).get_bb_from_operator(5, &operators);
 
                     assert!(roots.is_some())
                 }
@@ -1325,6 +1326,7 @@ mod tests {
         )
         .unwrap();
 
+        let config = WasmMutate::default();
         let mut parser = Parser::new(0);
         let mut consumed = 0;
         loop {
@@ -1346,10 +1348,11 @@ mod tests {
                         .collect::<wasmparser::Result<Vec<OperatorAndByteOffset>>>()
                         .unwrap();
 
-                    let bb = DFGBuilder::new()
+                    let bb = DFGBuilder::new(&config)
                         .get_bb_from_operator(0, &operators)
                         .unwrap();
-                    let roots = DFGBuilder::new().get_dfg(&ModuleInfo::default(), &operators, &bb);
+                    let roots =
+                        DFGBuilder::new(&config).get_dfg(&ModuleInfo::default(), &operators, &bb);
                     assert!(roots.is_some())
                 }
                 wasmparser::Payload::End => {
@@ -1405,6 +1408,7 @@ mod tests {
         )
         .unwrap();
 
+        let config = WasmMutate::default();
         let mut parser = Parser::new(0);
         let mut consumed = 0;
         loop {
@@ -1426,10 +1430,11 @@ mod tests {
                         .collect::<wasmparser::Result<Vec<OperatorAndByteOffset>>>()
                         .unwrap();
 
-                    let bb = DFGBuilder::new()
+                    let bb = DFGBuilder::new(&config)
                         .get_bb_from_operator(7, &operators)
                         .unwrap();
-                    let roots = DFGBuilder::new().get_dfg(&ModuleInfo::default(), &operators, &bb);
+                    let roots =
+                        DFGBuilder::new(&config).get_dfg(&ModuleInfo::default(), &operators, &bb);
                     assert!(roots.is_some());
                 }
                 wasmparser::Payload::End => {
@@ -1460,6 +1465,7 @@ mod tests {
         )
         .unwrap();
 
+        let config = WasmMutate::default();
         let info = ModuleInfo::new(original).unwrap();
 
         let mut parser = Parser::new(0);
@@ -1481,10 +1487,10 @@ mod tests {
                         .collect::<wasmparser::Result<Vec<OperatorAndByteOffset>>>()
                         .unwrap();
 
-                    let bb = DFGBuilder::new()
+                    let bb = DFGBuilder::new(&config)
                         .get_bb_from_operator(3, &operators)
                         .unwrap();
-                    let roots = DFGBuilder::new().get_dfg(&info, &operators, &bb);
+                    let roots = DFGBuilder::new(&config).get_dfg(&info, &operators, &bb);
                     assert!(roots.is_some());
                 }
                 wasmparser::Payload::End => {

--- a/crates/wasm-mutate/src/mutators/peephole/rules.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/rules.rs
@@ -480,6 +480,40 @@ impl PeepholeMutator {
                     "?x" => "ref.null.extern"
                         if self.is_type("?x", PrimitiveTypeInfo::ExternRef)
                 ),
+                // Try to outright delete some instructions and containers to
+                // help make input even smaller in wasm-shrink cases.
+                rewrite!(
+                    "remove-drop";
+                    "(drop ?x)" => "(container)"
+                ),
+                rewrite!(
+                    "remove-nop";
+                    "nop" => "(container)"
+                ),
+                rewrite!(
+                    "remove-global.set.0";
+                    "(global.set.0 ?x)" => "(container)"
+                ),
+                rewrite!(
+                    "remove-global.set.1";
+                    "(global.set.1 ?x)" => "(container)"
+                ),
+                rewrite!(
+                    "remove-elem.drop.0";
+                    "(elem.drop.0)" => "(container)"
+                ),
+                rewrite!(
+                    "remove-elem.drop.1";
+                    "(elem.drop.1)" => "(container)"
+                ),
+                rewrite!(
+                    "remove-data.drop.0";
+                    "(data.drop.0)" => "(container)"
+                ),
+                rewrite!(
+                    "remove-data.drop.1";
+                    "(data.drop.1)" => "(container)"
+                ),
             ]);
 
             if !config.reduce {


### PR DESCRIPTION
I was debugging #511 a bit more with @fitzgen and these are some tweaks which helped reduce the files I was looking at even further. These changes are all oriented at opening up more opportunities for wasm-shrink to continue to mutate and delete code.