### PR TITLE
wasm-smith: Generate fewer `drop` instructions

### DIFF
--- a/crates/wasm-smith/src/core/code_builder.rs
+++ b/crates/wasm-smith/src/core/code_builder.rs
@@ -107,7 +107,7 @@ instructions! {
     (Some(throw_valid), throw, Control, 850),
     (Some(rethrow_valid), rethrow, Control),
     // Parametric instructions.
-    (Some(drop_valid), drop, Parametric),
+    (Some(drop_valid), drop, Parametric, 990),
     (Some(select_valid), select, Parametric),
     // Variable instructions.
     (Some(local_get_valid), local_get, Variable),


### PR DESCRIPTION
They aren't very interesting because they tend to create dead code, which is
often shed relatively early in compiler pipelines.

When generating 1000 modules, each from 1000 bytes of random data, and then `grep`ing through their WAT for `drop` we get:

* Before: 9603
* After: 8813

(Note that `wasm-smith` inserts some `drop`s outside of the generate-arbitrary-instruction code to handle things like extra values on the stack when finishing a block, and this PR doesn't affect those).