### PR TITLE
Bump crate version numbers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-tools"
-version = "1.0.9"
+version = "1.0.10"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 description = "CLI tools for interoperating with WebAssembly files"
@@ -22,33 +22,33 @@ env_logger = "0.9"
 log = "0.4"
 clap = { version = "3.1.8", features = ['derive'] }
 tempfile = "3.2.0"
-wat = { path = "crates/wat", version = '1.0.47' }
+wat = { path = "crates/wat", version = '1.0.48' }
 
 # Dependencies of `validate`
-wasmparser = { path = "crates/wasmparser", optional = true, version = '0.88.0' }
+wasmparser = { path = "crates/wasmparser", optional = true, version = '0.89.0' }
 rayon = { version = "1.0", optional = true }
 
 # Dependencies of `print`
-wasmprinter = { path = "crates/wasmprinter", version = '0.2.38' }
+wasmprinter = { path = "crates/wasmprinter", version = '0.2.39' }
 
 # Dependencies of `smith`
 arbitrary = { version = "1.0.0", optional = true }
 serde = { version = "1", features = ['derive'], optional = true }
 serde_json = { version = "1", optional = true }
-wasm-smith = { path = "crates/wasm-smith", features = ["_internal_cli"], optional = true, version = '0.11.3' }
+wasm-smith = { path = "crates/wasm-smith", features = ["_internal_cli"], optional = true, version = '0.11.4' }
 
 # Dependencies of `shrink`
-wasm-shrink = { path = "crates/wasm-shrink", features = ["clap"], optional = true, version = '0.1.8' }
+wasm-shrink = { path = "crates/wasm-shrink", features = ["clap"], optional = true, version = '0.1.9' }
 is_executable = { version = "1.0.1", optional = true }
 
 # Dependencies of `mutate`
-wasm-mutate = { path = "crates/wasm-mutate", features = ["clap"], optional = true, version = '0.2.6' }
+wasm-mutate = { path = "crates/wasm-mutate", features = ["clap"], optional = true, version = '0.2.7' }
 
 # Dependencies of `dump`
-wasmparser-dump = { path = "crates/dump", optional = true, version = '0.1.6' }
+wasmparser-dump = { path = "crates/dump", optional = true, version = '0.1.7' }
 
 # Dependencies of `strip`
-wasm-encoder = { path = "crates/wasm-encoder", optional = true, version = '0.15.0' }
+wasm-encoder = { path = "crates/wasm-encoder", optional = true, version = '0.16.0' }
 
 # Dependencies of `compose`
 wasm-compose = { path = "crates/wasm-compose", optional = true, version = '0.1.0', features = ['cli'] }

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -23,7 +23,7 @@ wasmparser-dump = { version = "0.1.4", path = "../dump" }
 wasm-mutate = { version = "0.2.4", path = "../wasm-mutate" }
 wasm-shrink = { version = "0.1.6", path = "../wasm-shrink" }
 wasm-smith = { version = "0.11.2", path = "../wasm-smith" }
-wasmparser = { version = "0.88.0", path = "../wasmparser" }
+wasmparser = { version = "0.89.0", path = "../wasmparser" }
 wasmprinter = { version = "0.2.36", path = "../wasmprinter" }
-wast = { version = "45.0.0", path = "../wast" }
+wast = { version = "46.0.0", path = "../wast" }
 wat = { version = "1.0.44", path = "../wat" }

--- a/crates/dump/Cargo.toml
+++ b/crates/dump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser-dump"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -9,4 +9,4 @@ description = "Utility to dump debug information about the wasm binary format"
 
 [dependencies]
 anyhow = "1"
-wasmparser = { path = "../wasmparser", version = "0.88.0" }
+wasmparser = { path = "../wasmparser", version = "0.89.0" }

--- a/crates/wasm-compose/Cargo.toml
+++ b/crates/wasm-compose/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-compose"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Peter Huene <peter@huene.dev>"]
 license = "Apache-2.0 WITH LLVM-exception"
@@ -11,9 +11,9 @@ documentation = "https://docs.rs/wasm-compose"
 description = "A library for composing WebAssembly components."
 
 [dependencies]
-wat = { version = "1.0.47", path = "../wat" }
-wasm-encoder = { version = "0.15.0", path = "../wasm-encoder" }
-wasmparser = { version = "0.88.0", path = "../wasmparser" }
+wat = { version = "1.0.48", path = "../wat" }
+wasm-encoder = { version = "0.16.0", path = "../wasm-encoder" }
+wasmparser = { version = "0.89.0", path = "../wasmparser" }
 indexmap = { version = "1.9.1", features = ["serde"] }
 anyhow = "1.0.58"
 serde = { version = "1.0.137", features = ["derive"] }
@@ -29,4 +29,4 @@ cli = ["clap"]
 [dev-dependencies]
 glob = "0.3.0"
 pretty_assertions = "1.2.1"
-wasmprinter = { version = "0.2.37", path = "../wasmprinter" }
+wasmprinter = { version = "0.2.39", path = "../wasmprinter" }

--- a/crates/wasm-compose/example/backend/Cargo.toml
+++ b/crates/wasm-compose/example/backend/Cargo.toml
@@ -2,6 +2,7 @@
 name = "backend"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", default_features = false }

