### PR TITLE
wasmparser: fix validation of `realloc` option.

### DIFF
--- a/tests/local/component-model/func.wast
+++ b/tests/local/component-model/func.wast
@@ -17,3 +17,51 @@
   )
   "canonical option `memory` is required"
 )
+
+(component
+  (import "" (func $log (param string)))
+  (core module $libc
+    (memory (export "memory") 1)
+  )
+  (core instance $libc (instantiate $libc))
+  (core func (canon lower (func $log) (memory (core memory $libc "memory"))))
+)
+
+(component
+  (core module $m
+    (memory (export "memory") 1)
+    (func (export "ret-list") (result i32) unreachable)
+  )
+  (core instance $i (instantiate $m))
+
+  (func (export "ret-list") (result (list u8))
+    (canon lift (core func $i "ret-list") (memory (core memory $i "memory")))
+  )
+)
+
+(assert_invalid
+  (component
+    (import "" (func $log (result string)))
+    (core module $libc
+      (memory (export "memory") 1)
+    )
+    (core instance $libc (instantiate $libc))
+    (core func (canon lower (func $log) (memory (core memory $libc "memory"))))
+  )
+  "canonical option `realloc` is required"
+)
+
+(assert_invalid
+  (component
+    (core module $m
+      (memory (export "memory") 1)
+      (func (export "param-list") (param i32 i32) unreachable)
+    )
+    (core instance $i (instantiate $m))
+
+    (func (export "param-list") (param (list u8))
+      (canon lift (core func $i "param-list") (memory (core memory $i "memory")))
+    )
+  )
+  "canonical option `realloc` is required"
+)


### PR DESCRIPTION
This PR fixes the validation of the `realloc` option for canonical
functions.

Previously all parameters and the result was checked to see if the option was
required. However, the parameters should only be checked for lifting and the
result should only be checked for lowering.

Refactored things slightly so that `ComponentFuncType.lower` returns a struct
with named fields rather than a tuple with too many unnamed values.

Fixes #629.