### PR TITLE
Start support for component model in `wasm-tools dump`

### DIFF
--- a/crates/dump/src/lib.rs
+++ b/crates/dump/src/lib.rs
@@ -14,6 +14,7 @@ struct Dump<'a> {
     state: String,
     dst: String,
     nesting: u32,
+    offset_width: usize,
 }
 
 #[derive(Default)]
@@ -24,6 +25,10 @@ struct Indices {
     memories: u32,
     tags: u32,
     types: u32,
+    instances: u32,
+    components: u32,
+    modules: u32,
+    values: u32,
 }
 
 const NBYTES: usize = 4;
@@ -36,6 +41,7 @@ impl<'a> Dump<'a> {
             nesting: 0,
             state: String::new(),
             dst: String::new(),
+            offset_width: format!("{:x}", bytes.len()).len() + 1,
         }
     }
 
@@ -61,58 +67,40 @@ impl<'a> Dump<'a> {
                     self.print(range.end)?;
                 }
                 Payload::TypeSection(s) => self.section(s, "type", |me, end, t| {
-                    write!(me.state, "[type {}] {:?}", i.types, t)?;
-                    i.types += 1;
+                    write!(me.state, "[type {}] {:?}", inc(&mut i.types), t)?;
                     me.print(end)
                 })?,
                 Payload::ImportSection(s) => self.section(s, "import", |me, end, imp| {
                     write!(me.state, "import ")?;
                     match imp.ty {
-                        TypeRef::Func(_) => {
-                            write!(me.state, "[func {}]", i.funcs)?;
-                            i.funcs += 1;
-                        }
+                        TypeRef::Func(_) => write!(me.state, "[func {}]", inc(&mut i.funcs))?,
                         TypeRef::Memory(_) => {
-                            write!(me.state, "[memory {}]", i.memories)?;
-                            i.memories += 1;
+                            write!(me.state, "[memory {}]", inc(&mut i.memories))?
                         }
-                        TypeRef::Tag(_) => {
-                            write!(me.state, "[tag {}]", i.tags)?;
-                            i.tags += 1;
-                        }
-                        TypeRef::Table(_) => {
-                            write!(me.state, "[table {}]", i.tables)?;
-                            i.tables += 1;
-                        }
-                        TypeRef::Global(_) => {
-                            write!(me.state, "[global {}]", i.globals)?;
-                            i.globals += 1;
-                        }
+                        TypeRef::Tag(_) => write!(me.state, "[tag {}]", inc(&mut i.tags))?,
+                        TypeRef::Table(_) => write!(me.state, "[table {}]", inc(&mut i.tables))?,
+                        TypeRef::Global(_) => write!(me.state, "[global {}]", inc(&mut i.globals))?,
                     }
                     write!(me.state, " {:?}", imp)?;
                     me.print(end)
                 })?,
                 Payload::FunctionSection(s) => {
-                    let mut cnt = 0;
+                    let mut cnt = i.funcs;
                     self.section(s, "func", |me, end, f| {
-                        write!(me.state, "[func {}] type {:?}", cnt + i.funcs, f)?;
-                        cnt += 1;
+                        write!(me.state, "[func {}] type {:?}", inc(&mut cnt), f)?;
                         me.print(end)
                     })?
                 }
                 Payload::TableSection(s) => self.section(s, "table", |me, end, t| {
-                    write!(me.state, "[table {}] {:?}", i.tables, t)?;
-                    i.tables += 1;
+                    write!(me.state, "[table {}] {:?}", inc(&mut i.tables), t)?;
                     me.print(end)
                 })?,
                 Payload::MemorySection(s) => self.section(s, "memory", |me, end, m| {
-                    write!(me.state, "[memory {}] {:?}", i.memories, m)?;
-                    i.memories += 1;
+                    write!(me.state, "[memory {}] {:?}", inc(&mut i.memories), m)?;
                     me.print(end)
                 })?,
                 Payload::TagSection(s) => self.section(s, "tag", |me, end, m| {
-                    write!(me.state, "[tag {}] {:?}", i.tags, m)?;
-                    i.tags += 1;
+                    write!(me.state, "[tag {}] {:?}", inc(&mut i.tags), m)?;
                     me.print(end)
                 })?,
                 Payload::ExportSection(s) => self.section(s, "export", |me, end, e| {
@@ -120,8 +108,7 @@ impl<'a> Dump<'a> {
                     me.print(end)
                 })?,
                 Payload::GlobalSection(s) => self.section(s, "global", |me, _end, g| {
-                    write!(me.state, "[global {}] {:?}", i.globals, g.ty)?;
-                    i.globals += 1;
+                    write!(me.state, "[global {}] {:?}", inc(&mut i.globals), g.ty)?;
                     me.print(g.init_expr.get_binary_reader().original_position())?;
                     me.print_ops(g.init_expr.get_operators_reader())
                 })?,
@@ -181,7 +168,7 @@ impl<'a> Dump<'a> {
                             me.print_ops(init_expr.get_operators_reader())?;
                         }
                     }
