### PR TITLE
wasmparser: rename init_expr to offset_expr

### DIFF
--- a/crates/dump/src/lib.rs
+++ b/crates/dump/src/lib.rs
@@ -161,11 +161,11 @@ impl<'a> Dump<'a> {
                         }
                         ElementKind::Active {
                             table_index,
-                            init_expr,
+                            offset_expr,
                         } => {
                             write!(me.state, " table[{}]", table_index)?;
-                            me.print(init_expr.get_binary_reader().original_position())?;
-                            me.print_ops(init_expr.get_operators_reader())?;
+                            me.print(offset_expr.get_binary_reader().original_position())?;
+                            me.print_ops(offset_expr.get_operators_reader())?;
                             write!(me.state, "{} items", items.get_count())?;
                         }
                         ElementKind::Declared => {
@@ -189,11 +189,11 @@ impl<'a> Dump<'a> {
                         }
                         DataKind::Active {
                             memory_index,
-                            init_expr,
+                            offset_expr,
                         } => {
                             write!(me.state, "data memory[{}]", memory_index)?;
-                            me.print(init_expr.get_binary_reader().original_position())?;
-                            me.print_ops(init_expr.get_operators_reader())?;
+                            me.print(offset_expr.get_binary_reader().original_position())?;
+                            me.print_ops(offset_expr.get_operators_reader())?;
                         }
                     }
                     me.print_byte_header()?;

