### PR TITLE
Fix a nightly build error in wasm-mutate

### DIFF
--- a/crates/wasm-mutate/src/module.rs
+++ b/crates/wasm-mutate/src/module.rs
@@ -88,16 +88,18 @@ macro_rules! match_section_id {
         $($pat:ident => $result:expr,)*
         _ => $otherwise:expr,
     ) => {'result: loop {
-        #![allow(unreachable_code, non_upper_case_globals)]
-        $(const $pat: u8 = SectionId::$pat as u8;)*
-        break 'result match $scrutinee {
-            $($pat => $result,)*
-            _ => $otherwise,
-        };
-        // Check exhaustiveness of the SectionId match
-        match SectionId::Type {
-            $(SectionId::$pat => (),)*
-        };
+        #[allow(unreachable_code, non_upper_case_globals)]
+        {
+            $(const $pat: u8 = SectionId::$pat as u8;)*
+            break 'result match $scrutinee {
+                $($pat => $result,)*
+                _ => $otherwise,
+            };
+            // Check exhaustiveness of the SectionId match
+            match SectionId::Type {
+                $(SectionId::$pat => (),)*
+            };
+        }
     }}
 }
 pub(crate) use match_section_id;


### PR DESCRIPTION
Looks like recent nightlies are more strict about attribute-syntax than
they were prior.