### PR TITLE
Support `wasm-tools --version` on the CLI

### DIFF
--- a/src/bin/wasm-tools/main.rs
+++ b/src/bin/wasm-tools/main.rs
@@ -9,6 +9,7 @@ macro_rules! subcommands {
         )*
 
         #[derive(Parser)]
+        #[clap(version)]
         #[allow(non_camel_case_types)]
         enum WasmTools {
             $(


### PR DESCRIPTION
I was poking around today and saw this wasn't supported, so this adds in
support for a top-level `--version` flag.