### PR TITLE
wasm-tools: add a `verbose` option.

### DIFF
--- a/crates/wasm-compose/src/composer.rs
+++ b/crates/wasm-compose/src/composer.rs
@@ -46,7 +46,7 @@ impl Component {
         import_name: Option<String>,
     ) -> Result<Self> {
         let path = path.into();
-        log::debug!("parsing WebAssembly component `{}`", path.display());
+        log::info!("parsing WebAssembly component `{}`", path.display());
 
         let bytes = wat::parse_file(&path).with_context(|| {
             format!("failed to parse component `{path}`", path = path.display())
@@ -518,7 +518,7 @@ impl<'a> InstantiationGraphBuilder<'a> {
         }
 
         // Otherwise, search the paths for a valid component with the same name
-        log::debug!("searching for a component with name `{name}`");
+        log::info!("searching for a component with name `{name}`");
         for dir in std::iter::once(&self.config.dir).chain(self.config.search_paths.iter()) {
             if let Some(component) = Self::parse_component(index, dir, name)? {
                 return Ok(Some(component));
@@ -537,7 +537,7 @@ impl<'a> InstantiationGraphBuilder<'a> {
         for ext in ["wasm", "wat"] {
             path.set_extension(ext);
             if !path.is_file() {
-                log::debug!("component `{path}` does not exist", path = path.display());
+                log::info!("component `{path}` does not exist", path = path.display());
                 continue;
             }
 
@@ -684,7 +684,7 @@ impl<'a> InstantiationGraphBuilder<'a> {
     fn process_dependency(&mut self, dependency: Dependency) -> Result<(InstanceIndex, bool)> {
         let name = self.config.dependency_name(&dependency.instance);
 
-        log::debug!(
+        log::info!(
             "processing dependency `{name}` from instance `{dependent}` to instance `{instance}`",
             dependent = self
                 .graph

--- a/crates/wasm-compose/src/config.rs
+++ b/crates/wasm-compose/src/config.rs
@@ -110,7 +110,7 @@ impl Config {
     pub fn from_file(path: impl Into<PathBuf>) -> Result<Self> {
         let path = path.into();
 
-        log::debug!("reading configuration file `{}`", path.display());
+        log::info!("reading configuration file `{}`", path.display());
 
         let config = fs::read_to_string(&path)
             .with_context(|| format!("failed to read configuration file `{}`", path.display()))?;

--- a/src/bin/wasm-tools/main.rs
+++ b/src/bin/wasm-tools/main.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use clap::Parser;
 use std::io;
 use std::process::ExitCode;
+use wasm_tools::Verbosity;
 
 macro_rules! subcommands {
     ($(($name:ident, $string:tt))*) => {
@@ -19,6 +20,9 @@ macro_rules! subcommands {
                 $name {
                     #[clap(flatten)]
                     opts: $name::Opts,
+
+                    #[clap(flatten)]
+                    verbosity: Verbosity,
                 },
             )*
         }
@@ -28,7 +32,10 @@ macro_rules! subcommands {
                 match self {
                     $(
                         #[cfg(feature = $string)]
-                        WasmTools::$name { opts } => opts.run(),
+                        Self::$name { opts, verbosity } => {
+                            verbosity.init_logger();
+                            opts.run()
+                        }
                     )*
                 }
             }
@@ -50,10 +57,6 @@ subcommands! {
 }
 
 fn main() -> ExitCode {
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn"))
-        .format_target(false)
-        .init();
-
     let err = match <WasmTools as Parser>::parse().run() {
         Ok(()) => return ExitCode::SUCCESS,
         Err(e) => e,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,29 @@ use std::fs::File;
 use std::io::{BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 
+/// Implements the verbosity flag for the CLI commands.
+#[derive(clap::Parser)]
+pub struct Verbosity {
+    /// Use verbose output (-vv very verbose output).
+    #[clap(long = "verbose", short = 'v', parse(from_occurrences))]
+    verbose: usize,
+}
+
+impl Verbosity {
+    /// Initializes the logger based on the verbosity level.
+    pub fn init_logger(&self) {
+        let default = match self.verbose {
+            0 => "warn",
+            1 => "info",
+            _ => "debug",
+        };
+
+        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(default))
+            .format_target(false)
+            .init();
+    }
+}
+
 // This is intended to be included in a struct as:
 //
 //      #[clap(flatten)]


### PR DESCRIPTION
This is a simple PR that configures the default logging level used by `wasm-tools`.

Additionally, some of the messages logged by `wasm-compose` have been updated to use `info` level.