### PR TITLE
Fix `arbitrary_loop`'s minimum bound

### DIFF
--- a/crates/wasm-smith/src/lib.rs
+++ b/crates/wasm-smith/src/lib.rs
@@ -82,7 +82,7 @@ pub(crate) fn arbitrary_loop<'a>(
     assert!(max >= min);
     for _ in 0..min {
         if !f(u)? {
-            break;
+            return Err(arbitrary::Error::IncorrectFormat);
         }
     }
     for _ in 0..(max - min) {


### PR DESCRIPTION
Currently if the closure bails out for whatever reason we might not
reach the minimum bound required by `arbitrary_loop` when generating a
module. This commit updates this bail-out to return an error instead
since the data is not formatted correctly to allow for the minimum
number of loop iterations to get processed.