### PR TITLE
Minor optimizations for validation/parsing

### DIFF
--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -142,6 +142,7 @@ impl<'a> BinaryReader<'a> {
     }
 
     /// Gets the original position of the binary reader.
+    #[inline]
     pub fn original_position(&self) -> usize {
         self.original_offset + self.position
     }
@@ -939,16 +940,19 @@ impl<'a> BinaryReader<'a> {
     }
 
     /// Returns whether the `BinaryReader` has reached the end of the file.
+    #[inline]
     pub fn eof(&self) -> bool {
         self.position >= self.buffer.len()
     }
 
     /// Returns the `BinaryReader`'s current position.
+    #[inline]
     pub fn current_position(&self) -> usize {
         self.position
     }
 
     /// Returns the number of bytes remaining in the `BinaryReader`.
+    #[inline]
     pub fn bytes_remaining(&self) -> usize {
         self.buffer.len() - self.position
     }

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -489,9 +489,6 @@ impl<'resources, R: WasmModuleResources> OperatorValidatorTemp<'_, 'resources, R
     /// Validates that `memory_index` is valid in this module, and returns the
     /// type of address used to index the memory specified.
     fn check_memory_index(&self, offset: usize, memory_index: u32) -> Result<ValType> {
-        if memory_index > 0 && !self.features.multi_memory {
-            bail!(offset, "multi-memory support is not enabled");
-        }
         match self.resources.memory_at(memory_index) {
             Some(mem) => Ok(mem.index_type()),
             None => bail!(offset, "unknown memory {}", memory_index),


### PR DESCRIPTION
The addition of `#[inline]` should help cross-crate use cases when parsing and otherwise validation should be a tiny bit faster but not really all that much faster.