-                    write!(me.dst, "0x{:04x} |", me.cur)?;
+                    me.print_byte_header()?;
                     for _ in 0..NBYTES {
                         write!(me.dst, "---")?;
                     }
@@ -201,9 +188,8 @@ impl<'a> Dump<'a> {
                     write!(
                         self.dst,
                         "============== func {} ====================\n",
-                        i.funcs
+                        inc(&mut i.funcs),
                     )?;
-                    i.funcs += 1;
                     write!(self.state, "size of function")?;
                     self.print(body.get_binary_reader().original_position())?;
                     let mut locals = body.get_locals_reader()?;
@@ -218,15 +204,80 @@ impl<'a> Dump<'a> {
                 }
 
                 // Component sections
-                Payload::ComponentTypeSection(_) => todo!("component-model"),
-                Payload::ComponentImportSection(_) => todo!("component-model"),
-                Payload::ComponentFunctionSection(_) => todo!("component-model"),
-                Payload::ModuleSection { .. } => todo!("component-model"),
-                Payload::ComponentSection { .. } => todo!("component-model"),
-                Payload::InstanceSection(_) => todo!("component-model"),
-                Payload::ComponentExportSection(_) => todo!("component-model"),
+                Payload::ComponentTypeSection(s) => self.section(s, "type", |me, end, t| {
+                    write!(me.state, "[type {}] {:?}", inc(&mut i.types), t)?;
+                    me.print(end)
+                })?,
+
+                Payload::ComponentImportSection(s) => {
+                    self.section(s, "import", |me, end, item| {
+                        write!(me.state, "[func {}] {:?}", inc(&mut i.funcs), item)?;
+                        me.print(end)
+                    })?
+                }
+
+                Payload::ComponentFunctionSection(s) => {
+                    self.section(s, "component function", |me, end, f| {
+                        write!(me.state, "[func {}] {:?}", inc(&mut i.funcs), f)?;
+                        me.print(end)
+                    })?
+                }
+
+                Payload::ModuleSection { range, .. } => {
+                    write!(self.state, "[module {}] inline size", inc(&mut i.modules))?;
+                    self.print(range.start)?;
+                    self.nesting += 1;
+                    stack.push(i);
+                    i = Indices::default();
+                }
+
+                Payload::ComponentSection { range, .. } => {
+                    write!(
+                        self.state,
+                        "[component {}] inline size",
+                        inc(&mut i.components)
+                    )?;
+                    self.print(range.start)?;
+                    self.nesting += 1;
+                    stack.push(i);
+                    i = Indices::default();
+                }
+
+                Payload::InstanceSection(s) => self.section(s, "instance", |me, end, e| {
+                    write!(me.state, "[instance {}] {:?}", i.instances, e)?;
+                    me.print(end)
+                })?,
+
+                Payload::ComponentExportSection(s) => {
+                    self.section(s, "component-export", |me, end, e| {
+                        write!(me.state, "export {:?}", e)?;
+                        me.print(end)
+                    })?
+                }
+
                 Payload::ComponentStartSection { .. } => todo!("component-model"),
-                Payload::AliasSection(_) => todo!("component-model"),
+
+                Payload::AliasSection(s) => self.section(s, "alias", |me, end, a| {
+                    let (kind, num) = match a {
+                        Alias::InstanceExport { kind, .. } => match kind {
+                            AliasKind::Module => ("module", inc(&mut i.modules)),
+                            AliasKind::Component => ("component", inc(&mut i.components)),
+                            AliasKind::Instance => ("instance", inc(&mut i.instances)),
+                            AliasKind::ComponentFunc => ("component func", inc(&mut i.funcs)),
+                            AliasKind::Value => ("value", inc(&mut i.values)),
+                            AliasKind::Func => ("func", inc(&mut i.funcs)),
+                            AliasKind::Table => ("table", inc(&mut i.tables)),
+                            AliasKind::Memory => ("memory", inc(&mut i.memories)),
+                            AliasKind::Global => ("global", inc(&mut i.globals)),
+                            AliasKind::Tag => ("tag", inc(&mut i.tags)),
+                        },
+                        Alias::OuterModule { .. } => ("module", inc(&mut i.modules)),
+                        Alias::OuterComponent { .. } => ("component", inc(&mut i.components)),
+                        Alias::OuterType { .. } => ("type", inc(&mut i.types)),
+                    };
+                    write!(me.state, "alias [{} {}] {:?}", kind, num, a)?;
+                    me.print(end)
+                })?,
 
                 Payload::CustomSection {
                     name,
@@ -244,7 +295,7 @@ impl<'a> Dump<'a> {
                             self.print_custom_name_section(iter.read()?, iter.original_position())?;
                         }
                     } else {
-                        write!(self.dst, "0x{:04x} |", self.cur)?;
+                        self.print_byte_header()?;
                         for _ in 0..NBYTES {
                             write!(self.dst, "---")?;
                         }
@@ -259,7 +310,7 @@ impl<'a> Dump<'a> {
                 } => {
                     write!(self.state, "unknown section: {}", id)?;
                     self.print(range.start)?;
-                    write!(self.dst, "0x{:04x} |", self.cur)?;
+                    self.print_byte_header()?;
                     for _ in 0..NBYTES {
                         write!(self.dst, "---")?;
                     }
@@ -402,16 +453,16 @@ impl<'a> Dump<'a> {
             self.dst
         );
         let bytes = &self.bytes[self.cur..end];
-        for _ in 0..self.nesting - 1 {
-            write!(self.dst, "  ")?;
-        }
-        write!(self.dst, "0x{:04x} |", self.cur)?;
+        self.print_byte_header()?;
         for (i, chunk) in bytes.chunks(NBYTES).enumerate() {
             if i > 0 {
                 for _ in 0..self.nesting - 1 {
                     write!(self.dst, "  ")?;
                 }
-                self.dst.push_str("       |");
+                for _ in 0..self.offset_width {
+                    self.dst.push_str(" ");
+                }
+                self.dst.push_str("   |");
             }
             for j in 0..NBYTES {
                 match chunk.get(j) {
@@ -429,4 +480,23 @@ impl<'a> Dump<'a> {
         self.cur = end;
         Ok(())
     }
+
+    fn print_byte_header(&mut self) -> Result<()> {
+        for _ in 0..self.nesting - 1 {
+            write!(self.dst, "  ")?;
+        }
+        write!(
+            self.dst,
+            "{:#width$x} |",
+            self.cur,
+            width = self.offset_width + 2
+        )?;
+        Ok(())
+    }
+}
+
+fn inc(spot: &mut u32) -> u32 {
+    let ret = *spot;
+    *spot += 1;
+    return ret;
 }

--- a/tests/dump/names.wat.dump
+++ b/tests/dump/names.wat.dump
@@ -1,29 +1,29 @@
-0x0000 | 00 61 73 6d | version 1 (Module)
-       | 01 00 00 00
-0x0008 | 01 05       | type section
-0x000a | 01          | 1 count
-0x000b | 60 01 7f 00 | [type 0] Func(FuncType { params: [I32], returns: [] })
-0x000f | 03 02       | func section
-0x0011 | 01          | 1 count
-0x0012 | 00          | [func 0] type 0
-0x0013 | 0a 06       | code section
-0x0015 | 01          | 1 count
+  0x0 | 00 61 73 6d | version 1 (Module)
+      | 01 00 00 00
+  0x8 | 01 05       | type section
+  0xa | 01          | 1 count
+  0xb | 60 01 7f 00 | [type 0] Func(FuncType { params: [I32], returns: [] })
+  0xf | 03 02       | func section
+ 0x11 | 01          | 1 count
+ 0x12 | 00          | [func 0] type 0
+ 0x13 | 0a 06       | code section
+ 0x15 | 01          | 1 count
 ============== func 0 ====================
-0x0016 | 04          | size of function
-0x0017 | 01          | 1 local blocks
-0x0018 | 01 7c       | 1 locals of type F64
-0x001a | 0b          | End
-0x001b | 00 1c       | custom section
-0x001d | 04 6e 61 6d | name: "name"
-       | 65         
-0x0022 | 00 04       | module name
-0x0024 | 03 66 6f 6f | "foo"
-0x0028 | 01 04       | function names
-0x002a | 01          | 1 count
-0x002b | 00 01 66    | Naming { index: 0, name: "f" }
-0x002e | 02 09       | local names
-0x0030 | 01          | 1 count
-0x0031 | 00          | function 0 locals
-0x0032 | 02          | 2 count
-0x0033 | 00 01 78    | Naming { index: 0, name: "x" }
-0x0036 | 01 01 79    | Naming { index: 1, name: "y" }
+ 0x16 | 04          | size of function
+ 0x17 | 01          | 1 local blocks
+ 0x18 | 01 7c       | 1 locals of type F64
+ 0x1a | 0b          | End
+ 0x1b | 00 1c       | custom section
+ 0x1d | 04 6e 61 6d | name: "name"
+      | 65         
+ 0x22 | 00 04       | module name
+ 0x24 | 03 66 6f 6f | "foo"
+ 0x28 | 01 04       | function names
+ 0x2a | 01          | 1 count
+ 0x2b | 00 01 66    | Naming { index: 0, name: "f" }
+ 0x2e | 02 09       | local names
+ 0x30 | 01          | 1 count
+ 0x31 | 00          | function 0 locals
+ 0x32 | 02          | 2 count
+ 0x33 | 00 01 78    | Naming { index: 0, name: "x" }
+ 0x36 | 01 01 79    | Naming { index: 1, name: "y" }

--- a/tests/dump/select.wat.dump
+++ b/tests/dump/select.wat.dump
@@ -1,20 +1,20 @@
-0x0000 | 00 61 73 6d | version 1 (Module)
-       | 01 00 00 00
-0x0008 | 01 04       | type section
-0x000a | 01          | 1 count
-0x000b | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
-0x000e | 03 02       | func section
-0x0010 | 01          | 1 count
-0x0011 | 00          | [func 0] type 0
-0x0012 | 0a 0e       | code section
-0x0014 | 01          | 1 count
+  0x0 | 00 61 73 6d | version 1 (Module)
+      | 01 00 00 00
+  0x8 | 01 04       | type section
+  0xa | 01          | 1 count
+  0xb | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
+  0xe | 03 02       | func section
+ 0x10 | 01          | 1 count
+ 0x11 | 00          | [func 0] type 0
+ 0x12 | 0a 0e       | code section
+ 0x14 | 01          | 1 count
 ============== func 0 ====================
-0x0015 | 0c          | size of function
-0x0016 | 00          | 0 local blocks
-0x0017 | 1b          | Select
-0x0018 | 1c 00       | ??
-0x001a | 1c 01 7f    | TypedSelect { ty: I32 }
-0x001d | 1c 02       | ??
-0x001f | 7f          | I64DivS
-0x0020 | 7f          | I64DivS
-0x0021 | 0b          | End
+ 0x15 | 0c          | size of function
+ 0x16 | 00          | 0 local blocks
+ 0x17 | 1b          | Select
+ 0x18 | 1c 00       | ??
+ 0x1a | 1c 01 7f    | TypedSelect { ty: I32 }
+ 0x1d | 1c 02       | ??
+ 0x1f | 7f          | I64DivS
+ 0x20 | 7f          | I64DivS
+ 0x21 | 0b          | End

--- a/tests/dump/simple.wat.dump
+++ b/tests/dump/simple.wat.dump
@@ -1,73 +1,73 @@
-0x0000 | 00 61 73 6d | version 1 (Module)
-       | 01 00 00 00
-0x0008 | 01 08       | type section
-0x000a | 02          | 2 count
-0x000b | 60 01 7f 00 | [type 0] Func(FuncType { params: [I32], returns: [] })
-0x000f | 60 00 00    | [type 1] Func(FuncType { params: [], returns: [] })
-0x0012 | 02 07       | import section
-0x0014 | 01          | 1 count
-0x0015 | 01 6d 01 6e | import [func 0] Import { module: "m", name: "n", ty: Func(0) }
-       | 00 00      
-0x001b | 03 04       | func section
-0x001d | 03          | 3 count
-0x001e | 01          | [func 1] type 1
-0x001f | 01          | [func 2] type 1
-0x0020 | 01          | [func 3] type 1
-0x0021 | 04 04       | table section
-0x0023 | 01          | 1 count
-0x0024 | 70 00 01    | [table 0] TableType { element_type: FuncRef, initial: 1, maximum: None }
-0x0027 | 05 03       | memory section
-0x0029 | 01          | 1 count
-0x002a | 00 01       | [memory 0] MemoryType { memory64: false, shared: false, initial: 1, maximum: None }
-0x002c | 06 06       | global section
-0x002e | 01          | 1 count
-0x002f | 7f 00       | [global 0] GlobalType { content_type: I32, mutable: false }
-0x0031 | 41 00       | I32Const { value: 0 }
-0x0033 | 0b          | End
-0x0034 | 07 05       | export section
-0x0036 | 01          | 1 count
-0x0037 | 01 6d 02 00 | export Export { name: "m", kind: Memory, index: 0 }
-0x003b | 08 01       | start section
-0x003d | 00          | start function 0
-0x003e | 09 0f       | element section
-0x0040 | 03          | 3 count
-0x0041 | 00          | element FuncRef table[0]
-0x0042 | 41 03       | I32Const { value: 3 }
-0x0044 | 0b          | End
-0x0045 | 01          | 1 items
-0x0046 | 00          | item Func(0)
-0x0047 | 01 00 01    | element FuncRef passive, 1 items
-0x004a | 00          | item Func(0)
-0x004b | 03 00 01    | element FuncRef declared 1 items
-0x004e | 00          | item Func(0)
-0x004f | 0a 10       | code section
-0x0051 | 03          | 3 count
+  0x0 | 00 61 73 6d | version 1 (Module)
+      | 01 00 00 00
+  0x8 | 01 08       | type section
+  0xa | 02          | 2 count
+  0xb | 60 01 7f 00 | [type 0] Func(FuncType { params: [I32], returns: [] })
+  0xf | 60 00 00    | [type 1] Func(FuncType { params: [], returns: [] })
+ 0x12 | 02 07       | import section
+ 0x14 | 01          | 1 count
+ 0x15 | 01 6d 01 6e | import [func 0] Import { module: "m", name: "n", ty: Func(0) }
+      | 00 00      
+ 0x1b | 03 04       | func section
+ 0x1d | 03          | 3 count
+ 0x1e | 01          | [func 1] type 1
+ 0x1f | 01          | [func 2] type 1
+ 0x20 | 01          | [func 3] type 1
+ 0x21 | 04 04       | table section
+ 0x23 | 01          | 1 count
+ 0x24 | 70 00 01    | [table 0] TableType { element_type: FuncRef, initial: 1, maximum: None }
+ 0x27 | 05 03       | memory section
+ 0x29 | 01          | 1 count
+ 0x2a | 00 01       | [memory 0] MemoryType { memory64: false, shared: false, initial: 1, maximum: None }
+ 0x2c | 06 06       | global section
+ 0x2e | 01          | 1 count
+ 0x2f | 7f 00       | [global 0] GlobalType { content_type: I32, mutable: false }
+ 0x31 | 41 00       | I32Const { value: 0 }
+ 0x33 | 0b          | End
+ 0x34 | 07 05       | export section
+ 0x36 | 01          | 1 count
+ 0x37 | 01 6d 02 00 | export Export { name: "m", kind: Memory, index: 0 }
+ 0x3b | 08 01       | start section
+ 0x3d | 00          | start function 0
+ 0x3e | 09 0f       | element section
+ 0x40 | 03          | 3 count
+ 0x41 | 00          | element FuncRef table[0]
+ 0x42 | 41 03       | I32Const { value: 3 }
+ 0x44 | 0b          | End
+ 0x45 | 01          | 1 items
+ 0x46 | 00          | item Func(0)
+ 0x47 | 01 00 01    | element FuncRef passive, 1 items
+ 0x4a | 00          | item Func(0)
+ 0x4b | 03 00 01    | element FuncRef declared 1 items
+ 0x4e | 00          | item Func(0)
+ 0x4f | 0a 10       | code section
+ 0x51 | 03          | 3 count
 ============== func 1 ====================
-0x0052 | 02          | size of function
-0x0053 | 00          | 0 local blocks
-0x0054 | 0b          | End
+ 0x52 | 02          | size of function
+ 0x53 | 00          | 0 local blocks
+ 0x54 | 0b          | End
 ============== func 2 ====================
-0x0055 | 04          | size of function
-0x0056 | 01          | 1 local blocks
-0x0057 | 01 7f       | 1 locals of type I32
-0x0059 | 0b          | End
+ 0x55 | 04          | size of function
+ 0x56 | 01          | 1 local blocks
+ 0x57 | 01 7f       | 1 locals of type I32
+ 0x59 | 0b          | End
 ============== func 3 ====================
-0x005a | 06          | size of function
-0x005b | 01          | 1 local blocks
-0x005c | 01 7f       | 1 locals of type I32
-0x005e | 41 00       | I32Const { value: 0 }
-0x0060 | 0b          | End
-0x0061 | 0b 0a       | data section
-0x0063 | 02          | 2 count
-0x0064 | 00          | data memory[0]
-0x0065 | 41 08       | I32Const { value: 8 }
-0x0067 | 0b          | End
-0x0068 |-------------| ... 1 bytes of data
-0x006a | 01 01       | data passive
-0x006c |-------------| ... 1 bytes of data
-0x006d | 00 17       | custom section
-0x006f | 0f 6e 61 6d | name: "name-of-section"
-       | 65 2d 6f 66
-       | 2d 73 65 63
-       | 74 69 6f 6e
-0x007f |-------------| ... 7 bytes of data
+ 0x5a | 06          | size of function
+ 0x5b | 01          | 1 local blocks
+ 0x5c | 01 7f       | 1 locals of type I32
+ 0x5e | 41 00       | I32Const { value: 0 }
+ 0x60 | 0b          | End
+ 0x61 | 0b 0a       | data section
+ 0x63 | 02          | 2 count
+ 0x64 | 00          | data memory[0]
+ 0x65 | 41 08       | I32Const { value: 8 }
+ 0x67 | 0b          | End
+ 0x68 |-------------| ... 1 bytes of data
+ 0x6a | 01 01       | data passive
+ 0x6c |-------------| ... 1 bytes of data
+ 0x6d | 00 17       | custom section
+ 0x6f | 0f 6e 61 6d | name: "name-of-section"
+      | 65 2d 6f 66
+      | 2d 73 65 63
+      | 74 69 6f 6e
+ 0x7f |-------------| ... 7 bytes of data

--- a/tests/dump/try-delegate.wat.dump
+++ b/tests/dump/try-delegate.wat.dump
@@ -1,26 +1,26 @@
-0x0000 | 00 61 73 6d | version 1 (Module)
-       | 01 00 00 00
-0x0008 | 01 04       | type section
-0x000a | 01          | 1 count
-0x000b | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
-0x000e | 03 02       | func section
-0x0010 | 01          | 1 count
-0x0011 | 00          | [func 0] type 0
-0x0012 | 0a 0b       | code section
-0x0014 | 01          | 1 count
+  0x0 | 00 61 73 6d | version 1 (Module)
+      | 01 00 00 00
+  0x8 | 01 04       | type section
+  0xa | 01          | 1 count
+  0xb | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
+  0xe | 03 02       | func section
+ 0x10 | 01          | 1 count
+ 0x11 | 00          | [func 0] type 0
+ 0x12 | 0a 0b       | code section
+ 0x14 | 01          | 1 count
 ============== func 0 ====================
-0x0015 | 09          | size of function
-0x0016 | 00          | 0 local blocks
-0x0017 | 06 40       | Try { ty: Empty }
-0x0019 | 06 40       | Try { ty: Empty }
-0x001b | 18 00       | Delegate { relative_depth: 0 }
-0x001d | 0b          | End
-0x001e | 0b          | End
-0x001f | 00 0d       | custom section
-0x0021 | 04 6e 61 6d | name: "name"
-       | 65         
-0x0026 | 03 06       | label names
-0x0028 | 01          | 1 count
-0x0029 | 00          | function 0 labels
-0x002a | 01          | 1 count
-0x002b | 00 01 6c    | Naming { index: 0, name: "l" }
+ 0x15 | 09          | size of function
+ 0x16 | 00          | 0 local blocks
+ 0x17 | 06 40       | Try { ty: Empty }
+ 0x19 | 06 40       | Try { ty: Empty }
+ 0x1b | 18 00       | Delegate { relative_depth: 0 }
+ 0x1d | 0b          | End
+ 0x1e | 0b          | End
+ 0x1f | 00 0d       | custom section
+ 0x21 | 04 6e 61 6d | name: "name"
+      | 65         
+ 0x26 | 03 06       | label names
+ 0x28 | 01          | 1 count
+ 0x29 | 00          | function 0 labels
+ 0x2a | 01          | 1 count
+ 0x2b | 00 01 6c    | Naming { index: 0, name: "l" }


### PR DESCRIPTION
I found a need to do this when debugging a module for Wasmtime, so I
went ahead and filled out the basics of `wasm-tools dump` to help
debugging in the future as well.