### PR TITLE
Implemement outer core aliases in wasm-tools.

### DIFF
--- a/crates/dump/src/lib.rs
+++ b/crates/dump/src/lib.rs
@@ -263,6 +263,9 @@ impl<'a> Dump<'a> {
                             ExternalKind::Global => ("global", inc(&mut i.core_globals)),
                             ExternalKind::Tag => ("tag", inc(&mut i.core_tags)),
                         },
+                        Alias::Outer { kind, .. } => match kind {
+                            OuterAliasKind::Type => ("type", inc(&mut i.core_types)),
+                        },
                     };
                     write!(me.state, "core alias [{} {}] {:?}", kind, num, a)?;
                     me.print(end)

--- a/crates/wasm-encoder/src/component/aliases.rs
+++ b/crates/wasm-encoder/src/component/aliases.rs
@@ -3,6 +3,23 @@ use crate::{
     encode_section, ComponentExportKind, ComponentSection, ComponentSectionId, Encode, ExportKind,
 };
 
+/// Represents the kinds of outer core aliasable items in a component.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CoreOuterAliasKind {
+    /// The alias is to a core type.
+    Type,
+}
+
+impl Encode for CoreOuterAliasKind {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        match self {
+            Self::Type => {
+                sink.push(CORE_TYPE_SORT);
+            }
+        }
+    }
+}
+
 /// An encoder for the core alias section of WebAssembly components.
 ///
 /// # Example
@@ -51,6 +68,19 @@ impl AliasSection {
         self.bytes.push(0x00);
         instance_index.encode(&mut self.bytes);
         name.encode(&mut self.bytes);
+        self.num_added += 1;
+        self
+    }
+
+    /// Define an alias to an outer core item.
+    ///
+    /// The count starts at 0 to indicate the current component, 1 indicates the direct
+    /// parent, 2 the grandparent, etc.
+    pub fn outer(&mut self, count: u32, kind: CoreOuterAliasKind, index: u32) -> &mut Self {
+        kind.encode(&mut self.bytes);
+        self.bytes.push(0x01);
+        count.encode(&mut self.bytes);
+        index.encode(&mut self.bytes);
         self.num_added += 1;
         self
     }

--- a/crates/wasm-encoder/src/component/types.rs
+++ b/crates/wasm-encoder/src/component/types.rs
@@ -1,6 +1,6 @@
 use crate::{
     encode_section, ComponentOuterAliasKind, ComponentSection, ComponentSectionId,
-    ComponentTypeRef, Encode, EntityType, ValType,
+    ComponentTypeRef, CoreOuterAliasKind, Encode, EntityType, ValType,
 };
 
 /// Represents the type of a core module.
