### PR TITLE
Allow getting the types that have been parsed so far from the validator

### DIFF
--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -54,7 +54,7 @@ pub mod types;
 use self::component::*;
 pub use self::core::ValidatorResources;
 use self::core::*;
-use self::types::{TypeList, Types};
+use self::types::{TypeList, Types, TypesRef};
 pub use func::FuncValidator;
 
 fn check_max(cur_len: usize, amt_added: u32, max: usize, desc: &str, offset: usize) -> Result<()> {
@@ -364,6 +364,30 @@ impl Validator {
         }
 
         Ok(last_types.unwrap())
+    }
+
+    /// Gets the types known by the validator so far within the
+    /// module/component `level` modules/components up from the
+    /// module/component currently being parsed.
+    ///
+    /// For instance, calling `validator.types(0)` will get the types of the
+    /// module/component currently being parsed, and `validator.types(1)` will
+    /// get the types of the component containing that module/component.
+    ///
+    /// Returns `None` if there is no module/component that many levels up.
+    pub fn types(&self, mut level: usize) -> Option<TypesRef> {
+        if let Some(module) = &self.module {
+            if level == 0 {
+                return Some(TypesRef::from_module(&self.types, &module.module));
+            } else {
+                level -= 1;
+            }
+        }
+
+        self.components
+            .iter()
+            .nth_back(level)
+            .map(|component| TypesRef::from_component(&self.types, component))
     }
 
     /// Convenience function to validate a single [`Payload`].

--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -1005,6 +1005,265 @@ pub struct Types {
     kind: TypesKind,
 }
 
