### PR TITLE
Migrate `wasmprinter` to `visit_with_offset`

### DIFF
--- a/crates/wasmparser/src/readers/core/operators.rs
+++ b/crates/wasmparser/src/readers/core/operators.rs
@@ -1737,8 +1737,8 @@ pub trait VisitOperator<'a> {
         }
     }
 
-    fn visit_nop(&mut self, offset: usize) -> Self::Output;
     fn visit_unreachable(&mut self, offset: usize) -> Self::Output;
+    fn visit_nop(&mut self, offset: usize) -> Self::Output;
     fn visit_block(&mut self, offset: usize, ty: BlockType) -> Self::Output;
     fn visit_loop(&mut self, offset: usize, ty: BlockType) -> Self::Output;
     fn visit_if(&mut self, offset: usize, ty: BlockType) -> Self::Output;
@@ -1772,11 +1772,22 @@ pub trait VisitOperator<'a> {
     fn visit_drop(&mut self, offset: usize) -> Self::Output;
     fn visit_select(&mut self, offset: usize) -> Self::Output;
     fn visit_typed_select(&mut self, offset: usize, ty: ValType) -> Self::Output;
+    fn visit_ref_null(&mut self, offset: usize, ty: ValType) -> Self::Output;
+    fn visit_ref_is_null(&mut self, offset: usize) -> Self::Output;
+    fn visit_ref_func(&mut self, offset: usize, function_index: u32) -> Self::Output;
     fn visit_local_get(&mut self, offset: usize, local_index: u32) -> Self::Output;
     fn visit_local_set(&mut self, offset: usize, local_index: u32) -> Self::Output;
     fn visit_local_tee(&mut self, offset: usize, local_index: u32) -> Self::Output;
     fn visit_global_get(&mut self, offset: usize, global_index: u32) -> Self::Output;
     fn visit_global_set(&mut self, offset: usize, global_index: u32) -> Self::Output;
