### PR TITLE
Fix wasmprinter to print type bounds.

### DIFF
--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -243,11 +243,9 @@ impl ComponentState {
                 self.values.push((ty, false));
                 (self.values.len(), MAX_WASM_VALUES, "values")
             }
-            ComponentEntityType::Type(..) => {
-                return Err(BinaryReaderError::new(
-                    "component types cannot currently be imported",
-                    offset,
-                ));
+            ComponentEntityType::Type(id) => {
+                self.types.push(id);
+                (self.types.len(), MAX_WASM_TYPES, "types")
             }
         };
 

--- a/tests/local/component-model/import.wast
+++ b/tests/local/component-model/import.wast
@@ -1,7 +1,6 @@
 (component
   (import "a" (func))
   (import "b" (instance))
-
   (import "c" (instance
     (export "" (func))
   ))
@@ -9,6 +8,8 @@
     (import "" (core module))
     (export "" (func))
   ))
+  (type $t (func))
+  (import "e" (type (eq $t)))
 )
 
 (assert_invalid

--- a/tests/local/component-model/types.wast
+++ b/tests/local/component-model/types.wast
@@ -274,3 +274,18 @@
   )
   "only the local or enclosing scope can be aliased"
 )
+
+(component
+  (type (instance
+    (type string)
+    (export "" (type (eq 0)))
+  ))
+)
+
+(component
+  (type (component
+    (type string)
+    (import "" (type (eq 0)))
+    (export "" (type (eq 0)))
+  ))
+)


### PR DESCRIPTION
This commit fixes `wasmprinter` to print the type bounds for type imports and
exports within instance and component types.

It also updates `wasmparser` to not error on type imports.

Fixes #674.