### PR TITLE
Update component start functions

### DIFF
--- a/crates/wasm-encoder/src/component/start.rs
+++ b/crates/wasm-encoder/src/component/start.rs
@@ -7,7 +7,7 @@ use crate::{ComponentSection, ComponentSectionId, Encode};
 /// ```
 /// use wasm_encoder::{Component, ComponentStartSection};
 ///
-/// let start = ComponentStartSection { function_index: 0, args: [] };
+/// let start = ComponentStartSection { function_index: 0, args: [0, 1], results: 1 };
 ///
 /// let mut component = Component::new();
 /// component.section(&start);
@@ -22,6 +22,11 @@ pub struct ComponentStartSection<A> {
     ///
     /// An argument is an index to a value.
     pub args: A,
+    /// The number of expected results for the start function.
+    ///
+    /// This should match the number of results for the type of
+    /// the function referenced by `function_index`.
+    pub results: u32,
 }
 
 impl<A> Encode for ComponentStartSection<A>
@@ -32,6 +37,7 @@ where
         let mut bytes = Vec::new();
         self.function_index.encode(&mut bytes);
         self.args.as_ref().encode(&mut bytes);
+        self.results.encode(&mut bytes);
         bytes.encode(sink);
     }
 }

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -208,6 +208,7 @@ impl<'a> BinaryReader<'a> {
             arguments: (0..size)
                 .map(|_| self.read_var_u32())
                 .collect::<Result<_>>()?,
+            results: self.read_var_u32()?,
         })
     }
 

--- a/crates/wasmparser/src/readers/component/start.rs
+++ b/crates/wasmparser/src/readers/component/start.rs
@@ -10,6 +10,8 @@ pub struct ComponentStartFunction {
     ///
     /// The arguments are specified by value index.
     pub arguments: Box<[u32]>,
+    /// The number of expected results for the start function.
+    pub results: u32,
 }
 
 /// A reader for the start section of a WebAssembly component.
