### PR TITLE
wasmparser: Tweak how features work in the validator

### DIFF
--- a/crates/wasm-mutate/src/lib.rs
+++ b/crates/wasm-mutate/src/lib.rs
@@ -376,8 +376,7 @@ impl<'wasm> WasmMutate<'wasm> {
 
 #[cfg(test)]
 pub(crate) fn validate(bytes: &[u8]) {
-    let mut validator = wasmparser::Validator::new();
-    validator.wasm_features(wasmparser::WasmFeatures {
+    let mut validator = wasmparser::Validator::new_with_features(wasmparser::WasmFeatures {
         memory64: true,
         multi_memory: true,
         ..Default::default()

--- a/crates/wasm-shrink/src/lib.rs
+++ b/crates/wasm-shrink/src/lib.rs
@@ -216,8 +216,7 @@ impl ShrinkRun {
     }
 
     fn validate_wasm(&self, wasm: &[u8]) -> Result<()> {
-        let mut validator = wasmparser::Validator::new();
-        validator.wasm_features(wasmparser::WasmFeatures {
+        let mut validator = wasmparser::Validator::new_with_features(wasmparser::WasmFeatures {
             // TODO: we should have CLI flags for each Wasm proposal.
             reference_types: true,
             multi_value: true,

--- a/crates/wasm-smith/tests/core.rs
+++ b/crates/wasm-smith/tests/core.rs
@@ -1,6 +1,6 @@
 use arbitrary::{Arbitrary, Unstructured};
 use rand::{rngs::SmallRng, RngCore, SeedableRng};
-use wasm_smith::{Config, ConfiguredModule, Module, SwarmConfig};
+use wasm_smith::{ConfiguredModule, Module, SwarmConfig};
 use wasmparser::{Validator, WasmFeatures};
 
 fn wasm_features() -> WasmFeatures {
@@ -23,8 +23,7 @@ fn smoke_test_module() {
         if let Ok(module) = Module::arbitrary_take_rest(u) {
             let wasm_bytes = module.to_bytes();
 
-            let mut validator = Validator::new();
-            validator.wasm_features(wasm_features());
+            let mut validator = Validator::new_with_features(wasm_features());
             validate(&mut validator, &wasm_bytes);
         }
     }
@@ -41,8 +40,7 @@ fn smoke_test_ensure_termination() {
             module.ensure_termination(10);
             let wasm_bytes = module.to_bytes();
 
-            let mut validator = Validator::new();
-            validator.wasm_features(wasm_features());
+            let mut validator = Validator::new_with_features(wasm_features());
             validate(&mut validator, &wasm_bytes);
         }
     }
@@ -59,8 +57,7 @@ fn smoke_test_swarm_config() {
             let module = module.module;
             let wasm_bytes = module.to_bytes();
 
-            let mut validator = Validator::new();
-            validator.wasm_features(wasm_features());
+            let mut validator = Validator::new_with_features(wasm_features());
             validate(&mut validator, &wasm_bytes);
         }
     }
@@ -77,10 +74,9 @@ fn multi_value_disabled() {
         cfg.multi_value_enabled = false;
         if let Ok(module) = Module::new(cfg, &mut u) {
             let wasm_bytes = module.to_bytes();
-            let mut validator = Validator::new();
             let mut features = wasm_features();
             features.multi_value = false;
-            validator.wasm_features(features);
+            let mut validator = Validator::new_with_features(features);
             validate(&mut validator, &wasm_bytes);
         }
     }
@@ -107,7 +103,6 @@ fn smoke_can_smith_valid_webassembly_one_point_oh() {
         cfg.max_tables = 1;
         if let Ok(module) = Module::new(cfg, &mut u) {
             let wasm_bytes = module.to_bytes();
-            let mut validator = Validator::new();
             // This table should set to `true` only features specified in wasm-core-1 spec.
             let features = WasmFeatures {
                 mutable_global: true, // available in 1.0
@@ -127,7 +122,7 @@ fn smoke_can_smith_valid_webassembly_one_point_oh() {
                 extended_const: false,
                 component_model: false,
             };
-            validator.wasm_features(features);
+            let mut validator = Validator::new_with_features(features);
             validate(&mut validator, &wasm_bytes);
         }
     }

--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -202,8 +202,7 @@ fn it_works_benchmark(c: &mut Criterion) {
 
 fn validate_benchmark(c: &mut Criterion) {
     fn validator() -> Validator {
-        let mut ret = Validator::new();
-        ret.wasm_features(WasmFeatures {
+        Validator::new_with_features(WasmFeatures {
             reference_types: true,
             multi_value: true,
             simd: true,
@@ -220,8 +219,7 @@ fn validate_benchmark(c: &mut Criterion) {
             mutable_global: true,
             saturating_float_to_int: true,
             sign_extension: true,
-        });
-        return ret;
+        })
     }
     let mut inputs = collect_benchmark_inputs();
     // Filter out all benchmark inputs that fail to validate via `wasmparser`.

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -313,10 +313,22 @@ impl Validator {
         Validator::default()
     }
 
-    /// Configures the enabled WebAssembly features for this `Validator`.
-    pub fn wasm_features(&mut self, features: WasmFeatures) -> &mut Validator {
-        self.features = features;
-        self
+    /// Creates a new [`Validator`] which has the specified set of wasm
+    /// features activated for validation.
+    ///
+    /// This function is the same as [`Validator::new`] except it also allows
+    /// you to customize the active wasm features in use for validation. This
+    /// can allow enabling experimental proposals or also turning off
+    /// on-by-default wasm proposals.
+    pub fn new_with_features(features: WasmFeatures) -> Validator {
+        let mut ret = Validator::new();
+        ret.features = features;
+        ret
+    }
+
+    /// Returns the wasm features used for this validator.
+    pub fn features(&self) -> &WasmFeatures {
+        &self.features
     }
 
     /// Validates an entire in-memory module or component with this validator.
@@ -1246,8 +1258,7 @@ mod tests {
         "#,
         )?;
 
-        let mut validator = Validator::new();
-        validator.wasm_features(WasmFeatures {
+        let mut validator = Validator::new_with_features(WasmFeatures {
             exceptions: true,
             ..Default::default()
         });

--- a/fuzz/fuzz_targets/mutate.rs
+++ b/fuzz/fuzz_targets/mutate.rs
@@ -86,10 +86,8 @@ fuzz_target!(|bytes: &[u8]| {
             NUM_SUCCESSFUL_MUTATIONS.fetch_add(1, Ordering::Relaxed);
         }
 
-        let mut validator = wasmparser::Validator::new();
-        validator.wasm_features(features);
-
-        let validation_result = validator.validate_all(&mutated_wasm);
+        let validation_result =
+            wasmparser::Validator::new_with_features(features).validate_all(&mutated_wasm);
 
         if log::log_enabled!(log::Level::Debug) {
             log::debug!("writing mutated Wasm to `mutated.wasm`");

--- a/fuzz/fuzz_targets/validate-valid-module.rs
+++ b/fuzz/fuzz_targets/validate-valid-module.rs
@@ -12,8 +12,7 @@ fuzz_target!(|m: &[u8]| {
 
     // Validate the module and assert that it passes
     // validation.
-    let mut validator = wasmparser::Validator::new();
-    validator.wasm_features(wasmparser::WasmFeatures {
+    let mut validator = wasmparser::Validator::new_with_features(wasmparser::WasmFeatures {
         multi_value: config.multi_value_enabled,
         multi_memory: config.max_memories > 1,
         bulk_memory: true,

--- a/fuzz/fuzz_targets/validate.rs
+++ b/fuzz/fuzz_targets/validate.rs
@@ -4,7 +4,6 @@ use libfuzzer_sys::*;
 use wasmparser::{Validator, WasmFeatures};
 
 fuzz_target!(|data: &[u8]| {
-    let mut validator = Validator::new();
     let byte1 = match data.get(0) {
         Some(byte) => byte,
         None => return,
@@ -13,7 +12,7 @@ fuzz_target!(|data: &[u8]| {
         Some(byte) => byte,
         None => return,
     };
-    validator.wasm_features(WasmFeatures {
+    let mut validator = Validator::new_with_features(WasmFeatures {
         reference_types: (byte1 & 0b0000_0001) != 0,
         multi_value: (byte1 & 0b0000_0010) != 0,
         threads: (byte1 & 0b0000_0100) != 0,

--- a/src/bin/wasm-tools/validate.rs
+++ b/src/bin/wasm-tools/validate.rs
@@ -52,10 +52,7 @@ impl Opts {
         // `Validator` we're using as we navigate nested modules (the module
         // linking proposal) and any functions found are deferred to get
         // validated later.
-        let mut validator = Validator::new();
-        if let Some(features) = self.features {
-            validator.wasm_features(features);
-        }
+        let mut validator = Validator::new_with_features(self.features.unwrap_or_default());
         let mut functions_to_validate = Vec::new();
         let wasm = wat::parse_file(&self.input)?;
 
@@ -98,7 +95,9 @@ fn parse_features(arg: &str) -> Result<WasmFeatures> {
         ("memory64", |f| &mut f.memory64),
         ("extended-const", |f| &mut f.extended_const),
         ("deterministic", |f| &mut f.deterministic_only),
-        ("saturating-float-to-int", |f| &mut f.saturating_float_to_int),
+        ("saturating-float-to-int", |f| {
+            &mut f.saturating_float_to_int
+        }),
         ("sign-extension", |f| &mut f.sign_extension),
         ("mutable-global", |f| &mut f.mutable_global),
     ];

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -594,9 +594,7 @@ impl TestState {
                 _ => {}
             }
         }
-        let mut ret = Validator::new();
-        ret.wasm_features(features);
-        return ret;
+        Validator::new_with_features(features)
     }
 
     fn bump_ntests(&self) {


### PR DESCRIPTION
This commit removes the `Validator::wasm_features` setter method and
instead replaces it with a getter, allowing access to the activated
features of a `Validator`. At the same time a new constructor,
`Validator::new_with_features` is added. Upon reflection being able to
configure features after construction seems like it can run the risk of
being confusing where one section is validated with one set of features
and another section could be validated with a different set of features.
This API, however, forces the contract that a module is always validated
with the same set of features.