### PR TITLE
wasm-encoder: add a ConstExpr type for offsets and init expressions

### DIFF
--- a/crates/wasm-encoder/src/core/code.rs
+++ b/crates/wasm-encoder/src/core/code.rs
@@ -2738,59 +2738,61 @@ pub struct ConstExpr {
 
 impl ConstExpr {
     /// Create a new empty constant expression builder.
-    pub fn new() -> Self {
+    pub fn empty() -> Self {
         Self { bytes: Vec::new() }
     }
 
-    /// Add raw bytes to this constant expression.
-    pub fn raw(&mut self, bytes: impl IntoIterator<Item=u8>) -> &mut Self {
-        self.bytes.extend(bytes);
-        self
+    /// Create a constant expression with the specified raw encoding of instructions.
+    pub fn raw(bytes: impl IntoIterator<Item = u8>) -> Self {
+        Self {
+            bytes: bytes.into_iter().collect(),
+        }
     }
 
-    fn insn(&mut self, insn: Instruction) -> &mut Self {
-        insn.encode(&mut self.bytes);
-        self
+    fn new_insn(insn: Instruction) -> Self {
+        let mut bytes = vec![];
+        insn.encode(&mut bytes);
+        Self { bytes }
     }
 
-    /// Append a `global.get` instruction to this constant expression.
-    pub fn global_get(&mut self, index: u32) -> &mut Self {
-        self.insn(Instruction::GlobalGet(index))
+    /// Create a constant expression containing a single `global.get` instruction.
+    pub fn global_get(index: u32) -> Self {
+        Self::new_insn(Instruction::GlobalGet(index))
     }
 
-    /// Append a `ref.null` instruction to this constant expression.
-    pub fn ref_null(&mut self, ty: ValType) -> &mut Self {
-        self.insn(Instruction::RefNull(ty))
+    /// Create a constant expression containing a single `ref.null` instruction.
+    pub fn ref_null(ty: ValType) -> Self {
+        Self::new_insn(Instruction::RefNull(ty))
     }
 
-    /// Append a `ref.func` instruction to this constant expression.
-    pub fn ref_func(&mut self, func: u32) -> &mut Self {
-        self.insn(Instruction::RefFunc(func))
+    /// Create a constant expression containing a single `ref.func` instruction.
+    pub fn ref_func(func: u32) -> Self {
+        Self::new_insn(Instruction::RefFunc(func))
     }
 
-    /// Append an `i32.const` instruction to this constant expression.
-    pub fn i32_const(&mut self, value: i32) -> &mut Self {
-        self.insn(Instruction::I32Const(value))
+    /// Create a constant expression containing a single `i32.const` instruction.
+    pub fn i32_const(value: i32) -> Self {
+        Self::new_insn(Instruction::I32Const(value))
     }
 
-    /// Append a `i64.const` instruction to this constant expression.
-    pub fn i64_const(&mut self, value: i64) -> &mut Self {
-        self.insn(Instruction::I64Const(value))
+    /// Create a constant expression containing a single `i64.const` instruction.
+    pub fn i64_const(value: i64) -> Self {
+        Self::new_insn(Instruction::I64Const(value))
     }
 
-    /// Append an `f32.const` instruction to this constant expression.
-    pub fn f32_const(&mut self, value: f32) -> &mut Self {
-        self.insn(Instruction::F32Const(value))
+    /// Create a constant expression containing a single `f32.const` instruction.
+    pub fn f32_const(value: f32) -> Self {
+        Self::new_insn(Instruction::F32Const(value))
     }
 
-    /// Append an `f64.const` instruction to this constant expression.
-    pub fn f64_const(&mut self, value: f64) -> &mut Self {
-        self.insn(Instruction::F64Const(value))
+    /// Create a constant expression containing a single `f64.const` instruction.
+    pub fn f64_const(value: f64) -> Self {
+        Self::new_insn(Instruction::F64Const(value))
     }
 
-    /// Append an `f64.const` instruction to this constant expression.
-    pub fn v128_const(&mut self, value: i128) -> &mut Self {
-        self.insn(Instruction::V128Const(value))
+    /// Create a constant expression containing a single `v128.const` instruction.
+    pub fn v128_const(value: i128) -> Self {
+        Self::new_insn(Instruction::V128Const(value))
     }
 }
 

--- a/crates/wasm-encoder/src/core/code.rs
+++ b/crates/wasm-encoder/src/core/code.rs
@@ -2728,6 +2728,79 @@ impl Encode for Instruction<'_> {
     }
 }
 
+/// A constant expression.
+///
+/// Usable in contexts such as offsets or initializers.
+#[derive(Debug)]
+pub struct ConstExpr {
+    bytes: Vec<u8>,
+}
+
+impl ConstExpr {
+    /// Create a new empty constant expression builder.
+    pub fn new() -> Self {
+        Self { bytes: Vec::new() }
+    }
+
+    /// Add raw bytes to this constant expression.
+    pub fn raw(&mut self, bytes: impl IntoIterator<Item=u8>) -> &mut Self {
+        self.bytes.extend(bytes);
+        self
+    }
+
+    fn insn(&mut self, insn: Instruction) -> &mut Self {
+        insn.encode(&mut self.bytes);
+        self
+    }
+
+    /// Append a `global.get` instruction to this constant expression.
+    pub fn global_get(&mut self, index: u32) -> &mut Self {
+        self.insn(Instruction::GlobalGet(index))
+    }
+
+    /// Append a `ref.null` instruction to this constant expression.
+    pub fn ref_null(&mut self, ty: ValType) -> &mut Self {
+        self.insn(Instruction::RefNull(ty))
+    }
+
+    /// Append a `ref.func` instruction to this constant expression.
+    pub fn ref_func(&mut self, func: u32) -> &mut Self {
+        self.insn(Instruction::RefFunc(func))
+    }
+
+    /// Append an `i32.const` instruction to this constant expression.
+    pub fn i32_const(&mut self, value: i32) -> &mut Self {
+        self.insn(Instruction::I32Const(value))
+    }
+
+    /// Append a `i64.const` instruction to this constant expression.
+    pub fn i64_const(&mut self, value: i64) -> &mut Self {
+        self.insn(Instruction::I64Const(value))
+    }
+
+    /// Append an `f32.const` instruction to this constant expression.
+    pub fn f32_const(&mut self, value: f32) -> &mut Self {
+        self.insn(Instruction::F32Const(value))
+    }
+
+    /// Append an `f64.const` instruction to this constant expression.
+    pub fn f64_const(&mut self, value: f64) -> &mut Self {
+        self.insn(Instruction::F64Const(value))
+    }
+
+    /// Append an `f64.const` instruction to this constant expression.
+    pub fn v128_const(&mut self, value: i128) -> &mut Self {
+        self.insn(Instruction::V128Const(value))
+    }
+}
+
+impl Encode for ConstExpr {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        sink.extend(&self.bytes);
+        Instruction::End.encode(sink);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/crates/wasm-encoder/src/core/data.rs
+++ b/crates/wasm-encoder/src/core/data.rs
@@ -1,4 +1,4 @@
-use crate::{encode_section, encoding_size, Encode, Instruction, Section, SectionId};
+use crate::{encode_section, encoding_size, ConstExpr, Encode, Section, SectionId};
 
 /// An encoder for the data section.
 ///
@@ -8,7 +8,7 @@ use crate::{encode_section, encoding_size, Encode, Instruction, Section, Section
 ///
 /// ```
 /// use wasm_encoder::{
-///     DataSection, Instruction, MemorySection, MemoryType,
+///     ConstExpr, DataSection, Instruction, MemorySection, MemoryType,
 ///     Module,
 /// };
 ///
@@ -22,7 +22,7 @@ use crate::{encode_section, encoding_size, Encode, Instruction, Section, Section
 ///
 /// let mut data = DataSection::new();
 /// let memory_index = 0;
-/// let offset = Instruction::I32Const(42);
+/// let offset = ConstExpr::i32_const(42);
 /// let segment_data = b"hello";
 /// data.active(memory_index, &offset, segment_data.iter().copied());
 ///
@@ -56,7 +56,7 @@ pub enum DataSegmentMode<'a> {
         /// The memory this segment applies to.
         memory_index: u32,
         /// The offset where this segment's data is initialized at.
-        offset: &'a Instruction<'a>,
+        offset: &'a ConstExpr,
     },
     /// A passive data segment.
     ///
@@ -96,7 +96,6 @@ impl DataSection {
             } => {
                 self.bytes.push(0x00);
                 offset.encode(&mut self.bytes);
-                Instruction::End.encode(&mut self.bytes);
             }
             DataSegmentMode::Active {
                 memory_index,
@@ -105,7 +104,6 @@ impl DataSection {
                 self.bytes.push(0x02);
                 memory_index.encode(&mut self.bytes);
                 offset.encode(&mut self.bytes);
-                Instruction::End.encode(&mut self.bytes);
             }
         }
 
@@ -118,7 +116,7 @@ impl DataSection {
     }
 
     /// Define an active data segment.
-    pub fn active<D>(&mut self, memory_index: u32, offset: &Instruction, data: D) -> &mut Self
+    pub fn active<D>(&mut self, memory_index: u32, offset: &ConstExpr, data: D) -> &mut Self
     where
         D: IntoIterator<Item = u8>,
         D::IntoIter: ExactSizeIterator,

--- a/crates/wasm-encoder/src/core/elements.rs
+++ b/crates/wasm-encoder/src/core/elements.rs
@@ -1,4 +1,4 @@
-use crate::{encode_section, Encode, Instruction, Section, SectionId, ValType};
+use crate::{encode_section, ConstExpr, Encode, Instruction, Section, SectionId, ValType};
 
 /// An encoder for the element section.
 ///
@@ -8,8 +8,8 @@ use crate::{encode_section, Encode, Instruction, Section, SectionId, ValType};
 ///
 /// ```
 /// use wasm_encoder::{
-///     Elements, ElementSection, Instruction, Module, TableSection, TableType,
-///     ValType,
+///     Elements, ElementSection, Module, TableSection, TableType,
+///     ValType, ConstExpr
 /// };
 ///
 /// let mut tables = TableSection::new();
@@ -21,7 +21,8 @@ use crate::{encode_section, Encode, Instruction, Section, SectionId, ValType};
 ///
 /// let mut elements = ElementSection::new();
 /// let table_index = 0;
-/// let offset = Instruction::I32Const(42);
+/// let mut offset = ConstExpr::new();
+/// offset.i32_const(42);
 /// let element_type = ValType::FuncRef;
 /// let functions = Elements::Functions(&[
 ///     // Function indices...
@@ -47,16 +48,7 @@ pub enum Elements<'a> {
     /// A sequences of references to functions by their indices.
     Functions(&'a [u32]),
     /// A sequence of reference expressions.
-    Expressions(&'a [Element]),
-}
-
-/// An element in a segment in the element section.
-#[derive(Clone, Copy, Debug)]
-pub enum Element {
-    /// A null reference.
-    Null,
-    /// A `ref.func n`.
-    Func(u32),
+    Expressions(&'a [ConstExpr]),
 }
 
 /// An element segment's mode.
@@ -79,7 +71,7 @@ pub enum ElementMode<'a> {
         /// bulk memory proposal and can refer to tables with any valid reference type.
         table: Option<u32>,
         /// The offset within the table to place this segment.
-        offset: &'a Instruction<'a>,
+        offset: &'a ConstExpr,
     },
 }
 
@@ -123,7 +115,6 @@ impl ElementSection {
             } => {
                 (/* 0x00 | */expr_bit).encode(&mut self.bytes);
                 offset.encode(&mut self.bytes);
-                Instruction::End.encode(&mut self.bytes);
             }
             ElementMode::Passive => {
                 (0x01 | expr_bit).encode(&mut self.bytes);
@@ -140,7 +131,6 @@ impl ElementSection {
                 (0x02 | expr_bit).encode(&mut self.bytes);
                 i.encode(&mut self.bytes);
                 offset.encode(&mut self.bytes);
-                Instruction::End.encode(&mut self.bytes);
                 if expr_bit == 0 {
                     self.bytes.push(0x00); // elemkind == funcref
                 } else {
@@ -164,13 +154,7 @@ impl ElementSection {
             Elements::Expressions(e) => {
                 e.len().encode(&mut self.bytes);
                 for expr in e {
-                    match expr {
-                        Element::Func(i) => Instruction::RefFunc(*i).encode(&mut self.bytes),
-                        Element::Null => {
-                            Instruction::RefNull(segment.element_type).encode(&mut self.bytes)
-                        }
-                    }
-                    Instruction::End.encode(&mut self.bytes);
+                    expr.encode(&mut self.bytes);
                 }
             }
         }
@@ -187,7 +171,7 @@ impl ElementSection {
     pub fn active(
         &mut self,
         table_index: Option<u32>,
-        offset: &Instruction<'_>,
+        offset: &ConstExpr,
         element_type: ValType,
         elements: Elements<'_>,
     ) -> &mut Self {

--- a/crates/wasm-encoder/src/core/elements.rs
+++ b/crates/wasm-encoder/src/core/elements.rs
@@ -1,4 +1,4 @@
-use crate::{encode_section, ConstExpr, Encode, Instruction, Section, SectionId, ValType};
+use crate::{encode_section, ConstExpr, Encode, Section, SectionId, ValType};
 
 /// An encoder for the element section.
 ///
@@ -21,8 +21,7 @@ use crate::{encode_section, ConstExpr, Encode, Instruction, Section, SectionId, 
 ///
 /// let mut elements = ElementSection::new();
 /// let table_index = 0;
-/// let mut offset = ConstExpr::new();
-/// offset.i32_const(42);
+/// let offset = ConstExpr::i32_const(42);
 /// let element_type = ValType::FuncRef;
 /// let functions = Elements::Functions(&[
 ///     // Function indices...

--- a/crates/wasm-encoder/src/core/globals.rs
+++ b/crates/wasm-encoder/src/core/globals.rs
@@ -1,4 +1,4 @@
-use crate::{encode_section, Encode, Instruction, Section, SectionId, ValType};
+use crate::{encode_section, ConstExpr, Encode, Section, SectionId, ValType};
 
 /// An encoder for the global section.
 ///
@@ -7,7 +7,7 @@ use crate::{encode_section, Encode, Instruction, Section, SectionId, ValType};
 /// # Example
 ///
 /// ```
-/// use wasm_encoder::{Module, GlobalSection, GlobalType, Instruction, ValType};
+/// use wasm_encoder::{ConstExpr, Module, GlobalSection, GlobalType, Instruction, ValType};
 ///
 /// let mut globals = GlobalSection::new();
 /// globals.global(
@@ -15,7 +15,7 @@ use crate::{encode_section, Encode, Instruction, Section, SectionId, ValType};
 ///         val_type: ValType::I32,
 ///         mutable: false,
 ///     },
-///     &Instruction::I32Const(42),
+///     &ConstExpr::i32_const(42),
 /// );
 ///
 /// let mut module = Module::new();
@@ -46,10 +46,9 @@ impl GlobalSection {
     }
 
     /// Define a global.
-    pub fn global(&mut self, global_type: GlobalType, init_expr: &Instruction<'_>) -> &mut Self {
+    pub fn global(&mut self, global_type: GlobalType, init_expr: &ConstExpr) -> &mut Self {
         global_type.encode(&mut self.bytes);
         init_expr.encode(&mut self.bytes);
-        Instruction::End.encode(&mut self.bytes);
         self.num_added += 1;
         self
     }

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -88,7 +88,7 @@ pub struct Module {
 
     /// The indexes and initialization expressions of globals defined in this
     /// module.
-    defined_globals: Vec<(u32, Instruction)>,
+    defined_globals: Vec<(u32, GlobalInitExpr)>,
 
     /// All tags available to this module, sorted by their index. The list
     /// entry is the type of each tag.
@@ -329,8 +329,14 @@ enum DataSegmentKind {
     Passive,
     Active {
         memory_index: u32,
-        offset: Instruction,
+        offset: ConstExpr,
     },
+}
+
+#[derive(Debug)]
+pub(crate) enum GlobalInitExpr {
+    FuncRef(u32),
+    ConstExpr(ConstExpr),
 }
 
 impl Module {
@@ -838,7 +844,7 @@ impl Module {
     }
 
     fn arbitrary_globals(&mut self, u: &mut Unstructured) -> Result<()> {
-        let mut choices: Vec<Box<dyn Fn(&mut Unstructured, ValType) -> Result<Instruction>>> =
+        let mut choices: Vec<Box<dyn Fn(&mut Unstructured, ValType) -> Result<GlobalInitExpr>>> =
             vec![];
         let num_imported_globals = self.globals.len();
 
@@ -856,27 +862,29 @@ impl Module {
                 choices.clear();
                 let num_funcs = self.funcs.len() as u32;
                 choices.push(Box::new(move |u, ty| {
-                    Ok(match ty {
-                        ValType::I32 => Instruction::I32Const(u.arbitrary()?),
-                        ValType::I64 => Instruction::I64Const(u.arbitrary()?),
-                        ValType::F32 => Instruction::F32Const(u.arbitrary()?),
-                        ValType::F64 => Instruction::F64Const(u.arbitrary()?),
-                        ValType::V128 => Instruction::V128Const(u.arbitrary()?),
-                        ValType::ExternRef => Instruction::RefNull(ValType::ExternRef),
+                    Ok(GlobalInitExpr::ConstExpr(match ty {
+                        ValType::I32 => ConstExpr::i32_const(u.arbitrary()?),
+                        ValType::I64 => ConstExpr::i64_const(u.arbitrary()?),
+                        ValType::F32 => ConstExpr::f32_const(u.arbitrary()?),
+                        ValType::F64 => ConstExpr::f64_const(u.arbitrary()?),
+                        ValType::V128 => ConstExpr::v128_const(u.arbitrary()?),
+                        ValType::ExternRef => ConstExpr::ref_null(ValType::ExternRef),
                         ValType::FuncRef => {
                             if num_funcs > 0 && u.arbitrary()? {
                                 let func = u.int_in_range(0..=num_funcs - 1)?;
-                                Instruction::RefFunc(func)
+                                return Ok(GlobalInitExpr::FuncRef(func));
                             } else {
-                                Instruction::RefNull(ValType::FuncRef)
+                                ConstExpr::ref_null(ValType::FuncRef)
                             }
                         }
-                    })
+                    }))
                 }));
 
                 for (i, g) in self.globals[..num_imported_globals].iter().enumerate() {
                     if !g.mutable && g.val_type == ty.val_type {
-                        choices.push(Box::new(move |_, _| Ok(Instruction::GlobalGet(i as u32))));
+                        choices.push(Box::new(move |_, _| {
+                            Ok(GlobalInitExpr::ConstExpr(ConstExpr::global_get(i as u32)))
+                        }));
                     }
                 }
 
@@ -1011,11 +1019,9 @@ impl Module {
             }
         }
         let arbitrary_active_elem = |u: &mut Unstructured, min: u32, table: Option<u32>| {
-            let mut offset_expr = ConstExpr::new();
-            let max_size_hint = if !offset_global_choices.is_empty() && u.arbitrary()? {
+            let (offset, max_size_hint) = if !offset_global_choices.is_empty() && u.arbitrary()? {
                 let g = u.choose(&offset_global_choices)?;
-                offset_expr.global_get(*g);
-                None
+                (ConstExpr::global_get(*g), None)
             } else {
                 let offset = arbitrary_offset(u, min.into(), u32::MAX.into(), 0)? as u32;
                 let max_size_hint =
@@ -1024,10 +1030,9 @@ impl Module {
                     } else {
                         None
                     };
-                offset_expr.i32_const(offset as i32);
-                max_size_hint
+                (ConstExpr::i32_const(offset as i32), max_size_hint)
             };
-            Ok((ElementKind::Active { table, offset: offset_expr }, max_size_hint))
+            Ok((ElementKind::Active { table, offset }, max_size_hint))
         };
 
         type GenElemSegment<'a> =
@@ -1181,10 +1186,10 @@ impl Module {
             return Ok(());
         }
 
-        let mut choices32: Vec<Box<dyn Fn(&mut Unstructured, u64, usize) -> Result<Instruction>>> =
+        let mut choices32: Vec<Box<dyn Fn(&mut Unstructured, u64, usize) -> Result<ConstExpr>>> =
             vec![];
         choices32.push(Box::new(|u, min_size, data_len| {
-            Ok(Instruction::I32Const(arbitrary_offset(
+            Ok(ConstExpr::i32_const(arbitrary_offset(
                 u,
                 u32::try_from(min_size.saturating_mul(64 * 1024))
                     .unwrap_or(u32::MAX)
@@ -1193,10 +1198,10 @@ impl Module {
                 data_len,
             )? as i32))
         }));
-        let mut choices64: Vec<Box<dyn Fn(&mut Unstructured, u64, usize) -> Result<Instruction>>> =
+        let mut choices64: Vec<Box<dyn Fn(&mut Unstructured, u64, usize) -> Result<ConstExpr>>> =
             vec![];
         choices64.push(Box::new(|u, min_size, data_len| {
-            Ok(Instruction::I64Const(arbitrary_offset(
+            Ok(ConstExpr::i64_const(arbitrary_offset(
                 u,
                 min_size.saturating_mul(64 * 1024),
                 u64::MAX,
@@ -1212,13 +1217,9 @@ impl Module {
                 continue;
             }
             if g.val_type == ValType::I32 {
-                choices32.push(Box::new(move |_, _, _| {
-                    Ok(Instruction::GlobalGet(i as u32))
-                }));
+                choices32.push(Box::new(move |_, _, _| Ok(ConstExpr::global_get(i as u32))));
             } else if g.val_type == ValType::I64 {
-                choices64.push(Box::new(move |_, _, _| {
-                    Ok(Instruction::GlobalGet(i as u32))
-                }));
+                choices64.push(Box::new(move |_, _, _| Ok(ConstExpr::global_get(i as u32))));
             }
         }
 

--- a/crates/wasm-smith/src/core/code_builder.rs
+++ b/crates/wasm-smith/src/core/code_builder.rs
@@ -1,5 +1,6 @@
 use super::{
-    Elements, FuncType, Instruction, InstructionKind::*, InstructionKinds, Module, ValType,
+    Elements, FuncType, GlobalInitExpr, Instruction, InstructionKind::*, InstructionKinds, Module,
+    ValType,
 };
 use arbitrary::{Result, Unstructured};
 use std::collections::{BTreeMap, BTreeSet};
@@ -692,7 +693,7 @@ impl CodeBuilderAllocations {
 
         let mut referenced_functions = BTreeSet::new();
         for (_, expr) in module.defined_globals.iter() {
-            if let Instruction::RefFunc(i) = *expr {
+            if let GlobalInitExpr::FuncRef(i) = *expr {
                 referenced_functions.insert(i);
             }
         }

--- a/crates/wasm-smith/src/core/encode.rs
+++ b/crates/wasm-smith/src/core/encode.rs
@@ -164,7 +164,12 @@ impl Module {
             };
             match &el.kind {
                 ElementKind::Active { table, offset } => {
-                    elems.active(*table, offset, el.ty, elements);
+                    let offset = match *offset {
+                        Offset::Const32(n) => ConstExpr::i32_const(n),
+                        Offset::Const64(n) => ConstExpr::i64_const(n),
+                        Offset::Global(g) => ConstExpr::global_get(g),
+                    };
+                    elems.active(*table, &offset, el.ty, elements);
                 }
                 ElementKind::Passive => {
                     elems.passive(el.ty, elements);
@@ -227,7 +232,12 @@ impl Module {
                     memory_index,
                     offset,
                 } => {
-                    data.active(*memory_index, offset, seg.init.iter().copied());
+                    let offset = match *offset {
+                        Offset::Const32(n) => ConstExpr::i32_const(n),
+                        Offset::Const64(n) => ConstExpr::i64_const(n),
+                        Offset::Global(g) => ConstExpr::global_get(g),
+                    };
+                    data.active(*memory_index, &offset, seg.init.iter().copied());
                 }
                 DataSegmentKind::Passive => {
                     data.passive(seg.init.iter().copied());

--- a/crates/wasm-smith/src/core/terminate.rs
+++ b/crates/wasm-smith/src/core/terminate.rs
@@ -18,8 +18,10 @@ impl Module {
             val_type: ValType::I32,
             mutable: true,
         });
-        self.defined_globals
-            .push((fuel_global, Instruction::I32Const(default_fuel as i32)));
+        self.defined_globals.push((
+            fuel_global,
+            GlobalInitExpr::ConstExpr(ConstExpr::i32_const(default_fuel as i32)),
+        ));
 
         for code in &mut self.code {
             let check_fuel = |insts: &mut Vec<Instruction>| {


### PR DESCRIPTION
`Element` does not support all the various constant expressions that are
valid in the given position, making it infeasible to generate some valid
webassembly modules, for example those whose elements refer to imported
globals.

For the time being I went with a plain `Instruction`, since that is what
is being used in other places that require a constant expression, most
notably offsets. However, if we wanted to keep this more constrained, I
imagine we should add an equivalent of `wasm_parser::InitExpr` and use
that instead for both elements and offsets.