### PR TITLE
`wasmparser`: Add getters for useful internal state to the FuncValidator

### DIFF
--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -56,6 +56,7 @@ pub use self::core::ValidatorResources;
 use self::core::*;
 use self::types::{TypeList, Types, TypesRef};
 pub use func::FuncValidator;
+pub use operators::{Frame, FrameKind};
 
 fn check_max(cur_len: usize, amt_added: u32, max: usize, desc: &str, offset: usize) -> Result<()> {
     if max

--- a/crates/wasmparser/src/validator/func.rs
+++ b/crates/wasmparser/src/validator/func.rs
@@ -1,4 +1,4 @@
-use super::operators::OperatorValidator;
+use super::operators::{Frame, OperatorValidator};
 use crate::{BinaryReader, Result, ValType};
 use crate::{FunctionBody, Operator, WasmFeatures, WasmModuleResources};
 
@@ -37,14 +37,6 @@ impl<T: WasmModuleResources> FuncValidator<T> {
             resources,
             index,
         })
-    }
-
-    /// Get the current height of the operand stack.
-    ///
-    /// This returns the height of the whole operand stack for this function,
-    /// not just for the current control frame.
-    pub fn operand_stack_height(&self) -> u32 {
-        self.validator.operand_stack_height() as u32
     }
 
     /// Convenience function to validate an entire function's body.
@@ -117,6 +109,52 @@ impl<T: WasmModuleResources> FuncValidator<T> {
     /// is being validated.
     pub fn index(&self) -> u32 {
         self.index
+    }
+
+    /// Returns the number of defined local variables in the function.
+    pub fn len_locals(&self) -> u32 {
+        self.validator.locals.len_locals()
+    }
+
+    /// Returns the type of the local variable at the given `index` if any.
+    pub fn get_local_type(&self, index: u32) -> Option<ValType> {
+        self.validator.locals.get(index)
+    }
+
+    /// Get the current height of the operand stack.
+    ///
+    /// This returns the height of the whole operand stack for this function,
+    /// not just for the current control frame.
+    pub fn operand_stack_height(&self) -> u32 {
+        self.validator.operand_stack_height() as u32
+    }
+
+    /// Returns the optional value type of the value operand at the given
+    /// `index` from the top of the operand stack.
+    ///
+    /// Returns `None` if the `index` is out of bounds.
+    pub fn get_operand_type(&self, index: usize) -> Option<Option<ValType>> {
+        self.validator.peek_operand_at(index)
+    }
+
+    /// Returns the number of frames on the control flow stack.
+    ///
+    /// This returns the height of the whole control stack for this function,
+    /// not just for the current control frame.
+    pub fn control_stack_height(&self) -> u32 {
+        self.validator.control_stack_height() as u32
+    }
+
+    /// Returns a shared reference to the control flow [`Frame`] of the
+    /// control flow stack at the given `depth` if any.
+    ///
+    /// Returns `None` if the `depth` is out of bounds.
+    ///
+    /// # Note
+    ///
+    /// A `depth` of 0 will refer to the last frame on the stack.
+    pub fn get_control_frame(&self, depth: usize) -> Option<&Frame> {
+        self.validator.get_frame(depth)
     }
 }
 

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -228,7 +228,9 @@ impl OperatorValidator {
     /// Returns the optional value type of the value operand at the given
     /// `index` from the top of the operand stack.
     ///
-    /// Returns `None` if the `index` is out of bounds.
+    /// - Returns `None` if the `index` is out of bounds.
+    /// - Returns `Some(None)` if there is a value with unknown type
+    /// at the given `index`.
     ///
     /// # Note
     ///

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -96,7 +96,7 @@ pub(super) struct Locals {
 //
 // This structure corresponds to `ctrl_frame` as specified at in the validation
 // appendix of the wasm spec
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub struct Frame {
     /// Indicator for what kind of instruction pushed this frame.
     pub kind: FrameKind,

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -244,14 +244,6 @@ impl OperatorValidator {
         self.control.len()
     }
 
-    /// Returns a shared reference to the control flow [`Frame`] of the
-    /// control flow stack at the given `depth` if any.
-    ///
-    /// Returns `None` if the `depth` is out of bounds.
-    ///
-    /// # Note
-    ///
-    /// A `depth` of 0 will refer to the last frame on the stack.
     pub fn get_frame(&self, depth: usize) -> Option<&Frame> {
         self.control.iter().rev().nth(depth)
     }

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -233,7 +233,7 @@ impl OperatorValidator {
     /// # Note
     ///
     /// An `index` of 0 will refer to the last operand on the stack.
-    pub(super) fn peek_operand_at(&self, index: usize) -> Option<Option<ValType>> {
+    pub fn peek_operand_at(&self, index: usize) -> Option<Option<ValType>> {
         self.operands.iter().rev().nth(index).copied()
     }
 
@@ -250,7 +250,7 @@ impl OperatorValidator {
     /// # Note
     ///
     /// A `depth` of 0 will refer to the last frame on the stack.
-    pub(super) fn get_frame(&self, depth: usize) -> Option<&Frame> {
+    pub fn get_frame(&self, depth: usize) -> Option<&Frame> {
         self.control.iter().rev().nth(depth)
     }
 


### PR DESCRIPTION
Closes https://github.com/bytecodealliance/wasm-tools/issues/732.

This adds the following APIs:

- `fn len_locals() -> u32`
- `fn get_local_type(index) -> ValType`
- `fn operand_stack_height() -> u32` (already existed)
- `fn get_operand_type(index) -> Option<Option<ValType>>`
- `fn control_stack_height() -> u32`
- `fn get_control_frame(depth) -> Option<&Frame>`