### PR TITLE
wasmparser: fix validation not requiring realloc function.

### DIFF
--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -717,6 +717,7 @@ impl ComponentFuncType {
                 info.params.clear();
                 assert!(info.params.push(ValType::I32));
                 info.requires_memory = true;
+                info.requires_realloc = true;
                 break;
             }
         }

--- a/tests/local/component-model/func.wast
+++ b/tests/local/component-model/func.wast
@@ -41,6 +41,29 @@
 
 (assert_invalid
   (component
+    (core module $m
+      (memory (export "memory") 1)
+      (func (export "roundtrip") (param i32))
+    )
+    (core instance $m (instantiate $m))
+
+    (type $roundtrip (func
+      (param u32) (param u32) (param u32) (param u32) (param u32)
+      (param u32) (param u32) (param u32) (param u32) (param u32)
+      (param u32) (param u32) (param u32) (param u32) (param u32)
+      (param u32) (param u32) (param u32) (param u32) (param u32)
+    ))
+
+    (func $roundtrip (type $roundtrip)
+      (canon lift (core func $m "roundtrip") (memory $m "memory"))
+    )
+    (export "roundtrip" (func $roundtrip))
+  )
+  "canonical option `realloc` is required"
+)
+
+(assert_invalid
+  (component
     (import "" (func $log (result string)))
     (core module $libc
       (memory (export "memory") 1)


### PR DESCRIPTION
This PR fixes the validator to require the realloc function when the flat
parameter maximum is exceeded when lifting and lowering functions.

Fixes #684.