### PR TITLE
Fix a missing set insertion in wasm-smith

### DIFF
--- a/crates/wasm-smith/src/lib.rs
+++ b/crates/wasm-smith/src/lib.rs
@@ -147,5 +147,6 @@ pub(crate) fn unique_non_empty_string(
         use std::fmt::Write;
         write!(&mut s, "{}", names.len()).unwrap();
     }
+    names.insert(s.clone());
     Ok(s)
 }


### PR DESCRIPTION
The `unique_non_empty_string` accidentally didn't insert unique names
into the set if the original unique string was modified.