### PR TITLE
Add a first pass at support for invoking components in `*.wast`

### DIFF
--- a/crates/wast/src/component.rs
+++ b/crates/wast/src/component.rs
@@ -13,6 +13,7 @@ mod item_ref;
 mod module;
 mod resolve;
 mod types;
+mod wast;
 
 pub use self::alias::*;
 pub use self::component::*;
@@ -24,3 +25,4 @@ pub use self::instance::*;
 pub use self::item_ref::*;
 pub use self::module::*;
 pub use self::types::*;
+pub use self::wast::*;

--- a/crates/wast/src/component/wast.rs
+++ b/crates/wast/src/component/wast.rs
@@ -1,0 +1,149 @@
+use crate::kw;
+use crate::parser::{Cursor, Parse, Parser, Peek, Result};
+use crate::token::{Float32, Float64};
+
+/// Expression that can be used inside of `invoke` expressions for core wasm
+/// functions.
+#[derive(Debug)]
+#[allow(missing_docs)]
+pub enum WastVal<'a> {
+    Unit,
+    Bool(bool),
+    U8(u8),
+    S8(i8),
+    U16(u16),
+    S16(i16),
+    U32(u32),
+    S32(i32),
+    U64(u64),
+    S64(i64),
+    Float32(Float32),
+    Float64(Float64),
+    Char(char),
+    String(&'a str),
+    List(Vec<WastVal<'a>>),
+    Record(Vec<(&'a str, WastVal<'a>)>),
+    Tuple(Vec<WastVal<'a>>),
+    Variant(&'a str, Box<WastVal<'a>>),
+    Enum(&'a str),
+    Union(u32, Box<WastVal<'a>>),
+    Option(Option<Box<WastVal<'a>>>),
+    Expected(Result<Box<WastVal<'a>>, Box<WastVal<'a>>>),
+    Flags(Vec<&'a str>),
+}
+
+static CASES: &[(&str, fn(Parser<'_>) -> Result<WastVal<'_>>)] = {
+    use WastVal::*;
+    &[
+        ("unit.const", |_| Ok(Unit)),
+        ("bool.const", |p| {
+            let mut l = p.lookahead1();
+            if l.peek::<kw::true_>() {
+                p.parse::<kw::true_>()?;
+                Ok(Bool(true))
+            } else if l.peek::<kw::false_>() {
+                p.parse::<kw::false_>()?;
+                Ok(Bool(false))
+            } else {
+                Err(l.error())
+            }
+        }),
+        ("u8.const", |p| Ok(U8(p.parse()?))),
+        ("s8.const", |p| Ok(S8(p.parse()?))),
+        ("u16.const", |p| Ok(U16(p.parse()?))),
+        ("s16.const", |p| Ok(S16(p.parse()?))),
+        ("u32.const", |p| Ok(U32(p.parse()?))),
+        ("s32.const", |p| Ok(S32(p.parse()?))),
+        ("u64.const", |p| Ok(U64(p.parse()?))),
+        ("s64.const", |p| Ok(S64(p.parse()?))),
+        ("f32.const", |p| Ok(Float32(p.parse()?))),
+        ("f64.const", |p| Ok(Float64(p.parse()?))),
+        ("char.const", |p| {
+            let s = p.parse::<&str>()?;
+            let mut ch = s.chars();
+            let ret = match ch.next() {
+                Some(c) => c,
+                None => return Err(p.error("empty string")),
+            };
+            if ch.next().is_some() {
+                return Err(p.error("more than one character"));
+            }
+            Ok(Char(ret))
+        }),
+        ("str.const", |p| Ok(String(p.parse()?))),
+        ("list.const", |p| {
+            let mut ret = Vec::new();
+            while !p.is_empty() {
+                ret.push(p.parens(|p| p.parse())?);
+            }
+            Ok(List(ret))
+        }),
+        ("record.const", |p| {
+            let mut ret = Vec::new();
+            while !p.is_empty() {
+                ret.push(p.parens(|p| {
+                    p.parse::<kw::field>()?;
+                    Ok((p.parse()?, p.parse()?))
+                })?);
+            }
+            Ok(Record(ret))
+        }),
+        ("tuple.const", |p| {
+            let mut ret = Vec::new();
+            while !p.is_empty() {
+                ret.push(p.parens(|p| p.parse())?);
+            }
+            Ok(Tuple(ret))
+        }),
+        ("variant.const", |p| {
+            let name = p.parse()?;
+            let payload = Box::new(p.parse()?);
+            Ok(Variant(name, payload))
+        }),
+        ("enum.const", |p| Ok(Enum(p.parse()?))),
+        ("union.const", |p| {
+            let num = p.parse()?;
+            let payload = Box::new(p.parse()?);
+            Ok(Union(num, payload))
+        }),
+        ("option.none", |_| Ok(Option(None))),
+        ("option.some", |p| Ok(Option(Some(Box::new(p.parse()?))))),
+        ("expected.ok", |p| Ok(Expected(Ok(Box::new(p.parse()?))))),
+        ("expected.err", |p| Ok(Expected(Err(Box::new(p.parse()?))))),
+        ("flags.const", |p| {
+            let mut ret = Vec::new();
+            while !p.is_empty() {
+                ret.push(p.parse()?);
+            }
+            Ok(Flags(ret))
+        }),
+    ]
+};
+
+impl<'a> Parse<'a> for WastVal<'a> {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        let parse = parser.step(|c| {
+            if let Some((kw, rest)) = c.keyword() {
+                if let Some(i) = CASES.iter().position(|(name, _)| *name == kw) {
+                    return Ok((CASES[i].1, rest));
+                }
+            }
+            Err(c.error("expected a [type].const expression"))
+        })?;
+        parse(parser)
+    }
+}
+
+impl Peek for WastVal<'_> {
+    fn peek(cursor: Cursor<'_>) -> bool {
+        let kw = match cursor.keyword() {
+            Some((kw, _)) => kw,
+            None => return false,
+        };
+        CASES.iter().find(|(name, _)| *name == kw).is_some()
+    }
+
+    fn display() -> &'static str {
+        "core wasm argument"
+    }
+}

--- a/crates/wast/src/core.rs
+++ b/crates/wast/src/core.rs
@@ -11,6 +11,7 @@ mod module;
 mod table;
 mod tag;
 mod types;
+mod wast;
 pub use self::custom::*;
 pub use self::export::*;
 pub use self::expr::*;
@@ -22,6 +23,7 @@ pub use self::module::*;
 pub use self::table::*;
 pub use self::tag::*;
 pub use self::types::*;
+pub use self::wast::*;
 
 pub(crate) mod binary;
 pub(crate) mod resolve;

--- a/crates/wast/src/core/expr.rs
+++ b/crates/wast/src/core/expr.rs
@@ -578,7 +578,6 @@ instructions! {
 
         RefNull(HeapType<'a>) : [0xd0] : "ref.null",
         RefIsNull : [0xd1] : "ref.is_null",
-        RefExtern(u32) : [0xff] : "ref.extern", // only used in test harness
         RefFunc(Index<'a>) : [0xd2] : "ref.func",
 
         // function-references proposal
@@ -1163,9 +1162,9 @@ instructions! {
 impl<'a> Instruction<'a> {
     pub(crate) fn needs_data_count(&self) -> bool {
         match self {
-            Instruction::MemoryInit(_) |
-            Instruction::DataDrop(_) |
-            Instruction::ArrayNewData(_) => true,
+            Instruction::MemoryInit(_)
+            | Instruction::DataDrop(_)
+            | Instruction::ArrayNewData(_) => true,
             _ => false,
         }
     }

--- a/crates/wast/src/core/wast.rs
+++ b/crates/wast/src/core/wast.rs
@@ -1,53 +1,122 @@
-use crate::core::HeapType;
+use crate::core::{HeapType, V128Const};
 use crate::kw;
-use crate::parser::{Parse, Parser, Result};
+use crate::parser::{Cursor, Parse, Parser, Peek, Result};
 use crate::token::{Float32, Float64, Index};
 
-/// An expression that is valid inside an `assert_return` directive.
-///
-/// As of <https://github.com/WebAssembly/spec/pull/1104>, spec tests may
-/// include `assert_return` directives that allow NaN patterns
-/// (`"nan:canonical"`, `"nan:arithmetic"`). Parsing an
-/// `AssertExpression` means that:
-/// - only constant values (e.g. `i32.const 4`) are used in the `assert_return` directive
-/// - the NaN patterns are allowed (they are not allowed in regular `Expression`s).
+/// Expression that can be used inside of `invoke` expressions for core wasm
+/// functions.
 #[derive(Debug)]
 #[allow(missing_docs)]
-pub enum AssertExpression<'a> {
+pub enum WastArgCore<'a> {
+    I32(i32),
+    I64(i64),
+    F32(Float32),
+    F64(Float64),
+    V128(V128Const),
+    RefNull(HeapType<'a>),
+    RefExtern(u32),
+}
+
+static ARGS: &[(&str, fn(Parser<'_>) -> Result<WastArgCore<'_>>)] = {
+    use WastArgCore::*;
+    &[
+        ("i32.const", |p| Ok(I32(p.parse()?))),
+        ("i64.const", |p| Ok(I64(p.parse()?))),
+        ("f32.const", |p| Ok(F32(p.parse()?))),
+        ("f64.const", |p| Ok(F64(p.parse()?))),
+        ("v128.const", |p| Ok(V128(p.parse()?))),
+        ("ref.null", |p| Ok(RefNull(p.parse()?))),
+        ("ref.extern", |p| Ok(RefExtern(p.parse()?))),
+    ]
+};
+
+impl<'a> Parse<'a> for WastArgCore<'a> {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        let parse = parser.step(|c| {
+            if let Some((kw, rest)) = c.keyword() {
+                if let Some(i) = ARGS.iter().position(|(name, _)| *name == kw) {
+                    return Ok((ARGS[i].1, rest));
+                }
+            }
+            Err(c.error("expected a [type].const expression"))
+        })?;
+        parse(parser)
+    }
+}
+
+impl Peek for WastArgCore<'_> {
+    fn peek(cursor: Cursor<'_>) -> bool {
+        let kw = match cursor.keyword() {
+            Some((kw, _)) => kw,
+            None => return false,
+        };
+        ARGS.iter().find(|(name, _)| *name == kw).is_some()
+    }
+
+    fn display() -> &'static str {
+        "core wasm argument"
+    }
+}
+
+/// Expressions that can be used inside of `assert_return` to validate the
+/// return value of a core wasm function.
+#[derive(Debug)]
+#[allow(missing_docs)]
+pub enum WastRetCore<'a> {
     I32(i32),
     I64(i64),
     F32(NanPattern<Float32>),
     F64(NanPattern<Float64>),
     V128(V128Pattern),
 
+    /// A null reference is expected, optionally with a specified type.
     RefNull(Option<HeapType<'a>>),
+    /// A non-null externref is expected which should contain the specified
+    /// value.
     RefExtern(u32),
+    /// A non-null funcref is expected.
     RefFunc(Option<Index<'a>>),
-
-    // Either matches an f32 or f64 for an arithmetic nan pattern
-    LegacyArithmeticNaN,
-    // Either matches an f32 or f64 for a canonical nan pattern
-    LegacyCanonicalNaN,
 }
 
-impl<'a> Parse<'a> for AssertExpression<'a> {
-    fn parse(parser: Parser<'a>) -> Result<Self> {
-        let keyword = parser.step(|c| match c.keyword() {
-            Some(pair) => Ok(pair),
-            None => Err(c.error("expected a keyword")),
-        })?;
+static RETS: &[(&str, fn(Parser<'_>) -> Result<WastRetCore<'_>>)] = {
+    use WastRetCore::*;
+    &[
+        ("i32.const", |p| Ok(I32(p.parse()?))),
+        ("i64.const", |p| Ok(I64(p.parse()?))),
+        ("f32.const", |p| Ok(F32(p.parse()?))),
+        ("f64.const", |p| Ok(F64(p.parse()?))),
+        ("v128.const", |p| Ok(V128(p.parse()?))),
+        ("ref.null", |p| Ok(RefNull(p.parse()?))),
+        ("ref.extern", |p| Ok(RefExtern(p.parse()?))),
+        ("ref.func", |p| Ok(RefFunc(p.parse()?))),
+    ]
+};
 
-        match keyword {
-            "i32.const" => Ok(AssertExpression::I32(parser.parse()?)),
-            "i64.const" => Ok(AssertExpression::I64(parser.parse()?)),
-            "f32.const" => Ok(AssertExpression::F32(parser.parse()?)),
-            "f64.const" => Ok(AssertExpression::F64(parser.parse()?)),
-            "v128.const" => Ok(AssertExpression::V128(parser.parse()?)),
-            "ref.null" => Ok(AssertExpression::RefNull(parser.parse()?)),
-            "ref.extern" => Ok(AssertExpression::RefExtern(parser.parse()?)),
-            "ref.func" => Ok(AssertExpression::RefFunc(parser.parse()?)),
-            _ => Err(parser.error("expected a [type].const expression")),
-        }
+impl<'a> Parse<'a> for WastRetCore<'a> {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        let parse = parser.step(|c| {
+            if let Some((kw, rest)) = c.keyword() {
+                if let Some(i) = RETS.iter().position(|(name, _)| *name == kw) {
+                    return Ok((RETS[i].1, rest));
+                }
+            }
+            Err(c.error("expected a [type].const expression"))
+        })?;
+        parse(parser)
+    }
+}
+
+impl Peek for WastRetCore<'_> {
+    fn peek(cursor: Cursor<'_>) -> bool {
+        let kw = match cursor.keyword() {
+            Some((kw, _)) => kw,
+            None => return false,
+        };
+        RETS.iter().find(|(name, _)| *name == kw).is_some()
+    }
+
+    fn display() -> &'static str {
+        "core wasm return value"
     }
 }
 

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -359,10 +359,8 @@ macro_rules! id {
 
 #[cfg(feature = "wasm-module")]
 id! {
-    mod assert_expr;
     mod wast;
     mod wat;
-    pub use self::assert_expr::*;
     pub use self::wast::*;
     pub use self::wat::*;
 
@@ -505,6 +503,8 @@ pub mod kw {
     custom_keyword!(post_return = "post-return");
     custom_keyword!(with);
     custom_keyword!(core);
+    custom_keyword!(true_ = "true");
+    custom_keyword!(false_ = "false");
 }
 
 /// Common annotations used to parse WebAssembly text files.

--- a/crates/wast/src/token.rs
+++ b/crates/wast/src/token.rs
@@ -381,7 +381,7 @@ macro_rules! float {
         name: $parse:ident,
     })*) => ($(
         /// A parsed floating-point type
-        #[derive(Debug)]
+        #[derive(Debug, Copy, Clone)]
         pub struct $name {
             /// The raw bits that this floating point number represents.
             pub bits: $int,

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -1,8 +1,9 @@
-use crate::core::Expression;
+use crate::component::WastVal;
+use crate::core::{WastArgCore, WastRetCore};
 use crate::kw;
 use crate::parser::{self, Cursor, Parse, ParseBuffer, Parser, Peek, Result};
 use crate::token::{Id, Span};
-use crate::{AssertExpression, Error, Wat};
+use crate::{Error, Wat};
 
 /// A parsed representation of a `*.wast` file.
 ///
@@ -85,7 +86,7 @@ pub enum WastDirective<'a> {
     AssertReturn {
         span: Span,
         exec: WastExecute<'a>,
-        results: Vec<AssertExpression<'a>>,
+        results: Vec<WastRet<'a>>,
     },
     AssertExhaustion {
         span: Span,
@@ -247,7 +248,7 @@ pub struct WastInvoke<'a> {
     pub span: Span,
     pub module: Option<Id<'a>>,
     pub name: &'a str,
-    pub args: Vec<Expression<'a>>,
+    pub args: Vec<WastArg<'a>>,
 }
 
 impl<'a> Parse<'a> for WastInvoke<'a> {
@@ -325,6 +326,40 @@ impl<'a> Parse<'a> for QuoteWat<'a> {
             Ok(ctor(span, src))
         } else {
             Ok(QuoteWat::Wat(parse_wat(parser)?))
+        }
+    }
+}
+
+#[derive(Debug)]
+#[allow(missing_docs)]
+pub enum WastArg<'a> {
+    Core(WastArgCore<'a>),
+    Component(WastVal<'a>),
+}
+
+impl<'a> Parse<'a> for WastArg<'a> {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        if parser.peek::<WastArgCore<'_>>() {
+            Ok(WastArg::Core(parser.parse()?))
+        } else {
+            Ok(WastArg::Component(parser.parse()?))
+        }
+    }
+}
+
+#[derive(Debug)]
+#[allow(missing_docs)]
+pub enum WastRet<'a> {
+    Core(WastRetCore<'a>),
+    Component(WastVal<'a>),
+}
+
+impl<'a> Parse<'a> for WastRet<'a> {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        if parser.peek::<WastRetCore<'_>>() {
+            Ok(WastRet::Core(parser.parse()?))
+        } else {
+            Ok(WastRet::Component(parser.parse()?))
         }
     }
 }


### PR DESCRIPTION
This commit updates the `*.wast` parsing in the `wast` crate with a
first pass of parsing `assert_return` for both value arguments and value
returns for component-model-based values. The syntax for now is pretty
crude and seems highly likely to change, but I wanted to get something
started to help with tests in Wasmtime.