### PR TITLE
Fix a possible stack overflow in `*.wast` parsing

### DIFF
--- a/crates/wast/src/component/wast.rs
+++ b/crates/wast/src/component/wast.rs
@@ -136,6 +136,7 @@ static CASES: &[(&str, fn(Parser<'_>) -> Result<WastVal<'_>>)] = {
 
 impl<'a> Parse<'a> for WastVal<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
+        parser.depth_check()?;
         let parse = parser.step(|c| {
             if let Some((kw, rest)) = c.keyword() {
                 if let Some(i) = CASES.iter().position(|(name, _)| *name == kw) {


### PR DESCRIPTION
The fuzzers, ever dutiful at their jobs, have found a possible stack
overflow when parsing `*.wast` files with the component support added
recently.