### PR TITLE
wasm-smith: generate shared memory when `--threads` is present

### DIFF
--- a/crates/wasm-encoder/src/core/data.rs
+++ b/crates/wasm-encoder/src/core/data.rs
@@ -17,6 +17,7 @@ use crate::{encode_section, encoding_size, Encode, Instruction, Section, Section
 ///     minimum: 1,
 ///     maximum: None,
 ///     memory64: false,
+///     shared: false,
 /// });
 ///
 /// let mut data = DataSection::new();

--- a/crates/wasm-encoder/src/core/imports.rs
+++ b/crates/wasm-encoder/src/core/imports.rs
@@ -88,6 +88,7 @@ impl From<TagType> for EntityType {
 ///         minimum: 1,
 ///         maximum: None,
 ///         memory64: false,
+///         shared: false,
 ///     }
 /// );
 ///

--- a/crates/wasm-encoder/src/core/memories.rs
+++ b/crates/wasm-encoder/src/core/memories.rs
@@ -72,6 +72,8 @@ pub struct MemoryType {
     pub maximum: Option<u64>,
     /// Whether or not this is a 64-bit memory.
     pub memory64: bool,
+    /// Whether or not this memory is shared.
+    pub shared: bool,
 }
 
 impl Encode for MemoryType {
@@ -79,6 +81,9 @@ impl Encode for MemoryType {
         let mut flags = 0;
         if self.maximum.is_some() {
             flags |= 0b001;
+        }
+        if self.shared {
+            flags |= 0b010;
         }
         if self.memory64 {
             flags |= 0b100;

--- a/crates/wasm-encoder/src/core/memories.rs
+++ b/crates/wasm-encoder/src/core/memories.rs
@@ -14,6 +14,7 @@ use crate::{encode_section, Encode, Section, SectionId};
 ///     minimum: 1,
 ///     maximum: None,
 ///     memory64: false,
+///     shared: false,
 /// });
 ///
 /// let mut module = Module::new();

--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -153,6 +153,7 @@ pub fn memory_type(
         memory64: ty.memory64,
         minimum: ty.initial,
         maximum: ty.maximum,
+        shared: ty.shared,
     })
 }
 

--- a/crates/wasm-smith/src/config.rs
+++ b/crates/wasm-smith/src/config.rs
@@ -418,6 +418,18 @@ pub trait Config: 'static + std::fmt::Debug {
     fn generate_custom_sections(&self) -> bool {
         false
     }
+
+    /// Determines whether the threads proposal is enabled.
+    ///
+    /// The [threads proposal] involves shared linear memory, new atomic
+    /// instructions, and new `wait` and `notify` instructions.
+    ///
+    /// [threads proposal]: https://github.com/WebAssembly/threads/blob/master/proposals/threads/Overview.md
+    ///
+    /// Defaults to `false`.
+    fn threads_enabled(&self) -> bool {
+        false
+    }
 }
 
 /// The default configuration.

--- a/crates/wasm-smith/src/config.rs
+++ b/crates/wasm-smith/src/config.rs
@@ -532,7 +532,6 @@ impl<'a> Arbitrary<'a> for SwarmConfig {
             max_nesting_depth: u.int_in_range(0..=10)?,
             saturating_float_to_int_enabled: u.arbitrary()?,
             sign_extension_enabled: u.arbitrary()?,
-            threads_enabled: u.arbitrary()?,
 
             // These fields, unlike the ones above, are less useful to set.
             // They either make weird inputs or are for features not widely
@@ -561,6 +560,7 @@ impl<'a> Arbitrary<'a> for SwarmConfig {
             max_type_size: 1000,
             canonicalize_nans: false,
             available_imports: None,
+            threads_enabled: false,
         })
     }
 }

