### PR TITLE
wasmprinter: Always print the index of item definitions

### DIFF
--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -2070,10 +2070,11 @@ impl Printer {
     }
 
     fn print_name(&mut self, names: &HashMap<u32, Naming>, cur_idx: u32) -> Result<()> {
-        match names.get(&cur_idx) {
-            Some(name) => name.write(&mut self.result),
-            None => write!(self.result, "(;{};)", cur_idx)?,
+        if let Some(name) = names.get(&cur_idx) {
+            name.write(&mut self.result);
+            self.result.push_str(" ");
         }
+        write!(self.result, "(;{};)", cur_idx)?;
         Ok(())
     }
 


### PR DESCRIPTION
I often find myself with the need to find function N in the text format
of a wasm file but the default output of `wasmprinter` doesn't actually
print out indices if items are named. For example instead of:

    (func $foo)

this will now print out

    (func $foo (;2;))

which can be quite helpful if you're otherwise looking for function 800
in a 2000 function file.