+    fn visit_table_get(&mut self, offset: usize, table: u32) -> Self::Output;
+    fn visit_table_set(&mut self, offset: usize, table: u32) -> Self::Output;
+    fn visit_table_init(&mut self, offset: usize, segment: u32, table: u32) -> Self::Output;
+    fn visit_elem_drop(&mut self, offset: usize, segment: u32) -> Self::Output;
+    fn visit_table_copy(&mut self, offset: usize, dst_table: u32, src_table: u32) -> Self::Output;
+    fn visit_table_grow(&mut self, offset: usize, table: u32) -> Self::Output;
+    fn visit_table_size(&mut self, offset: usize, table: u32) -> Self::Output;
+    fn visit_table_fill(&mut self, offset: usize, table: u32) -> Self::Output;
     fn visit_i32_load(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
     fn visit_i64_load(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
     fn visit_f32_load(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
@@ -1802,6 +1813,10 @@ pub trait VisitOperator<'a> {
     fn visit_i64_store32(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
     fn visit_memory_size(&mut self, offset: usize, mem: u32, mem_byte: u8) -> Self::Output;
     fn visit_memory_grow(&mut self, offset: usize, mem: u32, mem_byte: u8) -> Self::Output;
+    fn visit_memory_init(&mut self, offset: usize, segment: u32, mem: u32) -> Self::Output;
+    fn visit_data_drop(&mut self, offset: usize, segment: u32) -> Self::Output;
+    fn visit_memory_copy(&mut self, offset: usize, dst: u32, src: u32) -> Self::Output;
+    fn visit_memory_fill(&mut self, offset: usize, mem: u32) -> Self::Output;
     fn visit_i32_const(&mut self, offset: usize, value: i32) -> Self::Output;
     fn visit_i64_const(&mut self, offset: usize, value: i64) -> Self::Output;
     fn visit_f32_const(&mut self, offset: usize, value: Ieee32) -> Self::Output;
@@ -1929,6 +1944,11 @@ pub trait VisitOperator<'a> {
     fn visit_i64_reinterpret_f64(&mut self, offset: usize) -> Self::Output;
     fn visit_f32_reinterpret_i32(&mut self, offset: usize) -> Self::Output;
     fn visit_f64_reinterpret_i64(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32_extend8_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32_extend16_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64_extend8_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64_extend16_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64_extend32_s(&mut self, offset: usize) -> Self::Output;
     fn visit_i32_trunc_sat_f32s(&mut self, offset: usize) -> Self::Output;
     fn visit_i32_trunc_sat_f32u(&mut self, offset: usize) -> Self::Output;
     fn visit_i32_trunc_sat_f64s(&mut self, offset: usize) -> Self::Output;
@@ -1937,227 +1957,6 @@ pub trait VisitOperator<'a> {
     fn visit_i64_trunc_sat_f32u(&mut self, offset: usize) -> Self::Output;
     fn visit_i64_trunc_sat_f64s(&mut self, offset: usize) -> Self::Output;
     fn visit_i64_trunc_sat_f64u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32_extend8_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32_extend16_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64_extend8_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64_extend16_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64_extend32_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32_atomic_load(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
-    fn visit_i32_atomic_load16_u(&mut self, offset: usize, memarg: MemoryImmediate)
-        -> Self::Output;
-    fn visit_i32_atomic_load8_u(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
-    fn visit_i64_atomic_load(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
-    fn visit_i64_atomic_load32_u(&mut self, offset: usize, memarg: MemoryImmediate)
-        -> Self::Output;
-    fn visit_i64_atomic_load16_u(&mut self, offset: usize, memarg: MemoryImmediate)
-        -> Self::Output;
-    fn visit_i64_atomic_load8_u(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
-    fn visit_i32_atomic_store(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
-    fn visit_i32_atomic_store16(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
-    fn visit_i32_atomic_store8(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
-    fn visit_i64_atomic_store(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
-    fn visit_i64_atomic_store32(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
-    fn visit_i64_atomic_store16(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
-    fn visit_i64_atomic_store8(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
-    fn visit_i32_atomic_rmw_add(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
-    fn visit_i32_atomic_rmw_sub(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
-    fn visit_i32_atomic_rmw_and(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
-    fn visit_i32_atomic_rmw_or(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
-    fn visit_i32_atomic_rmw_xor(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
-    fn visit_i32_atomic_rmw16_add_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i32_atomic_rmw16_sub_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i32_atomic_rmw16_and_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i32_atomic_rmw16_or_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i32_atomic_rmw16_xor_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i32_atomic_rmw8_add_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i32_atomic_rmw8_sub_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i32_atomic_rmw8_and_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i32_atomic_rmw8_or_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i32_atomic_rmw8_xor_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i64_atomic_rmw_add(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
-    fn visit_i64_atomic_rmw_sub(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
-    fn visit_i64_atomic_rmw_and(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
-    fn visit_i64_atomic_rmw_or(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
-    fn visit_i64_atomic_rmw_xor(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
-    fn visit_i64_atomic_rmw32_add_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i64_atomic_rmw32_sub_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i64_atomic_rmw32_and_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i64_atomic_rmw32_or_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i64_atomic_rmw32_xor_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i64_atomic_rmw16_add_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i64_atomic_rmw16_sub_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i64_atomic_rmw16_and_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i64_atomic_rmw16_or_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i64_atomic_rmw16_xor_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i64_atomic_rmw8_add_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i64_atomic_rmw8_sub_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i64_atomic_rmw8_and_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i64_atomic_rmw8_or_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i64_atomic_rmw8_xor_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i32_atomic_rmw_xchg(&mut self, offset: usize, memarg: MemoryImmediate)
-        -> Self::Output;
-    fn visit_i32_atomic_rmw16_xchg_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i32_atomic_rmw8_xchg_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i32_atomic_rmw_cmpxchg(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i32_atomic_rmw16_cmpxchg_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i32_atomic_rmw8_cmpxchg_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i64_atomic_rmw_xchg(&mut self, offset: usize, memarg: MemoryImmediate)
-        -> Self::Output;
-    fn visit_i64_atomic_rmw32_xchg_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i64_atomic_rmw16_xchg_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i64_atomic_rmw8_xchg_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i64_atomic_rmw_cmpxchg(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i64_atomic_rmw32_cmpxchg_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i64_atomic_rmw16_cmpxchg_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
-    fn visit_i64_atomic_rmw8_cmpxchg_u(
-        &mut self,
-        offset: usize,
-        memarg: MemoryImmediate,
-    ) -> Self::Output;
     fn visit_memory_atomic_notify(
         &mut self,
         offset: usize,
@@ -2174,254 +1973,244 @@ pub trait VisitOperator<'a> {
         memarg: MemoryImmediate,
     ) -> Self::Output;
     fn visit_atomic_fence(&mut self, offset: usize, flags: u8) -> Self::Output;
-    fn visit_ref_null(&mut self, offset: usize, ty: ValType) -> Self::Output;
-    fn visit_ref_is_null(&mut self, offset: usize) -> Self::Output;
-    fn visit_ref_func(&mut self, offset: usize, function_index: u32) -> Self::Output;
+    fn visit_i32_atomic_load(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
+    fn visit_i64_atomic_load(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
+    fn visit_i32_atomic_load8_u(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
+    fn visit_i32_atomic_load16_u(&mut self, offset: usize, memarg: MemoryImmediate)
+        -> Self::Output;
+    fn visit_i64_atomic_load8_u(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
+    fn visit_i64_atomic_load16_u(&mut self, offset: usize, memarg: MemoryImmediate)
+        -> Self::Output;
+    fn visit_i64_atomic_load32_u(&mut self, offset: usize, memarg: MemoryImmediate)
+        -> Self::Output;
+    fn visit_i32_atomic_store(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
+    fn visit_i64_atomic_store(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
+    fn visit_i32_atomic_store8(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
+    fn visit_i32_atomic_store16(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
+    fn visit_i64_atomic_store8(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
+    fn visit_i64_atomic_store16(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
+    fn visit_i64_atomic_store32(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
+
+    fn visit_i32_atomic_rmw_add(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
+    fn visit_i64_atomic_rmw_add(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
+    fn visit_i32_atomic_rmw8_add_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i32_atomic_rmw16_add_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i64_atomic_rmw8_add_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i64_atomic_rmw16_add_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i64_atomic_rmw32_add_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+
+    fn visit_i32_atomic_rmw_sub(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
+    fn visit_i64_atomic_rmw_sub(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
+    fn visit_i32_atomic_rmw8_sub_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i32_atomic_rmw16_sub_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i64_atomic_rmw8_sub_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i64_atomic_rmw16_sub_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i64_atomic_rmw32_sub_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+
+    fn visit_i32_atomic_rmw_and(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
+    fn visit_i64_atomic_rmw_and(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
+    fn visit_i32_atomic_rmw8_and_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i32_atomic_rmw16_and_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i64_atomic_rmw8_and_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i64_atomic_rmw16_and_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i64_atomic_rmw32_and_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+
+    fn visit_i32_atomic_rmw_or(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
+    fn visit_i64_atomic_rmw_or(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
+    fn visit_i32_atomic_rmw8_or_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i32_atomic_rmw16_or_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i64_atomic_rmw8_or_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i64_atomic_rmw16_or_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i64_atomic_rmw32_or_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+
+    fn visit_i32_atomic_rmw_xor(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
+    fn visit_i64_atomic_rmw_xor(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
+    fn visit_i32_atomic_rmw8_xor_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i32_atomic_rmw16_xor_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i64_atomic_rmw8_xor_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i64_atomic_rmw16_xor_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i64_atomic_rmw32_xor_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+
+    fn visit_i32_atomic_rmw_xchg(&mut self, offset: usize, memarg: MemoryImmediate)
+        -> Self::Output;
+    fn visit_i64_atomic_rmw_xchg(&mut self, offset: usize, memarg: MemoryImmediate)
+        -> Self::Output;
+    fn visit_i32_atomic_rmw8_xchg_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i32_atomic_rmw16_xchg_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i64_atomic_rmw8_xchg_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i64_atomic_rmw16_xchg_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i64_atomic_rmw32_xchg_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+
+    fn visit_i32_atomic_rmw_cmpxchg(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i64_atomic_rmw_cmpxchg(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i32_atomic_rmw8_cmpxchg_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i32_atomic_rmw16_cmpxchg_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i64_atomic_rmw8_cmpxchg_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i64_atomic_rmw16_cmpxchg_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+    fn visit_i64_atomic_rmw32_cmpxchg_u(
+        &mut self,
+        offset: usize,
+        memarg: MemoryImmediate,
+    ) -> Self::Output;
+
     fn visit_v128_load(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
-    fn visit_v128_store(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
-    fn visit_v128_const(&mut self, offset: usize, value: V128) -> Self::Output;
-    fn visit_i8x16_splat(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_splat(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_splat(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64x2_splat(&mut self, offset: usize) -> Self::Output;
-    fn visit_f32x4_splat(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_splat(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_extract_lane_s(&mut self, offset: usize, lane: SIMDLaneIndex) -> Self::Output;
-    fn visit_i8x16_extract_lane_u(&mut self, offset: usize, lane: SIMDLaneIndex) -> Self::Output;
-    fn visit_i16x8_extract_lane_s(&mut self, offset: usize, lane: SIMDLaneIndex) -> Self::Output;
-    fn visit_i16x8_extract_lane_u(&mut self, offset: usize, lane: SIMDLaneIndex) -> Self::Output;
-    fn visit_i32x4_extract_lane(&mut self, offset: usize, lane: SIMDLaneIndex) -> Self::Output;
-    fn visit_i8x16_replace_lane(&mut self, offset: usize, lane: SIMDLaneIndex) -> Self::Output;
-    fn visit_i16x8_replace_lane(&mut self, offset: usize, lane: SIMDLaneIndex) -> Self::Output;
-    fn visit_i32x4_replace_lane(&mut self, offset: usize, lane: SIMDLaneIndex) -> Self::Output;
-    fn visit_i64x2_extract_lane(&mut self, offset: usize, lane: SIMDLaneIndex) -> Self::Output;
-    fn visit_i64x2_replace_lane(&mut self, offset: usize, lane: SIMDLaneIndex) -> Self::Output;
-    fn visit_f32x4_extract_lane(&mut self, offset: usize, lane: SIMDLaneIndex) -> Self::Output;
-    fn visit_f32x4_replace_lane(&mut self, offset: usize, lane: SIMDLaneIndex) -> Self::Output;
-    fn visit_f64x2_extract_lane(&mut self, offset: usize, lane: SIMDLaneIndex) -> Self::Output;
-    fn visit_f64x2_replace_lane(&mut self, offset: usize, lane: SIMDLaneIndex) -> Self::Output;
-    fn visit_f32x4_eq(&mut self, offset: usize) -> Self::Output;
-    fn visit_f32x4_ne(&mut self, offset: usize) -> Self::Output;
-    fn visit_f32x4_lt(&mut self, offset: usize) -> Self::Output;
-    fn visit_f32x4_gt(&mut self, offset: usize) -> Self::Output;
-    fn visit_f32x4_le(&mut self, offset: usize) -> Self::Output;
-    fn visit_f32x4_ge(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_eq(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_ne(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_lt(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_gt(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_le(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_ge(&mut self, offset: usize) -> Self::Output;
-    fn visit_f32x4_add(&mut self, offset: usize) -> Self::Output;
-    fn visit_f32x4_sub(&mut self, offset: usize) -> Self::Output;
-    fn visit_f32x4_mul(&mut self, offset: usize) -> Self::Output;
-    fn visit_f32x4_div(&mut self, offset: usize) -> Self::Output;
-    fn visit_f32x4_min(&mut self, offset: usize) -> Self::Output;
-    fn visit_f32x4_max(&mut self, offset: usize) -> Self::Output;
-    fn visit_f32x4_p_min(&mut self, offset: usize) -> Self::Output;
-    fn visit_f32x4_p_max(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_add(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_sub(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_mul(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_div(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_min(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_max(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_p_min(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_p_max(&mut self, offset: usize) -> Self::Output;
-    fn visit_f32x4_relaxed_min(&mut self, offset: usize) -> Self::Output;
-    fn visit_f32x4_relaxed_max(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_relaxed_min(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_relaxed_max(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_eq(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_ne(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_lt_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_lt_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_gt_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_gt_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_le_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_le_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_ge_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_ge_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_eq(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_ne(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_lt_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_lt_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_gt_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_gt_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_le_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_le_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_ge_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_ge_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_eq(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_ne(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_lt_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_lt_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_gt_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_gt_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_le_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_le_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_ge_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_ge_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64x2_eq(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64x2_ne(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64x2_lt_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64x2_gt_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64x2_le_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64x2_ge_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_v128_and(&mut self, offset: usize) -> Self::Output;
-    fn visit_v128_and_not(&mut self, offset: usize) -> Self::Output;
-    fn visit_v128_or(&mut self, offset: usize) -> Self::Output;
-    fn visit_v128_xor(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_add(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_add_sat_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_add_sat_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_sub(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_sub_sat_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_sub_sat_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_min_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_min_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_max_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_max_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_add(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_add_sat_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_add_sat_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_sub(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_sub_sat_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_sub_sat_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_mul(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_min_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_min_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_max_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_max_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_add(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_sub(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_mul(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_min_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_min_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_max_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_max_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_dot_i16x8_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64x2_add(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64x2_sub(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64x2_mul(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_rounding_average_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_rounding_average_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_narrow_i16x8_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_narrow_i16x8_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_narrow_i32x4_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_narrow_i32x4_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_ext_mul_low_i8x16_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_ext_mul_high_i8x16_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_ext_mul_low_i8x16_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_ext_mul_high_i8x16_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_ext_mul_low_i16x8_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_ext_mul_high_i16x8_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_ext_mul_low_i16x8_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_ext_mul_high_i16x8_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64x2_ext_mul_low_i32x4_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64x2_ext_mul_high_i32x4_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64x2_ext_mul_low_i32x4_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64x2_ext_mul_high_i32x4_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_q15_mulr_sat_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_f32x4_ceil(&mut self, offset: usize) -> Self::Output;
-    fn visit_f32x4_floor(&mut self, offset: usize) -> Self::Output;
-    fn visit_f32x4_trunc(&mut self, offset: usize) -> Self::Output;
-    fn visit_f32x4_nearest(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_ceil(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_floor(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_trunc(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_nearest(&mut self, offset: usize) -> Self::Output;
-    fn visit_f32x4_abs(&mut self, offset: usize) -> Self::Output;
-    fn visit_f32x4_neg(&mut self, offset: usize) -> Self::Output;
-    fn visit_f32x4_sqrt(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_abs(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_neg(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_sqrt(&mut self, offset: usize) -> Self::Output;
-    fn visit_f32x4_demote_f64x2_zero(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_promote_low_f32x4(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_convert_low_i32x4_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_convert_low_i32x4_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_trunc_sat_f32x4_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_trunc_sat_f32x4_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_trunc_sat_f64x2_s_zero(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_trunc_sat_f64x2_u_zero(&mut self, offset: usize) -> Self::Output;
-    fn visit_f32x4_convert_i32x4_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_f32x4_convert_i32x4_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_v128_not(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_abs(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_neg(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_popcnt(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_abs(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_neg(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_abs(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_neg(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64x2_abs(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64x2_neg(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_extend_low_i8x16_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_extend_high_i8x16_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_extend_low_i8x16_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_extend_high_i8x16_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_extend_low_i16x8_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_extend_high_i16x8_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_extend_low_i16x8_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_extend_high_i16x8_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64x2_extend_low_i32x4_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64x2_extend_high_i32x4_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64x2_extend_low_i32x4_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64x2_extend_high_i32x4_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_ext_add_pairwise_i8x16_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_ext_add_pairwise_i8x16_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_ext_add_pairwise_i16x8_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_ext_add_pairwise_i16x8_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_relaxed_trunc_sat_f32x4_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_relaxed_trunc_sat_f32x4_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_relaxed_trunc_sat_f64x2_s_zero(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_relaxed_trunc_sat_f64x2_u_zero(&mut self, offset: usize) -> Self::Output;
-    fn visit_v128_bitselect(&mut self, offset: usize) -> Self::Output;
-    fn visit_f32x4_fma(&mut self, offset: usize) -> Self::Output;
-    fn visit_f32x4_fms(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_fma(&mut self, offset: usize) -> Self::Output;
-    fn visit_f64x2_fms(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_lane_select(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_lane_select(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_lane_select(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64x2_lane_select(&mut self, offset: usize) -> Self::Output;
-    fn visit_v128_any_true(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_all_true(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_bitmask(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_all_true(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_bitmask(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_all_true(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_bitmask(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64x2_all_true(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64x2_bitmask(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_shl(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_shr_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_shr_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_shl(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_shr_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i16x8_shr_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_shl(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_shr_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i32x4_shr_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64x2_shl(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64x2_shr_s(&mut self, offset: usize) -> Self::Output;
-    fn visit_i64x2_shr_u(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_swizzle(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_relaxed_swizzle(&mut self, offset: usize) -> Self::Output;
-    fn visit_i8x16_shuffle(&mut self, offset: usize, lanes: [SIMDLaneIndex; 16]) -> Self::Output;
-    fn visit_v128_load8_splat(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
-    fn visit_v128_load16_splat(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
-    fn visit_v128_load32_splat(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
-    fn visit_v128_load32_zero(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
-    fn visit_v128_load64_splat(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
-    fn visit_v128_load64_zero(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
     fn visit_v128_load8x8_s(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
     fn visit_v128_load8x8_u(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
     fn visit_v128_load16x4_s(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
     fn visit_v128_load16x4_u(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
     fn visit_v128_load32x2_s(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
     fn visit_v128_load32x2_u(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
+    fn visit_v128_load8_splat(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
+    fn visit_v128_load16_splat(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
+    fn visit_v128_load32_splat(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
+    fn visit_v128_load64_splat(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
+    fn visit_v128_load32_zero(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
+    fn visit_v128_load64_zero(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
+    fn visit_v128_store(&mut self, offset: usize, memarg: MemoryImmediate) -> Self::Output;
     fn visit_v128_load8_lane(
         &mut self,
         offset: usize,
@@ -2470,16 +2259,237 @@ pub trait VisitOperator<'a> {
         memarg: MemoryImmediate,
         lane: SIMDLaneIndex,
     ) -> Self::Output;
-    fn visit_memory_init(&mut self, offset: usize, segment: u32, mem: u32) -> Self::Output;
-    fn visit_data_drop(&mut self, offset: usize, segment: u32) -> Self::Output;
-    fn visit_memory_copy(&mut self, offset: usize, dst: u32, src: u32) -> Self::Output;
-    fn visit_memory_fill(&mut self, offset: usize, mem: u32) -> Self::Output;
-    fn visit_table_init(&mut self, offset: usize, segment: u32, table: u32) -> Self::Output;
-    fn visit_elem_drop(&mut self, offset: usize, segment: u32) -> Self::Output;
-    fn visit_table_copy(&mut self, offset: usize, dst_table: u32, src_table: u32) -> Self::Output;
-    fn visit_table_get(&mut self, offset: usize, table: u32) -> Self::Output;
-    fn visit_table_set(&mut self, offset: usize, table: u32) -> Self::Output;
-    fn visit_table_grow(&mut self, offset: usize, table: u32) -> Self::Output;
-    fn visit_table_size(&mut self, offset: usize, table: u32) -> Self::Output;
-    fn visit_table_fill(&mut self, offset: usize, table: u32) -> Self::Output;
+
+    fn visit_v128_const(&mut self, offset: usize, value: V128) -> Self::Output;
+    fn visit_i8x16_shuffle(&mut self, offset: usize, lanes: [SIMDLaneIndex; 16]) -> Self::Output;
+    fn visit_i8x16_extract_lane_s(&mut self, offset: usize, lane: SIMDLaneIndex) -> Self::Output;
+    fn visit_i8x16_extract_lane_u(&mut self, offset: usize, lane: SIMDLaneIndex) -> Self::Output;
+    fn visit_i8x16_replace_lane(&mut self, offset: usize, lane: SIMDLaneIndex) -> Self::Output;
+    fn visit_i16x8_extract_lane_s(&mut self, offset: usize, lane: SIMDLaneIndex) -> Self::Output;
+    fn visit_i16x8_extract_lane_u(&mut self, offset: usize, lane: SIMDLaneIndex) -> Self::Output;
+    fn visit_i16x8_replace_lane(&mut self, offset: usize, lane: SIMDLaneIndex) -> Self::Output;
+    fn visit_i32x4_extract_lane(&mut self, offset: usize, lane: SIMDLaneIndex) -> Self::Output;
+    fn visit_i32x4_replace_lane(&mut self, offset: usize, lane: SIMDLaneIndex) -> Self::Output;
+    fn visit_i64x2_extract_lane(&mut self, offset: usize, lane: SIMDLaneIndex) -> Self::Output;
+    fn visit_i64x2_replace_lane(&mut self, offset: usize, lane: SIMDLaneIndex) -> Self::Output;
+    fn visit_f32x4_extract_lane(&mut self, offset: usize, lane: SIMDLaneIndex) -> Self::Output;
+    fn visit_f32x4_replace_lane(&mut self, offset: usize, lane: SIMDLaneIndex) -> Self::Output;
+    fn visit_f64x2_extract_lane(&mut self, offset: usize, lane: SIMDLaneIndex) -> Self::Output;
+    fn visit_f64x2_replace_lane(&mut self, offset: usize, lane: SIMDLaneIndex) -> Self::Output;
+
+    fn visit_i8x16_swizzle(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_splat(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_splat(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_splat(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64x2_splat(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_splat(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_splat(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_eq(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_ne(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_lt_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_lt_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_gt_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_gt_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_le_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_le_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_ge_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_ge_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_eq(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_ne(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_lt_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_lt_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_gt_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_gt_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_le_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_le_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_ge_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_ge_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_eq(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_ne(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_lt_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_lt_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_gt_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_gt_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_le_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_le_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_ge_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_ge_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64x2_eq(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64x2_ne(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64x2_lt_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64x2_gt_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64x2_le_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64x2_ge_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_eq(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_ne(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_lt(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_gt(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_le(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_ge(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_eq(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_ne(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_lt(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_gt(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_le(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_ge(&mut self, offset: usize) -> Self::Output;
+    fn visit_v128_not(&mut self, offset: usize) -> Self::Output;
+    fn visit_v128_and(&mut self, offset: usize) -> Self::Output;
+    fn visit_v128_and_not(&mut self, offset: usize) -> Self::Output;
+    fn visit_v128_or(&mut self, offset: usize) -> Self::Output;
+    fn visit_v128_xor(&mut self, offset: usize) -> Self::Output;
+    fn visit_v128_bitselect(&mut self, offset: usize) -> Self::Output;
+    fn visit_v128_any_true(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_abs(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_neg(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_popcnt(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_all_true(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_bitmask(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_narrow_i16x8_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_narrow_i16x8_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_shl(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_shr_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_shr_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_add(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_add_sat_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_add_sat_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_sub(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_sub_sat_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_sub_sat_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_min_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_min_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_max_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_max_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_rounding_average_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_ext_add_pairwise_i8x16_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_ext_add_pairwise_i8x16_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_abs(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_neg(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_q15_mulr_sat_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_all_true(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_bitmask(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_narrow_i32x4_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_narrow_i32x4_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_extend_low_i8x16_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_extend_high_i8x16_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_extend_low_i8x16_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_extend_high_i8x16_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_shl(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_shr_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_shr_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_add(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_add_sat_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_add_sat_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_sub(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_sub_sat_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_sub_sat_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_mul(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_min_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_min_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_max_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_max_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_rounding_average_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_ext_mul_low_i8x16_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_ext_mul_high_i8x16_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_ext_mul_low_i8x16_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_ext_mul_high_i8x16_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_ext_add_pairwise_i16x8_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_ext_add_pairwise_i16x8_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_abs(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_neg(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_all_true(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_bitmask(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_extend_low_i16x8_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_extend_high_i16x8_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_extend_low_i16x8_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_extend_high_i16x8_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_shl(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_shr_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_shr_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_add(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_sub(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_mul(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_min_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_min_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_max_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_max_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_dot_i16x8_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_ext_mul_low_i16x8_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_ext_mul_high_i16x8_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_ext_mul_low_i16x8_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_ext_mul_high_i16x8_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64x2_abs(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64x2_neg(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64x2_all_true(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64x2_bitmask(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64x2_extend_low_i32x4_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64x2_extend_high_i32x4_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64x2_extend_low_i32x4_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64x2_extend_high_i32x4_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64x2_shl(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64x2_shr_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64x2_shr_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64x2_add(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64x2_sub(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64x2_mul(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64x2_ext_mul_low_i32x4_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64x2_ext_mul_high_i32x4_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64x2_ext_mul_low_i32x4_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64x2_ext_mul_high_i32x4_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_ceil(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_floor(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_trunc(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_nearest(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_abs(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_neg(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_sqrt(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_add(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_sub(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_mul(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_div(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_min(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_max(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_p_min(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_p_max(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_ceil(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_floor(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_trunc(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_nearest(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_abs(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_neg(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_sqrt(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_add(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_sub(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_mul(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_div(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_min(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_max(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_p_min(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_p_max(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_relaxed_min(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_relaxed_max(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_relaxed_min(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_relaxed_max(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_demote_f64x2_zero(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_promote_low_f32x4(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_convert_low_i32x4_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_convert_low_i32x4_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_trunc_sat_f32x4_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_trunc_sat_f32x4_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_trunc_sat_f64x2_s_zero(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_trunc_sat_f64x2_u_zero(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_convert_i32x4_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_convert_i32x4_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_relaxed_trunc_sat_f32x4_s(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_relaxed_trunc_sat_f32x4_u(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_relaxed_trunc_sat_f64x2_s_zero(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_relaxed_trunc_sat_f64x2_u_zero(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_fma(&mut self, offset: usize) -> Self::Output;
+    fn visit_f32x4_fms(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_fma(&mut self, offset: usize) -> Self::Output;
+    fn visit_f64x2_fms(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_lane_select(&mut self, offset: usize) -> Self::Output;
+    fn visit_i16x8_lane_select(&mut self, offset: usize) -> Self::Output;
+    fn visit_i32x4_lane_select(&mut self, offset: usize) -> Self::Output;
+    fn visit_i64x2_lane_select(&mut self, offset: usize) -> Self::Output;
+    fn visit_i8x16_relaxed_swizzle(&mut self, offset: usize) -> Self::Output;
 }

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -19,6 +19,8 @@ const MAX_LOCALS: u32 = 50000;
 const MAX_NESTING_TO_PRINT: u32 = 50;
 const MAX_WASM_FUNCTIONS: u32 = 1_000_000;
 
+mod operator;
+
 /// Reads a WebAssembly `file` from the filesystem and then prints it into an
 /// in-memory `String`.
 pub fn print_file(file: impl AsRef<Path>) -> Result<String> {
@@ -857,45 +859,52 @@ impl Printer {
             let nesting_start = self.nesting;
             let mut reader = body.get_operators_reader()?;
             reader.allow_memarg64(true);
+
+            let mut buf = String::new();
+            let mut op_printer = operator::PrintOperator::new(self, state);
             while !reader.eof() {
-                let operator = reader.read()?;
-                match operator {
+                // TODO
+                mem::swap(&mut buf, &mut op_printer.printer.result);
+                let op_kind = reader.visit_with_offset(&mut op_printer)??;
+                mem::swap(&mut buf, &mut op_printer.printer.result);
+
+                match op_kind {
                     // The final `end` in a reader is not printed, it's implied
                     // in the text format.
-                    Operator::End if reader.eof() => break,
+                    operator::OpKind::End if reader.eof() => break,
 
                     // When we start a block we newline to the current
                     // indentation, then we increase the indentation so further
                     // instructions are tabbed over.
-                    Operator::If { .. }
-                    | Operator::Block { .. }
-                    | Operator::Loop { .. }
-                    | Operator::Try { .. } => {
-                        self.newline();
-                        self.nesting += 1;
+                    operator::OpKind::BlockStart => {
+                        op_printer.printer.newline();
+                        op_printer.printer.nesting += 1;
                     }
 
                     // `else`/`catch` are special in that it's printed at
                     // the previous indentation, but it doesn't actually change
                     // our nesting level.
-                    Operator::Else | Operator::Catch { .. } | Operator::CatchAll => {
-                        self.nesting -= 1;
-                        self.newline();
-                        self.nesting += 1;
+                    operator::OpKind::BlockMid => {
+                        op_printer.printer.nesting -= 1;
+                        op_printer.printer.newline();
+                        op_printer.printer.nesting += 1;
                     }
 
                     // Exiting a block prints `end` at the previous indentation
                     // level. `delegate` also ends a block like `end` for `try`.
-                    Operator::End | Operator::Delegate { .. } if self.nesting > nesting_start => {
-                        self.nesting -= 1;
-                        self.newline();
+                    operator::OpKind::End | operator::OpKind::Delegate
+                        if op_printer.printer.nesting > nesting_start =>
+                    {
+                        op_printer.printer.nesting -= 1;
+                        op_printer.printer.newline();
                     }
 
                     // .. otherwise everything else just has a normal newline
                     // out in front.
-                    _ => self.newline(),
+                    _ => op_printer.printer.newline(),
                 }
-                self.print_operator(state, &operator, nesting_start)?;
+                op_printer.printer.result.push_str(&buf);
+                buf.truncate(0);
             }
 
             // If this was an invalid function body then the nesting may not
@@ -925,919 +934,6 @@ impl Printer {
         for _ in 0..self.nesting.min(MAX_NESTING_TO_PRINT) {
             self.result.push_str("  ");
         }
-    }
-
-    fn print_operator(
-        &mut self,
-        state: &mut State,
-        op: &Operator<'_>,
-        nesting_start: u32,
-    ) -> Result<()> {
-        use Operator::*;
-        let cur_depth = self.nesting - nesting_start;
-        let label = |relative: u32| match cur_depth.checked_sub(relative) {
-            Some(i) => format!("@{}", i),
-            None => " INVALID ".to_string(),
-        };
-        match op {
-            Nop => self.result.push_str("nop"),
-            Unreachable => self.result.push_str("unreachable"),
-            Block { ty } => {
-                self.result.push_str("block");
-                self.print_blockty(state, ty, cur_depth)?;
-            }
-            Loop { ty } => {
-                self.result.push_str("loop");
-                self.print_blockty(state, ty, cur_depth)?;
-            }
-            If { ty } => {
-                self.result.push_str("if");
-                self.print_blockty(state, ty, cur_depth)?;
-            }
-            Else => self.result.push_str("else"),
-            Try { ty } => {
-                self.result.push_str("try");
-                self.print_blockty(state, ty, cur_depth)?;
-            }
-            Catch { index } => {
-                write!(self.result, "catch {}", index)?;
-            }
-            Throw { index } => {
-                write!(self.result, "throw {}", index)?;
-            }
-            Rethrow { relative_depth } => {
-                write!(
-                    self.result,
-                    "rethrow {} (;{};)",
-                    relative_depth,
-                    label(*relative_depth)
-                )?;
-            }
-            End => self.result.push_str("end"),
-            Br { relative_depth } => {
-                write!(
-                    self.result,
-                    "br {} (;{};)",
-                    relative_depth,
-                    label(*relative_depth),
-                )?;
-            }
-            BrIf { relative_depth } => {
-                write!(
-                    self.result,
-                    "br_if {} (;{};)",
-                    relative_depth,
-                    label(*relative_depth),
-                )?;
-            }
-            BrTable { table } => {
-                self.result.push_str("br_table");
-                for item in table.targets().chain(Some(Ok(table.default()))) {
-                    let item = item?;
-                    write!(self.result, " {} (;{};)", item, label(item))?;
-                }
-            }
-
-            Return => self.result.push_str("return"),
-            Call { function_index } => {
-                self.result.push_str("call ");
-                self.print_idx(&state.core.func_names, *function_index)?;
-            }
-            CallIndirect {
-                table_index,
-                index,
-                table_byte: _,
-            } => {
-                self.result.push_str("call_indirect");
-                if *table_index != 0 {
-                    self.result.push(' ');
-                    self.print_idx(&state.core.table_names, *table_index)?;
-                }
-                self.print_type_ref(state, *index, true, None)?;
-            }
-            ReturnCall { function_index } => {
-                self.result.push_str("return_call ");
-                self.print_idx(&state.core.func_names, *function_index)?;
-            }
-            ReturnCallIndirect { table_index, index } => {
-                self.result.push_str("return_call_indirect");
-                if *table_index != 0 {
-                    self.result.push(' ');
-                    self.print_idx(&state.core.table_names, *table_index)?;
-                }
-                self.print_type_ref(state, *index, true, None)?;
-            }
-
-            Delegate { relative_depth } => {
-                write!(self.result, "delegate {}", relative_depth)?;
-            }
-            CatchAll => self.result.push_str("catch_all"),
-
-            Drop => self.result.push_str("drop"),
-            Select => self.result.push_str("select"),
-            TypedSelect { ty } => {
-                self.result.push_str("select (result ");
-                self.print_valtype(*ty)?;
-                self.result.push(')');
-            }
-            LocalGet { local_index } => {
-                self.result.push_str("local.get ");
-                self.print_local_idx(state, state.core.funcs, *local_index)?;
-            }
-            LocalSet { local_index } => {
-                self.result.push_str("local.set ");
-                self.print_local_idx(state, state.core.funcs, *local_index)?;
-            }
-            LocalTee { local_index } => {
-                self.result.push_str("local.tee ");
-                self.print_local_idx(state, state.core.funcs, *local_index)?;
-            }
-
-            GlobalGet { global_index } => {
-                self.result.push_str("global.get ");
-                self.print_idx(&state.core.global_names, *global_index)?;
-            }
-            GlobalSet { global_index } => {
-                self.result.push_str("global.set ");
-                self.print_idx(&state.core.global_names, *global_index)?;
-            }
-
-            I32Load { memarg } => self.mem_instr(state, "i32.load", memarg, 4)?,
-            I64Load { memarg } => self.mem_instr(state, "i64.load", memarg, 8)?,
-            F32Load { memarg } => self.mem_instr(state, "f32.load", memarg, 4)?,
-            F64Load { memarg } => self.mem_instr(state, "f64.load", memarg, 8)?,
-            I32Load8S { memarg } => self.mem_instr(state, "i32.load8_s", memarg, 1)?,
-            I32Load8U { memarg } => self.mem_instr(state, "i32.load8_u", memarg, 1)?,
-            I32Load16S { memarg } => self.mem_instr(state, "i32.load16_s", memarg, 2)?,
-            I32Load16U { memarg } => self.mem_instr(state, "i32.load16_u", memarg, 2)?,
-            I64Load8S { memarg } => self.mem_instr(state, "i64.load8_s", memarg, 1)?,
-            I64Load8U { memarg } => self.mem_instr(state, "i64.load8_u", memarg, 1)?,
-            I64Load16S { memarg } => self.mem_instr(state, "i64.load16_s", memarg, 2)?,
-            I64Load16U { memarg } => self.mem_instr(state, "i64.load16_u", memarg, 2)?,
-            I64Load32S { memarg } => self.mem_instr(state, "i64.load32_s", memarg, 4)?,
-            I64Load32U { memarg } => self.mem_instr(state, "i64.load32_u", memarg, 4)?,
-
-            I32Store { memarg } => self.mem_instr(state, "i32.store", memarg, 4)?,
-            I64Store { memarg } => self.mem_instr(state, "i64.store", memarg, 8)?,
-            F32Store { memarg } => self.mem_instr(state, "f32.store", memarg, 4)?,
-            F64Store { memarg } => self.mem_instr(state, "f64.store", memarg, 8)?,
-            I32Store8 { memarg } => self.mem_instr(state, "i32.store8", memarg, 1)?,
-            I32Store16 { memarg } => self.mem_instr(state, "i32.store16", memarg, 2)?,
-            I64Store8 { memarg } => self.mem_instr(state, "i64.store8", memarg, 1)?,
-            I64Store16 { memarg } => self.mem_instr(state, "i64.store16", memarg, 2)?,
-            I64Store32 { memarg } => self.mem_instr(state, "i64.store32", memarg, 4)?,
-
-            MemorySize { mem: 0, .. } => self.result.push_str("memory.size"),
-            MemorySize { mem, .. } => {
-                self.result.push_str("memory.size ");
-                self.print_idx(&state.core.memory_names, *mem)?;
-            }
-            MemoryGrow { mem: 0, .. } => self.result.push_str("memory.grow"),
-            MemoryGrow { mem, .. } => {
-                self.result.push_str("memory.grow ");
-                self.print_idx(&state.core.memory_names, *mem)?;
-            }
-
-            I32Const { value } => write!(self.result, "i32.const {}", value)?,
-            I64Const { value } => write!(self.result, "i64.const {}", value)?,
-            F32Const { value } => {
-                self.result.push_str("f32.const ");
-                self.print_f32(value.bits())?;
-            }
-            F64Const { value } => {
-                self.result.push_str("f64.const ");
-                self.print_f64(value.bits())?;
-            }
-
-            RefNull { ty } => {
-                self.result.push_str("ref.null ");
-                self.print_reftype(*ty)?;
-            }
-            RefIsNull => self.result.push_str("ref.is_null"),
-            RefFunc { function_index } => {
-                self.result.push_str("ref.func ");
-                self.print_idx(&state.core.func_names, *function_index)?;
-            }
-
-            I32Eqz => self.result.push_str("i32.eqz"),
-            I32Eq => self.result.push_str("i32.eq"),
-            I32Ne => self.result.push_str("i32.ne"),
-            I32LtS => self.result.push_str("i32.lt_s"),
-            I32LtU => self.result.push_str("i32.lt_u"),
-            I32GtS => self.result.push_str("i32.gt_s"),
-            I32GtU => self.result.push_str("i32.gt_u"),
-            I32LeS => self.result.push_str("i32.le_s"),
-            I32LeU => self.result.push_str("i32.le_u"),
-            I32GeS => self.result.push_str("i32.ge_s"),
-            I32GeU => self.result.push_str("i32.ge_u"),
-
-            I64Eqz => self.result.push_str("i64.eqz"),
-            I64Eq => self.result.push_str("i64.eq"),
-            I64Ne => self.result.push_str("i64.ne"),
-            I64LtS => self.result.push_str("i64.lt_s"),
-            I64LtU => self.result.push_str("i64.lt_u"),
-            I64GtS => self.result.push_str("i64.gt_s"),
-            I64GtU => self.result.push_str("i64.gt_u"),
-            I64LeS => self.result.push_str("i64.le_s"),
-            I64LeU => self.result.push_str("i64.le_u"),
-            I64GeS => self.result.push_str("i64.ge_s"),
-            I64GeU => self.result.push_str("i64.ge_u"),
-
-            F32Eq => self.result.push_str("f32.eq"),
-            F32Ne => self.result.push_str("f32.ne"),
-            F32Lt => self.result.push_str("f32.lt"),
-            F32Gt => self.result.push_str("f32.gt"),
-            F32Le => self.result.push_str("f32.le"),
-            F32Ge => self.result.push_str("f32.ge"),
-
-            F64Eq => self.result.push_str("f64.eq"),
-            F64Ne => self.result.push_str("f64.ne"),
-            F64Lt => self.result.push_str("f64.lt"),
-            F64Gt => self.result.push_str("f64.gt"),
-            F64Le => self.result.push_str("f64.le"),
-            F64Ge => self.result.push_str("f64.ge"),
-
-            I32Clz => self.result.push_str("i32.clz"),
-            I32Ctz => self.result.push_str("i32.ctz"),
-            I32Popcnt => self.result.push_str("i32.popcnt"),
-            I32Add => self.result.push_str("i32.add"),
-            I32Sub => self.result.push_str("i32.sub"),
-            I32Mul => self.result.push_str("i32.mul"),
-            I32DivS => self.result.push_str("i32.div_s"),
-            I32DivU => self.result.push_str("i32.div_u"),
-            I32RemS => self.result.push_str("i32.rem_s"),
-            I32RemU => self.result.push_str("i32.rem_u"),
-            I32And => self.result.push_str("i32.and"),
-            I32Or => self.result.push_str("i32.or"),
-            I32Xor => self.result.push_str("i32.xor"),
-            I32Shl => self.result.push_str("i32.shl"),
-            I32ShrS => self.result.push_str("i32.shr_s"),
-            I32ShrU => self.result.push_str("i32.shr_u"),
-            I32Rotl => self.result.push_str("i32.rotl"),
-            I32Rotr => self.result.push_str("i32.rotr"),
-
-            I64Clz => self.result.push_str("i64.clz"),
-            I64Ctz => self.result.push_str("i64.ctz"),
-            I64Popcnt => self.result.push_str("i64.popcnt"),
-            I64Add => self.result.push_str("i64.add"),
-            I64Sub => self.result.push_str("i64.sub"),
-            I64Mul => self.result.push_str("i64.mul"),
-            I64DivS => self.result.push_str("i64.div_s"),
-            I64DivU => self.result.push_str("i64.div_u"),
-            I64RemS => self.result.push_str("i64.rem_s"),
-            I64RemU => self.result.push_str("i64.rem_u"),
-            I64And => self.result.push_str("i64.and"),
-            I64Or => self.result.push_str("i64.or"),
-            I64Xor => self.result.push_str("i64.xor"),
-            I64Shl => self.result.push_str("i64.shl"),
-            I64ShrS => self.result.push_str("i64.shr_s"),
-            I64ShrU => self.result.push_str("i64.shr_u"),
-            I64Rotl => self.result.push_str("i64.rotl"),
-            I64Rotr => self.result.push_str("i64.rotr"),
-
-            F32Abs => self.result.push_str("f32.abs"),
-            F32Neg => self.result.push_str("f32.neg"),
-            F32Ceil => self.result.push_str("f32.ceil"),
-            F32Floor => self.result.push_str("f32.floor"),
-            F32Trunc => self.result.push_str("f32.trunc"),
-            F32Nearest => self.result.push_str("f32.nearest"),
-            F32Sqrt => self.result.push_str("f32.sqrt"),
-            F32Add => self.result.push_str("f32.add"),
-            F32Sub => self.result.push_str("f32.sub"),
-            F32Mul => self.result.push_str("f32.mul"),
-            F32Div => self.result.push_str("f32.div"),
-            F32Min => self.result.push_str("f32.min"),
-            F32Max => self.result.push_str("f32.max"),
-            F32Copysign => self.result.push_str("f32.copysign"),
-
-            F64Abs => self.result.push_str("f64.abs"),
-            F64Neg => self.result.push_str("f64.neg"),
-            F64Ceil => self.result.push_str("f64.ceil"),
-            F64Floor => self.result.push_str("f64.floor"),
-            F64Trunc => self.result.push_str("f64.trunc"),
-            F64Nearest => self.result.push_str("f64.nearest"),
-            F64Sqrt => self.result.push_str("f64.sqrt"),
-            F64Add => self.result.push_str("f64.add"),
-            F64Sub => self.result.push_str("f64.sub"),
-            F64Mul => self.result.push_str("f64.mul"),
-            F64Div => self.result.push_str("f64.div"),
-            F64Min => self.result.push_str("f64.min"),
-            F64Max => self.result.push_str("f64.max"),
-            F64Copysign => self.result.push_str("f64.copysign"),
-
-            I32WrapI64 => self.result.push_str("i32.wrap_i64"),
-            I32TruncF32S => self.result.push_str("i32.trunc_f32_s"),
-            I32TruncF32U => self.result.push_str("i32.trunc_f32_u"),
-            I32TruncF64S => self.result.push_str("i32.trunc_f64_s"),
-            I32TruncF64U => self.result.push_str("i32.trunc_f64_u"),
-            I64ExtendI32S => self.result.push_str("i64.extend_i32_s"),
-            I64ExtendI32U => self.result.push_str("i64.extend_i32_u"),
-            I64TruncF32S => self.result.push_str("i64.trunc_f32_s"),
-            I64TruncF32U => self.result.push_str("i64.trunc_f32_u"),
-            I64TruncF64S => self.result.push_str("i64.trunc_f64_s"),
-            I64TruncF64U => self.result.push_str("i64.trunc_f64_u"),
-
-            F32ConvertI32S => self.result.push_str("f32.convert_i32_s"),
-            F32ConvertI32U => self.result.push_str("f32.convert_i32_u"),
-            F32ConvertI64S => self.result.push_str("f32.convert_i64_s"),
-            F32ConvertI64U => self.result.push_str("f32.convert_i64_u"),
-            F32DemoteF64 => self.result.push_str("f32.demote_f64"),
-            F64ConvertI32S => self.result.push_str("f64.convert_i32_s"),
-            F64ConvertI32U => self.result.push_str("f64.convert_i32_u"),
-            F64ConvertI64S => self.result.push_str("f64.convert_i64_s"),
-            F64ConvertI64U => self.result.push_str("f64.convert_i64_u"),
-            F64PromoteF32 => self.result.push_str("f64.promote_f32"),
-
-            I32ReinterpretF32 => self.result.push_str("i32.reinterpret_f32"),
-            I64ReinterpretF64 => self.result.push_str("i64.reinterpret_f64"),
-            F32ReinterpretI32 => self.result.push_str("f32.reinterpret_i32"),
-            F64ReinterpretI64 => self.result.push_str("f64.reinterpret_i64"),
-
-            I32Extend8S => self.result.push_str("i32.extend8_s"),
-            I32Extend16S => self.result.push_str("i32.extend16_s"),
-            I64Extend8S => self.result.push_str("i64.extend8_s"),
-            I64Extend16S => self.result.push_str("i64.extend16_s"),
-            I64Extend32S => self.result.push_str("i64.extend32_s"),
-
-            I32TruncSatF32S => self.result.push_str("i32.trunc_sat_f32_s"),
-            I32TruncSatF32U => self.result.push_str("i32.trunc_sat_f32_u"),
-            I32TruncSatF64S => self.result.push_str("i32.trunc_sat_f64_s"),
-            I32TruncSatF64U => self.result.push_str("i32.trunc_sat_f64_u"),
-            I64TruncSatF32S => self.result.push_str("i64.trunc_sat_f32_s"),
-            I64TruncSatF32U => self.result.push_str("i64.trunc_sat_f32_u"),
-            I64TruncSatF64S => self.result.push_str("i64.trunc_sat_f64_s"),
-            I64TruncSatF64U => self.result.push_str("i64.trunc_sat_f64_u"),
-
-            MemoryInit { segment, mem } => {
-                self.result.push_str("memory.init ");
-                if *mem != 0 {
-                    self.print_idx(&state.core.memory_names, *mem)?;
-                    self.result.push(' ');
-                }
-                self.print_idx(&state.core.data_names, *segment)?;
-            }
-            DataDrop { segment } => {
-                self.result.push_str("data.drop ");
-                self.print_idx(&state.core.data_names, *segment)?;
-            }
-            MemoryCopy { src: 0, dst: 0 } => self.result.push_str("memory.copy"),
-            MemoryCopy { src, dst } => {
-                self.result.push_str("memory.copy ");
-                self.print_idx(&state.core.memory_names, *dst)?;
-                self.result.push(' ');
-                self.print_idx(&state.core.memory_names, *src)?;
-            }
-            MemoryFill { mem: 0 } => self.result.push_str("memory.fill"),
-            MemoryFill { mem } => {
-                self.result.push_str("memory.fill ");
-                self.print_idx(&state.core.memory_names, *mem)?;
-            }
-
-            TableInit { table, segment } => {
-                self.result.push_str("table.init ");
-                if *table != 0 {
-                    self.print_idx(&state.core.table_names, *table)?;
-                    self.result.push(' ');
-                }
-                self.print_idx(&state.core.element_names, *segment)?;
-            }
-            ElemDrop { segment } => {
-                self.result.push_str("elem.drop ");
-                self.print_idx(&state.core.element_names, *segment)?;
-            }
-            TableCopy {
-                dst_table,
-                src_table,
-            } => {
-                self.result.push_str("table.copy");
-                if *dst_table != *src_table || *src_table != 0 {
-                    self.result.push(' ');
-                    self.print_idx(&state.core.table_names, *dst_table)?;
-                    self.result.push(' ');
-                    self.print_idx(&state.core.table_names, *src_table)?;
-                }
-            }
-            TableGet { table } => {
-                self.result.push_str("table.get ");
-                self.print_idx(&state.core.table_names, *table)?;
-            }
-            TableSet { table } => {
-                self.result.push_str("table.set ");
-                self.print_idx(&state.core.table_names, *table)?;
-            }
-            TableGrow { table } => {
-                self.result.push_str("table.grow ");
-                self.print_idx(&state.core.table_names, *table)?;
-            }
-            TableSize { table } => {
-                self.result.push_str("table.size ");
-                self.print_idx(&state.core.table_names, *table)?;
-            }
-            TableFill { table } => {
-                self.result.push_str("table.fill ");
-                self.print_idx(&state.core.table_names, *table)?;
-            }
-
-            MemoryAtomicNotify { memarg } => {
-                self.mem_instr(state, "memory.atomic.notify", memarg, 4)?
-            }
-            MemoryAtomicWait32 { memarg } => {
-                self.mem_instr(state, "memory.atomic.wait32", memarg, 4)?
-            }
-            MemoryAtomicWait64 { memarg } => {
-                self.mem_instr(state, "memory.atomic.wait64", memarg, 8)?
-            }
-            AtomicFence { flags: _ } => self.result.push_str("atomic.fence"),
-
-            I32AtomicLoad { memarg } => self.mem_instr(state, "i32.atomic.load", memarg, 4)?,
-            I64AtomicLoad { memarg } => self.mem_instr(state, "i64.atomic.load", memarg, 8)?,
-            I32AtomicLoad8U { memarg } => self.mem_instr(state, "i32.atomic.load8_u", memarg, 1)?,
-            I32AtomicLoad16U { memarg } => {
-                self.mem_instr(state, "i32.atomic.load16_u", memarg, 2)?
-            }
-            I64AtomicLoad8U { memarg } => self.mem_instr(state, "i64.atomic.load8_u", memarg, 1)?,
-            I64AtomicLoad16U { memarg } => {
-                self.mem_instr(state, "i64.atomic.load16_u", memarg, 2)?
-            }
-            I64AtomicLoad32U { memarg } => {
-                self.mem_instr(state, "i64.atomic.load32_u", memarg, 4)?
-            }
-
-            I32AtomicStore { memarg } => self.mem_instr(state, "i32.atomic.store", memarg, 4)?,
-            I64AtomicStore { memarg } => self.mem_instr(state, "i64.atomic.store", memarg, 8)?,
-            I32AtomicStore8 { memarg } => self.mem_instr(state, "i32.atomic.store8", memarg, 1)?,
-            I32AtomicStore16 { memarg } => {
-                self.mem_instr(state, "i32.atomic.store16", memarg, 2)?
-            }
-            I64AtomicStore8 { memarg } => self.mem_instr(state, "i64.atomic.store8", memarg, 1)?,
-            I64AtomicStore16 { memarg } => {
-                self.mem_instr(state, "i64.atomic.store16", memarg, 2)?
-            }
-            I64AtomicStore32 { memarg } => {
-                self.mem_instr(state, "i64.atomic.store32", memarg, 4)?
-            }
-
-            I32AtomicRmwAdd { memarg } => self.mem_instr(state, "i32.atomic.rmw.add", memarg, 4)?,
-            I64AtomicRmwAdd { memarg } => self.mem_instr(state, "i64.atomic.rmw.add", memarg, 8)?,
-            I32AtomicRmw8AddU { memarg } => {
-                self.mem_instr(state, "i32.atomic.rmw8.add_u", memarg, 1)?
-            }
-            I32AtomicRmw16AddU { memarg } => {
-                self.mem_instr(state, "i32.atomic.rmw16.add_u", memarg, 2)?
-            }
-            I64AtomicRmw8AddU { memarg } => {
-                self.mem_instr(state, "i64.atomic.rmw8.add_u", memarg, 1)?
-            }
-            I64AtomicRmw16AddU { memarg } => {
-                self.mem_instr(state, "i64.atomic.rmw16.add_u", memarg, 2)?
-            }
-            I64AtomicRmw32AddU { memarg } => {
-                self.mem_instr(state, "i64.atomic.rmw32.add_u", memarg, 4)?
-            }
-
-            I32AtomicRmwSub { memarg } => self.mem_instr(state, "i32.atomic.rmw.sub", memarg, 4)?,
-            I64AtomicRmwSub { memarg } => self.mem_instr(state, "i64.atomic.rmw.sub", memarg, 8)?,
-            I32AtomicRmw8SubU { memarg } => {
-                self.mem_instr(state, "i32.atomic.rmw8.sub_u", memarg, 1)?
-            }
-            I32AtomicRmw16SubU { memarg } => {
-                self.mem_instr(state, "i32.atomic.rmw16.sub_u", memarg, 2)?
-            }
-            I64AtomicRmw8SubU { memarg } => {
-                self.mem_instr(state, "i64.atomic.rmw8.sub_u", memarg, 1)?
-            }
-            I64AtomicRmw16SubU { memarg } => {
-                self.mem_instr(state, "i64.atomic.rmw16.sub_u", memarg, 2)?
-            }
-            I64AtomicRmw32SubU { memarg } => {
-                self.mem_instr(state, "i64.atomic.rmw32.sub_u", memarg, 4)?
-            }
-
-            I32AtomicRmwAnd { memarg } => self.mem_instr(state, "i32.atomic.rmw.and", memarg, 4)?,
-            I64AtomicRmwAnd { memarg } => self.mem_instr(state, "i64.atomic.rmw.and", memarg, 8)?,
-            I32AtomicRmw8AndU { memarg } => {
-                self.mem_instr(state, "i32.atomic.rmw8.and_u", memarg, 1)?
-            }
-            I32AtomicRmw16AndU { memarg } => {
-                self.mem_instr(state, "i32.atomic.rmw16.and_u", memarg, 2)?
-            }
-            I64AtomicRmw8AndU { memarg } => {
-                self.mem_instr(state, "i64.atomic.rmw8.and_u", memarg, 1)?
-            }
-            I64AtomicRmw16AndU { memarg } => {
-                self.mem_instr(state, "i64.atomic.rmw16.and_u", memarg, 2)?
-            }
-            I64AtomicRmw32AndU { memarg } => {
-                self.mem_instr(state, "i64.atomic.rmw32.and_u", memarg, 4)?
-            }
-
-            I32AtomicRmwOr { memarg } => self.mem_instr(state, "i32.atomic.rmw.or", memarg, 4)?,
-            I64AtomicRmwOr { memarg } => self.mem_instr(state, "i64.atomic.rmw.or", memarg, 8)?,
-            I32AtomicRmw8OrU { memarg } => {
-                self.mem_instr(state, "i32.atomic.rmw8.or_u", memarg, 1)?
-            }
-            I32AtomicRmw16OrU { memarg } => {
-                self.mem_instr(state, "i32.atomic.rmw16.or_u", memarg, 2)?
-            }
-            I64AtomicRmw8OrU { memarg } => {
-                self.mem_instr(state, "i64.atomic.rmw8.or_u", memarg, 1)?
-            }
-            I64AtomicRmw16OrU { memarg } => {
-                self.mem_instr(state, "i64.atomic.rmw16.or_u", memarg, 2)?
-            }
-            I64AtomicRmw32OrU { memarg } => {
-                self.mem_instr(state, "i64.atomic.rmw32.or_u", memarg, 4)?
-            }
-
-            I32AtomicRmwXor { memarg } => self.mem_instr(state, "i32.atomic.rmw.xor", memarg, 4)?,
-            I64AtomicRmwXor { memarg } => self.mem_instr(state, "i64.atomic.rmw.xor", memarg, 8)?,
-            I32AtomicRmw8XorU { memarg } => {
-                self.mem_instr(state, "i32.atomic.rmw8.xor_u", memarg, 1)?
-            }
-            I32AtomicRmw16XorU { memarg } => {
-                self.mem_instr(state, "i32.atomic.rmw16.xor_u", memarg, 2)?
-            }
-            I64AtomicRmw8XorU { memarg } => {
-                self.mem_instr(state, "i64.atomic.rmw8.xor_u", memarg, 1)?
-            }
-            I64AtomicRmw16XorU { memarg } => {
-                self.mem_instr(state, "i64.atomic.rmw16.xor_u", memarg, 2)?
-            }
-            I64AtomicRmw32XorU { memarg } => {
-                self.mem_instr(state, "i64.atomic.rmw32.xor_u", memarg, 4)?
-            }
-
-            I32AtomicRmwXchg { memarg } => {
-                self.mem_instr(state, "i32.atomic.rmw.xchg", memarg, 4)?
-            }
-            I64AtomicRmwXchg { memarg } => {
-                self.mem_instr(state, "i64.atomic.rmw.xchg", memarg, 8)?
-            }
-            I32AtomicRmw8XchgU { memarg } => {
-                self.mem_instr(state, "i32.atomic.rmw8.xchg_u", memarg, 1)?
-            }
-            I32AtomicRmw16XchgU { memarg } => {
-                self.mem_instr(state, "i32.atomic.rmw16.xchg_u", memarg, 2)?
-            }
-            I64AtomicRmw8XchgU { memarg } => {
-                self.mem_instr(state, "i64.atomic.rmw8.xchg_u", memarg, 1)?
-            }
-            I64AtomicRmw16XchgU { memarg } => {
-                self.mem_instr(state, "i64.atomic.rmw16.xchg_u", memarg, 2)?
-            }
-            I64AtomicRmw32XchgU { memarg } => {
-                self.mem_instr(state, "i64.atomic.rmw32.xchg_u", memarg, 4)?
-            }
-
-            I32AtomicRmwCmpxchg { memarg } => {
-                self.mem_instr(state, "i32.atomic.rmw.cmpxchg", memarg, 4)?
-            }
-            I64AtomicRmwCmpxchg { memarg } => {
-                self.mem_instr(state, "i64.atomic.rmw.cmpxchg", memarg, 8)?
-            }
-            I32AtomicRmw8CmpxchgU { memarg } => {
-                self.mem_instr(state, "i32.atomic.rmw8.cmpxchg_u", memarg, 1)?
-            }
-            I32AtomicRmw16CmpxchgU { memarg } => {
-                self.mem_instr(state, "i32.atomic.rmw16.cmpxchg_u", memarg, 2)?
-            }
-            I64AtomicRmw8CmpxchgU { memarg } => {
-                self.mem_instr(state, "i64.atomic.rmw8.cmpxchg_u", memarg, 1)?
-            }
-            I64AtomicRmw16CmpxchgU { memarg } => {
-                self.mem_instr(state, "i64.atomic.rmw16.cmpxchg_u", memarg, 2)?
-            }
-            I64AtomicRmw32CmpxchgU { memarg } => {
-                self.mem_instr(state, "i64.atomic.rmw32.cmpxchg_u", memarg, 4)?
-            }
-
-            V128Load { memarg } => self.mem_instr(state, "v128.load", memarg, 16)?,
-            V128Store { memarg } => self.mem_instr(state, "v128.store", memarg, 16)?,
-            V128Const { value } => {
-                write!(self.result, "v128.const i32x4")?;
-                for chunk in value.bytes().chunks(4) {
-                    write!(
-                        self.result,
-                        " 0x{:02x}{:02x}{:02x}{:02x}",
-                        chunk[3], chunk[2], chunk[1], chunk[0]
-                    )?;
-                }
-            }
-
-            I8x16Splat => self.result.push_str("i8x16.splat"),
-            I8x16ExtractLaneS { lane } => write!(self.result, "i8x16.extract_lane_s {}", lane)?,
-            I8x16ExtractLaneU { lane } => write!(self.result, "i8x16.extract_lane_u {}", lane)?,
-            I8x16ReplaceLane { lane } => write!(self.result, "i8x16.replace_lane {}", lane)?,
-            I16x8Splat => self.result.push_str("i16x8.splat"),
-            I16x8ExtractLaneS { lane } => write!(self.result, "i16x8.extract_lane_s {}", lane)?,
-            I16x8ExtractLaneU { lane } => write!(self.result, "i16x8.extract_lane_u {}", lane)?,
-            I16x8ReplaceLane { lane } => write!(self.result, "i16x8.replace_lane {}", lane)?,
-            I32x4Splat => self.result.push_str("i32x4.splat"),
-            I32x4ExtractLane { lane } => write!(self.result, "i32x4.extract_lane {}", lane)?,
-            I32x4ReplaceLane { lane } => write!(self.result, "i32x4.replace_lane {}", lane)?,
-            I64x2Splat => self.result.push_str("i64x2.splat"),
-            I64x2ExtractLane { lane } => write!(self.result, "i64x2.extract_lane {}", lane)?,
-            I64x2ReplaceLane { lane } => write!(self.result, "i64x2.replace_lane {}", lane)?,
-            F32x4Splat => self.result.push_str("f32x4.splat"),
-            F32x4ExtractLane { lane } => write!(self.result, "f32x4.extract_lane {}", lane)?,
-            F32x4ReplaceLane { lane } => write!(self.result, "f32x4.replace_lane {}", lane)?,
-            F64x2Splat => self.result.push_str("f64x2.splat"),
-            F64x2ExtractLane { lane } => write!(self.result, "f64x2.extract_lane {}", lane)?,
-            F64x2ReplaceLane { lane } => write!(self.result, "f64x2.replace_lane {}", lane)?,
-
-            I8x16Eq => self.result.push_str("i8x16.eq"),
-            I8x16Ne => self.result.push_str("i8x16.ne"),
-            I8x16LtS => self.result.push_str("i8x16.lt_s"),
-            I8x16LtU => self.result.push_str("i8x16.lt_u"),
-            I8x16GtS => self.result.push_str("i8x16.gt_s"),
-            I8x16GtU => self.result.push_str("i8x16.gt_u"),
-            I8x16LeS => self.result.push_str("i8x16.le_s"),
-            I8x16LeU => self.result.push_str("i8x16.le_u"),
-            I8x16GeS => self.result.push_str("i8x16.ge_s"),
-            I8x16GeU => self.result.push_str("i8x16.ge_u"),
-
-            I16x8Eq => self.result.push_str("i16x8.eq"),
-            I16x8Ne => self.result.push_str("i16x8.ne"),
-            I16x8LtS => self.result.push_str("i16x8.lt_s"),
-            I16x8LtU => self.result.push_str("i16x8.lt_u"),
-            I16x8GtS => self.result.push_str("i16x8.gt_s"),
-            I16x8GtU => self.result.push_str("i16x8.gt_u"),
-            I16x8LeS => self.result.push_str("i16x8.le_s"),
-            I16x8LeU => self.result.push_str("i16x8.le_u"),
-            I16x8GeS => self.result.push_str("i16x8.ge_s"),
-            I16x8GeU => self.result.push_str("i16x8.ge_u"),
-
-            I32x4Eq => self.result.push_str("i32x4.eq"),
-            I32x4Ne => self.result.push_str("i32x4.ne"),
-            I32x4LtS => self.result.push_str("i32x4.lt_s"),
-            I32x4LtU => self.result.push_str("i32x4.lt_u"),
-            I32x4GtS => self.result.push_str("i32x4.gt_s"),
-            I32x4GtU => self.result.push_str("i32x4.gt_u"),
-            I32x4LeS => self.result.push_str("i32x4.le_s"),
-            I32x4LeU => self.result.push_str("i32x4.le_u"),
-            I32x4GeS => self.result.push_str("i32x4.ge_s"),
-            I32x4GeU => self.result.push_str("i32x4.ge_u"),
-
-            I64x2Eq => self.result.push_str("i64x2.eq"),
-            I64x2Ne => self.result.push_str("i64x2.ne"),
-            I64x2LtS => self.result.push_str("i64x2.lt_s"),
-            I64x2GtS => self.result.push_str("i64x2.gt_s"),
-            I64x2LeS => self.result.push_str("i64x2.le_s"),
-            I64x2GeS => self.result.push_str("i64x2.ge_s"),
-
-            F32x4Eq => self.result.push_str("f32x4.eq"),
-            F32x4Ne => self.result.push_str("f32x4.ne"),
-            F32x4Lt => self.result.push_str("f32x4.lt"),
-            F32x4Gt => self.result.push_str("f32x4.gt"),
-            F32x4Le => self.result.push_str("f32x4.le"),
-            F32x4Ge => self.result.push_str("f32x4.ge"),
-
-            F64x2Eq => self.result.push_str("f64x2.eq"),
-            F64x2Ne => self.result.push_str("f64x2.ne"),
-            F64x2Lt => self.result.push_str("f64x2.lt"),
-            F64x2Gt => self.result.push_str("f64x2.gt"),
-            F64x2Le => self.result.push_str("f64x2.le"),
-            F64x2Ge => self.result.push_str("f64x2.ge"),
-
-            V128Not => self.result.push_str("v128.not"),
-            V128And => self.result.push_str("v128.and"),
-            V128AndNot => self.result.push_str("v128.andnot"),
-            V128Or => self.result.push_str("v128.or"),
-            V128Xor => self.result.push_str("v128.xor"),
-            V128Bitselect => self.result.push_str("v128.bitselect"),
-            V128AnyTrue => self.result.push_str("v128.any_true"),
-
-            I8x16Abs => self.result.push_str("i8x16.abs"),
-            I8x16Neg => self.result.push_str("i8x16.neg"),
-            I8x16AllTrue => self.result.push_str("i8x16.all_true"),
-            I8x16Bitmask => self.result.push_str("i8x16.bitmask"),
-            I8x16Shl => self.result.push_str("i8x16.shl"),
-            I8x16ShrU => self.result.push_str("i8x16.shr_u"),
-            I8x16ShrS => self.result.push_str("i8x16.shr_s"),
-            I8x16Add => self.result.push_str("i8x16.add"),
-            I8x16AddSatS => self.result.push_str("i8x16.add_sat_s"),
-            I8x16AddSatU => self.result.push_str("i8x16.add_sat_u"),
-            I8x16Sub => self.result.push_str("i8x16.sub"),
-            I8x16SubSatS => self.result.push_str("i8x16.sub_sat_s"),
-            I8x16SubSatU => self.result.push_str("i8x16.sub_sat_u"),
-
-            I16x8Abs => self.result.push_str("i16x8.abs"),
-            I16x8Neg => self.result.push_str("i16x8.neg"),
-            I16x8AllTrue => self.result.push_str("i16x8.all_true"),
-            I16x8Bitmask => self.result.push_str("i16x8.bitmask"),
-            I16x8Shl => self.result.push_str("i16x8.shl"),
-            I16x8ShrU => self.result.push_str("i16x8.shr_u"),
-            I16x8ShrS => self.result.push_str("i16x8.shr_s"),
-            I16x8Add => self.result.push_str("i16x8.add"),
-            I16x8AddSatS => self.result.push_str("i16x8.add_sat_s"),
-            I16x8AddSatU => self.result.push_str("i16x8.add_sat_u"),
-            I16x8Sub => self.result.push_str("i16x8.sub"),
-            I16x8SubSatS => self.result.push_str("i16x8.sub_sat_s"),
-            I16x8SubSatU => self.result.push_str("i16x8.sub_sat_u"),
-            I16x8Mul => self.result.push_str("i16x8.mul"),
-
-            I32x4Abs => self.result.push_str("i32x4.abs"),
-            I32x4Neg => self.result.push_str("i32x4.neg"),
-            I32x4AllTrue => self.result.push_str("i32x4.all_true"),
-            I32x4Bitmask => self.result.push_str("i32x4.bitmask"),
-            I32x4Shl => self.result.push_str("i32x4.shl"),
-            I32x4ShrU => self.result.push_str("i32x4.shr_u"),
-            I32x4ShrS => self.result.push_str("i32x4.shr_s"),
-            I32x4Add => self.result.push_str("i32x4.add"),
-            I32x4Sub => self.result.push_str("i32x4.sub"),
-            I32x4Mul => self.result.push_str("i32x4.mul"),
-
-            I64x2Abs => self.result.push_str("i64x2.abs"),
-            I64x2Neg => self.result.push_str("i64x2.neg"),
-            I64x2AllTrue => self.result.push_str("i64x2.all_true"),
-            I64x2Bitmask => self.result.push_str("i64x2.bitmask"),
-            I64x2Shl => self.result.push_str("i64x2.shl"),
-            I64x2ShrU => self.result.push_str("i64x2.shr_u"),
-            I64x2ShrS => self.result.push_str("i64x2.shr_s"),
-            I64x2Add => self.result.push_str("i64x2.add"),
-            I64x2Sub => self.result.push_str("i64x2.sub"),
-            I64x2Mul => self.result.push_str("i64x2.mul"),
-
-            F32x4Ceil => self.result.push_str("f32x4.ceil"),
-            F32x4Floor => self.result.push_str("f32x4.floor"),
-            F32x4Trunc => self.result.push_str("f32x4.trunc"),
-            F32x4Nearest => self.result.push_str("f32x4.nearest"),
-            F64x2Ceil => self.result.push_str("f64x2.ceil"),
-            F64x2Floor => self.result.push_str("f64x2.floor"),
-            F64x2Trunc => self.result.push_str("f64x2.trunc"),
-            F64x2Nearest => self.result.push_str("f64x2.nearest"),
-            F32x4Abs => self.result.push_str("f32x4.abs"),
-            F32x4Neg => self.result.push_str("f32x4.neg"),
-            F32x4Sqrt => self.result.push_str("f32x4.sqrt"),
-            F32x4Add => self.result.push_str("f32x4.add"),
-            F32x4Sub => self.result.push_str("f32x4.sub"),
-            F32x4Div => self.result.push_str("f32x4.div"),
-            F32x4Mul => self.result.push_str("f32x4.mul"),
-            F32x4Min => self.result.push_str("f32x4.min"),
-            F32x4Max => self.result.push_str("f32x4.max"),
-            F32x4PMin => self.result.push_str("f32x4.pmin"),
-            F32x4PMax => self.result.push_str("f32x4.pmax"),
-
-            F64x2Abs => self.result.push_str("f64x2.abs"),
-            F64x2Neg => self.result.push_str("f64x2.neg"),
-            F64x2Sqrt => self.result.push_str("f64x2.sqrt"),
-            F64x2Add => self.result.push_str("f64x2.add"),
-            F64x2Sub => self.result.push_str("f64x2.sub"),
-            F64x2Div => self.result.push_str("f64x2.div"),
-            F64x2Mul => self.result.push_str("f64x2.mul"),
-            F64x2Min => self.result.push_str("f64x2.min"),
-            F64x2Max => self.result.push_str("f64x2.max"),
-            F64x2PMin => self.result.push_str("f64x2.pmin"),
-            F64x2PMax => self.result.push_str("f64x2.pmax"),
-
-            I32x4TruncSatF32x4S => self.result.push_str("i32x4.trunc_sat_f32x4_s"),
-            I32x4TruncSatF32x4U => self.result.push_str("i32x4.trunc_sat_f32x4_u"),
-            F32x4ConvertI32x4S => self.result.push_str("f32x4.convert_i32x4_s"),
-            F32x4ConvertI32x4U => self.result.push_str("f32x4.convert_i32x4_u"),
-
-            I8x16Swizzle => self.result.push_str("i8x16.swizzle"),
-            I8x16Shuffle { lanes } => {
-                self.result.push_str("i8x16.shuffle");
-                for lane in lanes {
-                    write!(self.result, " {}", lane)?;
-                }
-            }
-            V128Load8Splat { memarg } => self.mem_instr(state, "v128.load8_splat", memarg, 1)?,
-            V128Load16Splat { memarg } => self.mem_instr(state, "v128.load16_splat", memarg, 2)?,
-            V128Load32Splat { memarg } => self.mem_instr(state, "v128.load32_splat", memarg, 4)?,
-            V128Load64Splat { memarg } => self.mem_instr(state, "v128.load64_splat", memarg, 8)?,
-
-            V128Load32Zero { memarg } => self.mem_instr(state, "v128.load32_zero", memarg, 4)?,
-            V128Load64Zero { memarg } => self.mem_instr(state, "v128.load64_zero", memarg, 8)?,
-
-            I8x16NarrowI16x8S => self.result.push_str("i8x16.narrow_i16x8_s"),
-            I8x16NarrowI16x8U => self.result.push_str("i8x16.narrow_i16x8_u"),
-            I16x8NarrowI32x4S => self.result.push_str("i16x8.narrow_i32x4_s"),
-            I16x8NarrowI32x4U => self.result.push_str("i16x8.narrow_i32x4_u"),
-
-            I16x8ExtendLowI8x16S => self.result.push_str("i16x8.extend_low_i8x16_s"),
-            I16x8ExtendHighI8x16S => self.result.push_str("i16x8.extend_high_i8x16_s"),
-            I16x8ExtendLowI8x16U => self.result.push_str("i16x8.extend_low_i8x16_u"),
-            I16x8ExtendHighI8x16U => self.result.push_str("i16x8.extend_high_i8x16_u"),
-            I32x4ExtendLowI16x8S => self.result.push_str("i32x4.extend_low_i16x8_s"),
-            I32x4ExtendHighI16x8S => self.result.push_str("i32x4.extend_high_i16x8_s"),
-            I32x4ExtendLowI16x8U => self.result.push_str("i32x4.extend_low_i16x8_u"),
-            I32x4ExtendHighI16x8U => self.result.push_str("i32x4.extend_high_i16x8_u"),
-            I64x2ExtendLowI32x4S => self.result.push_str("i64x2.extend_low_i32x4_s"),
-            I64x2ExtendHighI32x4S => self.result.push_str("i64x2.extend_high_i32x4_s"),
-            I64x2ExtendLowI32x4U => self.result.push_str("i64x2.extend_low_i32x4_u"),
-            I64x2ExtendHighI32x4U => self.result.push_str("i64x2.extend_high_i32x4_u"),
-
-            I16x8ExtMulLowI8x16S => self.result.push_str("i16x8.extmul_low_i8x16_s"),
-            I16x8ExtMulHighI8x16S => self.result.push_str("i16x8.extmul_high_i8x16_s"),
-            I16x8ExtMulLowI8x16U => self.result.push_str("i16x8.extmul_low_i8x16_u"),
-            I16x8ExtMulHighI8x16U => self.result.push_str("i16x8.extmul_high_i8x16_u"),
-            I32x4ExtMulLowI16x8S => self.result.push_str("i32x4.extmul_low_i16x8_s"),
-            I32x4ExtMulHighI16x8S => self.result.push_str("i32x4.extmul_high_i16x8_s"),
-            I32x4ExtMulLowI16x8U => self.result.push_str("i32x4.extmul_low_i16x8_u"),
-            I32x4ExtMulHighI16x8U => self.result.push_str("i32x4.extmul_high_i16x8_u"),
-            I64x2ExtMulLowI32x4S => self.result.push_str("i64x2.extmul_low_i32x4_s"),
-            I64x2ExtMulHighI32x4S => self.result.push_str("i64x2.extmul_high_i32x4_s"),
-            I64x2ExtMulLowI32x4U => self.result.push_str("i64x2.extmul_low_i32x4_u"),
-            I64x2ExtMulHighI32x4U => self.result.push_str("i64x2.extmul_high_i32x4_u"),
-
-            I16x8Q15MulrSatS => self.result.push_str("i16x8.q15mulr_sat_s"),
-
-            V128Load8x8S { memarg } => self.mem_instr(state, "v128.load8x8_s", memarg, 8)?,
-            V128Load8x8U { memarg } => self.mem_instr(state, "v128.load8x8_u", memarg, 8)?,
-            V128Load16x4S { memarg } => self.mem_instr(state, "v128.load16x4_s", memarg, 8)?,
-            V128Load16x4U { memarg } => self.mem_instr(state, "v128.load16x4_u", memarg, 8)?,
-            V128Load32x2S { memarg } => self.mem_instr(state, "v128.load32x2_s", memarg, 8)?,
-            V128Load32x2U { memarg } => self.mem_instr(state, "v128.load32x2_u", memarg, 8)?,
-
-            V128Load8Lane { memarg, lane } => {
-                self.mem_instr(state, "v128.load8_lane", memarg, 1)?;
-                write!(self.result, " {}", lane)?;
-            }
-            V128Load16Lane { memarg, lane } => {
-                self.mem_instr(state, "v128.load16_lane", memarg, 2)?;
-                write!(self.result, " {}", lane)?;
-            }
-            V128Load32Lane { memarg, lane } => {
-                self.mem_instr(state, "v128.load32_lane", memarg, 4)?;
-                write!(self.result, " {}", lane)?;
-            }
-            V128Load64Lane { memarg, lane } => {
-                self.mem_instr(state, "v128.load64_lane", memarg, 8)?;
-                write!(self.result, " {}", lane)?;
-            }
-
-            V128Store8Lane { memarg, lane } => {
-                self.mem_instr(state, "v128.store8_lane", memarg, 1)?;
-                write!(self.result, " {}", lane)?;
-            }
-            V128Store16Lane { memarg, lane } => {
-                self.mem_instr(state, "v128.store16_lane", memarg, 2)?;
-                write!(self.result, " {}", lane)?;
-            }
-            V128Store32Lane { memarg, lane } => {
-                self.mem_instr(state, "v128.store32_lane", memarg, 4)?;
-                write!(self.result, " {}", lane)?;
-            }
-            V128Store64Lane { memarg, lane } => {
-                self.mem_instr(state, "v128.store64_lane", memarg, 8)?;
-                write!(self.result, " {}", lane)?;
-            }
-
-            I8x16RoundingAverageU => self.result.push_str("i8x16.avgr_u"),
-            I16x8RoundingAverageU => self.result.push_str("i16x8.avgr_u"),
-
-            I8x16MinS => self.result.push_str("i8x16.min_s"),
-            I8x16MinU => self.result.push_str("i8x16.min_u"),
-            I8x16MaxS => self.result.push_str("i8x16.max_s"),
-            I8x16MaxU => self.result.push_str("i8x16.max_u"),
-            I16x8MinS => self.result.push_str("i16x8.min_s"),
-            I16x8MinU => self.result.push_str("i16x8.min_u"),
-            I16x8MaxS => self.result.push_str("i16x8.max_s"),
-            I16x8MaxU => self.result.push_str("i16x8.max_u"),
-            I32x4MinS => self.result.push_str("i32x4.min_s"),
-            I32x4MinU => self.result.push_str("i32x4.min_u"),
-            I32x4MaxS => self.result.push_str("i32x4.max_s"),
-            I32x4MaxU => self.result.push_str("i32x4.max_u"),
-            I32x4DotI16x8S => self.result.push_str("i32x4.dot_i16x8_s"),
-
-            F32x4DemoteF64x2Zero => self.result.push_str("f32x4.demote_f64x2_zero"),
-            F64x2PromoteLowF32x4 => self.result.push_str("f64x2.promote_low_f32x4"),
-            F64x2ConvertLowI32x4S => self.result.push_str("f64x2.convert_low_i32x4_s"),
-            F64x2ConvertLowI32x4U => self.result.push_str("f64x2.convert_low_i32x4_u"),
-            I32x4TruncSatF64x2SZero => self.result.push_str("i32x4.trunc_sat_f64x2_s_zero"),
-            I32x4TruncSatF64x2UZero => self.result.push_str("i32x4.trunc_sat_f64x2_u_zero"),
-
-            I8x16Popcnt => self.result.push_str("i8x16.popcnt"),
-
-            I16x8ExtAddPairwiseI8x16S => self.result.push_str("i16x8.extadd_pairwise_i8x16_s"),
-            I16x8ExtAddPairwiseI8x16U => self.result.push_str("i16x8.extadd_pairwise_i8x16_u"),
-            I32x4ExtAddPairwiseI16x8S => self.result.push_str("i32x4.extadd_pairwise_i16x8_s"),
-            I32x4ExtAddPairwiseI16x8U => self.result.push_str("i32x4.extadd_pairwise_i16x8_u"),
-
-            I8x16RelaxedSwizzle => self.result.push_str("i8x16.relaxed_swizzle"),
-            I32x4RelaxedTruncSatF32x4S => self.result.push_str("i32x4.relaxed_trunc_f32x4_s"),
-            I32x4RelaxedTruncSatF32x4U => self.result.push_str("i32x4.relaxed_trunc_f32x4_u"),
-            I32x4RelaxedTruncSatF64x2SZero => {
-                self.result.push_str("i32x4.relaxed_trunc_f64x2_s_zero")
-            }
-            I32x4RelaxedTruncSatF64x2UZero => {
-                self.result.push_str("i32x4.relaxed_trunc_f64x2_u_zero")
-            }
-            F32x4Fma => self.result.push_str("f32x4.fma"),
-            F32x4Fms => self.result.push_str("f32x4.fms"),
-            F64x2Fma => self.result.push_str("f64x2.fma"),
-            F64x2Fms => self.result.push_str("f64x2.fms"),
-            I8x16LaneSelect => self.result.push_str("i8x16.laneselect"),
-            I16x8LaneSelect => self.result.push_str("i16x8.laneselect"),
-            I32x4LaneSelect => self.result.push_str("i32x4.laneselect"),
-            I64x2LaneSelect => self.result.push_str("i64x2.laneselect"),
-            F32x4RelaxedMin => self.result.push_str("f32x4.relaxed_min"),
-            F32x4RelaxedMax => self.result.push_str("f32x4.relaxed_max"),
-            F64x2RelaxedMin => self.result.push_str("f64x2.relaxed_min"),
-            F64x2RelaxedMax => self.result.push_str("f64x2.relaxed_max"),
-        }
-        Ok(())
     }
 
     fn mem_instr(
@@ -2064,52 +1160,66 @@ impl Printer {
         explicit: &str,
     ) -> Result<()> {
         self.start_group("");
+        let mut prev = mem::take(&mut self.result);
+        let mut reader = expr.get_operators_reader();
+        let mut op_printer = operator::PrintOperator::new(self, state);
         let mut first_op = None;
-        for (i, op) in expr.get_operators_reader().into_iter().enumerate() {
-            match op? {
-                Operator::End => {}
+        for i in 0.. {
+            if reader.eof() {
+                break;
+            }
+            match reader.visit_with_offset(&mut op_printer)?? {
+                operator::OpKind::End if reader.eof() => {}
 
-                // Save the first operator to get printed later.
-                other if i == 0 => first_op = Some(other),
+                _ if i == 0 => first_op = Some(mem::take(&mut op_printer.printer.result)),
 
-                // If this is the second operator (i == 1) then we push our
-                // un-sugared form with `explicit` as the starting delimiter and
-                // then the operators are printed.
-                other => {
+                _ => {
                     if i == 1 {
-                        self.result.push_str(explicit);
-                        self.result.push(' ');
-                        self.print_operator(state, &first_op.take().unwrap(), self.nesting)?;
+                        prev.push_str(explicit);
+                        prev.push(' ');
+                        prev.push_str(&first_op.take().unwrap());
                     }
-                    self.result.push(' ');
-                    self.print_operator(state, &other, self.nesting)?;
+                    prev.push(' ');
+                    prev.push_str(&op_printer.printer.result);
                 }
             }
+
+            op_printer.printer.result.truncate(0);
         }
 
         // If `first_op` is still set here then it means we don't need to print
         // an expression with `explicit` as the leading token, instead we can
         // print the single operator.
         if let Some(op) = first_op {
-            self.print_operator(state, &op, self.nesting)?;
+            prev.push_str(&op);
         }
+        self.result = prev;
         self.end_group();
         Ok(())
     }
 
     /// Prints the operators of `expr` space-separated.
     fn print_const_expr(&mut self, state: &mut State, expr: &ConstExpr) -> Result<()> {
-        for (i, op) in expr.get_operators_reader().into_iter().enumerate() {
-            match op? {
-                Operator::End => {}
-                other => {
-                    if i > 0 {
-                        self.result.push(' ');
-                    }
-                    self.print_operator(state, &other, self.nesting)?
+        let mut reader = expr.get_operators_reader();
+        let mut first = true;
+
+        let mut result = mem::take(&mut self.result);
+        let mut op_printer = operator::PrintOperator::new(self, state);
+        while !reader.eof() {
+            if first {
+                first = false;
+            } else {
+                op_printer.printer.result.push(' ');
+            }
+            match reader.visit_with_offset(&mut op_printer)?? {
+                operator::OpKind::End if reader.eof() => {}
+                _ => {
+                    result.push_str(&op_printer.printer.result);
+                    op_printer.printer.result.truncate(0);
                 }
             }
         }
+        self.result = result;
         Ok(())
     }
 

--- a/crates/wasmprinter/src/operator.rs
+++ b/crates/wasmprinter/src/operator.rs
@@ -1,0 +1,1908 @@
+use super::{Printer, State};
+use anyhow::Result;
+use std::fmt::Write;
+use wasmparser::{
+    BlockType, BrTable, Ieee32, Ieee64, MemoryImmediate as MI, ValType, VisitOperator, V128,
+};
+
+pub struct PrintOperator<'a, 'b> {
+    pub(super) printer: &'a mut Printer,
+    nesting_start: u32,
+    state: &'b mut State,
+}
+
+impl<'a, 'b> PrintOperator<'a, 'b> {
+    pub(super) fn new(printer: &'a mut Printer, state: &'b mut State) -> PrintOperator<'a, 'b> {
+        PrintOperator {
+            nesting_start: printer.nesting,
+            printer,
+            state,
+        }
+    }
+
+    fn push_str(&mut self, s: &str) {
+        self.printer.result.push_str(s);
+    }
+
+    fn result(&mut self) -> &mut String {
+        &mut self.printer.result
+    }
+
+    fn print_blockty(&mut self, ty: &BlockType) -> Result<()> {
+        self.printer.print_blockty(self.state, ty, self.cur_depth())
+    }
+
+    fn cur_depth(&self) -> u32 {
+        self.printer.nesting - self.nesting_start
+    }
+
+    fn label(&self, relative: u32) -> String {
+        match self.cur_depth().checked_sub(relative) {
+            Some(i) => format!("@{}", i),
+            None => " INVALID ".to_string(),
+        }
+    }
+
+    fn print_func_idx(&mut self, idx: u32) -> Result<()> {
+        self.printer.print_idx(&self.state.core.func_names, idx)
+    }
+
+    fn print_table_idx(&mut self, idx: u32) -> Result<()> {
+        self.printer.print_idx(&self.state.core.table_names, idx)
+    }
+
+    fn print_global_idx(&mut self, idx: u32) -> Result<()> {
+        self.printer.print_idx(&self.state.core.global_names, idx)
+    }
+
+    fn print_memory_idx(&mut self, idx: u32) -> Result<()> {
+        self.printer.print_idx(&self.state.core.memory_names, idx)
+    }
+
+    fn print_data_idx(&mut self, idx: u32) -> Result<()> {
+        self.printer.print_idx(&self.state.core.data_names, idx)
+    }
+
+    fn print_element_idx(&mut self, idx: u32) -> Result<()> {
+        self.printer.print_idx(&self.state.core.element_names, idx)
+    }
+
+    fn print_local_idx(&mut self, idx: u32) -> Result<()> {
+        self.printer
+            .print_local_idx(self.state, self.state.core.funcs, idx)
+    }
+
+    fn print_type_ref(&mut self, idx: u32) -> Result<()> {
+        self.printer.print_type_ref(self.state, idx, true, None)
+    }
+
+    fn print_valtype(&mut self, ty: ValType) -> Result<()> {
+        self.printer.print_valtype(ty)
+    }
+
+    fn instr(&mut self, name: &str) -> Result<OpKind> {
+        self.push_str(name);
+        Ok(OpKind::Normal)
+    }
+
+    fn mem_instr(&mut self, name: &str, memarg: &MI, align: u32) -> Result<OpKind> {
+        self.printer.mem_instr(self.state, name, memarg, align)?;
+        Ok(OpKind::Normal)
+    }
+}
+
+pub enum OpKind {
+    BlockStart,
+    BlockMid,
+    End,
+    Delegate,
+    Normal,
+}
+
+impl<'a> VisitOperator<'a> for PrintOperator<'_, '_> {
+    type Output = Result<OpKind>;
+
+    fn visit_unreachable(&mut self, _pos: usize) -> Self::Output {
+        self.instr("unreachable")
+    }
+    fn visit_nop(&mut self, _pos: usize) -> Self::Output {
+        self.instr("nop")
+    }
+    fn visit_block(&mut self, _pos: usize, ty: BlockType) -> Self::Output {
+        self.push_str("block");
+        self.print_blockty(&ty)?;
+        Ok(OpKind::BlockStart)
+    }
+    fn visit_loop(&mut self, _pos: usize, ty: BlockType) -> Self::Output {
+        self.push_str("loop");
+        self.print_blockty(&ty)?;
+        Ok(OpKind::BlockStart)
+    }
+    fn visit_if(&mut self, _pos: usize, ty: BlockType) -> Self::Output {
+        self.push_str("if");
+        self.print_blockty(&ty)?;
+        Ok(OpKind::BlockStart)
+    }
+    fn visit_else(&mut self, _pos: usize) -> Self::Output {
+        self.push_str("else");
+        Ok(OpKind::BlockMid)
+    }
+    fn visit_try(&mut self, _pos: usize, ty: BlockType) -> Self::Output {
+        self.push_str("try");
+        self.print_blockty(&ty)?;
+        Ok(OpKind::BlockStart)
+    }
+    fn visit_catch(&mut self, _pos: usize, index: u32) -> Self::Output {
+        write!(self.result(), "catch {index}")?;
+        Ok(OpKind::BlockMid)
+    }
+    fn visit_throw(&mut self, _pos: usize, index: u32) -> Self::Output {
+        write!(self.result(), "throw {index}")?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_rethrow(&mut self, _pos: usize, relative_depth: u32) -> Self::Output {
+        let label = self.label(relative_depth);
+        write!(self.result(), "rethrow {relative_depth} (;{label};)")?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_delegate(&mut self, _pos: usize, relative_depth: u32) -> Self::Output {
+        let label = self.label(relative_depth);
+        write!(self.result(), "delegate {relative_depth} (;{label};)")?;
+        Ok(OpKind::Delegate)
+    }
+    fn visit_catch_all(&mut self, _pos: usize) -> Self::Output {
+        self.push_str("catch_all");
+        Ok(OpKind::BlockMid)
+    }
+    fn visit_end(&mut self, _pos: usize) -> Self::Output {
+        self.push_str("end");
+        Ok(OpKind::End)
+    }
+    fn visit_br(&mut self, _pos: usize, relative_depth: u32) -> Self::Output {
+        let label = self.label(relative_depth);
+        write!(self.result(), "br {relative_depth} (;{label};)")?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_br_if(&mut self, _pos: usize, relative_depth: u32) -> Self::Output {
+        let label = self.label(relative_depth);
+        write!(self.result(), "br_if {relative_depth} (;{label};)")?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_br_table(&mut self, _pos: usize, table: &BrTable<'a>) -> Self::Output {
+        self.push_str("br_table");
+        for item in table.targets().chain(Some(Ok(table.default()))) {
+            let item = item?;
+            let label = self.label(item);
+            write!(self.result(), " {item} (;{label};)")?;
+        }
+        Ok(OpKind::Normal)
+    }
+    fn visit_return(&mut self, _pos: usize) -> Self::Output {
+        self.instr("return")
+    }
+    fn visit_call(&mut self, _pos: usize, function_index: u32) -> Self::Output {
+        self.push_str("call ");
+        self.print_func_idx(function_index)?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_return_call(&mut self, _pos: usize, function_index: u32) -> Self::Output {
+        self.push_str("return_call ");
+        self.print_func_idx(function_index)?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_call_indirect(
+        &mut self,
+        _pos: usize,
+        index: u32,
+        table_index: u32,
+        _table_byte: u8,
+    ) -> Self::Output {
+        self.push_str("call_indirect");
+        if table_index != 0 {
+            self.push_str(" ");
+            self.print_table_idx(table_index)?;
+        }
+        self.print_type_ref(index)?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_return_call_indirect(
+        &mut self,
+        _pos: usize,
+        index: u32,
+        table_index: u32,
+    ) -> Self::Output {
+        self.push_str("return_call_indirect");
+        if table_index != 0 {
+            self.push_str(" ");
+            self.print_table_idx(table_index)?;
+        }
+        self.print_type_ref(index)?;
+        Ok(OpKind::Normal)
+    }
+
+    fn visit_drop(&mut self, _pos: usize) -> Self::Output {
+        self.instr("drop")
+    }
+    fn visit_select(&mut self, _pos: usize) -> Self::Output {
+        self.instr("select")
+    }
+    fn visit_typed_select(&mut self, _pos: usize, ty: ValType) -> Self::Output {
+        self.push_str("select (result ");
+        self.print_valtype(ty)?;
+        self.instr(")")
+    }
+
+    fn visit_ref_null(&mut self, _pos: usize, ty: ValType) -> Self::Output {
+        self.push_str("ref.null ");
+        self.printer.print_reftype(ty)?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_ref_is_null(&mut self, _pos: usize) -> Self::Output {
+        self.instr("ref.is_null")
+    }
+    fn visit_ref_func(&mut self, _pos: usize, function_index: u32) -> Self::Output {
+        self.push_str("ref.func ");
+        self.print_func_idx(function_index)?;
+        Ok(OpKind::Normal)
+    }
+
+    fn visit_local_get(&mut self, _pos: usize, local_index: u32) -> Self::Output {
+        self.push_str("local.get ");
+        self.print_local_idx(local_index)?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_local_set(&mut self, _pos: usize, local_index: u32) -> Self::Output {
+        self.push_str("local.set ");
+        self.print_local_idx(local_index)?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_local_tee(&mut self, _pos: usize, local_index: u32) -> Self::Output {
+        self.push_str("local.tee ");
+        self.print_local_idx(local_index)?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_global_get(&mut self, _pos: usize, global_index: u32) -> Self::Output {
+        self.push_str("global.get ");
+        self.print_global_idx(global_index)?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_global_set(&mut self, _pos: usize, global_index: u32) -> Self::Output {
+        self.push_str("global.set ");
+        self.print_global_idx(global_index)?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_table_get(&mut self, _pos: usize, table: u32) -> Self::Output {
+        self.push_str("table.get ");
+        self.print_table_idx(table)?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_table_set(&mut self, _pos: usize, table: u32) -> Self::Output {
+        self.push_str("table.set ");
+        self.print_table_idx(table)?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_table_init(&mut self, _pos: usize, segment: u32, table: u32) -> Self::Output {
+        self.push_str("table.init ");
+        if table != 0 {
+            self.print_table_idx(table)?;
+            self.push_str(" ");
+        }
+        self.print_element_idx(segment)?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_elem_drop(&mut self, _pos: usize, segment: u32) -> Self::Output {
+        self.push_str("elem.drop ");
+        self.print_element_idx(segment)?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_table_copy(&mut self, _pos: usize, dst: u32, src: u32) -> Self::Output {
+        self.push_str("table.copy");
+        if dst != 0 || src != 0 {
+            self.push_str(" ");
+            self.print_table_idx(dst)?;
+            self.push_str(" ");
+            self.print_table_idx(src)?;
+        }
+        Ok(OpKind::Normal)
+    }
+    fn visit_table_grow(&mut self, _pos: usize, table: u32) -> Self::Output {
+        self.push_str("table.grow ");
+        self.print_table_idx(table)?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_table_size(&mut self, _pos: usize, table: u32) -> Self::Output {
+        self.push_str("table.size ");
+        self.print_table_idx(table)?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_table_fill(&mut self, _pos: usize, table: u32) -> Self::Output {
+        self.push_str("table.fill ");
+        self.print_table_idx(table)?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_i32_load(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.load", &memarg, 4)
+    }
+    fn visit_i64_load(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.load", &memarg, 8)
+    }
+    fn visit_f32_load(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("f32.load", &memarg, 4)
+    }
+    fn visit_f64_load(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("f64.load", &memarg, 8)
+    }
+    fn visit_i32_load8_s(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.load8_s", &memarg, 1)
+    }
+    fn visit_i32_load8_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.load8_u", &memarg, 1)
+    }
+    fn visit_i32_load16_s(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.load16_s", &memarg, 2)
+    }
+    fn visit_i32_load16_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.load16_u", &memarg, 2)
+    }
+    fn visit_i64_load8_s(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.load8_s", &memarg, 1)
+    }
+    fn visit_i64_load8_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.load8_u", &memarg, 1)
+    }
+    fn visit_i64_load16_s(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.load16_s", &memarg, 2)
+    }
+    fn visit_i64_load16_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.load16_u", &memarg, 2)
+    }
+    fn visit_i64_load32_s(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.load32_s", &memarg, 4)
+    }
+    fn visit_i64_load32_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.load32_u", &memarg, 4)
+    }
+    fn visit_i32_store(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.store", &memarg, 4)
+    }
+    fn visit_i64_store(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.store", &memarg, 8)
+    }
+    fn visit_f32_store(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("f32.store", &memarg, 4)
+    }
+    fn visit_f64_store(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("f64.store", &memarg, 8)
+    }
+    fn visit_i32_store8(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.store8", &memarg, 1)
+    }
+    fn visit_i32_store16(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.store16", &memarg, 2)
+    }
+    fn visit_i64_store8(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.store8", &memarg, 1)
+    }
+    fn visit_i64_store16(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.store16", &memarg, 2)
+    }
+    fn visit_i64_store32(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.store32", &memarg, 4)
+    }
+    fn visit_memory_size(&mut self, _pos: usize, mem: u32, _mem_byte: u8) -> Self::Output {
+        self.push_str("memory.size");
+        if mem != 0 {
+            self.push_str(" ");
+            self.print_memory_idx(mem)?;
+        }
+        Ok(OpKind::Normal)
+    }
+    fn visit_memory_grow(&mut self, _pos: usize, mem: u32, _mem_byte: u8) -> Self::Output {
+        self.push_str("memory.grow");
+        if mem != 0 {
+            self.push_str(" ");
+            self.print_memory_idx(mem)?;
+        }
+        Ok(OpKind::Normal)
+    }
+    fn visit_memory_init(&mut self, _pos: usize, segment: u32, mem: u32) -> Self::Output {
+        self.push_str("memory.init ");
+        if mem != 0 {
+            self.print_memory_idx(mem)?;
+            self.push_str(" ");
+        }
+        self.print_data_idx(segment)?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_data_drop(&mut self, _pos: usize, segment: u32) -> Self::Output {
+        self.push_str("data.drop ");
+        self.print_data_idx(segment)?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_memory_copy(&mut self, _pos: usize, dst: u32, src: u32) -> Self::Output {
+        self.push_str("memory.copy");
+        if dst != 0 || src != 0 {
+            self.push_str(" ");
+            self.print_memory_idx(dst)?;
+            self.push_str(" ");
+            self.print_memory_idx(src)?;
+        }
+        Ok(OpKind::Normal)
+    }
+    fn visit_memory_fill(&mut self, _pos: usize, mem: u32) -> Self::Output {
+        self.push_str("memory.fill");
+        if mem != 0 {
+            self.push_str(" ");
+            self.print_memory_idx(mem)?;
+        }
+        Ok(OpKind::Normal)
+    }
+    fn visit_i32_const(&mut self, _pos: usize, value: i32) -> Self::Output {
+        write!(self.result(), "i32.const {value}")?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_i64_const(&mut self, _pos: usize, value: i64) -> Self::Output {
+        write!(self.result(), "i64.const {value}")?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_f32_const(&mut self, _pos: usize, value: Ieee32) -> Self::Output {
+        self.push_str("f32.const ");
+        self.printer.print_f32(value.bits())?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_f64_const(&mut self, _pos: usize, value: Ieee64) -> Self::Output {
+        self.push_str("f64.const ");
+        self.printer.print_f64(value.bits())?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_i32_eqz(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.eqz")
+    }
+    fn visit_i32_eq(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.eq")
+    }
+    fn visit_i32_ne(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.ne")
+    }
+    fn visit_i32_lt_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.lt_s")
+    }
+    fn visit_i32_lt_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.lt_u")
+    }
+    fn visit_i32_gt_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.gt_s")
+    }
+    fn visit_i32_gt_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.gt_u")
+    }
+    fn visit_i32_le_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.le_s")
+    }
+    fn visit_i32_le_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.le_u")
+    }
+    fn visit_i32_ge_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.ge_s")
+    }
+    fn visit_i32_ge_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.ge_u")
+    }
+    fn visit_i64_eqz(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.eqz")
+    }
+    fn visit_i64_eq(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.eq")
+    }
+    fn visit_i64_ne(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.ne")
+    }
+    fn visit_i64_lt_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.lt_s")
+    }
+    fn visit_i64_lt_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.lt_u")
+    }
+    fn visit_i64_gt_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.gt_s")
+    }
+    fn visit_i64_gt_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.gt_u")
+    }
+    fn visit_i64_le_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.le_s")
+    }
+    fn visit_i64_le_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.le_u")
+    }
+    fn visit_i64_ge_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.ge_s")
+    }
+    fn visit_i64_ge_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.ge_u")
+    }
+    fn visit_f32_eq(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32.eq")
+    }
+    fn visit_f32_ne(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32.ne")
+    }
+    fn visit_f32_lt(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32.lt")
+    }
+    fn visit_f32_gt(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32.gt")
+    }
+    fn visit_f32_le(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32.le")
+    }
+    fn visit_f32_ge(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32.ge")
+    }
+    fn visit_f64_eq(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64.eq")
+    }
+    fn visit_f64_ne(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64.ne")
+    }
+    fn visit_f64_lt(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64.lt")
+    }
+    fn visit_f64_gt(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64.gt")
+    }
+    fn visit_f64_le(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64.le")
+    }
+    fn visit_f64_ge(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64.ge")
+    }
+    fn visit_i32_clz(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.clz")
+    }
+    fn visit_i32_ctz(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.ctz")
+    }
+    fn visit_i32_popcnt(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.popcnt")
+    }
+    fn visit_i32_add(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.add")
+    }
+    fn visit_i32_sub(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.sub")
+    }
+    fn visit_i32_mul(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.mul")
+    }
+    fn visit_i32_div_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.div_s")
+    }
+    fn visit_i32_div_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.div_u")
+    }
+    fn visit_i32_rem_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.rem_s")
+    }
+    fn visit_i32_rem_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.rem_u")
+    }
+    fn visit_i32_and(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.and")
+    }
+    fn visit_i32_or(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.or")
+    }
+    fn visit_i32_xor(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.xor")
+    }
+    fn visit_i32_shl(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.shl")
+    }
+    fn visit_i32_shr_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.shr_s")
+    }
+    fn visit_i32_shr_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.shr_u")
+    }
+    fn visit_i32_rotl(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.rotl")
+    }
+    fn visit_i32_rotr(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.rotr")
+    }
+
+    fn visit_i64_clz(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.clz")
+    }
+    fn visit_i64_ctz(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.ctz")
+    }
+    fn visit_i64_popcnt(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.popcnt")
+    }
+    fn visit_i64_add(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.add")
+    }
+    fn visit_i64_sub(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.sub")
+    }
+    fn visit_i64_mul(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.mul")
+    }
+    fn visit_i64_div_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.div_s")
+    }
+    fn visit_i64_div_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.div_u")
+    }
+    fn visit_i64_rem_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.rem_s")
+    }
+    fn visit_i64_rem_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.rem_u")
+    }
+    fn visit_i64_and(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.and")
+    }
+    fn visit_i64_or(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.or")
+    }
+    fn visit_i64_xor(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.xor")
+    }
+    fn visit_i64_shl(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.shl")
+    }
+    fn visit_i64_shr_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.shr_s")
+    }
+    fn visit_i64_shr_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.shr_u")
+    }
+    fn visit_i64_rotl(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.rotl")
+    }
+    fn visit_i64_rotr(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.rotr")
+    }
+
+    fn visit_f32_abs(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32.abs")
+    }
+    fn visit_f32_neg(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32.neg")
+    }
+    fn visit_f32_ceil(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32.ceil")
+    }
+    fn visit_f32_floor(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32.floor")
+    }
+    fn visit_f32_trunc(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32.trunc")
+    }
+    fn visit_f32_nearest(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32.nearest")
+    }
+    fn visit_f32_sqrt(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32.sqrt")
+    }
+    fn visit_f32_add(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32.add")
+    }
+    fn visit_f32_sub(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32.sub")
+    }
+    fn visit_f32_mul(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32.mul")
+    }
+    fn visit_f32_div(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32.div")
+    }
+    fn visit_f32_min(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32.min")
+    }
+    fn visit_f32_max(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32.max")
+    }
+    fn visit_f32_copysign(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32.copysign")
+    }
+
+    fn visit_f64_abs(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64.abs")
+    }
+    fn visit_f64_neg(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64.neg")
+    }
+    fn visit_f64_ceil(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64.ceil")
+    }
+    fn visit_f64_floor(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64.floor")
+    }
+    fn visit_f64_trunc(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64.trunc")
+    }
+    fn visit_f64_nearest(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64.nearest")
+    }
+    fn visit_f64_sqrt(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64.sqrt")
+    }
+    fn visit_f64_add(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64.add")
+    }
+    fn visit_f64_sub(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64.sub")
+    }
+    fn visit_f64_mul(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64.mul")
+    }
+    fn visit_f64_div(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64.div")
+    }
+    fn visit_f64_min(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64.min")
+    }
+    fn visit_f64_max(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64.max")
+    }
+    fn visit_f64_copysign(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64.copysign")
+    }
+
+    fn visit_i32_wrap_i64(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.wrap_i64")
+    }
+    fn visit_i32_trunc_f32s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.trunc_f32_s")
+    }
+    fn visit_i32_trunc_f32u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.trunc_f32_u")
+    }
+    fn visit_i32_trunc_f64s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.trunc_f64_s")
+    }
+    fn visit_i32_trunc_f64u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.trunc_f64_u")
+    }
+    fn visit_i64_extend_i32s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.extend_i32_s")
+    }
+    fn visit_i64_extend_i32u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.extend_i32_u")
+    }
+    fn visit_i64_trunc_f32s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.trunc_f32_s")
+    }
+    fn visit_i64_trunc_f32u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.trunc_f32_u")
+    }
+    fn visit_i64_trunc_f64s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.trunc_f64_s")
+    }
+    fn visit_i64_trunc_f64u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.trunc_f64_u")
+    }
+
+    fn visit_f32_convert_i32s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32.convert_i32_s")
+    }
+    fn visit_f32_convert_i32u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32.convert_i32_u")
+    }
+    fn visit_f32_convert_i64s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32.convert_i64_s")
+    }
+    fn visit_f32_convert_i64u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32.convert_i64_u")
+    }
+    fn visit_f32_demote_f64(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32.demote_f64")
+    }
+    fn visit_f64_convert_i32s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64.convert_i32_s")
+    }
+    fn visit_f64_convert_i32u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64.convert_i32_u")
+    }
+    fn visit_f64_convert_i64s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64.convert_i64_s")
+    }
+    fn visit_f64_convert_i64u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64.convert_i64_u")
+    }
+    fn visit_f64_promote_f32(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64.promote_f32")
+    }
+    fn visit_i32_reinterpret_f32(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.reinterpret_f32")
+    }
+    fn visit_i64_reinterpret_f64(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.reinterpret_f64")
+    }
+    fn visit_f32_reinterpret_i32(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32.reinterpret_i32")
+    }
+    fn visit_f64_reinterpret_i64(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64.reinterpret_i64")
+    }
+    fn visit_i32_extend8_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.extend8_s")
+    }
+    fn visit_i32_extend16_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.extend16_s")
+    }
+    fn visit_i64_extend8_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.extend8_s")
+    }
+    fn visit_i64_extend16_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.extend16_s")
+    }
+    fn visit_i64_extend32_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.extend32_s")
+    }
+
+    fn visit_i32_trunc_sat_f32s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.trunc_sat_f32_s")
+    }
+    fn visit_i32_trunc_sat_f32u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.trunc_sat_f32_u")
+    }
+    fn visit_i32_trunc_sat_f64s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.trunc_sat_f64_s")
+    }
+    fn visit_i32_trunc_sat_f64u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32.trunc_sat_f64_u")
+    }
+    fn visit_i64_trunc_sat_f32s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.trunc_sat_f32_s")
+    }
+    fn visit_i64_trunc_sat_f32u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.trunc_sat_f32_u")
+    }
+    fn visit_i64_trunc_sat_f64s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.trunc_sat_f64_s")
+    }
+    fn visit_i64_trunc_sat_f64u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64.trunc_sat_f64_u")
+    }
+
+    fn visit_memory_atomic_notify(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("memory.atomic.notify", &memarg, 4)
+    }
+    fn visit_memory_atomic_wait32(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("memory.atomic.wait32", &memarg, 4)
+    }
+    fn visit_memory_atomic_wait64(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("memory.atomic.wait64", &memarg, 8)
+    }
+
+    fn visit_i32_atomic_load(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.atomic.load", &memarg, 4)
+    }
+    fn visit_i64_atomic_load(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.load", &memarg, 8)
+    }
+    fn visit_i32_atomic_load8_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.atomic.load8_u", &memarg, 1)
+    }
+    fn visit_i32_atomic_load16_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.atomic.load16_u", &memarg, 2)
+    }
+    fn visit_i64_atomic_load8_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.load8_u", &memarg, 1)
+    }
+    fn visit_i64_atomic_load16_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.load16_u", &memarg, 2)
+    }
+    fn visit_i64_atomic_load32_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.load32_u", &memarg, 4)
+    }
+    fn visit_i32_atomic_store(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.atomic.store", &memarg, 4)
+    }
+    fn visit_i32_atomic_store8(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.atomic.store8", &memarg, 1)
+    }
+    fn visit_i32_atomic_store16(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.atomic.store16", &memarg, 2)
+    }
+    fn visit_i64_atomic_store(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.store", &memarg, 8)
+    }
+    fn visit_i64_atomic_store8(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.store8", &memarg, 1)
+    }
+    fn visit_i64_atomic_store16(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.store16", &memarg, 2)
+    }
+    fn visit_i64_atomic_store32(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.store32", &memarg, 4)
+    }
+
+    fn visit_i32_atomic_rmw_add(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.atomic.rmw.add", &memarg, 4)
+    }
+    fn visit_i32_atomic_rmw8_add_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.atomic.rmw8.add_u", &memarg, 1)
+    }
+    fn visit_i32_atomic_rmw16_add_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.atomic.rmw16.add_u", &memarg, 2)
+    }
+    fn visit_i64_atomic_rmw_add(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.rmw.add", &memarg, 8)
+    }
+    fn visit_i64_atomic_rmw8_add_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.rmw8.add_u", &memarg, 1)
+    }
+    fn visit_i64_atomic_rmw16_add_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.rmw16.add_u", &memarg, 2)
+    }
+    fn visit_i64_atomic_rmw32_add_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.rmw32.add_u", &memarg, 4)
+    }
+
+    fn visit_i32_atomic_rmw_sub(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.atomic.rmw.sub", &memarg, 4)
+    }
+    fn visit_i32_atomic_rmw8_sub_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.atomic.rmw8.sub_u", &memarg, 1)
+    }
+    fn visit_i32_atomic_rmw16_sub_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.atomic.rmw16.sub_u", &memarg, 2)
+    }
+    fn visit_i64_atomic_rmw_sub(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.rmw.sub", &memarg, 8)
+    }
+    fn visit_i64_atomic_rmw8_sub_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.rmw8.sub_u", &memarg, 1)
+    }
+    fn visit_i64_atomic_rmw16_sub_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.rmw16.sub_u", &memarg, 2)
+    }
+    fn visit_i64_atomic_rmw32_sub_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.rmw32.sub_u", &memarg, 4)
+    }
+
+    fn visit_i32_atomic_rmw_and(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.atomic.rmw.and", &memarg, 4)
+    }
+    fn visit_i32_atomic_rmw8_and_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.atomic.rmw8.and_u", &memarg, 1)
+    }
+    fn visit_i32_atomic_rmw16_and_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.atomic.rmw16.and_u", &memarg, 2)
+    }
+    fn visit_i64_atomic_rmw_and(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.rmw.and", &memarg, 8)
+    }
+    fn visit_i64_atomic_rmw8_and_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.rmw8.and_u", &memarg, 1)
+    }
+    fn visit_i64_atomic_rmw16_and_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.rmw16.and_u", &memarg, 2)
+    }
+    fn visit_i64_atomic_rmw32_and_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.rmw32.and_u", &memarg, 4)
+    }
+
+    fn visit_i32_atomic_rmw_or(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.atomic.rmw.or", &memarg, 4)
+    }
+    fn visit_i32_atomic_rmw8_or_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.atomic.rmw8.or_u", &memarg, 1)
+    }
+    fn visit_i32_atomic_rmw16_or_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.atomic.rmw16.or_u", &memarg, 2)
+    }
+    fn visit_i64_atomic_rmw_or(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.rmw.or", &memarg, 8)
+    }
+    fn visit_i64_atomic_rmw8_or_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.rmw8.or_u", &memarg, 1)
+    }
+    fn visit_i64_atomic_rmw16_or_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.rmw16.or_u", &memarg, 2)
+    }
+    fn visit_i64_atomic_rmw32_or_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.rmw32.or_u", &memarg, 4)
+    }
+
+    fn visit_i32_atomic_rmw_xor(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.atomic.rmw.xor", &memarg, 4)
+    }
+    fn visit_i32_atomic_rmw8_xor_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.atomic.rmw8.xor_u", &memarg, 1)
+    }
+    fn visit_i32_atomic_rmw16_xor_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.atomic.rmw16.xor_u", &memarg, 2)
+    }
+    fn visit_i64_atomic_rmw_xor(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.rmw.xor", &memarg, 8)
+    }
+    fn visit_i64_atomic_rmw8_xor_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.rmw8.xor_u", &memarg, 1)
+    }
+    fn visit_i64_atomic_rmw16_xor_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.rmw16.xor_u", &memarg, 2)
+    }
+    fn visit_i64_atomic_rmw32_xor_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.rmw32.xor_u", &memarg, 4)
+    }
+
+    fn visit_i32_atomic_rmw_xchg(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.atomic.rmw.xchg", &memarg, 4)
+    }
+    fn visit_i32_atomic_rmw8_xchg_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.atomic.rmw8.xchg_u", &memarg, 1)
+    }
+    fn visit_i32_atomic_rmw16_xchg_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.atomic.rmw16.xchg_u", &memarg, 2)
+    }
+    fn visit_i64_atomic_rmw_xchg(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.rmw.xchg", &memarg, 8)
+    }
+    fn visit_i64_atomic_rmw8_xchg_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.rmw8.xchg_u", &memarg, 1)
+    }
+    fn visit_i64_atomic_rmw16_xchg_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.rmw16.xchg_u", &memarg, 2)
+    }
+    fn visit_i64_atomic_rmw32_xchg_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.rmw32.xchg_u", &memarg, 4)
+    }
+
+    fn visit_i32_atomic_rmw_cmpxchg(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.atomic.rmw.cmpxchg", &memarg, 4)
+    }
+    fn visit_i32_atomic_rmw8_cmpxchg_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.atomic.rmw8.cmpxchg_u", &memarg, 1)
+    }
+    fn visit_i32_atomic_rmw16_cmpxchg_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i32.atomic.rmw16.cmpxchg_u", &memarg, 2)
+    }
+    fn visit_i64_atomic_rmw_cmpxchg(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.rmw.cmpxchg", &memarg, 8)
+    }
+    fn visit_i64_atomic_rmw8_cmpxchg_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.rmw8.cmpxchg_u", &memarg, 1)
+    }
+    fn visit_i64_atomic_rmw16_cmpxchg_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.rmw16.cmpxchg_u", &memarg, 2)
+    }
+    fn visit_i64_atomic_rmw32_cmpxchg_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("i64.atomic.rmw32.cmpxchg_u", &memarg, 4)
+    }
+
+    fn visit_atomic_fence(&mut self, _pos: usize, _flags: u8) -> Self::Output {
+        self.instr("atomic.fence")
+    }
+
+    fn visit_v128_load(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("v128.load", &memarg, 16)
+    }
+    fn visit_v128_store(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("v128.store", &memarg, 16)
+    }
+    fn visit_v128_const(&mut self, _pos: usize, value: V128) -> Self::Output {
+        write!(self.result(), "v128.const i32x4")?;
+        for chunk in value.bytes().chunks(4) {
+            write!(
+                self.result(),
+                " 0x{:02x}{:02x}{:02x}{:02x}",
+                chunk[3],
+                chunk[2],
+                chunk[1],
+                chunk[0],
+            )?;
+        }
+        Ok(OpKind::Normal)
+    }
+    fn visit_i8x16_splat(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.splat")
+    }
+    fn visit_i16x8_splat(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.splat")
+    }
+    fn visit_i32x4_splat(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.splat")
+    }
+    fn visit_i64x2_splat(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64x2.splat")
+    }
+    fn visit_f32x4_splat(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.splat")
+    }
+    fn visit_f64x2_splat(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.splat")
+    }
+    fn visit_i8x16_extract_lane_s(&mut self, _pos: usize, lane: u8) -> Self::Output {
+        write!(self.result(), "i8x16.extract_lane_s {lane}")?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_i8x16_extract_lane_u(&mut self, _pos: usize, lane: u8) -> Self::Output {
+        write!(self.result(), "i8x16.extract_lane_u {lane}")?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_i16x8_extract_lane_s(&mut self, _pos: usize, lane: u8) -> Self::Output {
+        write!(self.result(), "i16x8.extract_lane_s {lane}")?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_i16x8_extract_lane_u(&mut self, _pos: usize, lane: u8) -> Self::Output {
+        write!(self.result(), "i16x8.extract_lane_u {lane}")?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_i32x4_extract_lane(&mut self, _pos: usize, lane: u8) -> Self::Output {
+        write!(self.result(), "i32x4.extract_lane {lane}")?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_i64x2_extract_lane(&mut self, _pos: usize, lane: u8) -> Self::Output {
+        write!(self.result(), "i64x2.extract_lane {lane}")?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_i8x16_replace_lane(&mut self, _pos: usize, lane: u8) -> Self::Output {
+        write!(self.result(), "i8x16.replace_lane {lane}")?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_i16x8_replace_lane(&mut self, _pos: usize, lane: u8) -> Self::Output {
+        write!(self.result(), "i16x8.replace_lane {lane}")?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_i32x4_replace_lane(&mut self, _pos: usize, lane: u8) -> Self::Output {
+        write!(self.result(), "i32x4.replace_lane {lane}")?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_i64x2_replace_lane(&mut self, _pos: usize, lane: u8) -> Self::Output {
+        write!(self.result(), "i64x2.replace_lane {lane}")?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_f32x4_extract_lane(&mut self, _pos: usize, lane: u8) -> Self::Output {
+        write!(self.result(), "f32x4.extract_lane {lane}")?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_f32x4_replace_lane(&mut self, _pos: usize, lane: u8) -> Self::Output {
+        write!(self.result(), "f32x4.replace_lane {lane}")?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_f64x2_extract_lane(&mut self, _pos: usize, lane: u8) -> Self::Output {
+        write!(self.result(), "f64x2.extract_lane {lane}")?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_f64x2_replace_lane(&mut self, _pos: usize, lane: u8) -> Self::Output {
+        write!(self.result(), "f64x2.replace_lane {lane}")?;
+        Ok(OpKind::Normal)
+    }
+
+    fn visit_f32x4_eq(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.eq")
+    }
+    fn visit_f32x4_ne(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.ne")
+    }
+    fn visit_f32x4_lt(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.lt")
+    }
+    fn visit_f32x4_gt(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.gt")
+    }
+    fn visit_f32x4_le(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.le")
+    }
+    fn visit_f32x4_ge(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.ge")
+    }
+
+    fn visit_f64x2_eq(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.eq")
+    }
+    fn visit_f64x2_ne(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.ne")
+    }
+    fn visit_f64x2_lt(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.lt")
+    }
+    fn visit_f64x2_gt(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.gt")
+    }
+    fn visit_f64x2_le(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.le")
+    }
+    fn visit_f64x2_ge(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.ge")
+    }
+
+    fn visit_f32x4_add(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.add")
+    }
+    fn visit_f32x4_sub(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.sub")
+    }
+    fn visit_f32x4_mul(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.mul")
+    }
+    fn visit_f32x4_div(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.div")
+    }
+    fn visit_f32x4_min(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.min")
+    }
+    fn visit_f32x4_max(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.max")
+    }
+    fn visit_f32x4_p_min(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.pmin")
+    }
+    fn visit_f32x4_p_max(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.pmax")
+    }
+
+    fn visit_f64x2_add(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.add")
+    }
+    fn visit_f64x2_sub(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.sub")
+    }
+    fn visit_f64x2_mul(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.mul")
+    }
+    fn visit_f64x2_div(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.div")
+    }
+    fn visit_f64x2_min(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.min")
+    }
+    fn visit_f64x2_max(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.max")
+    }
+    fn visit_f64x2_p_min(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.pmin")
+    }
+    fn visit_f64x2_p_max(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.pmax")
+    }
+
+    fn visit_f32x4_relaxed_min(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.relaxed_min")
+    }
+    fn visit_f32x4_relaxed_max(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.relaxed_max")
+    }
+    fn visit_f64x2_relaxed_min(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.relaxed_min")
+    }
+    fn visit_f64x2_relaxed_max(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.relaxed_max")
+    }
+
+    fn visit_i8x16_eq(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.eq")
+    }
+    fn visit_i8x16_ne(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.ne")
+    }
+    fn visit_i8x16_lt_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.lt_s")
+    }
+    fn visit_i8x16_lt_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.lt_u")
+    }
+    fn visit_i8x16_gt_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.gt_s")
+    }
+    fn visit_i8x16_gt_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.gt_u")
+    }
+    fn visit_i8x16_le_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.le_s")
+    }
+    fn visit_i8x16_le_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.le_u")
+    }
+    fn visit_i8x16_ge_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.ge_s")
+    }
+    fn visit_i8x16_ge_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.ge_u")
+    }
+
+    fn visit_i16x8_eq(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.eq")
+    }
+    fn visit_i16x8_ne(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.ne")
+    }
+    fn visit_i16x8_lt_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.lt_s")
+    }
+    fn visit_i16x8_lt_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.lt_u")
+    }
+    fn visit_i16x8_gt_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.gt_s")
+    }
+    fn visit_i16x8_gt_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.gt_u")
+    }
+    fn visit_i16x8_le_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.le_s")
+    }
+    fn visit_i16x8_le_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.le_u")
+    }
+    fn visit_i16x8_ge_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.ge_s")
+    }
+    fn visit_i16x8_ge_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.ge_u")
+    }
+
+    fn visit_i32x4_eq(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.eq")
+    }
+    fn visit_i32x4_ne(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.ne")
+    }
+    fn visit_i32x4_lt_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.lt_s")
+    }
+    fn visit_i32x4_lt_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.lt_u")
+    }
+    fn visit_i32x4_gt_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.gt_s")
+    }
+    fn visit_i32x4_gt_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.gt_u")
+    }
+    fn visit_i32x4_le_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.le_s")
+    }
+    fn visit_i32x4_le_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.le_u")
+    }
+    fn visit_i32x4_ge_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.ge_s")
+    }
+    fn visit_i32x4_ge_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.ge_u")
+    }
+
+    fn visit_i64x2_eq(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64x2.eq")
+    }
+    fn visit_i64x2_ne(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64x2.ne")
+    }
+    fn visit_i64x2_lt_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64x2.lt_s")
+    }
+    fn visit_i64x2_gt_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64x2.gt_s")
+    }
+    fn visit_i64x2_le_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64x2.le_s")
+    }
+    fn visit_i64x2_ge_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64x2.ge_s")
+    }
+
+    fn visit_v128_and(&mut self, _pos: usize) -> Self::Output {
+        self.instr("v128.and")
+    }
+    fn visit_v128_and_not(&mut self, _pos: usize) -> Self::Output {
+        self.instr("v128.andnot")
+    }
+    fn visit_v128_or(&mut self, _pos: usize) -> Self::Output {
+        self.instr("v128.or")
+    }
+    fn visit_v128_xor(&mut self, _pos: usize) -> Self::Output {
+        self.instr("v128.xor")
+    }
+
+    fn visit_i8x16_add(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.add")
+    }
+    fn visit_i8x16_add_sat_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.add_sat_s")
+    }
+    fn visit_i8x16_add_sat_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.add_sat_u")
+    }
+    fn visit_i8x16_sub(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.sub")
+    }
+    fn visit_i8x16_sub_sat_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.sub_sat_s")
+    }
+    fn visit_i8x16_sub_sat_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.sub_sat_u")
+    }
+    fn visit_i8x16_min_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.min_s")
+    }
+    fn visit_i8x16_min_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.min_u")
+    }
+    fn visit_i8x16_max_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.max_s")
+    }
+    fn visit_i8x16_max_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.max_u")
+    }
+
+    fn visit_i16x8_add(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.add")
+    }
+    fn visit_i16x8_add_sat_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.add_sat_s")
+    }
+    fn visit_i16x8_add_sat_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.add_sat_u")
+    }
+    fn visit_i16x8_sub(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.sub")
+    }
+    fn visit_i16x8_sub_sat_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.sub_sat_s")
+    }
+    fn visit_i16x8_sub_sat_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.sub_sat_u")
+    }
+    fn visit_i16x8_min_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.min_s")
+    }
+    fn visit_i16x8_min_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.min_u")
+    }
+    fn visit_i16x8_max_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.max_s")
+    }
+    fn visit_i16x8_max_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.max_u")
+    }
+    fn visit_i16x8_mul(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.mul")
+    }
+
+    fn visit_i32x4_add(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.add")
+    }
+    fn visit_i32x4_sub(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.sub")
+    }
+    fn visit_i32x4_min_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.min_s")
+    }
+    fn visit_i32x4_min_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.min_u")
+    }
+    fn visit_i32x4_max_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.max_s")
+    }
+    fn visit_i32x4_max_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.max_u")
+    }
+    fn visit_i32x4_mul(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.mul")
+    }
+    fn visit_i32x4_dot_i16x8_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.dot_i16x8_s")
+    }
+
+    fn visit_i64x2_add(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64x2.add")
+    }
+    fn visit_i64x2_sub(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64x2.sub")
+    }
+    fn visit_i64x2_mul(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64x2.mul")
+    }
+
+    fn visit_i8x16_rounding_average_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.avgr_u")
+    }
+    fn visit_i16x8_rounding_average_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.avgr_u")
+    }
+    fn visit_i8x16_narrow_i16x8_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.narrow_i16x8_s")
+    }
+    fn visit_i8x16_narrow_i16x8_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.narrow_i16x8_u")
+    }
+    fn visit_i16x8_narrow_i32x4_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.narrow_i32x4_s")
+    }
+    fn visit_i16x8_narrow_i32x4_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.narrow_i32x4_u")
+    }
+    fn visit_i16x8_ext_mul_low_i8x16_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.extmul_low_i8x16_s")
+    }
+    fn visit_i16x8_ext_mul_high_i8x16_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.extmul_high_i8x16_s")
+    }
+    fn visit_i16x8_ext_mul_low_i8x16_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.extmul_low_i8x16_u")
+    }
+    fn visit_i16x8_ext_mul_high_i8x16_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.extmul_high_i8x16_u")
+    }
+    fn visit_i32x4_ext_mul_low_i16x8_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.extmul_low_i16x8_s")
+    }
+    fn visit_i32x4_ext_mul_high_i16x8_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.extmul_high_i16x8_s")
+    }
+    fn visit_i32x4_ext_mul_low_i16x8_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.extmul_low_i16x8_u")
+    }
+    fn visit_i32x4_ext_mul_high_i16x8_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.extmul_high_i16x8_u")
+    }
+    fn visit_i64x2_ext_mul_low_i32x4_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64x2.extmul_low_i32x4_s")
+    }
+    fn visit_i64x2_ext_mul_high_i32x4_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64x2.extmul_high_i32x4_s")
+    }
+    fn visit_i64x2_ext_mul_low_i32x4_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64x2.extmul_low_i32x4_u")
+    }
+    fn visit_i64x2_ext_mul_high_i32x4_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64x2.extmul_high_i32x4_u")
+    }
+    fn visit_i16x8_q15_mulr_sat_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.q15mulr_sat_s")
+    }
+
+    fn visit_f32x4_ceil(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.ceil")
+    }
+    fn visit_f32x4_floor(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.floor")
+    }
+    fn visit_f32x4_trunc(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.trunc")
+    }
+    fn visit_f32x4_nearest(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.nearest")
+    }
+
+    fn visit_f64x2_ceil(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.ceil")
+    }
+    fn visit_f64x2_floor(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.floor")
+    }
+    fn visit_f64x2_trunc(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.trunc")
+    }
+    fn visit_f64x2_nearest(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.nearest")
+    }
+
+    fn visit_f32x4_abs(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.abs")
+    }
+    fn visit_f32x4_neg(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.neg")
+    }
+    fn visit_f32x4_sqrt(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.sqrt")
+    }
+    fn visit_f64x2_abs(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.abs")
+    }
+    fn visit_f64x2_neg(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.neg")
+    }
+    fn visit_f64x2_sqrt(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.sqrt")
+    }
+
+    fn visit_f32x4_demote_f64x2_zero(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.demote_f64x2_zero")
+    }
+    fn visit_f64x2_promote_low_f32x4(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.promote_low_f32x4")
+    }
+    fn visit_f64x2_convert_low_i32x4_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.convert_low_i32x4_s")
+    }
+    fn visit_f64x2_convert_low_i32x4_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.convert_low_i32x4_u")
+    }
+    fn visit_i32x4_trunc_sat_f32x4_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.trunc_sat_f32x4_s")
+    }
+    fn visit_i32x4_trunc_sat_f32x4_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.trunc_sat_f32x4_u")
+    }
+    fn visit_i32x4_trunc_sat_f64x2_s_zero(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.trunc_sat_f64x2_s_zero")
+    }
+    fn visit_i32x4_trunc_sat_f64x2_u_zero(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.trunc_sat_f64x2_u_zero")
+    }
+    fn visit_f32x4_convert_i32x4_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.convert_i32x4_s")
+    }
+    fn visit_f32x4_convert_i32x4_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.convert_i32x4_u")
+    }
+    fn visit_v128_not(&mut self, _pos: usize) -> Self::Output {
+        self.instr("v128.not")
+    }
+    fn visit_i8x16_abs(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.abs")
+    }
+    fn visit_i8x16_neg(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.neg")
+    }
+    fn visit_i8x16_popcnt(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.popcnt")
+    }
+    fn visit_i16x8_abs(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.abs")
+    }
+    fn visit_i16x8_neg(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.neg")
+    }
+    fn visit_i32x4_abs(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.abs")
+    }
+    fn visit_i32x4_neg(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.neg")
+    }
+    fn visit_i64x2_abs(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64x2.abs")
+    }
+    fn visit_i64x2_neg(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64x2.neg")
+    }
+    fn visit_i16x8_extend_low_i8x16_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.extend_low_i8x16_s")
+    }
+    fn visit_i16x8_extend_high_i8x16_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.extend_high_i8x16_s")
+    }
+    fn visit_i16x8_extend_low_i8x16_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.extend_low_i8x16_u")
+    }
+    fn visit_i16x8_extend_high_i8x16_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.extend_high_i8x16_u")
+    }
+    fn visit_i32x4_extend_low_i16x8_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.extend_low_i16x8_s")
+    }
+    fn visit_i32x4_extend_high_i16x8_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.extend_high_i16x8_s")
+    }
+    fn visit_i32x4_extend_low_i16x8_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.extend_low_i16x8_u")
+    }
+    fn visit_i32x4_extend_high_i16x8_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.extend_high_i16x8_u")
+    }
+    fn visit_i64x2_extend_low_i32x4_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64x2.extend_low_i32x4_s")
+    }
+    fn visit_i64x2_extend_high_i32x4_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64x2.extend_high_i32x4_s")
+    }
+    fn visit_i64x2_extend_low_i32x4_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64x2.extend_low_i32x4_u")
+    }
+    fn visit_i64x2_extend_high_i32x4_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64x2.extend_high_i32x4_u")
+    }
+    fn visit_i16x8_ext_add_pairwise_i8x16_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.extadd_pairwise_i8x16_s")
+    }
+    fn visit_i16x8_ext_add_pairwise_i8x16_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.extadd_pairwise_i8x16_u")
+    }
+    fn visit_i32x4_ext_add_pairwise_i16x8_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.extadd_pairwise_i16x8_s")
+    }
+    fn visit_i32x4_ext_add_pairwise_i16x8_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.extadd_pairwise_i16x8_u")
+    }
+    fn visit_i32x4_relaxed_trunc_sat_f32x4_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.relaxed_trunc_f32x4_s")
+    }
+    fn visit_i32x4_relaxed_trunc_sat_f32x4_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.relaxed_trunc_f32x4_u")
+    }
+    fn visit_i32x4_relaxed_trunc_sat_f64x2_s_zero(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.relaxed_trunc_f64x2_s_zero")
+    }
+    fn visit_i32x4_relaxed_trunc_sat_f64x2_u_zero(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.relaxed_trunc_f64x2_u_zero")
+    }
+    fn visit_v128_bitselect(&mut self, _pos: usize) -> Self::Output {
+        self.instr("v128.bitselect")
+    }
+    fn visit_f32x4_fma(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.fma")
+    }
+    fn visit_f32x4_fms(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f32x4.fms")
+    }
+    fn visit_f64x2_fma(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.fma")
+    }
+    fn visit_f64x2_fms(&mut self, _pos: usize) -> Self::Output {
+        self.instr("f64x2.fms")
+    }
+    fn visit_i8x16_lane_select(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.laneselect")
+    }
+    fn visit_i16x8_lane_select(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.laneselect")
+    }
+    fn visit_i32x4_lane_select(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.laneselect")
+    }
+    fn visit_i64x2_lane_select(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64x2.laneselect")
+    }
+    fn visit_v128_any_true(&mut self, _pos: usize) -> Self::Output {
+        self.instr("v128.any_true")
+    }
+    fn visit_i8x16_all_true(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.all_true")
+    }
+    fn visit_i8x16_bitmask(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.bitmask")
+    }
+    fn visit_i16x8_all_true(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.all_true")
+    }
+    fn visit_i16x8_bitmask(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.bitmask")
+    }
+    fn visit_i32x4_all_true(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.all_true")
+    }
+    fn visit_i32x4_bitmask(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.bitmask")
+    }
+    fn visit_i64x2_all_true(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64x2.all_true")
+    }
+    fn visit_i64x2_bitmask(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64x2.bitmask")
+    }
+    fn visit_i8x16_shl(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.shl")
+    }
+    fn visit_i8x16_shr_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.shr_s")
+    }
+    fn visit_i8x16_shr_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.shr_u")
+    }
+    fn visit_i16x8_shl(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.shl")
+    }
+    fn visit_i16x8_shr_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.shr_s")
+    }
+    fn visit_i16x8_shr_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i16x8.shr_u")
+    }
+    fn visit_i32x4_shl(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.shl")
+    }
+    fn visit_i32x4_shr_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.shr_s")
+    }
+    fn visit_i32x4_shr_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i32x4.shr_u")
+    }
+    fn visit_i64x2_shl(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64x2.shl")
+    }
+    fn visit_i64x2_shr_s(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64x2.shr_s")
+    }
+    fn visit_i64x2_shr_u(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i64x2.shr_u")
+    }
+
+    fn visit_i8x16_swizzle(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.swizzle")
+    }
+    fn visit_i8x16_relaxed_swizzle(&mut self, _pos: usize) -> Self::Output {
+        self.instr("i8x16.relaxed_swizzle")
+    }
+    fn visit_i8x16_shuffle(&mut self, _pos: usize, lanes: [u8; 16]) -> Self::Output {
+        self.push_str("i8x16.shuffle");
+        for lane in lanes {
+            write!(self.result(), " {}", lane)?;
+        }
+        Ok(OpKind::Normal)
+    }
+    fn visit_v128_load8_splat(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("v128.load8_splat", &memarg, 1)
+    }
+    fn visit_v128_load16_splat(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("v128.load16_splat", &memarg, 2)
+    }
+    fn visit_v128_load32_splat(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("v128.load32_splat", &memarg, 4)
+    }
+    fn visit_v128_load32_zero(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("v128.load32_zero", &memarg, 4)
+    }
+    fn visit_v128_load64_splat(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("v128.load64_splat", &memarg, 8)
+    }
+    fn visit_v128_load64_zero(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("v128.load64_zero", &memarg, 8)
+    }
+    fn visit_v128_load8x8_s(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("v128.load8x8_s", &memarg, 8)
+    }
+    fn visit_v128_load8x8_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("v128.load8x8_u", &memarg, 8)
+    }
+    fn visit_v128_load16x4_s(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("v128.load16x4_s", &memarg, 8)
+    }
+    fn visit_v128_load16x4_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("v128.load16x4_u", &memarg, 8)
+    }
+    fn visit_v128_load32x2_s(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("v128.load32x2_s", &memarg, 8)
+    }
+    fn visit_v128_load32x2_u(&mut self, _pos: usize, memarg: MI) -> Self::Output {
+        self.mem_instr("v128.load32x2_u", &memarg, 8)
+    }
+    fn visit_v128_load8_lane(&mut self, _pos: usize, memarg: MI, lane: u8) -> Self::Output {
+        self.mem_instr("v128.load8_lane", &memarg, 1)?;
+        write!(self.result(), " {lane}")?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_v128_load16_lane(&mut self, _pos: usize, memarg: MI, lane: u8) -> Self::Output {
+        self.mem_instr("v128.load16_lane", &memarg, 2)?;
+        write!(self.result(), " {lane}")?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_v128_load32_lane(&mut self, _pos: usize, memarg: MI, lane: u8) -> Self::Output {
+        self.mem_instr("v128.load32_lane", &memarg, 4)?;
+        write!(self.result(), " {lane}")?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_v128_load64_lane(&mut self, _pos: usize, memarg: MI, lane: u8) -> Self::Output {
+        self.mem_instr("v128.load64_lane", &memarg, 8)?;
+        write!(self.result(), " {lane}")?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_v128_store8_lane(&mut self, _pos: usize, memarg: MI, lane: u8) -> Self::Output {
+        self.mem_instr("v128.store8_lane", &memarg, 1)?;
+        write!(self.result(), " {lane}")?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_v128_store16_lane(&mut self, _pos: usize, memarg: MI, lane: u8) -> Self::Output {
+        self.mem_instr("v128.store16_lane", &memarg, 2)?;
+        write!(self.result(), " {lane}")?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_v128_store32_lane(&mut self, _pos: usize, memarg: MI, lane: u8) -> Self::Output {
+        self.mem_instr("v128.store32_lane", &memarg, 4)?;
+        write!(self.result(), " {lane}")?;
+        Ok(OpKind::Normal)
+    }
+    fn visit_v128_store64_lane(&mut self, _pos: usize, memarg: MI, lane: u8) -> Self::Output {
+        self.mem_instr("v128.store64_lane", &memarg, 8)?;
+        write!(self.result(), " {lane}")?;
+        Ok(OpKind::Normal)
+    }
+}

--- a/crates/wast/src/core/expr.rs
+++ b/crates/wast/src/core/expr.rs
@@ -1140,10 +1140,10 @@ instructions! {
 
         // Relaxed SIMD proposal
         I8x16RelaxedSwizzle : [0xfd, 0xa2]: "i8x16.relaxed_swizzle",
-        I32x4RelaxedTruncSatF32x4S : [0xfd, 0xa5]: "i32x4.relaxed_trunc_f32x4_s",
-        I32x4RelaxedTruncSatF32x4U : [0xfd, 0xa6]: "i32x4.relaxed_trunc_f32x4_u",
-        I32x4RelaxedTruncSatF64x2SZero : [0xfd, 0xc5]: "i32x4.relaxed_trunc_f64x2_s_zero",
-        I32x4RelaxedTruncSatF64x2UZero : [0xfd, 0xc6]: "i32x4.relaxed_trunc_f64x2_u_zero",
+        I32x4RelaxedTruncF32x4S : [0xfd, 0xa5]: "i32x4.relaxed_trunc_f32x4_s",
+        I32x4RelaxedTruncF32x4U : [0xfd, 0xa6]: "i32x4.relaxed_trunc_f32x4_u",
+        I32x4RelaxedTruncF64x2SZero : [0xfd, 0xc5]: "i32x4.relaxed_trunc_f64x2_s_zero",
+        I32x4RelaxedTruncF64x2UZero : [0xfd, 0xc6]: "i32x4.relaxed_trunc_f64x2_u_zero",
         F32x4Fma : [0xfd, 0xaf]: "f32x4.fma",
         F32x4Fms : [0xfd, 0xb0]: "f32x4.fms",
         F64x4Fma : [0xfd, 0xcf]: "f64x2.fma",


### PR DESCRIPTION
This also reorders methods in the trait definition to match the order
they're defined in the spec to try to organize things together a bit
more.

cc #711