### PR TITLE
Bump crate version numbers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-tools"
-version = "1.0.3"
+version = "1.0.4"
 authors = ["The Wasmtime Project Developers"]
 edition = "2018"
 description = "CLI tools for interoperating with WebAssembly files"
@@ -21,30 +21,30 @@ env_logger = "0.9"
 log = "0.4"
 clap = { version = "3.1.8", features = ['derive'] }
 tempfile = "3.2.0"
-wat = { path = "crates/wat", optional = true, version = '1.0.41' }
+wat = { path = "crates/wat", optional = true, version = '1.0.42' }
 
 # Dependencies of `validate`
-wasmparser = { path = "crates/wasmparser", optional = true, version = '0.83.0' }
+wasmparser = { path = "crates/wasmparser", optional = true, version = '0.84.0' }
 rayon = { version = "1.0", optional = true }
 
 # Dependencies of `print`
-wasmprinter = { path = "crates/wasmprinter", optional = true, version = '0.2.33' }
+wasmprinter = { path = "crates/wasmprinter", optional = true, version = '0.2.34' }
 
 # Dependencies of `smith`
 arbitrary = { version = "1.0.0", optional = true }
 serde = { version = "1", features = ['derive'], optional = true }
 serde_json = { version = "1", optional = true }
-wasm-smith = { path = "crates/wasm-smith", features = ["_internal_cli"], optional = true, version = '0.9.1' }
+wasm-smith = { path = "crates/wasm-smith", features = ["_internal_cli"], optional = true, version = '0.10.0' }
 
 # Dependencies of `shrink`
-wasm-shrink = { path = "crates/wasm-shrink", features = ["clap"], optional = true, version = '0.1.3' }
+wasm-shrink = { path = "crates/wasm-shrink", features = ["clap"], optional = true, version = '0.1.4' }
 is_executable = { version = "1.0.1", optional = true }
 
 # Dependencies of `mutate`
-wasm-mutate = { path = "crates/wasm-mutate", features = ["clap"], optional = true, version = '0.2.1' }
+wasm-mutate = { path = "crates/wasm-mutate", features = ["clap"], optional = true, version = '0.2.2' }
 
 # Dependencies of `dump`
-wasmparser-dump = { path = "crates/dump", optional = true, version = '0.1.1' }
+wasmparser-dump = { path = "crates/dump", optional = true, version = '0.1.2' }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/crates/dump/Cargo.toml
+++ b/crates/dump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser-dump"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["The Wasmtime Project Developers"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -9,4 +9,4 @@ description = "Utility to dump debug information about the wasm binary format"
 
 [dependencies]
 anyhow = "1"
-wasmparser = { path = "../wasmparser", version = "0.83.0" }
+wasmparser = { path = "../wasmparser", version = "0.84.0" }

--- a/crates/wasm-encoder/Cargo.toml
+++ b/crates/wasm-encoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-encoder"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasm-mutate/Cargo.toml
+++ b/crates/wasm-mutate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-mutate"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-mutate"
@@ -9,8 +9,8 @@ description = "A WebAssembly test case mutator"
 [dependencies]
 clap = { optional = true, version = "3.0", features = ['derive'] }
 thiserror = "1.0.28"
-wasmparser = { version = "0.83.0", path = "../wasmparser" }
-wasm-encoder = { version = "0.10.0", path = "../wasm-encoder"}
+wasmparser = { version = "0.84.0", path = "../wasmparser" }
+wasm-encoder = { version = "0.11.0", path = "../wasm-encoder"}
 rand = { version = "0.8.0", features = ["small_rng"] }
 log = "0.4.14"
 egg = "0.6.0"

--- a/crates/wasm-shrink/Cargo.toml
+++ b/crates/wasm-shrink/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-shrink"
 name = "wasm-shrink"
-version = "0.1.3"
+version = "0.1.4"
 
 [dependencies]
 anyhow = "1"
@@ -16,8 +16,8 @@ blake3 = "1.2.0"
 log = "0.4"
 rand = { version = "0.8.4", features = ["small_rng"] }
 clap = { version = "3.0", optional = true, features = ['derive'] }
-wasm-mutate = { version = "0.2.1", path = "../wasm-mutate" }
-wasmparser = { version = "0.83.0", path = "../wasmparser" }
+wasm-mutate = { version = "0.2.2", path = "../wasm-mutate" }
+wasmparser = { version = "0.84.0", path = "../wasmparser" }
 
 [dev-dependencies]
 env_logger = "0.9"

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "wasm-smith"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-smith"
-version = "0.9.1"
+version = "0.10.0"
 exclude = ["/benches/corpus"]
 
 [[bench]]
@@ -21,8 +21,8 @@ flagset = "0.4"
 indexmap = "1.6"
 leb128 = "0.2.4"
 serde = { version = "1", features = ['derive'], optional = true }
-wasm-encoder = { version = "0.10.0", path = "../wasm-encoder" }
-wasmparser = { version = "0.83", path = "../wasmparser" }
+wasm-encoder = { version = "0.11.0", path = "../wasm-encoder" }
+wasmparser = { version = "0.84", path = "../wasmparser" }
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.83.0"
+version = "0.84.0"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser"

--- a/crates/wasmprinter/Cargo.toml
+++ b/crates/wasmprinter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmprinter"
-version = "0.2.33"
+version = "0.2.34"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -14,7 +14,7 @@ Rust converter from the WebAssembly binary format to the text format.
 
 [dependencies]
 anyhow = "1.0"
-wasmparser = { path = '../wasmparser', version = '0.83.0' }
+wasmparser = { path = '../wasmparser', version = '0.84.0' }
 
 [dev-dependencies]
 diff = "0.1"

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wast"
-version = "39.0.0"
+version = "40.0.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wat/Cargo.toml
+++ b/crates/wat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wat"
-version = "1.0.41"
+version = "1.0.42"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2018"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -13,4 +13,4 @@ Rust parser for the WebAssembly Text format, WAT
 """
 
 [dependencies]
-wast = { path = '../wast', version = '39.0.0' }
+wast = { path = '../wast', version = '40.0.0' }


### PR DESCRIPTION
It's been awhile since we last published and I don't want Wasmtime to
fall too far behind changes such as the removal of module linking. This
commit bumps the version numbers with major version bumps for:

* `wasmparser`
* `wast`
* `wasm-encoder`
* `wasm-smith`

along with necessary minor bumps for everything else