### PR TITLE
Bump wasmparser to 0.89.1

### DIFF
--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.89.0"
+version = "0.89.1"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser"


### PR DESCRIPTION
Pull in https://github.com/bytecodealliance/wasm-tools/pull/724 to a minor version bump