### PR TITLE
wasmparser: improve component validation.

### DIFF
--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -1204,6 +1204,14 @@ impl Validator {
             State::Component => {
                 let mut component = self.components.pop().unwrap();
 
+                // Validate that all values were used for the component
+                if let Some(index) = component.values.iter().position(|(_, used)| !*used) {
+                    return Err(BinaryReaderError::new(
+                        format!("value index {index} was not used as part of an instantiation, start function, or export"),
+                        offset,
+                    ));
+                }
+
                 // If there's a parent component, pop the stack, add it to the parent,
                 // and continue to validate the component
                 if let Some(parent) = self.components.last_mut() {

--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -19,7 +19,7 @@ use crate::{
     ComponentTypeRef, ExternalKind, FuncType, GlobalType, InstantiationArgKind, MemoryType,
     PrimitiveValType, Result, TableType, TypeBounds, ValType, WasmFeatures,
 };
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use std::mem;
 
 pub(crate) struct ComponentState {
@@ -1620,19 +1620,24 @@ impl ComponentState {
         offset: usize,
     ) -> Result<ComponentDefinedType> {
         let mut type_size = 1;
-        let fields = fields
-            .iter()
-            .map(|(name, ty)| {
-                Self::check_name(name, "record field", offset)?;
-                let ty = self.create_component_val_type(*ty, types, offset)?;
-                type_size = combine_type_sizes(type_size, ty.type_size(), offset)?;
-                Ok((name.to_string(), ty))
-            })
-            .collect::<Result<_>>()?;
+        let mut field_map = IndexMap::with_capacity(fields.len());
+
+        for (name, ty) in fields {
+            Self::check_name(name, "record field", offset)?;
+            let ty = self.create_component_val_type(*ty, types, offset)?;
+            type_size = combine_type_sizes(type_size, ty.type_size(), offset)?;
+
+            if field_map.insert(name.to_string(), ty).is_some() {
+                return Err(BinaryReaderError::new(
+                    format!("duplicate field named `{}` in record type", name),
+                    offset,
+                ));
+            }
+        }
 
         Ok(ComponentDefinedType::Record(RecordType {
             type_size,
-            fields,
+            fields: field_map,
         }))
     }
 
@@ -1643,33 +1648,48 @@ impl ComponentState {
         offset: usize,
     ) -> Result<ComponentDefinedType> {
         let mut type_size = 1;
-        let cases = cases
-            .iter()
-            .map(|case| {
-                Self::check_name(case.name, "variant case", offset)?;
-                if let Some(refines) = case.refines {
-                    if refines >= cases.len() as u32 {
-                        return Err(BinaryReaderError::new(
-                            format!("variant case refines index {} is out of bounds", refines),
-                            offset,
-                        ));
-                    }
+        let mut case_map = IndexMap::with_capacity(cases.len());
+
+        if cases.is_empty() {
+            return Err(BinaryReaderError::new(
+                "variant type must have at least one case",
+                offset,
+            ));
+        }
+
+        for (i, case) in cases.iter().enumerate() {
+            Self::check_name(case.name, "variant case", offset)?;
+            if let Some(refines) = case.refines {
+                if refines >= i as u32 {
+                    return Err(BinaryReaderError::new(
+                        "variant case can only refine a previously defined case",
+                        offset,
+                    ));
                 }
-                let ty = self.create_component_val_type(case.ty, types, offset)?;
-                type_size = combine_type_sizes(type_size, ty.type_size(), offset)?;
-                Ok((
+            }
+            let ty = self.create_component_val_type(case.ty, types, offset)?;
+            type_size = combine_type_sizes(type_size, ty.type_size(), offset)?;
+
+            if case_map
+                .insert(
                     case.name.to_string(),
                     VariantCase {
                         ty,
                         refines: case.refines.map(|i| cases[i as usize].name.to_string()),
                     },
-                ))
-            })
-            .collect::<Result<_>>()?;
+                )
+                .is_some()
+            {
+                return Err(BinaryReaderError::new(
+                    format!("duplicate case named `{}` in variant type", case.name),
+                    offset,
+                ));
+            }
+        }
 
         Ok(ComponentDefinedType::Variant(VariantType {
             type_size,
-            cases,
+            cases: case_map,
         }))
     }
 
@@ -1693,15 +1713,19 @@ impl ComponentState {
     }
 
     fn create_flags_type(&self, names: &[&str], offset: usize) -> Result<ComponentDefinedType> {
-        Ok(ComponentDefinedType::Flags(
-            names
-                .iter()
-                .map(|name| {
-                    Self::check_name(name, "flag", offset)?;
-                    Ok(name.to_string())
-                })
-                .collect::<Result<_>>()?,
-        ))
+        let mut names_set = IndexSet::with_capacity(names.len());
+
+        for name in names {
+            Self::check_name(name, "flag", offset)?;
+            if !names_set.insert(name.to_string()) {
+                return Err(BinaryReaderError::new(
+                    format!("duplicate flag named `{}`", name),
+                    offset,
+                ));
+            }
+        }
+
+        Ok(ComponentDefinedType::Flags(names_set))
     }
 
     fn create_enum_type(&self, cases: &[&str], offset: usize) -> Result<ComponentDefinedType> {
@@ -1712,15 +1736,19 @@ impl ComponentState {
             ));
         }
 
-        Ok(ComponentDefinedType::Enum(
-            cases
-                .iter()
-                .map(|name| {
-                    Self::check_name(name, "enum tag", offset)?;
-                    Ok(name.to_string())
-                })
-                .collect::<Result<_>>()?,
-        ))
+        let mut tags = IndexSet::with_capacity(cases.len());
+
+        for tag in cases {
+            Self::check_name(tag, "enum tag", offset)?;
+            if !tags.insert(tag.to_string()) {
+                return Err(BinaryReaderError::new(
+                    format!("duplicate enum tag named `{}`", tag),
+                    offset,
+                ));
+            }
+        }
+
+        Ok(ComponentDefinedType::Enum(tags))
     }
 
     fn create_union_type(

--- a/tests/local/component-model/a.wast
+++ b/tests/local/component-model/a.wast
@@ -4,7 +4,7 @@
 (component
   (import "one" (func))
 
-  (import "two" (value string))
+  (import "two" (value $v string))
   (import "three" (instance
     (export "four" (instance
       (export "five" (core module
@@ -13,5 +13,7 @@
       ))
     ))
   ))
+
+  (export "one" (value $v))
   ;; ...
 )

--- a/tests/local/component-model/definedtypes.wast
+++ b/tests/local/component-model/definedtypes.wast
@@ -18,11 +18,10 @@
   (type $A14b (record (field "x" unit)))
   (type $A14c (record (field "x" $A0)))
 
-  (type $A15a (variant))
-  (type $A15b (variant (case "x" unit)))
-  (type $A15c (variant (case "x" $A1)))
-  (type $A15e (variant (case $x "x" unit) (case $y "y" string (refines $x)) (case "z" string (refines $y))))
-  (type $A15f (variant (case "x" unit) (case "y" string (refines 0)) (case "z" string (refines 1))))
+  (type $A15a (variant (case "x" unit)))
+  (type $A15b (variant (case "x" $A1)))
+  (type $A15c (variant (case $x "x" unit) (case $y "y" string (refines $x)) (case "z" string (refines $y))))
+  (type $A15d (variant (case "x" unit) (case "y" string (refines 0)) (case "z" string (refines 1))))
 
   (type $A16a (list unit))
   (type $A16b (list $A3))
@@ -77,7 +76,15 @@
     (type $t string)
     (type $v (variant (case "x" $t (refines 1))))
   )
-  "variant case refines index 1 is out of bounds"
+  "variant case can only refine a previously defined case"
+)
+
+(assert_invalid
+  (component
+    (type $t string)
+    (type $v (variant (case "x" $t) (case "y" u64 (refines 2)) (case "z" string)))
+  )
+  "variant case can only refine a previously defined case"
 )
 
 (assert_invalid
@@ -132,17 +139,31 @@
   "index out of bounds")
 
 (assert_invalid
+  (component (type (record (field "x" string) (field "x" u8))))
+  "duplicate field named `x` in record type")
+(assert_invalid
+  (component (type (variant (case "x" s64) (case "x" s64))))
+  "duplicate case named `x` in variant type")
+(assert_invalid
+  (component (type (flags "x" "y" "x")))
+  "duplicate flag named `x`")
+(assert_invalid
+  (component (type (enum "x" "y" "x")))
+  "duplicate enum tag named `x`")
+
+(assert_invalid
   (component (type (record (field "" s32))))
   "name cannot be empty")
-
 (assert_invalid
   (component (type (variant (case "" s32))))
   "name cannot be empty")
-
 (assert_invalid
   (component (type (flags "")))
   "name cannot be empty")
-
 (assert_invalid
   (component (type (enum "")))
   "name cannot be empty")
+
+(assert_invalid
+  (component (type (variant)))
+  "variant type must have at least one case")

--- a/tests/local/component-model/import.wast
+++ b/tests/local/component-model/import.wast
@@ -96,6 +96,13 @@
   )
   "type index out of bounds")
 
+(assert_invalid
+  (component
+    (import "" (value string))
+  )
+  "value index 0 was not used as part of an instantiation, start function, or export")
+
 (component
   (import "" (value string))
+  (export "" (value 0))
 )


### PR DESCRIPTION
This PR improves component validation by checking:

* Record field names, variant case names, enum tag names, and flag names should
  be unique per type definition.
* Variants must have at least one case.
* Variant case refinement index must be less than the current case index.
* Every value in the component must be used at exactly once.

Due to the last bullet point above, this commit also temporarily halts
generating value imports in `wasm-smith` because there currently is no way to
use them via instantiation, start function, or export.

Fixes #622.