### PR TITLE
style: Use strip_prefix instead of manual test and strip

### DIFF
--- a/crates/wast/src/ast/expr.rs
+++ b/crates/wast/src/ast/expr.rs
@@ -1287,8 +1287,8 @@ impl<'a> MemArg<'a> {
                     return Ok((None, c));
                 }
                 let num = &kw[1..];
-                let num = if num.starts_with("0x") {
-                    f(c, &num[2..], 16)?
+                let num = if let Some(stripped) = num.strip_prefix("0x") {
+                    f(c, stripped, 16)?
                 } else {
                     f(c, num, 10)?
                 };

--- a/crates/wast/src/lexer.rs
+++ b/crates/wast/src/lexer.rs
@@ -483,10 +483,10 @@ impl<'a> Lexer<'a> {
     }
 
     fn number(&self, src: &'a str) -> Option<Token<'a>> {
-        let (sign, num) = if src.starts_with('+') {
-            (Some(SignToken::Plus), &src[1..])
-        } else if src.starts_with('-') {
-            (Some(SignToken::Minus), &src[1..])
+        let (sign, num) = if let Some(stripped) = src.strip_prefix('+') {
+            (Some(SignToken::Plus), stripped)
+        } else if let Some(stripped) = src.strip_prefix('-') {
+            (Some(SignToken::Minus), stripped)
         } else {
             (None, src)
         };
@@ -507,8 +507,8 @@ impl<'a> Lexer<'a> {
                     negative,
                 },
             }))));
-        } else if num.starts_with("nan:0x") {
-            let mut it = num[6..].chars();
+        } else if let Some(stripped) = num.strip_prefix("nan:0x") {
+            let mut it = stripped.chars();
             let to_parse = skip_undescores(&mut it, false, char::is_ascii_hexdigit)?;
             if it.next().is_some() {
                 return None;
@@ -524,9 +524,9 @@ impl<'a> Lexer<'a> {
         }
 
         // Figure out if we're a hex number or not
-        let (mut it, hex, test_valid) = if num.starts_with("0x") {
+        let (mut it, hex, test_valid) = if let Some(stripped) = num.strip_prefix("0x") {
             (
-                num[2..].chars(),
+                stripped.chars(),
                 true,
                 char::is_ascii_hexdigit as fn(&char) -> bool,
             )


### PR DESCRIPTION
cargo clippy warning: stripping a prefix manually

```rust
if src.starts_with('-') {
    (Some(SignToken::Minus), &src[1..])
}
```

recommend use `strip_prefix`

```rust
if let Some(stripped) = src.strip_prefix('-') {
    (Some(SignToken::Minus), stripped)
}
```

for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_strip

Signed-off-by: zu1k <i@zu1k.com>