### PR TITLE
Improve docs of FuncValidator::get_operand_type

### DIFF
--- a/crates/wasmparser/src/validator/func.rs
+++ b/crates/wasmparser/src/validator/func.rs
@@ -130,11 +130,17 @@ impl<T: WasmModuleResources> FuncValidator<T> {
     }
 
     /// Returns the optional value type of the value operand at the given
-    /// `index` from the top of the operand stack.
+    /// `depth` from the top of the operand stack.
     ///
-    /// Returns `None` if the `index` is out of bounds.
-    pub fn get_operand_type(&self, index: usize) -> Option<Option<ValType>> {
-        self.validator.peek_operand_at(index)
+    /// - Returns `None` if the `depth` is out of bounds.
+    /// - Returns `Some(None)` if there is a value with unknown type
+    /// at the given `depth`.
+    ///
+    /// # Note
+    ///
+    /// An `depth` of 0 will refer to the last operand on the stack.
+    pub fn get_operand_type(&self, depth: usize) -> Option<Option<ValType>> {
+        self.validator.peek_operand_at(depth)
     }
 
     /// Returns the number of frames on the control flow stack.

--- a/crates/wasmparser/src/validator/func.rs
+++ b/crates/wasmparser/src/validator/func.rs
@@ -138,7 +138,7 @@ impl<T: WasmModuleResources> FuncValidator<T> {
     ///
     /// # Note
     ///
-    /// An `depth` of 0 will refer to the last operand on the stack.
+    /// A `depth` of 0 will refer to the last operand on the stack.
     pub fn get_operand_type(&self, depth: usize) -> Option<Option<ValType>> {
         self.validator.peek_operand_at(depth)
     }

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -226,17 +226,17 @@ impl OperatorValidator {
     }
 
     /// Returns the optional value type of the value operand at the given
-    /// `index` from the top of the operand stack.
+    /// `depth` from the top of the operand stack.
     ///
-    /// - Returns `None` if the `index` is out of bounds.
+    /// - Returns `None` if the `depth` is out of bounds.
     /// - Returns `Some(None)` if there is a value with unknown type
-    /// at the given `index`.
+    /// at the given `depth`.
     ///
     /// # Note
     ///
-    /// An `index` of 0 will refer to the last operand on the stack.
-    pub fn peek_operand_at(&self, index: usize) -> Option<Option<ValType>> {
-        self.operands.iter().rev().nth(index).copied()
+    /// An `depth` of 0 will refer to the last operand on the stack.
+    pub fn peek_operand_at(&self, depth: usize) -> Option<Option<ValType>> {
+        self.operands.iter().rev().nth(depth).copied()
     }
 
     /// Returns the number of frames on the control flow stack.

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -234,7 +234,7 @@ impl OperatorValidator {
     ///
     /// # Note
     ///
-    /// An `depth` of 0 will refer to the last operand on the stack.
+    /// A `depth` of 0 will refer to the last operand on the stack.
     pub fn peek_operand_at(&self, depth: usize) -> Option<Option<ValType>> {
         self.operands.iter().rev().nth(depth).copied()
     }


### PR DESCRIPTION
Nothing fancy, just saw this when implementing the new `wasmparser` version on `wasmi` ...

- Apparently when I was fixing the docs on the former PR I did so in the wrong location.
- Replaces `index` with `depth` as that makes more sense and also mirrors the same naming in adjacent methods.
- Adds information about returning `Some(None)` and what happens at a `depth` of 0.

---

![2022-08-29-094621_1360x349_scrot](https://user-images.githubusercontent.com/8193155/187150747-07c629f5-acec-4d52-8fe5-531223d0e617.png)
