### PR TITLE
Add more tests for components parsing

### DIFF
--- a/coverage.sh
+++ b/coverage.sh
@@ -1,0 +1,25 @@
+set -ex
+
+cargo test --test roundtrip
+
+rm -rf cov
+mkdir cov
+
+export LLVM_PROFILE_FILE="`pwd`/cov/coverage-%m.profraw"
+export RUSTFLAGS="-C instrument-coverage"
+export CARGO_TARGET_DIR=`pwd`/target/coverage
+
+cargo test --test roundtrip
+
+llvm-profdata merge -sparse cov/coverage-*.profraw -o cov/coverage.profdata
+llvm-cov show -Xdemangler=rustfilt \
+  ./target/coverage/debug/deps/roundtrip-92d636af98ebdc72 \
+  --format=html \
+  --ignore-filename-regex='/.cargo/registry' \
+  --ignore-filename-regex='/rustc/' \
+  --instr-profile=cov/coverage.profdata \
+  --show-line-counts-or-regions \
+  --show-instantiations \
+  --show-regions \
+  --output-dir=cov
+

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -2807,14 +2807,12 @@ impl Printer {
         for option in options {
             self.result.push(' ');
             match option {
-                CanonicalOption::UTF8 => self.result.push_str("utf8"),
-                CanonicalOption::UTF16 => self.result.push_str("utf16"),
-                CanonicalOption::CompactUTF16 => self.result.push_str("latin1+utf16"),
+                CanonicalOption::UTF8 => self.result.push_str("string=utf8"),
+                CanonicalOption::UTF16 => self.result.push_str("string=utf16"),
+                CanonicalOption::CompactUTF16 => self.result.push_str("string=latin1+utf16"),
                 CanonicalOption::Into(index) => {
                     self.start_group("into ");
-                    self.start_group("instance ");
                     self.print_idx(&state.instance_names, *index)?;
-                    self.end_group();
                     self.end_group();
                 }
             }

--- a/crates/wast/src/component/binary.rs
+++ b/crates/wast/src/component/binary.rs
@@ -512,7 +512,7 @@ impl<'a> Encode for ComponentFunctionType<'a> {
 
 impl<'a> Encode for ComponentFunctionParam<'a> {
     fn encode(&self, e: &mut Vec<u8>) {
-        if let Some(id) = self.id {
+        if let Some(id) = self.name {
             e.push(0x01);
             id.encode(e);
         } else {
@@ -528,7 +528,8 @@ impl<'a> Encode for ValueType<'a> {
         self.value_type.encode(e)
     }
 }
-impl<T: Encode> Encode for ComponentTypeUse<'_, T> {
+
+impl<T> Encode for ComponentTypeUse<'_, T> {
     fn encode(&self, e: &mut Vec<u8>) {
         match self {
             ComponentTypeUse::Inline(_) => unreachable!("should be expanded already"),
@@ -536,6 +537,7 @@ impl<T: Encode> Encode for ComponentTypeUse<'_, T> {
         }
     }
 }
+
 impl Encode for ComponentExport<'_> {
     fn encode(&self, e: &mut Vec<u8>) {
         self.name.encode(e);
@@ -560,7 +562,7 @@ impl Encode for ComponentExport<'_> {
 impl Encode for ComponentFunc<'_> {
     fn encode(&self, e: &mut Vec<u8>) {
         match &self.kind {
-            ComponentFuncKind::Import { .. } => unreachable!("should be expanded already"),
+            ComponentFuncKind::Import { .. } => unreachable!("should be expanded by now"),
             ComponentFuncKind::Inline { body } => {
                 body.encode(e);
             }

--- a/crates/wast/src/component/module.rs
+++ b/crates/wast/src/component/module.rs
@@ -1,7 +1,7 @@
 use crate::component::*;
 use crate::core;
 use crate::kw;
-use crate::parser::{Cursor, Parse, Parser, Peek, Result};
+use crate::parser::{Parse, Parser, Result};
 use crate::token::{Id, NameAnnotation, Span};
 
 /// A nested WebAssembly module to be created as part of a component.
@@ -79,40 +79,5 @@ impl<'a> Parse<'a> for Module<'a> {
             exports,
             kind,
         })
-    }
-}
-
-// Note that this is a custom implementation to get multi-token lookahead to
-// figure out how to parse `(type ...` when it's in an inline module. If this is
-// `(type $x)` or `(type 0)` then it's an inline type annotation, otherwise it's
-// probably a typedef like `(type $x (func))` or something like that. We only
-// want to parse the two-token variant right now.
-struct InlineType;
-
-impl Peek for InlineType {
-    fn peek(cursor: Cursor<'_>) -> bool {
-        let cursor = match cursor.lparen() {
-            Some(cursor) => cursor,
-            None => return false,
-        };
-        let cursor = match cursor.keyword() {
-            Some(("type", cursor)) => cursor,
-            _ => return false,
-        };
-
-        // optional identifier
-        let cursor = match cursor.id() {
-            Some((_, cursor)) => cursor,
-            None => match cursor.integer() {
-                Some((_, cursor)) => cursor,
-                None => return false,
-            },
-        };
-
-        cursor.rparen().is_some()
-    }
-
-    fn display() -> &'static str {
-        "inline type"
     }
 }

--- a/crates/wast/src/component/types.rs
+++ b/crates/wast/src/component/types.rs
@@ -1,7 +1,7 @@
 use crate::component::*;
 use crate::kw;
-use crate::parser::{Cursor, Parse, Parser, Peek, Result};
-use crate::token::{Id, Index, NameAnnotation, Span};
+use crate::parser::{Parse, Parser, Result};
+use crate::token::{Id, NameAnnotation, Span};
 
 /// A definition of a type.
 ///
@@ -80,37 +80,14 @@ pub enum ComponentTypeUse<'a, T> {
     Inline(T),
 }
 
-impl<'a, T> ComponentTypeUse<'a, T> {
-    /// Constructs a new instance of `ComponentTypeUse` without an inline definition but
-    /// with an index specified.
-    pub fn new_with_index(idx: Index<'a>) -> ComponentTypeUse<'a, T> {
-        ComponentTypeUse::Ref(ItemRef {
-            idx,
-            kind: kw::r#type::default(),
-            export_names: Vec::new(),
-        })
-    }
-}
-
-impl<'a, T: Peek + Parse<'a>> Parse<'a> for ComponentTypeUse<'a, T> {
+impl<'a, T: Parse<'a>> Parse<'a> for ComponentTypeUse<'a, T> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
         if parser.peek::<IndexOrRef<'a, kw::r#type>>() {
             Ok(ComponentTypeUse::Ref(
                 parser.parse::<IndexOrRef<kw::r#type>>()?.0,
             ))
-        } else if parser.peek::<Index>() {
-            Ok(ComponentTypeUse::Ref(parser.parse()?))
         } else {
             Ok(ComponentTypeUse::Inline(parser.parse()?))
         }
-    }
-}
-
-impl<'a, T: Peek + Parse<'a>> Peek for ComponentTypeUse<'a, T> {
-    fn peek(cursor: Cursor<'_>) -> bool {
-        kw::r#type::peek(cursor) || T::peek(cursor)
-    }
-    fn display() -> &'static str {
-        T::display()
     }
 }

