### PR TITLE
Use std::ops::Range instead of a custom type

### DIFF
--- a/crates/wasm-mutate/src/info.rs
+++ b/crates/wasm-mutate/src/info.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use std::collections::HashSet;
 use std::convert::TryFrom;
+use std::ops::Range;
 use wasm_encoder::{RawSection, SectionId};
 use wasmparser::{Chunk, Parser, Payload, SectionReader};
 
@@ -79,7 +80,7 @@ impl<'a> ModuleInfo<'a> {
                     size: _,
                 } => {
                     info.code = Some(info.raw_sections.len());
-                    info.section(SectionId::Code.into(), range, input_wasm);
+                    info.section(SectionId::Code.into(), range.clone(), input_wasm);
                     parser.skip_section();
                     // update slice, bypass the section
                     wasm = &input_wasm[range.end..];
@@ -249,10 +250,10 @@ impl<'a> ModuleInfo<'a> {
     }
 
     /// Registers a new raw_section in the ModuleInfo
-    pub fn section(&mut self, id: u8, range: wasmparser::Range, full_wasm: &'a [u8]) {
+    pub fn section(&mut self, id: u8, range: Range<usize>, full_wasm: &'a [u8]) {
         self.raw_sections.push(RawSection {
             id,
-            data: &full_wasm[range.start..range.end],
+            data: &full_wasm[range],
         });
     }
 

--- a/crates/wasm-mutate/src/mutators/codemotion/ir/parse_context.rs
+++ b/crates/wasm-mutate/src/mutators/codemotion/ir/parse_context.rs
@@ -1,5 +1,6 @@
 use crate::{Error, Result};
-use wasmparser::{BlockType, Range};
+use std::ops::Range;
+use wasmparser::BlockType;
 
 #[derive(Debug, Default)]
 pub struct Ast {
@@ -50,12 +51,12 @@ pub enum Node {
         alternative: Option<Vec<usize>>,
         /// The block type for the branches.
         ty: BlockType,
-        range: Range,
+        range: Range<usize>,
     },
     /// Code node
     Code {
         /// Range on the instructions stream
-        range: Range,
+        range: Range<usize>,
     },
     /// Loop Node
     Loop {
@@ -64,7 +65,7 @@ pub enum Node {
         /// Block type
         ty: BlockType,
         /// Range on the instructions stream
-        range: Range,
+        range: Range<usize>,
     },
     /// Block Node
     Block {
@@ -73,7 +74,7 @@ pub enum Node {
         /// Block type
         ty: BlockType,
         /// Range on the instructions stream
-        range: Range,
+        range: Range<usize>,
     },
     /// Special node to wrap the root nodes of the Ast
     Root(Vec<usize>),
@@ -93,7 +94,7 @@ pub(crate) struct ParseContext {
     current_parsing: Vec<usize>,
     stack: Vec<Vec<usize>>,
     frames: Vec<(State, Option<BlockType>, usize)>,
-    current_code_range: Range,
+    current_code_range: Range<usize>,
     nodes: Vec<Node>,
 
     ifs: Vec<usize>,
@@ -104,7 +105,7 @@ pub(crate) struct ParseContext {
 impl Default for ParseContext {
     fn default() -> Self {
         ParseContext {
-            current_code_range: Range::new(0, 0),
+            current_code_range: 0..0,
             current_parsing: Vec::new(),
             stack: Vec::new(),
             frames: Vec::new(),
@@ -185,13 +186,13 @@ impl ParseContext {
     /// Pushes the current code parsing as a `Node::Code` instance
     pub fn push_current_code_as_node(&mut self) -> usize {
         self.push_node_to_current_parsing(Node::Code {
-            range: self.current_code_range,
+            range: self.current_code_range.clone(),
         })
     }
 
     /// Resets the current code parsing
     pub fn reset_code_range_at(&mut self, idx: usize) {
-        self.current_code_range = Range::new(idx, idx);
+        self.current_code_range = idx..idx;
     }
 
     /// Augmnents current code parsing to include the next instruction

--- a/crates/wasm-mutate/src/mutators/peephole.rs
+++ b/crates/wasm-mutate/src/mutators/peephole.rs
@@ -40,6 +40,7 @@ use crate::{
 };
 use egg::{Rewrite, Runner};
 use rand::{prelude::SmallRng, Rng};
+use std::ops::Range;
 use std::{borrow::Cow, fmt::Debug};
 use wasm_encoder::{CodeSection, Function, GlobalSection, Instruction, Module, ValType};
 use wasmparser::{CodeSectionReader, FunctionBody, GlobalSectionReader, LocalsReader};
@@ -467,7 +468,7 @@ pub(crate) trait CodeMutator {
         operator_index: usize,
         operators: Vec<OperatorAndByteOffset>,
         funcreader: FunctionBody,
-        body_range: wasmparser::Range,
+        body_range: Range<usize>,
         function_data: &[u8],
     ) -> Result<Function>;
 

--- a/crates/wasm-mutate/src/mutators/peephole/dfg.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/dfg.rs
@@ -9,7 +9,8 @@ use crate::mutators::OperatorAndByteOffset;
 use crate::{ModuleInfo, WasmMutate};
 use egg::{Id, Language, RecExpr};
 use std::collections::HashMap;
-use wasmparser::{Operator, Range};
+use std::ops::Range;
+use wasmparser::Operator;
 
 /// It executes a minimal symbolic evaluation of the stack to detect operands
 /// location in the code for certain operators
@@ -34,7 +35,7 @@ pub struct DFGBuilder {
 /// function
 #[derive(Debug)]
 pub struct BBlock {
-    pub(crate) range: Range,
+    pub(crate) range: Range<usize>,
 }
 
 /// Node of a DFG extracted from a basic block in the Wasm code
@@ -226,10 +227,8 @@ impl<'a> DFGBuilder {
         operator_index: usize,
         operators: &[OperatorAndByteOffset],
     ) -> Option<BBlock> {
-        let mut range = Range {
-            start: operator_index,
-            end: operator_index + 1, // The range is inclusive in the last operator
-        };
+        // The range is inclusive in the last operator
+        let mut range = operator_index..operator_index + 1;
         // We only need the basic block upward
         let mut found = false;
         loop {

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder.rs
@@ -36,7 +36,7 @@ impl Encoder {
         egraph: &EG,
     ) -> crate::Result<Vec<ResourceRequest>> {
         // Copy previous code
-        let range = basicblock.range;
+        let range = basicblock.range.clone();
         let byterange = (&operators[0].1, &operators[range.start].1);
         let bytes = &config.info().get_code_section().data[*byterange.0..*byterange.1];
         newfunc.raw(bytes.iter().copied());
@@ -60,7 +60,7 @@ impl Encoder {
         }
 
         // Copy remaining function
-        let range = basicblock.range;
+        let range = basicblock.range.clone();
         let byterange = (
             &operators[range.end].1, // In the worst case the next instruction will be and end
             &operators[operators.len() - 1].1,

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -26,6 +26,7 @@ use crate::{ComponentArg, ComponentArgKind};
 use std::convert::TryInto;
 use std::error::Error;
 use std::fmt;
+use std::ops::Range;
 use std::str;
 
 fn is_name(name: &str, expected: &'static str) -> bool {
@@ -37,31 +38,6 @@ fn is_name_prefix(name: &str, prefix: &'static str) -> bool {
 }
 
 const WASM_MAGIC_NUMBER: &[u8; 4] = b"\0asm";
-
-/// Bytecode range in the WebAssembly module.
-#[derive(Copy, Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct Range {
-    /// The start bound of the range.
-    pub start: usize,
-    /// The end bound of the range.
-    pub end: usize,
-}
-
-impl Range {
-    /// Constructs a new instance of `Range`.
-    ///
-    /// # Panics
-    /// If `start` is greater than `end`.
-    pub fn new(start: usize, end: usize) -> Range {
-        assert!(start <= end);
-        Range { start, end }
-    }
-
-    /// Returns a new slice between `start` and `end - 1` from `data`.
-    pub fn slice<'a>(&self, data: &'a [u8]) -> &'a [u8] {
-        &data[self.start..self.end]
-    }
-}
 
 /// A binary reader for WebAssembly modules.
 #[derive(Debug, Clone)]
@@ -181,11 +157,8 @@ impl<'a> BinaryReader<'a> {
     }
 
     /// Returns a range from the starting offset to the end of the buffer.
-    pub fn range(&self) -> Range {
-        Range {
-            start: self.original_offset,
-            end: self.original_offset + self.buffer.len(),
-        }
+    pub fn range(&self) -> Range<usize> {
+        self.original_offset..self.original_offset + self.buffer.len()
     }
 
     pub(crate) fn remaining_buffer(&self) -> &'a [u8] {

--- a/crates/wasmparser/src/lib.rs
+++ b/crates/wasmparser/src/lib.rs
@@ -25,7 +25,7 @@
 
 #![deny(missing_docs)]
 
-pub use crate::binary_reader::{BinaryReader, BinaryReaderError, Range, Result};
+pub use crate::binary_reader::{BinaryReader, BinaryReaderError, Result};
 pub use crate::module_resources::*;
 pub use crate::parser::*;
 pub use crate::readers::*;

--- a/crates/wasmparser/src/readers.rs
+++ b/crates/wasmparser/src/readers.rs
@@ -13,7 +13,8 @@
  * limitations under the License.
  */
 
-use crate::{BinaryReaderError, Range, Result};
+use crate::{BinaryReaderError, Result};
+use std::ops::Range;
 
 mod component;
 mod core;
@@ -36,7 +37,7 @@ pub trait SectionReader {
     fn original_position(&self) -> usize;
 
     /// Gets the range of the reader.
-    fn range(&self) -> Range;
+    fn range(&self) -> Range<usize>;
 
     /// Ensures the reader is at the end of the section.
     ///

--- a/crates/wasmparser/src/readers/component/aliases.rs
+++ b/crates/wasmparser/src/readers/component/aliases.rs
@@ -1,6 +1,5 @@
-use crate::{
-    BinaryReader, Range, Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems,
-};
+use crate::{BinaryReader, Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems};
+use std::ops::Range;
 
 /// Represents a kind of alias.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -119,7 +118,7 @@ impl<'a> SectionReader for AliasSectionReader<'a> {
         Self::original_position(self)
     }
 
-    fn range(&self) -> Range {
+    fn range(&self) -> Range<usize> {
         self.reader.range()
     }
 }

--- a/crates/wasmparser/src/readers/component/exports.rs
+++ b/crates/wasmparser/src/readers/component/exports.rs
@@ -1,7 +1,8 @@
 use crate::{
-    BinaryReader, ComponentArgKind, Range, Result, SectionIteratorLimited, SectionReader,
+    BinaryReader, ComponentArgKind, Result, SectionIteratorLimited, SectionReader,
     SectionWithLimitedItems,
 };
+use std::ops::Range;
 
 /// Represents the kind of export in a WebAssembly component.
 pub type ComponentExportKind = ComponentArgKind;
@@ -73,7 +74,7 @@ impl<'a> SectionReader for ComponentExportSectionReader<'a> {
         Self::original_position(self)
     }
 
-    fn range(&self) -> Range {
+    fn range(&self) -> Range<usize> {
         self.reader.range()
     }
 }

--- a/crates/wasmparser/src/readers/component/functions.rs
+++ b/crates/wasmparser/src/readers/component/functions.rs
@@ -1,6 +1,5 @@
-use crate::{
-    BinaryReader, Range, Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems,
-};
+use crate::{BinaryReader, Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems};
+use std::ops::Range;
 
 /// Represents options for component functions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -98,7 +97,7 @@ impl<'a> SectionReader for ComponentFunctionSectionReader<'a> {
         Self::original_position(self)
     }
 
-    fn range(&self) -> Range {
+    fn range(&self) -> Range<usize> {
         self.reader.range()
     }
 }

--- a/crates/wasmparser/src/readers/component/imports.rs
+++ b/crates/wasmparser/src/readers/component/imports.rs
@@ -1,6 +1,5 @@
-use crate::{
-    BinaryReader, Range, Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems,
-};
+use crate::{BinaryReader, Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems};
+use std::ops::Range;
 
 /// Represents an import in a WebAssembly component
 #[derive(Debug, Copy, Clone)]
@@ -68,7 +67,7 @@ impl<'a> SectionReader for ComponentImportSectionReader<'a> {
         Self::original_position(self)
     }
 
-    fn range(&self) -> Range {
+    fn range(&self) -> Range<usize> {
         self.reader.range()
     }
 }

--- a/crates/wasmparser/src/readers/component/instances.rs
+++ b/crates/wasmparser/src/readers/component/instances.rs
@@ -1,7 +1,8 @@
 use crate::{
-    BinaryReader, ComponentExport, Export, Range, Result, SectionIteratorLimited, SectionReader,
+    BinaryReader, ComponentExport, Export, Result, SectionIteratorLimited, SectionReader,
     SectionWithLimitedItems,
 };
+use std::ops::Range;
 
 /// Represents the kind of argument when instantiating a WebAssembly module.
 #[derive(Debug, Clone)]
@@ -125,7 +126,7 @@ impl<'a> SectionReader for InstanceSectionReader<'a> {
         Self::original_position(self)
     }
 
-    fn range(&self) -> Range {
+    fn range(&self) -> Range<usize> {
         self.reader.range()
     }
 }

--- a/crates/wasmparser/src/readers/component/start.rs
+++ b/crates/wasmparser/src/readers/component/start.rs
@@ -1,4 +1,5 @@
-use crate::{BinaryReader, Range, Result, SectionReader};
+use crate::{BinaryReader, Result, SectionReader};
+use std::ops::Range;
 
 /// Represents the start function in a WebAssembly component.
 #[derive(Debug, Clone)]
@@ -57,7 +58,7 @@ impl<'a> SectionReader for ComponentStartSectionReader<'a> {
         Self::original_position(self)
     }
 
-    fn range(&self) -> Range {
+    fn range(&self) -> Range<usize> {
         self.0.range()
     }
 }

--- a/crates/wasmparser/src/readers/component/types.rs
+++ b/crates/wasmparser/src/readers/component/types.rs
@@ -1,7 +1,8 @@
 use crate::{
-    BinaryReader, ComponentImport, Import, Range, Result, SectionIteratorLimited, SectionReader,
+    BinaryReader, ComponentImport, Import, Result, SectionIteratorLimited, SectionReader,
     SectionWithLimitedItems, TypeDef, TypeRef,
 };
+use std::ops::Range;
 
 /// Represents a type defined in a WebAssembly component.
 #[derive(Debug, Clone)]
@@ -267,7 +268,7 @@ impl<'a> SectionReader for ComponentTypeSectionReader<'a> {
         Self::original_position(self)
     }
 
-    fn range(&self) -> Range {
+    fn range(&self) -> Range<usize> {
         self.reader.range()
     }
 }

--- a/crates/wasmparser/src/readers/core/code.rs
+++ b/crates/wasmparser/src/readers/core/code.rs
@@ -14,9 +14,10 @@
  */
 
 use crate::{
-    BinaryReader, BinaryReaderError, OperatorsReader, Range, Result, SectionIteratorLimited,
+    BinaryReader, BinaryReaderError, OperatorsReader, Result, SectionIteratorLimited,
     SectionReader, SectionWithLimitedItems, Type,
 };
+use std::ops::Range;
 
 /// Represents a WebAssembly function body.
 #[derive(Debug, Clone, Copy)]
@@ -88,11 +89,8 @@ impl<'a> FunctionBody<'a> {
     }
 
     /// Gets the range of the function body.
-    pub fn range(&self) -> Range {
-        Range {
-            start: self.offset,
-            end: self.offset + self.data.len(),
-        }
+    pub fn range(&self) -> Range<usize> {
+        self.offset..self.offset + self.data.len()
     }
 }
 
@@ -236,7 +234,7 @@ impl<'a> SectionReader for CodeSectionReader<'a> {
     fn original_position(&self) -> usize {
         CodeSectionReader::original_position(self)
     }
-    fn range(&self) -> Range {
+    fn range(&self) -> Range<usize> {
         self.reader.range()
     }
 }

--- a/crates/wasmparser/src/readers/core/custom.rs
+++ b/crates/wasmparser/src/readers/core/custom.rs
@@ -1,4 +1,5 @@
-use crate::{BinaryReader, Range, Result};
+use crate::{BinaryReader, Result};
+use std::ops::Range;
 
 /// A reader for custom sections of a WebAssembly module.
 #[derive(Clone)]
@@ -7,7 +8,7 @@ pub struct CustomSectionReader<'a> {
     pub(crate) name: &'a str,
     pub(crate) data_offset: usize,
     pub(crate) data: &'a [u8],
-    pub(crate) range: Range,
+    pub(crate) range: Range<usize>,
 }
 
 impl<'a> CustomSectionReader<'a> {
@@ -45,8 +46,8 @@ impl<'a> CustomSectionReader<'a> {
     /// The range of bytes that specify this whole custom section (including
     /// both the name of this custom section and its data) specified in
     /// offsets relative to the start of the byte stream.
-    pub fn range(&self) -> Range {
-        self.range
+    pub fn range(&self) -> Range<usize> {
+        self.range.clone()
     }
 }
 

--- a/crates/wasmparser/src/readers/core/data.rs
+++ b/crates/wasmparser/src/readers/core/data.rs
@@ -14,19 +14,20 @@
  */
 
 use crate::{
-    BinaryReader, BinaryReaderError, InitExpr, Range, Result, SectionIteratorLimited,
-    SectionReader, SectionWithLimitedItems,
+    BinaryReader, BinaryReaderError, InitExpr, Result, SectionIteratorLimited, SectionReader,
+    SectionWithLimitedItems,
 };
+use std::ops::Range;
 
 /// Represents a data segment in a core WebAssembly module.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct Data<'a> {
     /// The kind of data segment.
     pub kind: DataKind<'a>,
     /// The data of the data segment.
     pub data: &'a [u8],
     /// The range of the data segment.
-    pub range: Range,
+    pub range: Range<usize>,
 }
 
 /// The kind of data segment.
@@ -150,7 +151,7 @@ impl<'a> DataSectionReader<'a> {
         self.reader.skip_to(data_end);
 
         let segment_end = self.reader.original_position();
-        let range = Range::new(segment_start, segment_end);
+        let range = segment_start..segment_end;
 
         Ok(Data { kind, data, range })
     }
@@ -167,7 +168,7 @@ impl<'a> SectionReader for DataSectionReader<'a> {
     fn original_position(&self) -> usize {
         DataSectionReader::original_position(self)
     }
-    fn range(&self) -> Range {
+    fn range(&self) -> Range<usize> {
         self.reader.range()
     }
 }

--- a/crates/wasmparser/src/readers/core/elements.rs
+++ b/crates/wasmparser/src/readers/core/elements.rs
@@ -14,9 +14,10 @@
  */
 
 use crate::{
-    BinaryReader, BinaryReaderError, ExternalKind, InitExpr, Range, Result, SectionIteratorLimited,
+    BinaryReader, BinaryReaderError, ExternalKind, InitExpr, Result, SectionIteratorLimited,
     SectionReader, SectionWithLimitedItems, Type,
 };
+use std::ops::Range;
 
 /// Represents a core WebAssembly element segment.
 #[derive(Clone)]
@@ -28,7 +29,7 @@ pub struct Element<'a> {
     /// The type of the elements.
     pub ty: Type,
     /// The range of the the element segment.
-    pub range: Range,
+    pub range: Range<usize>,
 }
 
 /// The kind of element segment.
@@ -289,7 +290,7 @@ impl<'a> ElementSectionReader<'a> {
         };
 
         let elem_end = self.reader.original_position();
-        let range = Range::new(elem_start, elem_end);
+        let range = elem_start..elem_end;
 
         Ok(Element {
             kind,
@@ -311,7 +312,7 @@ impl<'a> SectionReader for ElementSectionReader<'a> {
     fn original_position(&self) -> usize {
         ElementSectionReader::original_position(self)
     }
-    fn range(&self) -> Range {
+    fn range(&self) -> Range<usize> {
         self.reader.range()
     }
 }

--- a/crates/wasmparser/src/readers/core/exports.rs
+++ b/crates/wasmparser/src/readers/core/exports.rs
@@ -13,9 +13,8 @@
  * limitations under the License.
  */
 
-use crate::{
-    BinaryReader, Range, Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems,
-};
+use crate::{BinaryReader, Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems};
+use std::ops::Range;
 
 /// External types as defined [here].
 ///
@@ -103,7 +102,7 @@ impl<'a> SectionReader for ExportSectionReader<'a> {
         Self::original_position(self)
     }
 
-    fn range(&self) -> Range {
+    fn range(&self) -> Range<usize> {
         self.reader.range()
     }
 }

--- a/crates/wasmparser/src/readers/core/functions.rs
+++ b/crates/wasmparser/src/readers/core/functions.rs
@@ -13,9 +13,8 @@
  * limitations under the License.
  */
 
-use crate::{
-    BinaryReader, Range, Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems,
-};
+use crate::{BinaryReader, Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems};
+use std::ops::Range;
 
 /// A reader for the function section of a WebAssembly module.
 #[derive(Clone)]
@@ -75,7 +74,7 @@ impl<'a> SectionReader for FunctionSectionReader<'a> {
         Self::original_position(self)
     }
 
-    fn range(&self) -> Range {
+    fn range(&self) -> Range<usize> {
         self.reader.range()
     }
 }

--- a/crates/wasmparser/src/readers/core/globals.rs
+++ b/crates/wasmparser/src/readers/core/globals.rs
@@ -14,9 +14,10 @@
  */
 
 use crate::{
-    BinaryReader, GlobalType, InitExpr, Range, Result, SectionIteratorLimited, SectionReader,
+    BinaryReader, GlobalType, InitExpr, Result, SectionIteratorLimited, SectionReader,
     SectionWithLimitedItems,
 };
+use std::ops::Range;
 
 /// Represents a core WebAssembly global.
 #[derive(Debug, Copy, Clone)]
@@ -88,7 +89,7 @@ impl<'a> SectionReader for GlobalSectionReader<'a> {
     fn original_position(&self) -> usize {
         GlobalSectionReader::original_position(self)
     }
-    fn range(&self) -> Range {
+    fn range(&self) -> Range<usize> {
         self.reader.range()
     }
 }

--- a/crates/wasmparser/src/readers/core/imports.rs
+++ b/crates/wasmparser/src/readers/core/imports.rs
@@ -14,9 +14,10 @@
  */
 
 use crate::{
-    BinaryReader, GlobalType, MemoryType, Range, Result, SectionIteratorLimited, SectionReader,
+    BinaryReader, GlobalType, MemoryType, Result, SectionIteratorLimited, SectionReader,
     SectionWithLimitedItems, TableType, TagType,
 };
+use std::ops::Range;
 
 /// Represents a reference to a type definition.
 #[derive(Debug, Clone, Copy)]
@@ -107,7 +108,7 @@ impl<'a> SectionReader for ImportSectionReader<'a> {
         Self::original_position(self)
     }
 
-    fn range(&self) -> Range {
+    fn range(&self) -> Range<usize> {
         self.reader.range()
     }
 }

--- a/crates/wasmparser/src/readers/core/linking.rs
+++ b/crates/wasmparser/src/readers/core/linking.rs
@@ -13,9 +13,8 @@
  * limitations under the License.
  */
 
-use crate::{
-    BinaryReader, Range, Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems,
-};
+use crate::{BinaryReader, Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems};
+use std::ops::Range;
 
 /// Represents a linking type.
 #[derive(Debug, Copy, Clone)]
@@ -68,7 +67,7 @@ impl<'a> SectionReader for LinkingSectionReader<'a> {
     fn original_position(&self) -> usize {
         LinkingSectionReader::original_position(self)
     }
-    fn range(&self) -> Range {
+    fn range(&self) -> Range<usize> {
         self.reader.range()
     }
 }

--- a/crates/wasmparser/src/readers/core/memories.rs
+++ b/crates/wasmparser/src/readers/core/memories.rs
@@ -14,9 +14,10 @@
  */
 
 use crate::{
-    BinaryReader, MemoryType, Range, Result, SectionIteratorLimited, SectionReader,
+    BinaryReader, MemoryType, Result, SectionIteratorLimited, SectionReader,
     SectionWithLimitedItems,
 };
+use std::ops::Range;
 
 /// A reader for the memory section of a WebAssembly module.
 #[derive(Clone)]
@@ -71,7 +72,7 @@ impl<'a> SectionReader for MemorySectionReader<'a> {
     fn original_position(&self) -> usize {
         MemorySectionReader::original_position(self)
     }
-    fn range(&self) -> Range {
+    fn range(&self) -> Range<usize> {
         self.reader.range()
     }
 }

--- a/crates/wasmparser/src/readers/core/names.rs
+++ b/crates/wasmparser/src/readers/core/names.rs
@@ -13,7 +13,8 @@
  * limitations under the License.
  */
 
-use crate::{BinaryReader, BinaryReaderError, Range, Result, SectionIterator, SectionReader};
+use crate::{BinaryReader, BinaryReaderError, Result, SectionIterator, SectionReader};
+use std::ops::Range;
 
 /// Represents a name for an index from the names section.
 #[derive(Debug, Copy, Clone)]
@@ -228,7 +229,7 @@ impl<'a> IndirectNameMap<'a> {
 }
 
 /// Represents a name read from the names custom section.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub enum Name<'a> {
     /// The name is for the module.
     Module(SingleName<'a>),
@@ -258,7 +259,7 @@ pub enum Name<'a> {
         data: &'a [u8],
         /// The range of bytes, relative to the start of the original data
         /// stream, that the contents of this subsection reside in.
-        range: Range,
+        range: Range<usize>,
     },
 }
 
@@ -322,7 +323,7 @@ impl<'a> NameSectionReader<'a> {
             NameType::Unknown(ty) => Name::Unknown {
                 ty,
                 data,
-                range: Range::new(offset, offset + payload_len),
+                range: offset..offset + payload_len,
             },
         })
     }
@@ -339,7 +340,7 @@ impl<'a> SectionReader for NameSectionReader<'a> {
     fn original_position(&self) -> usize {
         NameSectionReader::original_position(self)
     }
-    fn range(&self) -> Range {
+    fn range(&self) -> Range<usize> {
         self.reader.range()
     }
 }

--- a/crates/wasmparser/src/readers/core/producers.rs
+++ b/crates/wasmparser/src/readers/core/producers.rs
@@ -13,9 +13,8 @@
  * limitations under the License.
  */
 
-use crate::{
-    BinaryReader, Range, Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems,
-};
+use crate::{BinaryReader, Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems};
+use std::ops::Range;
 
 /// Represents a field value in the producers custom section.
 #[derive(Debug, Copy, Clone)]
@@ -191,7 +190,7 @@ impl<'a> SectionReader for ProducersSectionReader<'a> {
     fn original_position(&self) -> usize {
         ProducersSectionReader::original_position(self)
     }
-    fn range(&self) -> Range {
+    fn range(&self) -> Range<usize> {
         self.reader.range()
     }
 }

--- a/crates/wasmparser/src/readers/core/relocs.rs
+++ b/crates/wasmparser/src/readers/core/relocs.rs
@@ -13,9 +13,8 @@
  * limitations under the License.
  */
 
-use crate::{
-    BinaryReader, Range, Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems,
-};
+use crate::{BinaryReader, Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems};
+use std::ops::Range;
 
 /// Represents a relocation type.
 #[derive(Debug, Copy, Clone)]
@@ -178,7 +177,7 @@ impl<'a> SectionReader for RelocSectionReader<'a> {
     fn original_position(&self) -> usize {
         RelocSectionReader::original_position(self)
     }
-    fn range(&self) -> Range {
+    fn range(&self) -> Range<usize> {
         self.reader.range()
     }
 }

--- a/crates/wasmparser/src/readers/core/tables.rs
+++ b/crates/wasmparser/src/readers/core/tables.rs
@@ -14,9 +14,9 @@
  */
 
 use crate::{
-    BinaryReader, Range, Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems,
-    TableType,
+    BinaryReader, Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems, TableType,
 };
+use std::ops::Range;
 
 /// A reader for the table section of a WebAssembly module.
 #[derive(Clone)]
@@ -72,7 +72,7 @@ impl<'a> SectionReader for TableSectionReader<'a> {
     fn original_position(&self) -> usize {
         TableSectionReader::original_position(self)
     }
-    fn range(&self) -> Range {
+    fn range(&self) -> Range<usize> {
         self.reader.range()
     }
 }

--- a/crates/wasmparser/src/readers/core/tags.rs
+++ b/crates/wasmparser/src/readers/core/tags.rs
@@ -14,9 +14,9 @@
  */
 
 use crate::{
-    BinaryReader, Range, Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems,
-    TagType,
+    BinaryReader, Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems, TagType,
 };
+use std::ops::Range;
 
 /// A reader for the tags section of a WebAssembly module.
 #[derive(Clone)]
@@ -71,7 +71,7 @@ impl<'a> SectionReader for TagSectionReader<'a> {
     fn original_position(&self) -> usize {
         TagSectionReader::original_position(self)
     }
-    fn range(&self) -> Range {
+    fn range(&self) -> Range<usize> {
         self.reader.range()
     }
 }

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -13,9 +13,8 @@
  * limitations under the License.
  */
 
-use crate::{
-    BinaryReader, Range, Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems,
-};
+use crate::{BinaryReader, Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems};
+use std::ops::Range;
 
 /// Represents the types of values in a WebAssembly module.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -186,7 +185,7 @@ impl<'a> SectionReader for TypeSectionReader<'a> {
         Self::original_position(self)
     }
 
-    fn range(&self) -> Range {
+    fn range(&self) -> Range<usize> {
         self.reader.range()
     }
 }

--- a/src/bin/wasm-tools/objdump.rs
+++ b/src/bin/wasm-tools/objdump.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
+use std::ops::Range;
 use std::path::PathBuf;
-use wasmparser::{CustomSectionReader, Parser, Payload::*};
+use wasmparser::{Parser, Payload::*};
 
 /// Dumps information about sections in a WebAssembly file.
 ///
@@ -47,10 +48,7 @@ impl Opts {
                 AliasSection(_) => todo!("component-model"),
 
                 CustomSection(c) => printer.section_raw(
-                    wasmparser::Range {
-                        start: c.data_offset(),
-                        end: c.data_offset() + c.data().len(),
-                    },
+                    c.data_offset()..c.data_offset() + c.data().len(),
                     1,
                     &format!("custom {:?}", c.name()),
                 ),
@@ -98,7 +96,7 @@ impl Printer {
         self.section_raw(section.range(), section.get_count(), name)
     }
 
-    fn section_raw(&self, range: wasmparser::Range, count: u32, name: &str) {
+    fn section_raw(&self, range: Range<usize>, count: u32, name: &str) {
         println!(
             "{:40} | {:#10x} - {:#10x} | {:9} bytes | {} count",
             format!("{}{}", self.header(), name),


### PR DESCRIPTION
This commit removes `wasmparser::Range` and instead uses
`std::ops::Range<usize>` instead. This is inspired by review on
bytecodealliance/wasmtime#4005 where it's more convenience to have all
the libstd methods available.