### PR TITLE
wasm-smith: limit component function type parameter counts.

### DIFF
--- a/crates/wasm-smith/src/component.rs
+++ b/crates/wasm-smith/src/component.rs
@@ -1226,7 +1226,17 @@ impl ComponentBuilder {
     ) -> Result<Rc<FuncType>> {
         let mut params = vec![];
         let mut param_names = HashSet::new();
-        arbitrary_loop(u, 0, 20, |u| {
+
+        // Note: parameters are currently limited to a maximum of 16
+        // because any additional parameters will require indirect access
+        // via a pointer argument; when this occurs, validation of any
+        // lowered function will fail because it will be missing a
+        // memory option (not yet implemented).
+        //
+        // When options are correctly specified on canonical functions,
+        // we should increase this maximum to test indirect parameter
+        // passing.
+        arbitrary_loop(u, 0, 16, |u| {
             *type_fuel = type_fuel.saturating_sub(1);
             if *type_fuel == 0 {
                 return Ok(false);


### PR DESCRIPTION
This PR limits `wasm-smith` to 16 parameters so that the `memory` option is
not required for any canonical functions that might use the function type.

As there's currently a 1:1 between parameter type and core wasm value type for
component function signatures, more than 16 parameters will necessitate
indirect passing of the parameters via memory; when this occurs, component
validation will require the `memory` option to be present.

However, `wasm-smith` doesn't yet set any options for the canonical functions
it generates.