### PR TITLE
wasm-encoder: support already-encoded instructions

### DIFF
--- a/crates/wasm-encoder/src/core/code.rs
+++ b/crates/wasm-encoder/src/core/code.rs
@@ -303,6 +303,9 @@ impl Encode for BlockType {
 #[non_exhaustive]
 #[allow(missing_docs, non_camel_case_types)]
 pub enum Instruction<'a> {
+    // Raw encoding of an instruction.
+    Raw(Cow<'a, [u8]>),
+
     // Control instructions.
     Unreachable,
     Nop,
@@ -783,6 +786,8 @@ pub enum Instruction<'a> {
 impl Encode for Instruction<'_> {
     fn encode(&self, sink: &mut Vec<u8>) {
         match *self {
+            Instruction::Raw(ref encoding) => sink.extend(&**encoding),
+
             // Control instructions.
             Instruction::Unreachable => sink.push(0x00),
             Instruction::Nop => sink.push(0x01),


### PR DESCRIPTION
wasm-encoder already has a budding support for splating raw bytes into a
section of a module as raw bytes. Right now it seems quite supported on
a fairly ad-hoc basis, but is extremely useful when transformations are
being applied.

One particularly high-value addition to this support that I found is
with `Instructions` – there are a ton of these and, when modifying a
module, most of these will be copied over, with only a couple of
interesting instructions being inspected and/or modified.

Right now this requires effectively a HUGE match statement spanning
hundreds of lines to implement. `Instruction::Raw` would provide
a reasonable escape hatch here, much like e.g. `RawSection` and such do.