### PR TITLE
`dump`: allow dumping to arbitrary `impl Write` things

### DIFF
--- a/src/bin/wasm-tools/dump.rs
+++ b/src/bin/wasm-tools/dump.rs
@@ -14,8 +14,8 @@ pub struct Opts {
 impl Opts {
     pub fn run(&self) -> Result<()> {
         let input = wat::parse_file(&self.input)?;
-        println!("{}", wasmparser_dump::dump_wasm(&input)?);
-
+        let stdout = std::io::stdout();
+        wasmparser_dump::dump_wasm_into(&input, stdout.lock())?;
         Ok(())
     }
 }


### PR DESCRIPTION
And make `wasm-tools dump` write to `stdout` so that even if we encounter an
error, we still see the dump output leading up to that error.