### PR TITLE
Swap order of alias index printing

### DIFF
--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -2501,21 +2501,24 @@ impl Printer {
             self.result.push(' ');
             let index = match kind {
                 OuterAliasKind::Type => {
-                    self.start_group("type");
-                    write!(self.result, " (;{};) ", state.types.len() as u32)?;
                     self.print_idx(&outer.type_names, index)?;
+                    self.result.push(' ');
+                    self.start_group("type ");
+                    self.print_name(&state.type_names, state.types.len() as u32)?;
                     Some(outer.ty(index)?)
                 }
                 OuterAliasKind::Module => {
-                    self.start_group("module ");
-                    write!(self.result, " (;{};) ", state.modules)?;
                     self.print_idx(&outer.module_names, index)?;
+                    self.result.push(' ');
+                    self.start_group("module ");
+                    self.print_name(&state.module_names, state.modules)?;
                     None
                 }
                 OuterAliasKind::Component => {
-                    self.start_group("component ");
-                    write!(self.result, " (;{};) ", state.components.len() as u32)?;
                     self.print_idx(&outer.component_names, index)?;
+                    self.result.push(' ');
+                    self.start_group("component ");
+                    self.print_name(&state.component_names, state.components.len() as u32)?;
                     Some(outer.component(index)?)
                 }
             };


### PR DESCRIPTION
From bytecodealliance/wit-bindgen#183 I realized that the current
explainer has the printing of indices here slightly different where the
outer index/name is outside in the `alias` annotation where the local
name/index is printed inside of the `type` or item container.

This also updates the printing of the local index to attempt to use the
name section, if one is present.