### PR TITLE
Remove usage of `Operator` in `wasm-tools dump`

### DIFF
--- a/crates/dump/src/lib.rs
+++ b/crates/dump/src/lib.rs
@@ -551,8 +551,8 @@ impl<'a> Dump<'a> {
 
     fn print_ops(&mut self, mut i: OperatorsReader) -> Result<()> {
         while !i.eof() {
-            match i.read() {
-                Ok(op) => write!(self.state, "{:?}", op)?,
+            match i.visit_with_offset(self) {
+                Ok(()) => {}
                 Err(_) => write!(self.state, "??")?,
             }
             self.print(i.original_position())?;
@@ -615,4 +615,773 @@ fn inc(spot: &mut u32) -> u32 {
     let ret = *spot;
     *spot += 1;
     ret
+}
+
+macro_rules! dump {
+    ($(fn $name:ident(&mut self, offset: usize $(, $arg:ident: $argty:ty)* $(,)?))*) => {
+        $(
+            fn $name(&mut self, _offset: usize $(, $arg: $argty)*) {
+                write!(
+                    self.state,
+                    concat!(
+                        "op:{}"
+                        $(, " ", stringify!($arg), ":{:?}")*
+                    ),
+                    stringify!($name).strip_prefix("visit_").unwrap(),
+                    $($arg,)*
+                ).unwrap();
+            }
+        )*
+    }
+}
+
+impl<'a> VisitOperator<'a> for Dump<'_> {
+    type Output = ();
+    dump! {
+        fn visit_nop(&mut self, offset: usize)
+        fn visit_unreachable(&mut self, offset: usize)
+        fn visit_block(&mut self, offset: usize, ty: BlockType)
+        fn visit_loop(&mut self, offset: usize, ty: BlockType)
+        fn visit_if(&mut self, offset: usize, ty: BlockType)
+        fn visit_else(&mut self, offset: usize)
+        fn visit_try(&mut self, offset: usize, ty: BlockType)
+        fn visit_catch(&mut self, offset: usize, index: u32)
+        fn visit_throw(&mut self, offset: usize, index: u32)
+        fn visit_rethrow(&mut self, offset: usize, relative_depth: u32)
+        fn visit_delegate(&mut self, offset: usize, relative_depth: u32)
+        fn visit_catch_all(&mut self, offset: usize)
+        fn visit_end(&mut self, offset: usize)
+        fn visit_br(&mut self, offset: usize, relative_depth: u32)
+        fn visit_br_if(&mut self, offset: usize, relative_depth: u32)
+        fn visit_br_table(&mut self, offset: usize, table: &BrTable<'a>)
+        fn visit_return(&mut self, offset: usize)
+        fn visit_call(&mut self, offset: usize, function_index: u32)
+        fn visit_return_call(&mut self, offset: usize, function_index: u32)
+        fn visit_call_indirect(
+            &mut self,
+            offset: usize,
+            index: u32,
+            table_index: u32,
+            table_byte: u8,
+        )
+        fn visit_return_call_indirect(
+            &mut self,
+            offset: usize,
+            index: u32,
+            table_index: u32,
+        )
+        fn visit_drop(&mut self, offset: usize)
+        fn visit_select(&mut self, offset: usize)
+        fn visit_typed_select(&mut self, offset: usize, ty: ValType)
+        fn visit_local_get(&mut self, offset: usize, local_index: u32)
+        fn visit_local_set(&mut self, offset: usize, local_index: u32)
+        fn visit_local_tee(&mut self, offset: usize, local_index: u32)
+        fn visit_global_get(&mut self, offset: usize, global_index: u32)
+        fn visit_global_set(&mut self, offset: usize, global_index: u32)
+        fn visit_i32_load(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i64_load(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_f32_load(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_f64_load(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i32_load8_s(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i32_load8_u(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i32_load16_s(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i32_load16_u(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i64_load8_s(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i64_load8_u(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i64_load16_s(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i64_load16_u(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i64_load32_s(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i64_load32_u(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i32_store(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i64_store(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_f32_store(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_f64_store(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i32_store8(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i32_store16(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i64_store8(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i64_store16(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i64_store32(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_memory_size(&mut self, offset: usize, mem: u32, mem_byte: u8)
+        fn visit_memory_grow(&mut self, offset: usize, mem: u32, mem_byte: u8)
+        fn visit_i32_const(&mut self, offset: usize, value: i32)
+        fn visit_i64_const(&mut self, offset: usize, value: i64)
+        fn visit_f32_const(&mut self, offset: usize, value: Ieee32)
+        fn visit_f64_const(&mut self, offset: usize, value: Ieee64)
+        fn visit_i32_eqz(&mut self, offset: usize)
+        fn visit_i32_eq(&mut self, offset: usize)
+        fn visit_i32_ne(&mut self, offset: usize)
+        fn visit_i32_lt_s(&mut self, offset: usize)
+        fn visit_i32_lt_u(&mut self, offset: usize)
+        fn visit_i32_gt_s(&mut self, offset: usize)
+        fn visit_i32_gt_u(&mut self, offset: usize)
+        fn visit_i32_le_s(&mut self, offset: usize)
+        fn visit_i32_le_u(&mut self, offset: usize)
+        fn visit_i32_ge_s(&mut self, offset: usize)
+        fn visit_i32_ge_u(&mut self, offset: usize)
+        fn visit_i64_eqz(&mut self, offset: usize)
+        fn visit_i64_eq(&mut self, offset: usize)
+        fn visit_i64_ne(&mut self, offset: usize)
+        fn visit_i64_lt_s(&mut self, offset: usize)
+        fn visit_i64_lt_u(&mut self, offset: usize)
+        fn visit_i64_gt_s(&mut self, offset: usize)
+        fn visit_i64_gt_u(&mut self, offset: usize)
+        fn visit_i64_le_s(&mut self, offset: usize)
+        fn visit_i64_le_u(&mut self, offset: usize)
+        fn visit_i64_ge_s(&mut self, offset: usize)
+        fn visit_i64_ge_u(&mut self, offset: usize)
+        fn visit_f32_eq(&mut self, offset: usize)
+        fn visit_f32_ne(&mut self, offset: usize)
+        fn visit_f32_lt(&mut self, offset: usize)
+        fn visit_f32_gt(&mut self, offset: usize)
+        fn visit_f32_le(&mut self, offset: usize)
+        fn visit_f32_ge(&mut self, offset: usize)
+        fn visit_f64_eq(&mut self, offset: usize)
+        fn visit_f64_ne(&mut self, offset: usize)
+        fn visit_f64_lt(&mut self, offset: usize)
+        fn visit_f64_gt(&mut self, offset: usize)
+        fn visit_f64_le(&mut self, offset: usize)
+        fn visit_f64_ge(&mut self, offset: usize)
+        fn visit_i32_clz(&mut self, offset: usize)
+        fn visit_i32_ctz(&mut self, offset: usize)
+        fn visit_i32_popcnt(&mut self, offset: usize)
+        fn visit_i32_add(&mut self, offset: usize)
+        fn visit_i32_sub(&mut self, offset: usize)
+        fn visit_i32_mul(&mut self, offset: usize)
+        fn visit_i32_div_s(&mut self, offset: usize)
+        fn visit_i32_div_u(&mut self, offset: usize)
+        fn visit_i32_rem_s(&mut self, offset: usize)
+        fn visit_i32_rem_u(&mut self, offset: usize)
+        fn visit_i32_and(&mut self, offset: usize)
+        fn visit_i32_or(&mut self, offset: usize)
+        fn visit_i32_xor(&mut self, offset: usize)
+        fn visit_i32_shl(&mut self, offset: usize)
+        fn visit_i32_shr_s(&mut self, offset: usize)
+        fn visit_i32_shr_u(&mut self, offset: usize)
+        fn visit_i32_rotl(&mut self, offset: usize)
+        fn visit_i32_rotr(&mut self, offset: usize)
+        fn visit_i64_clz(&mut self, offset: usize)
+        fn visit_i64_ctz(&mut self, offset: usize)
+        fn visit_i64_popcnt(&mut self, offset: usize)
+        fn visit_i64_add(&mut self, offset: usize)
+        fn visit_i64_sub(&mut self, offset: usize)
+        fn visit_i64_mul(&mut self, offset: usize)
+        fn visit_i64_div_s(&mut self, offset: usize)
+        fn visit_i64_div_u(&mut self, offset: usize)
+        fn visit_i64_rem_s(&mut self, offset: usize)
+        fn visit_i64_rem_u(&mut self, offset: usize)
+        fn visit_i64_and(&mut self, offset: usize)
+        fn visit_i64_or(&mut self, offset: usize)
+        fn visit_i64_xor(&mut self, offset: usize)
+        fn visit_i64_shl(&mut self, offset: usize)
+        fn visit_i64_shr_s(&mut self, offset: usize)
+        fn visit_i64_shr_u(&mut self, offset: usize)
+        fn visit_i64_rotl(&mut self, offset: usize)
+        fn visit_i64_rotr(&mut self, offset: usize)
+        fn visit_f32_abs(&mut self, offset: usize)
+        fn visit_f32_neg(&mut self, offset: usize)
+        fn visit_f32_ceil(&mut self, offset: usize)
+        fn visit_f32_floor(&mut self, offset: usize)
+        fn visit_f32_trunc(&mut self, offset: usize)
+        fn visit_f32_nearest(&mut self, offset: usize)
+        fn visit_f32_sqrt(&mut self, offset: usize)
+        fn visit_f32_add(&mut self, offset: usize)
+        fn visit_f32_sub(&mut self, offset: usize)
+        fn visit_f32_mul(&mut self, offset: usize)
+        fn visit_f32_div(&mut self, offset: usize)
+        fn visit_f32_min(&mut self, offset: usize)
+        fn visit_f32_max(&mut self, offset: usize)
+        fn visit_f32_copysign(&mut self, offset: usize)
+        fn visit_f64_abs(&mut self, offset: usize)
+        fn visit_f64_neg(&mut self, offset: usize)
+        fn visit_f64_ceil(&mut self, offset: usize)
+        fn visit_f64_floor(&mut self, offset: usize)
+        fn visit_f64_trunc(&mut self, offset: usize)
+        fn visit_f64_nearest(&mut self, offset: usize)
+        fn visit_f64_sqrt(&mut self, offset: usize)
+        fn visit_f64_add(&mut self, offset: usize)
+        fn visit_f64_sub(&mut self, offset: usize)
+        fn visit_f64_mul(&mut self, offset: usize)
+        fn visit_f64_div(&mut self, offset: usize)
+        fn visit_f64_min(&mut self, offset: usize)
+        fn visit_f64_max(&mut self, offset: usize)
+        fn visit_f64_copysign(&mut self, offset: usize)
+        fn visit_i32_wrap_i64(&mut self, offset: usize)
+        fn visit_i32_trunc_f32s(&mut self, offset: usize)
+        fn visit_i32_trunc_f32u(&mut self, offset: usize)
+        fn visit_i32_trunc_f64s(&mut self, offset: usize)
+        fn visit_i32_trunc_f64u(&mut self, offset: usize)
+        fn visit_i64_extend_i32s(&mut self, offset: usize)
+        fn visit_i64_extend_i32u(&mut self, offset: usize)
+        fn visit_i64_trunc_f32s(&mut self, offset: usize)
+        fn visit_i64_trunc_f32u(&mut self, offset: usize)
+        fn visit_i64_trunc_f64s(&mut self, offset: usize)
+        fn visit_i64_trunc_f64u(&mut self, offset: usize)
+        fn visit_f32_convert_i32s(&mut self, offset: usize)
+        fn visit_f32_convert_i32u(&mut self, offset: usize)
+        fn visit_f32_convert_i64s(&mut self, offset: usize)
+        fn visit_f32_convert_i64u(&mut self, offset: usize)
+        fn visit_f32_demote_f64(&mut self, offset: usize)
+        fn visit_f64_convert_i32s(&mut self, offset: usize)
+        fn visit_f64_convert_i32u(&mut self, offset: usize)
+        fn visit_f64_convert_i64s(&mut self, offset: usize)
+        fn visit_f64_convert_i64u(&mut self, offset: usize)
+        fn visit_f64_promote_f32(&mut self, offset: usize)
+        fn visit_i32_reinterpret_f32(&mut self, offset: usize)
+        fn visit_i64_reinterpret_f64(&mut self, offset: usize)
+        fn visit_f32_reinterpret_i32(&mut self, offset: usize)
+        fn visit_f64_reinterpret_i64(&mut self, offset: usize)
+        fn visit_i32_trunc_sat_f32s(&mut self, offset: usize)
+        fn visit_i32_trunc_sat_f32u(&mut self, offset: usize)
+        fn visit_i32_trunc_sat_f64s(&mut self, offset: usize)
+        fn visit_i32_trunc_sat_f64u(&mut self, offset: usize)
+        fn visit_i64_trunc_sat_f32s(&mut self, offset: usize)
+        fn visit_i64_trunc_sat_f32u(&mut self, offset: usize)
+        fn visit_i64_trunc_sat_f64s(&mut self, offset: usize)
+        fn visit_i64_trunc_sat_f64u(&mut self, offset: usize)
+        fn visit_i32_extend8_s(&mut self, offset: usize)
+        fn visit_i32_extend16_s(&mut self, offset: usize)
+        fn visit_i64_extend8_s(&mut self, offset: usize)
+        fn visit_i64_extend16_s(&mut self, offset: usize)
+        fn visit_i64_extend32_s(&mut self, offset: usize)
+        fn visit_i32_atomic_load(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i32_atomic_load16_u(&mut self, offset: usize, memarg: MemoryImmediate)
+
+        fn visit_i32_atomic_load8_u(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i64_atomic_load(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i64_atomic_load32_u(&mut self, offset: usize, memarg: MemoryImmediate)
+
+        fn visit_i64_atomic_load16_u(&mut self, offset: usize, memarg: MemoryImmediate)
+
+        fn visit_i64_atomic_load8_u(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i32_atomic_store(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i32_atomic_store16(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i32_atomic_store8(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i64_atomic_store(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i64_atomic_store32(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i64_atomic_store16(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i64_atomic_store8(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i32_atomic_rmw_add(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i32_atomic_rmw_sub(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i32_atomic_rmw_and(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i32_atomic_rmw_or(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i32_atomic_rmw_xor(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i32_atomic_rmw16_add_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i32_atomic_rmw16_sub_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i32_atomic_rmw16_and_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i32_atomic_rmw16_or_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i32_atomic_rmw16_xor_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i32_atomic_rmw8_add_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i32_atomic_rmw8_sub_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i32_atomic_rmw8_and_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i32_atomic_rmw8_or_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i32_atomic_rmw8_xor_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i64_atomic_rmw_add(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i64_atomic_rmw_sub(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i64_atomic_rmw_and(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i64_atomic_rmw_or(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i64_atomic_rmw_xor(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_i64_atomic_rmw32_add_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i64_atomic_rmw32_sub_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i64_atomic_rmw32_and_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i64_atomic_rmw32_or_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i64_atomic_rmw32_xor_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i64_atomic_rmw16_add_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i64_atomic_rmw16_sub_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i64_atomic_rmw16_and_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i64_atomic_rmw16_or_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i64_atomic_rmw16_xor_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i64_atomic_rmw8_add_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i64_atomic_rmw8_sub_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i64_atomic_rmw8_and_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i64_atomic_rmw8_or_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i64_atomic_rmw8_xor_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i32_atomic_rmw_xchg(&mut self, offset: usize, memarg: MemoryImmediate)
+
+        fn visit_i32_atomic_rmw16_xchg_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i32_atomic_rmw8_xchg_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i32_atomic_rmw_cmpxchg(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i32_atomic_rmw16_cmpxchg_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i32_atomic_rmw8_cmpxchg_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i64_atomic_rmw_xchg(&mut self, offset: usize, memarg: MemoryImmediate)
+
+        fn visit_i64_atomic_rmw32_xchg_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i64_atomic_rmw16_xchg_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i64_atomic_rmw8_xchg_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i64_atomic_rmw_cmpxchg(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i64_atomic_rmw32_cmpxchg_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i64_atomic_rmw16_cmpxchg_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_i64_atomic_rmw8_cmpxchg_u(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_memory_atomic_notify(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_memory_atomic_wait32(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_memory_atomic_wait64(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+        )
+        fn visit_atomic_fence(&mut self, offset: usize, flags: u8)
+        fn visit_ref_null(&mut self, offset: usize, ty: ValType)
+        fn visit_ref_is_null(&mut self, offset: usize)
+        fn visit_ref_func(&mut self, offset: usize, function_index: u32)
+        fn visit_v128_load(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_v128_store(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_v128_const(&mut self, offset: usize, value: V128)
+        fn visit_i8x16_splat(&mut self, offset: usize)
+        fn visit_i16x8_splat(&mut self, offset: usize)
+        fn visit_i32x4_splat(&mut self, offset: usize)
+        fn visit_i64x2_splat(&mut self, offset: usize)
+        fn visit_f32x4_splat(&mut self, offset: usize)
+        fn visit_f64x2_splat(&mut self, offset: usize)
+        fn visit_i8x16_extract_lane_s(&mut self, offset: usize, lane: SIMDLaneIndex)
+        fn visit_i8x16_extract_lane_u(&mut self, offset: usize, lane: SIMDLaneIndex)
+        fn visit_i16x8_extract_lane_s(&mut self, offset: usize, lane: SIMDLaneIndex)
+        fn visit_i16x8_extract_lane_u(&mut self, offset: usize, lane: SIMDLaneIndex)
+        fn visit_i32x4_extract_lane(&mut self, offset: usize, lane: SIMDLaneIndex)
+        fn visit_i8x16_replace_lane(&mut self, offset: usize, lane: SIMDLaneIndex)
+        fn visit_i16x8_replace_lane(&mut self, offset: usize, lane: SIMDLaneIndex)
+        fn visit_i32x4_replace_lane(&mut self, offset: usize, lane: SIMDLaneIndex)
+        fn visit_i64x2_extract_lane(&mut self, offset: usize, lane: SIMDLaneIndex)
+        fn visit_i64x2_replace_lane(&mut self, offset: usize, lane: SIMDLaneIndex)
+        fn visit_f32x4_extract_lane(&mut self, offset: usize, lane: SIMDLaneIndex)
+        fn visit_f32x4_replace_lane(&mut self, offset: usize, lane: SIMDLaneIndex)
+        fn visit_f64x2_extract_lane(&mut self, offset: usize, lane: SIMDLaneIndex)
+        fn visit_f64x2_replace_lane(&mut self, offset: usize, lane: SIMDLaneIndex)
+        fn visit_f32x4_eq(&mut self, offset: usize)
+        fn visit_f32x4_ne(&mut self, offset: usize)
+        fn visit_f32x4_lt(&mut self, offset: usize)
+        fn visit_f32x4_gt(&mut self, offset: usize)
+        fn visit_f32x4_le(&mut self, offset: usize)
+        fn visit_f32x4_ge(&mut self, offset: usize)
+        fn visit_f64x2_eq(&mut self, offset: usize)
+        fn visit_f64x2_ne(&mut self, offset: usize)
+        fn visit_f64x2_lt(&mut self, offset: usize)
+        fn visit_f64x2_gt(&mut self, offset: usize)
+        fn visit_f64x2_le(&mut self, offset: usize)
+        fn visit_f64x2_ge(&mut self, offset: usize)
+        fn visit_f32x4_add(&mut self, offset: usize)
+        fn visit_f32x4_sub(&mut self, offset: usize)
+        fn visit_f32x4_mul(&mut self, offset: usize)
+        fn visit_f32x4_div(&mut self, offset: usize)
+        fn visit_f32x4_min(&mut self, offset: usize)
+        fn visit_f32x4_max(&mut self, offset: usize)
+        fn visit_f32x4_p_min(&mut self, offset: usize)
+        fn visit_f32x4_p_max(&mut self, offset: usize)
+        fn visit_f64x2_add(&mut self, offset: usize)
+        fn visit_f64x2_sub(&mut self, offset: usize)
+        fn visit_f64x2_mul(&mut self, offset: usize)
+        fn visit_f64x2_div(&mut self, offset: usize)
+        fn visit_f64x2_min(&mut self, offset: usize)
+        fn visit_f64x2_max(&mut self, offset: usize)
+        fn visit_f64x2_p_min(&mut self, offset: usize)
+        fn visit_f64x2_p_max(&mut self, offset: usize)
+        fn visit_f32x4_relaxed_min(&mut self, offset: usize)
+        fn visit_f32x4_relaxed_max(&mut self, offset: usize)
+        fn visit_f64x2_relaxed_min(&mut self, offset: usize)
+        fn visit_f64x2_relaxed_max(&mut self, offset: usize)
+        fn visit_i8x16_eq(&mut self, offset: usize)
+        fn visit_i8x16_ne(&mut self, offset: usize)
+        fn visit_i8x16_lt_s(&mut self, offset: usize)
+        fn visit_i8x16_lt_u(&mut self, offset: usize)
+        fn visit_i8x16_gt_s(&mut self, offset: usize)
+        fn visit_i8x16_gt_u(&mut self, offset: usize)
+        fn visit_i8x16_le_s(&mut self, offset: usize)
+        fn visit_i8x16_le_u(&mut self, offset: usize)
+        fn visit_i8x16_ge_s(&mut self, offset: usize)
+        fn visit_i8x16_ge_u(&mut self, offset: usize)
+        fn visit_i16x8_eq(&mut self, offset: usize)
+        fn visit_i16x8_ne(&mut self, offset: usize)
+        fn visit_i16x8_lt_s(&mut self, offset: usize)
+        fn visit_i16x8_lt_u(&mut self, offset: usize)
+        fn visit_i16x8_gt_s(&mut self, offset: usize)
+        fn visit_i16x8_gt_u(&mut self, offset: usize)
+        fn visit_i16x8_le_s(&mut self, offset: usize)
+        fn visit_i16x8_le_u(&mut self, offset: usize)
+        fn visit_i16x8_ge_s(&mut self, offset: usize)
+        fn visit_i16x8_ge_u(&mut self, offset: usize)
+        fn visit_i32x4_eq(&mut self, offset: usize)
+        fn visit_i32x4_ne(&mut self, offset: usize)
+        fn visit_i32x4_lt_s(&mut self, offset: usize)
+        fn visit_i32x4_lt_u(&mut self, offset: usize)
+        fn visit_i32x4_gt_s(&mut self, offset: usize)
+        fn visit_i32x4_gt_u(&mut self, offset: usize)
+        fn visit_i32x4_le_s(&mut self, offset: usize)
+        fn visit_i32x4_le_u(&mut self, offset: usize)
+        fn visit_i32x4_ge_s(&mut self, offset: usize)
+        fn visit_i32x4_ge_u(&mut self, offset: usize)
+        fn visit_i64x2_eq(&mut self, offset: usize)
+        fn visit_i64x2_ne(&mut self, offset: usize)
+        fn visit_i64x2_lt_s(&mut self, offset: usize)
+        fn visit_i64x2_gt_s(&mut self, offset: usize)
+        fn visit_i64x2_le_s(&mut self, offset: usize)
+        fn visit_i64x2_ge_s(&mut self, offset: usize)
+        fn visit_v128_and(&mut self, offset: usize)
+        fn visit_v128_and_not(&mut self, offset: usize)
+        fn visit_v128_or(&mut self, offset: usize)
+        fn visit_v128_xor(&mut self, offset: usize)
+        fn visit_i8x16_add(&mut self, offset: usize)
+        fn visit_i8x16_add_sat_s(&mut self, offset: usize)
+        fn visit_i8x16_add_sat_u(&mut self, offset: usize)
+        fn visit_i8x16_sub(&mut self, offset: usize)
+        fn visit_i8x16_sub_sat_s(&mut self, offset: usize)
+        fn visit_i8x16_sub_sat_u(&mut self, offset: usize)
+        fn visit_i8x16_min_s(&mut self, offset: usize)
+        fn visit_i8x16_min_u(&mut self, offset: usize)
+        fn visit_i8x16_max_s(&mut self, offset: usize)
+        fn visit_i8x16_max_u(&mut self, offset: usize)
+        fn visit_i16x8_add(&mut self, offset: usize)
+        fn visit_i16x8_add_sat_s(&mut self, offset: usize)
+        fn visit_i16x8_add_sat_u(&mut self, offset: usize)
+        fn visit_i16x8_sub(&mut self, offset: usize)
+        fn visit_i16x8_sub_sat_s(&mut self, offset: usize)
+        fn visit_i16x8_sub_sat_u(&mut self, offset: usize)
+        fn visit_i16x8_mul(&mut self, offset: usize)
+        fn visit_i16x8_min_s(&mut self, offset: usize)
+        fn visit_i16x8_min_u(&mut self, offset: usize)
+        fn visit_i16x8_max_s(&mut self, offset: usize)
+        fn visit_i16x8_max_u(&mut self, offset: usize)
+        fn visit_i32x4_add(&mut self, offset: usize)
+        fn visit_i32x4_sub(&mut self, offset: usize)
+        fn visit_i32x4_mul(&mut self, offset: usize)
+        fn visit_i32x4_min_s(&mut self, offset: usize)
+        fn visit_i32x4_min_u(&mut self, offset: usize)
+        fn visit_i32x4_max_s(&mut self, offset: usize)
+        fn visit_i32x4_max_u(&mut self, offset: usize)
+        fn visit_i32x4_dot_i16x8_s(&mut self, offset: usize)
+        fn visit_i64x2_add(&mut self, offset: usize)
+        fn visit_i64x2_sub(&mut self, offset: usize)
+        fn visit_i64x2_mul(&mut self, offset: usize)
+        fn visit_i8x16_rounding_average_u(&mut self, offset: usize)
+        fn visit_i16x8_rounding_average_u(&mut self, offset: usize)
+        fn visit_i8x16_narrow_i16x8_s(&mut self, offset: usize)
+        fn visit_i8x16_narrow_i16x8_u(&mut self, offset: usize)
+        fn visit_i16x8_narrow_i32x4_s(&mut self, offset: usize)
+        fn visit_i16x8_narrow_i32x4_u(&mut self, offset: usize)
+        fn visit_i16x8_ext_mul_low_i8x16_s(&mut self, offset: usize)
+        fn visit_i16x8_ext_mul_high_i8x16_s(&mut self, offset: usize)
+        fn visit_i16x8_ext_mul_low_i8x16_u(&mut self, offset: usize)
+        fn visit_i16x8_ext_mul_high_i8x16_u(&mut self, offset: usize)
+        fn visit_i32x4_ext_mul_low_i16x8_s(&mut self, offset: usize)
+        fn visit_i32x4_ext_mul_high_i16x8_s(&mut self, offset: usize)
+        fn visit_i32x4_ext_mul_low_i16x8_u(&mut self, offset: usize)
+        fn visit_i32x4_ext_mul_high_i16x8_u(&mut self, offset: usize)
+        fn visit_i64x2_ext_mul_low_i32x4_s(&mut self, offset: usize)
+        fn visit_i64x2_ext_mul_high_i32x4_s(&mut self, offset: usize)
+        fn visit_i64x2_ext_mul_low_i32x4_u(&mut self, offset: usize)
+        fn visit_i64x2_ext_mul_high_i32x4_u(&mut self, offset: usize)
+        fn visit_i16x8_q15_mulr_sat_s(&mut self, offset: usize)
+        fn visit_f32x4_ceil(&mut self, offset: usize)
+        fn visit_f32x4_floor(&mut self, offset: usize)
+        fn visit_f32x4_trunc(&mut self, offset: usize)
+        fn visit_f32x4_nearest(&mut self, offset: usize)
+        fn visit_f64x2_ceil(&mut self, offset: usize)
+        fn visit_f64x2_floor(&mut self, offset: usize)
+        fn visit_f64x2_trunc(&mut self, offset: usize)
+        fn visit_f64x2_nearest(&mut self, offset: usize)
+        fn visit_f32x4_abs(&mut self, offset: usize)
+        fn visit_f32x4_neg(&mut self, offset: usize)
+        fn visit_f32x4_sqrt(&mut self, offset: usize)
+        fn visit_f64x2_abs(&mut self, offset: usize)
+        fn visit_f64x2_neg(&mut self, offset: usize)
+        fn visit_f64x2_sqrt(&mut self, offset: usize)
+        fn visit_f32x4_demote_f64x2_zero(&mut self, offset: usize)
+        fn visit_f64x2_promote_low_f32x4(&mut self, offset: usize)
+        fn visit_f64x2_convert_low_i32x4_s(&mut self, offset: usize)
+        fn visit_f64x2_convert_low_i32x4_u(&mut self, offset: usize)
+        fn visit_i32x4_trunc_sat_f32x4_s(&mut self, offset: usize)
+        fn visit_i32x4_trunc_sat_f32x4_u(&mut self, offset: usize)
+        fn visit_i32x4_trunc_sat_f64x2_s_zero(&mut self, offset: usize)
+        fn visit_i32x4_trunc_sat_f64x2_u_zero(&mut self, offset: usize)
+        fn visit_f32x4_convert_i32x4_s(&mut self, offset: usize)
+        fn visit_f32x4_convert_i32x4_u(&mut self, offset: usize)
+        fn visit_v128_not(&mut self, offset: usize)
+        fn visit_i8x16_abs(&mut self, offset: usize)
+        fn visit_i8x16_neg(&mut self, offset: usize)
+        fn visit_i8x16_popcnt(&mut self, offset: usize)
+        fn visit_i16x8_abs(&mut self, offset: usize)
+        fn visit_i16x8_neg(&mut self, offset: usize)
+        fn visit_i32x4_abs(&mut self, offset: usize)
+        fn visit_i32x4_neg(&mut self, offset: usize)
+        fn visit_i64x2_abs(&mut self, offset: usize)
+        fn visit_i64x2_neg(&mut self, offset: usize)
+        fn visit_i16x8_extend_low_i8x16_s(&mut self, offset: usize)
+        fn visit_i16x8_extend_high_i8x16_s(&mut self, offset: usize)
+        fn visit_i16x8_extend_low_i8x16_u(&mut self, offset: usize)
+        fn visit_i16x8_extend_high_i8x16_u(&mut self, offset: usize)
+        fn visit_i32x4_extend_low_i16x8_s(&mut self, offset: usize)
+        fn visit_i32x4_extend_high_i16x8_s(&mut self, offset: usize)
+        fn visit_i32x4_extend_low_i16x8_u(&mut self, offset: usize)
+        fn visit_i32x4_extend_high_i16x8_u(&mut self, offset: usize)
+        fn visit_i64x2_extend_low_i32x4_s(&mut self, offset: usize)
+        fn visit_i64x2_extend_high_i32x4_s(&mut self, offset: usize)
+        fn visit_i64x2_extend_low_i32x4_u(&mut self, offset: usize)
+        fn visit_i64x2_extend_high_i32x4_u(&mut self, offset: usize)
+        fn visit_i16x8_ext_add_pairwise_i8x16_s(&mut self, offset: usize)
+        fn visit_i16x8_ext_add_pairwise_i8x16_u(&mut self, offset: usize)
+        fn visit_i32x4_ext_add_pairwise_i16x8_s(&mut self, offset: usize)
+        fn visit_i32x4_ext_add_pairwise_i16x8_u(&mut self, offset: usize)
+        fn visit_i32x4_relaxed_trunc_sat_f32x4_s(&mut self, offset: usize)
+        fn visit_i32x4_relaxed_trunc_sat_f32x4_u(&mut self, offset: usize)
+        fn visit_i32x4_relaxed_trunc_sat_f64x2_s_zero(&mut self, offset: usize)
+        fn visit_i32x4_relaxed_trunc_sat_f64x2_u_zero(&mut self, offset: usize)
+        fn visit_v128_bitselect(&mut self, offset: usize)
+        fn visit_f32x4_fma(&mut self, offset: usize)
+        fn visit_f32x4_fms(&mut self, offset: usize)
+        fn visit_f64x2_fma(&mut self, offset: usize)
+        fn visit_f64x2_fms(&mut self, offset: usize)
+        fn visit_i8x16_lane_select(&mut self, offset: usize)
+        fn visit_i16x8_lane_select(&mut self, offset: usize)
+        fn visit_i32x4_lane_select(&mut self, offset: usize)
+        fn visit_i64x2_lane_select(&mut self, offset: usize)
+        fn visit_v128_any_true(&mut self, offset: usize)
+        fn visit_i8x16_all_true(&mut self, offset: usize)
+        fn visit_i8x16_bitmask(&mut self, offset: usize)
+        fn visit_i16x8_all_true(&mut self, offset: usize)
+        fn visit_i16x8_bitmask(&mut self, offset: usize)
+        fn visit_i32x4_all_true(&mut self, offset: usize)
+        fn visit_i32x4_bitmask(&mut self, offset: usize)
+        fn visit_i64x2_all_true(&mut self, offset: usize)
+        fn visit_i64x2_bitmask(&mut self, offset: usize)
+        fn visit_i8x16_shl(&mut self, offset: usize)
+        fn visit_i8x16_shr_s(&mut self, offset: usize)
+        fn visit_i8x16_shr_u(&mut self, offset: usize)
+        fn visit_i16x8_shl(&mut self, offset: usize)
+        fn visit_i16x8_shr_s(&mut self, offset: usize)
+        fn visit_i16x8_shr_u(&mut self, offset: usize)
+        fn visit_i32x4_shl(&mut self, offset: usize)
+        fn visit_i32x4_shr_s(&mut self, offset: usize)
+        fn visit_i32x4_shr_u(&mut self, offset: usize)
+        fn visit_i64x2_shl(&mut self, offset: usize)
+        fn visit_i64x2_shr_s(&mut self, offset: usize)
+        fn visit_i64x2_shr_u(&mut self, offset: usize)
+        fn visit_i8x16_swizzle(&mut self, offset: usize)
+        fn visit_i8x16_relaxed_swizzle(&mut self, offset: usize)
+        fn visit_i8x16_shuffle(&mut self, offset: usize, lanes: [SIMDLaneIndex; 16])
+        fn visit_v128_load8_splat(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_v128_load16_splat(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_v128_load32_splat(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_v128_load32_zero(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_v128_load64_splat(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_v128_load64_zero(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_v128_load8x8_s(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_v128_load8x8_u(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_v128_load16x4_s(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_v128_load16x4_u(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_v128_load32x2_s(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_v128_load32x2_u(&mut self, offset: usize, memarg: MemoryImmediate)
+        fn visit_v128_load8_lane(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+            lane: SIMDLaneIndex,
+        )
+        fn visit_v128_load16_lane(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+            lane: SIMDLaneIndex,
+        )
+        fn visit_v128_load32_lane(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+            lane: SIMDLaneIndex,
+        )
+        fn visit_v128_load64_lane(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+            lane: SIMDLaneIndex,
+        )
+        fn visit_v128_store8_lane(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+            lane: SIMDLaneIndex,
+        )
+        fn visit_v128_store16_lane(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+            lane: SIMDLaneIndex,
+        )
+        fn visit_v128_store32_lane(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+            lane: SIMDLaneIndex,
+        )
+        fn visit_v128_store64_lane(
+            &mut self,
+            offset: usize,
+            memarg: MemoryImmediate,
+            lane: SIMDLaneIndex,
+        )
+        fn visit_memory_init(&mut self, offset: usize, mem: u32, segment: u32)
+        fn visit_data_drop(&mut self, offset: usize, segment: u32)
+        fn visit_memory_copy(&mut self, offset: usize, src: u32, dst: u32)
+        fn visit_memory_fill(&mut self, offset: usize, mem: u32)
+        fn visit_table_init(&mut self, offset: usize, segment: u32, table: u32)
+        fn visit_elem_drop(&mut self, offset: usize, segment: u32)
+        fn visit_table_copy(&mut self, offset: usize, dst_table: u32, src_table: u32)
+        fn visit_table_get(&mut self, offset: usize, table: u32)
+        fn visit_table_set(&mut self, offset: usize, table: u32)
+        fn visit_table_grow(&mut self, offset: usize, table: u32)
+        fn visit_table_size(&mut self, offset: usize, table: u32)
+        fn visit_table_fill(&mut self, offset: usize, table: u32)
+    }
 }

--- a/crates/dump/src/lib.rs
+++ b/crates/dump/src/lib.rs
@@ -624,7 +624,7 @@ macro_rules! dump {
                 write!(
                     self.state,
                     concat!(
-                        "op:{}"
+                        "{}"
                         $(, " ", stringify!($arg), ":{:?}")*
                     ),
                     stringify!($name).strip_prefix("visit_").unwrap(),

--- a/tests/dump/alias.wat.dump
+++ b/tests/dump/alias.wat.dump
@@ -41,7 +41,7 @@
 ============== func 0 ====================
    0x67 | 02          | size of function
    0x68 | 00          | 0 local blocks
-   0x69 | 0b          | op:end
+   0x69 | 0b          | end
    0x6a | 00 09       | custom section
    0x6c | 04 6e 61 6d | name: "name"
         | 65         

--- a/tests/dump/alias.wat.dump
+++ b/tests/dump/alias.wat.dump
@@ -41,7 +41,7 @@
 ============== func 0 ====================
    0x67 | 02          | size of function
    0x68 | 00          | 0 local blocks
-   0x69 | 0b          | End
+   0x69 | 0b          | op:end
    0x6a | 00 09       | custom section
    0x6c | 04 6e 61 6d | name: "name"
         | 65         

--- a/tests/dump/alias2.wat.dump
+++ b/tests/dump/alias2.wat.dump
@@ -115,7 +115,7 @@
    0x129 | 06 04       | global section
    0x12b | 01          | 1 count
    0x12c | 7f 00       | [global 0] GlobalType { content_type: I32, mutable: false }
-   0x12e | 0b          | op:end
+   0x12e | 0b          | end
    0x12f | 07 11       | export section
    0x131 | 04          | 4 count
    0x132 | 01 31 00 00 | export Export { name: "1", kind: Func, index: 0 }
@@ -127,7 +127,7 @@
 ============== func 0 ====================
    0x145 | 02          | size of function
    0x146 | 00          | 0 local blocks
-   0x147 | 0b          | op:end
+   0x147 | 0b          | end
    0x148 | 00 0a       | custom section
    0x14a | 04 6e 61 6d | name: "name"
          | 65         

--- a/tests/dump/alias2.wat.dump
+++ b/tests/dump/alias2.wat.dump
@@ -115,7 +115,7 @@
    0x129 | 06 04       | global section
    0x12b | 01          | 1 count
    0x12c | 7f 00       | [global 0] GlobalType { content_type: I32, mutable: false }
-   0x12e | 0b          | End
+   0x12e | 0b          | op:end
    0x12f | 07 11       | export section
    0x131 | 04          | 4 count
    0x132 | 01 31 00 00 | export Export { name: "1", kind: Func, index: 0 }
@@ -127,7 +127,7 @@
 ============== func 0 ====================
    0x145 | 02          | size of function
    0x146 | 00          | 0 local blocks
-   0x147 | 0b          | End
+   0x147 | 0b          | op:end
    0x148 | 00 0a       | custom section
    0x14a | 04 6e 61 6d | name: "name"
          | 65         

--- a/tests/dump/bundled.wat.dump
+++ b/tests/dump/bundled.wat.dump
@@ -42,8 +42,8 @@
 ============== func 0 ====================
     0x73 | 03          | size of function
     0x74 | 00          | 0 local blocks
-    0x75 | 00          | op:unreachable
-    0x76 | 0b          | op:end
+    0x75 | 00          | unreachable
+    0x76 | 0b          | end
     0x77 | 00 0c       | custom section
     0x79 | 04 6e 61 6d | name: "name"
          | 65         
@@ -80,8 +80,8 @@
 ============== func 1 ====================
     0xc5 | 03          | size of function
     0xc6 | 00          | 0 local blocks
-    0xc7 | 00          | op:unreachable
-    0xc8 | 0b          | op:end
+    0xc7 | 00          | unreachable
+    0xc8 | 0b          | end
     0xc9 | 00 21       | custom section
     0xcb | 04 6e 61 6d | name: "name"
          | 65         
@@ -126,13 +126,13 @@
 ============== func 1 ====================
    0x132 | 03          | size of function
    0x133 | 00          | 0 local blocks
-   0x134 | 00          | op:unreachable
-   0x135 | 0b          | op:end
+   0x134 | 00          | unreachable
+   0x135 | 0b          | end
 ============== func 2 ====================
    0x136 | 03          | size of function
    0x137 | 00          | 0 local blocks
-   0x138 | 00          | op:unreachable
-   0x139 | 0b          | op:end
+   0x138 | 00          | unreachable
+   0x139 | 0b          | end
    0x13a | 00 12       | custom section
    0x13c | 04 6e 61 6d | name: "name"
          | 65         

--- a/tests/dump/bundled.wat.dump
+++ b/tests/dump/bundled.wat.dump
@@ -42,8 +42,8 @@
 ============== func 0 ====================
     0x73 | 03          | size of function
     0x74 | 00          | 0 local blocks
-    0x75 | 00          | Unreachable
-    0x76 | 0b          | End
+    0x75 | 00          | op:unreachable
+    0x76 | 0b          | op:end
     0x77 | 00 0c       | custom section
     0x79 | 04 6e 61 6d | name: "name"
          | 65         
@@ -80,8 +80,8 @@
 ============== func 1 ====================
     0xc5 | 03          | size of function
     0xc6 | 00          | 0 local blocks
-    0xc7 | 00          | Unreachable
-    0xc8 | 0b          | End
+    0xc7 | 00          | op:unreachable
+    0xc8 | 0b          | op:end
     0xc9 | 00 21       | custom section
     0xcb | 04 6e 61 6d | name: "name"
          | 65         
@@ -126,13 +126,13 @@
 ============== func 1 ====================
    0x132 | 03          | size of function
    0x133 | 00          | 0 local blocks
-   0x134 | 00          | Unreachable
-   0x135 | 0b          | End
+   0x134 | 00          | op:unreachable
+   0x135 | 0b          | op:end
 ============== func 2 ====================
    0x136 | 03          | size of function
    0x137 | 00          | 0 local blocks
-   0x138 | 00          | Unreachable
-   0x139 | 0b          | End
+   0x138 | 00          | op:unreachable
+   0x139 | 0b          | op:end
    0x13a | 00 12       | custom section
    0x13c | 04 6e 61 6d | name: "name"
          | 65         

--- a/tests/dump/component-expand-bundle.wat.dump
+++ b/tests/dump/component-expand-bundle.wat.dump
@@ -17,7 +17,7 @@
 ============== func 0 ====================
    0x25 | 02          | size of function
    0x26 | 00          | 0 local blocks
-   0x27 | 0b          | End
+   0x27 | 0b          | op:end
    0x28 | 00 09       | custom section
    0x2a | 04 6e 61 6d | name: "name"
         | 65         

--- a/tests/dump/component-expand-bundle.wat.dump
+++ b/tests/dump/component-expand-bundle.wat.dump
@@ -17,7 +17,7 @@
 ============== func 0 ====================
    0x25 | 02          | size of function
    0x26 | 00          | 0 local blocks
-   0x27 | 0b          | op:end
+   0x27 | 0b          | end
    0x28 | 00 09       | custom section
    0x2a | 04 6e 61 6d | name: "name"
         | 65         

--- a/tests/dump/import-modules.wat.dump
+++ b/tests/dump/import-modules.wat.dump
@@ -25,7 +25,7 @@
 ============== func 0 ====================
    0x3c | 02          | size of function
    0x3d | 00          | 0 local blocks
-   0x3e | 0b          | op:end
+   0x3e | 0b          | end
    0x3f | 00 0a       | custom section
    0x41 | 04 6e 61 6d | name: "name"
         | 65         

--- a/tests/dump/import-modules.wat.dump
+++ b/tests/dump/import-modules.wat.dump
@@ -25,7 +25,7 @@
 ============== func 0 ====================
    0x3c | 02          | size of function
    0x3d | 00          | 0 local blocks
-   0x3e | 0b          | End
+   0x3e | 0b          | op:end
    0x3f | 00 0a       | custom section
    0x41 | 04 6e 61 6d | name: "name"
         | 65         

--- a/tests/dump/names.wat.dump
+++ b/tests/dump/names.wat.dump
@@ -12,7 +12,7 @@
  0x16 | 04          | size of function
  0x17 | 01          | 1 local blocks
  0x18 | 01 7c       | 1 locals of type F64
- 0x1a | 0b          | op:end
+ 0x1a | 0b          | end
  0x1b | 00 1c       | custom section
  0x1d | 04 6e 61 6d | name: "name"
       | 65         

--- a/tests/dump/names.wat.dump
+++ b/tests/dump/names.wat.dump
@@ -12,7 +12,7 @@
  0x16 | 04          | size of function
  0x17 | 01          | 1 local blocks
  0x18 | 01 7c       | 1 locals of type F64
- 0x1a | 0b          | End
+ 0x1a | 0b          | op:end
  0x1b | 00 1c       | custom section
  0x1d | 04 6e 61 6d | name: "name"
       | 65         

--- a/tests/dump/select.wat.dump
+++ b/tests/dump/select.wat.dump
@@ -11,10 +11,10 @@
 ============== func 0 ====================
  0x15 | 0c          | size of function
  0x16 | 00          | 0 local blocks
- 0x17 | 1b          | op:select
+ 0x17 | 1b          | select
  0x18 | 1c 00       | ??
- 0x1a | 1c 01 7f    | op:typed_select ty:I32
+ 0x1a | 1c 01 7f    | typed_select ty:I32
  0x1d | 1c 02       | ??
- 0x1f | 7f          | op:i64_div_s
- 0x20 | 7f          | op:i64_div_s
- 0x21 | 0b          | op:end
+ 0x1f | 7f          | i64_div_s
+ 0x20 | 7f          | i64_div_s
+ 0x21 | 0b          | end

--- a/tests/dump/select.wat.dump
+++ b/tests/dump/select.wat.dump
@@ -11,10 +11,10 @@
 ============== func 0 ====================
  0x15 | 0c          | size of function
  0x16 | 00          | 0 local blocks
- 0x17 | 1b          | Select
+ 0x17 | 1b          | op:select
  0x18 | 1c 00       | ??
- 0x1a | 1c 01 7f    | TypedSelect { ty: I32 }
+ 0x1a | 1c 01 7f    | op:typed_select ty:I32
  0x1d | 1c 02       | ??
- 0x1f | 7f          | I64DivS
- 0x20 | 7f          | I64DivS
- 0x21 | 0b          | End
+ 0x1f | 7f          | op:i64_div_s
+ 0x20 | 7f          | op:i64_div_s
+ 0x21 | 0b          | op:end

--- a/tests/dump/simple.wat.dump
+++ b/tests/dump/simple.wat.dump
@@ -22,8 +22,8 @@
  0x2c | 06 06       | global section
  0x2e | 01          | 1 count
  0x2f | 7f 00       | [global 0] GlobalType { content_type: I32, mutable: false }
- 0x31 | 41 00       | op:i32_const value:0
- 0x33 | 0b          | op:end
+ 0x31 | 41 00       | i32_const value:0
+ 0x33 | 0b          | end
  0x34 | 07 05       | export section
  0x36 | 01          | 1 count
  0x37 | 01 6d 02 00 | export Export { name: "m", kind: Memory, index: 0 }
@@ -32,8 +32,8 @@
  0x3e | 09 0f       | element section
  0x40 | 03          | 3 count
  0x41 | 00          | element FuncRef table[0]
- 0x42 | 41 03       | op:i32_const value:3
- 0x44 | 0b          | op:end
+ 0x42 | 41 03       | i32_const value:3
+ 0x44 | 0b          | end
  0x45 | 01          | 1 items
  0x46 | 00          | item Func(0)
  0x47 | 01 00 01    | element FuncRef passive, 1 items
@@ -45,23 +45,23 @@
 ============== func 1 ====================
  0x52 | 02          | size of function
  0x53 | 00          | 0 local blocks
- 0x54 | 0b          | op:end
+ 0x54 | 0b          | end
 ============== func 2 ====================
  0x55 | 04          | size of function
  0x56 | 01          | 1 local blocks
  0x57 | 01 7f       | 1 locals of type I32
- 0x59 | 0b          | op:end
+ 0x59 | 0b          | end
 ============== func 3 ====================
  0x5a | 06          | size of function
  0x5b | 01          | 1 local blocks
  0x5c | 01 7f       | 1 locals of type I32
- 0x5e | 41 00       | op:i32_const value:0
- 0x60 | 0b          | op:end
+ 0x5e | 41 00       | i32_const value:0
+ 0x60 | 0b          | end
  0x61 | 0b 0a       | data section
  0x63 | 02          | 2 count
  0x64 | 00          | data memory[0]
- 0x65 | 41 08       | op:i32_const value:8
- 0x67 | 0b          | op:end
+ 0x65 | 41 08       | i32_const value:8
+ 0x67 | 0b          | end
  0x68 |-------------| ... 1 bytes of data
  0x6a | 01 01       | data passive
  0x6c |-------------| ... 1 bytes of data

--- a/tests/dump/simple.wat.dump
+++ b/tests/dump/simple.wat.dump
@@ -22,8 +22,8 @@
  0x2c | 06 06       | global section
  0x2e | 01          | 1 count
  0x2f | 7f 00       | [global 0] GlobalType { content_type: I32, mutable: false }
- 0x31 | 41 00       | I32Const { value: 0 }
- 0x33 | 0b          | End
+ 0x31 | 41 00       | op:i32_const value:0
+ 0x33 | 0b          | op:end
  0x34 | 07 05       | export section
  0x36 | 01          | 1 count
  0x37 | 01 6d 02 00 | export Export { name: "m", kind: Memory, index: 0 }
@@ -32,8 +32,8 @@
  0x3e | 09 0f       | element section
  0x40 | 03          | 3 count
  0x41 | 00          | element FuncRef table[0]
- 0x42 | 41 03       | I32Const { value: 3 }
- 0x44 | 0b          | End
+ 0x42 | 41 03       | op:i32_const value:3
+ 0x44 | 0b          | op:end
  0x45 | 01          | 1 items
  0x46 | 00          | item Func(0)
  0x47 | 01 00 01    | element FuncRef passive, 1 items
@@ -45,23 +45,23 @@
 ============== func 1 ====================
  0x52 | 02          | size of function
  0x53 | 00          | 0 local blocks
- 0x54 | 0b          | End
+ 0x54 | 0b          | op:end
 ============== func 2 ====================
  0x55 | 04          | size of function
  0x56 | 01          | 1 local blocks
  0x57 | 01 7f       | 1 locals of type I32
- 0x59 | 0b          | End
+ 0x59 | 0b          | op:end
 ============== func 3 ====================
  0x5a | 06          | size of function
  0x5b | 01          | 1 local blocks
  0x5c | 01 7f       | 1 locals of type I32
- 0x5e | 41 00       | I32Const { value: 0 }
- 0x60 | 0b          | End
+ 0x5e | 41 00       | op:i32_const value:0
+ 0x60 | 0b          | op:end
  0x61 | 0b 0a       | data section
  0x63 | 02          | 2 count
  0x64 | 00          | data memory[0]
- 0x65 | 41 08       | I32Const { value: 8 }
- 0x67 | 0b          | End
+ 0x65 | 41 08       | op:i32_const value:8
+ 0x67 | 0b          | op:end
  0x68 |-------------| ... 1 bytes of data
  0x6a | 01 01       | data passive
  0x6c |-------------| ... 1 bytes of data

--- a/tests/dump/try-delegate.wat.dump
+++ b/tests/dump/try-delegate.wat.dump
@@ -11,11 +11,11 @@
 ============== func 0 ====================
  0x15 | 09          | size of function
  0x16 | 00          | 0 local blocks
- 0x17 | 06 40       | op:try ty:Empty
- 0x19 | 06 40       | op:try ty:Empty
- 0x1b | 18 00       | op:delegate relative_depth:0
- 0x1d | 0b          | op:end
- 0x1e | 0b          | op:end
+ 0x17 | 06 40       | try ty:Empty
+ 0x19 | 06 40       | try ty:Empty
+ 0x1b | 18 00       | delegate relative_depth:0
+ 0x1d | 0b          | end
+ 0x1e | 0b          | end
  0x1f | 00 0d       | custom section
  0x21 | 04 6e 61 6d | name: "name"
       | 65         

--- a/tests/dump/try-delegate.wat.dump
+++ b/tests/dump/try-delegate.wat.dump
@@ -11,11 +11,11 @@
 ============== func 0 ====================
  0x15 | 09          | size of function
  0x16 | 00          | 0 local blocks
- 0x17 | 06 40       | Try { ty: Empty }
- 0x19 | 06 40       | Try { ty: Empty }
- 0x1b | 18 00       | Delegate { relative_depth: 0 }
- 0x1d | 0b          | End
- 0x1e | 0b          | End
+ 0x17 | 06 40       | op:try ty:Empty
+ 0x19 | 06 40       | op:try ty:Empty
+ 0x1b | 18 00       | op:delegate relative_depth:0
+ 0x1d | 0b          | op:end
+ 0x1e | 0b          | op:end
  0x1f | 00 0d       | custom section
  0x21 | 04 6e 61 6d | name: "name"
       | 65         


### PR DESCRIPTION
cc #711