### PR TITLE
`wasm-mutate`: Fix the `AddTypeMutator` when the first section is a custom section

### DIFF
--- a/crates/fuzz-stats/Cargo.toml
+++ b/crates/fuzz-stats/Cargo.toml
@@ -10,7 +10,7 @@ arbitrary = "1.0"
 num_cpus = "1.13"
 rand = "0.8"
 wasm-smith = { path = '../wasm-smith' }
-wasmtime = "0.32.0"
+wasmtime = "0.35.2"
 
 [lib]
 doctest = false

--- a/crates/wasm-mutate-stats/Cargo.toml
+++ b/crates/wasm-mutate-stats/Cargo.toml
@@ -12,7 +12,7 @@ rand = { version = "0.8.0", features = ["small_rng"] }
 wasm-mutate = { path = '../wasm-mutate' }
 wasmprinter = { path = '../wasmprinter' }
 wasmparser = { path = "../wasmparser" }
-wasmtime = "0.32.0"
+wasmtime = "0.35.2"
 env_logger = "0.9"
 itertools = "0.10.0"
 clap = "3.0"

--- a/crates/wasm-mutate/src/info.rs
+++ b/crates/wasm-mutate/src/info.rs
@@ -299,6 +299,7 @@ impl<'a> ModuleInfo<'a> {
         i: usize,
         new_section: &impl wasm_encoder::Section,
     ) -> wasm_encoder::Module {
+        log::trace!("inserting new section at {}", i);
         let mut module = wasm_encoder::Module::new();
         self.raw_sections.iter().enumerate().for_each(|(j, s)| {
             if i == j {
@@ -318,14 +319,15 @@ impl<'a> ModuleInfo<'a> {
         i: usize,
         new_section: &impl wasm_encoder::Section,
     ) -> wasm_encoder::Module {
+        log::trace!("replacing section {}", i);
         let mut module = wasm_encoder::Module::new();
-        self.raw_sections.iter().enumerate().for_each(|(j, s)| {
+        for (j, s) in self.raw_sections.iter().enumerate() {
             if i == j {
                 module.section(new_section);
             } else {
                 module.section(s);
             }
-        });
+        }
         module
     }
 

--- a/crates/wasm-mutate/src/lib.rs
+++ b/crates/wasm-mutate/src/lib.rs
@@ -43,13 +43,17 @@ macro_rules! define_mutators {
             // Start by the current node
             let m = $first;
 
-            if m.can_mutate($self) {
+            let can_mutate = m.can_mutate($self);
+            log::trace!("Can `{}` mutate? {}", m.name(), can_mutate);
+            if can_mutate {
+                log::debug!("attempting to mutate with `{}`", m.name());
                 match m.clone().mutate($self) {
                     Ok(iter) => {
+                        log::debug!("mutator `{}` succeeded", m.name());
                         return Ok(Box::new(iter.into_iter().map(|r| r.map(|m| m.finish()))))
                     }
                     Err(e) => {
-                        log::debug!("mutator {} failed: {}; will try again", m.name(), e);
+                        log::debug!("mutator `{}` failed: {}", m.name(), e);
                         return Err(e);
                     }
                 }
@@ -58,13 +62,17 @@ macro_rules! define_mutators {
             $(
                 let m = $rest;
 
-                if m.can_mutate($self) {
+                let can_mutate = m.can_mutate($self);
+                log::trace!("Can `{}` mutate? {}", m.name(), can_mutate);
+                if can_mutate {
+                    log::debug!("attempting to mutate with `{}`", m.name());
                     match m.clone().mutate($self) {
                         Ok(iter) => {
+                            log::debug!("mutator `{}` succeeded", m.name());
                             return Ok(Box::new(iter.into_iter().map(|r| r.map(|m| m.finish()))))
                         }
                         Err(e) => {
-                            log::debug!("mutator {} failed: {}; will try again", m.name(), e);
+                            log::debug!("mutator {} failed: {}", m.name(), e);
                             return Err(e);
                         }
                     }

--- a/crates/wasm-mutate/src/mutators/add_type.rs
+++ b/crates/wasm-mutate/src/mutators/add_type.rs
@@ -141,4 +141,27 @@ mod tests {
             "#,
         );
     }
+
+    #[test]
+    fn add_type_with_custom_section_first() {
+        crate::mutators::match_mutation(
+            r#"
+                (module
+                    (@custom "HI" (before type) "xxx")
+                    (type (;0;) (func (param i32) (result i64)))
+                )
+            "#,
+            AddTypeMutator {
+                max_params: 1,
+                max_results: 1,
+            },
+            r#"
+                (module
+                    (@custom "HI" (before type) "xxx")
+                    (type (;0;) (func (param i32) (result i64)))
+                    (type (;0;) (func (param i64) (result i32)))
+                )
+            "#,
+        );
+    }
 }

--- a/crates/wasm-mutate/src/mutators/add_type.rs
+++ b/crates/wasm-mutate/src/mutators/add_type.rs
@@ -74,9 +74,10 @@ impl Mutator for AddTypeMutator {
             }
             // And then add our new type.
             types.function(params, results);
+            let types_section_index = config.info().types.unwrap();
             Ok(Box::new(iter::once(Ok(config
                 .info()
-                .replace_section(0, &types)))))
+                .replace_section(types_section_index, &types)))))
         } else {
             types.function(params, results);
             Ok(Box::new(iter::once(Ok(config

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,7 +17,7 @@ wasm-mutate = { path = "../crates/wasm-mutate" }
 wasm-smith = { path = "../crates/wasm-smith" }
 wasmparser = { path = "../crates/wasmparser" }
 wasmprinter = { path = "../crates/wasmprinter" }
-wasmtime = { version = "0.32.0", optional = true }
+wasmtime = { version = "0.35.2", optional = true }
 wast = { path = "../crates/wast" }
 wat = { path = "../crates/wat" }
 


### PR DESCRIPTION
And the type section follows that. Before we would accidentally replace the custom section with the new type section and then incorrectly have two type sections. Now we leave the custom section and correctly replace the old type section.