### PR TITLE
Fix an accidental regression from #697

### DIFF
--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -215,6 +215,11 @@ impl OperatorValidator {
                 "control frames remain at end of function: END opcode expected"
             );
         }
+
+        // The `end` opcode is one byte which means that the `offset` here
+        // should point just beyond the `end` opcode which emptied the control
+        // stack. If not that means more instructions were present after the
+        // control stack was emptied.
         if offset != self.end_which_emptied_control.unwrap() + 1 {
             return Err(self.err_beyond_end(offset));
         }

--- a/fuzz/fuzz_targets/validate.rs
+++ b/fuzz/fuzz_targets/validate.rs
@@ -4,6 +4,7 @@ use libfuzzer_sys::*;
 use wasmparser::{Validator, WasmFeatures};
 
 fuzz_target!(|data: &[u8]| {
+    drop(env_logger::try_init());
     let byte1 = match data.get(0) {
         Some(byte) => byte,
         None => return,
@@ -31,5 +32,10 @@ fuzz_target!(|data: &[u8]| {
         sign_extension: (byte2 & 0b1000_0000) != 0,
     });
 
-    drop(validator.validate_all(&data[2..]));
+    let wasm = &data[2..];
+    if log::log_enabled!(log::Level::Debug) {
+        log::debug!("writing input to `test.wasm`");
+        std::fs::write("test.wasm", wasm).unwrap();
+    }
+    drop(validator.validate_all(wasm));
 });

--- a/tests/local/invalid/func.wast
+++ b/tests/local/invalid/func.wast
@@ -1,0 +1,62 @@
+(assert_invalid
+  (module binary
+    "\00asm" "\01\00\00\00" ;; magic header
+
+    "\01\04"    ;; type section
+    "\01"       ;; 1 count
+    "\60\00\00" ;; no params or results
+
+    "\03\02"    ;; func section
+    "\01"       ;; 1 count
+    "\00"       ;; type 0
+
+    "\0a\05"    ;; code section
+    "\01"       ;; 1 count
+    "\03"       ;; size of function
+    "\00"       ;; no locals
+    "\0b"       ;; end
+    "\01"       ;; nop
+  )
+  "operators remaining after end of function")
+
+(assert_invalid
+  (module binary
+    "\00asm" "\01\00\00\00" ;; magic header
+
+    "\01\04"    ;; type section
+    "\01"       ;; 1 count
+    "\60\00\00" ;; no params or results
+
+    "\03\02"    ;; func section
+    "\01"       ;; 1 count
+    "\00"       ;; type 0
+
+    "\0a\05"    ;; code section
+    "\01"       ;; 1 count
+    "\03"       ;; size of function
+    "\00"       ;; no locals
+    "\0b"       ;; end
+    "\9d"       ;; f64.trunc
+  )
+  "operators remaining after end of function")
+
+(assert_invalid
+  (module binary
+    "\00asm" "\01\00\00\00" ;; magic header
+
+    "\01\04"    ;; type section
+    "\01"       ;; 1 count
+    "\60\00\00" ;; no params or results
+
+    "\03\02"    ;; func section
+    "\01"       ;; 1 count
+    "\00"       ;; type 0
+
+    "\0a\05"    ;; code section
+    "\01"       ;; 1 count
+    "\03"       ;; size of function
+    "\00"       ;; no locals
+    "\0b"       ;; end
+    "\0b"       ;; end
+  )
+  "operators remaining after end of function")


### PR DESCRIPTION
This commit fixes a regression introduced in #697 which could cause a
panic when validating an invalid wasm module. The issue introduced was
that a [check that the control stack is non-empty][check] was lost in
the refactoring of the operator validator. This check ran for every
single operator and verified that there was a frame on the control stack
that the operator could be attached to, otherwise it means instructions
were present after the end of the function.

The current design of `VisitOperator` doesn't have an easy place to slot
this in so I decided to fix this via a different route than was
implemented before. Anything which operates on the control stack now
checks to see if it's empty instead of asserting it's non-empty.
Operators which don't touch the control stack are then checked by
ensuring that the `end` opcode which emptied the control stack was the
last operator processed in the function.

This exposed a minor issue where when validating const expressions the
offset that was passed in as the final offset of the expression was
actually the first offset of the expression.

Additionally this adds some tests to exercise this corner case (unsure
why the spec test suite doesn't have them already!)

[check]: https://github.com/bytecodealliance/wasm-tools/blob/8732e0bc8a579cd9f15d9134af997c5d3d95af5d/crates/wasmparser/src/validator/operators.rs#L581-L583