### PR TITLE
wasm-smith: no flag encoding in elems w/o feats

### DIFF
--- a/crates/wasm-encoder/src/core/elements.rs
+++ b/crates/wasm-encoder/src/core/elements.rs
@@ -74,8 +74,9 @@ pub enum ElementMode<'a> {
     Active {
         /// The table index.
         ///
-        /// `None` is implicitly table `0`. Non-`None` tables are part of the
-        /// reference types proposal, including `Some(0)`.
+        /// `Active` element specifying a `None` table forces the MVP encoding and refers to the
+        /// 0th table holding `funcref`s. Non-`None` tables use the encoding introduced with the
+        /// bulk memory proposal and can refer to tables with any valid reference type.
         table: Option<u32>,
         /// The offset within the table to place this segment.
         offset: &'a Instruction<'a>,
@@ -184,8 +185,9 @@ impl ElementSection {
 
     /// Define an active element segment.
     ///
-    /// Table `None` is implicitly table `0`. Non-`None` tables are part of the
-    /// reference types proposal, including `Some(0)`.
+    /// `Active` element specifying a `None` table forces the MVP encoding and refers to the 0th
+    /// table holding `funcref`s. Non-`None` tables use the encoding introduced with the bulk
+    /// memory proposal and can refer to tables with any valid reference type.
     pub fn active(
         &mut self,
         table_index: Option<u32>,

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -1091,9 +1091,10 @@ impl Module {
             if i == 0 && ty.element_type == ValType::FuncRef {
                 dst.push(Box::new(move |u| arbitrary_active_elem(u, minimum, None)));
             }
-            dst.push(Box::new(move |u| {
-                arbitrary_active_elem(u, minimum, Some(i as u32))
-            }));
+            if self.config.bulk_memory_enabled() {
+                let idx = Some(i as u32);
+                dst.push(Box::new(move |u| arbitrary_active_elem(u, minimum, idx)));
+            }
         }
 
         // Reference types allows us to create passive and declared element


### PR DESCRIPTION
The encoding used by the `Some` table indices requires the bulk_memory
proposal. This proposal introduced the flag-based encoding, including
the `02` flag.

Sadly I don't think I can write an actual test here, because wasmparser's
binary reader will accept either encoding regardless of the features AFAIK.