--- a/crates/wasm-mutate/src/mutators/modify_data.rs
+++ b/crates/wasm-mutate/src/mutators/modify_data.rs
@@ -32,10 +32,10 @@ impl Mutator for ModifyDataMutator {
             let mode = match &data.kind {
                 DataKind::Active {
                     memory_index,
-                    init_expr,
+                    offset_expr,
                 } => {
                     offset = DefaultTranslator.translate_init_expr(
-                        init_expr,
+                        offset_expr,
                         &wasmparser::ValType::I32,
                         InitExprKind::DataOffset,
                     )?;

--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -229,10 +229,10 @@ pub fn element(
     let mode = match &element.kind {
         ElementKind::Active {
             table_index,
-            init_expr,
+            offset_expr,
         } => {
             offset = t.translate_init_expr(
-                init_expr,
+                offset_expr,
                 &wasmparser::ValType::I32,
                 InitExprKind::ElementOffset,
             )?;
@@ -949,10 +949,10 @@ pub fn data(t: &mut dyn Translator, data: wasmparser::Data<'_>, s: &mut DataSect
     let mode = match &data.kind {
         DataKind::Active {
             memory_index,
-            init_expr,
+            offset_expr,
         } => {
             offset = t.translate_init_expr(
-                init_expr,
+                offset_expr,
                 &wasmparser::ValType::I32,
                 InitExprKind::DataOffset,
             )?;

--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -127,8 +127,8 @@ fn read_all_wasm(wasm: &[u8]) -> Result<()> {
             ElementSection(s) => {
                 for item in s {
                     let item = item?;
-                    if let ElementKind::Active { init_expr, .. } = item.kind {
-                        for op in init_expr.get_operators_reader() {
+                    if let ElementKind::Active { offset_expr, .. } = item.kind {
+                        for op in offset_expr.get_operators_reader() {
                             op?;
                         }
                     }
@@ -140,8 +140,8 @@ fn read_all_wasm(wasm: &[u8]) -> Result<()> {
             DataSection(s) => {
                 for item in s {
                     let item = item?;
-                    if let DataKind::Active { init_expr, .. } = item.kind {
-                        for op in init_expr.get_operators_reader() {
+                    if let DataKind::Active { offset_expr, .. } = item.kind {
+                        for op in offset_expr.get_operators_reader() {
                             op?;
                         }
                     }

--- a/crates/wasmparser/src/readers/core/data.rs
+++ b/crates/wasmparser/src/readers/core/data.rs
@@ -40,7 +40,7 @@ pub enum DataKind<'a> {
         /// The memory index for the data segment.
         memory_index: u32,
         /// The initialization expression for the data segment.
-        init_expr: InitExpr<'a>,
+        offset_expr: InitExpr<'a>,
     },
 }
 
@@ -90,9 +90,9 @@ impl<'a> DataSectionReader<'a> {
     /// for _ in 0..data_reader.get_count() {
     ///     let data = data_reader.read().expect("data");
     ///     println!("Data: {:?}", data);
-    ///     if let DataKind::Active { init_expr, .. } = data.kind {
-    ///         let mut init_expr_reader = init_expr.get_binary_reader();
-    ///         let op = init_expr_reader.read_operator().expect("op");
+    ///     if let DataKind::Active { offset_expr, .. } = data.kind {
+    ///         let mut offset_expr_reader = offset_expr.get_binary_reader();
+    ///         let op = offset_expr_reader.read_operator().expect("op");
     ///         println!("Init const: {:?}", op);
     ///     }
     /// }
@@ -125,7 +125,7 @@ impl<'a> DataSectionReader<'a> {
                 } else {
                     self.reader.read_var_u32()?
                 };
-                let init_expr = {
+                let offset_expr = {
                     let expr_offset = self.reader.position;
                     self.reader.skip_init_expr()?;
                     let data = &self.reader.buffer[expr_offset..self.reader.position];
@@ -133,7 +133,7 @@ impl<'a> DataSectionReader<'a> {
                 };
                 DataKind::Active {
                     memory_index,
-                    init_expr,
+                    offset_expr,
                 }
             }
             _ => {

--- a/crates/wasmparser/src/readers/core/elements.rs
+++ b/crates/wasmparser/src/readers/core/elements.rs
@@ -42,7 +42,7 @@ pub enum ElementKind<'a> {
         /// The index of the table being initialized.
         table_index: u32,
         /// The initial expression of the element segment.
-        init_expr: InitExpr<'a>,
+        offset_expr: InitExpr<'a>,
     },
     /// The element segment is declared.
     Declared,
@@ -193,9 +193,9 @@ impl<'a> ElementSectionReader<'a> {
     /// let mut element_reader = ElementSectionReader::new(data, 0).unwrap();
     /// for _ in 0..element_reader.get_count() {
     ///     let element = element_reader.read().expect("element");
-    ///     if let ElementKind::Active { init_expr, .. } = element.kind {
-    ///         let mut init_expr_reader = init_expr.get_binary_reader();
-    ///         let op = init_expr_reader.read_operator().expect("op");
+    ///     if let ElementKind::Active { offset_expr, .. } = element.kind {
+    ///         let mut offset_expr_reader = offset_expr.get_binary_reader();
+    ///         let op = offset_expr_reader.read_operator().expect("op");
     ///         println!("Init const: {:?}", op);
     ///     }
     ///     let mut items_reader = element.items.get_items_reader().expect("items reader");
@@ -242,7 +242,7 @@ impl<'a> ElementSectionReader<'a> {
             } else {
                 self.reader.read_var_u32()?
             };
-            let init_expr = {
+            let offset_expr = {
                 let expr_offset = self.reader.position;
                 self.reader.skip_init_expr()?;
                 let data = &self.reader.buffer[expr_offset..self.reader.position];
@@ -250,7 +250,7 @@ impl<'a> ElementSectionReader<'a> {
             };
             ElementKind::Active {
                 table_index,
-                init_expr,
+                offset_expr,
             }
         };
         let exprs = flags & 0b100 != 0;

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -158,10 +158,10 @@ impl ModuleState {
             DataKind::Passive => Ok(()),
             DataKind::Active {
                 memory_index,
-                init_expr,
+                offset_expr,
             } => {
                 let ty = self.module.memory_at(memory_index, offset)?.index_type();
-                self.check_init_expr(&init_expr, ty, features, types, offset)
+                self.check_init_expr(&offset_expr, ty, features, types, offset)
             }
         }
     }
@@ -187,7 +187,7 @@ impl ModuleState {
         match e.kind {
             ElementKind::Active {
                 table_index,
-                init_expr,
+                offset_expr,
             } => {
                 let table = self.module.table_at(table_index, offset)?;
                 if e.ty != table.element_type {
@@ -197,7 +197,7 @@ impl ModuleState {
                     ));
                 }
 
-                self.check_init_expr(&init_expr, ValType::I32, features, types, offset)?;
+                self.check_init_expr(&offset_expr, ValType::I32, features, types, offset)?;
             }
             ElementKind::Passive | ElementKind::Declared => {
                 if !features.bulk_memory {

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -1996,7 +1996,7 @@ impl Printer {
                 ElementKind::Declared => write!(self.result, " declare")?,
                 ElementKind::Active {
                     table_index,
-                    init_expr,
+                    offset_expr,
                 } => {
                     if *table_index != 0 {
                         self.result.push_str(" (table ");
@@ -2004,7 +2004,7 @@ impl Printer {
                         self.result.push(')');
                     }
                     self.result.push(' ');
-                    self.print_init_expr_sugar(state, init_expr, "offset")?;
+                    self.print_init_expr_sugar(state, offset_expr, "offset")?;
                 }
             }
             let mut items_reader = elem.items.get_items_reader()?;
@@ -2037,14 +2037,14 @@ impl Printer {
                 DataKind::Passive => {}
                 DataKind::Active {
                     memory_index,
-                    init_expr,
+                    offset_expr,
                 } => {
                     if *memory_index != 0 {
                         self.result.push_str("(memory ");
                         self.print_idx(&state.core.memory_names, *memory_index)?;
                         self.result.push_str(") ");
                     }
-                    self.print_init_expr_sugar(state, init_expr, "offset")?;
+                    self.print_init_expr_sugar(state, offset_expr, "offset")?;
                     self.result.push(' ');
                 }
             }


### PR DESCRIPTION
Some of the expressions representing an offset into a memory or table
entity are named `init_expr`. This has caused me a significant amount of
confusion multiple times now. Each time I ended up having to stop
working on my code and going to re-read the spec and the implementation
of wasmparser.

Naming these expressions `offset_expr` would make it much clearer what
they represent and put them closer to both the spec wording and wat
representation (`(offset ...)`) as well.

This is a breaking change though.