### PR TITLE
Enhance `validate` fuzzer with `MaybeInvalidModule`

### DIFF
--- a/fuzz/fuzz_targets/validate.rs
+++ b/fuzz/fuzz_targets/validate.rs
@@ -37,7 +37,7 @@ fuzz_target!(|data: &[u8]| {
         saturating_float_to_int: (byte2 & 0b0100_0000) != 0,
         sign_extension: (byte2 & 0b1000_0000) != 0,
     });
-    let use_maybe_invalid = bytes3 & 0b0000_0001 != 0;
+    let use_maybe_invalid = byte3 & 0b0000_0001 != 0;
 
     let wasm = &data[3..];
     if log::log_enabled!(log::Level::Debug) {


### PR DESCRIPTION
This commit is intended to help increase the likelihood of seeing and
otherwise valid module except for the function body and then perform
validation to ensure we don't have any sort of resource exhaustion or
similar on invalid modules.