@@ -15,6 +15,18 @@ impl ModuleType {
     /// Creates a new core module type.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Defines an outer core type alias in this module type.
+    pub fn alias_outer_core_type(&mut self, count: u32, index: u32) -> &mut Self {
+        self.bytes.push(0x02);
+        CoreOuterAliasKind::Type.encode(&mut self.bytes);
+        self.bytes.push(0x01);
+        count.encode(&mut self.bytes);
+        index.encode(&mut self.bytes);
+        self.num_added += 1;
+        self.types_added += 1;
+        self
     }
 
     /// Defines an import in this module type.

--- a/crates/wasm-smith/src/component/encode.rs
+++ b/crates/wasm-smith/src/component/encode.rs
@@ -115,6 +115,9 @@ impl CoreTypeSection {
 impl CoreType {
     fn encode(&self, enc: wasm_encoder::CoreTypeEncoder<'_>) {
         match self {
+            Self::Func(ty) => {
+                enc.function(ty.params.iter().copied(), ty.results.iter().copied());
+            }
             Self::Module(mod_ty) => {
                 let mut enc_mod_ty = wasm_encoder::ModuleType::new();
                 for def in &mod_ty.defs {
@@ -125,6 +128,16 @@ impl CoreType {
                                 func_ty.results.iter().copied(),
                             );
                         }
+                        ModuleTypeDef::Alias(alias) => match alias {
+                            CoreAlias::Outer {
+                                count,
+                                i,
+                                kind: CoreOuterAliasKind::Type(_),
+                            } => {
+                                enc_mod_ty.alias_outer_core_type(*count, *i);
+                            }
+                            CoreAlias::InstanceExport { .. } => unreachable!(),
+                        },
                         ModuleTypeDef::Import(imp) => {
                             enc_mod_ty.import(
                                 &imp.module,

--- a/crates/wasmparser/src/readers/component/aliases.rs
+++ b/crates/wasmparser/src/readers/component/aliases.rs
@@ -4,6 +4,13 @@ use crate::{
 };
 use std::ops::Range;
 
+/// Represents the kind of an outer core alias in a WebAssembly component.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OuterAliasKind {
+    /// The alias is to a core type.
+    Type,
+}
+
 /// Represents a core alias for a WebAssembly module.
 #[derive(Debug, Clone)]
 pub enum Alias<'a> {
@@ -15,6 +22,15 @@ pub enum Alias<'a> {
         instance_index: u32,
         /// The export name.
         name: &'a str,
+    },
+    /// The alias is to an outer item.
+    Outer {
+        /// The alias kind.
+        kind: OuterAliasKind,
+        /// The outward count, starting at zero for the current component.
+        count: u32,
+        /// The index of the item within the outer component.
+        index: u32,
     },
 }
 

--- a/crates/wasmparser/src/readers/component/types.rs
+++ b/crates/wasmparser/src/readers/component/types.rs
@@ -1,6 +1,6 @@
 use crate::{
-    BinaryReader, ComponentAlias, ComponentImport, ComponentTypeRef, FuncType, Import, Result,
-    SectionIteratorLimited, SectionReader, SectionWithLimitedItems, Type, TypeRef,
+    Alias, BinaryReader, ComponentAlias, ComponentImport, ComponentTypeRef, FuncType, Import,
+    Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems, Type, TypeRef,
 };
 use std::ops::Range;
 
@@ -25,6 +25,8 @@ pub enum ModuleTypeDeclaration<'a> {
         /// The type reference of the export.
         ty: TypeRef,
     },
+    /// The module type declaration is for an alias.
+    Alias(Alias<'a>),
     /// The module type definition is for an import.
     Import(Import<'a>),
 }

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -922,10 +922,7 @@ impl Validator {
             "core alias",
             |_, _, _, _| Ok(()), // maximums checked via `add_alias`
             |components, types, _, alias, offset| -> Result<(), BinaryReaderError> {
-                components
-                    .last_mut()
-                    .unwrap()
-                    .add_core_alias(alias, types, offset)
+                ComponentState::add_core_alias(components, alias, types, offset)
             },
         )
     }
@@ -945,8 +942,9 @@ impl Validator {
                 Ok(())
             },
             |components, types, features, ty, offset| {
-                let current = components.last_mut().unwrap();
-                current.add_core_type(ty, features, types, offset, false /* checked above */)
+                ComponentState::add_core_type(
+                    components, ty, features, types, offset, false, /* checked above */
+                )
             },
         )
     }

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -529,14 +529,13 @@ impl Module {
         Ok(())
     }
 
-    fn type_at<'a>(&self, idx: u32, types: &'a TypeList, offset: usize) -> Result<&'a Type> {
-        match self.types.get(idx as usize) {
-            Some(id) => Ok(&types[*id]),
-            None => Err(BinaryReaderError::new(
+    pub fn type_at(&self, idx: u32, offset: usize) -> Result<TypeId> {
+        self.types.get(idx as usize).copied().ok_or_else(|| {
+            BinaryReaderError::new(
                 format!("unknown type {}: type index out of bounds", idx),
                 offset,
-            )),
-        }
+            )
+        })
     }
 
     fn func_type_at<'a>(
@@ -545,7 +544,7 @@ impl Module {
         types: &'a TypeList,
         offset: usize,
     ) -> Result<&'a FuncType> {
-        self.type_at(type_index, types, offset)?
+        types[self.type_at(type_index, offset)?]
             .as_func_type()
             .ok_or_else(|| {
                 BinaryReaderError::new(

--- a/crates/wast/src/component/alias.rs
+++ b/crates/wast/src/component/alias.rs
@@ -36,25 +36,64 @@ pub struct CoreAlias<'a> {
     pub target: CoreAliasTarget<'a>,
 }
 
-impl<'a> Parse<'a> for CoreAlias<'a> {
-    fn parse(parser: Parser<'a>) -> Result<Self> {
-        let span = parser.parse::<kw::core>()?.0;
-        parser.parse::<kw::alias>()?;
+impl<'a> CoreAlias<'a> {
+    /// Parses only an outer type alias.
+    pub fn parse_outer_type_alias(parser: Parser<'a>) -> Result<Self> {
+        let span = parser.parse::<kw::alias>()?.0;
+        parser.parse::<kw::outer>()?;
+        let outer = parser.parse()?;
+        let index = parser.parse()?;
 
-        // Right now only export aliases are supported for core aliases.
-        parser.parse::<kw::export>()?;
-
-        let instance = parser.parse()?;
-        let export_name = parser.parse()?;
-        let (kind, id, name) = parser.parens(|p| Ok((p.parse()?, p.parse()?, p.parse()?)))?;
+        let (kind, id, name) =
+            parser.parens(|parser| Ok((parser.parse()?, parser.parse()?, parser.parse()?)))?;
 
         Ok(Self {
             span,
-            target: CoreAliasTarget::Export {
-                instance,
-                name: export_name,
-                kind,
-            },
+            target: CoreAliasTarget::Outer { outer, index, kind },
+            id,
+            name,
+        })
+    }
+}
+
+impl<'a> Parse<'a> for CoreAlias<'a> {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        let span = parser.parse::<kw::core>()?.0;
+        parser.parse::<kw::alias>()?.0;
+
+        let mut l = parser.lookahead1();
+
+        let (target, id, name) = if l.peek::<kw::outer>() {
+            parser.parse::<kw::outer>()?;
+            let outer = parser.parse()?;
+            let index = parser.parse()?;
+            let (kind, id, name) =
+                parser.parens(|parser| Ok((parser.parse()?, parser.parse()?, parser.parse()?)))?;
+
+            (CoreAliasTarget::Outer { outer, index, kind }, id, name)
+        } else if l.peek::<kw::export>() {
+            parser.parse::<kw::export>()?;
+            let instance = parser.parse()?;
+            let export_name = parser.parse()?;
+            let (kind, id, name) =
+                parser.parens(|parser| Ok((parser.parse()?, parser.parse()?, parser.parse()?)))?;
+
+            (
+                CoreAliasTarget::Export {
+                    instance,
+                    name: export_name,
+                    kind,
+                },
+                id,
+                name,
+            )
+        } else {
+            return Err(l.error());
+        };
+
+        Ok(Self {
+            span,
+            target,
             id,
             name,
         })
@@ -73,6 +112,29 @@ pub enum CoreAliasTarget<'a> {
         /// The export kind of the alias.
         kind: ExportKind,
     },
+    /// The alias is to an item from an outer scope.
+    Outer {
+        /// The number of enclosing scopes to skip.
+        outer: Index<'a>,
+        /// The index of the item being aliased.
+        index: Index<'a>,
+        /// The outer alias kind.
+        kind: CoreOuterAliasKind,
+    },
+}
+
+/// Represents the kind of core outer alias.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum CoreOuterAliasKind {
+    /// The alias is to an outer type.
+    Type,
+}
+
+impl<'a> Parse<'a> for CoreOuterAliasKind {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        parser.parse::<kw::r#type>()?;
+        Ok(Self::Type)
+    }
 }
 
 /// An alias to a component item.

