### PR TITLE
wasmparser: enforce effective type size limits for validation.

### DIFF
--- a/crates/wasmparser/src/limits.rs
+++ b/crates/wasmparser/src/limits.rs
@@ -54,3 +54,4 @@ pub const MAX_WASM_INSTANTIATION_EXPORTS: usize = 1000;
 pub const MAX_WASM_FUNCTION_OPTIONS: usize = 10;
 pub const MAX_WASM_INSTANTIATION_ARGS: usize = 1000;
 pub const MAX_WASM_START_ARGS: usize = 1000;
+pub const MAX_WASM_TYPE_SIZE: usize = 100_000;

--- a/crates/wasmparser/src/readers/component/types.rs
+++ b/crates/wasmparser/src/readers/component/types.rs
@@ -159,6 +159,13 @@ impl PrimitiveInterfaceType {
                     )
             )
     }
+
+    pub(crate) fn type_size(&self) -> usize {
+        match self {
+            Self::Unit => 0,
+            _ => 1,
+        }
+    }
 }
 
 /// Represents a reference to an interface type.


### PR DESCRIPTION
This PR reintroduces the effective type size limit in the validator that
existed with the prior module linking proposal.

With the limit enforced, an upper bound is placed on how much work the
validator will do when performing subtype checks.

This also fixes type, import, and export limit enforcement in module,
component, and instance types.

Fixes #580.