### PR TITLE
Fix a failing test on `main`

### DIFF
--- a/crates/wast/src/component/component.rs
+++ b/crates/wast/src/component/component.rs
@@ -211,7 +211,7 @@ impl<'a> Parse<'a> for Start<'a> {
         parser.parse::<kw::start>()?;
         let func = parser.parse::<IndexOrRef<_>>()?.0;
         let mut args = Vec::new();
-        while !parser.peek2::<kw::result>() {
+        while !parser.is_empty() && !parser.peek2::<kw::result>() {
             args.push(parser.parse()?);
         }
         let result = if !parser.is_empty() {


### PR DESCRIPTION
Currently `(start $f)` fails to compile because the loop that parses
values expected a `(result ..)` to always be present, but it is not
alwyas guaranteed to be present.