### PR TITLE
`wasm-smith`: Generate module types with canonical ABI functions

### DIFF
--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -16,7 +16,7 @@ name = "corpus"
 harness = false
 
 [dependencies]
-arbitrary = { version = "1.0.0", features = ["derive"] }
+arbitrary = { version = "1.1.0", features = ["derive"] }
 flagset = "0.4"
 indexmap = "1.6"
 leb128 = "0.2.4"


### PR DESCRIPTION
It is highly unlikely that we would ever generate module types that export the
canonical ABI's expected `realloc` and `free` functions by chance, and passing
certain types across an interface types boundary requires these functions, so
special case them and generate them most of the time for most modules. Do the
same for the `memory` export.