### PR TITLE
wasmparser: validate `memory` option is present.

### DIFF
--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -666,9 +666,14 @@ impl ComponentFuncType {
 
     /// Lowers the component function type to core parameter and result types for the
     /// canonical ABI.
-    pub(crate) fn lower(&self, types: &TypeList, import: bool) -> (LoweredTypes, LoweredTypes) {
+    pub(crate) fn lower(
+        &self,
+        types: &TypeList,
+        import: bool,
+    ) -> (LoweredTypes, LoweredTypes, bool) {
         let mut params = LoweredTypes::new(MAX_FLAT_FUNC_PARAMS);
         let mut results = LoweredTypes::new(MAX_FLAT_FUNC_RESULTS);
+        let mut requires_memory = false;
 
         for (_, ty) in self.params.iter() {
             if !ty.push_wasm_types(types, &mut params) {
@@ -677,6 +682,7 @@ impl ComponentFuncType {
                 // via linear memory
                 params.clear();
                 assert!(params.push(ValType::I32));
+                requires_memory = true;
                 break;
             }
         }
@@ -691,9 +697,10 @@ impl ComponentFuncType {
             } else {
                 assert!(results.push(ValType::I32));
             }
+            requires_memory = true;
         }
 
-        (params, results)
+        (params, results, requires_memory)
     }
 }
 

--- a/tests/local/component-model/func.wast
+++ b/tests/local/component-model/func.wast
@@ -2,3 +2,18 @@
   (import "" (func (param "foo" string)))
   (import "a" (func (param "foo" string) (param s32) (param "bar" u32)))
 )
+
+(assert_invalid
+  (component
+      (core module $m
+          (memory (export "memory") 1)
+          (func (export "foo") (result i32) unreachable)
+      )
+      (core instance $i (instantiate $m))
+
+      (func (export "tuple") (result (tuple s8 u8))
+          (canon lift (core func $i "foo"))
+      )
+  )
+  "canonical option `memory` is required"
+)


### PR DESCRIPTION
This PR updates the component validation in `wasmparser` to check if the
`memory` option is present when the lowered signature of a canonical function
would need indirect memory access (e.g. the parameters or results exceeds the
canonical ABI maximums and are passed indirectly through memory).

Fixes #619.