### PR TITLE
fuzz-targets: fix `incremental-parse` to handle submodules/subcomponents.

### DIFF
--- a/fuzz/fuzz_targets/incremental-parse.rs
+++ b/fuzz/fuzz_targets/incremental-parse.rs
@@ -165,9 +165,27 @@ fuzz_target!(|data: Vec<Vec<u8>>| {
             (ComponentFunctionSection(a), ComponentFunctionSection(b)) => {
                 assert_eq!(a.range(), b.range())
             }
-            (ModuleSection { range: a, .. }, ModuleSection { range: b, .. }) => assert_eq!(a, b),
-            (ComponentSection { range: a, .. }, ComponentSection { range: b, .. }) => {
-                assert_eq!(a, b)
+            (
+                ModuleSection {
+                    parser: p,
+                    range: a,
+                },
+                ModuleSection { range: b, .. },
+            ) => {
+                assert_eq!(a, b);
+                stack.push(parser);
+                parser = p;
+            }
+            (
+                ComponentSection {
+                    parser: p,
+                    range: a,
+                },
+                ComponentSection { range: b, .. },
+            ) => {
+                assert_eq!(a, b);
+                stack.push(parser);
+                parser = p;
             }
             (InstanceSection(a), InstanceSection(b)) => assert_eq!(a.range(), b.range()),
             (ComponentExportSection(a), ComponentExportSection(b)) => {


### PR DESCRIPTION
This PR adds the missing push of the current parser to the stack and
assignment of the nested parser to the current parser when encountering a
module or component section in the parse.