### PR TITLE
Support smithing 1.0 WebAssembly modules

### DIFF
--- a/crates/wasm-smith/src/config.rs
+++ b/crates/wasm-smith/src/config.rs
@@ -283,6 +283,20 @@ pub trait Config: 'static + std::fmt::Debug {
         true
     }
 
+    /// Determines whether the nontrapping-float-to-int-conversions propsal is enabled.
+    ///
+    /// Defaults to `true`.
+    fn saturating_float_to_int_enabled(&self) -> bool {
+        true
+    }
+
+    /// Determines whether the sign-extension-ops propsal is enabled.
+    ///
+    /// Defaults to `true`.
+    fn sign_extension_ops_enabled(&self) -> bool {
+        true
+    }
+
     /// Determines whether a `start` export may be included. Defaults to `true`.
     fn allow_start_export(&self) -> bool {
         true
@@ -375,51 +389,49 @@ impl Config for DefaultConfig {}
 #[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub struct SwarmConfig {
-    // These fields are configured via `Arbitrary`
-    pub max_types: usize,
-    pub max_imports: usize,
-    pub max_tags: usize,
-    pub max_funcs: usize,
-    pub max_globals: usize,
-    pub max_exports: usize,
+    pub allow_start_export: bool,
+    pub bulk_memory_enabled: bool,
+    pub canonicalize_nans: bool,
+    pub exceptions_enabled: bool,
+    pub max_aliases: usize,
+    pub max_data_segments: usize,
     pub max_element_segments: usize,
     pub max_elements: usize,
-    pub max_data_segments: usize,
+    pub max_exports: usize,
+    pub max_funcs: usize,
+    pub max_globals: usize,
+    pub max_imports: usize,
+    pub max_instances: usize,
     pub max_instructions: usize,
     pub max_memories: usize,
-    pub min_uleb_size: u8,
-    pub max_tables: usize,
     pub max_memory_pages: u64,
-    pub bulk_memory_enabled: bool,
-    pub reference_types_enabled: bool,
-    pub max_aliases: usize,
+    pub max_modules: usize,
     pub max_nesting_depth: usize,
-
-    // These fields are always set to their default value as specified in the
-    // default trait implementation.
+    pub max_tables: usize,
+    pub max_tags: usize,
+    pub max_type_size: u32,
+    pub max_types: usize,
     pub memory64_enabled: bool,
-    pub min_types: usize,
-    pub min_imports: usize,
-    pub min_tags: usize,
-    pub min_funcs: usize,
-    pub min_globals: usize,
-    pub min_exports: usize,
+    pub memory_max_size_required: bool,
+    pub memory_offset_choices: (u32, u32, u32),
     pub min_data_segments: usize,
     pub min_element_segments: usize,
     pub min_elements: usize,
+    pub min_exports: usize,
+    pub min_funcs: usize,
+    pub min_globals: usize,
+    pub min_imports: usize,
     pub min_memories: u32,
     pub min_tables: u32,
-    pub max_instances: usize,
-    pub max_modules: usize,
-    pub memory_offset_choices: (u32, u32, u32),
-    pub memory_max_size_required: bool,
-    pub simd_enabled: bool,
+    pub min_tags: usize,
+    pub min_types: usize,
+    pub min_uleb_size: u8,
     pub multi_value_enabled: bool,
+    pub reference_types_enabled: bool,
     pub relaxed_simd_enabled: bool,
-    pub exceptions_enabled: bool,
-    pub allow_start_export: bool,
-    pub max_type_size: u32,
-    pub canonicalize_nans: bool,
+    pub saturating_float_to_int_enabled: bool,
+    pub sign_extension_enabled: bool,
+    pub simd_enabled: bool,
 }
 
 impl<'a> Arbitrary<'a> for SwarmConfig {
@@ -450,6 +462,8 @@ impl<'a> Arbitrary<'a> for SwarmConfig {
             multi_value_enabled: u.arbitrary()?,
             max_aliases: u.int_in_range(0..=MAX_MAXIMUM)?,
             max_nesting_depth: u.int_in_range(0..=10)?,
+            saturating_float_to_int_enabled: u.arbitrary()?,
+            sign_extension_enabled: u.arbitrary()?,
 
             // These fields, unlike the ones above, are less useful to set.
             // They either make weird inputs or are for features not widely
@@ -614,6 +628,14 @@ impl Config for SwarmConfig {
 
     fn multi_value_enabled(&self) -> bool {
         self.multi_value_enabled
+    }
+
+    fn saturating_float_to_int_enabled(&self) -> bool {
+        self.saturating_float_to_int_enabled
+    }
+
+    fn sign_extension_ops_enabled(&self) -> bool {
+        self.sign_extension_enabled
     }
 
     fn allow_start_export(&self) -> bool {

--- a/crates/wasm-smith/src/core/code_builder.rs
+++ b/crates/wasm-smith/src/core/code_builder.rs
@@ -264,19 +264,19 @@ instructions! {
     (Some(f64_on_stack), i64_reinterpret_f64, Numeric),
     (Some(i32_on_stack), f32_reinterpret_i32, Numeric),
     (Some(i64_on_stack), f64_reinterpret_i64, Numeric),
-    (Some(i32_on_stack), i32_extend_8_s, Numeric),
-    (Some(i32_on_stack), i32_extend_16_s, Numeric),
-    (Some(i64_on_stack), i64_extend_8_s, Numeric),
-    (Some(i64_on_stack), i64_extend_16_s, Numeric),
-    (Some(i64_on_stack), i64_extend_32_s, Numeric),
-    (Some(f32_on_stack), i32_trunc_sat_f32_s, Numeric),
-    (Some(f32_on_stack), i32_trunc_sat_f32_u, Numeric),
-    (Some(f64_on_stack), i32_trunc_sat_f64_s, Numeric),
-    (Some(f64_on_stack), i32_trunc_sat_f64_u, Numeric),
-    (Some(f32_on_stack), i64_trunc_sat_f32_s, Numeric),
-    (Some(f32_on_stack), i64_trunc_sat_f32_u, Numeric),
-    (Some(f64_on_stack), i64_trunc_sat_f64_s, Numeric),
-    (Some(f64_on_stack), i64_trunc_sat_f64_u, Numeric),
+    (Some(extendable_i32_on_stack), i32_extend_8_s, Numeric),
+    (Some(extendable_i32_on_stack), i32_extend_16_s, Numeric),
+    (Some(extendable_i64_on_stack), i64_extend_8_s, Numeric),
+    (Some(extendable_i64_on_stack), i64_extend_16_s, Numeric),
+    (Some(extendable_i64_on_stack), i64_extend_32_s, Numeric),
+    (Some(nontrapping_f32_on_stack), i32_trunc_sat_f32_s, Numeric),
+    (Some(nontrapping_f32_on_stack), i32_trunc_sat_f32_u, Numeric),
+    (Some(nontrapping_f64_on_stack), i32_trunc_sat_f64_s, Numeric),
+    (Some(nontrapping_f64_on_stack), i32_trunc_sat_f64_u, Numeric),
+    (Some(nontrapping_f32_on_stack), i64_trunc_sat_f32_s, Numeric),
+    (Some(nontrapping_f32_on_stack), i64_trunc_sat_f32_u, Numeric),
+    (Some(nontrapping_f64_on_stack), i64_trunc_sat_f64_s, Numeric),
+    (Some(nontrapping_f64_on_stack), i64_trunc_sat_f64_u, Numeric),
     // reference types proposal
     (Some(ref_null_valid), ref_null, Reference),
     (Some(ref_func_valid), ref_func, Reference),
@@ -2777,6 +2777,10 @@ fn i32_wrap_i64(
     Ok(Instruction::I32WrapI64)
 }
 
+fn nontrapping_f32_on_stack(module: &Module, builder: &mut CodeBuilder) -> bool {
+    module.config.saturating_float_to_int_enabled() && f32_on_stack(module, builder)
+}
+
 fn i32_trunc_f32_s(
     _: &mut Unstructured,
     _: &Module,
@@ -2795,6 +2799,10 @@ fn i32_trunc_f32_u(
     builder.pop_operands(&[ValType::F32]);
     builder.push_operands(&[ValType::I32]);
     Ok(Instruction::I32TruncF32U)
+}
+
+fn nontrapping_f64_on_stack(module: &Module, builder: &mut CodeBuilder) -> bool {
+    module.config.saturating_float_to_int_enabled() && f64_on_stack(module, builder)
 }
 
 fn i32_trunc_f64_s(
@@ -3017,6 +3025,10 @@ fn f64_reinterpret_i64(
     Ok(Instruction::F64ReinterpretI64)
 }
 
+fn extendable_i32_on_stack(module: &Module, builder: &mut CodeBuilder) -> bool {
+    module.config.sign_extension_ops_enabled() && i32_on_stack(module, builder)
+}
+
 fn i32_extend_8_s(
     _: &mut Unstructured,
     _: &Module,
@@ -3035,6 +3047,10 @@ fn i32_extend_16_s(
     builder.pop_operands(&[ValType::I32]);
     builder.push_operands(&[ValType::I32]);
     Ok(Instruction::I32Extend16S)
+}
+
+fn extendable_i64_on_stack(module: &Module, builder: &mut CodeBuilder) -> bool {
+    module.config.sign_extension_ops_enabled() && i64_on_stack(module, builder)
 }
 
 fn i64_extend_8_s(


### PR DESCRIPTION
Add an ability to disable saturating_float_to_int and sign_extension_ops
proposals.