### PR TITLE
Add a feature to `wasmprinter` to print binary offsets

### DIFF
--- a/crates/wasmparser/src/readers.rs
+++ b/crates/wasmparser/src/readers.rs
@@ -55,9 +55,20 @@ pub trait SectionReader {
 }
 
 /// Implemented by sections with a limited number of items.
-pub trait SectionWithLimitedItems {
+pub trait SectionWithLimitedItems: SectionReader {
     /// Gets the count of the items in the section.
     fn get_count(&self) -> u32;
+
+    /// Returns an iterator over the items within this section where the offset
+    /// in the original section is provided with the item.
+    fn into_iter_with_offsets(self) -> IntoIterWithOffsets<Self>
+    where
+        Self: Sized,
+    {
+        IntoIterWithOffsets {
+            iter: SectionIteratorLimited::new(self),
+        }
+    }
 }
 
 /// An iterator over items in a section.
@@ -96,10 +107,7 @@ where
 }
 
 /// An iterator over a limited section iterator.
-pub struct SectionIteratorLimited<R>
-where
-    R: SectionReader + SectionWithLimitedItems,
-{
+pub struct SectionIteratorLimited<R> {
     reader: R,
     left: u32,
     end: bool,
@@ -107,7 +115,7 @@ where
 
 impl<R> SectionIteratorLimited<R>
 where
-    R: SectionReader + SectionWithLimitedItems,
+    R: SectionWithLimitedItems,
 {
     /// Constructs a new `SectionIteratorLimited` for the given limited section reader.
     pub fn new(reader: R) -> SectionIteratorLimited<R> {
@@ -122,7 +130,7 @@ where
 
 impl<R> Iterator for SectionIteratorLimited<R>
 where
-    R: SectionReader + SectionWithLimitedItems,
+    R: SectionWithLimitedItems,
 {
     type Item = Result<R::Item>;
 
@@ -148,5 +156,26 @@ where
     fn size_hint(&self) -> (usize, Option<usize>) {
         let count = self.reader.get_count() as usize;
         (count, Some(count))
+    }
+}
+
+/// An iterator over a limited section iterator.
+pub struct IntoIterWithOffsets<R> {
+    iter: SectionIteratorLimited<R>,
+}
+
+impl<R> Iterator for IntoIterWithOffsets<R>
+where
+    R: SectionWithLimitedItems,
+{
+    type Item = Result<(usize, R::Item)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let pos = self.iter.reader.original_position();
+        Some(self.iter.next()?.map(|item| (pos, item)))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
     }
 }

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -1311,7 +1311,7 @@ impl Validator {
         ) -> Result<()>,
     ) -> Result<()>
     where
-        T: SectionReader + Clone + SectionWithLimitedItems,
+        T: Clone + SectionWithLimitedItems,
     {
         let offset = section.range().start;
 

--- a/src/bin/wasm-tools/print.rs
+++ b/src/bin/wasm-tools/print.rs
@@ -6,12 +6,19 @@ use clap::Parser;
 pub struct Opts {
     #[clap(flatten)]
     io: wasm_tools::InputOutput,
+
+    /// Whether or not to print binary offsets intermingled in the text format
+    /// as comments for debugging.
+    #[clap(short, long)]
+    print_offsets: bool,
 }
 
 impl Opts {
     pub fn run(&self) -> Result<()> {
         let wasm = self.io.parse_input_wasm()?;
-        let wat = wasmprinter::print_bytes(&wasm)?;
+        let mut printer = wasmprinter::Printer::new();
+        printer.print_offsets(self.print_offsets);
+        let wat = printer.print(&wasm)?;
         self.io.output(wasm_tools::Output::Wat(&wat))?;
         Ok(())
     }


### PR DESCRIPTION
I often find myself trying to debug error messages here and there
related to low-level validation. These error messages have an offset
within the original file of the offending opcode, but finding that
opcode within the text format is typically not trivial. This was the
original motivation for `wasm-tools dump` but that output is also quite
verbose and not always easy to parse. Consequently this problem
motivates this commit.

This commit adds a `-p` flag to the `wasm-tools print` subcommand which
will print, in comments at the start of each line, the binary offset of
the corresponding item in the binary. This notably prints the binary
offset of all instructions and should ideally make it much easier to use
just the text format to find the offending instruction given a
particular offset.