### PR TITLE
Fix validation of `catch`/`catch_all` with `try` params

### DIFF
--- a/src/bin/wasm-tools/validate.rs
+++ b/src/bin/wasm-tools/validate.rs
@@ -100,6 +100,7 @@ fn parse_features(arg: &str) -> Result<WasmFeatures> {
         }),
         ("sign-extension", |f| &mut f.sign_extension),
         ("mutable-global", |f| &mut f.mutable_global),
+        ("relaxed-simd", |f| &mut f.relaxed_simd),
     ];
 
     for part in arg.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()) {

--- a/tests/local/exception-handling.wast
+++ b/tests/local/exception-handling.wast
@@ -23,6 +23,22 @@
     drop
     drop
   )
+  (func $try-with-params
+    i32.const 0
+    try (param i32) (result i32 i64)
+      i32.popcnt
+      drop
+      call $check-throw
+      unreachable
+    catch 1
+      i64.const 2
+    catch_all
+      i32.const 0
+      i64.const 2
+    end
+    drop
+    drop
+  )
 )
 
 (assert_invalid


### PR DESCRIPTION
This commit fixes an accidental regression from #697 in the refactoring
I added at the end where manual modification of `self.control` was
replaced with `self.push_ctrl`. For the exceptions proposal specifically
this is not valid since the `block_type` for the frame doesn't get the
parameters pushed when the `catch` and `catch_all` instructions are
encountered.