### PR TITLE
Remove the `todo!()`s from wasm-smith's no trapping mode

### DIFF
--- a/crates/wasm-smith/src/core/no_traps.rs
+++ b/crates/wasm-smith/src/core/no_traps.rs
@@ -347,9 +347,11 @@ impl Module {
                         return Err(NotSupported { opcode: inst })
                     }
 
-                    Instruction::MemoryCopy { src: _, dst: _ } => todo!(),
-                    Instruction::MemoryFill(_) => todo!(),
-                    Instruction::MemoryInit { mem: _, data: _ } => todo!(),
+                    Instruction::MemoryCopy { src: _, dst: _ }
+                    | Instruction::MemoryFill(_)
+                    | Instruction::MemoryInit { mem: _, data: _ } => {
+                        return Err(NotSupported { opcode: inst })
+                    }
 
                     // Unsigned integer division and remainder will trap when
                     // the divisor is 0. To avoid the trap, we will set any 0
@@ -519,14 +521,16 @@ impl Module {
                         // [input_or_0:conv_type]
                         new_insts.push(inst);
                     }
-                    Instruction::TableFill { table: _ } => todo!(),
-                    Instruction::TableSet { table: _ } => todo!(),
-                    Instruction::TableGet { table: _ } => todo!(),
-                    Instruction::TableInit {
+                    Instruction::TableFill { table: _ }
+                    | Instruction::TableSet { table: _ }
+                    | Instruction::TableGet { table: _ }
+                    | Instruction::TableInit {
                         segment: _,
                         table: _,
-                    } => todo!(),
-                    Instruction::TableCopy { src: _, dst: _ } => todo!(),
+                    }
+                    | Instruction::TableCopy { src: _, dst: _ } => {
+                        return Err(NotSupported { opcode: inst })
+                    }
 
                     // None of the other instructions can trap, so just copy them over.
                     inst => new_insts.push(inst),


### PR DESCRIPTION
Accidentally left these in when initially writing this. We're removing them and returning NotSupported for now instead of panicking.