--- a/crates/wast/src/parser.rs
+++ b/crates/wast/src/parser.rs
@@ -582,13 +582,6 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// `is_empty` meets `peek2`. Looks past a token and checks if there are any
-    /// more tokens after that.
-    pub fn peek2_empty(self) -> bool {
-        let mut cursor = self.cursor();
-        cursor.advance_token().is_some()
-    }
-
     /// A helper structure to perform a sequence of `peek` operations and if
     /// they all fail produce a nice error message.
     ///

--- a/tests/local/component-model/adapt.wast
+++ b/tests/local/component-model/adapt.wast
@@ -1,0 +1,57 @@
+(component
+  (import "log" (func $log (param string)))
+  (module $libc
+    (memory (export "memory") 1)
+    (func (export "canonical_abi_realloc") (param i32 i32 i32 i32) (result i32)
+      unreachable)
+    (func (export "canonical_abi_free") (param i32 i32 i32)
+      unreachable)
+  )
+
+  (module $my_module
+    (import "env" "log-utf8" (func $log_utf8 (param i32 i32)))
+    (import "env" "log-utf16" (func $log_utf16 (param i32 i32)))
+    (import "env" "log-compact-utf16" (func $log_compact_utf16 (param i32 i32)))
+
+    (func (export "log-utf8") (param i32 i32)
+      local.get 0
+      local.get 1
+      call $log_utf8
+    )
+    (func (export "log-utf16") (param i32 i32)
+      local.get 0
+      local.get 1
+      call $log_utf16
+    )
+    (func (export "log-compact-utf16") (param i32 i32)
+      local.get 0
+      local.get 1
+      call $log_compact_utf16
+    )
+  )
+
+  (instance $libc (instantiate (module $libc)))
+
+  (func $log_lower_utf8 (canon.lower string=utf8 (into $libc) (func $log)))
+  (func $log_lower_utf16 (canon.lower string=utf16 (into $libc) (func $log)))
+  (func $log_lower_compact_utf16 (canon.lower string=latin1+utf16 (into $libc) (func $log)))
+
+  (instance $my_instance (instantiate (module $my_module)
+    (with "libc" (instance $libc))
+    (with "env" (instance
+      (export "log-utf8" (func $log_lower_utf8))
+      (export "log-utf16" (func $log_lower_utf16))
+      (export "log-compact-utf16" (func $log_lower_compact_utf16))
+    ))
+  ))
+
+  (func (export "log1")
+    (canon.lift (func (param string)) string=utf8 (into $libc)
+      (func $my_instance "log-utf8")))
+  (func (export "log2")
+    (canon.lift (func (param string)) string=utf16 (into $libc)
+      (func $my_instance "log-utf16")))
+  (func (export "log3")
+    (canon.lift (func (param string)) string=latin1+utf16 (into $libc)
+      (func $my_instance "log-compact-utf16")))
+)

