### PR TITLE
wasmparser: delay lowered function type calculation in component validation

### DIFF
--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2021"
 
 [dependencies]
 indexmap = "1.8.0"
+once_cell = "1.10.0"
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2021"
 
 [dependencies]
 indexmap = "1.8.0"
-once_cell = "1.10.0"
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/crates/wasmparser/src/readers/core/custom.rs
+++ b/crates/wasmparser/src/readers/core/custom.rs
@@ -19,12 +19,12 @@ impl<'a> CustomSectionReader<'a> {
         let data_offset = reader.original_position();
         let data = reader.remaining_buffer();
         let range = reader.range();
-        return Ok(CustomSectionReader {
+        Ok(CustomSectionReader {
             name,
             data_offset,
             data,
             range,
-        });
+        })
     }
 
     /// The name of the custom section.

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -2077,12 +2077,7 @@ impl OperatorValidator {
     }
 
     pub fn finish(&mut self) -> OperatorValidatorResult<()> {
-        if let Some(last) = self.control.last() {
-            // match last.kind {
-            //     FrameKind::Block | FrameKind::If | FrameKind::Else
-            // }
-            // bail_op_err!("control frames remain at end of function");
-            drop(last);
+        if self.control.last().is_some() {
             bail_op_err!("control frames remain at end of function: END opcode expected");
         }
         Ok(())

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -2357,7 +2357,7 @@ impl Printer {
             InterfaceType::List(ty) => self.print_list_type(state, ty)?,
             InterfaceType::Tuple(tys) => self.print_tuple_or_union_type("tuple", state, tys)?,
             InterfaceType::Flags(names) => self.print_flag_or_enum_type("flags", names)?,
-            InterfaceType::Enum(names) => self.print_flag_or_enum_type("enum", names)?,
+            InterfaceType::Enum(cases) => self.print_flag_or_enum_type("enum", cases)?,
             InterfaceType::Union(tys) => self.print_tuple_or_union_type("union", state, tys)?,
             InterfaceType::Option(ty) => self.print_option_type(state, ty)?,
             InterfaceType::Expected { ok, error } => self.print_expected_type(state, ok, error)?,


### PR DESCRIPTION
This PR delays the calculation of the lowered function type of a component function type until referenced from a component function definition.

This will remove unnecessary lowered function type calculations for things like component type definitions that may contain function types never referenced from a function definition.

This PR also updates `wasmparser` to validate with the latest expected canonical ABI signatures.