### PR TITLE
Don't check value types on `push_operand`

### DIFF
--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -35,6 +35,19 @@ pub enum ValType {
     ExternRef,
 }
 
+impl ValType {
+    /// Returns whether this value type is a "reference type".
+    ///
+    /// Only reference types are allowed in tables, for example, and with some
+    /// instructions. Current reference types include `funcref` and `externref`.
+    pub fn is_reference_type(&self) -> bool {
+        match self {
+            ValType::FuncRef | ValType::ExternRef => true,
+            _ => false,
+        }
+    }
+}
+
 /// Represents a type in a WebAssembly module.
 #[derive(Debug, Clone)]
 pub enum Type {

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -178,9 +178,8 @@ impl ModuleState {
         if e.ty != ValType::FuncRef {
             check_value_type(e.ty, features, offset)?;
         }
-        match e.ty {
-            ValType::FuncRef | ValType::ExternRef => {}
-            _ => return Err(BinaryReaderError::new("malformed reference type", offset)),
+        if !e.ty.is_reference_type() {
+            return Err(BinaryReaderError::new("malformed reference type", offset));
         }
         match e.kind {
             ElementKind::Active {
@@ -593,14 +592,11 @@ impl Module {
             check_value_type(ty.element_type, features, offset)?;
         }
 
-        match ty.element_type {
-            ValType::FuncRef | ValType::ExternRef => {}
-            _ => {
-                return Err(BinaryReaderError::new(
-                    "element is not reference type",
-                    offset,
-                ))
-            }
+        if !ty.element_type.is_reference_type() {
+            return Err(BinaryReaderError::new(
+                "element is not reference type",
+                offset,
+            ));
         }
         self.check_limits(ty.initial, ty.maximum, offset)?;
         if ty.initial > MAX_WASM_TABLE_ENTRIES as u32 {

--- a/tests/local/missing-features/simd-func-param.wast
+++ b/tests/local/missing-features/simd-func-param.wast
@@ -1,3 +1,0 @@
-(assert_invalid
-  (module (func (param v128)))
-  "SIMD support is not enabled")

--- a/tests/local/missing-features/v128-without-simd-feature.wast
+++ b/tests/local/missing-features/v128-without-simd-feature.wast
@@ -1,0 +1,24 @@
+(assert_invalid
+  (module (func (param v128)))
+  "SIMD support is not enabled")
+(assert_invalid
+  (module (type (func (param v128))))
+  "SIMD support is not enabled")
+(assert_invalid
+  (module (type (func (result v128))))
+  "SIMD support is not enabled")
+(assert_invalid
+  (module (import "" "" (global v128)))
+  "SIMD support is not enabled")
+(assert_invalid
+  (module (import "" "" (global (mut v128))))
+  "SIMD support is not enabled")
+(assert_invalid
+  (module (global v128 v128.const i64x2 0 0))
+  "SIMD support is not enabled")
+(assert_invalid
+  (module (func select (result v128)))
+  "SIMD support is not enabled")
+(assert_invalid
+  (module (func block (result v128) end))
+  "SIMD support is not enabled")


### PR DESCRIPTION
During validation the `push_operand` operation is quite hot and
shouldn't do too much extra work. This commit removes the
`check_value_type` call during that operation, instead deferring it to
the "edges" where value types may be introduced. This commit extends the
testing for this and adds necessary `check_value_type` in the other
locations that value types can be defined within a wasm module.

Overall this gives about a 10% win on the validation benchmarks added
in #704