### PR TITLE
wasmparser: use `IndexMap` in the validator.

### DIFF
--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -19,7 +19,8 @@ use crate::{
     ComponentTypeRef, ExternalKind, FuncType, GlobalType, InstantiationArgKind, MemoryType,
     PrimitiveValType, Result, TableType, TypeBounds, ValType, WasmFeatures,
 };
-use std::{collections::HashMap, mem};
+use indexmap::IndexMap;
+use std::mem;
 
 pub(crate) struct ComponentState {
     // Core index spaces
@@ -39,8 +40,8 @@ pub(crate) struct ComponentState {
     pub instances: Vec<TypeId>,
     pub components: Vec<TypeId>,
 
-    pub imports: HashMap<String, ComponentEntityType>,
-    pub exports: HashMap<String, ComponentEntityType>,
+    pub imports: IndexMap<String, ComponentEntityType>,
+    pub exports: IndexMap<String, ComponentEntityType>,
     has_start: bool,
     type_size: usize,
 }
@@ -896,7 +897,7 @@ impl ComponentState {
             module: &'a str,
             name: &'a str,
             arg: EntityType,
-            args: &mut HashMap<(&'a str, &'a str), EntityType>,
+            args: &mut IndexMap<(&'a str, &'a str), EntityType>,
             offset: usize,
         ) -> Result<()> {
             if args.insert((module, name), arg).is_some() {
@@ -913,7 +914,7 @@ impl ComponentState {
         }
 
         let module_type_id = self.module_at(module_index, offset)?;
-        let mut args = HashMap::new();
+        let mut args = IndexMap::new();
 
         // Populate the arguments
         for module_arg in module_args {
@@ -1003,7 +1004,7 @@ impl ComponentState {
         fn insert_arg<'a>(
             name: &'a str,
             arg: ComponentEntityType,
-            args: &mut HashMap<&'a str, ComponentEntityType>,
+            args: &mut IndexMap<&'a str, ComponentEntityType>,
             offset: usize,
         ) -> Result<()> {
             if args.insert(name, arg).is_some() {
@@ -1020,7 +1021,7 @@ impl ComponentState {
         }
 
         let component_type_id = self.component_at(component_index, offset)?;
-        let mut args = HashMap::new();
+        let mut args = IndexMap::new();
 
         // Populate the arguments
         for component_arg in component_args {
@@ -1150,7 +1151,7 @@ impl ComponentState {
         fn insert_export(
             name: &str,
             export: ComponentEntityType,
-            exports: &mut HashMap<String, ComponentEntityType>,
+            exports: &mut IndexMap<String, ComponentEntityType>,
             type_size: &mut usize,
             offset: usize,
         ) -> Result<()> {
@@ -1170,7 +1171,7 @@ impl ComponentState {
         }
 
         let mut type_size = 1;
-        let mut inst_exports = HashMap::new();
+        let mut inst_exports = IndexMap::new();
         for export in exports {
             match export.kind {
                 ComponentExternalKind::Module => {
@@ -1254,7 +1255,7 @@ impl ComponentState {
         fn insert_export(
             name: &str,
             export: EntityType,
-            exports: &mut HashMap<String, EntityType>,
+            exports: &mut IndexMap<String, EntityType>,
             type_size: &mut usize,
             offset: usize,
         ) -> Result<()> {
@@ -1274,7 +1275,7 @@ impl ComponentState {
         }
 
         let mut type_size = 1;
-        let mut inst_exports = HashMap::new();
+        let mut inst_exports = IndexMap::new();
         for export in exports {
             match export.kind {
                 ExternalKind::Func => {

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -10,10 +10,8 @@ use crate::{
     FuncType, Global, GlobalType, InitExpr, MemoryType, Operator, Result, TableType, TagType,
     TypeRef, ValType, WasmFeatures, WasmModuleResources,
 };
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use indexmap::IndexMap;
+use std::{collections::HashSet, sync::Arc};
 
 fn check_value_type(ty: ValType, features: &WasmFeatures, offset: usize) -> Result<()> {
     match features.check_value_type(ty) {
@@ -362,8 +360,8 @@ pub(crate) struct Module {
     pub functions: Vec<u32>,
     pub tags: Vec<TypeId>,
     pub function_references: HashSet<u32>,
-    pub imports: HashMap<(String, String), Vec<EntityType>>,
-    pub exports: HashMap<String, EntityType>,
+    pub imports: IndexMap<(String, String), Vec<EntityType>>,
+    pub exports: IndexMap<String, EntityType>,
     pub type_size: usize,
     num_imported_globals: u32,
     num_imported_functions: u32,
@@ -670,7 +668,7 @@ impl Module {
     pub(crate) fn imports_for_module_type(
         &self,
         offset: usize,
-    ) -> Result<HashMap<(String, String), EntityType>> {
+    ) -> Result<IndexMap<(String, String), EntityType>> {
         // Ensure imports are unique, which is a requirement of the component model
         self.imports.iter().map(|((module, name), types)| {
             if types.len() != 1 {

--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -5,7 +5,6 @@ use crate::{FuncType, GlobalType, MemoryType, PrimitiveValType, TableType, ValTy
 use indexmap::{IndexMap, IndexSet};
 use std::{
     borrow::Borrow,
-    collections::HashMap,
     hash::{Hash, Hasher},
     mem,
     sync::Arc,
@@ -397,9 +396,9 @@ pub struct ModuleType {
     /// The effective type size for the module type.
     pub(crate) type_size: usize,
     /// The imports of the module type.
-    pub imports: HashMap<(String, String), EntityType>,
+    pub imports: IndexMap<(String, String), EntityType>,
     /// The exports of the module type.
-    pub exports: HashMap<String, EntityType>,
+    pub exports: IndexMap<String, EntityType>,
 }
 
 impl ModuleType {
@@ -438,7 +437,7 @@ pub enum InstanceTypeKind {
     /// The instance type is the result of instantiating a module type.
     Instantiated(TypeId),
     /// The instance type is the result of instantiating from exported items.
-    Exports(HashMap<String, EntityType>),
+    Exports(IndexMap<String, EntityType>),
 }
 
 /// Represents a module instance type.
@@ -451,7 +450,7 @@ pub struct InstanceType {
 }
 
 impl InstanceType {
-    pub(crate) fn exports<'a>(&'a self, types: &'a TypeList) -> &'a HashMap<String, EntityType> {
+    pub(crate) fn exports<'a>(&'a self, types: &'a TypeList) -> &'a IndexMap<String, EntityType> {
         match &self.kind {
             InstanceTypeKind::Instantiated(id) => &types[*id].as_module_type().unwrap().exports,
             InstanceTypeKind::Exports(exports) => exports,
@@ -536,9 +535,9 @@ pub struct ComponentType {
     /// The effective type size for the component type.
     pub(crate) type_size: usize,
     /// The imports of the component type.
-    pub imports: HashMap<String, ComponentEntityType>,
+    pub imports: IndexMap<String, ComponentEntityType>,
     /// The exports of the component type.
-    pub exports: HashMap<String, ComponentEntityType>,
+    pub exports: IndexMap<String, ComponentEntityType>,
 }
 
 impl ComponentType {
@@ -568,11 +567,11 @@ impl ComponentType {
 #[derive(Debug, Clone)]
 pub enum ComponentInstanceTypeKind {
     /// The instance type is from a definition.
-    Defined(HashMap<String, ComponentEntityType>),
+    Defined(IndexMap<String, ComponentEntityType>),
     /// The instance type is the result of instantiating a component type.
     Instantiated(TypeId),
     /// The instance type is the result of instantiating from exported items.
-    Exports(HashMap<String, ComponentEntityType>),
+    Exports(IndexMap<String, ComponentEntityType>),
 }
 
 /// Represents a type of a component instance.
@@ -588,7 +587,7 @@ impl ComponentInstanceType {
     pub(crate) fn exports<'a>(
         &'a self,
         types: &'a TypeList,
-    ) -> &'a HashMap<String, ComponentEntityType> {
+    ) -> &'a IndexMap<String, ComponentEntityType> {
         match &self.kind {
             ComponentInstanceTypeKind::Defined(exports)
             | ComponentInstanceTypeKind::Exports(exports) => exports,

--- a/tests/local/component-model/instantiate.wast
+++ b/tests/local/component-model/instantiate.wast
@@ -556,3 +556,35 @@
     (export "" (instance 100 ""))
   )
   "index out of bounds")
+
+(assert_invalid
+  (component
+    (import "" (core module $libc
+      (export "memory" (memory 1))
+      (export "table" (table 0 funcref))
+      (export "func" (func))
+      (export "global" (global i32))
+      (export "global mut" (global (mut i64)))
+    ))
+    (core instance $libc (instantiate $libc))
+    (core alias export $libc "memory" (memory $mem))
+    (core alias export $libc "table" (table $tbl))
+    (core alias export $libc "func" (func $func))
+    (core alias export $libc "global" (global $global))
+    (core alias export $libc "global mut" (global $global_mut))
+
+    (import "x" (core module $needs_libc
+      (import "" "memory" (memory 1))
+      (import "" "table" (table 0 funcref))
+      (import "" "func" (func))
+      (import "" "global" (global i32))
+      (import "" "global mut" (global (mut i64)))
+    ))
+
+    (core instance
+      (instantiate $needs_libc
+        (with "" (instance (export "memory" (memory $mem))))
+      )
+    )
+  )
+  "missing module instantiation argument named `::table`")


### PR DESCRIPTION
This PR uses `IndexMap` for storing imports and exports in the type
information associated with component validation.

This allows the validator to have a stable iteration order for these collections
which will help in testing the validator by giving consistent error messages.

Fixes #593.