--- a/crates/wast/src/component/expand.rs
+++ b/crates/wast/src/component/expand.rs
@@ -380,6 +380,7 @@ impl<'a> Expander<'a> {
                     core::TypeDef::Struct(_) => {}
                     core::TypeDef::Array(_) => {}
                 },
+                ModuleTypeDecl::Alias(_) => {},
                 ModuleTypeDecl::Import(ty) => {
                     expand_sig(&mut ty.item, &mut to_prepend, &mut func_type_to_idx);
                 }

--- a/crates/wast/src/component/types.rs
+++ b/crates/wast/src/component/types.rs
@@ -96,7 +96,10 @@ impl<'a> Parse<'a> for ModuleTypeDecl<'a> {
         if l.peek::<kw::r#type>() {
             Ok(Self::Type(parser.parse()?))
         } else if l.peek::<kw::alias>() {
-            Ok(Self::Alias(CoreAlias::parse_outer_type_alias(parser)?))
+            let span = parser.parse::<kw::alias>()?.0;
+            Ok(Self::Alias(CoreAlias::parse_outer_type_alias(
+                span, parser,
+            )?))
         } else if l.peek::<kw::import>() {
             Ok(Self::Import(parser.parse()?))
         } else if l.peek::<kw::export>() {

--- a/crates/wast/src/component/types.rs
+++ b/crates/wast/src/component/types.rs
@@ -82,6 +82,8 @@ impl<'a> Parse<'a> for ModuleType<'a> {
 pub enum ModuleTypeDecl<'a> {
     /// A core type.
     Type(core::Type<'a>),
+    /// An alias local to the module type.
+    Alias(CoreAlias<'a>),
     /// An import.
     Import(core::Import<'a>),
     /// An export.
@@ -93,6 +95,8 @@ impl<'a> Parse<'a> for ModuleTypeDecl<'a> {
         let mut l = parser.lookahead1();
         if l.peek::<kw::r#type>() {
             Ok(Self::Type(parser.parse()?))
+        } else if l.peek::<kw::alias>() {
+            Ok(Self::Alias(CoreAlias::parse_outer_type_alias(parser)?))
         } else if l.peek::<kw::import>() {
             Ok(Self::Import(parser.parse()?))
         } else if l.peek::<kw::export>() {

--- a/tests/local/component-model/alias.wast
+++ b/tests/local/component-model/alias.wast
@@ -226,6 +226,17 @@
 )
 
 (component $C
+  (core type $t (func))
+  (component $C2
+    (core alias outer $C $t (type $t2))
+    (component
+      (core alias outer $C $t (type))
+      (core alias outer $C2 $t2 (type))
+    )
+  )
+)
+
+(component $C
   (core module $m)
   (alias outer $C $m (core module $target))
   (export "v" (core module $target))
@@ -236,6 +247,14 @@
   (alias outer $C $m (component $target))
   (export "v" (component $target))
 )
+
+(assert_invalid
+  (component (core alias outer 100 0 (type)))
+  "invalid outer alias count of 100")
+
+(assert_invalid
+  (component (core alias outer 0 0 (type)))
+  "index out of bounds")
 
 (assert_invalid
   (component (alias outer 100 0 (core module)))

--- a/tests/local/component-model/invalid.wast
+++ b/tests/local/component-model/invalid.wast
@@ -17,7 +17,7 @@
   (component quote
     "(alias outer 100 $foo (type $foo))"
   )
-  "component depth of `100` is too large")
+  "outer count of `100` is too large")
 
 (assert_malformed
   (component quote

--- a/tests/local/component-model/types.wast
+++ b/tests/local/component-model/types.wast
@@ -120,6 +120,31 @@
 
 (assert_invalid
   (component $c
+    (core type $t (module
+      (alias outer $c $t (type))
+    ))
+  )
+  "failed to find core type named `$t`")
+
+(assert_invalid
+  (component $c
+    (core type $t (module
+      (alias outer $c 0 (type))
+    ))
+  )
+  "type index out of bounds")
+
+(assert_invalid
+  (component $c
+    (type $f (func))
+    (core type $t (module
+      (alias outer 100 0 (type))
+    ))
+  )
+  "outer type aliases in module type declarations are limited to a maximum count of 1")
+
+(assert_invalid
+  (component $c
     (type $t (component
       (alias outer $c $t (type))
     ))
@@ -217,4 +242,35 @@
 
 (component
   (type $t (func (result (tuple (list u8) u32))))
+)
+
+(component $C
+  (core type $t (func))
+  (core type (module
+    (alias outer $C $t (type $a))
+    (import "" "" (func (type $a)))
+  ))
+)
+
+(component $C
+  (component $C2
+    (core type $t (func))
+    (core type (module
+      (alias outer $C2 $t (type $a))
+      (import "" "" (func (type $a)))
+    ))
+  )
+)
+
+(assert_invalid
+  (component $C
+    (core type $t (func))
+    (component $C2
+      (core type (module
+        (alias outer $C $t (type $a))
+        (import "" "" (func (type $a)))
+      ))
+    )
+  )
+  "only the local or enclosing scope can be aliased"
 )


### PR DESCRIPTION
This PR updates the various tools in `wasm-tools` to support outer core aliases, based on [changes to the component model spec](https://github.com/WebAssembly/component-model/pull/44).

To support fuzzing these changes, `wasm-smith` was also updated to encode arbitrary core function types in the core type section of components.