### PR TITLE
wasmparser: fix function type subtype check.

### DIFF
--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -564,6 +564,11 @@ impl ComponentFuncType {
             return false;
         }
 
+        // The supertype cannot have fewer parameters than the subtype.
+        if other.params.len() < self.params.len() {
+            return false;
+        }
+
         // All overlapping parameters must have the same name and are contravariant subtypes
         for ((name, ty), (other_name, other_ty)) in self.params.iter().zip(other.params.iter()) {
             if name != other_name {


### PR DESCRIPTION
This PR ensures that function type subchecking ensures that the supertype
does not have fewer parameters than the subtype, as the remainder of the
validation check assumes that is the case.

Fixes #587.