### PR TITLE
Add a small `strip` subcommand to `wasm-tools`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,9 @@ wasm-mutate = { path = "crates/wasm-mutate", features = ["clap"], optional = tru
 # Dependencies of `dump`
 wasmparser-dump = { path = "crates/dump", optional = true, version = '0.1.4' }
 
+# Dependencies of `strip`
+wasm-encoder = { path = "crates/wasm-encoder", optional = true, version = '0.13.0' }
+
 [dev-dependencies]
 anyhow = "1.0"
 getopts = "0.2"
@@ -66,7 +69,7 @@ harness = false
 
 [features]
 # By default, all subcommands are built
-default = ['shrink', 'smith', 'mutate', 'validate', 'print', 'parse', 'dump', 'objdump']
+default = ['shrink', 'smith', 'mutate', 'validate', 'print', 'parse', 'dump', 'objdump', 'strip']
 
 # Each subcommand is gated behind a feature and lists the dependencies it needs
 validate = ['wasmparser', 'rayon']
@@ -77,3 +80,4 @@ shrink = ['wasm-shrink', 'is_executable']
 mutate = ['wasm-mutate']
 dump = ['wasmparser-dump']
 objdump = ['wasmparser']
+strip = ['wasm-encoder']

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ programmatically as well:
 | `wasm-tools shrink` | [wasm-shrink] | Shrink a wasm file while preserving a predicate |
 | `wasm-tools dump` |   | Print debugging information about the binary format |
 | `wasm-tools objdump` |   | Print debugging information about section headers |
+| `wasm-tools strip` |   | Remove custom sections from a WebAssembly file |
 
 [wasmparser]: https://crates.io/crates/wasmparser
 [wat]: https://crates.io/crates/wat

--- a/src/bin/wasm-tools/main.rs
+++ b/src/bin/wasm-tools/main.rs
@@ -43,6 +43,7 @@ subcommands! {
     (mutate, "mutate")
     (dump, "dump")
     (objdump, "objdump")
+    (strip, "strip")
 }
 
 fn main() -> Result<()> {

--- a/src/bin/wasm-tools/strip.rs
+++ b/src/bin/wasm-tools/strip.rs
@@ -1,0 +1,106 @@
+use anyhow::{bail, Result};
+use std::ops::Range;
+use wasm_encoder::{RawSection, SectionId};
+use wasmparser::{Encoding, Parser, Payload::*, SectionReader};
+
+/// Removes custom sections from an input WebAssembly file.
+///
+/// This command will by default strip all custom sections such as DWARF
+/// debugging information from a wasm file. It will not strip the `name` section
+/// by default unless the `--all` flag is passed.
+#[derive(clap::Parser)]
+pub struct Opts {
+    #[clap(flatten)]
+    io: wasm_tools::InputOutput,
+
+    /// Strip all custom sections, including the `name` section
+    #[clap(long, short)]
+    all: bool,
+
+    /// Output the text format of WebAssembly instead of the binary format.
+    #[clap(short = 't', long)]
+    wat: bool,
+}
+
+impl Opts {
+    pub fn run(&self) -> Result<()> {
+        let input = self.io.parse_input_wasm()?;
+
+        let mut module = wasm_encoder::Module::new();
+
+        for payload in Parser::new(0).parse_all(&input) {
+            let payload = payload?;
+            let mut section = |id: SectionId, range: Range<usize>| {
+                module.section(&RawSection {
+                    id: id as u8,
+                    data: &input[range],
+                });
+            };
+            match payload {
+                Version {
+                    encoding: Encoding::Module,
+                    ..
+                } => {}
+                Version {
+                    encoding: Encoding::Component,
+                    ..
+                } => {
+                    bail!("components are not supported yet with the `strip` command");
+                }
+
+                TypeSection(s) => section(SectionId::Type, s.range()),
+                ImportSection(s) => section(SectionId::Import, s.range()),
+                FunctionSection(s) => section(SectionId::Function, s.range()),
+                TableSection(s) => section(SectionId::Table, s.range()),
+                MemorySection(s) => section(SectionId::Memory, s.range()),
+                TagSection(s) => section(SectionId::Tag, s.range()),
+                GlobalSection(s) => section(SectionId::Global, s.range()),
+                ExportSection(s) => section(SectionId::Export, s.range()),
+                ElementSection(s) => section(SectionId::Element, s.range()),
+                DataSection(s) => section(SectionId::Data, s.range()),
+                StartSection { range, .. } => section(SectionId::Start, range),
+                DataCountSection { range, .. } => section(SectionId::DataCount, range),
+                CodeSectionStart { range, .. } => section(SectionId::Code, range),
+                CodeSectionEntry(_) => {}
+
+                ModuleSection { .. }
+                | InstanceSection(_)
+                | AliasSection(_)
+                | CoreTypeSection(_)
+                | ComponentSection { .. }
+                | ComponentInstanceSection(_)
+                | ComponentAliasSection(_)
+                | ComponentTypeSection(_)
+                | ComponentCanonicalSection(_)
+                | ComponentStartSection(_)
+                | ComponentImportSection(_)
+                | ComponentExportSection(_) => unimplemented!("component model"),
+
+                CustomSection(c) if c.name() == "name" && !self.all => {
+                    module.section(&RawSection {
+                        id: SectionId::Custom as u8,
+                        data: &input[c.range()],
+                    });
+                }
+
+                CustomSection(_) => {}
+
+                UnknownSection {
+                    id,
+                    contents,
+                    range: _,
+                } => {
+                    module.section(&RawSection { id, data: contents });
+                }
+
+                End(_) => {}
+            }
+        }
+
+        self.io.output(wasm_tools::Output::Wasm {
+            bytes: module.as_slice(),
+            wat: self.wat,
+        })?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
I often find myself wanting this, namely to strip most sections but not
the `name` section. This differs from the behavior of the `wasm-strip`
tool from wabt so I figured I'd add it to our suite.