### PR TITLE
A few small `wasm-smith` index space refactorings

### DIFF
--- a/crates/wasm-smith/src/component.rs
+++ b/crates/wasm-smith/src/component.rs
@@ -174,18 +174,7 @@ struct ComponentContext {
     instances: Vec<(usize, usize)>,
 
     // This component's value index space.
-    //
-    // An indirect list of all values inside this component.
-    //
-    // Each entry is of the form `(i, j)` where `component.sections[i]` is
-    // guaranteed to be either
-    //
-    // * a `Section::Start` and we are referencing the `j`th result of the start
-    //   function, or
-    //
-    // * a `Section::Import` and we are referenceing the `j`th import in that
-    //   section, which is guaranteed to be a value import.
-    values: Vec<(usize, usize)>,
+    values: Vec<ValueType>,
 }
 
 impl ComponentContext {
@@ -1289,9 +1278,9 @@ impl ComponentBuilder {
                 self.total_instances += 1;
                 self.component_mut().instances.push((section_index, nth));
             }
-            Type::Value(_) => {
+            Type::Value(ty) => {
                 self.total_values += 1;
-                self.component_mut().values.push((section_index, nth));
+                self.component_mut().values.push(ty.clone());
             }
             Type::Interface(_) => unreachable!("cannot import interface types"),
         }

--- a/crates/wasm-smith/src/component/encode.rs
+++ b/crates/wasm-smith/src/component/encode.rs
@@ -67,7 +67,7 @@ impl ImportSection {
     fn encode(&self, component: &mut wasm_encoder::Component) {
         let mut sec = wasm_encoder::ComponentImportSection::new();
         for imp in &self.imports {
-            sec.import(&imp.name, imp.ty);
+            sec.import(&imp.name, imp.ty.index);
         }
         component.section(&sec);
     }
@@ -131,13 +131,13 @@ impl Type {
                 for def in &comp_ty.defs {
                     match def {
                         ComponentTypeDef::Import(imp) => {
-                            enc_comp_ty.import(&imp.name, imp.ty);
+                            enc_comp_ty.import(&imp.name, imp.ty.index);
                         }
                         ComponentTypeDef::Type(ty) => {
                             ty.encode(enc_comp_ty.ty());
                         }
                         ComponentTypeDef::Export { name, ty } => {
-                            enc_comp_ty.export(name, *ty);
+                            enc_comp_ty.export(name, ty.index);
                         }
                         ComponentTypeDef::Alias(Alias::Outer {
                             count,
@@ -159,7 +159,7 @@ impl Type {
                             ty.encode(enc_inst_ty.ty());
                         }
                         InstanceTypeDef::Export { name, ty } => {
-                            enc_inst_ty.export(name, *ty);
+                            enc_inst_ty.export(name, ty.index);
                         }
                         InstanceTypeDef::Alias(Alias::Outer {
                             count,


### PR DESCRIPTION
Trying to split things out of my big WIP patch that adds support for instantiating modules and components in `wasm-smith`.

There will be some more things along these lines soon, but they will also involve things like copying a type definition into a new index space (needed for getting `InstanceType`s and `ComponentType`s of instantiations and components we generate) and are a bit more involved so I figured this was a good check point.