### PR TITLE
Fix stack overflow parsing deeply recursive component types

### DIFF
--- a/crates/wast/src/component/types.rs
+++ b/crates/wast/src/component/types.rs
@@ -692,6 +692,7 @@ pub enum ComponentTypeDecl<'a> {
 
 impl<'a> Parse<'a> for ComponentTypeDecl<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
+        parser.depth_check()?;
         let mut l = parser.lookahead1();
         if l.peek::<kw::core>() {
             Ok(Self::CoreType(parser.parse()?))


### PR DESCRIPTION
This was found on oss-fuzz and component types can be recursive so a
check needs to be added to ensure they don't recurse too deeply.