### PR TITLE
Fix some more panics in the validator

### DIFF
--- a/tests/local/invalid/func.wast
+++ b/tests/local/invalid/func.wast
@@ -60,3 +60,28 @@
     "\0b"       ;; end
   )
   "operators remaining after end of function")
+
+(assert_invalid
+  (module
+    (func end unreachable))
+  "operators remaining after end of function")
+
+(assert_invalid
+  (module
+    (func end return))
+  "operators remaining after end of function")
+
+(assert_invalid
+  (module
+    (func end br 0))
+  "operators remaining after end of function")
+
+(assert_invalid
+  (module
+    (func end br 100000))
+  "operators remaining after end of function")
+
+(assert_invalid
+  (module
+    (func end br_table 0))
+  "operators remaining after end of function")


### PR DESCRIPTION
This commit fixes some more regressions from #697 where an empty
`control` stack was previously unexpected but now possible in some
instructions. All of these bugs were identified by oss-fuzz.