### PR TITLE
Bump `wasmparser` to 0.90.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ tempfile = "3.2.0"
 wat = { path = "crates/wat", version = '1.0.48' }
 
 # Dependencies of `validate`
-wasmparser = { path = "crates/wasmparser", optional = true, version = '0.89.0' }
+wasmparser = { path = "crates/wasmparser", optional = true, version = '0.90.0' }
 rayon = { version = "1.0", optional = true }
 
 # Dependencies of `print`

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -23,7 +23,7 @@ wasmparser-dump = { version = "0.1.4", path = "../dump" }
 wasm-mutate = { version = "0.2.4", path = "../wasm-mutate" }
 wasm-shrink = { version = "0.1.6", path = "../wasm-shrink" }
 wasm-smith = { version = "0.11.2", path = "../wasm-smith" }
-wasmparser = { version = "0.89.0", path = "../wasmparser" }
+wasmparser = { version = "0.90.0", path = "../wasmparser" }
 wasmprinter = { version = "0.2.36", path = "../wasmprinter" }
 wast = { version = "46.0.0", path = "../wast" }
 wat = { version = "1.0.44", path = "../wat" }

--- a/crates/dump/Cargo.toml
+++ b/crates/dump/Cargo.toml
@@ -9,4 +9,4 @@ description = "Utility to dump debug information about the wasm binary format"
 
 [dependencies]
 anyhow = "1"
-wasmparser = { path = "../wasmparser", version = "0.89.0" }
+wasmparser = { path = "../wasmparser", version = "0.90.0" }

--- a/crates/wasm-compose/Cargo.toml
+++ b/crates/wasm-compose/Cargo.toml
@@ -13,7 +13,7 @@ description = "A library for composing WebAssembly components."
 [dependencies]
 wat = { version = "1.0.48", path = "../wat" }
 wasm-encoder = { version = "0.16.0", path = "../wasm-encoder" }
-wasmparser = { version = "0.89.0", path = "../wasmparser" }
+wasmparser = { version = "0.90.0", path = "../wasmparser" }
 indexmap = { version = "1.9.1", features = ["serde"] }
 anyhow = "1.0.58"
 serde = { version = "1.0.137", features = ["derive"] }

--- a/crates/wasm-mutate/Cargo.toml
+++ b/crates/wasm-mutate/Cargo.toml
@@ -9,7 +9,7 @@ description = "A WebAssembly test case mutator"
 [dependencies]
 clap = { optional = true, version = "3.0", features = ['derive'] }
 thiserror = "1.0.28"
-wasmparser = { version = "0.89.0", path = "../wasmparser" }
+wasmparser = { version = "0.90.0", path = "../wasmparser" }
 wasm-encoder = { version = "0.16.0", path = "../wasm-encoder"}
 rand = { version = "0.8.0", features = ["small_rng"] }
 log = "0.4.14"

--- a/crates/wasm-shrink/Cargo.toml
+++ b/crates/wasm-shrink/Cargo.toml
@@ -17,7 +17,7 @@ log = "0.4"
 rand = { version = "0.8.4", features = ["small_rng"] }
 clap = { version = "3.0", optional = true, features = ['derive'] }
 wasm-mutate = { version = "0.2.7", path = "../wasm-mutate" }
-wasmparser = { version = "0.89.0", path = "../wasmparser" }
+wasmparser = { version = "0.90.0", path = "../wasmparser" }
 
 [dev-dependencies]
 env_logger = "0.9"

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -22,7 +22,7 @@ indexmap = "1.6"
 leb128 = "0.2.4"
 serde = { version = "1", features = ['derive'], optional = true }
 wasm-encoder = { version = "0.16.0", path = "../wasm-encoder" }
-wasmparser = { version = "0.89.0", path = "../wasmparser" }
+wasmparser = { version = "0.90.0", path = "../wasmparser" }
 
 [dev-dependencies]
 criterion = "0.3.3"

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.89.1"
+version = "0.90.0"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser"

--- a/crates/wasmprinter/Cargo.toml
+++ b/crates/wasmprinter/Cargo.toml
@@ -14,7 +14,7 @@ Rust converter from the WebAssembly binary format to the text format.
 
 [dependencies]
 anyhow = "1.0"
-wasmparser = { path = '../wasmparser', version = '0.89.0' }
+wasmparser = { path = '../wasmparser', version = '0.90.0' }
 
 [dev-dependencies]
 diff = "0.1"


### PR DESCRIPTION
To cut a release without the benchmark Wasm binaries (cc #741).