### PR TITLE
Refactor the input/output handling of the `wasm-tools` CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,18 +17,19 @@ members = ['fuzz', 'crates/wasm-encoder', 'crates/fuzz-stats', 'crates/wasm-muta
 
 [dependencies]
 anyhow = "1.0"
+atty = "0.2"
 env_logger = "0.9"
 log = "0.4"
 clap = { version = "3.1.8", features = ['derive'] }
 tempfile = "3.2.0"
-wat = { path = "crates/wat", optional = true, version = '1.0.42' }
+wat = { path = "crates/wat", version = '1.0.42' }
 
 # Dependencies of `validate`
 wasmparser = { path = "crates/wasmparser", optional = true, version = '0.84.0' }
 rayon = { version = "1.0", optional = true }
 
 # Dependencies of `print`
-wasmprinter = { path = "crates/wasmprinter", optional = true, version = '0.2.34' }
+wasmprinter = { path = "crates/wasmprinter", version = '0.2.34' }
 
 # Dependencies of `smith`
 arbitrary = { version = "1.0.0", optional = true }
@@ -68,11 +69,11 @@ harness = false
 default = ['shrink', 'smith', 'mutate', 'validate', 'print', 'parse', 'dump', 'objdump']
 
 # Each subcommand is gated behind a feature and lists the dependencies it needs
-validate = ['wasmparser', 'rayon', 'wat']
-print = ['wasmprinter', 'wat']
-parse = ['wat']
-smith = ['wasm-smith', 'arbitrary', 'serde', 'serde_json', 'wat']
-shrink = ['wasm-shrink', 'is_executable', 'wat', 'wasmprinter']
-mutate = ['wasm-mutate', 'wat', 'wasmprinter']
-dump = ['wasmparser-dump', 'wat']
-objdump = ['wasmparser', 'wat']
+validate = ['wasmparser', 'rayon']
+print = []
+parse = []
+smith = ['wasm-smith', 'arbitrary', 'serde', 'serde_json']
+shrink = ['wasm-shrink', 'is_executable']
+mutate = ['wasm-mutate']
+dump = ['wasmparser-dump']
+objdump = ['wasmparser']

--- a/src/bin/wasm-tools/dump.rs
+++ b/src/bin/wasm-tools/dump.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use std::path::PathBuf;
 
 /// Debugging utility to dump information about a wasm binary.
 ///
@@ -7,15 +6,15 @@ use std::path::PathBuf;
 /// classified or where particular constructs are at particular offsets.
 #[derive(clap::Parser)]
 pub struct Opts {
-    /// Input WebAssembly file to dump information about.
-    input: PathBuf,
+    #[clap(flatten)]
+    io: wasm_tools::InputOutput,
 }
 
 impl Opts {
     pub fn run(&self) -> Result<()> {
-        let input = wat::parse_file(&self.input)?;
-        let stdout = std::io::stdout();
-        wasmparser_dump::dump_wasm_into(&input, stdout.lock())?;
+        let input = self.io.parse_input_wasm()?;
+        let output = self.io.output_writer()?;
+        wasmparser_dump::dump_wasm_into(&input, output)?;
         Ok(())
     }
 }

--- a/src/bin/wasm-tools/parse.rs
+++ b/src/bin/wasm-tools/parse.rs
@@ -1,6 +1,5 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::Parser;
-use std::path::PathBuf;
 
 /// Parse the WebAssembly text format.
 ///
@@ -8,23 +7,21 @@ use std::path::PathBuf;
 /// and optionally write the binary form to a provided file.
 #[derive(Parser)]
 pub struct Opts {
-    /// Input WebAssembly text file to parse.
-    input: PathBuf,
+    #[clap(flatten)]
+    io: wasm_tools::InputOutput,
 
-    /// An optional output file to place the binary WebAssembly output into.
-    ///
-    /// If this is not provided then the input is simply parsed for validity and
-    /// the output is not placed anywhere.
-    #[clap(short = 'o', long)]
-    output: Option<PathBuf>,
+    /// Output the text format of WebAssembly instead of the binary format.
+    #[clap(short = 't', long)]
+    wat: bool,
 }
 
 impl Opts {
     pub fn run(&self) -> Result<()> {
-        let binary = wat::parse_file(&self.input)?;
-        if let Some(output) = &self.output {
-            std::fs::write(&output, binary).context(format!("failed to write: {:?}", output))?;
-        }
+        let binary = self.io.parse_input_wasm()?;
+        self.io.output(wasm_tools::Output::Wasm {
+            bytes: &binary,
+            wat: self.wat,
+        })?;
         Ok(())
     }
 }

--- a/src/bin/wasm-tools/print.rs
+++ b/src/bin/wasm-tools/print.rs
@@ -1,30 +1,18 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::Parser;
-use std::path::PathBuf;
 
 /// Print the textual form of a WebAssembly binary.
 #[derive(Parser)]
 pub struct Opts {
-    /// Input WebAssembly file to print.
-    input: PathBuf,
-
-    /// An optional output file to place the output into.
-    ///
-    /// If not specified then the wasm file is printed to standard output.
-    #[clap(short = 'o', long)]
-    output: Option<PathBuf>,
+    #[clap(flatten)]
+    io: wasm_tools::InputOutput,
 }
 
 impl Opts {
     pub fn run(&self) -> Result<()> {
-        let wasm = wat::parse_file(&self.input)?;
+        let wasm = self.io.parse_input_wasm()?;
         let wat = wasmprinter::print_bytes(&wasm)?;
-        if let Some(output) = &self.output {
-            std::fs::write(&output, wat).context(format!("failed to write {:?}", output))?;
-        } else {
-            println!("{}", wat);
-        }
-
+        self.io.output(wasm_tools::Output::Wat(&wat))?;
         Ok(())
     }
 }

--- a/src/bin/wasm-tools/validate.rs
+++ b/src/bin/wasm-tools/validate.rs
@@ -1,6 +1,5 @@
 use anyhow::{anyhow, Result};
 use rayon::prelude::*;
-use std::path::PathBuf;
 use std::time::Instant;
 use wasmparser::{Parser, ValidPayload, Validator, WasmFeatures};
 
@@ -33,11 +32,8 @@ pub struct Opts {
     #[clap(long, short = 'f', parse(try_from_str = parse_features))]
     features: Option<WasmFeatures>,
 
-    /// Input WebAssembly file to validate.
-    ///
-    /// This can either be a WebAssembly binary (*.wasm) or a WebAssembly text
-    /// file (*.wat) which will be translated to binary before validation.
-    input: PathBuf,
+    #[clap(flatten)]
+    io: wasm_tools::InputOutput,
 }
 
 impl Opts {
@@ -54,7 +50,7 @@ impl Opts {
         // validated later.
         let mut validator = Validator::new_with_features(self.features.unwrap_or_default());
         let mut functions_to_validate = Vec::new();
-        let wasm = wat::parse_file(&self.input)?;
+        let wasm = self.io.parse_input_wasm()?;
 
         let start = Instant::now();
         for payload in Parser::new(0).parse_all(&wasm) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,113 @@
+//! Shared input/output routines amongst most `wasm-tools` subcommands
+
+use anyhow::{bail, Context, Result};
+use std::fs::File;
+use std::io::{BufWriter, Read, Write};
+use std::path::{Path, PathBuf};
+
+// This is intended to be included in a struct as:
+//
+//      #[clap(flatten)]
+//      io: wasm_tools::InputOutput,
+//
+// and then the methods are used to read the arguments,
+#[derive(clap::Parser)]
+pub struct InputOutput {
+    /// Input file to process.
+    ///
+    /// If not provided or if this is `-` then stdin is read entirely and
+    /// processed. Note that for most subcommands this input can either be a
+    /// binary `*.wasm` file or a textual format `*.wat` file.
+    input: Option<PathBuf>,
+
+    #[clap(flatten)]
+    output: OutputArg,
+}
+
+#[derive(clap::Parser)]
+pub struct OutputArg {
+    /// Where to place output.
+    ///
+    /// If not provided then stdout is used.
+    #[clap(short, long)]
+    output: Option<PathBuf>,
+}
+
+pub enum Output<'a> {
+    Wat(&'a str),
+    Wasm { bytes: &'a [u8], wat: bool },
+}
+
+impl InputOutput {
+    pub fn parse_input_wasm(&self) -> Result<Vec<u8>> {
+        if let Some(path) = &self.input {
+            if path != Path::new("-") {
+                let bytes = wat::parse_file(path)?;
+                return Ok(bytes);
+            }
+        }
+        let mut stdin = Vec::new();
+        std::io::stdin()
+            .read_to_end(&mut stdin)
+            .context("failed to read <stdin>")?;
+        let bytes = wat::parse_bytes(&stdin).map_err(|mut e| {
+            e.set_path("<stdin>");
+            e
+        })?;
+        Ok(bytes.into_owned())
+    }
+
+    pub fn output(&self, bytes: Output<'_>) -> Result<()> {
+        self.output.output(bytes)
+    }
+
+    pub fn output_writer(&self) -> Result<Box<dyn Write>> {
+        self.output.output_writer()
+    }
+}
+
+impl OutputArg {
+    pub fn output(&self, output: Output<'_>) -> Result<()> {
+        match output {
+            Output::Wat(s) => self.output_str(s),
+            Output::Wasm { bytes, wat: true } => {
+                self.output_str(&wasmprinter::print_bytes(&bytes)?)
+            }
+            Output::Wasm { bytes, wat: false } => {
+                match &self.output {
+                    Some(path) => {
+                        std::fs::write(path, bytes)
+                            .context(format!("failed to write `{}`", path.display()))?;
+                    }
+                    None => {
+                        if atty::is(atty::Stream::Stdout) {
+                            bail!("cannot print binary wasm output to a terminal, pass the `-t` flag to print the text format");
+                        }
+                        std::io::stdout()
+                            .write_all(bytes)
+                            .context("failed to write to stdout")?;
+                    }
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn output_str(&self, output: &str) -> Result<()> {
+        match &self.output {
+            Some(path) => {
+                std::fs::write(path, output)
+                    .context(format!("failed to write `{}`", path.display()))?;
+            }
+            None => println!("{output}"),
+        }
+        Ok(())
+    }
+
+    pub fn output_writer(&self) -> Result<Box<dyn Write>> {
+        match &self.output {
+            Some(output) => Ok(Box::new(BufWriter::new(File::create(&output)?))),
+            None => Ok(Box::new(std::io::stdout())),
+        }
+    }
+}


### PR DESCRIPTION
This commit centralizes handling input/output for the `wasm-tools` CLI
in one location for a more consistent interface across all commands. All
commands now have an optional input argument and an optional output
argument. Commands which print binary wasm modules by default all have a
`-t` argument to print the text format and will otherwise by default
error out if trying to print a binary output to a tty stdout (since that
typically corrupts terminals anyway).

Nothing really major here but I find it kinda useful to pipe input and
output between commands sometimes and it felt kinda nice to centralize
everything to avoid have some duplication and missing features in some
commands.