### PR TITLE
fix: Follow cargo clippy

### DIFF
--- a/crates/dump/src/lib.rs
+++ b/crates/dump/src/lib.rs
@@ -185,7 +185,7 @@ impl<'a> Dump<'a> {
                     for _ in 0..NBYTES {
                         write!(me.dst, "---")?;
                     }
-                    write!(me.dst, "-| ... {} bytes of data\n", i.data.len())?;
+                    writeln!(me.dst, "-| ... {} bytes of data", i.data.len())?;
                     me.cur = end;
                     Ok(())
                 })?,
@@ -198,9 +198,9 @@ impl<'a> Dump<'a> {
                 }
 
                 Payload::CodeSectionEntry(body) => {
-                    write!(
+                    writeln!(
                         self.dst,
-                        "============== func {} ====================\n",
+                        "============== func {} ====================",
                         i.funcs
                     )?;
                     i.funcs += 1;
@@ -248,7 +248,7 @@ impl<'a> Dump<'a> {
                         for _ in 0..NBYTES {
                             write!(self.dst, "---")?;
                         }
-                        write!(self.dst, "-| ... {} bytes of data\n", data.len())?;
+                        writeln!(self.dst, "-| ... {} bytes of data", data.len())?;
                         self.cur += data.len();
                     }
                 }
@@ -263,7 +263,7 @@ impl<'a> Dump<'a> {
                     for _ in 0..NBYTES {
                         write!(self.dst, "---")?;
                     }
-                    write!(self.dst, "-| ... {} bytes of data\n", contents.len())?;
+                    writeln!(self.dst, "-| ... {} bytes of data", contents.len())?;
                     self.cur += contents.len();
                 }
                 Payload::End(_) => {
@@ -424,7 +424,7 @@ impl<'a> Dump<'a> {
                 self.dst.push_str(&self.state);
                 self.state.truncate(0);
             }
-            self.dst.push_str("\n");
+            self.dst.push('\n');
         }
         self.cur = end;
         Ok(())

--- a/crates/wasm-encoder/src/core/elements.rs
+++ b/crates/wasm-encoder/src/core/elements.rs
@@ -120,6 +120,7 @@ impl ElementSection {
                 table: None,
                 offset,
             } => {
+                #[allow(clippy::identity_op)]
                 self.bytes.extend(encoders::u32(0x00 | expr_bit));
                 offset.encode(&mut self.bytes);
                 Instruction::End.encode(&mut self.bytes);

--- a/crates/wasm-encoder/src/lib.rs
+++ b/crates/wasm-encoder/src/lib.rs
@@ -88,18 +88,12 @@ mod test {
     #[test]
     fn it_encodes_an_empty_module() {
         let bytes = Module::new().finish();
-        assert_eq!(
-            bytes,
-            [0x00, 'a' as u8, 's' as u8, 'm' as u8, 0x01, 0x00, 0x00, 0x00]
-        );
+        assert_eq!(bytes, [0x00, b'a', b's', b'm', 0x01, 0x00, 0x00, 0x00]);
     }
 
     #[test]
     fn it_encodes_an_empty_component() {
         let bytes = Component::new().finish();
-        assert_eq!(
-            bytes,
-            [0x00, 'a' as u8, 's' as u8, 'm' as u8, 0x0a, 0x00, 0x01, 0x00]
-        );
+        assert_eq!(bytes, [0x00, b'a', b's', b'm', 0x0a, 0x00, 0x01, 0x00]);
     }
 }

--- a/crates/wasm-mutate/src/lib.rs
+++ b/crates/wasm-mutate/src/lib.rs
@@ -7,6 +7,7 @@
 //! tool. `wasm-mutate` can serve as a custom mutator for mutation-based
 //! fuzzing.
 
+#![allow(clippy::field_reassign_with_default, clippy::too_many_arguments)]
 #![cfg_attr(not(feature = "clap"), deny(missing_docs))]
 
 mod error;
@@ -179,7 +180,7 @@ pub struct WasmMutate<'wasm> {
     // Note: this is only exposed via the programmatic interface, not via the
     // CLI.
     #[cfg_attr(feature = "clap", clap(skip = None))]
-    raw_mutate_func: Option<Arc<dyn Fn(&mut Vec<u8>, usize) -> Result<()>>>,
+    raw_mutate_func: Option<Arc<FnRawMutate>>,
 
     #[cfg_attr(feature = "clap", clap(skip = None))]
     rng: Option<SmallRng>,
@@ -187,6 +188,8 @@ pub struct WasmMutate<'wasm> {
     #[cfg_attr(feature = "clap", clap(skip = None))]
     info: Option<ModuleInfo<'wasm>>,
 }
+
+type FnRawMutate = dyn Fn(&mut Vec<u8>, usize) -> Result<()>;
 
 #[cfg(feature = "clap")]
 fn parse_fuel(s: &str) -> Result<Cell<u64>, String> {
@@ -253,10 +256,7 @@ impl<'wasm> WasmMutate<'wasm> {
     /// mutated data should be. After mutating the data, the function should
     /// `resize` the data to its final, mutated size, which should be less than
     /// or equal to the maximum size.
-    pub fn raw_mutate_func(
-        &mut self,
-        raw_mutate_func: Option<Arc<dyn Fn(&mut Vec<u8>, usize) -> Result<()>>>,
-    ) -> &mut Self {
+    pub fn raw_mutate_func(&mut self, raw_mutate_func: Option<Arc<FnRawMutate>>) -> &mut Self {
         self.raw_mutate_func = raw_mutate_func;
         self
     }

--- a/crates/wasm-mutate/src/mutators.rs
+++ b/crates/wasm-mutate/src/mutators.rs
@@ -129,7 +129,7 @@ impl WasmMutate<'_> {
         let expected_text = wasmprinter::print_bytes(expected).unwrap();
 
         let mut config = self.clone();
-        config.setup(&original).unwrap();
+        config.setup(original).unwrap();
 
         let can_mutate = mutator.can_mutate(&config);
 

--- a/crates/wasm-mutate/src/mutators/add_function.rs
+++ b/crates/wasm-mutate/src/mutators/add_function.rs
@@ -43,9 +43,7 @@ impl Mutator for AddFunctionMutator {
                 code_sec_enc.raw(&raw_code_sec.data[range.start..range.end]);
             }
         }
-        let func_ty = match &config.info().types_map[usize::try_from(ty_idx).unwrap()] {
-            TypeInfo::Func(func_ty) => func_ty,
-        };
+        let TypeInfo::Func(func_ty) = &config.info().types_map[usize::try_from(ty_idx).unwrap()];
         let mut func = wasm_encoder::Function::new(vec![]);
         for ty in &func_ty.returns {
             match ty {

--- a/crates/wasm-mutate/src/mutators/codemotion.rs
+++ b/crates/wasm-mutate/src/mutators/codemotion.rs
@@ -122,7 +122,7 @@ pub trait AstMutator {
         config: &'a mut WasmMutate,
         ast: &Ast,
         locals: &[(u32, ValType)],
-        operators: &Vec<OperatorAndByteOffset>,
+        operators: &[OperatorAndByteOffset],
         input_wasm: &'a [u8],
     ) -> Result<Function>;
 

--- a/crates/wasm-mutate/src/mutators/codemotion/if_complement.rs
+++ b/crates/wasm-mutate/src/mutators/codemotion/if_complement.rs
@@ -37,7 +37,7 @@ impl IfComplementWriter {
         then: &[usize],
         alternative: &Option<Vec<usize>>,
         newfunc: &mut wasm_encoder::Function,
-        operators: &Vec<crate::mutators::OperatorAndByteOffset>,
+        operators: &[crate::mutators::OperatorAndByteOffset],
         input_wasm: &'a [u8],
         ty: &wasmparser::BlockType,
     ) -> crate::Result<()> {
@@ -73,7 +73,7 @@ impl AstWriter for IfComplementWriter {
         then: &[usize],
         alternative: &Option<Vec<usize>>,
         newfunc: &mut wasm_encoder::Function,
-        operators: &Vec<crate::mutators::OperatorAndByteOffset>,
+        operators: &[crate::mutators::OperatorAndByteOffset],
         input_wasm: &'a [u8],
         ty: &wasmparser::BlockType,
     ) -> crate::Result<()> {
@@ -114,7 +114,7 @@ impl AstMutator for IfComplementMutator {
         config: &'a mut WasmMutate,
         ast: &Ast,
         locals: &[(u32, ValType)],
-        operators: &Vec<OperatorAndByteOffset>,
+        operators: &[OperatorAndByteOffset],
         input_wasm: &'a [u8],
     ) -> crate::Result<Function> {
         // Select the if index

--- a/crates/wasm-mutate/src/mutators/codemotion/ir.rs
+++ b/crates/wasm-mutate/src/mutators/codemotion/ir.rs
@@ -26,7 +26,7 @@ pub trait AstWriter {
         nodeidx: usize,
         body: &[usize],
         newfunc: &mut Function,
-        operators: &Vec<OperatorAndByteOffset>,
+        operators: &[OperatorAndByteOffset],
         input_wasm: &'a [u8],
         ty: &BlockType,
     ) -> crate::Result<()> {
@@ -43,7 +43,7 @@ pub trait AstWriter {
         _nodeidx: usize,
         body: &[usize],
         newfunc: &mut Function,
-        operators: &Vec<OperatorAndByteOffset>,
+        operators: &[OperatorAndByteOffset],
         input_wasm: &'a [u8],
         ty: &BlockType,
     ) -> crate::Result<()> {
@@ -65,7 +65,7 @@ pub trait AstWriter {
         _nodeidx: usize,
         body: &[usize],
         newfunc: &mut Function,
-        operators: &Vec<OperatorAndByteOffset>,
+        operators: &[OperatorAndByteOffset],
         input_wasm: &'a [u8],
         ty: &BlockType,
     ) -> crate::Result<()> {
@@ -91,7 +91,7 @@ pub trait AstWriter {
         nodeidx: usize,
         body: &[usize],
         newfunc: &mut Function,
-        operators: &Vec<OperatorAndByteOffset>,
+        operators: &[OperatorAndByteOffset],
         input_wasm: &'a [u8],
         ty: &BlockType,
     ) -> crate::Result<()> {
@@ -111,7 +111,7 @@ pub trait AstWriter {
         then: &[usize],
         alternative: &Option<Vec<usize>>,
         newfunc: &mut Function,
-        operators: &Vec<OperatorAndByteOffset>,
+        operators: &[OperatorAndByteOffset],
         input_wasm: &'a [u8],
         ty: &BlockType,
     ) -> crate::Result<()> {
@@ -138,7 +138,7 @@ pub trait AstWriter {
         then: &[usize],
         alternative: &Option<Vec<usize>>,
         newfunc: &mut Function,
-        operators: &Vec<OperatorAndByteOffset>,
+        operators: &[OperatorAndByteOffset],
         input_wasm: &'a [u8],
         ty: &BlockType,
     ) -> crate::Result<()> {
@@ -171,7 +171,7 @@ pub trait AstWriter {
         _nodeidx: usize,
         range: Range,
         newfunc: &mut Function,
-        operators: &Vec<OperatorAndByteOffset>,
+        operators: &[OperatorAndByteOffset],
         input_wasm: &'a [u8],
     ) -> crate::Result<()> {
         let operator_range = (range.start, range.end);
@@ -194,7 +194,7 @@ pub trait AstWriter {
         nodeidx: usize,
         range: Range,
         newfunc: &mut Function,
-        operators: &Vec<OperatorAndByteOffset>,
+        operators: &[OperatorAndByteOffset],
         input_wasm: &'a [u8],
     ) -> crate::Result<()> {
         self.write_code(ast, nodeidx, range, newfunc, operators, input_wasm)
@@ -208,7 +208,7 @@ pub trait AstWriter {
         ast: &Ast,
         nodeidx: usize,
         newfunc: &mut Function,
-        operators: &Vec<OperatorAndByteOffset>,
+        operators: &[OperatorAndByteOffset],
         input_wasm: &'a [u8],
     ) -> crate::Result<()> {
         let node = &ast.get_nodes()[nodeidx];

--- a/crates/wasm-mutate/src/mutators/codemotion/loop_unrolling.rs
+++ b/crates/wasm-mutate/src/mutators/codemotion/loop_unrolling.rs
@@ -56,7 +56,7 @@ impl LoopUnrollWriter {
         ast: &Ast,
         nodeidx: usize,
         newfunc: &mut Function,
-        operators: &Vec<OperatorAndByteOffset>,
+        operators: &[OperatorAndByteOffset],
         input_wasm: &'a [u8],
     ) -> crate::Result<()> {
         let nodes = ast.get_nodes();
@@ -156,7 +156,7 @@ impl AstWriter for LoopUnrollWriter {
         nodeidx: usize,
         body: &[usize],
         newfunc: &mut Function,
-        operators: &Vec<OperatorAndByteOffset>,
+        operators: &[OperatorAndByteOffset],
         input_wasm: &'a [u8],
         ty: &wasmparser::BlockType,
     ) -> crate::Result<()> {
@@ -171,7 +171,7 @@ impl AstWriter for LoopUnrollWriter {
 
 impl LoopUnrollMutator {
     /// Returns the indexes of empty return loop definitions inside the Wasm function
-    pub fn get_empty_returning_loops<'a>(&self, ast: &'a Ast) -> Vec<usize> {
+    pub fn get_empty_returning_loops(&self, ast: &'_ Ast) -> Vec<usize> {
         let nodes = ast.get_nodes();
         let mut loops = vec![];
         for idx in ast.get_loops() {
@@ -204,7 +204,7 @@ impl AstMutator for LoopUnrollMutator {
         config: &'a mut WasmMutate,
         ast: &Ast,
         locals: &[(u32, ValType)],
-        operators: &Vec<OperatorAndByteOffset>,
+        operators: &[OperatorAndByteOffset],
         input_wasm: &'a [u8],
     ) -> crate::Result<Function> {
         // Select the if index

--- a/crates/wasm-mutate/src/mutators/function_body_unreachable.rs
+++ b/crates/wasm-mutate/src/mutators/function_body_unreachable.rs
@@ -92,6 +92,6 @@ mod tests {
         let wasm = b"\x00\x61\x73\x6d\x01\x00\x00\x00\x0a\x02\x00\x0b";
         let mut config = crate::WasmMutate::default();
         config.setup(wasm).unwrap();
-        assert_eq!(FunctionBodyUnreachable.can_mutate(&config), false);
+        assert!(!FunctionBodyUnreachable.can_mutate(&config));
     }
 }

--- a/crates/wasm-mutate/src/mutators/peephole.rs
+++ b/crates/wasm-mutate/src/mutators/peephole.rs
@@ -307,7 +307,7 @@ impl PeepholeMutator {
                         // Needed globals
                         let mut new_global_section = GlobalSection::new();
                         // Reparse and reencode global section
-                        if let Some(_) = config.info().globals {
+                        if config.info().globals.is_some() {
                             // If the global section was already there, try to copy it to the
                             // new raw section
                             let global_section = config.info().get_global_section();
@@ -325,7 +325,7 @@ impl PeepholeMutator {
                             }
                         }
 
-                        if needed_resources.len() > 0 {
+                        if !needed_resources.is_empty() {
                             log::trace!("Adding {} additional resources", needed_resources.len());
                         }
 
@@ -387,7 +387,7 @@ impl PeepholeMutator {
                             move |index, _sectionid, module: &mut wasm_encoder::Module| {
                                 if insert_globals_before == index
                             // Write if needed or if it wasm in the init Wasm
-                            && (new_global_section.len() > 0 || global_index.is_some() )
+                            && (!new_global_section.is_empty() || global_index.is_some() )
                                 {
                                     // Insert the new globals here
                                     module.section(&new_global_section);
@@ -584,11 +584,7 @@ mod tests {
                     let eclass = &egraph[subst[var]];
                     if eclass.nodes.len() == 1 {
                         let node = &eclass.nodes[0];
-                        match node {
-                            Lang::I32(_) => true,
-                            Lang::I64(_) => true,
-                            _ => false,
-                        }
+                        matches!(node, Lang::I32(_) | Lang::I64(_))
                     } else {
                         false
                     }
@@ -941,7 +937,7 @@ mod tests {
 
         let can_mutate = mutator.can_mutate(&wasmmutate);
 
-        assert_eq!(can_mutate, true);
+        assert!(can_mutate);
         let rules = mutator.get_rules(&wasmmutate);
 
         for mutated in mutator.mutate_with_rules(&mut wasmmutate, &rules).unwrap() {

--- a/crates/wasm-mutate/src/mutators/peephole/dfg.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/dfg.rs
@@ -87,8 +87,7 @@ impl MiniDFG {
         colors
             .get(0)
             .map(|&val| colors.iter().all(|&x| x == val))
-            .or(Some(false))
-            .unwrap()
+            .unwrap_or(false)
     }
 
     /// Return true if the coloring of the children subtrees is the same as the root
@@ -138,7 +137,7 @@ impl MiniDFG {
             builder: &mut String,
         ) {
             let entry = &minidfg.entries[entryidx];
-            builder.push_str(&(&preffix).to_string());
+            builder.push_str((&preffix).as_ref());
             let color = get_ansi_term_color(entry.color);
             builder.push_str(
                 format!(
@@ -369,9 +368,13 @@ impl<'a> DFGBuilder {
         // the stack. If an operator is missing in the stack then it probably
         // comes from a previous BB.
 
-        for idx in basicblock.range.start..basicblock.range.end {
+        for (idx, (operator, _)) in operators
+            .iter()
+            .enumerate()
+            .take(basicblock.range.end)
+            .skip(basicblock.range.start)
+        {
             // We dont care about the jump
-            let (operator, _) = &operators[idx];
             // Check if it is not EOF
 
             match operator {

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/analysis.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/analysis.rs
@@ -545,10 +545,6 @@ impl PartialEq for ClassData {
     fn eq(&self, other: &Self) -> bool {
         self.tpe == other.tpe
     }
-
-    fn ne(&self, other: &Self) -> bool {
-        !self.eq(other)
-    }
 }
 
 impl Analysis<Lang> for PeepholeMutationAnalysis {

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/expr_enumerator.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/expr_enumerator.rs
@@ -67,7 +67,7 @@ pub fn lazy_expand<'a>(
 
     let t = indices
         .map(move |i| nodes[i].clone())
-        .map(move |mut l| {
+        .flat_map(move |mut l| {
             let depth = match l {
                 // This is a patch to avoid expansion of non-statically known
                 // values.
@@ -150,8 +150,7 @@ pub fn lazy_expand<'a>(
                 }
             };
             iter
-        })
-        .flatten();
+        });
     Box::new(t)
 }
 
@@ -249,7 +248,7 @@ mod tests {
         let mut it = lazy_expand(root, Rc::new(egraph), 10, rnd, recexpr);
         let mut h: HashMap<String, usize> = HashMap::new();
         for _ in 0..100000 {
-            if let Some(_) = it.next() {
+            if it.next().is_some() {
                 let t = format!("{}", r.borrow());
 
                 assert!(!h.contains_key(&t));

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
@@ -175,7 +175,7 @@ macro_rules! lang {
     (@from_op_str $op:ident $children:ident $name:tt $lang:ident :: $case:ident) => ({
         if $op == $name {
             if $children.len() != 0 {
-                return Err(format!("expected zero children"))
+                return Err("expected zero children".to_string())
             }
             return Ok($lang::$case);
         }
@@ -211,7 +211,7 @@ macro_rules! lang {
                     // node has no children. Verify as such and then parse the
                     // suffix for the static information.
                     if $children.len() != 0 {
-                        return Err(format!("expected zero children"))
+                        return Err("expected zero children".to_string())
                     }
                     return Ok($lang::$case(
                         match suffix.parse() {
@@ -1050,22 +1050,22 @@ impl FromStr for MemArg {
         let mut parts = s.split('.');
         let static_offset = parts
             .next()
-            .ok_or_else(|| format!("expected more static instr info"))?
+            .ok_or_else(|| "expected more static instr info".to_string())?
             .parse::<u64>()
             .map_err(|e| e.to_string())?;
         let align = parts
             .next()
-            .ok_or_else(|| format!("expected more static instr info"))?
+            .ok_or_else(|| "expected more static instr info".to_string())?
             .parse::<u8>()
             .map_err(|e| e.to_string())?;
         let mem = parts
             .next()
-            .ok_or_else(|| format!("expected more static instr info"))?
+            .ok_or_else(|| "expected more static instr info".to_string())?
             .parse::<u32>()
             .map_err(|e| e.to_string())?;
 
         if parts.next().is_some() {
-            return Err(format!("too much info after instruction"));
+            return Err("too much info after instruction".to_string());
         }
 
         Ok(MemArg {
@@ -1096,16 +1096,15 @@ impl FromStr for MemArgLane {
         let mut parts = s.rsplitn(2, '.');
         let lane = parts
             .next()
-            .ok_or_else(|| format!("expected more static instr info"))?
+            .ok_or_else(|| "expected more static instr info".to_string())?
             .parse::<u8>()
             .map_err(|e| e.to_string())?;
         let memarg = parts
             .next()
-            .ok_or_else(|| format!("expected more static instr info"))?
-            .parse::<MemArg>()
-            .map_err(|e| e.to_string())?;
+            .ok_or_else(|| "expected more static instr info".to_string())?
+            .parse::<MemArg>()?;
         if parts.next().is_some() {
-            return Err(format!("too much info after instruction"));
+            return Err("too much info after instruction".to_string());
         }
 
         Ok(MemArgLane { lane, memarg })
@@ -1170,17 +1169,17 @@ where
     let mut parts = s.split('.');
     let t = parts
         .next()
-        .ok_or_else(|| format!("expected more static instr info"))?
+        .ok_or_else(|| "expected more static instr info".to_string())?
         .parse::<T>()
         .map_err(|e| e.to_string())?;
     let u = parts
         .next()
-        .ok_or_else(|| format!("expected more static instr info"))?
+        .ok_or_else(|| "expected more static instr info".to_string())?
         .parse::<U>()
         .map_err(|e| e.to_string())?;
 
     if parts.next().is_some() {
-        return Err(format!("too much info after instruction"));
+        return Err("too much info after instruction".to_string());
     }
 
     Ok((t, u))
@@ -1310,7 +1309,7 @@ mod tests {
             [Lang::RefNull(RefType::Func), Lang::RefNull(RefType::Extern)],
         ];
         for [l, r] in pairs {
-            assert_eq!(l.matches(&r), false);
+            assert!(!l.matches(&r));
         }
     }
 }

--- a/crates/wasm-mutate/src/mutators/peephole/rules.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/rules.rs
@@ -646,13 +646,10 @@ impl PeepholeMutator {
                     let eclass = &egraph[subst[var]];
                     if eclass.nodes.len() == 1 {
                         let node = &eclass.nodes[0];
-                        match node {
-                            Lang::I32(_) => true,
-                            Lang::I64(_) => true,
-                            Lang::F32(_) => true,
-                            Lang::F64(_) => true,
-                            _ => false,
-                        }
+                        matches!(
+                            node,
+                            Lang::I32(_) | Lang::I64(_) | Lang::F32(_) | Lang::F64(_)
+                        )
                     } else {
                         false
                     }

--- a/crates/wasm-mutate/src/mutators/remove_item.rs
+++ b/crates/wasm-mutate/src/mutators/remove_item.rs
@@ -430,6 +430,7 @@ impl Translator for RemoveItem {
             }
         }
 
+        #[allow(clippy::if_same_then_else)]
         if item != self.item {
             // Different kind of item, no change
             Ok(idx)

--- a/crates/wasm-mutate/src/mutators/snip_function.rs
+++ b/crates/wasm-mutate/src/mutators/snip_function.rs
@@ -118,6 +118,6 @@ mod tests {
         let wasm = b"\x00\x61\x73\x6d\x01\x00\x00\x00\x0a\x02\x00\x0b";
         let mut config = crate::WasmMutate::default();
         config.setup(wasm).unwrap();
-        assert_eq!(SnipMutator.can_mutate(&config), false);
+        assert!(!SnipMutator.can_mutate(&config));
     }
 }

--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -102,8 +102,8 @@ pub trait Translator {
         memarg(self.as_obj(), arg)
     }
 
-    fn remap(&mut self, item: Item, idx: u32) -> Result<u32> {
-        drop(item);
+    fn remap(&mut self, _item: Item, idx: u32) -> Result<u32> {
+        // TODO: Item impl Copy;    drop(item);
         Ok(idx)
     }
 }

--- a/crates/wasm-shrink/src/lib.rs
+++ b/crates/wasm-shrink/src/lib.rs
@@ -10,7 +10,7 @@ use rand::{rngs::SmallRng, Rng, SeedableRng};
 use wasm_mutate::WasmMutate;
 
 #[rustfmt::skip]
-static EMPTY_WASM: &'static [u8] = &[
+static EMPTY_WASM: &[u8] = &[
     // Magic.
     0x00, b'a', b's', b'm',
     // Version.
@@ -81,8 +81,10 @@ pub struct WasmShrink {
     seed: u64,
 
     #[cfg_attr(feature = "clap", clap(skip))]
-    on_new_smallest: Option<Box<dyn FnMut(&[u8]) -> Result<()>>>,
+    on_new_smallest: Option<Box<FnOnNewSmallest>>,
 }
+
+type FnOnNewSmallest = dyn FnMut(&[u8]) -> Result<()>;
 
 impl Default for WasmShrink {
     fn default() -> Self {
@@ -121,10 +123,7 @@ impl WasmShrink {
 
     /// Set the callback that is called each time we discover a new smallest
     /// test case that is interesting.
-    pub fn on_new_smallest(
-        mut self,
-        on_new_smallest: Option<Box<dyn FnMut(&[u8]) -> Result<()>>>,
-    ) -> WasmShrink {
+    pub fn on_new_smallest(mut self, on_new_smallest: Option<Box<FnOnNewSmallest>>) -> WasmShrink {
         self.on_new_smallest = on_new_smallest;
         self
     }

--- a/crates/wasm-smith/src/component/encode.rs
+++ b/crates/wasm-smith/src/component/encode.rs
@@ -136,10 +136,7 @@ impl Type {
             }
             Type::Func(func_ty) => {
                 enc.function(
-                    func_ty
-                        .params
-                        .iter()
-                        .map(|p| translate_optional_named_type(p)),
+                    func_ty.params.iter().map(translate_optional_named_type),
                     func_ty.result,
                 );
             }
@@ -158,13 +155,13 @@ impl InterfaceType {
         match self {
             InterfaceType::Primitive(ty) => enc.primitive(*ty),
             InterfaceType::Record(ty) => {
-                enc.record(ty.fields.iter().map(|f| translate_named_type(f)));
+                enc.record(ty.fields.iter().map(translate_named_type));
             }
             InterfaceType::Variant(ty) => {
                 enc.variant(
                     ty.cases
                         .iter()
-                        .map(|(ty, default_to)| (ty.name.as_str(), ty.ty, default_to.clone())),
+                        .map(|(ty, default_to)| (ty.name.as_str(), ty.ty, *default_to)),
                 );
             }
             InterfaceType::List(ty) => {

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -400,7 +400,7 @@ impl Module {
     }
 
     fn can_add_local_or_import_func(&self) -> bool {
-        self.func_types.len() > 0 && self.funcs.len() < self.config.max_funcs()
+        !self.func_types.is_empty() && self.funcs.len() < self.config.max_funcs()
     }
 
     fn can_add_local_or_import_table(&self) -> bool {
@@ -487,9 +487,9 @@ impl Module {
             match &ty {
                 EntityType::Tag(ty) => self.tags.push(ty.clone()),
                 EntityType::Func(idx, ty) => self.funcs.push((Some(*idx), ty.clone())),
-                EntityType::Global(ty) => self.globals.push(ty.clone()),
-                EntityType::Table(ty) => self.tables.push(ty.clone()),
-                EntityType::Memory(ty) => self.memories.push(ty.clone()),
+                EntityType::Global(ty) => self.globals.push(*ty),
+                EntityType::Table(ty) => self.tables.push(*ty),
+                EntityType::Memory(ty) => self.memories.push(*ty),
             }
 
             self.num_imports += 1;
@@ -511,9 +511,9 @@ impl Module {
 
     fn type_of(&self, item: &Export) -> EntityType {
         match *item {
-            Export::Global(idx) => EntityType::Global(self.globals[idx as usize].clone()),
-            Export::Memory(idx) => EntityType::Memory(self.memories[idx as usize].clone()),
-            Export::Table(idx) => EntityType::Table(self.tables[idx as usize].clone()),
+            Export::Global(idx) => EntityType::Global(self.globals[idx as usize]),
+            Export::Memory(idx) => EntityType::Memory(self.memories[idx as usize]),
+            Export::Table(idx) => EntityType::Table(self.tables[idx as usize]),
             Export::Function(idx) => {
                 let (_idx, ty) = &self.funcs[idx as usize];
                 EntityType::Func(u32::max_value(), ty.clone())
@@ -533,7 +533,7 @@ impl Module {
         }
     }
 
-    fn func_types<'a>(&'a self) -> impl Iterator<Item = (u32, &'a FuncType)> + 'a {
+    fn func_types(&self) -> impl Iterator<Item = (u32, &'_ FuncType)> + '_ {
         self.func_types
             .iter()
             .copied()
@@ -546,14 +546,14 @@ impl Module {
         }
     }
 
-    fn tags<'a>(&'a self) -> impl Iterator<Item = (u32, &'a TagType)> + 'a {
+    fn tags<'a>(&'a self) -> impl Iterator<Item = (u32, &'_ TagType)> + '_ {
         self.tags
             .iter()
             .enumerate()
             .map(move |(i, ty)| (i as u32, ty))
     }
 
-    fn funcs<'a>(&'a self) -> impl Iterator<Item = (u32, &'a Rc<FuncType>)> + 'a {
+    fn funcs<'a>(&'a self) -> impl Iterator<Item = (u32, &'_ Rc<FuncType>)> + '_ {
         self.funcs
             .iter()
             .enumerate()
@@ -564,11 +564,11 @@ impl Module {
         self.tag_func_types().next().is_some()
     }
 
-    fn tag_func_types<'a>(&'a self) -> impl Iterator<Item = u32> + 'a {
+    fn tag_func_types<'a>(&'a self) -> impl Iterator<Item = u32> + '_ {
         self.func_types
             .iter()
             .copied()
-            .filter(move |i| self.func_type(*i).results.len() == 0)
+            .filter(move |i| self.func_type(*i).results.is_empty())
     }
 
     fn arbitrary_valtype(&self, u: &mut Unstructured) -> Result<ValType> {
@@ -655,8 +655,7 @@ impl Module {
     }
 
     fn arbitrary_globals(&mut self, u: &mut Unstructured) -> Result<()> {
-        let mut choices: Vec<Box<dyn Fn(&mut Unstructured, ValType) -> Result<Instruction>>> =
-            vec![];
+        let mut choices: Vec<Box<FnChoice>> = vec![];
         let num_imported_globals = self.globals.len();
 
         arbitrary_loop(
@@ -750,8 +749,8 @@ impl Module {
                 for list in choices.iter_mut() {
                     list.retain(|c| self.type_of(c).size() + 1 < max_size);
                 }
-                choices.retain(|list| list.len() > 0);
-                if choices.len() == 0 {
+                choices.retain(|list| !list.is_empty());
+                if choices.is_empty() {
                     return Ok(false);
                 }
 
@@ -880,10 +879,10 @@ impl Module {
 
                 // Select a kind for this segment now that we know the number of
                 // items the segment will hold.
-                let (kind, max_size_hint) = u.choose(&kind_candidates)?(u)?;
+                let (kind, max_size_hint) = u.choose(kind_candidates)?(u)?;
                 let max = max_size_hint
                     .map(|i| usize::try_from(i).unwrap())
-                    .unwrap_or(self.config.max_elements());
+                    .unwrap_or_else(|| self.config.max_elements());
 
                 // Pick whether we're going to use expression elements or
                 // indices. Note that externrefs must use expressions,
@@ -969,8 +968,7 @@ impl Module {
             return Ok(());
         }
 
-        let mut choices32: Vec<Box<dyn Fn(&mut Unstructured, u64, usize) -> Result<Instruction>>> =
-            vec![];
+        let mut choices32: Vec<Box<FnChoice32>> = vec![];
         choices32.push(Box::new(|u, min_size, data_len| {
             Ok(Instruction::I32Const(arbitrary_offset(
                 u,
@@ -981,8 +979,7 @@ impl Module {
                 data_len,
             )? as i32))
         }));
-        let mut choices64: Vec<Box<dyn Fn(&mut Unstructured, u64, usize) -> Result<Instruction>>> =
-            vec![];
+        let mut choices64: Vec<Box<FnChoice32>> = vec![];
         choices64.push(Box::new(|u, min_size, data_len| {
             Ok(Instruction::I64Const(arbitrary_offset(
                 u,
@@ -1025,7 +1022,7 @@ impl Module {
         // With memories we can generate data segments, and with bulk memory we
         // can generate passive segments. Without these though we can't create
         // a valid module with data segments.
-        if memories.len() == 0 && !self.config.bulk_memory_enabled() {
+        if memories.is_empty() && !self.config.bulk_memory_enabled() {
             return Ok(());
         }
 
@@ -1075,6 +1072,9 @@ impl Module {
         }
     }
 }
+
+type FnChoice = dyn Fn(&mut Unstructured, ValType) -> Result<Instruction>;
+type FnChoice32 = dyn Fn(&mut Unstructured, u64, usize) -> Result<Instruction>;
 
 pub(crate) fn arbitrary_limits32(
     u: &mut Unstructured,
@@ -1250,13 +1250,13 @@ fn gradually_grow(u: &mut Unstructured, min: u64, max_inbounds: u64, max: u64) -
             output.end
         );
 
-        let x = map_linear(value, input.clone(), 0.0..1.0);
+        let x = map_linear(value, input, 0.0..1.0);
         let result = if x < PCT_INBOUNDS {
             if output_inbounds.start == output_inbounds.end {
                 output_inbounds.start
             } else {
                 let unscaled = x * x * x * x * x * x;
-                map_linear(unscaled, 0.0..1.0, output_inbounds.clone())
+                map_linear(unscaled, 0.0..1.0, output_inbounds)
             }
         } else {
             map_linear(x, 0.0..1.0, output.clone())

--- a/crates/wasm-smith/src/core/encode.rs
+++ b/crates/wasm-smith/src/core/encode.rs
@@ -50,7 +50,7 @@ impl Module {
     fn encode_imports(&self, module: &mut wasm_encoder::Module, imports: &[Import]) {
         let mut section = wasm_encoder::ImportSection::new();
         for Import(module, name, ty) in imports {
-            section.import(module, &name, translate_entity_type(ty));
+            section.import(module, name, translate_entity_type(ty));
         }
         module.section(&section);
     }

--- a/crates/wasm-smith/src/core/terminate.rs
+++ b/crates/wasm-smith/src/core/terminate.rs
@@ -1,5 +1,5 @@
 use super::*;
-use std::mem;
+
 use wasm_encoder::BlockType;
 
 impl Module {
@@ -50,7 +50,7 @@ impl Module {
             // recursion.
             check_fuel(&mut new_insts);
 
-            for inst in mem::replace(instrs, vec![]) {
+            for inst in std::mem::take(instrs) {
                 let is_loop = matches!(&inst, Instruction::Loop(_));
                 new_insts.push(inst);
 

--- a/crates/wasm-smith/src/lib.rs
+++ b/crates/wasm-smith/src/lib.rs
@@ -103,10 +103,10 @@ pub(crate) fn arbitrary_loop<'a>(
 pub(crate) fn limited_str<'a>(max_size: usize, u: &mut Unstructured<'a>) -> Result<&'a str> {
     let size = u.arbitrary_len::<u8>()?;
     let size = std::cmp::min(size, max_size);
-    match str::from_utf8(&u.peek_bytes(size).unwrap()) {
+    match str::from_utf8(u.peek_bytes(size).unwrap()) {
         Ok(s) => {
             u.bytes(size).unwrap();
-            Ok(s.into())
+            Ok(s)
         }
         Err(e) => {
             let i = e.valid_up_to();

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -2077,12 +2077,11 @@ impl OperatorValidator {
     }
 
     pub fn finish(&mut self) -> OperatorValidatorResult<()> {
-        if let Some(last) = self.control.last() {
+        if let Some(_last) = self.control.pop() {
             // match last.kind {
             //     FrameKind::Block | FrameKind::If | FrameKind::Else
             // }
             // bail_op_err!("control frames remain at end of function");
-            drop(last);
             bail_op_err!("control frames remain at end of function: END opcode expected");
         }
         Ok(())

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -33,13 +33,15 @@ pub fn print_bytes(wasm: impl AsRef<[u8]>) -> Result<String> {
     Printer::new().print(wasm.as_ref())
 }
 
+type FnPrinter = dyn FnMut(&mut Printer, usize, &[u8]) -> Result<()>;
+
 /// Context used for printing a WebAssembly binary.
 ///
 /// This is largely only required if you'd like to register custom printers for
 /// custom sections in a wasm binary.
 #[derive(Default)]
 pub struct Printer {
-    printers: HashMap<String, Box<dyn FnMut(&mut Printer, usize, &[u8]) -> Result<()>>>,
+    printers: HashMap<String, Box<FnPrinter>>,
     result: String,
     nesting: u32,
     line: usize,

--- a/crates/wast/src/ast/memory.rs
+++ b/crates/wast/src/ast/memory.rs
@@ -60,11 +60,7 @@ impl<'a> Parse<'a> for Memory<'a> {
         } else if l.peek::<ast::LParen>() || parser.peek2::<ast::LParen>() {
             let is_32 = if parser.parse::<Option<kw::i32>>()?.is_some() {
                 true
-            } else if parser.parse::<Option<kw::i64>>()?.is_some() {
-                false
-            } else {
-                true
-            };
+            } else { parser.parse::<Option<kw::i64>>()?.is_none() };
             let data = parser.parens(|parser| {
                 parser.parse::<kw::data>()?;
                 let mut data = Vec::new();
@@ -217,6 +213,11 @@ impl DataVal<'_> {
             DataVal::String(s) => s.len(),
             DataVal::Integral(s) => s.len(),
         }
+    }
+
+    /// Return whether the memory this data used is empty
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
     /// Pushes the value of this data value onto the provided list of bytes.

--- a/crates/wast/src/ast/token.rs
+++ b/crates/wast/src/ast/token.rs
@@ -152,10 +152,7 @@ impl Index<'_> {
     }
 
     pub(crate) fn is_resolved(&self) -> bool {
-        match self {
-            Index::Num(..) => true,
-            _ => false,
-        }
+        matches!(self, Index::Num(..))
     }
 }
 
@@ -245,7 +242,7 @@ impl<'a, K> ItemRef<'a, K> {
     pub fn unwrap_index(&self) -> &Index<'a> {
         match self {
             ItemRef::Item { idx, exports, .. } => {
-                debug_assert!(exports.len() == 0);
+                debug_assert!(exports.is_empty());
                 idx
             }
             ItemRef::Outer { .. } => panic!("unwrap_index called on Parent"),

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -45,6 +45,7 @@
 //! [`Parse`]: parser::Parse
 //! [`LexError`]: lexer::LexError
 
+#![allow(clippy::field_reassign_with_default)]
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 
 use std::fmt;
@@ -109,7 +110,7 @@ impl Error {
             }),
         };
         ret.set_text(content);
-        return ret;
+        ret
     }
 
     fn parse(span: Span, content: &str, message: String) -> Error {
@@ -122,7 +123,7 @@ impl Error {
             }),
         };
         ret.set_text(content);
-        return ret;
+        ret
     }
 
     /// Creates a new error with the given `message` which is targeted at the

--- a/crates/wast/tests/annotations.rs
+++ b/crates/wast/tests/annotations.rs
@@ -76,17 +76,14 @@ fn assert_local_name(name: &str, wat: &str) -> anyhow::Result<()> {
     let wasm = wat::parse_str(wat)?;
     let mut found = false;
     for s in get_name_section(&wasm)? {
-        match s? {
-            Name::Local(n) => {
-                let mut reader = n.get_indirect_map()?;
-                let section = reader.read()?;
-                let mut map = section.get_map()?;
-                let naming = map.read()?;
-                assert_eq!(naming.index, 0);
-                assert_eq!(naming.name, name);
-                found = true;
-            }
-            _ => {}
+        if let Name::Local(n) = s? {
+            let mut reader = n.get_indirect_map()?;
+            let section = reader.read()?;
+            let mut map = section.get_map()?;
+            let naming = map.read()?;
+            assert_eq!(naming.index, 0);
+            assert_eq!(naming.name, name);
+            found = true;
         }
     }
     assert!(found);
@@ -94,7 +91,7 @@ fn assert_local_name(name: &str, wat: &str) -> anyhow::Result<()> {
 }
 
 fn get_name_section(wasm: &[u8]) -> anyhow::Result<NameSectionReader<'_>> {
-    for payload in Parser::new(0).parse_all(&wasm) {
+    for payload in Parser::new(0).parse_all(wasm) {
         if let Payload::CustomSection {
             name: "name",
             data,

--- a/crates/wast/tests/parse-fail.rs
+++ b/crates/wast/tests/parse-fail.rs
@@ -53,13 +53,13 @@ fn run_test(test: &Path, bless: bool) -> anyhow::Result<()> {
     };
     let assert = test.with_extension("wat.err");
     if bless {
-        std::fs::write(assert, err.to_string())?;
+        std::fs::write(assert, &err)?;
         return Ok(());
     }
 
     // Ignore CRLF line ending and force always `\n`
     let assert = std::fs::read_to_string(assert)
-        .unwrap_or(String::new())
+        .unwrap_or_default()
         .replace("\r\n", "\n");
 
     // Compare normalize verisons which handles weirdness like path differences
@@ -74,11 +74,11 @@ fn run_test(test: &Path, bless: bool) -> anyhow::Result<()> {
     );
 
     fn normalize(s: &str) -> String {
-        s.replace("\\", "/")
+        s.replace('\\', "/")
     }
 
     fn tab(s: &str) -> String {
-        s.replace("\n", "\n\t")
+        s.replace('\n', "\n\t")
     }
 }
 

--- a/crates/wast/tests/recursive.rs
+++ b/crates/wast/tests/recursive.rs
@@ -1,6 +1,6 @@
 #[test]
 fn no_stack_overflow() {
-    let mut s = format!("(module (func \n");
+    let mut s = "(module (func \n".to_string();
     for _ in 0..10_000 {
         s.push_str("(i32.add\n");
     }

--- a/crates/wat/src/lib.rs
+++ b/crates/wat/src/lib.rs
@@ -216,9 +216,9 @@ pub fn parse_str(wat: impl AsRef<str>) -> Result<Vec<u8>> {
 }
 
 fn _parse_str(wat: &str) -> Result<Vec<u8>> {
-    let buf = ParseBuffer::new(&wat).map_err(|e| Error::cvt(e, wat))?;
+    let buf = ParseBuffer::new(wat).map_err(|e| Error::cvt(e, wat))?;
     let mut ast = parser::parse::<wast::Wat>(&buf).map_err(|e| Error::cvt(e, wat))?;
-    Ok(ast.module.encode().map_err(|e| Error::cvt(e, wat))?)
+    ast.module.encode().map_err(|e| Error::cvt(e, wat))
 }
 
 /// A convenience type definition for `Result` where the error is [`Error`]

--- a/src/bin/wasm-tools/objdump.rs
+++ b/src/bin/wasm-tools/objdump.rs
@@ -119,6 +119,6 @@ impl Printer {
         for _ in 0..self.module_code_counts.len() {
             s.push_str("  ");
         }
-        return s;
+        s
     }
 }

--- a/src/bin/wasm-tools/shrink.rs
+++ b/src/bin/wasm-tools/shrink.rs
@@ -175,9 +175,9 @@ impl IsInteresting for OutputIsInteresting {
     }
 }
 
-fn make_predicate<'a>(
-    predicate_script: &'a Path,
-) -> impl FnMut(&[u8]) -> Result<OutputIsInteresting> + 'a {
+fn make_predicate(
+    predicate_script: &'_ Path,
+) -> impl FnMut(&[u8]) -> Result<OutputIsInteresting> + '_ {
     move |wasm| {
         let tmp = NamedTempFile::new().context("Failed to create a temporary file.")?;
         std::fs::write(tmp.path(), wasm).with_context(|| {

--- a/src/bin/wasm-tools/smith.rs
+++ b/src/bin/wasm-tools/smith.rs
@@ -166,7 +166,7 @@ struct Config {
     /// reference, parametric, variable, table, memory, control. Specify
     /// multiple kinds with a comma-separated list: e.g.,
     /// `--allowed-instructions numeric,control,parametric`
-    #[clap(long = "allowed-instructions", use_delimiter = true)]
+    #[clap(long = "allowed-instructions", use_value_delimiter = true)]
     allowed_instructions: Option<Vec<InstructionKind>>,
 }
 

--- a/src/bin/wasm-tools/validate.rs
+++ b/src/bin/wasm-tools/validate.rs
@@ -79,10 +79,12 @@ impl Opts {
     }
 }
 
+type FnWasmFeatureParser = fn(&mut WasmFeatures) -> &mut bool;
+
 fn parse_features(arg: &str) -> Result<WasmFeatures> {
     let mut ret = WasmFeatures::default();
 
-    const FEATURES: &[(&str, fn(&mut WasmFeatures) -> &mut bool)] = &[
+    const FEATURES: &[(&str, FnWasmFeatureParser)] = &[
         ("reference-types", |f| &mut f.reference_types),
         ("simd", |f| &mut f.simd),
         ("threads", |f| &mut f.threads),
@@ -103,7 +105,7 @@ fn parse_features(arg: &str) -> Result<WasmFeatures> {
     ];
 
     for part in arg.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()) {
-        let (enable, part) = if let Some(part) = part.strip_prefix("-") {
+        let (enable, part) = if let Some(part) = part.strip_prefix('-') {
             (false, part)
         } else {
             (true, part)

--- a/tests/dump.rs
+++ b/tests/dump.rs
@@ -59,7 +59,7 @@ fn run_test(test: &Path, bless: bool) -> Result<()> {
 
     // Ignore CRLF line ending and force always `\n`
     let assert = std::fs::read_to_string(assert)
-        .unwrap_or(String::new())
+        .unwrap_or_default()
         .replace("\r\n", "\n");
 
     let mut bad = false;
@@ -68,20 +68,20 @@ fn run_test(test: &Path, bless: bool) -> Result<()> {
         match diff {
             diff::Result::Left(s) => {
                 bad = true;
-                result.push_str("-");
+                result.push('-');
                 result.push_str(s);
             }
             diff::Result::Right(s) => {
                 bad = true;
-                result.push_str("+");
+                result.push('+');
                 result.push_str(s);
             }
             diff::Result::Both(s, _) => {
-                result.push_str(" ");
+                result.push(' ');
                 result.push_str(s);
             }
         }
-        result.push_str("\n");
+        result.push('\n');
     }
     if bad {
         bail!(

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -46,7 +46,7 @@ fn main() {
                 }
             }
             let contents = std::fs::read(test).unwrap();
-            if skip_test(&test, &contents) {
+            if skip_test(test, &contents) {
                 None
             } else {
                 Some((test, contents))
@@ -250,7 +250,7 @@ impl TestState {
                 err.set_text(contents);
             }
             s.push_str("\n\n\t--------------------------------\n\n\t");
-            s.push_str(&format!("{:?}", error).replace("\n", "\n\t"));
+            s.push_str(&format!("{:?}", error).replace('\n', "\n\t"));
         }
         bail!("{}", s)
     }
@@ -377,7 +377,7 @@ impl TestState {
                 Ok(s) => ret.push_str(s),
                 Err(_) => bail!("malformed UTF-8 encoding"),
             }
-            ret.push_str(" ");
+            ret.push(' ');
         }
         let buf = ParseBuffer::new(&ret)?;
         let mut wat = parser::parse::<Wat>(&buf)?;
@@ -418,7 +418,7 @@ impl TestState {
             .find(|((_, actual), expected)| actual != expected);
         let pos = match difference {
             Some(((pos, _), _)) => format!("at byte {} ({0:#x})", pos),
-            None => format!("by being too small"),
+            None => "by being too small".to_string(),
         };
         let mut msg = format!("error: actual wasm differs {} from expected wasm\n", pos);
 
@@ -429,8 +429,8 @@ impl TestState {
             msg.push_str(&format!("       | + {:#04x}\n", actual[pos]));
         }
 
-        if let Ok(actual) = wasmparser_dump::dump_wasm(&actual) {
-            if let Ok(expected) = wasmparser_dump::dump_wasm(&expected) {
+        if let Ok(actual) = wasmparser_dump::dump_wasm(actual) {
+            if let Ok(expected) = wasmparser_dump::dump_wasm(expected) {
                 let mut actual = actual.lines();
                 let mut expected = expected.lines();
                 let mut differences = 0;
@@ -447,7 +447,7 @@ impl TestState {
 
                     if actual_state == expected_state {
                         if differences > 0 && !last_dots {
-                            msg.push_str(&format!(" ...\n"));
+                            msg.push_str(" ...\n");
                             last_dots = true;
                         }
                         continue;
@@ -649,5 +649,5 @@ fn error_matches(error: &str, message: &str) -> bool {
         return error.contains("section out of order");
     }
 
-    return false;
+    false
 }


### PR DESCRIPTION
By means of auto-correction and manual modification, I modified the code as suggested by `cargo clippy` to make it pass.

Note in the following sections:

- Some `drop` calls do not work because the parameter is a reference or implements `Copy`. I mark `TODO`, and need further inspection.
- I split some overly complex types, I don't know if this is what you expected.
- `clippy` recommends no more than 7 function parameters, I ignored these suggestions in some crates, I hope you can find a way to fix it later.

Signed-off-by: zu1k <i@zu1k.com>