### PR TITLE
wasm-compose: fix wasmtime version in example.

### DIFF
--- a/crates/wasm-compose/example/server/Cargo.toml
+++ b/crates/wasm-compose/example/server/Cargo.toml
@@ -8,6 +8,6 @@ async-std = { version = "1.12.0", features = ["attributes"] }
 clap = { version = "3.2.16", features = ["derive"] }
 driftwood = "0.0.6"
 tide = "0.16.0"
-wasmtime = { version = "0.40.0", features = ["component-model"], git = "https://github.com/bytecodealliance/wasmtime", rev = "1ce9e8aa5f32a8dad42f02c8fd84514a641c4a5c" }
+wasmtime = { version = "0.41.0", features = ["component-model"], git = "https://github.com/bytecodealliance/wasmtime", rev = "1ce9e8aa5f32a8dad42f02c8fd84514a641c4a5c" }
 
 [workspace]


### PR DESCRIPTION
The wasmtime version was bumped just prior to the needed fix landed in the
`main` branch.

This updates the dependency version to match what the commit pointed at has.