### PR TITLE
`wasmparser`: Refactor `FuncType`

### DIFF
--- a/crates/wasm-compose/src/encoding.rs
+++ b/crates/wasm-compose/src/encoding.rs
@@ -120,8 +120,8 @@ impl<'a> TypeEncoder<'a> {
                         let ty = self.0.type_from_id(id).unwrap().as_func_type().unwrap();
                         let index = encodable.type_count();
                         encodable.ty().function(
-                            ty.params.iter().copied().map(Self::val_type),
-                            ty.returns.iter().copied().map(Self::val_type),
+                            ty.params().iter().copied().map(Self::val_type),
+                            ty.results().iter().copied().map(Self::val_type),
                         );
                         *e.insert(index)
                     }
@@ -138,8 +138,8 @@ impl<'a> TypeEncoder<'a> {
                         let ty = self.0.type_from_id(id).unwrap().as_func_type().unwrap();
                         let index = encodable.type_count();
                         encodable.ty().function(
-                            ty.params.iter().copied().map(Self::val_type),
-                            ty.returns.iter().copied().map(Self::val_type),
+                            ty.params().iter().copied().map(Self::val_type),
+                            ty.results().iter().copied().map(Self::val_type),
                         );
                         *e.insert(index)
                     }

--- a/crates/wasm-mutate/src/module.rs
+++ b/crates/wasm-mutate/src/module.rs
@@ -47,12 +47,12 @@ impl TryFrom<wasmparser::Type> for TypeInfo {
         match value {
             wasmparser::Type::Func(ft) => Ok(TypeInfo::Func(FuncInfo {
                 params: ft
-                    .params
+                    .params()
                     .iter()
                     .map(|&t| PrimitiveTypeInfo::from(t))
                     .collect(),
                 returns: ft
-                    .returns
+                    .results()
                     .iter()
                     .map(|&t| PrimitiveTypeInfo::from(t))
                     .collect(),

--- a/crates/wasm-mutate/src/mutators/add_type.rs
+++ b/crates/wasm-mutate/src/mutators/add_type.rs
@@ -59,12 +59,12 @@ impl Mutator for AddTypeMutator {
                 match ty {
                     wasmparser::Type::Func(ty) => {
                         let params = ty
-                            .params
+                            .params()
                             .iter()
                             .map(translate_type)
                             .collect::<Result<Vec<_>, _>>()?;
                         let results = ty
-                            .returns
+                            .results()
                             .iter()
                             .map(translate_type)
                             .collect::<Result<Vec<_>, _>>()?;

--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -117,11 +117,11 @@ pub fn type_def(t: &mut dyn Translator, ty: Type, s: &mut TypeSection) -> Result
     match ty {
         Type::Func(f) => {
             s.function(
-                f.params
+                f.params()
                     .iter()
                     .map(|ty| t.translate_ty(ty))
                     .collect::<Result<Vec<_>>>()?,
-                f.returns
+                f.results()
                     .iter()
                     .map(|ty| t.translate_ty(ty))
                     .collect::<Result<Vec<_>>>()?,

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -589,14 +589,22 @@ impl Module {
                 None => panic!("signature index refers to a type out of bounds"),
                 Some((_, Some(idx))) => *idx as usize,
                 Some((wasmparser::Type::Func(func_type), index_store)) => {
-                    let multi_value_required = func_type.returns.len() > 1;
+                    let multi_value_required = func_type.results().len() > 1;
                     let new_index = first_type_index + new_types.len();
                     if new_index >= max_types || (multi_value_required && !multi_value_enabled) {
                         return None;
                     }
                     let func_type = Rc::new(FuncType {
-                        params: func_type.params.iter().map(|t| convert_type(*t)).collect(),
-                        results: func_type.returns.iter().map(|t| convert_type(*t)).collect(),
+                        params: func_type
+                            .params()
+                            .iter()
+                            .map(|t| convert_type(*t))
+                            .collect(),
+                        results: func_type
+                            .results()
+                            .iter()
+                            .map(|t| convert_type(*t))
+                            .collect(),
                     });
                     index_store.replace(new_index as u32);
                     new_types.push(Type::Func(Rc::clone(&func_type)));

--- a/crates/wasm-smith/tests/core.rs
+++ b/crates/wasm-smith/tests/core.rs
@@ -155,16 +155,16 @@ fn smoke_test_imports_config() {
                                 *seen = true
                             }
                             (Some((seen, I::Func(p, r))), TypeRef::Func(sig_idx))
-                                if &sig_types[*sig_idx as usize].params[..] == *p
-                                    && &sig_types[*sig_idx as usize].returns[..] == *r =>
+                                if sig_types[*sig_idx as usize].params() == *p
+                                    && sig_types[*sig_idx as usize].results() == *r =>
                             {
                                 *seen = true
                             }
                             (
                                 Some((seen, I::Tag(p))),
                                 TypeRef::Tag(wasmparser::TagType { func_type_idx, .. }),
-                            ) if &sig_types[*func_type_idx as usize].params[..] == *p
-                                && sig_types[*func_type_idx as usize].returns.is_empty() =>
+                            ) if sig_types[*func_type_idx as usize].params() == *p
+                                && sig_types[*func_type_idx as usize].results().is_empty() =>
                             {
                                 *seen = true
                             }

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -272,20 +272,17 @@ impl<'a> BinaryReader<'a> {
     }
 
     pub(crate) fn read_func_type(&mut self) -> Result<FuncType> {
-        let params_len = self.read_size(MAX_WASM_FUNCTION_PARAMS, "function params")?;
-        let mut params = Vec::with_capacity(params_len);
-        for _ in 0..params_len {
-            params.push(self.read_val_type()?);
+        let len_params = self.read_size(MAX_WASM_FUNCTION_PARAMS, "function params")?;
+        let mut params_results = Vec::with_capacity(len_params);
+        for _ in 0..len_params {
+            params_results.push(self.read_val_type()?);
         }
-        let returns_len = self.read_size(MAX_WASM_FUNCTION_RETURNS, "function returns")?;
-        let mut returns = Vec::with_capacity(returns_len);
-        for _ in 0..returns_len {
-            returns.push(self.read_val_type()?);
+        let len_results = self.read_size(MAX_WASM_FUNCTION_RETURNS, "function returns")?;
+        params_results.reserve(len_results);
+        for _ in 0..len_results {
+            params_results.push(self.read_val_type()?);
         }
-        Ok(FuncType {
-            params: params.into_boxed_slice(),
-            returns: returns.into_boxed_slice(),
-        })
+        Ok(FuncType::from_raw_parts(params_results.into(), len_params))
     }
 
     pub(crate) fn read_type(&mut self) -> Result<Type> {

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -66,7 +66,7 @@ impl Debug for FuncType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FuncType")
             .field("params", &self.params())
-            .field("results", &self.results())
+            .field("returns", &self.results())
             .finish()
     }
 }

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -103,17 +103,13 @@ impl FuncType {
     /// Returns a shared slice to the parameter types of the [`FuncType`].
     #[inline]
     pub fn params(&self) -> &[ValType] {
-        // Safety: `len_params` is asserted to be less than or equal to
-        //         `params_results.len()` by construction.
-        unsafe { self.params_results.get_unchecked(..self.len_params) }
+        &self.params_results[..self.len_params]
     }
 
     /// Returns a shared slice to the result types of the [`FuncType`].
     #[inline]
     pub fn results(&self) -> &[ValType] {
-        // Safety: `len_params` is asserted to be less than or equal to
-        //         `params_results.len()` by construction.
-        unsafe { self.params_results.get_unchecked(self.len_params..) }
+        &self.params_results[self.len_params..]
     }
 }
 

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -91,6 +91,7 @@ impl FuncType {
     }
 
     /// Returns a shared slice to the parameter types of the [`FuncType`].
+    #[inline]
     pub fn params(&self) -> &[ValType] {
         // Safety: `len_params` is asserted to be less than or equal to
         //         `params_results.len()` by construction.
@@ -98,6 +99,7 @@ impl FuncType {
     }
 
     /// Returns a shared slice to the result types of the [`FuncType`].
+    #[inline]
     pub fn results(&self) -> &[ValType] {
         // Safety: `len_params` is asserted to be less than or equal to
         //         `params_results.len()` by construction.

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -14,6 +14,7 @@
  */
 
 use crate::{BinaryReader, Result, SectionIteratorLimited, SectionReader, SectionWithLimitedItems};
+use std::fmt::Debug;
 use std::ops::Range;
 
 /// Represents the types of values in a WebAssembly module.
@@ -53,12 +54,21 @@ pub enum Type {
 }
 
 /// Represents a type of a function in a WebAssembly module.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Clone, Eq, PartialEq, Hash)]
 pub struct FuncType {
     /// The combined parameters and result types.
     params_results: Box<[ValType]>,
     /// The number of paramter types.
     len_params: usize,
+}
+
+impl Debug for FuncType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FuncType")
+            .field("params", &self.params())
+            .field("results", &self.results())
+            .finish()
+    }
 }
 
 impl FuncType {

--- a/crates/wasmparser/src/resources.rs
+++ b/crates/wasmparser/src/resources.rs
@@ -310,18 +310,18 @@ where
 
 impl WasmFuncType for FuncType {
     fn len_inputs(&self) -> usize {
-        self.params.len()
+        self.params().len()
     }
 
     fn len_outputs(&self) -> usize {
-        self.returns.len()
+        self.results().len()
     }
 
     fn input_at(&self, at: u32) -> Option<ValType> {
-        self.params.get(at as usize).copied()
+        self.params().get(at as usize).copied()
     }
 
     fn output_at(&self, at: u32) -> Option<ValType> {
-        self.returns.get(at as usize).copied()
+        self.results().get(at as usize).copied()
     }
 }

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -736,7 +736,7 @@ impl Validator {
         state.update_order(Order::Start, offset)?;
 
         let ty = state.module.get_func_type(func, &self.types, offset)?;
-        if !ty.params.is_empty() || !ty.returns.is_empty() {
+        if !ty.params().is_empty() || !ty.results().is_empty() {
             return Err(BinaryReaderError::new(
                 "invalid start function type",
                 offset,
@@ -1392,16 +1392,16 @@ mod tests {
 
         match types.func_type_at(0) {
             Some(ty) => {
-                assert_eq!(ty.params.as_ref(), [ValType::I32, ValType::I64]);
-                assert_eq!(ty.returns.as_ref(), [ValType::I32]);
+                assert_eq!(ty.params(), [ValType::I32, ValType::I64]);
+                assert_eq!(ty.results(), [ValType::I32]);
             }
             _ => unreachable!(),
         }
 
         match types.func_type_at(1) {
             Some(ty) => {
-                assert_eq!(ty.params.as_ref(), [ValType::I64, ValType::I32]);
-                assert_eq!(ty.returns.as_ref(), []);
+                assert_eq!(ty.params(), [ValType::I64, ValType::I32]);
+                assert_eq!(ty.results(), []);
             }
             _ => unreachable!(),
         }
@@ -1435,16 +1435,16 @@ mod tests {
 
         match types.function_at(0) {
             Some(ty) => {
-                assert_eq!(ty.params.as_ref(), [ValType::I32, ValType::I64]);
-                assert_eq!(ty.returns.as_ref(), [ValType::I32]);
+                assert_eq!(ty.params(), [ValType::I32, ValType::I64]);
+                assert_eq!(ty.results(), [ValType::I32]);
             }
             _ => unreachable!(),
         }
 
         match types.tag_at(0) {
             Some(ty) => {
-                assert_eq!(ty.params.as_ref(), [ValType::I64, ValType::I32]);
-                assert_eq!(ty.returns.as_ref(), []);
+                assert_eq!(ty.params(), [ValType::I64, ValType::I32]);
+                assert_eq!(ty.results(), []);
             }
             _ => unreachable!(),
         }

--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -308,23 +308,23 @@ impl ComponentState {
         let info = ty.lower(types, false);
         self.check_options(Some(core_ty), &info, &options, types, offset)?;
 
-        if core_ty.params.as_ref() != info.params.as_slice() {
+        if core_ty.params() != info.params.as_slice() {
             return Err(BinaryReaderError::new(
                 format!(
                     "lowered parameter types `{:?}` do not match parameter types `{:?}` of core function {core_func_index}",
                     info.params.as_slice(),
-                    core_ty.params
+                    core_ty.params()
                 ),
                 offset,
             ));
         }
 
-        if core_ty.returns.as_ref() != info.results.as_slice() {
+        if core_ty.results() != info.results.as_slice() {
             return Err(BinaryReaderError::new(
                 format!(
                     "lowered result types `{:?}` do not match result types `{:?}` of core function {core_func_index}",
                     info.results.as_slice(),
-                    core_ty.returns
+                    core_ty.results()
                 ),
                 offset,
             ));
@@ -561,9 +561,9 @@ impl ComponentState {
                             let ty = types[self.core_function_at(*idx, offset)?]
                                 .as_func_type()
                                 .unwrap();
-                            if ty.params.as_ref()
+                            if ty.params()
                                 != [ValType::I32, ValType::I32, ValType::I32, ValType::I32]
-                                || ty.returns.as_ref() != [ValType::I32]
+                                || ty.results() != [ValType::I32]
                             {
                                 return Err(BinaryReaderError::new(
                                     "canonical option `realloc` uses a core function with an incorrect signature",
@@ -594,7 +594,7 @@ impl ComponentState {
                                 .as_func_type()
                                 .unwrap();
 
-                            if ty.params != core_ty.returns || !ty.returns.is_empty() {
+                            if ty.params() != core_ty.results() || !ty.results().is_empty() {
                                 return Err(BinaryReaderError::new(
                                     "canonical option `post-return` uses a core function with an incorrect signature",
                                     offset,

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -453,10 +453,10 @@ impl Module {
     ) -> Result<()> {
         let ty = match ty {
             crate::Type::Func(t) => {
-                for ty in t.params.iter().chain(t.returns.iter()) {
+                for ty in t.params().iter().chain(t.results()) {
                     check_value_type(*ty, features, offset)?;
                 }
-                if t.returns.len() > 1 && !features.multi_value {
+                if t.results().len() > 1 && !features.multi_value {
                     return Err(BinaryReaderError::new(
                         "func type returns multiple values but the multi-value feature is not enabled",
                         offset,
@@ -770,7 +770,7 @@ impl Module {
             ));
         }
         let ty = self.func_type_at(ty.func_type_idx, types, offset)?;
-        if ty.returns.len() > 0 {
+        if !ty.results().is_empty() {
             return Err(BinaryReaderError::new(
                 "invalid exception type: non-empty tag result type",
                 offset,

--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -94,10 +94,10 @@ pub(crate) struct LoweringInfo {
 
 impl LoweringInfo {
     pub(crate) fn into_func_type(self) -> FuncType {
-        FuncType {
-            params: self.params.as_slice().to_vec().into_boxed_slice(),
-            returns: self.results.as_slice().to_vec().into_boxed_slice(),
-        }
+        FuncType::new(
+            self.params.as_slice().iter().copied(),
+            self.results.as_slice().iter().copied(),
+        )
     }
 }
 
@@ -233,7 +233,7 @@ impl Type {
 
     pub(crate) fn type_size(&self) -> usize {
         match self {
-            Self::Func(ty) => 1 + ty.params.len() + ty.returns.len(),
+            Self::Func(ty) => 1 + ty.params().len() + ty.results().len(),
             Self::Module(ty) => ty.type_size,
             Self::Instance(ty) => ty.type_size,
             Self::Component(ty) => ty.type_size,

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -621,7 +621,7 @@ impl Printer {
         ty: &FuncType,
         names_for: Option<u32>,
     ) -> Result<u32> {
-        if ty.params.len() > 0 {
+        if ty.params().len() > 0 {
             self.result.push(' ');
         }
 
@@ -629,22 +629,22 @@ impl Printer {
         // Note that named parameters must be alone in a `param` block, so
         // we need to be careful to terminate previous param blocks and open
         // a new one if that's the case with a named parameter.
-        for (i, param) in ty.params.iter().enumerate() {
+        for (i, param) in ty.params().iter().enumerate() {
             let name = names_for.and_then(|n| state.core.local_names.get(&(n, i as u32)));
             params.start_local(name, &mut self.result);
             self.print_valtype(*param)?;
             params.end_local(&mut self.result);
         }
         params.finish(&mut self.result);
-        if ty.returns.len() > 0 {
+        if ty.results().len() > 0 {
             self.result.push_str(" (result");
-            for result in ty.returns.iter() {
+            for result in ty.results().iter() {
                 self.result.push(' ');
                 self.print_valtype(*result)?;
             }
             self.result.push(')');
         }
-        Ok(ty.params.len() as u32)
+        Ok(ty.params().len() as u32)
     }
 
     fn print_valtype(&mut self, ty: ValType) -> Result<()> {


### PR DESCRIPTION
This refactors the `FuncType` type in the `wasmparser` crate for the following benefits:

- Instead of accessing the bare fields `FuncType` now has a proper API which helped in cleaning up parts of the codebase. Also this may help in future refactors of the crate.
- `FuncType` memory footprint (`size_of`) slightly decreased.
- Halfs the amount of heap memory allocations performed during parsing.
- Provides better space locality between parameter and result types of the `FuncType`.
- Some of the `parse` benchmarks show improvements above noise treshold using the `lto="fat",codegen-units=1` profile. No significant difference for the default profile. (x86)

The main point of this PR is not optimizations but to reduce unnecessary pressure on the heap memory allocator. This especially is useful for embedded platforms that cannot afford a high-perf allocator. Besides that the refactoring introduces the new API which helps to clean up other parts of the codebase.