### PR TITLE
Mark error-creation functions as `#[cold]`

### DIFF
--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -62,6 +62,7 @@ impl fmt::Display for BinaryReaderError {
 }
 
 impl BinaryReaderError {
+    #[cold]
     pub(crate) fn new(message: impl Into<String>, offset: usize) -> Self {
         let message = message.into();
         BinaryReaderError {
@@ -73,6 +74,7 @@ impl BinaryReaderError {
         }
     }
 
+    #[cold]
     pub(crate) fn eof(offset: usize, needed_hint: usize) -> Self {
         BinaryReaderError {
             inner: Box::new(BinaryReaderErrorInner {


### PR DESCRIPTION
This brings up to 10% speedups in the benchmarks added in #704 and is a
net win across all benchmarks locally.