### PR TITLE
wasm-shrink: Avoid local minima

### DIFF
--- a/crates/wasm-shrink/tests/tests.rs
+++ b/crates/wasm-shrink/tests/tests.rs
@@ -26,7 +26,7 @@ fn wasm() -> Vec<u8> {
 
 #[test]
 fn shrink_to_empty_is_error() -> Result<()> {
-    let result = WasmShrink::default().run(wasm(), |_| Ok(true), |_| Ok(()));
+    let result = WasmShrink::default().run(wasm(), |_| Ok(true));
     assert!(result.is_err());
     let err_msg = result.err().unwrap().to_string();
     assert!(dbg!(err_msg).contains("empty Wasm module"));
@@ -37,20 +37,16 @@ fn shrink_to_empty_is_error() -> Result<()> {
 fn shrink_to_empty_allowed() -> Result<()> {
     WasmShrink::default()
         .allow_empty(true)
-        .run(wasm(), |_| Ok(true), |_| Ok(()))?;
+        .run(wasm(), |_| Ok(true))?;
     Ok(())
 }
 
 #[test]
 fn smoke_test() -> Result<()> {
-    let info = WasmShrink::default().attempts(100).run(
-        wasm(),
-        |wasm| {
-            let wat = wasmprinter::print_bytes(&wasm)?;
-            Ok(wat.contains("local.get"))
-        },
-        |_| Ok(()),
-    )?;
+    let info = WasmShrink::default().attempts(100).run(wasm(), |wasm| {
+        let wat = wasmprinter::print_bytes(&wasm)?;
+        Ok(wat.contains("local.get"))
+    })?;
 
     assert!(info.input_size > info.output_size);
 


### PR DESCRIPTION
This commit allows individual mutations to grow the code size of the Wasm that
we are shrinking with a low probability. At the same time, we decouple the
concept of the smallest interesting Wasm we've discovered so far and the current
Wasm that we are mutating and trying to find more smaller interesting Wasms
from. This technique is borrowed from [MCMC]. As an example, it allows us to
accept an intermediate mutation that replaces a `func.ref $f` with a
`ref.null` (which by itself does not shrink code size) so that a later mutation
can recognize that `$f` might be dead code now and can be completely
removed (which is generally a large code size win).

Additionally, this refactors how the `WasmShrink::run` method was defined and
factors its local variable state out into a `ShrinkRun` struct and the closures
that were defined within it into methods on `ShrinkRun`.

[MCMC]: https://en.wikipedia.org/wiki/Markov_chain_Monte_Carlo