### PR TITLE
Defer `linecol_in` when testing until there's an error

### DIFF
--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -215,9 +215,10 @@ impl TestState {
             .directives
             .into_par_iter()
             .filter_map(|directive| {
-                let (line, col) = directive.span().linecol_in(contents);
+                let span = directive.span();
                 self.test_wast_directive(test, directive)
                     .with_context(|| {
+                        let (line, col) = span.linecol_in(contents);
                         format!(
                             "failed directive on {}:{}:{}",
                             test.display(),


### PR DESCRIPTION
This method is actually quite inefficient due to having to iterate over
newlines to find which line number and column an error points to. This
commit defers the usage of `linecol_in` in the test suite of this crate
itself to happen only if an error occurs. This should help speed up the
test suite ideally.

Locally on an arm64 machine this makes the test suite go from taking 45
cpu seconds to taking 14 cpu seconds. Due to the tests all being
parallel the wall time doesn't really decrease all that much but this
should help for less parallel machines. Additionally I don't think this
will help as much on x86_64 machines since the newline-finding routine
uses simd in the standard library and is much more efficient, where I
think that the Rust standard library only uses the generic fallback for
byte finding routines at this time.