### PR TITLE
Don't print panic messages on `EPIPE`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,9 @@ impl OutputArg {
                 std::fs::write(path, output)
                     .context(format!("failed to write `{}`", path.display()))?;
             }
-            None => println!("{output}"),
+            None => std::io::stdout()
+                .write_all(output.as_bytes())
+                .context("failed to write to stdout")?,
         }
         Ok(())
     }


### PR DESCRIPTION
This commit fixes the behavior of the `wasm-tools` CLI command to ignore
`EPIPE` errors in terms of printing error messages. The process will
still report a failure message but `EPIPE` is explicitly ignored since
that generally only comes from closing stdout which is a signal to close
the program quickly.

It's worth noting that this doesn't use `SIGPIPE` or reset the behavior
of the Rust standard library to work on Windows as well where there is
no `SIGPIPE`.