### PR TITLE
Implement another round of validator optimizations

### DIFF
--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -998,6 +998,7 @@ impl<'a> BinaryReader<'a> {
     /// # Errors
     ///
     /// If `BinaryReader` has no bytes remaining.
+    #[inline]
     pub fn read_u8(&mut self) -> Result<u8> {
         let b = match self.buffer.get(self.position) {
             Some(b) => *b,

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -75,6 +75,11 @@ impl BinaryReaderError {
     }
 
     #[cold]
+    pub(crate) fn fmt(args: fmt::Arguments<'_>, offset: usize) -> Self {
+        BinaryReaderError::new(args.to_string(), offset)
+    }
+
+    #[cold]
     pub(crate) fn eof(offset: usize, needed_hint: usize) -> Self {
         BinaryReaderError {
             inner: Box::new(BinaryReaderErrorInner {
@@ -845,10 +850,7 @@ impl<'a> BinaryReader<'a> {
     fn read_size(&mut self, limit: usize, desc: &str) -> Result<usize> {
         let size = self.read_var_u32()? as usize;
         if size > limit {
-            return Err(BinaryReaderError::new(
-                format!("{} size is out of bounds", desc),
-                self.original_position() - 4,
-            ));
+            bail!(self.original_position() - 4, "{desc} size is out of bounds",);
         }
         Ok(size)
     }
@@ -1308,12 +1310,8 @@ impl<'a> BinaryReader<'a> {
         ))
     }
 
-    #[cold]
     fn invalid_leading_byte_error(byte: u8, desc: &str, offset: usize) -> BinaryReaderError {
-        BinaryReaderError::new(
-            format!("invalid leading byte (0x{:x}) for {}", byte, desc),
-            offset,
-        )
+        format_err!(offset, "invalid leading byte (0x{byte:x}) for {desc}")
     }
 
     fn peek(&self) -> Result<u8> {
@@ -1597,12 +1595,7 @@ impl<'a> BinaryReader<'a> {
             0xfd => self.visit_0xfd_operator(pos, visitor)?,
             0xfe => self.visit_0xfe_operator(pos, visitor)?,
 
-            _ => {
-                return Err(BinaryReaderError::new(
-                    format!("illegal opcode: 0x{:x}", code),
-                    self.original_position() - 1,
-                ));
-            }
+            _ => bail!(pos, "illegal opcode: 0x{code:x}"),
         })
     }
 
@@ -1672,12 +1665,7 @@ impl<'a> BinaryReader<'a> {
                 visitor.visit_table_fill(pos, table)
             }
 
-            _ => {
-                return Err(BinaryReaderError::new(
-                    format!("unknown 0xfc subopcode: 0x{:x}", code),
-                    self.original_position() - 1,
-                ));
-            }
+            _ => bail!(pos, "unknown 0xfc subopcode: 0x{code:x}"),
         })
     }
 
@@ -1990,12 +1978,7 @@ impl<'a> BinaryReader<'a> {
             0xfe => visitor.visit_f64x2_convert_low_i32x4_s(pos),
             0xff => visitor.visit_f64x2_convert_low_i32x4_u(pos),
 
-            _ => {
-                return Err(BinaryReaderError::new(
-                    format!("unknown 0xfd subopcode: 0x{:x}", code),
-                    self.original_position() - 1,
-                ));
-            }
+            _ => bail!(pos, "unknown 0xfd subopcode: 0x{code:x}"),
         })
     }
 
@@ -2077,12 +2060,7 @@ impl<'a> BinaryReader<'a> {
             0x4d => visitor.visit_i64_atomic_rmw16_cmpxchg_u(pos, self.read_memarg_of_align(1)?),
             0x4e => visitor.visit_i64_atomic_rmw32_cmpxchg_u(pos, self.read_memarg_of_align(2)?),
 
-            _ => {
-                return Err(BinaryReaderError::new(
-                    format!("unknown 0xfe subopcode: 0x{:x}", code),
-                    self.original_position() - 1,
-                ));
-            }
+            _ => bail!(pos, "unknown 0xfe subopcode: 0x{code:x}"),
         })
     }
 

