### PR TITLE
`wasmparser` and `wast`: bug fixes related to component value types.

### DIFF
--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -282,7 +282,18 @@ impl ComponentValType {
                 .as_defined_type()
                 .unwrap()
                 .is_subtype_of(types[*other_ty].as_defined_type().unwrap(), types),
-            _ => false,
+            (ComponentValType::Primitive(ty), ComponentValType::Type(other_ty)) => {
+                match types[*other_ty].as_defined_type().unwrap() {
+                    ComponentDefinedType::Primitive(other_ty) => ty.is_subtype_of(other_ty),
+                    _ => false,
+                }
+            }
+            (ComponentValType::Type(ty), ComponentValType::Primitive(other_ty)) => {
+                match types[*ty].as_defined_type().unwrap() {
+                    ComponentDefinedType::Primitive(ty) => ty.is_subtype_of(other_ty),
+                    _ => false,
+                }
+            }
         }
     }
 

--- a/crates/wast/src/component/binary.rs
+++ b/crates/wast/src/component/binary.rs
@@ -578,7 +578,9 @@ impl<T> From<&ComponentTypeUse<'_, T>> for u32 {
 impl From<&ComponentValType<'_>> for wasm_encoder::ComponentValType {
     fn from(r: &ComponentValType) -> Self {
         match r {
-            ComponentValType::Primitive(p) => Self::Primitive((*p).into()),
+            ComponentValType::Inline(ComponentDefinedType::Primitive(p)) => {
+                Self::Primitive((*p).into())
+            }
             ComponentValType::Ref(i) => Self::Type(u32::from(*i)),
             ComponentValType::Inline(_) => unreachable!("should be expanded by now"),
         }
@@ -621,7 +623,7 @@ impl From<&ItemSigKind<'_>> for wasm_encoder::ComponentTypeRef {
             ItemSigKind::Component(c) => Self::Component(c.into()),
             ItemSigKind::CoreModule(m) => Self::Module(m.into()),
             ItemSigKind::Instance(i) => Self::Instance(i.into()),
-            ItemSigKind::Value(v) => Self::Value(v.into()),
+            ItemSigKind::Value(v) => Self::Value((&v.0).into()),
             ItemSigKind::Func(f) => Self::Func(f.into()),
             ItemSigKind::Type(TypeBounds::Eq(t)) => {
                 Self::Type(wasm_encoder::TypeBounds::Eq, (*t).into())

--- a/crates/wast/src/component/expand.rs
+++ b/crates/wast/src/component/expand.rs
@@ -380,7 +380,7 @@ impl<'a> Expander<'a> {
                     core::TypeDef::Struct(_) => {}
                     core::TypeDef::Array(_) => {}
                 },
-                ModuleTypeDecl::Alias(_) => {},
+                ModuleTypeDecl::Alias(_) => {}
                 ModuleTypeDecl::Import(ty) => {
                     expand_sig(&mut ty.item, &mut to_prepend, &mut func_type_to_idx);
                 }
@@ -467,7 +467,7 @@ impl<'a> Expander<'a> {
                 self.expand_component_type_use(t);
             }
             ItemSigKind::Value(t) => {
-                self.expand_component_val_ty(t);
+                self.expand_component_val_ty(&mut t.0);
             }
             ItemSigKind::Type(_) => {}
         }
@@ -513,7 +513,8 @@ impl<'a> Expander<'a> {
 
     fn expand_component_val_ty(&mut self, ty: &mut ComponentValType<'a>) {
         let inline = match ty {
-            ComponentValType::Primitive(_) | ComponentValType::Ref(_) => return,
+            ComponentValType::Inline(ComponentDefinedType::Primitive(_))
+            | ComponentValType::Ref(_) => return,
             ComponentValType::Inline(inline) => {
                 self.expand_defined_ty(inline);
                 mem::take(inline)

--- a/crates/wast/src/component/import.rs
+++ b/crates/wast/src/component/import.rs
@@ -88,7 +88,7 @@ pub enum ItemSigKind<'a> {
     /// The item signature is for an instance.
     Instance(ComponentTypeUse<'a, InstanceType<'a>>),
     /// The item signature is for a value.
-    Value(ComponentValType<'a>),
+    Value(ComponentValTypeUse<'a>),
     /// The item signature is for a type.
     Type(TypeBounds<'a>),
 }

--- a/crates/wast/src/component/resolve.rs
+++ b/crates/wast/src/component/resolve.rs
@@ -256,7 +256,7 @@ impl<'a> Resolver<'a> {
             ItemSigKind::Func(t) => self.component_type_use(t),
             ItemSigKind::Component(t) => self.component_type_use(t),
             ItemSigKind::Instance(t) => self.component_type_use(t),
-            ItemSigKind::Value(t) => self.component_val_type(t),
+            ItemSigKind::Value(t) => self.component_val_type(&mut t.0),
             ItemSigKind::Type(b) => match b {
                 TypeBounds::Eq(i) => self.resolve_ns(i, Ns::Type),
             },
@@ -473,8 +473,8 @@ impl<'a> Resolver<'a> {
 
     fn component_val_type(&mut self, ty: &mut ComponentValType<'a>) -> Result<(), Error> {
         match ty {
-            ComponentValType::Primitive(_) => Ok(()),
             ComponentValType::Ref(idx) => self.resolve_ns(idx, Ns::Type),
+            ComponentValType::Inline(ComponentDefinedType::Primitive(_)) => Ok(()),
             ComponentValType::Inline(_) => unreachable!("should be expanded by now"),
         }
     }

--- a/tests/local/component-model/instantiate.wast
+++ b/tests/local/component-model/instantiate.wast
@@ -74,6 +74,13 @@
 )
 
 (component
+  (type $t string)
+  (import "a" (value (type $t)))
+  (component $c (import "a" (value string)) (export "a" (value 0)))
+  (instance (instantiate $c (with "a" (value 0))))
+)
+
+(component
   (import "a" (component $m
     (import "" (instance
       (export "a" (core module))


### PR DESCRIPTION
The fixes two bugs I found:

* `wasmparser`: the subtype check did not account for primitive values compared against primitive values via a type index.
* `wast`: component value types in item sigs (specifically for `value` types) were not parsed correctly, e.g. `(import "" (value (type <idx>)))`.
