### PR TITLE
wast: Emit data count section for ArrayNewData

### DIFF
--- a/crates/wast/src/core/binary.rs
+++ b/crates/wast/src/core/binary.rs
@@ -66,7 +66,7 @@ pub fn encode(
     }
     e.custom_sections(After(Start));
     e.section_list(9, Elem, &elem);
-    if contains_bulk_memory(&funcs) {
+    if needs_data_count(&funcs) {
         e.section(12, &data.len());
     }
     e.section_list(10, Code, &funcs);
@@ -80,7 +80,7 @@ pub fn encode(
 
     return e.wasm;
 
-    fn contains_bulk_memory(funcs: &[&crate::core::Func<'_>]) -> bool {
+    fn needs_data_count(funcs: &[&crate::core::Func<'_>]) -> bool {
         funcs
             .iter()
             .filter_map(|f| match &f.kind {
@@ -88,10 +88,7 @@ pub fn encode(
                 _ => None,
             })
             .flat_map(|e| e.instrs.iter())
-            .any(|i| match i {
-                Instruction::MemoryInit(_) | Instruction::DataDrop(_) => true,
-                _ => false,
-            })
+            .any(|i| i.needs_data_count())
     }
 }
 

--- a/crates/wast/src/core/expr.rs
+++ b/crates/wast/src/core/expr.rs
@@ -1160,6 +1160,17 @@ instructions! {
     }
 }
 
+impl<'a> Instruction<'a> {
+    pub(crate) fn needs_data_count(&self) -> bool {
+        match self {
+            Instruction::MemoryInit(_) |
+            Instruction::DataDrop(_) |
+            Instruction::ArrayNewData(_) => true,
+            _ => false,
+        }
+    }
+}
+
 /// Extra information associated with block-related instructions.
 ///
 /// This is used to label blocks and also annotate what types are expected for


### PR DESCRIPTION
I missed that we only emit data_count when an instruction
might need it, and this causes ArrayNewData to not be able
to validate.