@@ -33,7 +35,7 @@ impl<'a> ComponentStartSectionReader<'a> {
     /// ```
     /// use wasmparser::ComponentStartSectionReader;
     ///
-    /// # let data: &[u8] = &[0x00, 0x03, 0x01, 0x02, 0x03];
+    /// # let data: &[u8] = &[0x00, 0x03, 0x01, 0x02, 0x03, 0x01];
     /// let mut reader = ComponentStartSectionReader::new(data, 0).unwrap();
     /// let start = reader.read().expect("start");
     /// println!("Start: {:?}", start);

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -41,10 +41,7 @@ impl ValType {
     /// Only reference types are allowed in tables, for example, and with some
     /// instructions. Current reference types include `funcref` and `externref`.
     pub fn is_reference_type(&self) -> bool {
-        match self {
-            ValType::FuncRef | ValType::ExternRef => true,
-            _ => false,
-        }
+        matches!(self, ValType::FuncRef | ValType::ExternRef)
     }
 }
 

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -1131,6 +1131,7 @@ impl Validator {
         self.components.last_mut().unwrap().add_start(
             f.func_index,
             &f.arguments,
+            f.results,
             &self.types,
             range.start,
         )

--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -437,6 +437,7 @@ impl ComponentState {
         &mut self,
         func_index: u32,
         args: &[u32],
+        results: u32,
         types: &TypeList,
         offset: usize,
     ) -> Result<()> {
@@ -457,6 +458,16 @@ impl ComponentState {
                     "component start function requires {} arguments but was given {}",
                     ft.params.len(),
                     args.len()
+                ),
+                offset,
+            ));
+        }
+
+        if ft.results.len() as u32 != results {
+            return Err(BinaryReaderError::new(
+                format!(
+                    "component start function has a result count of {results} but the function type has a result count of {type_results}",
+                    type_results = ft.results.len(),
                 ),
                 offset,
             ));
@@ -1546,15 +1557,13 @@ impl ComponentState {
                         self.values.push((*ty, false));
                         Ok(())
                     }
-                    _ => {
-                        return Err(BinaryReaderError::new(
-                            format!(
-                                "export `{}` for instance {} is not a value",
-                                name, instance_index
-                            ),
-                            offset,
-                        ))
-                    }
+                    _ => Err(BinaryReaderError::new(
+                        format!(
+                            "export `{}` for instance {} is not a value",
+                            name, instance_index
+                        ),
+                        offset,
+                    )),
                 }
             }
             ComponentExternalKind::Type => {
@@ -1932,12 +1941,10 @@ impl ComponentState {
             .get(name)
         {
             Some(export) => Ok(export),
-            None => {
-                return Err(BinaryReaderError::new(
-                    format!("instance {} has no export named `{}`", instance_index, name),
-                    offset,
-                ))
-            }
+            None => Err(BinaryReaderError::new(
+                format!("instance {} has no export named `{}`", instance_index, name),
+                offset,
+            )),
         }
     }
 
@@ -2019,15 +2026,13 @@ impl ComponentState {
             .get(name)
         {
             Some(export) => Ok(export),
-            None => {
-                return Err(BinaryReaderError::new(
-                    format!(
-                        "core instance {} has no export named `{}`",
-                        instance_index, name
-                    ),
-                    offset,
-                ))
-            }
+            None => Err(BinaryReaderError::new(
+                format!(
+                    "core instance {} has no export named `{}`",
+                    instance_index, name
+                ),
+                offset,
+            )),
         }
     }
 

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -241,7 +241,7 @@ impl OperatorValidator {
 impl<R> Deref for OperatorValidatorTemp<'_, '_, R> {
     type Target = OperatorValidator;
     fn deref(&self) -> &OperatorValidator {
-        &self.inner
+        self.inner
     }
 }
 
@@ -403,7 +403,7 @@ impl<'resources, R: WasmModuleResources> OperatorValidatorTemp<'_, 'resources, R
     /// Returns the type signature of the block that we're jumping to as well
     /// as the kind of block if the jump is valid. Otherwise returns an error.
     fn jump(&self, offset: usize, depth: u32) -> Result<(BlockType, FrameKind)> {
-        if self.control.len() == 0 {
+        if self.control.is_empty() {
             return Err(self.err_beyond_end(offset));
         }
         match (self.control.len() - 1).checked_sub(depth as usize) {

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -2073,9 +2073,15 @@ impl Printer {
             self.end_group();
         }
 
-        // TODO: print results; there's no easy way to do so with the current
-        // binary component encoding.
-        // See: https://github.com/WebAssembly/component-model/issues/84
+        for _ in 0..start.results {
+            self.result.push(' ');
+            self.start_group("result ");
+            self.start_group("value ");
+            self.print_name(&state.component.value_names, state.component.values)?;
+            self.end_group();
+            self.end_group();
+            state.component.values += 1;
+        }
 
         self.end_group(); // start
 

--- a/crates/wast/src/component/binary.rs
+++ b/crates/wast/src/component/binary.rs
@@ -294,6 +294,7 @@ impl Encoder {
         self.component.section(&ComponentStartSection {
             function_index: start.func.into(),
             args: start.args.iter().map(|a| a.idx.into()).collect::<Vec<_>>(),
+            results: start.results.len() as u32,
         });
     }
 

--- a/crates/wast/src/component/resolve.rs
+++ b/crates/wast/src/component/resolve.rs
@@ -799,7 +799,12 @@ impl<'a> ComponentState<'a> {
             ComponentField::CoreFunc(_) | ComponentField::Func(_) => {
                 unreachable!("should be expanded already")
             }
-            ComponentField::Start(s) => self.values.register(s.result, "value")?,
+            ComponentField::Start(s) => {
+                for r in &s.results {
+                    self.values.register(*r, "value")?;
+                }
+                return Ok(());
+            }
             ComponentField::Import(i) => match &i.item.kind {
                 ItemSigKind::CoreModule(_) => {
                     self.core_modules.register(i.item.id, "core module")?

--- a/tests/local/component-model/start.wast
+++ b/tests/local/component-model/start.wast
@@ -2,7 +2,7 @@
 (assert_invalid
   (component
     (import "" (func $f (param string)))
-    (start $f (result))
+    (start $f)
   )
   "start function requires 1 arguments")
 
@@ -10,7 +10,7 @@
   (component
     (import "" (func $f (param string)))
     (import "v" (value $v string))
-    (start $f (value $v) (value $v) (result))
+    (start $f (value $v) (value $v))
   )
   "start function requires 1 arguments")
 
@@ -18,7 +18,7 @@
   (component
     (import "" (func $f (param "1" string) (param "2" string)))
     (import "v" (value $v string))
-    (start $f (value $v) (value $v) (result))
+    (start $f (value $v) (value $v))
   )
   "cannot be used more than once")
 
@@ -27,7 +27,7 @@
     (import "" (func $f (param "x" string) (param "y" string)))
     (import "v" (value $v string))
     (import "v2" (value $v2 u32))
-    (start $f (value $v) (value $v2) (result))
+    (start $f (value $v) (value $v2))
   )
   "type mismatch for component start function argument 1")
 
@@ -35,13 +35,28 @@
   (import "" (func $f (param "z" string) (param "a" string)))
   (import "v" (value $v string))
   (import "v2" (value $v2 string))
-  (start $f (value $v) (value $v2) (result))
+  (start $f (value $v) (value $v2))
+)
+
+(component
+  (import "" (func $f (result string)))
+  (start $f (result (value $a)))
+  (export "a" (value $a))
+)
+
+(component
+  (import "" (func $f (param "a" string) (param "b" string) (result "c" s32) (result "d" s32)))
+  (import "v" (value $v string))
+  (import "v2" (value $v2 string))
+  (start $f (value $v) (value $v2) (result (value $c)) (result (value $d)))
+  (export "c" (value $c))
+  (export "d" (value $d))
 )
 
 (assert_invalid
   (component
     (import "" (func $f))
-    (start $f (result))
-    (start $f (result))
+    (start $f)
+    (start $f)
   )
   "cannot have more than one start")

--- a/tests/local/component-model/start.wast
+++ b/tests/local/component-model/start.wast
@@ -55,6 +55,17 @@
 
 (assert_invalid
   (component
+    (import "" (func $f (param "a" string) (param "b" string) (result "c" s32) (result "d" s32)))
+    (import "v" (value $v string))
+    (import "v2" (value $v2 string))
+    (start $f (value $v) (value $v2) (result (value $c)))
+    (export "c" (value $c))
+  )
+  "component start function has a result count of 1 but the function type has a result count of 2"
+)
+
+(assert_invalid
+  (component
     (import "" (func $f))
     (start $f)
     (start $f)


### PR DESCRIPTION
This PR addresses the following:

* Fix `wast` to correctly parse component start functions with multiple result values.
* Update the tools for https://github.com/WebAssembly/component-model/pull/92, which allows `wasmprinter` to properly print component start functions.