### PR TITLE
Fix a typo in parameter orderings

### DIFF
--- a/crates/dump/src/lib.rs
+++ b/crates/dump/src/lib.rs
@@ -1371,9 +1371,9 @@ impl<'a> VisitOperator<'a> for Dump<'_> {
             memarg: MemoryImmediate,
             lane: SIMDLaneIndex,
         )
-        fn visit_memory_init(&mut self, offset: usize, mem: u32, segment: u32)
+        fn visit_memory_init(&mut self, offset: usize, segment: u32, mem: u32)
         fn visit_data_drop(&mut self, offset: usize, segment: u32)
-        fn visit_memory_copy(&mut self, offset: usize, src: u32, dst: u32)
+        fn visit_memory_copy(&mut self, offset: usize, dst: u32, src: u32)
         fn visit_memory_fill(&mut self, offset: usize, mem: u32)
         fn visit_table_init(&mut self, offset: usize, segment: u32, table: u32)
         fn visit_elem_drop(&mut self, offset: usize, segment: u32)

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -1613,7 +1613,7 @@ impl<'a> BinaryReader<'a> {
             0x08 => {
                 let segment = self.read_var_u32()?;
                 let mem = self.read_var_u32()?;
-                visitor.visit_memory_init(pos, mem, segment)
+                visitor.visit_memory_init(pos, segment,mem)
             }
             0x09 => {
                 let segment = self.read_var_u32()?;
@@ -1622,7 +1622,7 @@ impl<'a> BinaryReader<'a> {
             0x0a => {
                 let dst = self.read_var_u32()?;
                 let src = self.read_var_u32()?;
-                visitor.visit_memory_copy(pos, src, dst)
+                visitor.visit_memory_copy(pos, dst,src)
             }
             0x0b => {
                 let mem = self.read_var_u32()?;
@@ -2804,9 +2804,9 @@ impl<'a> VisitOperator<'a> for OperatorFactory<'a> {
     fn visit_v128_store16_lane(&mut self, _offset: usize, memarg: MemoryImmediate, lane: SIMDLaneIndex) -> Self::Output { Operator::V128Store16Lane { memarg, lane } }
     fn visit_v128_store32_lane(&mut self, _offset: usize, memarg: MemoryImmediate, lane: SIMDLaneIndex) -> Self::Output { Operator::V128Store32Lane { memarg, lane } }
     fn visit_v128_store64_lane(&mut self, _offset: usize, memarg: MemoryImmediate, lane: SIMDLaneIndex) -> Self::Output { Operator::V128Store64Lane { memarg, lane } }
-    fn visit_memory_init(&mut self, _offset: usize, mem: u32, segment: u32) -> Self::Output { Operator::MemoryInit { mem, segment } }
+    fn visit_memory_init(&mut self, _offset: usize, segment: u32, mem: u32) -> Self::Output { Operator::MemoryInit { mem, segment } }
     fn visit_data_drop(&mut self, _offset: usize, segment: u32) -> Self::Output { Operator::DataDrop { segment } }
-    fn visit_memory_copy(&mut self, _offset: usize, src: u32, dst: u32) -> Self::Output { Operator::MemoryCopy { src, dst } }
+    fn visit_memory_copy(&mut self, _offset: usize, dst: u32, src: u32) -> Self::Output { Operator::MemoryCopy { src, dst } }
     fn visit_memory_fill(&mut self, _offset: usize, mem: u32) -> Self::Output { Operator::MemoryFill { mem } }
     fn visit_table_init(&mut self, _offset: usize, segment: u32, table: u32) -> Self::Output { Operator::TableInit { segment, table } }
     fn visit_elem_drop(&mut self, _offset: usize, segment: u32) -> Self::Output { Operator::ElemDrop { segment } }

--- a/crates/wasmparser/src/readers/core/operators.rs
+++ b/crates/wasmparser/src/readers/core/operators.rs
@@ -1404,7 +1404,7 @@ pub trait VisitOperator<'a> {
             Operator::I64TruncSatF64U => self.visit_i64_trunc_sat_f64u(offset),
             Operator::MemoryInit { segment, mem } => self.visit_memory_init(offset, segment, mem),
             Operator::DataDrop { segment } => self.visit_data_drop(offset, segment),
-            Operator::MemoryCopy { src, dst } => self.visit_memory_copy(offset, src, dst),
+            Operator::MemoryCopy { src, dst } => self.visit_memory_copy(offset, dst, src),
             Operator::MemoryFill { mem } => self.visit_memory_fill(offset, mem),
             Operator::TableInit { segment, table } => self.visit_table_init(offset, segment, table),
             Operator::ElemDrop { segment } => self.visit_elem_drop(offset, segment),
@@ -2470,9 +2470,9 @@ pub trait VisitOperator<'a> {
         memarg: MemoryImmediate,
         lane: SIMDLaneIndex,
     ) -> Self::Output;
-    fn visit_memory_init(&mut self, offset: usize, mem: u32, segment: u32) -> Self::Output;
+    fn visit_memory_init(&mut self, offset: usize, segment: u32, mem: u32) -> Self::Output;
     fn visit_data_drop(&mut self, offset: usize, segment: u32) -> Self::Output;
-    fn visit_memory_copy(&mut self, offset: usize, src: u32, dst: u32) -> Self::Output;
+    fn visit_memory_copy(&mut self, offset: usize, dst: u32, src: u32) -> Self::Output;
     fn visit_memory_fill(&mut self, offset: usize, mem: u32) -> Self::Output;
     fn visit_table_init(&mut self, offset: usize, segment: u32, table: u32) -> Self::Output;
     fn visit_elem_drop(&mut self, offset: usize, segment: u32) -> Self::Output;

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -3171,7 +3171,7 @@ where
         self.pop_operand(offset, Some(idx))?;
         Ok(())
     }
-    fn visit_memory_init(&mut self, offset: usize, mem: u32, segment: u32) -> Self::Output {
+    fn visit_memory_init(&mut self, offset: usize, segment: u32, mem: u32) -> Self::Output {
         self.check_bulk_memory_enabled(offset)?;
         let ty = self.check_memory_index(offset, mem)?;
         match self.resources.data_count() {
@@ -3193,7 +3193,7 @@ where
         }
         Ok(())
     }
-    fn visit_memory_copy(&mut self, offset: usize, src: u32, dst: u32) -> Self::Output {
+    fn visit_memory_copy(&mut self, offset: usize, dst: u32, src: u32) -> Self::Output {
         self.check_bulk_memory_enabled(offset)?;
         let dst_ty = self.check_memory_index(offset, dst)?;
         let src_ty = self.check_memory_index(offset, src)?;


### PR DESCRIPTION
This fixes a bug when using the `Operator`-based interface to the
`Validator` where the `mem` and `segment` indices were accidentally
swapped for the `memory.init` instruction. This commit goes a bit
further though and reorders method parameters to match their order of
appearance in the binary encoding, swapping the parameters in both the
`memory.init` and `memory.copy` visit functions.