### PR TITLE
Fix panics on empty ranges in `wasm-mutate`

### DIFF
--- a/crates/wasm-mutate/src/mutators/modify_const_exprs.rs
+++ b/crates/wasm-mutate/src/mutators/modify_const_exprs.rs
@@ -98,12 +98,14 @@ impl<'cfg, 'wasm> Translator for InitTranslator<'cfg, 'wasm> {
                 T::F32 if should_zero => CE::f32_const(0.0),
                 T::F64 if should_zero => CE::f64_const(0.0),
                 T::I32 => CE::i32_const(if let O::I32Const { value } = op {
-                    self.config.rng().gen_range(0..value)
+                    let range = if value < 0 { value..0 } else { 0..value };
+                    self.config.rng().gen_range(range)
                 } else {
                     self.config.rng().gen()
                 }),
                 T::I64 => CE::i64_const(if let O::I64Const { value } = op {
-                    self.config.rng().gen_range(0..value)
+                    let range = if value < 0 { value..0 } else { 0..value };
+                    self.config.rng().gen_range(range)
                 } else {
                     self.config.rng().gen()
                 }),


### PR DESCRIPTION
This fixes a panic I encountered locally running `wasm-tools shrink` on
a test case where a constant expression with a negative value was trying
to select a new value for the constant expression but the negative value
produced an empty range. This commit fixes the issue by swapping the
range ordering when the original value is negative.