### PR TITLE
wasm-smith: fix bug in tag type generation for components

### DIFF
--- a/crates/wasm-smith/src/component.rs
+++ b/crates/wasm-smith/src/component.rs
@@ -659,8 +659,8 @@ impl ComponentBuilder {
                 counts.tags += 1;
                 let tag_func_types = types
                     .iter()
-                    .filter(|ty| ty.results.is_empty())
                     .enumerate()
+                    .filter(|(_, ty)| ty.results.is_empty())
                     .map(|(i, _)| u32::try_from(i).unwrap())
                     .collect::<Vec<_>>();
                 Ok(crate::core::EntityType::Tag(


### PR DESCRIPTION
This fixes a bug found by the fuzz target introduced in https://github.com/bytecodealliance/wasm-tools/pull/565. Filtering for empty tag results *before* enumerating was causing the following exception:

```thread '<unnamed>' panicked at 'Invalid module: invalid exception type: non-empty tag result type (at offset 0xb)', fuzz/fuzz_targets/validate-component.rs:25:9```

The call to enumerate should come first and then we can successfully filter for empty tag result types