--- a/crates/wasm-smith/src/config.rs
+++ b/crates/wasm-smith/src/config.rs
@@ -499,6 +499,7 @@ pub struct SwarmConfig {
     pub saturating_float_to_int_enabled: bool,
     pub sign_extension_enabled: bool,
     pub simd_enabled: bool,
+    pub threads_enabled: bool,
 }
 
 impl<'a> Arbitrary<'a> for SwarmConfig {
@@ -531,6 +532,7 @@ impl<'a> Arbitrary<'a> for SwarmConfig {
             max_nesting_depth: u.int_in_range(0..=10)?,
             saturating_float_to_int_enabled: u.arbitrary()?,
             sign_extension_enabled: u.arbitrary()?,
+            threads_enabled: u.arbitrary()?,
 
             // These fields, unlike the ones above, are less useful to set.
             // They either make weird inputs or are for features not widely
@@ -736,5 +738,9 @@ impl Config for SwarmConfig {
 
     fn canonicalize_nans(&self) -> bool {
         self.canonicalize_nans
+    }
+
+    fn threads_enabled(&self) -> bool {
+        self.threads_enabled
     }
 }

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -656,6 +656,7 @@ impl Module {
                         minimum: memory_ty.initial,
                         maximum: memory_ty.maximum,
                         memory64: memory_ty.memory64,
+                        shared: memory_ty.shared,
                     };
                     let entity = EntityType::Memory(memory_ty);
                     let type_size = entity.size();
@@ -1341,6 +1342,7 @@ pub(crate) fn arbitrary_table_type(u: &mut Unstructured, config: &dyn Config) ->
 }
 
 pub(crate) fn arbitrary_memtype(u: &mut Unstructured, config: &dyn Config) -> Result<MemoryType> {
+    let threads = config.threads_enabled() && u.arbitrary()?;
     let memory64 = config.memory64_enabled() && u.arbitrary()?;
     // We want to favor memories <= 1gb in size, allocate at most 16k pages,
     // depending on the maximum number of memories.
@@ -1352,10 +1354,12 @@ pub(crate) fn arbitrary_memtype(u: &mut Unstructured, config: &dyn Config) -> Re
         config.memory_max_size_required(),
         max_inbounds.min(max_pages),
     )?;
+    let shared = threads && u.arbitrary()?;
     Ok(MemoryType {
         minimum,
         maximum,
         memory64,
+        shared,
     })
 }
 

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -1342,7 +1342,6 @@ pub(crate) fn arbitrary_table_type(u: &mut Unstructured, config: &dyn Config) ->
 }
 
 pub(crate) fn arbitrary_memtype(u: &mut Unstructured, config: &dyn Config) -> Result<MemoryType> {
-    let threads = config.threads_enabled() && u.arbitrary()?;
     let memory64 = config.memory64_enabled() && u.arbitrary()?;
     // We want to favor memories <= 1gb in size, allocate at most 16k pages,
     // depending on the maximum number of memories.
@@ -1354,7 +1353,9 @@ pub(crate) fn arbitrary_memtype(u: &mut Unstructured, config: &dyn Config) -> Re
         config.memory_max_size_required(),
         max_inbounds.min(max_pages),
     )?;
-    let shared = threads && u.arbitrary()?;
+    // When threads are enabled, we only want to generate shared memories about
+    // 25% of the time.
+    let shared = config.threads_enabled() && u.ratio(1, 4)?;
     Ok(MemoryType {
         minimum,
         maximum,

--- a/crates/wast/src/component/binary.rs
+++ b/crates/wast/src/component/binary.rs
@@ -458,17 +458,18 @@ impl From<core::TableType<'_>> for wasm_encoder::TableType {
 
 impl From<core::MemoryType> for wasm_encoder::MemoryType {
     fn from(ty: core::MemoryType) -> Self {
-        let (minimum, maximum, memory64) = match ty {
-            core::MemoryType::B32 { limits, shared: _ } => {
-                (limits.min.into(), limits.max.map(Into::into), false)
+        let (minimum, maximum, memory64, shared) = match ty {
+            core::MemoryType::B32 { limits, shared } => {
+                (limits.min.into(), limits.max.map(Into::into), false, shared)
             }
-            core::MemoryType::B64 { limits, shared: _ } => (limits.min, limits.max, true),
+            core::MemoryType::B64 { limits, shared } => (limits.min, limits.max, true, shared),
         };
 
         Self {
             minimum,
             maximum,
             memory64,
+            shared,
         }
     }
 }

--- a/src/bin/wasm-tools/smith.rs
+++ b/src/bin/wasm-tools/smith.rs
@@ -178,6 +178,9 @@ struct Config {
     /// `--allowed-instructions numeric,control,parametric`
     #[clap(long = "allowed-instructions", use_value_delimiter = true)]
     allowed_instructions: Option<Vec<InstructionKind>>,
+    #[clap(long = "threads")]
+    #[serde(rename = "threads")]
+    threads_enabled: Option<bool>,
 }
 
 impl Opts {
@@ -295,6 +298,7 @@ impl wasm_smith::Config for CliAndJsonConfig {
         (max_type_size, u32, 1000),
         (canonicalize_nans, bool, false),
         (generate_custom_sections, bool, false),
+        (threads_enabled, bool, false),
     }
 
     fn max_memory_pages(&self, _is_64: bool) -> u64 {


### PR DESCRIPTION
One of the parts to the threads proposal is the addition of shared
memory. This change allows `wasm-smith` to generate Wasm code using
memory that is shared; it does not include the other parts of the
threads proposal (atomics, `wait/notify`).