+enum TypesRefKind<'a> {
+    Module(&'a Module),
+    Component(&'a ComponentState),
+}
+
+/// Represents the types known to a [`crate::Validator`] during validation.
+///
+/// Retrieved via. the [`crate::Validator::types`] method.
+pub struct TypesRef<'a> {
+    types: &'a TypeList,
+    kind: TypesRefKind<'a>,
+}
+
+impl<'a> TypesRef<'a> {
+    pub(crate) fn from_module(types: &'a TypeList, module: &'a Module) -> Self {
+        Self {
+            types,
+            kind: TypesRefKind::Module(module),
+        }
+    }
+
+    pub(crate) fn from_component(types: &'a TypeList, component: &'a ComponentState) -> Self {
+        Self {
+            types,
+            kind: TypesRefKind::Component(component),
+        }
+    }
+
+    fn types(&self, core: bool) -> Option<&'a [TypeId]> {
+        Some(match &self.kind {
+            TypesRefKind::Module(module) => {
+                if core {
+                    &module.types
+                } else {
+                    return None;
+                }
+            }
+            TypesRefKind::Component(component) => {
+                if core {
+                    &component.core_types
+                } else {
+                    &component.types
+                }
+            }
+        })
+    }
+
+    /// Gets a type based on its type id.
+    ///
+    /// Returns `None` if the type id is unknown.
+    pub fn type_from_id(&self, id: TypeId) -> Option<&'a Type> {
+        self.types.get(id.index)
+    }
+
+    /// Gets a type id from a type index.
+    ///
+    /// Returns `None` if the type index is out of bounds or the type has not
+    /// been parsed yet.
+    pub fn id_from_type_index(&self, index: u32, core: bool) -> Option<TypeId> {
+        self.types(core)?.get(index as usize).copied()
+    }
+
+    /// Gets a type at the given type index.
+    ///
+    /// Returns `None` if the type index is out of bounds or the type has not
+    /// been parsed yet.
+    pub fn type_at(&self, index: u32, core: bool) -> Option<&'a Type> {
+        self.type_from_id(*self.types(core)?.get(index as usize)?)
+    }
+
+    /// Gets a defined core function type at the given type index.
+    ///
+    /// Returns `None` if the type index is out of bounds or the type has not
+    /// been parsed yet.
+    pub fn func_type_at(&self, index: u32) -> Option<&'a FuncType> {
+        match self.type_at(index, true)? {
+            Type::Func(ty) => Some(ty),
+            _ => None,
+        }
+    }
+
+    /// Gets the type of a table at the given table index.
+    ///
+    /// Returns `None` if the type index is out of bounds or the type has not
+    /// been parsed yet.
+    pub fn table_at(&self, index: u32) -> Option<TableType> {
+        let tables = match &self.kind {
+            TypesRefKind::Module(module) => &module.tables,
+            TypesRefKind::Component(component) => &component.core_tables,
+        };
+
+        tables.get(index as usize).copied()
+    }
+
+    /// Gets the type of a memory at the given memory index.
+    ///
+    /// Returns `None` if the type index is out of bounds or the type has not
+    /// been parsed yet.
+    pub fn memory_at(&self, index: u32) -> Option<MemoryType> {
+        let memories = match &self.kind {
+            TypesRefKind::Module(module) => &module.memories,
+            TypesRefKind::Component(component) => &component.core_memories,
+        };
+
+        memories.get(index as usize).copied()
+    }
+
+    /// Gets the type of a global at the given global index.
+    ///
+    /// Returns `None` if the type index is out of bounds or the type has not
+    /// been parsed yet.
+    pub fn global_at(&self, index: u32) -> Option<GlobalType> {
+        let globals = match &self.kind {
+            TypesRefKind::Module(module) => &module.globals,
+            TypesRefKind::Component(component) => &component.core_globals,
+        };
+
+        globals.get(index as usize).copied()
+    }
+
+    /// Gets the type of a tag at the given tag index.
+    ///
+    /// Returns `None` if the type index is out of bounds or the type has not
+    /// been parsed yet.
+    pub fn tag_at(&self, index: u32) -> Option<&'a FuncType> {
+        let tags = match &self.kind {
+            TypesRefKind::Module(module) => &module.tags,
+            TypesRefKind::Component(component) => &component.core_tags,
+        };
+
+        Some(
+            self.types[*tags.get(index as usize)?]
+                .as_func_type()
+                .unwrap(),
+        )
+    }
+
+    /// Gets the type of a core function at the given function index.
+    ///
+    /// Returns `None` if the type index is out of bounds or the type has not
+    /// been parsed yet.
+    pub fn function_at(&self, index: u32) -> Option<&'a FuncType> {
+        let id = match &self.kind {
+            TypesRefKind::Module(module) => {
+                &module.types[*module.functions.get(index as usize)? as usize]
+            }
+            TypesRefKind::Component(component) => component.core_funcs.get(index as usize)?,
+        };
+
+        match &self.types[*id] {
+            Type::Func(ty) => Some(ty),
+            _ => None,
+        }
+    }
+
+    /// Gets the type of an element segment at the given element segment index.
+    ///
+    /// Returns `None` if the type index is out of bounds or the type has not
+    /// been parsed yet.
+    pub fn element_at(&self, index: u32) -> Option<ValType> {
+        match &self.kind {
+            TypesRefKind::Module(module) => module.element_types.get(index as usize).copied(),
+            TypesRefKind::Component(_) => None,
+        }
+    }
+
+    /// Gets the type of a component function at the given function index.
+    ///
+    /// Returns `None` if the type index is out of bounds or the type has not
+    /// been parsed yet.
+    pub fn component_function_at(&self, index: u32) -> Option<&'a ComponentFuncType> {
+        match &self.kind {
+            TypesRefKind::Module(_) => None,
+            TypesRefKind::Component(component) => Some(
+                self.types[*component.funcs.get(index as usize)?]
+                    .as_component_func_type()
+                    .unwrap(),
+            ),
+        }
+    }
+
+    /// Gets the type of a module at the given module index.
+    ///
+    /// Returns `None` if the type index is out of bounds or the type has not
+    /// been parsed yet.
+    pub fn module_at(&self, index: u32) -> Option<&'a ModuleType> {
+        match &self.kind {
+            TypesRefKind::Module(_) => None,
+            TypesRefKind::Component(component) => Some(
+                self.types[*component.core_modules.get(index as usize)?]
+                    .as_module_type()
+                    .unwrap(),
+            ),
+        }
+    }
+
+    /// Gets the type of a module instance at the given module instance index.
+    ///
+    /// Returns `None` if the type index is out of bounds or the type has not
+    /// been parsed yet.
+    pub fn instance_at(&self, index: u32) -> Option<&'a InstanceType> {
+        match &self.kind {
+            TypesRefKind::Module(_) => None,
+            TypesRefKind::Component(component) => {
+                let id = component.core_instances.get(index as usize)?;
+                match &self.types[*id] {
+                    Type::Instance(ty) => Some(ty),
+                    _ => None,
+                }
+            }
+        }
+    }
+
+    /// Gets the type of a component at the given component index.
+    ///
+    /// Returns `None` if the type index is out of bounds or the type has not
+    /// been parsed yet.
+    pub fn component_at(&self, index: u32) -> Option<&'a ComponentType> {
+        match &self.kind {
+            TypesRefKind::Module(_) => None,
+            TypesRefKind::Component(component) => Some(
+                self.types[*component.components.get(index as usize)?]
+                    .as_component_type()
+                    .unwrap(),
+            ),
+        }
+    }
+
+    /// Gets the type of an component instance at the given component instance index.
+    ///
+    /// Returns `None` if the type index is out of bounds or the type has not
+    /// been parsed yet.
+    pub fn component_instance_at(&self, index: u32) -> Option<&'a ComponentInstanceType> {
+        match &self.kind {
+            TypesRefKind::Module(_) => None,
+            TypesRefKind::Component(component) => {
+                let id = component.instances.get(index as usize)?;
+                match &self.types[*id] {
+                    Type::ComponentInstance(ty) => Some(ty),
+                    _ => None,
+                }
+            }
+        }
+    }
+
+    /// Gets the type of a value at the given value index.
+    ///
+    /// Returns `None` if the type index is out of bounds or the type has not
+    /// been parsed yet.
+    pub fn value_at(&self, index: u32) -> Option<ComponentValType> {
+        match &self.kind {
+            TypesRefKind::Module(_) => None,
+            TypesRefKind::Component(component) => {
+                component.values.get(index as usize).map(|(r, _)| *r)
+            }
+        }
+    }
+}
+
 impl Types {
     pub(crate) fn from_module(types: TypeList, module: Arc<Module>) -> Self {
         Self {
@@ -1020,54 +1279,42 @@ impl Types {
         }
     }
 
-    fn types(&self, core: bool) -> Option<&Vec<TypeId>> {
-        Some(match &self.kind {
-            TypesKind::Module(module) => {
-                if core {
-                    &module.types
-                } else {
-                    return None;
-                }
-            }
-            TypesKind::Component(component) => {
-                if core {
-                    &component.core_types
-                } else {
-                    &component.types
-                }
-            }
-        })
+    fn as_ref(&self) -> TypesRef {
+        TypesRef {
+            types: &self.types,
+            kind: match &self.kind {
+                TypesKind::Module(module) => TypesRefKind::Module(module),
+                TypesKind::Component(component) => TypesRefKind::Component(component),
+            },
+        }
     }
 
     /// Gets a type based on its type id.
     ///
     /// Returns `None` if the type id is unknown.
     pub fn type_from_id(&self, id: TypeId) -> Option<&Type> {
-        self.types.get(id.index)
+        self.as_ref().type_from_id(id)
     }
 
     /// Gets a type id from a type index.
     ///
     /// Returns `None` if the type index is out of bounds.
     pub fn id_from_type_index(&self, index: u32, core: bool) -> Option<TypeId> {
-        self.types(core)?.get(index as usize).copied()
+        self.as_ref().id_from_type_index(index, core)
     }
 
     /// Gets a type at the given type index.
     ///
     /// Returns `None` if the index is out of bounds.
     pub fn type_at(&self, index: u32, core: bool) -> Option<&Type> {
-        self.type_from_id(*self.types(core)?.get(index as usize)?)
+        self.as_ref().type_at(index, core)
     }
 
     /// Gets a defined core function type at the given type index.
     ///
     /// Returns `None` if the index is out of bounds.
     pub fn func_type_at(&self, index: u32) -> Option<&FuncType> {
-        match self.type_at(index, true)? {
-            Type::Func(ty) => Some(ty),
-            _ => None,
-        }
+        self.as_ref().func_type_at(index)
     }
 
     /// Gets the count of core types.
@@ -1082,12 +1329,7 @@ impl Types {
     ///
     /// Returns `None` if the index is out of bounds.
     pub fn table_at(&self, index: u32) -> Option<TableType> {
-        let tables = match &self.kind {
-            TypesKind::Module(module) => &module.tables,
-            TypesKind::Component(component) => &component.core_tables,
-        };
-
-        tables.get(index as usize).copied()
+        self.as_ref().table_at(index)
     }
 
     /// Gets the count of imported and defined tables.
@@ -1102,12 +1344,7 @@ impl Types {
     ///
     /// Returns `None` if the index is out of bounds.
     pub fn memory_at(&self, index: u32) -> Option<MemoryType> {
-        let memories = match &self.kind {
-            TypesKind::Module(module) => &module.memories,
-            TypesKind::Component(component) => &component.core_memories,
-        };
-
-        memories.get(index as usize).copied()
+        self.as_ref().memory_at(index)
     }
 
     /// Gets the count of imported and defined memories.
@@ -1122,12 +1359,7 @@ impl Types {
     ///
     /// Returns `None` if the index is out of bounds.
     pub fn global_at(&self, index: u32) -> Option<GlobalType> {
-        let globals = match &self.kind {
-            TypesKind::Module(module) => &module.globals,
-            TypesKind::Component(component) => &component.core_globals,
-        };
-
-        globals.get(index as usize).copied()
+        self.as_ref().global_at(index)
     }
 
     /// Gets the count of imported and defined globals.
@@ -1142,16 +1374,7 @@ impl Types {
     ///
     /// Returns `None` if the index is out of bounds.
     pub fn tag_at(&self, index: u32) -> Option<&FuncType> {
-        let tags = match &self.kind {
-            TypesKind::Module(module) => &module.tags,
-            TypesKind::Component(component) => &component.core_tags,
-        };
-
-        Some(
-            self.types[*tags.get(index as usize)?]
-                .as_func_type()
-                .unwrap(),
-        )
+        self.as_ref().tag_at(index)
     }
 
     /// Gets the count of imported and defined tags.
@@ -1166,17 +1389,7 @@ impl Types {
     ///
     /// Returns `None` if the index is out of bounds.
     pub fn function_at(&self, index: u32) -> Option<&FuncType> {
-        let id = match &self.kind {
-            TypesKind::Module(module) => {
-                &module.types[*module.functions.get(index as usize)? as usize]
-            }
-            TypesKind::Component(component) => component.core_funcs.get(index as usize)?,
-        };
-
-        match &self.types[*id] {
-            Type::Func(ty) => Some(ty),
-            _ => None,
-        }
+        self.as_ref().function_at(index)
     }
 
     /// Gets the count of imported and defined core functions.
@@ -1193,10 +1406,7 @@ impl Types {
     ///
     /// Returns `None` if the index is out of bounds.
     pub fn element_at(&self, index: u32) -> Option<ValType> {
-        match &self.kind {
-            TypesKind::Module(module) => module.element_types.get(index as usize).copied(),
-            TypesKind::Component(_) => None,
-        }
+        self.as_ref().element_at(index)
     }
 
     /// Gets the count of element segments.
@@ -1211,14 +1421,7 @@ impl Types {
     ///
     /// Returns `None` if the index is out of bounds.
     pub fn component_function_at(&self, index: u32) -> Option<&ComponentFuncType> {
-        match &self.kind {
-            TypesKind::Module(_) => None,
-            TypesKind::Component(component) => Some(
-                self.types[*component.funcs.get(index as usize)?]
-                    .as_component_func_type()
-                    .unwrap(),
-            ),
-        }
+        self.as_ref().component_function_at(index)
     }
 
     /// Gets the count of imported, exported, or aliased component functions.
@@ -1233,14 +1436,7 @@ impl Types {
     ///
     /// Returns `None` if the index is out of bounds.
     pub fn module_at(&self, index: u32) -> Option<&ModuleType> {
-        match &self.kind {
-            TypesKind::Module(_) => None,
-            TypesKind::Component(component) => Some(
-                self.types[*component.core_modules.get(index as usize)?]
-                    .as_module_type()
-                    .unwrap(),
-            ),
-        }
+        self.as_ref().module_at(index)
     }
 
     /// Gets the count of imported, exported, or aliased modules.
@@ -1255,16 +1451,7 @@ impl Types {
     ///
     /// Returns `None` if the index is out of bounds.
     pub fn instance_at(&self, index: u32) -> Option<&InstanceType> {
-        match &self.kind {
-            TypesKind::Module(_) => None,
-            TypesKind::Component(component) => {
-                let id = component.core_instances.get(index as usize)?;
-                match &self.types[*id] {
-                    Type::Instance(ty) => Some(ty),
-                    _ => None,
-                }
-            }
-        }
+        self.as_ref().instance_at(index)
     }
 
     /// Gets the count of imported, exported, or aliased core module instances.
@@ -1279,14 +1466,7 @@ impl Types {
     ///
     /// Returns `None` if the index is out of bounds.
     pub fn component_at(&self, index: u32) -> Option<&ComponentType> {
-        match &self.kind {
-            TypesKind::Module(_) => None,
-            TypesKind::Component(component) => Some(
-                self.types[*component.components.get(index as usize)?]
-                    .as_component_type()
-                    .unwrap(),
-            ),
-        }
+        self.as_ref().component_at(index)
     }
 
     /// Gets the count of imported, exported, or aliased components.
@@ -1301,16 +1481,7 @@ impl Types {
     ///
     /// Returns `None` if the index is out of bounds.
     pub fn component_instance_at(&self, index: u32) -> Option<&ComponentInstanceType> {
-        match &self.kind {
-            TypesKind::Module(_) => None,
-            TypesKind::Component(component) => {
-                let id = component.instances.get(index as usize)?;
-                match &self.types[*id] {
-                    Type::ComponentInstance(ty) => Some(ty),
-                    _ => None,
-                }
-            }
-        }
+        self.as_ref().component_instance_at(index)
     }
 
     /// Gets the count of imported, exported, or aliased component instances.
@@ -1325,12 +1496,7 @@ impl Types {
     ///
     /// Returns `None` if the index is out of bounds.
     pub fn value_at(&self, index: u32) -> Option<ComponentValType> {
-        match &self.kind {
-            TypesKind::Module(_) => None,
-            TypesKind::Component(component) => {
-                component.values.get(index as usize).map(|(r, _)| *r)
-            }
-        }
+        self.as_ref().value_at(index)
     }
 
     /// Gets the count of imported, exported, or aliased values.


### PR DESCRIPTION
Ref #271 - after looking at `WasmModuleResources`, I realised that it's heavily geared towards what's needed for validating the code section, and as such doesn't allow getting any component types. So instead of implementing that, I've added a separate mechanism to get types from a `Validator` midway through parsing.

I've added a `types` method to `Validator`, which returns a `TypesRef` for all of the types in a module or component being parsed. `TypesRef` is meant as a borrowed version of `Types`.

Unfortunately, this does mean duplicating the methods between them; I had hoped to make `Types` deref to `TypesRef`, but `Deref` requires producing a *reference* to the target type.

I was able to unify the implementation though, with a regular method to go from `&Types` to `TypesRef`.

I didn't include any of the methods for getting the counts of things on `TypesRef`, with the reasoning that the final numbers aren't known at that point; I don't know if that really makes sense though so I'm fine to add them.

In general I'm not set on any aspect of the API, this is just the first thing I came up with.