### PR TITLE
Fix a deprecation warning from clap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = ['fuzz', 'crates/wasm-encoder', 'crates/fuzz-stats', 'crates/wasm-muta
 anyhow = "1.0"
 env_logger = "0.9"
 log = "0.4"
-clap = { version = "3.0", features = ['derive'] }
+clap = { version = "3.1.8", features = ['derive'] }
 tempfile = "3.2.0"
 wat = { path = "crates/wat", optional = true, version = '1.0.41' }
 

--- a/src/bin/wasm-tools/smith.rs
+++ b/src/bin/wasm-tools/smith.rs
@@ -166,7 +166,7 @@ struct Config {
     /// reference, parametric, variable, table, memory, control. Specify
     /// multiple kinds with a comma-separated list: e.g.,
     /// `--allowed-instructions numeric,control,parametric`
-    #[clap(long = "allowed-instructions", use_delimiter = true)]
+    #[clap(long = "allowed-instructions", use_value_delimiter = true)]
     allowed_instructions: Option<Vec<InstructionKind>>,
 }
 


### PR DESCRIPTION
I've seen this popping up in builds so apply clap's suggestion.