### PR TITLE
wast: Update GC text format for latest changes

### DIFF
--- a/crates/wast/src/component/binary.rs
+++ b/crates/wast/src/component/binary.rs
@@ -419,9 +419,6 @@ impl From<core::ValType<'_>> for wasm_encoder::ValType {
             core::ValType::F64 => Self::F64,
             core::ValType::V128 => Self::V128,
             core::ValType::Ref(r) => r.into(),
-            core::ValType::Rtt(..) => {
-                todo!("encoding of GC proposal types not yet implemented")
-            }
         }
     }
 }

--- a/crates/wast/src/component/expand.rs
+++ b/crates/wast/src/component/expand.rs
@@ -421,6 +421,7 @@ impl<'a> Expander<'a> {
                         id: Some(id),
                         name: None,
                         def: key.to_def(item.span),
+                        parent: None,
                     }));
                     let idx = Index::Id(id);
                     t.index = Some(idx);

--- a/crates/wast/src/core/binary.rs
+++ b/crates/wast/src/core/binary.rs
@@ -176,6 +176,11 @@ impl Encode for RecOrType<'_> {
 
 impl Encode for Type<'_> {
     fn encode(&self, e: &mut Vec<u8>) {
+        if let Some(parent) = &self.parent {
+            e.push(0x50);
+            (1 as usize).encode(e);
+            parent.encode(e);
+        }
         match &self.def {
             TypeDef::Func(func) => {
                 e.push(0x60);

--- a/crates/wast/src/core/binary.rs
+++ b/crates/wast/src/core/binary.rs
@@ -227,15 +227,6 @@ impl<'a> Encode for ValType<'a> {
             ValType::F32 => e.push(0x7d),
             ValType::F64 => e.push(0x7c),
             ValType::V128 => e.push(0x7b),
-            ValType::Rtt(Some(depth), index) => {
-                e.push(0x69);
-                depth.encode(e);
-                index.encode(e);
-            }
-            ValType::Rtt(None, index) => {
-                e.push(0x68);
-                index.encode(e);
-            }
             ValType::Ref(ty) => {
                 ty.encode(e);
             }

--- a/crates/wast/src/core/binary.rs
+++ b/crates/wast/src/core/binary.rs
@@ -242,6 +242,7 @@ impl<'a> Encode for HeapType<'a> {
             HeapType::Any => e.push(0x6e),
             HeapType::Eq => e.push(0x6d),
             HeapType::Data => e.push(0x67),
+            HeapType::Array => e.push(0x66),
             HeapType::I31 => e.push(0x6a),
             HeapType::Index(index) => {
                 index.encode(e);

--- a/crates/wast/src/core/binary.rs
+++ b/crates/wast/src/core/binary.rs
@@ -1046,3 +1046,31 @@ impl Encode for StructAccess<'_> {
         self.field.encode(e);
     }
 }
+
+impl Encode for ArrayCopy<'_> {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.dest_array.encode(e);
+        self.src_array.encode(e);
+    }
+}
+
+impl Encode for ArrayInit<'_> {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.array.encode(e);
+        self.length.encode(e);
+    }
+}
+
+impl Encode for ArrayInitFromData<'_> {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.array.encode(e);
+        self.data_idx.encode(e);
+    }
+}
+
+impl Encode for BrOnCast<'_> {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.label.encode(e);
+        self.r#type.encode(e);
+    }
+}