--- a/tests/local/component-model/alias.wast
+++ b/tests/local/component-model/alias.wast
@@ -238,3 +238,31 @@
   ))
 )
 "instance 3 is not a module instance")
+
+;; alias some constructs
+(component
+  (import "" (instance $foo (export "v" (value s32))))
+  (export "v" (value $foo "v"))
+)
+
+(component
+  (import "" (instance $foo (export "v" (component))))
+  (export "v" (component $foo "v"))
+)
+
+(component
+  (import "" (instance $foo (export "v" (module))))
+  (export "v" (module $foo "v"))
+)
+
+(component $C
+  (module $m)
+  (alias outer $C $m (module $target))
+  (export "v" (module $target))
+)
+
+(component $C
+  (component $m)
+  (alias outer $C $m (component $target))
+  (export "v" (component $target))
+)

--- a/tests/local/component-model/func.wast
+++ b/tests/local/component-model/func.wast
@@ -1,0 +1,4 @@
+(component
+  (import "" (func (param "foo" string)))
+  (import "a" (func (param "foo" string) (param s32) (param "bar" u32)))
+)

--- a/tests/local/component-model/invalid.wast
+++ b/tests/local/component-model/invalid.wast
@@ -15,3 +15,27 @@
     )
   )
   "invalid leading byte")
+
+(assert_malformed
+  (module quote
+    "(component"
+      "(export \"\" (func $foo))"
+    ")"
+  )
+  "failed to find func named")
+
+(assert_malformed
+  (module quote
+    "(component"
+      "(alias outer 100 $foo (func $foo))"
+    ")"
+  )
+  "component depth of `100` is too large")
+
+(assert_malformed
+  (module quote
+    "(component"
+      "(alias outer $nonexistent $foo (func $foo))"
+    ")"
+  )
+  "outer component `nonexistent` not found")


### PR DESCRIPTION
This commit uses coverage to find holes in where we weren't testing
parser support for a feature in the component model. Additionally some
AST changes were made along the way:

* The `wasmprinter` output for canonical abi options were tweaked:
  * string-related options are prefixed with `string=`
  * the `into` option no longer prints `(instance ...)`, it only prints
    the instance index
* The name of parameters in function types was changed to a `&str` from
  the id/name annotation combo.
* A number of unused `Peek` implementations were removed.
* Some dynamically dead code was replaced with `unreachable!` to
  emphasize it shouldn't be executed.
* A subtraction-overflow issue was fixed in name resolution for outer
  aliases which try to reach too far.
* Parsing `ComponentTypeUse` as a simple index like `$foo` was removed
  as it's expected to either be `(type $idx)` or an inline definition.