### PR TITLE
`wasmparser`: Exclude benchmark wasm binaries from publish bundle

### DIFF
--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -10,6 +10,7 @@ description = """
 A simple event-driven library for parsing WebAssembly binary files.
 """
 edition = "2021"
+exclude = ["benches/*.wasm"]
 
 [dependencies]
 indexmap = "1.8.0"


### PR DESCRIPTION
Fixes #741