### PR TITLE
Remove bulk-memory special case for decoding of data sections

### DIFF
--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -836,12 +836,9 @@ impl Validator {
     ///
     /// This method should only be called when parsing a module.
     pub fn data_section(&mut self, section: &crate::DataSectionReader<'_>) -> Result<()> {
-        let mut section = section.clone();
-        section.forbid_bulk_memory(!self.features.bulk_memory);
-
         self.ensure_module_section(
             Order::Data,
-            &section,
+            section,
             "data",
             |state, _, _, count, offset| {
                 state.data_segment_count = count;

--- a/tests/local/missing-features/issue540.wast
+++ b/tests/local/missing-features/issue540.wast
@@ -1,0 +1,33 @@
+(module binary
+  "\00asm\01\00\00\00"    ;; the header
+
+  "\05\06\01"       ;; a memory section with 1 entry
+  "\01\70\e0\ab\02" ;; definition of the 0th memory
+
+  "\0b\08\01"       ;; a data section with 1 entry
+  "\02\00"          ;; data section entry referencing 0th memory using flag 02 encoding.
+  "\41\ca\0f\0b\00" ;; offset and data for the entry
+)
+
+(module binary
+  "\00asm\01\00\00\00"    ;; the header
+
+  "\05\06\01"       ;; a memory section with 1 entry
+  "\01\70\e0\ab\02" ;; a definition of the 0th memory
+
+  "\0b\08\01"       ;; a data section with 1 entry
+  "\80\00"          ;; data section entry referencing 0th memory using a WebAssembly 1.0 encoding
+                    ;; this encoding is not supported in current WebAssembly draft.
+  "\41\ca\0f\0b\00" ;; offset and data for the entry
+)
+
+(module binary
+  "\00asm\01\00\00\00"    ;; the header
+
+  "\04\04\01"             ;; table section with 1 entry
+  "\70\00\00"             ;; no max, minimum 0, funcref
+
+  "\09\08\01"             ;; Element section with 1 entry
+  "\02\00"                ;; Table index 0, using flag 02 encoding
+  "\41\00\0b\00\00"       ;; offset and no elements
+)

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -497,6 +497,7 @@ impl TestState {
                     features.sign_extension = false;
                     features.saturating_float_to_int = false;
                     features.mutable_global = false;
+                    features.bulk_memory = false;
                 }
                 "threads" => {
                     features.threads = true;


### PR DESCRIPTION
Worth noting that this brings the implementation in-line with the one used for the table element section.

Fixes #540