### PR TITLE
Print function indices on failed validation

### DIFF
--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -831,8 +831,10 @@ impl Validator {
 
         let state = self.module.as_mut().unwrap();
 
+        let (index, ty) = state.next_code_index_and_type(offset)?;
         Ok(FuncValidator::new(
-            state.next_code_entry_type(offset)?,
+            index,
+            ty,
             0,
             ValidatorResources(state.module.arc().clone()),
             &self.features,

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -109,7 +109,7 @@ impl ModuleState {
         Ok(())
     }
 
-    pub fn next_code_entry_type(&mut self, offset: usize) -> Result<u32> {
+    pub fn next_code_index_and_type(&mut self, offset: usize) -> Result<(u32, u32)> {
         let index = self
             .code_section_index
             .get_or_insert(self.module.num_imported_functions as usize);
@@ -124,7 +124,7 @@ impl ModuleState {
         let ty = self.module.functions[*index];
         *index += 1;
 
-        Ok(ty)
+        Ok(((*index - 1) as u32, ty))
     }
 
     pub fn add_global(

--- a/crates/wasmparser/src/validator/func.rs
+++ b/crates/wasmparser/src/validator/func.rs
@@ -185,7 +185,7 @@ mod tests {
 
     #[test]
     fn operand_stack_height() {
-        let mut v = FuncValidator::new(0, 0, &EmptyResources, &Default::default()).unwrap();
+        let mut v = FuncValidator::new(0, 0, 0, &EmptyResources, &Default::default()).unwrap();
 
         // Initially zero values on the stack.
         assert_eq!(v.operand_stack_height(), 0);

--- a/crates/wasmparser/src/validator/func.rs
+++ b/crates/wasmparser/src/validator/func.rs
@@ -12,6 +12,7 @@ use crate::{FunctionBody, Operator, WasmFeatures, WasmModuleResources};
 pub struct FuncValidator<T> {
     validator: OperatorValidator,
     resources: T,
+    index: u32,
 }
 
 impl<T: WasmModuleResources> FuncValidator<T> {
@@ -25,6 +26,7 @@ impl<T: WasmModuleResources> FuncValidator<T> {
     /// The returned validator can be used to then parse a [`FunctionBody`], for
     /// example, to read locals and validate operators.
     pub fn new(
+        index: u32,
         ty: u32,
         offset: usize,
         resources: T,
@@ -33,6 +35,7 @@ impl<T: WasmModuleResources> FuncValidator<T> {
         Ok(FuncValidator {
             validator: OperatorValidator::new_func(ty, offset, features, &resources)?,
             resources,
+            index,
         })
     }
 
@@ -112,6 +115,12 @@ impl<T: WasmModuleResources> FuncValidator<T> {
     /// Returns the underlying module resources that this validator is using.
     pub fn resources(&self) -> &T {
         &self.resources
+    }
+
+    /// The index of the function within the module's function index space that
+    /// is being validated.
+    pub fn index(&self) -> u32 {
+        self.index
     }
 }
 

--- a/src/bin/wasm-tools/validate.rs
+++ b/src/bin/wasm-tools/validate.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use rayon::prelude::*;
 use std::time::Instant;
 use wasmparser::{Parser, ValidPayload, Validator, WasmFeatures};
@@ -69,7 +69,11 @@ impl Opts {
         let start = Instant::now();
         functions_to_validate
             .into_par_iter()
-            .try_for_each(|(mut validator, body)| validator.validate(&body))?;
+            .try_for_each(|(mut validator, body)| {
+                validator
+                    .validate(&body)
+                    .with_context(|| format!("func {} failed to validate", validator.index()))
+            })?;
         log::info!("functions validated in {:?}", start.elapsed());
         Ok(())
     }


### PR DESCRIPTION
A minor tweak to the `wasm-tools validate` feature to print the index of
the function that failed to validate in addition to the offset from the
error message itself.