### PR TITLE
wasm-smith: generate all shared memories with a maximum

### DIFF
--- a/fuzz/fuzz_targets/validate-valid-module.rs
+++ b/fuzz/fuzz_targets/validate-valid-module.rs
@@ -41,6 +41,7 @@ fuzz_target!(|data: &[u8]| {
         simd: config.simd_enabled,
         relaxed_simd: config.relaxed_simd_enabled,
         memory64: config.memory64_enabled,
+        threads: config.threads_enabled,
         exceptions: config.exceptions_enabled,
         ..wasmparser::WasmFeatures::default()
     });

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -13,6 +13,7 @@ pub fn generate_valid_module(
     config.simd_enabled = u.arbitrary()?;
     config.relaxed_simd_enabled = config.simd_enabled && u.arbitrary()?;
     config.memory64_enabled = u.arbitrary()?;
+    config.threads_enabled = u.arbitrary()?;
     config.exceptions_enabled = u.arbitrary()?;
     config.canonicalize_nans = u.arbitrary()?;
 


### PR DESCRIPTION
According to the threads proposal specification, all shared memories must have a declared maximum. This change adds a maximum if shared memories are enabled. Also, this enables the threads proposal in the wasm-smith fuzzing to catch this kind of issue in the future.