### PR TITLE
Add missing expansion of recursive intertypes

### DIFF
--- a/crates/wast/src/component/expand.rs
+++ b/crates/wast/src/component/expand.rs
@@ -395,6 +395,7 @@ impl<'a> Expander<'a> {
         let inline = match ty {
             InterTypeRef::Primitive(_) | InterTypeRef::Ref(_) => return,
             InterTypeRef::Inline(inline) => {
+                self.expand_intertype(inline);
                 mem::replace(inline, InterType::Primitive(Primitive::Unit))
             }
         };

--- a/tests/local/component-model/types.wast
+++ b/tests/local/component-model/types.wast
@@ -215,3 +215,7 @@
     (type $f (func (param "" string)))
   )
   "function parameter name cannot be empty")
+
+(component
+  (type $t (func (result (tuple (list u8) u32))))
+)


### PR DESCRIPTION
This fixes a panic I found locally in `wast` where intertype references
accidentally weren't recursively expande with inline definitions.