### PR TITLE
Remove `ItemRef` and `IndexOrRef` from core `wast` support

### DIFF
--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -1957,9 +1957,8 @@ impl Printer {
     ) -> Result<()> {
         self.result.push_str(name);
         if memarg.memory != 0 {
-            self.result.push_str(" (memory ");
+            self.result.push_str(" ");
             self.print_idx(&state.memory_names, memarg.memory)?;
-            self.result.push(')');
         }
         if memarg.offset != 0 {
             write!(self.result, " offset={}", memarg.offset)?;

--- a/crates/wast/src/component/expand.rs
+++ b/crates/wast/src/component/expand.rs
@@ -2,7 +2,7 @@ use crate::component::*;
 use crate::core;
 use crate::gensym;
 use crate::kw;
-use crate::token::{self, Id, Index, Span};
+use crate::token::{Id, Index, Span};
 use std::collections::HashMap;
 use std::mem;
 
@@ -304,10 +304,7 @@ impl<'a> Expander<'a> {
                     let ty = t.inline.take().unwrap_or_default();
                     let key = ty.key();
                     if let Some(idx) = func_type_to_idx.get(&key) {
-                        t.index = Some(token::ItemRef {
-                            idx: idx.clone(),
-                            kind: kw::r#type(item.span),
-                        });
+                        t.index = Some(idx.clone());
                         return;
                     }
                     let id = gensym::gen(item.span);
@@ -318,10 +315,7 @@ impl<'a> Expander<'a> {
                         def: key.to_def(item.span),
                     }));
                     let idx = Index::Id(id);
-                    t.index = Some(token::ItemRef {
-                        idx,
-                        kind: kw::r#type(item.span),
-                    });
+                    t.index = Some(idx);
                 }
                 core::ItemKind::Global(_)
                 | core::ItemKind::Table(_)

--- a/crates/wast/src/component/resolve.rs
+++ b/crates/wast/src/component/resolve.rs
@@ -660,7 +660,7 @@ fn resolve_moduletype(ty: &mut ModuleType<'_>) -> Result<(), Error> {
         match &mut sig.kind {
             core::ItemKind::Func(ty) | core::ItemKind::Tag(core::TagType::Exception(ty)) => {
                 let idx = ty.index.as_mut().expect("index should be filled in");
-                names.resolve(&mut idx.idx, "type")?;
+                names.resolve(idx, "type")?;
             }
             core::ItemKind::Memory(_) | core::ItemKind::Global(_) | core::ItemKind::Table(_) => {}
         }

--- a/crates/wast/src/core/export.rs
+++ b/crates/wast/src/core/export.rs
@@ -1,6 +1,6 @@
 use crate::kw;
 use crate::parser::{Cursor, Parse, Parser, Peek, Result};
-use crate::token::{ItemRef, Span};
+use crate::token::{Index, Span};
 
 /// A entry in a WebAssembly module's export section.
 #[derive(Debug)]
@@ -9,8 +9,10 @@ pub struct Export<'a> {
     pub span: Span,
     /// The name of this export from the module.
     pub name: &'a str,
+    /// The kind of item being exported.
+    pub kind: ExportKind,
     /// What's being exported from the module.
-    pub index: ItemRef<'a, ExportKind>,
+    pub item: Index<'a>,
 }
 
 /// Different kinds of elements that can be exported from a WebAssembly module,
@@ -28,10 +30,14 @@ pub enum ExportKind {
 
 impl<'a> Parse<'a> for Export<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
+        let span = parser.parse::<kw::export>()?.0;
+        let name = parser.parse()?;
+        let (kind, item) = parser.parens(|p| Ok((p.parse()?, p.parse()?)))?;
         Ok(Export {
-            span: parser.parse::<kw::export>()?.0,
-            name: parser.parse()?,
-            index: parser.parse()?,
+            span,
+            name,
+            kind,
+            item,
         })
     }
 }

