### PR TITLE
Add wasm-smith configuration for table limits

### DIFF
--- a/crates/wasm-smith/src/config.rs
+++ b/crates/wasm-smith/src/config.rs
@@ -566,7 +566,7 @@ impl<'a> Arbitrary<'a> for SwarmConfig {
                 InstructionKinds::new(&allowed)
             },
             table_max_size_required: u.arbitrary()?,
-            max_table_elements: u.arbitrary()?,
+            max_table_elements: u.int_in_range(0..=1_000_000)?,
 
             // These fields, unlike the ones above, are less useful to set.
             // They either make weird inputs or are for features not widely

--- a/crates/wasm-smith/src/config.rs
+++ b/crates/wasm-smith/src/config.rs
@@ -223,6 +223,19 @@ pub trait Config: 'static + std::fmt::Debug {
         false
     }
 
+    /// The maximum, elements, of any table's initial or maximum size.
+    ///
+    /// Defaults to 1 million.
+    fn max_table_elements(&self) -> u32 {
+        1_000_000
+    }
+
+    /// Whether every Wasm table must have a maximum size specified. Defaults
+    /// to `false`.
+    fn table_max_size_required(&self) -> bool {
+        false
+    }
+
     /// The maximum number of instances to use. Defaults to 10. This includes
     /// imported instances.
     ///
@@ -508,6 +521,8 @@ pub struct SwarmConfig {
     pub simd_enabled: bool,
     pub threads_enabled: bool,
     pub allowed_instructions: InstructionKinds,
+    pub max_table_elements: u32,
+    pub table_max_size_required: bool,
 }
 
 impl<'a> Arbitrary<'a> for SwarmConfig {
@@ -550,6 +565,8 @@ impl<'a> Arbitrary<'a> for SwarmConfig {
                 }
                 InstructionKinds::new(&allowed)
             },
+            table_max_size_required: u.arbitrary()?,
+            max_table_elements: u.arbitrary()?,
 
             // These fields, unlike the ones above, are less useful to set.
             // They either make weird inputs or are for features not widely
@@ -769,5 +786,13 @@ impl Config for SwarmConfig {
 
     fn allowed_instructions(&self) -> InstructionKinds {
         self.allowed_instructions
+    }
+
+    fn max_table_elements(&self) -> u32 {
+        self.max_table_elements
+    }
+
+    fn table_max_size_required(&self) -> bool {
+        self.table_max_size_required
     }
 }

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -1354,7 +1354,13 @@ pub(crate) fn arbitrary_table_type(u: &mut Unstructured, config: &dyn Config) ->
     // We don't want to generate tables that are too large on average, so
     // keep the "inbounds" limit here a bit smaller.
     let max_inbounds = 10_000;
-    let (minimum, maximum) = arbitrary_limits32(u, 1_000_000, false, max_inbounds)?;
+    let max_elements = config.max_table_elements();
+    let (minimum, maximum) = arbitrary_limits32(
+        u,
+        max_elements,
+        config.table_max_size_required(),
+        max_inbounds.min(max_elements),
+    )?;
     Ok(TableType {
         element_type: if config.reference_types_enabled() {
             *u.choose(&[ValType::FuncRef, ValType::ExternRef])?

--- a/src/bin/wasm-tools/smith.rs
+++ b/src/bin/wasm-tools/smith.rs
@@ -128,6 +128,10 @@ struct Config {
     max_memory_pages: Option<u64>,
     #[clap(long = "memory-max-size-required")]
     memory_max_size_required: Option<bool>,
+    #[clap(long = "max-table-elements")]
+    max_table_elements: Option<u32>,
+    #[clap(long = "table-max-size-required")]
+    table_max_size_required: Option<bool>,
     #[clap(long = "max-instances")]
     max_instances: Option<usize>,
     #[clap(long = "max-modules")]
@@ -283,6 +287,8 @@ impl wasm_smith::Config for CliAndJsonConfig {
         (min_tables, u32, 0),
         (max_tables, usize, 1),
         (memory_max_size_required, bool, false),
+        (max_table_elements, u32, 1_000_000),
+        (table_max_size_required, bool, false),
         (max_instances, usize, 10),
         (max_modules, usize, 10),
         (min_uleb_size, u8, 1),


### PR DESCRIPTION
Enable configuring the total maximum size of any table generated in
addition to being able to require a maximum table size.