### PR TITLE
Revert "wasmparser: remove enforcement that `into` instances must exp…

### DIFF
--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -486,6 +486,16 @@ impl ComponentState {
             Some(idx) => {
                 let into_ty = self.module_instance_at(idx, types, offset)?;
 
+                match into_ty.exports.get("memory") {
+                    Some(EntityType::Memory(_)) => {}
+                    _ => {
+                        return Err(BinaryReaderError::new(
+                            "instance specified by `into` option does not export a memory named `memory`",
+                            offset,
+                        ));
+                    }
+                }
+
                 check_into_func(
                     into_ty,
                     "canonical_abi_realloc",


### PR DESCRIPTION
…ort a memory. (#506)"

This reverts commit b95e9439c8f7c7903d74bbc6c72a87fedc6b4d52.