### PR TITLE
fix: Enhance how Instance::* variants are printed

### DIFF
--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -2882,7 +2882,7 @@ impl Printer {
                     self.print_idx(&state.module_names, index)?;
                     self.end_group();
                     for arg in args.iter() {
-                        self.result.push(' ');
+                        self.newline();
                         self.print_module_arg(state, arg)?;
                     }
                     self.end_group();
@@ -2896,7 +2896,7 @@ impl Printer {
                     self.print_idx(&state.component_names, index)?;
                     self.end_group();
                     for arg in args.iter() {
-                        self.result.push(' ');
+                        self.newline();
                         self.print_component_arg(state, arg)?;
                     }
                     self.end_group();
@@ -2908,7 +2908,7 @@ impl Printer {
                 Instance::ModuleFromExports(exports) => {
                     self.result.push_str(" core");
                     for export in exports.iter() {
-                        self.result.push(' ');
+                        self.newline();
                         self.print_export(state, export)?;
                     }
 
@@ -2917,7 +2917,7 @@ impl Printer {
                 Instance::ComponentFromExports(exports) => {
                     let mut type_exports = HashMap::new();
                     for export in exports.iter() {
-                        self.result.push(' ');
+                        self.newline();
                         self.print_component_export(state, export)?;
 
                         let existing = match export.kind {


### PR DESCRIPTION
Fixes #547 

This commit replaces spaces for newlines when printing each of the
Instance::* variants.

---
Some notes:

- I'm assuming `wasmprinter` doesn't have any unit tests for components, given that wast doesn't support components yet. 
- Aside from adding support for instantiation from exports, I've added also formatting for the other `Instance` variants. Running wasm-tools on the [examples in `wit-bindgen`](https://github.com/bytecodealliance/wit-bindgen/tree/main/crates/wit-component/tests/components/imports) gives the following:

```wat
;; 1
(instance (;6;) core
  (export "foo1" (func 11))
  (export "foo2" (func 12))
  (export "foo3" (func 13))
)

;; 2 
(instance (;7;) (instantiate (module 0)
    (with "bar" (instance 4))
    (with "baz" (instance 5))
    (with "foo" (instance 6))
  )
)

;; 3
(instance (;2;)
  (export "a" (func 11))
  (export "b" (func 12))
  (export "c" (func 13))
)

```

Open question/thought:

- Is there a preference to print 2 in the snippet above (`Instance::Module`), like this instead:
```wat
(instance (;7;) (instantiate (module 0)
  (with "bar" (instance 4))
  (with "baz" (instance 5))
  (with "foo" (instance 6))
))
```


cc/ @peterhuene 