### PR TITLE
Add Span::offset

### DIFF
--- a/crates/wast/src/token.rs
+++ b/crates/wast/src/token.rs
@@ -38,6 +38,11 @@ impl Span {
         }
         (text.lines().count(), 0)
     }
+
+    /// Returns the byte offset of this span.
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
 }
 
 /// An identifier in a WebAssembly module, prefixed by `$` in the textual


### PR DESCRIPTION
See #653. I used `&self` since `Span::linecol_in`, a similar function, uses `&self` rather than `self`.