--- a/crates/wast/src/core/expr.rs
+++ b/crates/wast/src/core/expr.rs
@@ -514,11 +514,11 @@ instructions! {
         BrIf(Index<'a>) : [0x0d] : "br_if",
         BrTable(BrTableIndices<'a>) : [0x0e] : "br_table",
         Return : [0x0f] : "return",
-        Call(IndexOrRef<'a, kw::func>) : [0x10] : "call",
+        Call(Index<'a>) : [0x10] : "call",
         CallIndirect(CallIndirect<'a>) : [0x11] : "call_indirect",
 
         // tail-call proposal
-        ReturnCall(IndexOrRef<'a, kw::func>) : [0x12] : "return_call",
+        ReturnCall(Index<'a>) : [0x12] : "return_call",
         ReturnCallIndirect(CallIndirect<'a>) : [0x13] : "return_call_indirect",
 
         // function-references proposal
@@ -532,8 +532,8 @@ instructions! {
         LocalGet(Index<'a>) : [0x20] : "local.get" | "get_local",
         LocalSet(Index<'a>) : [0x21] : "local.set" | "set_local",
         LocalTee(Index<'a>) : [0x22] : "local.tee" | "tee_local",
-        GlobalGet(IndexOrRef<'a, kw::global>) : [0x23] : "global.get" | "get_global",
-        GlobalSet(IndexOrRef<'a, kw::global>) : [0x24] : "global.set" | "set_global",
+        GlobalGet(Index<'a>) : [0x23] : "global.get" | "get_global",
+        GlobalSet(Index<'a>) : [0x24] : "global.set" | "set_global",
 
         TableGet(TableArg<'a>) : [0x25] : "table.get",
         TableSet(TableArg<'a>) : [0x26] : "table.set",
@@ -579,7 +579,7 @@ instructions! {
         RefNull(HeapType<'a>) : [0xd0] : "ref.null",
         RefIsNull : [0xd1] : "ref.is_null",
         RefExtern(u32) : [0xff] : "ref.extern", // only used in test harness
-        RefFunc(IndexOrRef<'a, kw::func>) : [0xd2] : "ref.func",
+        RefFunc(Index<'a>) : [0xd2] : "ref.func",
 
         // function-references proposal
         RefAsNonNull : [0xd3] : "ref.as_non_null",
@@ -1267,7 +1267,7 @@ pub struct MemArg<'a> {
     /// The offset, in bytes of this access.
     pub offset: u64,
     /// The memory index we're accessing
-    pub memory: ItemRef<'a, kw::memory>,
+    pub memory: Index<'a>,
 }
 
 impl<'a> MemArg<'a> {
@@ -1313,9 +1313,8 @@ impl<'a> MemArg<'a> {
         }
 
         let memory = parser
-            .parse::<Option<IndexOrRef<'a, kw::memory>>>()?
-            .map(|i| i.0)
-            .unwrap_or(idx_zero(parser.prev_span(), kw::memory));
+            .parse::<Option<_>>()?
+            .unwrap_or(Index::Num(0, parser.prev_span()));
         let offset = parse_u64("offset", parser)?.unwrap_or(0);
         let align = match parse_u32("align", parser)? {
             Some(n) if !n.is_power_of_two() => {
@@ -1329,13 +1328,6 @@ impl<'a> MemArg<'a> {
             align,
             memory,
         })
-    }
-}
-
-fn idx_zero<T>(span: Span, mk_kind: fn(Span) -> T) -> ItemRef<'static, T> {
-    ItemRef {
-        kind: mk_kind(span),
-        idx: Index::Num(0, span),
     }
 }
 
@@ -1385,7 +1377,7 @@ impl<'a> LoadOrStoreLane<'a> {
                 MemArg {
                     align: default_align,
                     offset: 0,
-                    memory: idx_zero(parser.prev_span(), kw::memory),
+                    memory: Index::Num(0, parser.prev_span()),
                 }
             },
             lane: LaneArg::parse(parser)?,
@@ -1397,7 +1389,7 @@ impl<'a> LoadOrStoreLane<'a> {
 #[derive(Debug)]
 pub struct CallIndirect<'a> {
     /// The table that this call is going to be indexing.
-    pub table: ItemRef<'a, kw::table>,
+    pub table: Index<'a>,
     /// Type type signature that this `call_indirect` instruction is using.
     pub ty: TypeUse<'a, FunctionType<'a>>,
 }
@@ -1405,10 +1397,10 @@ pub struct CallIndirect<'a> {
 impl<'a> Parse<'a> for CallIndirect<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
         let prev_span = parser.prev_span();
-        let table: Option<IndexOrRef<_>> = parser.parse()?;
+        let table: Option<_> = parser.parse()?;
         let ty = parser.parse::<TypeUse<'a, FunctionTypeNoNames<'a>>>()?;
         Ok(CallIndirect {
-            table: table.map(|i| i.0).unwrap_or(idx_zero(prev_span, kw::table)),
+            table: table.unwrap_or(Index::Num(0, prev_span)),
             ty: ty.into(),
         })
     }
@@ -1418,7 +1410,7 @@ impl<'a> Parse<'a> for CallIndirect<'a> {
 #[derive(Debug)]
 pub struct TableInit<'a> {
     /// The index of the table we're copying into.
-    pub table: ItemRef<'a, kw::table>,
+    pub table: Index<'a>,
     /// The index of the element segment we're copying into a table.
     pub elem: Index<'a>,
 }
@@ -1426,11 +1418,11 @@ pub struct TableInit<'a> {
 impl<'a> Parse<'a> for TableInit<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
         let prev_span = parser.prev_span();
-        let (elem, table) = if parser.peek::<ItemRef<kw::table>>() || parser.peek2::<Index>() {
-            let table = parser.parse::<IndexOrRef<_>>()?.0;
+        let (elem, table) = if parser.peek2::<Index>() {
+            let table = parser.parse()?;
             (parser.parse()?, table)
         } else {
-            (parser.parse()?, idx_zero(prev_span, kw::table))
+            (parser.parse()?, Index::Num(0, prev_span))
         };
         Ok(TableInit { table, elem })
     }
@@ -1440,18 +1432,18 @@ impl<'a> Parse<'a> for TableInit<'a> {
 #[derive(Debug)]
 pub struct TableCopy<'a> {
     /// The index of the destination table to copy into.
-    pub dst: ItemRef<'a, kw::table>,
+    pub dst: Index<'a>,
     /// The index of the source table to copy from.
-    pub src: ItemRef<'a, kw::table>,
+    pub src: Index<'a>,
 }
 
 impl<'a> Parse<'a> for TableCopy<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
-        let (dst, src) = match parser.parse::<Option<IndexOrRef<_>>>()? {
-            Some(dst) => (dst.0, parser.parse::<IndexOrRef<_>>()?.0),
+        let (dst, src) = match parser.parse::<Option<_>>()? {
+            Some(dst) => (dst, parser.parse()?),
             None => (
-                idx_zero(parser.prev_span(), kw::table),
-                idx_zero(parser.prev_span(), kw::table),
+                Index::Num(0, parser.prev_span()),
+                Index::Num(0, parser.prev_span()),
             ),
         };
         Ok(TableCopy { dst, src })
@@ -1462,15 +1454,15 @@ impl<'a> Parse<'a> for TableCopy<'a> {
 #[derive(Debug)]
 pub struct TableArg<'a> {
     /// The index of the table argument.
-    pub dst: ItemRef<'a, kw::table>,
+    pub dst: Index<'a>,
 }
 
 impl<'a> Parse<'a> for TableArg<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
-        let dst = if let Some(dst) = parser.parse::<Option<IndexOrRef<_>>>()? {
-            dst.0
+        let dst = if let Some(dst) = parser.parse()? {
+            dst
         } else {
-            idx_zero(parser.prev_span(), kw::table)
+            Index::Num(0, parser.prev_span())
         };
         Ok(TableArg { dst })
     }
@@ -1480,15 +1472,15 @@ impl<'a> Parse<'a> for TableArg<'a> {
 #[derive(Debug)]
 pub struct MemoryArg<'a> {
     /// The index of the memory space.
-    pub mem: ItemRef<'a, kw::memory>,
+    pub mem: Index<'a>,
 }
 
 impl<'a> Parse<'a> for MemoryArg<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
-        let mem = if let Some(mem) = parser.parse::<Option<IndexOrRef<_>>>()? {
-            mem.0
+        let mem = if let Some(mem) = parser.parse()? {
+            mem
         } else {
-            idx_zero(parser.prev_span(), kw::memory)
+            Index::Num(0, parser.prev_span())
         };
         Ok(MemoryArg { mem })
     }
@@ -1500,17 +1492,17 @@ pub struct MemoryInit<'a> {
     /// The index of the data segment we're copying into memory.
     pub data: Index<'a>,
     /// The index of the memory we're copying into,
-    pub mem: ItemRef<'a, kw::memory>,
+    pub mem: Index<'a>,
 }
 
 impl<'a> Parse<'a> for MemoryInit<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
         let prev_span = parser.prev_span();
-        let (data, mem) = if parser.peek::<ItemRef<kw::memory>>() || parser.peek2::<Index>() {
-            let memory = parser.parse::<IndexOrRef<_>>()?.0;
+        let (data, mem) = if parser.peek2::<Index>() {
+            let memory = parser.parse()?;
             (parser.parse()?, memory)
         } else {
-            (parser.parse()?, idx_zero(prev_span, kw::memory))
+            (parser.parse()?, Index::Num(0, prev_span))
         };
         Ok(MemoryInit { data, mem })
     }
@@ -1520,18 +1512,18 @@ impl<'a> Parse<'a> for MemoryInit<'a> {
 #[derive(Debug)]
 pub struct MemoryCopy<'a> {
     /// The index of the memory we're copying from.
-    pub src: ItemRef<'a, kw::memory>,
+    pub src: Index<'a>,
     /// The index of the memory we're copying to.
-    pub dst: ItemRef<'a, kw::memory>,
+    pub dst: Index<'a>,
 }
 
 impl<'a> Parse<'a> for MemoryCopy<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
-        let (src, dst) = match parser.parse::<Option<IndexOrRef<_>>>()? {
-            Some(dst) => (parser.parse::<IndexOrRef<_>>()?.0, dst.0),
+        let (src, dst) = match parser.parse()? {
+            Some(dst) => (parser.parse()?, dst),
             None => (
-                idx_zero(parser.prev_span(), kw::memory),
-                idx_zero(parser.prev_span(), kw::memory),
+                Index::Num(0, parser.prev_span()),
+                Index::Num(0, parser.prev_span()),
             ),
         };
         Ok(MemoryCopy { src, dst })

--- a/crates/wast/src/core/module.rs
+++ b/crates/wast/src/core/module.rs
@@ -1,6 +1,6 @@
 use crate::core::*;
 use crate::parser::{Parse, Parser, Result};
-use crate::token::{Id, IndexOrRef, ItemRef, NameAnnotation, Span};
+use crate::token::{Id, Index, NameAnnotation, Span};
 use crate::{annotation, kw};
 
 pub use crate::core::resolve::Names;
@@ -145,7 +145,7 @@ pub enum ModuleField<'a> {
     Memory(Memory<'a>),
     Global(Global<'a>),
     Export(Export<'a>),
-    Start(ItemRef<'a, kw::func>),
+    Start(Index<'a>),
     Elem(Elem<'a>),
     Data(Data<'a>),
     Tag(Tag<'a>),
@@ -187,7 +187,7 @@ impl<'a> Parse<'a> for ModuleField<'a> {
         }
         if parser.peek::<kw::start>() {
             parser.parse::<kw::start>()?;
-            return Ok(ModuleField::Start(parser.parse::<IndexOrRef<_>>()?.0));
+            return Ok(ModuleField::Start(parser.parse()?));
         }
         if parser.peek::<kw::elem>() {
             return Ok(ModuleField::Elem(parser.parse()?));

--- a/crates/wast/src/core/resolve/deinline_import_export.rs
+++ b/crates/wast/src/core/resolve/deinline_import_export.rs
@@ -1,7 +1,6 @@
 use crate::core::*;
 use crate::gensym;
-use crate::kw;
-use crate::token::{Id, Index, ItemRef, Span};
+use crate::token::{Id, Index, Span};
 use std::mem;
 
 pub fn run(fields: &mut Vec<ModuleField>) {
@@ -82,7 +81,7 @@ pub fn run(fields: &mut Vec<ModuleField>) {
                             id: None,
                             name: None,
                             kind: DataKind::Active {
-                                memory: item_ref(kw::memory(m.span), id),
+                                memory: Index::Id(id),
                                 offset: Expression {
                                     instrs: Box::new([if is_32 {
                                         Instruction::I32Const(0)
@@ -141,7 +140,7 @@ pub fn run(fields: &mut Vec<ModuleField>) {
                             id: None,
                             name: None,
                             kind: ElemKind::Active {
-                                table: item_ref(kw::table(t.span), id),
+                                table: Index::Id(id),
                                 offset: Expression {
                                     instrs: Box::new([Instruction::I32Const(0)]),
                                 },
@@ -228,13 +227,7 @@ fn export<'a>(
     ModuleField::Export(Export {
         span,
         name,
-        index: item_ref(kind, id),
-    })
-}
-
-fn item_ref<'a, K>(kind: K, id: impl Into<Index<'a>>) -> ItemRef<'a, K> {
-    ItemRef {
         kind,
-        idx: id.into(),
-    }
+        item: Index::Id(id),
+    })
 }

--- a/crates/wast/src/core/resolve/types.rs
+++ b/crates/wast/src/core/resolve/types.rs
@@ -1,7 +1,6 @@
 use crate::core::*;
 use crate::gensym;
-use crate::kw;
-use crate::token::{Index, ItemRef, Span};
+use crate::token::{Index, Span};
 use std::collections::HashMap;
 
 pub fn expand<'a>(fields: &mut Vec<ModuleField<'a>>) {
@@ -180,7 +179,7 @@ impl<'a> Expander<'a> {
         T: TypeReference<'a>,
     {
         if let Some(idx) = &item.index {
-            return idx.idx.clone();
+            return idx.clone();
         }
         let key = match item.inline.as_mut() {
             Some(ty) => {
@@ -191,10 +190,7 @@ impl<'a> Expander<'a> {
         };
         let span = Span::from_offset(0); // FIXME: don't manufacture
         let idx = self.key_to_idx(span, key);
-        item.index = Some(ItemRef {
-            idx,
-            kind: kw::r#type(span),
-        });
+        item.index = Some(idx);
         return idx;
     }
 

--- a/crates/wast/src/token.rs
+++ b/crates/wast/src/token.rs
@@ -251,36 +251,6 @@ impl<'a, K: Peek> Peek for ItemRef<'a, K> {
     }
 }
 
-/// Convenience structure to parse `$f` or `(item $f)`.
-#[derive(Clone, Debug)]
-pub struct IndexOrRef<'a, K>(pub ItemRef<'a, K>);
-
-impl<'a, K> Parse<'a> for IndexOrRef<'a, K>
-where
-    K: Parse<'a> + Default,
-{
-    fn parse(parser: Parser<'a>) -> Result<Self> {
-        if parser.peek::<Index<'_>>() {
-            Ok(IndexOrRef(ItemRef {
-                kind: K::default(),
-                idx: parser.parse()?,
-            }))
-        } else {
-            Ok(IndexOrRef(parser.parse()?))
-        }
-    }
-}
-
-impl<'a, K: Peek> Peek for IndexOrRef<'a, K> {
-    fn peek(cursor: Cursor<'_>) -> bool {
-        Index::peek(cursor) || ItemRef::<K>::peek(cursor)
-    }
-
-    fn display() -> &'static str {
-        "an item reference"
-    }
-}
-
 /// An `@name` annotation in source, currently of the form `@name "foo"`
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct NameAnnotation<'a> {

--- a/tests/local/atomics.wast
+++ b/tests/local/atomics.wast
@@ -8,7 +8,7 @@
   (func (result i32)
     i32.const 0
     i32.const 0
-    memory.atomic.notify (memory 0) offset=0
+    memory.atomic.notify 0 offset=0
   )
 )
 
@@ -19,7 +19,7 @@
       i32.const 0
       i32.const 0
       i64.const 0
-      memory.atomic.wait32 (memory 1) offset=0
+      memory.atomic.wait32 1 offset=0
     )
   )
   "unknown memory 1")

--- a/tests/local/multi-memory.wast
+++ b/tests/local/multi-memory.wast
@@ -10,36 +10,36 @@
     drop
 
     i32.const 0
-    i32.load (memory 0)
+    i32.load 0
     drop
 
     i32.const 0
-    i32.load (memory 1)
+    i32.load 1
     drop
 
     i32.const 0
-    i32.load (memory $a)
+    i32.load $a
     drop
 
     i32.const 0
-    i32.load (memory $b)
+    i32.load $b
     drop
 
     i32.const 0
     i32.const 0
-    i32.store (memory 0)
+    i32.store 0
 
     i32.const 0
     i32.const 0
-    i32.store (memory 1)
+    i32.store 1
 
     i32.const 0
     i32.const 0
-    i32.store (memory $a)
+    i32.store $a
 
     i32.const 0
     i32.const 0
-    i32.store (memory $b)
+    i32.store $b
 
     i32.const 0
     i32.const 0
@@ -72,132 +72,132 @@
     i32.const 0 memory.grow $b drop
 
     i32.const 0 i32.load drop
-    i32.const 0 i64.load (memory $b) drop
-    i32.const 0 f32.load (memory $b) drop
-    i32.const 0 f64.load (memory $b) drop
-    i32.const 0 i32.load8_s (memory $b) drop
-    i32.const 0 i32.load8_u (memory $b) drop
-    i32.const 0 i32.load16_s (memory $b) drop
-    i32.const 0 i32.load16_u (memory $b) drop
-    i32.const 0 i64.load8_s (memory $b) drop
-    i32.const 0 i64.load8_u (memory $b) drop
-    i32.const 0 i64.load16_s (memory $b) drop
-    i32.const 0 i64.load16_u (memory $b) drop
-    i32.const 0 i64.load32_s (memory $b) drop
-    i32.const 0 i64.load32_u (memory $b) drop
-    i32.const 0 i32.const 0 i32.store (memory $b)
-    i32.const 0 i64.const 0 i64.store (memory $b)
-    i32.const 0 f32.const 0 f32.store (memory $b)
-    i32.const 0 f64.const 0 f64.store (memory $b)
-    i32.const 0 i32.const 0 i32.store8 (memory $b)
-    i32.const 0 i32.const 0 i32.store16 (memory $b)
-    i32.const 0 i64.const 0 i64.store8 (memory $b)
-    i32.const 0 i64.const 0 i64.store16 (memory $b)
-    i32.const 0 i64.const 0 i64.store32 (memory $b)
+    i32.const 0 i64.load $b drop
+    i32.const 0 f32.load $b drop
+    i32.const 0 f64.load $b drop
+    i32.const 0 i32.load8_s $b drop
+    i32.const 0 i32.load8_u $b drop
+    i32.const 0 i32.load16_s $b drop
+    i32.const 0 i32.load16_u $b drop
+    i32.const 0 i64.load8_s $b drop
+    i32.const 0 i64.load8_u $b drop
+    i32.const 0 i64.load16_s $b drop
+    i32.const 0 i64.load16_u $b drop
+    i32.const 0 i64.load32_s $b drop
+    i32.const 0 i64.load32_u $b drop
+    i32.const 0 i32.const 0 i32.store $b
+    i32.const 0 i64.const 0 i64.store $b
+    i32.const 0 f32.const 0 f32.store $b
+    i32.const 0 f64.const 0 f64.store $b
+    i32.const 0 i32.const 0 i32.store8 $b
+    i32.const 0 i32.const 0 i32.store16 $b
+    i32.const 0 i64.const 0 i64.store8 $b
+    i32.const 0 i64.const 0 i64.store16 $b
+    i32.const 0 i64.const 0 i64.store32 $b
 
     i32.const 0
     i32.const 0
-    memory.atomic.notify (memory $b)
+    memory.atomic.notify $b
     drop
 
     i32.const 0
     i32.const 0
     i64.const 0
-    memory.atomic.wait32 (memory $b)
+    memory.atomic.wait32 $b
     drop
 
     i32.const 0
     i64.const 0
     i64.const 0
-    memory.atomic.wait64 (memory $b)
+    memory.atomic.wait64 $b
     drop
 
-    i32.const 0 i32.atomic.load (memory $b) drop
-    i32.const 0 i64.atomic.load (memory $b) drop
-    i32.const 0 i32.atomic.load8_u (memory $b) drop
-    i32.const 0 i32.atomic.load16_u (memory $b) drop
-    i32.const 0 i64.atomic.load8_u (memory $b) drop
-    i32.const 0 i64.atomic.load16_u (memory $b) drop
-    i32.const 0 i64.atomic.load32_u (memory $b) drop
-    i32.const 0 i32.const 0 i32.atomic.store (memory $b)
-    i32.const 0 i64.const 0 i64.atomic.store (memory $b)
-    i32.const 0 i32.const 0 i32.atomic.store8 (memory $b)
-    i32.const 0 i32.const 0 i32.atomic.store16 (memory $b)
-    i32.const 0 i64.const 0 i64.atomic.store8 (memory $b)
-    i32.const 0 i64.const 0 i64.atomic.store16 (memory $b)
-    i32.const 0 i64.const 0 i64.atomic.store32 (memory $b)
-    i32.const 0 i32.const 0 i32.atomic.rmw.add (memory $b) drop
-    i32.const 0 i64.const 0 i64.atomic.rmw.add (memory $b) drop
-    i32.const 0 i32.const 0 i32.atomic.rmw8.add_u (memory $b) drop
-    i32.const 0 i32.const 0 i32.atomic.rmw16.add_u (memory $b) drop
-    i32.const 0 i64.const 0 i64.atomic.rmw8.add_u (memory $b) drop
-    i32.const 0 i64.const 0 i64.atomic.rmw16.add_u (memory $b) drop
-    i32.const 0 i64.const 0 i64.atomic.rmw32.add_u (memory $b) drop
-    i32.const 0 i32.const 0 i32.atomic.rmw.sub (memory $b) drop
-    i32.const 0 i64.const 0 i64.atomic.rmw.sub (memory $b) drop
-    i32.const 0 i32.const 0 i32.atomic.rmw8.sub_u (memory $b) drop
-    i32.const 0 i32.const 0 i32.atomic.rmw16.sub_u (memory $b) drop
-    i32.const 0 i64.const 0 i64.atomic.rmw8.sub_u (memory $b) drop
-    i32.const 0 i64.const 0 i64.atomic.rmw16.sub_u (memory $b) drop
-    i32.const 0 i64.const 0 i64.atomic.rmw32.sub_u (memory $b) drop
-    i32.const 0 i32.const 0 i32.atomic.rmw.and (memory $b) drop
-    i32.const 0 i64.const 0 i64.atomic.rmw.and (memory $b) drop
-    i32.const 0 i32.const 0 i32.atomic.rmw8.and_u (memory $b) drop
-    i32.const 0 i32.const 0 i32.atomic.rmw16.and_u (memory $b) drop
-    i32.const 0 i64.const 0 i64.atomic.rmw8.and_u (memory $b) drop
-    i32.const 0 i64.const 0 i64.atomic.rmw16.and_u (memory $b) drop
-    i32.const 0 i64.const 0 i64.atomic.rmw32.and_u (memory $b) drop
-    i32.const 0 i32.const 0 i32.atomic.rmw.or (memory $b) drop
-    i32.const 0 i64.const 0 i64.atomic.rmw.or (memory $b) drop
-    i32.const 0 i32.const 0 i32.atomic.rmw8.or_u (memory $b) drop
-    i32.const 0 i32.const 0 i32.atomic.rmw16.or_u (memory $b) drop
-    i32.const 0 i64.const 0 i64.atomic.rmw8.or_u (memory $b) drop
-    i32.const 0 i64.const 0 i64.atomic.rmw16.or_u (memory $b) drop
-    i32.const 0 i64.const 0 i64.atomic.rmw32.or_u (memory $b) drop
-    i32.const 0 i32.const 0 i32.atomic.rmw.xor (memory $b) drop
-    i32.const 0 i64.const 0 i64.atomic.rmw.xor (memory $b) drop
-    i32.const 0 i32.const 0 i32.atomic.rmw8.xor_u (memory $b) drop
-    i32.const 0 i32.const 0 i32.atomic.rmw16.xor_u (memory $b) drop
-    i32.const 0 i64.const 0 i64.atomic.rmw8.xor_u (memory $b) drop
-    i32.const 0 i64.const 0 i64.atomic.rmw16.xor_u (memory $b) drop
-    i32.const 0 i64.const 0 i64.atomic.rmw32.xor_u (memory $b) drop
-    i32.const 0 i32.const 0 i32.atomic.rmw.xchg (memory $b) drop
-    i32.const 0 i64.const 0 i64.atomic.rmw.xchg (memory $b) drop
-    i32.const 0 i32.const 0 i32.atomic.rmw8.xchg_u (memory $b) drop
-    i32.const 0 i32.const 0 i32.atomic.rmw16.xchg_u (memory $b) drop
-    i32.const 0 i64.const 0 i64.atomic.rmw8.xchg_u (memory $b) drop
-    i32.const 0 i64.const 0 i64.atomic.rmw16.xchg_u (memory $b) drop
-    i32.const 0 i64.const 0 i64.atomic.rmw32.xchg_u (memory $b) drop
-    i32.const 0 i32.const 0 i32.const 0 i32.atomic.rmw.cmpxchg (memory $b) drop
-    i32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw.cmpxchg (memory $b) drop
-    i32.const 0 i32.const 0 i32.const 0 i32.atomic.rmw8.cmpxchg_u (memory $b) drop
-    i32.const 0 i32.const 0 i32.const 0 i32.atomic.rmw16.cmpxchg_u (memory $b) drop
-    i32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw8.cmpxchg_u (memory $b) drop
-    i32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw16.cmpxchg_u (memory $b) drop
-    i32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw32.cmpxchg_u (memory $b) drop
+    i32.const 0 i32.atomic.load $b drop
+    i32.const 0 i64.atomic.load $b drop
+    i32.const 0 i32.atomic.load8_u $b drop
+    i32.const 0 i32.atomic.load16_u $b drop
+    i32.const 0 i64.atomic.load8_u $b drop
+    i32.const 0 i64.atomic.load16_u $b drop
+    i32.const 0 i64.atomic.load32_u $b drop
+    i32.const 0 i32.const 0 i32.atomic.store $b
+    i32.const 0 i64.const 0 i64.atomic.store $b
+    i32.const 0 i32.const 0 i32.atomic.store8 $b
+    i32.const 0 i32.const 0 i32.atomic.store16 $b
+    i32.const 0 i64.const 0 i64.atomic.store8 $b
+    i32.const 0 i64.const 0 i64.atomic.store16 $b
+    i32.const 0 i64.const 0 i64.atomic.store32 $b
+    i32.const 0 i32.const 0 i32.atomic.rmw.add $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw.add $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw8.add_u $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw16.add_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw8.add_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw16.add_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw32.add_u $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw.sub $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw.sub $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw8.sub_u $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw16.sub_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw8.sub_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw16.sub_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw32.sub_u $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw.and $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw.and $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw8.and_u $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw16.and_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw8.and_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw16.and_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw32.and_u $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw.or $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw.or $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw8.or_u $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw16.or_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw8.or_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw16.or_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw32.or_u $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw.xor $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw.xor $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw8.xor_u $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw16.xor_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw8.xor_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw16.xor_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw32.xor_u $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw.xchg $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw.xchg $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw8.xchg_u $b drop
+    i32.const 0 i32.const 0 i32.atomic.rmw16.xchg_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw8.xchg_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw16.xchg_u $b drop
+    i32.const 0 i64.const 0 i64.atomic.rmw32.xchg_u $b drop
+    i32.const 0 i32.const 0 i32.const 0 i32.atomic.rmw.cmpxchg $b drop
+    i32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw.cmpxchg $b drop
+    i32.const 0 i32.const 0 i32.const 0 i32.atomic.rmw8.cmpxchg_u $b drop
+    i32.const 0 i32.const 0 i32.const 0 i32.atomic.rmw16.cmpxchg_u $b drop
+    i32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw8.cmpxchg_u $b drop
+    i32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw16.cmpxchg_u $b drop
+    i32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw32.cmpxchg_u $b drop
 
-    i32.const 0 v128.load (memory $b) drop
-    i32.const 0 v128.load8x8_s (memory $b) drop
-    i32.const 0 v128.load8x8_u (memory $b) drop
-    i32.const 0 v128.load16x4_s (memory $b) drop
-    i32.const 0 v128.load16x4_u (memory $b) drop
-    i32.const 0 v128.load32x2_s (memory $b) drop
-    i32.const 0 v128.load32x2_u (memory $b) drop
-    i32.const 0 v128.load8_splat (memory $b) drop
-    i32.const 0 v128.load16_splat (memory $b) drop
-    i32.const 0 v128.load32_splat (memory $b) drop
-    i32.const 0 v128.load64_splat (memory $b) drop
-    i32.const 0 v128.load32_zero (memory $b) drop
-    i32.const 0 v128.load64_zero (memory $b) drop
-    i32.const 0 v128.const i64x2 0 0 v128.load8_lane (memory $b) 0 drop
-    i32.const 0 v128.const i64x2 0 0 v128.load16_lane (memory $b) 0 drop
-    i32.const 0 v128.const i64x2 0 0 v128.load32_lane (memory $b) 0 drop
-    i32.const 0 v128.const i64x2 0 0 v128.load64_lane (memory $b) 0 drop
-    i32.const 0 v128.const i64x2 0 0 v128.store8_lane (memory $b) 0
-    i32.const 0 v128.const i64x2 0 0 v128.store16_lane (memory $b) 0
-    i32.const 0 v128.const i64x2 0 0 v128.store32_lane (memory $b) 0
-    i32.const 0 v128.const i64x2 0 0 v128.store64_lane (memory $b) 0
-    i32.const 0 i32.const 0 i8x16.splat v128.store (memory $b)
+    i32.const 0 v128.load $b drop
+    i32.const 0 v128.load8x8_s $b drop
+    i32.const 0 v128.load8x8_u $b drop
+    i32.const 0 v128.load16x4_s $b drop
+    i32.const 0 v128.load16x4_u $b drop
+    i32.const 0 v128.load32x2_s $b drop
+    i32.const 0 v128.load32x2_u $b drop
+    i32.const 0 v128.load8_splat $b drop
+    i32.const 0 v128.load16_splat $b drop
+    i32.const 0 v128.load32_splat $b drop
+    i32.const 0 v128.load64_splat $b drop
+    i32.const 0 v128.load32_zero $b drop
+    i32.const 0 v128.load64_zero $b drop
+    i32.const 0 v128.const i64x2 0 0 v128.load8_lane $b 0 drop
+    i32.const 0 v128.const i64x2 0 0 v128.load16_lane $b 0 drop
+    i32.const 0 v128.const i64x2 0 0 v128.load32_lane $b 0 drop
+    i32.const 0 v128.const i64x2 0 0 v128.load64_lane $b 0 drop
+    i32.const 0 v128.const i64x2 0 0 v128.store8_lane $b 0
+    i32.const 0 v128.const i64x2 0 0 v128.store16_lane $b 0
+    i32.const 0 v128.const i64x2 0 0 v128.store32_lane $b 0
+    i32.const 0 v128.const i64x2 0 0 v128.store64_lane $b 0
+    i32.const 0 i32.const 0 i8x16.splat v128.store $b
   )
 )
 
@@ -206,7 +206,7 @@
     (memory 0)
     (func
       i32.const 0
-      i32.load (memory 1)
+      i32.load 1
       drop
     )
   )
@@ -214,7 +214,7 @@
 
 (assert_malformed
   (module quote
-    "(func i32.load (memory $a))"
+    "(func i32.load $a)"
   )
   "failed to find memory")
 

--- a/tests/local/multi-memory64.wast
+++ b/tests/local/multi-memory64.wast
@@ -16,9 +16,9 @@
   (memory $c i64 (data "..."))
 
   (func
-    i32.const 0 (i32.load (memory $a)) drop
-    i32.const 0 (i32.load (memory $b)) drop
-    i64.const 0 (i32.load (memory $c)) drop
+    i32.const 0 (i32.load $a) drop
+    i32.const 0 (i32.load $b) drop
+    i64.const 0 (i32.load $c) drop
   )
 )
 


### PR DESCRIPTION
These constructs are vestiges of the old module linking proposal where
any reference to any item could be replaced with
`(kind $instance "export")` as sugar for injectin aliases. At this time
core wasm does not support nested instances so this removes the support
in the `wast` crate to bring the core wasm support more in line with the
specification.