--- a/crates/wasmparser/src/lib.rs
+++ b/crates/wasmparser/src/lib.rs
@@ -667,6 +667,16 @@ macro_rules! for_each_operator {
     };
 }
 
+macro_rules! format_err {
+    ($offset:expr, $($arg:tt)*) => {
+        crate::BinaryReaderError::fmt(format_args!($($arg)*), $offset)
+    }
+}
+
+macro_rules! bail {
+    ($($arg:tt)*) => {return Err(format_err!($($arg)*))}
+}
+
 pub use crate::binary_reader::{BinaryReader, BinaryReaderError, Result};
 pub use crate::parser::*;
 pub use crate::readers::*;

--- a/crates/wasmparser/src/parser.rs
+++ b/crates/wasmparser/src/parser.rs
@@ -598,13 +598,11 @@ impl Parser {
                     (Encoding::Component, 1 /* module */)
                     | (Encoding::Component, 4 /* component */) => {
                         if len as usize > MAX_WASM_MODULE_SIZE {
-                            return Err(BinaryReaderError::new(
-                                format!(
-                                    "{} section is too large",
-                                    if id == 1 { "module" } else { "component " }
-                                ),
+                            bail!(
                                 len_pos,
-                            ));
+                                "{} section is too large",
+                                if id == 1 { "module" } else { "component " }
+                            );
                         }
 
                         let range =
@@ -895,10 +893,10 @@ fn single_u32<'a>(
     // expected.
     let index = content.read_var_u32().map_err(clear_hint)?;
     if !content.eof() {
-        return Err(BinaryReaderError::new(
-            format!("unexpected content in the {} section", desc),
+        bail!(
             content.original_position(),
-        ));
+            "unexpected content in the {desc} section",
+        );
     }
     Ok((index, range))
 }

--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -1862,12 +1862,14 @@ impl<T> SnapshotList<T> {
 impl<T> std::ops::Index<usize> for SnapshotList<T> {
     type Output = T;
 
+    #[inline]
     fn index(&self, index: usize) -> &T {
         self.get(index).unwrap()
     }
 }
 
 impl<T> std::ops::IndexMut<usize> for SnapshotList<T> {
+    #[inline]
     fn index_mut(&mut self, index: usize) -> &mut T {
         self.get_mut(index).unwrap()
     }
@@ -1876,12 +1878,14 @@ impl<T> std::ops::IndexMut<usize> for SnapshotList<T> {
 impl<T> std::ops::Index<TypeId> for SnapshotList<T> {
     type Output = T;
 
+    #[inline]
     fn index(&self, id: TypeId) -> &T {
         self.get(id.index).unwrap()
     }
 }
 
 impl<T> std::ops::IndexMut<TypeId> for SnapshotList<T> {
+    #[inline]
     fn index_mut(&mut self, id: TypeId) -> &mut T {
         self.get_mut(id.index).unwrap()
     }


### PR DESCRIPTION
This commit implements another batch of optimizations for the operator
validator in wasmparser. This results in a 15-20% improvement in
validation time for the benchmarked modules in this repository. The
optimizations implemented here are:

* The `pop_operand` method has been split into two with a "fast path"
  that can be inlined into callers and a slower path that is not
  inlined. The fast path is expected to be always taken for valid
  modules which is where the expected type is indeed on the stack. The
  slow path handles the case of mismatched types, unreachable code, etc.
  This is by far the largest optimization implemented in this commit.

* Creation of a `BinaryReaderError` has been updated to uniformly use a
  new `format_err!` macro and `bail!` macro, both modeled after the
  preexisting `format_op_err` and `bail_op_err` macros. These
  additionally use a new `BinaryReaderError::fmt` constructor to perform
  the string allocation within the constructor rather than within the
  caller, ideally reducing code size and the footprint of these
  constructors.

* The `br_if` validation now only calls `self.label_types(...)` once
  instead of twice.

* The `Locals::get` method has been split manually into two functions
  with the fast-path it's-in-the-vector being inlineable and the binary
  search is outlined to a separate function.