### PR TITLE
wasmparser: fix component start function validation.

### DIFF
--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -330,7 +330,8 @@ impl ComponentState {
         }
 
         for (i, ((_, ty), arg)) in ft.params.iter().zip(args).enumerate() {
-            if ty != self.value_at(*arg, offset)? {
+            // Ensure the value's type is a subtype of the parameter type
+            if !self.value_at(*arg, offset)?.is_subtype_of(ty, types) {
                 return Err(BinaryReaderError::new(
                     format!(
                         "value type mismatch for component start function argument {}",

--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -203,7 +203,7 @@ impl TypeDef {
 }
 
 /// A reference to an interface type.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy)]
 pub enum InterfaceTypeRef {
     /// The interface type is one of the primitive types.
     Primitive(PrimitiveInterfaceType),


### PR DESCRIPTION
This PR fixes the validation of component start function parameters.

Previously, validation checked that the argument type was equal to the
parameter type. However, the types being checked with interface type references
that should not support equality checks.

The fix is to instead ensure that the argument's type is a subtype of the
parameter's type according to the subtyping rules. Additionally, the
`PartialEq` and `Eq` implementation was removed for `InterfaceTypeRef` to
prevent incorrect checks like this in the future.

Fixes #584.