### PR TITLE
Update CI to only have one in-flight build at a time

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,13 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main, component-model]
+    branches: [main]
+
+# Cancel any in-flight jobs for the same PR/branch so there's only one active
+# at a time
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:


### PR DESCRIPTION
Use the same concurrency key that Wasmtime uses to auto-cancel builds of
stale revisions. This should help reduce CI load if a PR is pushed to
multiple times.