### PR TITLE
`wasm-mutate`: Properly parse floats in peephole rules

### DIFF
--- a/crates/wasm-mutate/src/mutators/peephole.rs
+++ b/crates/wasm-mutate/src/mutators/peephole.rs
@@ -1496,13 +1496,13 @@ mod tests {
     #[test]
     fn test_peep_floats1() {
         let rules: &[Rewrite<super::Lang, PeepholeMutationAnalysis>] =
-            &[rewrite!("rule";  "f32.const.1065353216" => "f32.const.0" )];
+            &[rewrite!("rule";  "f32.const.1,0" => "f32.const.0,0" )];
 
         test_peephole_mutator(
             r#"
         (module
             (func (export "exported_func") (result f32) (local i64 i64)
-                f32.const 1
+                f32.const 1.0
             )
         )
         "#,

--- a/crates/wasm-mutate/src/mutators/peephole/dfg.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/dfg.rs
@@ -422,10 +422,10 @@ impl<'a> DFGBuilder {
                     self.push_node(Lang::I64(*value), idx);
                 }
                 Operator::F32Const { value } => {
-                    self.push_node(Lang::F32(value.bits()), idx);
+                    self.push_node(Lang::F32((*value).into()), idx);
                 }
                 Operator::F64Const { value } => {
-                    self.push_node(Lang::F64(value.bits()), idx);
+                    self.push_node(Lang::F64((*value).into()), idx);
                 }
                 Operator::V128Const { value } => {
                     self.push_node(Lang::V128(value.i128()), idx);

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder/expr2wasm.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder/expr2wasm.rs
@@ -171,8 +171,8 @@ pub fn expr2wasm(
                     }
                     Lang::I32(v) => insn(Instruction::I32Const(*v)),
                     Lang::I64(v) => insn(Instruction::I64Const(*v)),
-                    Lang::F32(v) => insn(Instruction::F32Const(f32::from_bits(*v))),
-                    Lang::F64(v) => insn(Instruction::F64Const(f64::from_bits(*v))),
+                    Lang::F32(v) => insn(Instruction::F32Const(v.to_f32())),
+                    Lang::F64(v) => insn(Instruction::F64Const(v.to_f64())),
                     Lang::V128(v) => insn(Instruction::V128Const(*v)),
                     Lang::I32Add(_) => insn(Instruction::I32Add),
                     Lang::I64Add(_) => insn(Instruction::I64Add),

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
@@ -973,11 +973,12 @@ lang! {
         I32(i32) = "i32.const",
         /// I64 constant node
         I64(i64) = "i64.const",
+
         // Save bits
         /// F32 constant node
-        F32(u32) = "f32.const",
+        F32(F32) = "f32.const",
         /// F64 constant node
-        F64(u64) = "f64.const",
+        F64(F64) = "f64.const",
         /// V128 constant node
         V128(i128) = "v128.const",
         /// constant ref.null node
@@ -990,6 +991,76 @@ lang! {
 impl Default for Lang {
     fn default() -> Self {
         Lang::Undef
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
+pub struct F32(u32);
+
+impl F32 {
+    pub fn to_f32(self) -> f32 {
+        f32::from_bits(self.0)
+    }
+}
+
+impl FromStr for F32 {
+    type Err = <f32 as FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(F32(f32::from_str(&s.replace(",", "."))?.to_bits()))
+    }
+}
+
+impl From<f32> for F32 {
+    fn from(f: f32) -> Self {
+        Self(f.to_bits())
+    }
+}
+
+impl From<wasmparser::Ieee32> for F32 {
+    fn from(f: wasmparser::Ieee32) -> Self {
+        Self(f.bits())
+    }
+}
+
+impl fmt::Display for F32 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.to_f32(), f)
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
+pub struct F64(u64);
+
+impl F64 {
+    pub fn to_f64(self) -> f64 {
+        f64::from_bits(self.0)
+    }
+}
+
+impl FromStr for F64 {
+    type Err = <f64 as FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(F64(f64::from_str(&s.replace(",", "."))?.to_bits()))
+    }
+}
+
+impl From<f64> for F64 {
+    fn from(f: f64) -> Self {
+        Self(f.to_bits())
+    }
+}
+
+impl From<wasmparser::Ieee64> for F64 {
+    fn from(f: wasmparser::Ieee64) -> Self {
+        Self(f.bits())
+    }
+}
+
+impl fmt::Display for F64 {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(&self.to_f64(), f)
     }
 }
 

--- a/crates/wasm-mutate/src/mutators/peephole/rules.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/rules.rs
@@ -34,12 +34,12 @@ impl PeepholeMutator {
                 rewrite!("i64.sub-0"; "(i64.sub ?x i64.const.0)" => "?x"),
                 rewrite!("i32.mul-x-1"; "(i32.mul ?x i32.const.1)" => "?x"),
                 rewrite!("i64.mul-x-1"; "(i64.mul ?x i64.const.1)" => "?x"),
-                rewrite!("f32.mul-x-1"; "(f32.mul ?x f32.const.1)" => "?x"),
-                rewrite!("f64.mul-x-1"; "(f64.mul ?x f64.const.1)" => "?x"),
+                rewrite!("f32.mul-x-1"; "(f32.mul ?x f32.const.1,0)" => "?x"),
+                rewrite!("f64.mul-x-1"; "(f64.mul ?x f64.const.1,0)" => "?x"),
                 rewrite!("i32.add-x-0"; "(i32.add ?x i32.const.0)" => "?x"),
                 rewrite!("i64.add-x-0"; "(i64.add ?x i64.const.0)" => "?x"),
-                rewrite!("f32-add-x-0"; "(f32.add ?x f32.const.0)" => "?x"),
-                rewrite!("f64.add-x-0"; "(f64.add ?x f64.const.0)" => "?x"),
+                rewrite!("f32-add-x-0"; "(f32.add ?x f32.const.0,0)" => "?x"),
+                rewrite!("f64.add-x-0"; "(f64.add ?x f64.const.0,0)" => "?x"),
                 rewrite!("i32.xor-x-0"; "(i32.xor ?x i32.const.0)" => "?x"),
                 rewrite!("i64.xor-x-0"; "(i64.xor ?x i64.const.0)" => "?x"),
                 rewrite!("i32.eq-x-0"; "(i32.eq ?x i32.const.0)" => "(i32.eqz ?x)"),
@@ -105,12 +105,12 @@ impl PeepholeMutator {
 
             rules.extend(rewrite!(
                 "f32.mul-x-1";
-                "?x" <=> "(f32.mul ?x f32.const.1)"
+                "?x" <=> "(f32.mul ?x f32.const.1,0)"
                     if self.is_type("?x", PrimitiveTypeInfo::F32)
             ));
             rules.extend(rewrite!(
                 "f64.mul-x-1";
-                "?x" <=> "(f64.mul ?x f64.const.1)"
+                "?x" <=> "(f64.mul ?x f64.const.1,0)"
                     if self.is_type("?x", PrimitiveTypeInfo::F64)
             ));
 
@@ -126,12 +126,12 @@ impl PeepholeMutator {
             ));
             rules.extend(rewrite!(
                 "f32-add-x-0";
-                "?x" <=> "(f32.add ?x f32.const.0)"
+                "?x" <=> "(f32.add ?x f32.const.0,0)"
                     if self.is_type("?x", PrimitiveTypeInfo::F32)
             ));
             rules.extend(rewrite!(
                 "f64.add-x-0";
-                "?x" <=> "(f64.add ?x f64.const.0)"
+                "?x" <=> "(f64.add ?x f64.const.0,0)"
                     if self.is_type("?x", PrimitiveTypeInfo::F64)
             ));
 
@@ -327,12 +327,12 @@ impl PeepholeMutator {
                 ),
                 rewrite!(
                     "f32.drop-x";
-                    "(drop ?x)" => "(drop f32.const.0)"
+                    "(drop ?x)" => "(drop f32.const.0,0)"
                         if self.is_type("?x", PrimitiveTypeInfo::F32)
                 ),
                 rewrite!(
                     "f64.drop-x";
-                    "(drop ?x)" => "(drop f32.const.0)"
+                    "(drop ?x)" => "(drop f32.const.0,0)"
                         if self.is_type("?x", PrimitiveTypeInfo::F64)
                 ),
             ]);
@@ -417,12 +417,12 @@ impl PeepholeMutator {
                 ),
                 rewrite!(
                     "replace-with-f32-1.0";
-                    "?x" => "f32.const.1065353216"
+                    "?x" => "f32.const.1,0"
                         if self.is_type("?x", PrimitiveTypeInfo::F32)
                 ),
                 rewrite!(
                     "replace-with-f64-1.0";
-                    "?x" => "f64.const.4607182418800017408"
+                    "?x" => "f64.const.1,0"
                         if self.is_type("?x", PrimitiveTypeInfo::F64)
                 ),
                 rewrite!(
@@ -437,12 +437,12 @@ impl PeepholeMutator {
                 ),
                 rewrite!(
                     "replace-with-f32-0";
-                    "?x" => "f32.const.0"
+                    "?x" => "f32.const.0,0"
                         if self.is_type("?x", PrimitiveTypeInfo::F32)
                 ),
                 rewrite!(
                     "replace-with-f64-0";
-                    "?x" => "f64.const.0"
+                    "?x" => "f64.const.0,0"
                         if self.is_type("?x", PrimitiveTypeInfo::F64)
                 ),
                 rewrite!(


### PR DESCRIPTION
Don't parse them as integers and use that as the bits for the float. Instead
actually parse floats (although we have to use "," as the decimal instead of "."
because of the way that we already use "." for instruction prefixes.

This also fixes some buggy rewrite rules that previously assumed that we *did* parse `f32.const.1` as a float and not the float bits.