### PR TITLE
feat: Initial Component Model support in objdump

### DIFF
--- a/src/bin/wasm-tools/objdump.rs
+++ b/src/bin/wasm-tools/objdump.rs
@@ -58,7 +58,7 @@ impl Opts {
 
                 InstanceSection(s) => printer.section(s, "instances"),
                 ComponentExportSection(s) => printer.section(s, "exports"),
-                ComponentStartSection(_) => {}
+                ComponentStartSection(s) => printer.section_raw(s.range(), 1, "start"),
                 AliasSection(s) => printer.section(s, "alias"),
 
                 CustomSection(c) => printer.section_raw(


### PR DESCRIPTION
Part of https://github.com/bytecodealliance/wasm-tools/issues/450

But as in https://github.com/bytecodealliance/wasm-tools/pull/549 I think that it might be best to wait until https://github.com/bytecodealliance/wasm-tools/pull/529 lands to confidently test and merge. 

---

This commit modifies the original implementation of `objdump` to support
the Component Model.

The main difference with the previous implementation is that it augments
the properties of the `Printer` implementation to track the component
and module indices as well as the encoding that is currently being
processed `(Module | Component)`

--- 
Results:

Encoding [this component](https://github.com/bytecodealliance/wit-bindgen/blob/main/crates/wit-component/tests/components/import-conflict/component.wat) with `wit-component` and then applying `wasm-tools objdump`, this is the result:

<details>

```
  types                                  |        0xa -       0x45 |        59 bytes | 7 count
  module                                 |       0x48 -       0xd5 |       141 bytes | 1 count
    ------ start module 0 -------------
    types                                |       0x52 -       0x6a |        24 bytes | 4 count
    imports                              |       0x6c -       0x87 |        27 bytes | 3 count
    functions                            |       0x89 -       0x8c |         3 bytes | 2 count
    memories                             |       0x8e -       0x91 |         3 bytes | 1 count
    exports                              |       0x93 -       0xca |        55 bytes | 3 count
    code                                 |       0xcc -       0xd5 |         9 bytes | 2 count
    ------ end module 0 -------------
  imports                                |       0xd7 -       0xe7 |        16 bytes | 3 count
  module                                 |       0xe9 -      0x141 |        88 bytes | 1 count
    ------ start module 1 -------------
    types                                |       0xf3 -      0x100 |        13 bytes | 2 count
    functions                            |      0x102 -      0x105 |         3 bytes | 2 count
    tables                               |      0x107 -      0x10c |         5 bytes | 1 count
    exports                              |      0x10e -      0x122 |        20 bytes | 3 count
    code                                 |      0x124 -      0x141 |        29 bytes | 2 count
    ------ end module 1 -------------
  module                                 |      0x143 -      0x180 |        61 bytes | 1 count
    ------ start module 2 -------------
    types                                |      0x14d -      0x15a |        13 bytes | 2 count
    imports                              |      0x15c -      0x176 |        26 bytes | 3 count
    elements                             |      0x178 -      0x180 |         8 bytes | 1 count
    ------ end module 2 -------------
  instances                              |      0x182 -      0x187 |         5 bytes | 1 count
  alias                                  |      0x189 -      0x199 |        16 bytes | 3 count
  functions                              |      0x19b -      0x19f |         4 bytes | 1 count
  instances                              |      0x1a1 -      0x1cc |        43 bytes | 4 count
  alias                                  |      0x1ce -      0x1e7 |        25 bytes | 3 count
  functions                              |      0x1e9 -      0x1f5 |        12 bytes | 2 count
  instances                              |      0x1f7 -      0x214 |        29 bytes | 2 count
  exports                                |      0x216 -      0x217 |         1 bytes | 0 count

```

</details>

Similarly running `objdump` on a core wasm module, for example [this one](https://github.com/bytecodealliance/wasm-tools/blob/main/tests/local/br_if-loop-stack.wasm), gives:

<details>

```
  types                                  |        0xa -        0xf |         5 bytes | 1 count
  functions                              |       0x11 -       0x13 |         2 bytes | 1 count
  exports                                |       0x15 -       0x1d |         8 bytes | 1 count
  code                                   |       0x1f -       0x32 |        19 bytes | 1 count
  custom "name"                          |       0x39 -       0x47 |        14 bytes | 1 count
```
</details>

---

Some open questions:

1. wasmparser's new `Payload`, doesn't return a `count` for `Payload::ComponentSection` and `Payload::ModuleSection` so I've defaulted to adding a count of 1 when processing either or. Not sure if we'd like to change that approach, since it might be a bit confusing for someone reading and expecting the total count as it was before. Although that information can be easily derived with the counts and information about each module/component.
2. I'm not able to find any roundtrip tests for `objdump`; is this right or am I missing something? If this is right, would there be any value on adding some tests for this, either on this PR or a subsequent one? (Ideally once https://github.com/bytecodealliance/wasm-tools/pull/529 lands I guess)
3. As of this change I'm keeping the component section names without an explicit differentiator in the name (e.g. "types" instead of "component types"). I'm marking the start/end of each component/module so IMO that should be difference enough to avoid having different names for the component sections. Another reason why I went this way is because the spec doesn't seem to give these sections different names. Let me know if I'm missing something here or if this should be changed.  

Thoughts? @peterhuene @alexcrichton 
