### PR TITLE
wasmparser: fix variant lowering calculation.

### DIFF
--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -168,7 +168,14 @@ impl ComponentState {
             || core_ty.returns.as_ref() != results.as_slice()
         {
             return Err(BinaryReaderError::new(
-                "lowered function type does not match core function type",
+                format!("lowered parameter types `{:?}` do not match parameter types `{:?}` of core function {func_index}", params.as_slice(), core_ty.params),
+                offset,
+            ));
+        }
+
+        if core_ty.returns.as_ref() != results.as_slice() {
+            return Err(BinaryReaderError::new(
+                format!("lowered result types `{:?}` do not match result types `{:?}` of core function {func_index}", results.as_slice(), core_ty.returns),
                 offset,
             ));
         }

--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -50,6 +50,14 @@ impl LoweredTypes {
         self.len == self.max
     }
 
+    fn get_mut(&mut self, index: usize) -> Option<&mut Type> {
+        if index < self.len {
+            Some(&mut self.types[index])
+        } else {
+            None
+        }
+    }
+
     fn push(&mut self, ty: Type) -> bool {
         if self.maxed() {
             return false;
@@ -714,13 +722,13 @@ impl InterfaceType {
         types: &TypeList,
         lowered_types: &mut LoweredTypes,
     ) -> bool {
-        if cases.len() <= u32::max_value() as usize {
-            lowered_types.push(Type::I32);
+        let pushed = if cases.len() <= u32::max_value() as usize {
+            lowered_types.push(Type::I32)
         } else {
-            lowered_types.push(Type::I64);
-        }
+            lowered_types.push(Type::I64)
+        };
 
-        if lowered_types.maxed() {
+        if !pushed {
             return false;
         }
 
@@ -734,7 +742,7 @@ impl InterfaceType {
             }
 
             for (i, ty) in temp.iter().enumerate() {
-                match lowered_types.types.get_mut(start + i) {
+                match lowered_types.get_mut(start + i) {
                     Some(prev) => *prev = Self::join_types(*prev, ty),
                     None => {
                         if !lowered_types.push(ty) {


### PR DESCRIPTION
This PR fixes variant lowering when calculating lowered function
signatures.

A `get_mut` call was being made on underlying storage space for the
`LoweredTypes` helper type, which always returned success, causing the case
types to never be appended on to the original list of lowered types.

This commit fixes this by implementing `get_mut` on `LoweredTypes` and also
improves the error message for when there is a lowered signature mismatch when
validating lifting core functions.