### PR TITLE
Unpin the nightly CI.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
             rust: beta
           - build: nightly
             os: ubuntu-latest
-            rust: nightly-2021-12-10
+            rust: nightly
           - build: macos
             os: macos-latest
             rust: stable


### PR DESCRIPTION
This PR unpins the nightly CI from an old nightly version.