### PR TITLE
Implement module/component alias sugar when instantiating

### DIFF
--- a/crates/wast/src/component/binary.rs
+++ b/crates/wast/src/component/binary.rs
@@ -173,7 +173,7 @@ impl Encoder {
         match &instance.kind {
             CoreInstanceKind::Instantiate { module, args } => {
                 self.core_instances.instantiate(
-                    (*module).into(),
+                    module.into(),
                     args.iter().map(|arg| (arg.name, (&arg.kind).into())),
                 );
             }
@@ -230,7 +230,7 @@ impl Encoder {
             InstanceKind::Import { .. } => unreachable!("should be expanded already"),
             InstanceKind::Instantiate { component, args } => {
                 self.instances.instantiate(
-                    (*component).into(),
+                    component.into(),
                     args.iter().map(|arg| {
                         let (kind, index) = (&arg.kind).into();
                         (arg.name, kind, index)
@@ -545,6 +545,13 @@ impl From<Index<'_>> for u32 {
             Index::Num(i, _) => i,
             Index::Id(_) => unreachable!("unresolved index in encoding: {:?}", i),
         }
+    }
+}
+
+impl<T> From<&ItemRef<'_, T>> for u32 {
+    fn from(i: &ItemRef<'_, T>) -> Self {
+        assert!(i.export_names.is_empty());
+        i.idx.into()
     }
 }
 

--- a/crates/wast/src/component/instance.rs
+++ b/crates/wast/src/component/instance.rs
@@ -2,7 +2,7 @@ use crate::component::*;
 use crate::core;
 use crate::kw;
 use crate::parser::{Parse, Parser, Result};
-use crate::token::{Id, Index, LParen, NameAnnotation, Span};
+use crate::token::{Id, LParen, NameAnnotation, Span};
 
 /// A core instance defined by instantiation or exporting core items.
 #[derive(Debug)]
@@ -41,7 +41,7 @@ pub enum CoreInstanceKind<'a> {
     /// Instantiate a core module.
     Instantiate {
         /// The module being instantiated.
-        module: Index<'a>,
+        module: ItemRef<'a, kw::module>,
         /// Arguments used to instantiate the instance.
         args: Vec<CoreInstantiationArg<'a>>,
     },
@@ -55,13 +55,19 @@ impl<'a> Parse<'a> for CoreInstanceKind<'a> {
             parser.parens(|parser| {
                 parser.parse::<kw::instantiate>()?;
                 Ok(Self::Instantiate {
-                    module: parser.parse()?,
+                    module: parser.parse::<IndexOrRef<'_, _>>()?.0,
                     args: parser.parse()?,
                 })
             })
         } else {
             Ok(Self::BundleOfExports(parser.parse()?))
         }
+    }
+}
+
+impl Default for kw::module {
+    fn default() -> kw::module {
+        kw::module(Span::from_offset(0))
     }
 }
 
@@ -198,7 +204,7 @@ pub enum InstanceKind<'a> {
     /// Instantiate a component.
     Instantiate {
         /// The component being instantiated.
-        component: Index<'a>,
+        component: ItemRef<'a, kw::component>,
         /// Arguments used to instantiate the instance.
         args: Vec<InstantiationArg<'a>>,
     },
@@ -219,13 +225,19 @@ impl<'a> Parse<'a> for InstanceKind<'a> {
             parser.parens(|parser| {
                 parser.parse::<kw::instantiate>()?;
                 Ok(Self::Instantiate {
-                    component: parser.parse()?,
+                    component: parser.parse::<IndexOrRef<'_, _>>()?.0,
                     args: parser.parse()?,
                 })
             })
         } else {
             Ok(Self::BundleOfExports(parser.parse()?))
         }
+    }
+}
+
+impl Default for kw::component {
+    fn default() -> kw::component {
+        kw::component(Span::from_offset(0))
     }
 }
 

--- a/crates/wast/src/component/item_ref.rs
+++ b/crates/wast/src/component/item_ref.rs
@@ -110,3 +110,24 @@ impl<'a, K: Peek> Peek for ItemRef<'a, K> {
         "a component item reference"
     }
 }
+
+/// Convenience structure to parse `$f` or `(item $f)`.
+#[derive(Clone, Debug)]
+pub struct IndexOrRef<'a, K>(pub ItemRef<'a, K>);
+
+impl<'a, K> Parse<'a> for IndexOrRef<'a, K>
+where
+    K: Parse<'a> + Default,
+{
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        if parser.peek::<Index<'_>>() {
+            Ok(IndexOrRef(ItemRef {
+                kind: K::default(),
+                idx: parser.parse()?,
+                export_names: Vec::new(),
+            }))
+        } else {
+            Ok(IndexOrRef(parser.parens(|p| p.parse())?))
+        }
+    }
+}

--- a/crates/wast/src/component/resolve.rs
+++ b/crates/wast/src/component/resolve.rs
@@ -190,7 +190,7 @@ impl<'a> Resolver<'a> {
     fn core_instance(&mut self, instance: &mut CoreInstance<'a>) -> Result<(), Error> {
         match &mut instance.kind {
             CoreInstanceKind::Instantiate { module, args } => {
-                self.resolve_ns(module, Ns::CoreModule)?;
+                self.component_item_ref(module)?;
                 for arg in args {
                     match &mut arg.kind {
                         CoreInstantiationArgKind::Instance(i) => {
@@ -214,7 +214,7 @@ impl<'a> Resolver<'a> {
     fn instance(&mut self, instance: &mut Instance<'a>) -> Result<(), Error> {
         match &mut instance.kind {
             InstanceKind::Instantiate { component, args } => {
-                self.resolve_ns(component, Ns::Component)?;
+                self.component_item_ref(component)?;
                 for arg in args {
                     match &mut arg.kind {
                         InstantiationArgKind::Item(e) => {

--- a/tests/local/component-model/alias.wast
+++ b/tests/local/component-model/alias.wast
@@ -252,3 +252,19 @@
 (assert_invalid
   (component (alias outer 0 0 (component)))
   "index out of bounds")
+
+(component
+  (import "" (instance $i
+     (export "x" (core module))
+  ))
+  ;; inline alias injection sugar works for module references
+  (core instance (instantiate (module $i "x")))
+)
+
+(component
+  (import "" (instance $i
+     (export "x" (component))
+  ))
+  ;; inline alias injection sugar works for component references
+  (instance (instantiate (component $i "x")))
+)


### PR DESCRIPTION
The syntax for instantiation changed slightly in #621 where a bare index
is now required, but this syntax prevents the inline injection and usage
of an alias of an export of another component/instance. This commit
soups up the support here by bringing back the `IndexOrRef` structure
which can be used to parse one of the two, allowing both a bare
reference plus a parenthesized reference that enables alias injection.