### PR TITLE
Bump crate versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-tools"
-version = "1.0.8"
+version = "1.0.9"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 description = "CLI tools for interoperating with WebAssembly files"
@@ -22,33 +22,33 @@ env_logger = "0.9"
 log = "0.4"
 clap = { version = "3.1.8", features = ['derive'] }
 tempfile = "3.2.0"
-wat = { path = "crates/wat", version = '1.0.46' }
+wat = { path = "crates/wat", version = '1.0.47' }
 
 # Dependencies of `validate`
-wasmparser = { path = "crates/wasmparser", optional = true, version = '0.87.0' }
+wasmparser = { path = "crates/wasmparser", optional = true, version = '0.88.0' }
 rayon = { version = "1.0", optional = true }
 
 # Dependencies of `print`
-wasmprinter = { path = "crates/wasmprinter", version = '0.2.37' }
+wasmprinter = { path = "crates/wasmprinter", version = '0.2.38' }
 
 # Dependencies of `smith`
 arbitrary = { version = "1.0.0", optional = true }
 serde = { version = "1", features = ['derive'], optional = true }
 serde_json = { version = "1", optional = true }
-wasm-smith = { path = "crates/wasm-smith", features = ["_internal_cli"], optional = true, version = '0.11.2' }
+wasm-smith = { path = "crates/wasm-smith", features = ["_internal_cli"], optional = true, version = '0.11.3' }
 
 # Dependencies of `shrink`
-wasm-shrink = { path = "crates/wasm-shrink", features = ["clap"], optional = true, version = '0.1.7' }
+wasm-shrink = { path = "crates/wasm-shrink", features = ["clap"], optional = true, version = '0.1.8' }
 is_executable = { version = "1.0.1", optional = true }
 
 # Dependencies of `mutate`
-wasm-mutate = { path = "crates/wasm-mutate", features = ["clap"], optional = true, version = '0.2.5' }
+wasm-mutate = { path = "crates/wasm-mutate", features = ["clap"], optional = true, version = '0.2.6' }
 
 # Dependencies of `dump`
-wasmparser-dump = { path = "crates/dump", optional = true, version = '0.1.5' }
+wasmparser-dump = { path = "crates/dump", optional = true, version = '0.1.6' }
 
 # Dependencies of `strip`
-wasm-encoder = { path = "crates/wasm-encoder", optional = true, version = '0.14.0' }
+wasm-encoder = { path = "crates/wasm-encoder", optional = true, version = '0.15.0' }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -23,7 +23,7 @@ wasmparser-dump = { version = "0.1.4", path = "../dump" }
 wasm-mutate = { version = "0.2.4", path = "../wasm-mutate" }
 wasm-shrink = { version = "0.1.6", path = "../wasm-shrink" }
 wasm-smith = { version = "0.11.2", path = "../wasm-smith" }
-wasmparser = { version = "0.87.0", path = "../wasmparser" }
+wasmparser = { version = "0.88.0", path = "../wasmparser" }
 wasmprinter = { version = "0.2.36", path = "../wasmprinter" }
-wast = { version = "44.0.0", path = "../wast" }
+wast = { version = "45.0.0", path = "../wast" }
 wat = { version = "1.0.44", path = "../wat" }

--- a/crates/dump/Cargo.toml
+++ b/crates/dump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser-dump"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -9,4 +9,4 @@ description = "Utility to dump debug information about the wasm binary format"
 
 [dependencies]
 anyhow = "1"
-wasmparser = { path = "../wasmparser", version = "0.87.0" }
+wasmparser = { path = "../wasmparser", version = "0.88.0" }

--- a/crates/wasm-encoder/Cargo.toml
+++ b/crates/wasm-encoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-encoder"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasm-mutate/Cargo.toml
+++ b/crates/wasm-mutate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-mutate"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-mutate"
@@ -9,8 +9,8 @@ description = "A WebAssembly test case mutator"
 [dependencies]
 clap = { optional = true, version = "3.0", features = ['derive'] }
 thiserror = "1.0.28"
-wasmparser = { version = "0.87.0", path = "../wasmparser" }
-wasm-encoder = { version = "0.14.0", path = "../wasm-encoder"}
+wasmparser = { version = "0.88.0", path = "../wasmparser" }
+wasm-encoder = { version = "0.15.0", path = "../wasm-encoder"}
 rand = { version = "0.8.0", features = ["small_rng"] }
 log = "0.4.14"
 egg = "0.6.0"

--- a/crates/wasm-shrink/Cargo.toml
+++ b/crates/wasm-shrink/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-shrink"
 name = "wasm-shrink"
-version = "0.1.7"
+version = "0.1.8"
 
 [dependencies]
 anyhow = "1"
@@ -16,8 +16,8 @@ blake3 = "1.2.0"
 log = "0.4"
 rand = { version = "0.8.4", features = ["small_rng"] }
 clap = { version = "3.0", optional = true, features = ['derive'] }
-wasm-mutate = { version = "0.2.5", path = "../wasm-mutate" }
-wasmparser = { version = "0.87.0", path = "../wasmparser" }
+wasm-mutate = { version = "0.2.6", path = "../wasm-mutate" }
+wasmparser = { version = "0.88.0", path = "../wasmparser" }
 
 [dev-dependencies]
 env_logger = "0.9"

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "wasm-smith"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-smith"
-version = "0.11.2"
+version = "0.11.3"
 exclude = ["/benches/corpus"]
 
 [[bench]]
@@ -21,8 +21,8 @@ flagset = "0.4"
 indexmap = "1.6"
 leb128 = "0.2.4"
 serde = { version = "1", features = ['derive'], optional = true }
-wasm-encoder = { version = "0.14.0", path = "../wasm-encoder" }
-wasmparser = { version = "0.87.0", path = "../wasmparser" }
+wasm-encoder = { version = "0.15.0", path = "../wasm-encoder" }
+wasmparser = { version = "0.88.0", path = "../wasmparser" }
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.87.0"
+version = "0.88.0"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser"

--- a/crates/wasmprinter/Cargo.toml
+++ b/crates/wasmprinter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmprinter"
-version = "0.2.37"
+version = "0.2.38"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -14,7 +14,7 @@ Rust converter from the WebAssembly binary format to the text format.
 
 [dependencies]
 anyhow = "1.0"
-wasmparser = { path = '../wasmparser', version = '0.87.0' }
+wasmparser = { path = '../wasmparser', version = '0.88.0' }
 
 [dev-dependencies]
 diff = "0.1"

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wast"
-version = "44.0.0"
+version = "45.0.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -16,7 +16,7 @@ Customizable Rust parsers for the WebAssembly Text formats WAT and WAST
 leb128 = "0.2"
 unicode-width = "0.1.9"
 memchr = "2.4.1"
-wasm-encoder = { version = "0.14.0", path = "../wasm-encoder" }
+wasm-encoder = { version = "0.15.0", path = "../wasm-encoder" }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/crates/wat/Cargo.toml
+++ b/crates/wat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wat"
-version = "1.0.46"
+version = "1.0.47"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -13,4 +13,4 @@ Rust parser for the WebAssembly Text format, WAT
 """
 
 [dependencies]
-wast = { path = '../wast', version = '44.0.0' }
+wast = { path = '../wast', version = '45.0.0' }


### PR DESCRIPTION
New major versions for wast/wasmparser/wasm-encoder, but otherwise
everything else is getting a minor version bump.