### PR TITLE
Fix a few minor issues in `wasmprinter`

### DIFF
--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -208,7 +208,7 @@ impl<'a> BinaryReader<'a> {
             arguments: (0..size)
                 .map(|_| self.read_var_u32())
                 .collect::<Result<_>>()?,
-            results: self.read_var_u32()?,
+            results: self.read_size(MAX_WASM_FUNCTION_RETURNS, "start function results")? as u32,
         })
     }
 

--- a/crates/wasmparser/src/readers/core/names.rs
+++ b/crates/wasmparser/src/readers/core/names.rs
@@ -68,7 +68,14 @@ impl<'a> SingleName<'a> {
         'a: 'b,
     {
         let mut reader = BinaryReader::new_with_offset(self.data, self.offset);
-        reader.read_string()
+        let result = reader.read_string()?;
+        if !reader.eof() {
+            return Err(BinaryReaderError::new(
+                "trailing data at the end of a name",
+                reader.original_position(),
+            ));
+        }
+        Ok(result)
     }
 
     /// Gets the original position of the name.

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -1127,7 +1127,15 @@ impl Validator {
         let range = section.range();
         self.state.ensure_component("start", range.start)?;
 
-        let f = section.clone().read()?;
+        let mut section = section.clone();
+        let f = section.read()?;
+
+        if !section.eof() {
+            return Err(BinaryReaderError::new(
+                "trailing data at the end of the start section",
+                section.original_position(),
+            ));
+        }
 
         self.components.last_mut().unwrap().add_start(
             f.func_index,

--- a/tests/local/component-model/start.wast
+++ b/tests/local/component-model/start.wast
@@ -71,3 +71,48 @@
     (start $f)
   )
   "cannot have more than one start")
+
+(assert_invalid
+  (component binary
+    "\00asm" "\0a\00\01\00"   ;; component header
+
+    "\08\06"          ;; type section, 6 bytes large
+    "\01"             ;; 1 count
+    "\40"             ;; function
+    "\01\00"          ;; parameters, named, 0 count
+    "\01\00"          ;; results, named, 0 count
+
+    "\0b\04"          ;; import section, 4 bytes large
+    "\01"             ;; 1 count
+    "\00"             ;; name = ""
+    "\01\00"          ;; type = func ($type 0)
+
+    "\0a\06"          ;; start section, 6 bytes large
+    "\00"             ;; function 0
+    "\00"             ;; no arguments
+    "\ff\ff\ff\00"    ;; tons of results
+  )
+  "start function results size is out of bounds")
+
+(assert_invalid
+  (component binary
+    "\00asm" "\0a\00\01\00"   ;; component header
+
+    "\08\06"          ;; type section, 6 bytes large
+    "\01"             ;; 1 count
+    "\40"             ;; function
+    "\01\00"          ;; parameters, named, 0 count
+    "\01\00"          ;; results, named, 0 count
+
+    "\0b\04"          ;; import section, 4 bytes large
+    "\01"             ;; 1 count
+    "\00"             ;; name = ""
+    "\01\00"          ;; type = func ($type 0)
+
+    "\0a\04"          ;; start section, 4 bytes large
+    "\00"             ;; function 0
+    "\00"             ;; no arguments
+    "\00"             ;; no results
+    "\ff"             ;; trailing garbage byte
+  )
+  "trailing data at the end of the start section")


### PR DESCRIPTION
I was investigating a fuzz-generated issue discovered on oss-fuzz where
`wasmprinter` would OOM with a very small input and found a number of
minor issues.

* The main problem which resulted in OOM was that `wasmprinter` was
  printing the `(value ...)` results for a component start function and
  the number of results weren't limited in any way. This commit updates
  the binary parsing of this field to place a limit, when it's parsed,
  on the maximum value.

* Another issue I noticed was that `wasmparser` accepting an invalid
  component start section where data remained after the start section
  was successfully parsed. I added a case to validation such that after
  the start function is read the reader is asserted to be at eof.

* Finally I noticed a similar issue when parsing the `module` subsection
  of the `name` section where the module's name discarded trailing data
  at the end of the module name subsection instead of error'ing out on
  the presence of this data.

I've fixed all these issues locally and added some tests for the
component model `start`-related issues.