--- a/crates/wasm-compose/example/middleware/Cargo.toml
+++ b/crates/wasm-compose/example/middleware/Cargo.toml
@@ -2,6 +2,7 @@
 name = "middleware"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 flate2 = "1.0.24"

--- a/crates/wasm-compose/example/server/Cargo.toml
+++ b/crates/wasm-compose/example/server/Cargo.toml
@@ -2,6 +2,7 @@
 name = "host"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }

--- a/crates/wasm-compose/example/service/Cargo.toml
+++ b/crates/wasm-compose/example/service/Cargo.toml
@@ -2,6 +2,7 @@
 name = "svc"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 wit-bindgen-rust = { git = "https://github.com/bytecodealliance/wit-bindgen", default_features = false }

--- a/crates/wasm-encoder/Cargo.toml
+++ b/crates/wasm-encoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-encoder"
-version = "0.15.0"
+version = "0.16.0"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasm-mutate/Cargo.toml
+++ b/crates/wasm-mutate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-mutate"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-mutate"
@@ -9,8 +9,8 @@ description = "A WebAssembly test case mutator"
 [dependencies]
 clap = { optional = true, version = "3.0", features = ['derive'] }
 thiserror = "1.0.28"
-wasmparser = { version = "0.88.0", path = "../wasmparser" }
-wasm-encoder = { version = "0.15.0", path = "../wasm-encoder"}
+wasmparser = { version = "0.89.0", path = "../wasmparser" }
+wasm-encoder = { version = "0.16.0", path = "../wasm-encoder"}
 rand = { version = "0.8.0", features = ["small_rng"] }
 log = "0.4.14"
 egg = "0.6.0"

--- a/crates/wasm-shrink/Cargo.toml
+++ b/crates/wasm-shrink/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-shrink"
 name = "wasm-shrink"
-version = "0.1.8"
+version = "0.1.9"
 
 [dependencies]
 anyhow = "1"
@@ -16,8 +16,8 @@ blake3 = "1.2.0"
 log = "0.4"
 rand = { version = "0.8.4", features = ["small_rng"] }
 clap = { version = "3.0", optional = true, features = ['derive'] }
-wasm-mutate = { version = "0.2.6", path = "../wasm-mutate" }
-wasmparser = { version = "0.88.0", path = "../wasmparser" }
+wasm-mutate = { version = "0.2.7", path = "../wasm-mutate" }
+wasmparser = { version = "0.89.0", path = "../wasmparser" }
 
 [dev-dependencies]
 env_logger = "0.9"

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "wasm-smith"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-smith"
-version = "0.11.3"
+version = "0.11.4"
 exclude = ["/benches/corpus"]
 
 [[bench]]
@@ -21,8 +21,8 @@ flagset = "0.4"
 indexmap = "1.6"
 leb128 = "0.2.4"
 serde = { version = "1", features = ['derive'], optional = true }
-wasm-encoder = { version = "0.15.0", path = "../wasm-encoder" }
-wasmparser = { version = "0.88.0", path = "../wasmparser" }
+wasm-encoder = { version = "0.16.0", path = "../wasm-encoder" }
+wasmparser = { version = "0.89.0", path = "../wasmparser" }
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.88.0"
+version = "0.89.0"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser"

--- a/crates/wasmprinter/Cargo.toml
+++ b/crates/wasmprinter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmprinter"
-version = "0.2.38"
+version = "0.2.39"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -14,7 +14,7 @@ Rust converter from the WebAssembly binary format to the text format.
 
 [dependencies]
 anyhow = "1.0"
-wasmparser = { path = '../wasmparser', version = '0.88.0' }
+wasmparser = { path = '../wasmparser', version = '0.89.0' }
 
 [dev-dependencies]
 diff = "0.1"

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wast"
-version = "45.0.0"
+version = "46.0.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -16,7 +16,7 @@ Customizable Rust parsers for the WebAssembly Text formats WAT and WAST
 leb128 = "0.2"
 unicode-width = "0.1.9"
 memchr = "2.4.1"
-wasm-encoder = { version = "0.15.0", path = "../wasm-encoder" }
+wasm-encoder = { version = "0.16.0", path = "../wasm-encoder" }
 
 [dev-dependencies]
 anyhow = "1.0"

--- a/crates/wat/Cargo.toml
+++ b/crates/wat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wat"
-version = "1.0.47"
+version = "1.0.48"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition = "2021"
 license = "Apache-2.0 WITH LLVM-exception"
@@ -13,4 +13,4 @@ Rust parser for the WebAssembly Text format, WAT
 """
 
 [dependencies]
-wast = { path = '../wast', version = '45.0.0' }
+wast = { path = '../wast', version = '46.0.0' }

--- a/publish.rs
+++ b/publish.rs
@@ -36,6 +36,7 @@ const CRATES_TO_PUBLISH: &[&str] = &[
     "wasm-mutate",
     "wasm-shrink",
     "wasm-tools",
+    "wasm-compose",
 ];
 
 #[derive(Clone)]


### PR DESCRIPTION
This'll be used to pull all the recent changes into Wasmtime, namely
around parsing operators and the component model.