--- a/crates/wast/src/core/expr.rs
+++ b/crates/wast/src/core/expr.rs
@@ -589,48 +589,57 @@ instructions! {
         // gc proposal: eqref
         RefEq : [0xd5] : "ref.eq",
 
-        // gc proposal (moz specific, will be removed)
-        StructNew(Index<'a>) : [0xfb, 0x0] : "struct.new",
-
         // gc proposal: struct
-        StructNewWithRtt(Index<'a>) : [0xfb, 0x01] : "struct.new_with_rtt",
-        StructNewDefaultWithRtt(Index<'a>) : [0xfb, 0x02] : "struct.new_default_with_rtt",
+        StructNew(Index<'a>) : [0xfb, 0x07] : "struct.new",
+        StructNewDefault(Index<'a>) : [0xfb, 0x08] : "struct.new_default",
         StructGet(StructAccess<'a>) : [0xfb, 0x03] : "struct.get",
         StructGetS(StructAccess<'a>) : [0xfb, 0x04] : "struct.get_s",
         StructGetU(StructAccess<'a>) : [0xfb, 0x05] : "struct.get_u",
         StructSet(StructAccess<'a>) : [0xfb, 0x06] : "struct.set",
 
         // gc proposal: array
-        ArrayNewWithRtt(Index<'a>) : [0xfb, 0x11] : "array.new_with_rtt",
-        ArrayNewDefaultWithRtt(Index<'a>) : [0xfb, 0x12] : "array.new_default_with_rtt",
+        ArrayNew(Index<'a>) : [0xfb, 0x1b] : "array.new",
+        ArrayNewDefault(Index<'a>) : [0xfb, 0x1c] : "array.new_default",
         ArrayGet(Index<'a>) : [0xfb, 0x13] : "array.get",
         ArrayGetS(Index<'a>) : [0xfb, 0x14] : "array.get_s",
         ArrayGetU(Index<'a>) : [0xfb, 0x15] : "array.get_u",
         ArraySet(Index<'a>) : [0xfb, 0x16] : "array.set",
         ArrayLen(Index<'a>) : [0xfb, 0x17] : "array.len",
+        ArrayCopy(ArrayCopy<'a>) : [0xfb, 0x18] : "array.copy",
+        ArrayInit(ArrayInit<'a>) : [0xfb, 0x1a] : "array.init",
+        ArrayInitFromData(ArrayInitFromData<'a>) : [0xfb, 0x1d] : "array.init_from_data",
 
         // gc proposal, i31
         I31New : [0xfb, 0x20] : "i31.new",
         I31GetS : [0xfb, 0x21] : "i31.get_s",
         I31GetU : [0xfb, 0x22] : "i31.get_u",
 
-        // gc proposal, rtt casting
-        RTTCanon(Index<'a>) : [0xfb, 0x30] : "rtt.canon",
-        RTTSub(Index<'a>) : [0xfb, 0x31] : "rtt.sub",
-        RefTest : [0xfb, 0x40] : "ref.test",
-        RefCast : [0xfb, 0x41] : "ref.cast",
-        BrOnCast(Index<'a>) : [0xfb, 0x42] : "br_on_cast",
+        // gc proposal, concrete casting
+        RefTest(Index<'a>) : [0xfb, 0x44] : "ref.test",
+        RefCast(Index<'a>) : [0xfb, 0x45] : "ref.cast",
+        BrOnCast(BrOnCast<'a>) : [0xfb, 0x46] : "br_on_cast",
+        BrOnCastFail(BrOnCast<'a>) : [0xfb, 0x47] : "br_on_cast_fail",
 
         // gc proposal, heap casting
         RefIsFunc : [0xfb, 0x50] : "ref.is_func",
         RefIsData : [0xfb, 0x51] : "ref.is_data",
         RefIsI31 : [0xfb, 0x52] : "ref.is_i31",
+        RefIsArray : [0xfb, 0x53] : "ref.is_array",
+
         RefAsFunc : [0xfb, 0x58] : "ref.as_func",
         RefAsData : [0xfb, 0x59] : "ref.as_data",
         RefAsI31 : [0xfb, 0x5a] : "ref.as_i31",
+        RefAsArray : [0xfb, 0x5b] : "ref.as_array",
+
         BrOnFunc(Index<'a>) : [0xfb, 0x60] : "br_on_func",
         BrOnData(Index<'a>) : [0xfb, 0x61] : "br_on_data",
         BrOnI31(Index<'a>) : [0xfb, 0x62] : "br_on_i31",
+        BrOnArray(Index<'a>) : [0xfb, 0x66] : "br_on_array",
+
+        BrOnNonFunc(Index<'a>) : [0xfb, 0x63] : "br_on_non_func",
+        BrOnNonData(Index<'a>) : [0xfb, 0x64] : "br_on_non_data",
+        BrOnNonI31(Index<'a>) : [0xfb, 0x65] : "br_on_non_i31",
+        BrOnNonArray(Index<'a>) : [0xfb, 0x67] : "br_on_non_array",
 
         I32Const(i32) : [0x41] : "i32.const",
         I64Const(i64) : [0x42] : "i64.const",
@@ -1543,6 +1552,78 @@ impl<'a> Parse<'a> for StructAccess<'a> {
         Ok(StructAccess {
             r#struct: parser.parse()?,
             field: parser.parse()?,
+        })
+    }
+}
+
+/// Extra data associated with the `array.copy` instruction
+#[derive(Debug)]
+pub struct ArrayCopy<'a> {
+    /// The index of the array type we're copying to.
+    pub dest_array: Index<'a>,
+    /// The index of the array type we're copying from.
+    pub src_array: Index<'a>,
+}
+
+impl<'a> Parse<'a> for ArrayCopy<'a> {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        Ok(ArrayCopy {
+            dest_array: parser.parse()?,
+            src_array: parser.parse()?,
+        })
+    }
+}
+
+/// Extra data associated with the `array.init` instruction
+#[derive(Debug)]
+pub struct ArrayInit<'a> {
+    /// The index of the array type we're accessing.
+    pub array: Index<'a>,
+    /// The amount of values to initialize the array with.
+    pub length: u32,
+}
+
+impl<'a> Parse<'a> for ArrayInit<'a> {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        Ok(ArrayInit {
+            array: parser.parse()?,
+            length: parser.parse()?,
+        })
+    }
+}
+
+/// Extra data associated with the `array.init_from_data` instruction
+#[derive(Debug)]
+pub struct ArrayInitFromData<'a> {
+    /// The index of the array type we're accessing.
+    pub array: Index<'a>,
+    /// The data segment to initialize from.
+    pub data_idx: Index<'a>,
+}
+
+impl<'a> Parse<'a> for ArrayInitFromData<'a> {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        Ok(ArrayInitFromData {
+            array: parser.parse()?,
+            data_idx: parser.parse()?,
+        })
+    }
+}
+
+/// Extra data associated with the `br_on_cast` instruction
+#[derive(Debug)]
+pub struct BrOnCast<'a> {
+    /// The label to branch to.
+    pub label: Index<'a>,
+    /// The index of the type we're casting.
+    pub r#type: Index<'a>,
+}
+
+impl<'a> Parse<'a> for BrOnCast<'a> {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        Ok(BrOnCast {
+            label: parser.parse()?,
+            r#type: parser.parse()?,
         })
     }
 }

--- a/crates/wast/src/core/module.rs
+++ b/crates/wast/src/core/module.rs
@@ -139,6 +139,7 @@ impl<'a> Parse<'a> for Module<'a> {
 #[derive(Debug)]
 pub enum ModuleField<'a> {
     Type(Type<'a>),
+    Rec(Rec<'a>),
     Import(Import<'a>),
     Func(Func<'a>),
     Table(Table<'a>),
@@ -166,6 +167,9 @@ impl<'a> Parse<'a> for ModuleField<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
         if parser.peek::<kw::r#type>() {
             return Ok(ModuleField::Type(parser.parse()?));
+        }
+        if parser.peek::<kw::rec>() {
+            return Ok(ModuleField::Rec(parser.parse()?));
         }
         if parser.peek::<kw::import>() {
             return Ok(ModuleField::Import(parser.parse()?));

--- a/crates/wast/src/core/module.rs
+++ b/crates/wast/src/core/module.rs
@@ -165,7 +165,7 @@ impl<'a> ModuleField<'a> {
 
 impl<'a> Parse<'a> for ModuleField<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
-        if parser.peek::<kw::r#type>() {
+        if parser.peek::<Type<'a>>() {
             return Ok(ModuleField::Type(parser.parse()?));
         }
         if parser.peek::<kw::rec>() {

--- a/crates/wast/src/core/resolve/deinline_import_export.rs
+++ b/crates/wast/src/core/resolve/deinline_import_export.rs
@@ -199,6 +199,7 @@ pub fn run(fields: &mut Vec<ModuleField>) {
 
             ModuleField::Import(_)
             | ModuleField::Type(_)
+            | ModuleField::Rec(_)
             | ModuleField::Export(_)
             | ModuleField::Start(_)
             | ModuleField::Elem(_)

--- a/crates/wast/src/core/resolve/names.rs
+++ b/crates/wast/src/core/resolve/names.rs
@@ -601,7 +601,13 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
                 self.resolve_label(i)?;
             }
 
-            BrOnCast(l) | BrOnFunc(l) | BrOnData(l) | BrOnI31(l) => {
+            BrOnCast(i) | BrOnCastFail(i) => {
+                self.resolve_label(&mut i.label)?;
+                self.resolver.resolve(&mut i.r#type, Ns::Type)?;
+            }
+
+            BrOnFunc(l) | BrOnData(l) | BrOnI31(l) | BrOnArray(l) |
+            BrOnNonFunc(l) | BrOnNonData(l) | BrOnNonI31(l) | BrOnNonArray(l) => {
                 self.resolve_label(l)?;
             }
 
@@ -613,11 +619,12 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
                 }
             }
 
-            StructNew(i)
-            | StructNewWithRtt(i)
-            | StructNewDefaultWithRtt(i)
-            | ArrayNewWithRtt(i)
-            | ArrayNewDefaultWithRtt(i)
+            RefTest(i)
+            | RefCast(i)
+            | StructNew(i)
+            | StructNewDefault(i)
+            | ArrayNew(i)
+            | ArrayNewDefault(i)
             | ArrayGet(i)
             | ArrayGetS(i)
             | ArrayGetU(i)
@@ -625,16 +632,22 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
             | ArrayLen(i) => {
                 self.resolver.resolve(i, Ns::Type)?;
             }
-            RTTCanon(i) => {
-                self.resolver.resolve(i, Ns::Type)?;
-            }
-            RTTSub(i) => {
-                self.resolver.resolve(i, Ns::Type)?;
-            }
 
             StructSet(s) | StructGet(s) | StructGetS(s) | StructGetU(s) => {
                 self.resolver.resolve(&mut s.r#struct, Ns::Type)?;
                 self.resolver.fields.resolve(&mut s.field, "field")?;
+            }
+
+            ArrayCopy(a) => {
+                self.resolver.resolve(&mut a.dest_array, Ns::Type)?;
+                self.resolver.resolve(&mut a.src_array, Ns::Type)?;
+            }
+            ArrayInit(a) => {
+                self.resolver.resolve(&mut a.array, Ns::Type)?;
+            }
+            ArrayInitFromData(a) => {
+                self.resolver.resolve(&mut a.array, Ns::Type)?;
+                self.resolver.datas.resolve(&mut a.data_idx, "data")?;
             }
 
             RefNull(ty) => self.resolver.resolve_heaptype(ty)?,

--- a/crates/wast/src/core/resolve/names.rs
+++ b/crates/wast/src/core/resolve/names.rs
@@ -125,6 +125,9 @@ impl<'a> Resolver<'a> {
             }
             TypeDef::Array(array) => self.resolve_storagetype(&mut array.ty)?,
         }
+        if let Some(parent) = &mut ty.parent {
+            self.resolve(parent, Ns::Type)?;
+        }
         Ok(())
     }
 

--- a/crates/wast/src/core/resolve/names.rs
+++ b/crates/wast/src/core/resolve/names.rs
@@ -275,9 +275,6 @@ impl<'a> Resolver<'a> {
     fn resolve_valtype(&self, ty: &mut ValType<'a>) -> Result<(), Error> {
         match ty {
             ValType::Ref(ty) => self.resolve_heaptype(&mut ty.heap)?,
-            ValType::Rtt(_d, i) => {
-                self.resolve(i, Ns::Type)?;
-            }
             _ => {}
         }
         Ok(())

--- a/crates/wast/src/core/resolve/types.rs
+++ b/crates/wast/src/core/resolve/types.rs
@@ -66,6 +66,7 @@ impl<'a> Expander<'a> {
         match item {
             // This is pre-expanded above
             ModuleField::Type(_) => {}
+            ModuleField::Rec(_) => {}
 
             ModuleField::Import(i) => {
                 self.expand_item_sig(&mut i.item);

--- a/crates/wast/src/core/resolve/types.rs
+++ b/crates/wast/src/core/resolve/types.rs
@@ -209,6 +209,7 @@ impl<'a> Expander<'a> {
             id: Some(id),
             name: None,
             def: key.to_def(span),
+            parent: None,
         }));
         let idx = Index::Id(id);
         key.insert(self, idx);

--- a/crates/wast/src/core/types.rs
+++ b/crates/wast/src/core/types.rs
@@ -74,6 +74,8 @@ pub enum HeapType<'a> {
     Eq,
     /// A reference to a GC object. This is part of the GC proposal.
     Data,
+    /// A reference to a GC array. This is part of the GC proposal.
+    Array,
     /// An unboxed 31-bit integer: i31ref. This may be going away if there is no common
     /// supertype of all reference types. Part of the GC proposal.
     I31,
@@ -100,6 +102,9 @@ impl<'a> Parse<'a> for HeapType<'a> {
         } else if l.peek::<kw::data>() {
             parser.parse::<kw::data>()?;
             Ok(HeapType::Data)
+        } else if l.peek::<kw::array>() {
+            parser.parse::<kw::array>()?;
+            Ok(HeapType::Array)
         } else if l.peek::<kw::i31>() {
             parser.parse::<kw::i31>()?;
             Ok(HeapType::I31)
@@ -118,6 +123,7 @@ impl<'a> Peek for HeapType<'a> {
             || kw::any::peek(cursor)
             || kw::eq::peek(cursor)
             || kw::data::peek(cursor)
+            || kw::array::peek(cursor)
             || kw::i31::peek(cursor)
             || (LParen::peek(cursor) && kw::r#type::peek2(cursor))
     }
@@ -175,6 +181,14 @@ impl<'a> RefType<'a> {
         }
     }
 
+    /// An `arrayref` as an abbreviation for `(ref null array)`.
+    pub fn array() -> Self {
+        RefType {
+            nullable: true,
+            heap: HeapType::Array,
+        }
+    }
+
     /// An `i31ref` as an abbreviation for `(ref null i31)`.
     pub fn i31() -> Self {
         RefType {
@@ -205,6 +219,9 @@ impl<'a> Parse<'a> for RefType<'a> {
         } else if l.peek::<kw::dataref>() {
             parser.parse::<kw::dataref>()?;
             Ok(RefType::data())
+        } else if l.peek::<kw::arrayref>() {
+            parser.parse::<kw::arrayref>()?;
+            Ok(RefType::array())
         } else if l.peek::<kw::i31ref>() {
             parser.parse::<kw::i31ref>()?;
             Ok(RefType::i31())
@@ -242,6 +259,7 @@ impl<'a> Peek for RefType<'a> {
             || kw::anyref::peek(cursor)
             || kw::eqref::peek(cursor)
             || kw::dataref::peek(cursor)
+            || kw::arrayref::peek(cursor)
             || kw::i31ref::peek(cursor)
             || (LParen::peek(cursor) && kw::r#ref::peek2(cursor))
     }

--- a/crates/wast/src/core/types.rs
+++ b/crates/wast/src/core/types.rs
@@ -14,7 +14,6 @@ pub enum ValType<'a> {
     F64,
     V128,
     Ref(RefType<'a>),
-    Rtt(Option<u32>, Index<'a>),
 }
 
 impl<'a> Parse<'a> for ValType<'a> {
@@ -37,16 +36,6 @@ impl<'a> Parse<'a> for ValType<'a> {
             Ok(ValType::V128)
         } else if l.peek::<RefType>() {
             Ok(ValType::Ref(parser.parse()?))
-        } else if l.peek::<LParen>() {
-            parser.parens(|p| {
-                let mut l = p.lookahead1();
-                if l.peek::<kw::rtt>() {
-                    p.parse::<kw::rtt>()?;
-                    Ok(ValType::Rtt(p.parse()?, p.parse()?))
-                } else {
-                    Err(l.error())
-                }
-            })
         } else {
             Err(l.error())
         }
@@ -60,7 +49,6 @@ impl<'a> Peek for ValType<'a> {
             || kw::f32::peek(cursor)
             || kw::f64::peek(cursor)
             || kw::v128::peek(cursor)
-            || (LParen::peek(cursor) && kw::rtt::peek2(cursor))
             || RefType::peek(cursor)
     }
     fn display() -> &'static str {

--- a/crates/wast/src/core/types.rs
+++ b/crates/wast/src/core/types.rs
@@ -680,6 +680,31 @@ impl<'a> Parse<'a> for Type<'a> {
     }
 }
 
+/// A recursion group declaration in a module
+#[derive(Debug)]
+pub struct Rec<'a> {
+    /// Where this recursion group was defined.
+    pub span: Span,
+    /// The types that we're defining in this group.
+    pub types: Vec<Type<'a>>,
+}
+
+impl<'a> Parse<'a> for Rec<'a> {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        let span = parser.parse::<kw::r#rec>()?.0;
+        let mut types = Vec::new();
+        while parser.peek2::<kw::r#type>() {
+            types.push(parser.parens(|p| {
+                p.parse()
+            })?);
+        }
+        Ok(Rec {
+            span,
+            types
+        })
+    }
+}
+
 /// A reference to a type defined in this module.
 #[derive(Clone, Debug)]
 pub struct TypeUse<'a, T> {

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -464,6 +464,7 @@ pub mod kw {
     custom_keyword!(shared);
     custom_keyword!(start);
     custom_keyword!(r#struct = "struct");
+    custom_keyword!(sub);
     custom_keyword!(table);
     custom_keyword!(then);
     custom_keyword!(r#try = "try");

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -458,6 +458,7 @@ pub mod kw {
     custom_keyword!(ref_func = "ref.func");
     custom_keyword!(ref_null = "ref.null");
     custom_keyword!(register);
+    custom_keyword!(rec);
     custom_keyword!(result);
     custom_keyword!(rtt);
     custom_keyword!(shared);

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -460,7 +460,6 @@ pub mod kw {
     custom_keyword!(register);
     custom_keyword!(rec);
     custom_keyword!(result);
-    custom_keyword!(rtt);
     custom_keyword!(shared);
     custom_keyword!(start);
     custom_keyword!(r#struct = "struct");

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -382,6 +382,7 @@ pub mod kw {
     custom_keyword!(anyref);
     custom_keyword!(arg);
     custom_keyword!(array);
+    custom_keyword!(arrayref);
     custom_keyword!(assert_exception);
     custom_keyword!(assert_exhaustion);
     custom_keyword!(assert_invalid);

--- a/tests/local/gc/gc-array.wat
+++ b/tests/local/gc/gc-array.wat
@@ -1,0 +1,14 @@
+;; --enable-gc
+
+(module
+  (type $a (array i32))
+  (type $b (array (mut i32)))
+  (type $c (array (mut (ref null $b))))
+
+  (func
+    array.new $a
+    array.new_default $a
+    array.get $a
+    array.set $b
+  )
+)

--- a/tests/local/gc/gc-heaptypes.wat
+++ b/tests/local/gc/gc-heaptypes.wat
@@ -1,0 +1,11 @@
+;; --enable-gc
+
+(module
+  (func (param funcref (ref func) (ref null func)))
+  (func (param externref (ref extern) (ref null extern)))
+  (func (param anyref (ref any) (ref null any)))
+  (func (param eqref (ref eq) (ref null eq)))
+  (func (param i31ref (ref i31) (ref null i31)))
+  (func (param dataref (ref data) (ref null data)))
+  (func (param arrayref (ref array) (ref null array)))
+)

--- a/tests/local/gc/gc-rec-sub.wat
+++ b/tests/local/gc/gc-rec-sub.wat
@@ -1,0 +1,39 @@
+;; --enable-gc
+
+(module
+  (rec
+    (type (func))
+  )
+  (rec
+    (type (func))
+    (type (func))
+  )
+  (rec
+    (type (struct))
+  )
+  (rec
+    (type (struct))
+    (type (struct))
+  )
+  (rec
+    (type (array i32))
+  )
+  (rec
+    (type (array i32))
+    (type (array i32))
+  )
+  (rec
+    (type (func))
+    (type (struct))
+    (type (array i32))
+  )
+
+  (rec
+    (type $a (func))
+    (sub $a (type (func)))
+  )
+  (rec
+    (sub $a (type (func)))
+  )
+  (sub $a (type (func)))
+)

--- a/tests/local/gc/gc-struct.wat
+++ b/tests/local/gc/gc-struct.wat
@@ -15,8 +15,8 @@
   (type (struct (field $field_b externref) (field $field_c funcref)))
 
   (func
-    rtt.canon $a
-    struct.new_with_rtt $a
+    struct.new $a
+    struct.new_default $a
     struct.get $a $field_a
     struct.set $b $field_c
   )


### PR DESCRIPTION
Updates the GC text format for:
  * Removal of RTT value types and fallout
  * New instructions
  * New type system (recursion groups/declared subtyping)