### PR TITLE
wasm-compose: add a `no-imports` CLI option to error on missing deps.

### DIFF
--- a/crates/wasm-compose/src/cli.rs
+++ b/crates/wasm-compose/src/cli.rs
@@ -28,6 +28,10 @@ pub struct WasmComposeCommand {
     #[clap(long)]
     pub skip_validation: bool,
 
+    /// Do not allow instance imports in the composed output component.
+    #[clap(long = "no-imports")]
+    pub disallow_imports: bool,
+
     /// The path to the root component to compose.
     #[clap(value_name = "COMPONENT")]
     pub component: PathBuf,
@@ -91,6 +95,7 @@ impl WasmComposeCommand {
 
         config.search_paths.extend(self.paths.iter().cloned());
         config.skip_validation |= self.skip_validation;
+        config.disallow_imports |= self.disallow_imports;
         Ok(config)
     }
 }

--- a/crates/wasm-compose/src/composer.rs
+++ b/crates/wasm-compose/src/composer.rs
@@ -572,6 +572,12 @@ impl<'a> InstantiationGraphBuilder<'a> {
                 Instance::Instantiation { component }
             }
             None => {
+                if self.config.disallow_imports {
+                    bail!(
+                        "a dependency named `{component_name}` could not be found and instance imports are not allowed",
+                    );
+                }
+
                 log::warn!("instance `{name}` will be imported because a dependency named `{component_name}` could not be found");
                 Instance::Import([import.unwrap()].into())
             }

--- a/crates/wasm-compose/src/config.rs
+++ b/crates/wasm-compose/src/config.rs
@@ -96,6 +96,13 @@ pub struct Config {
     #[serde(default)]
     pub skip_validation: bool,
 
+    /// Whether or not to disallow instance imports in the output component.
+    ///
+    /// Enabling this option will cause an error if a dependency cannot be
+    /// located.
+    #[serde(default)]
+    pub disallow_imports: bool,
+
     /// The explicit, transitive dependencies of the root component.
     #[serde(default, deserialize_with = "de::index_map")]
     pub dependencies: IndexMap<String, Dependency>,

--- a/crates/wasm-compose/tests/compositions/disallow-imports/config.yml
+++ b/crates/wasm-compose/tests/compositions/disallow-imports/config.yml
@@ -1,0 +1,1 @@
+disallow-imports: true

--- a/crates/wasm-compose/tests/compositions/disallow-imports/error.txt
+++ b/crates/wasm-compose/tests/compositions/disallow-imports/error.txt
@@ -1,0 +1,1 @@
+a dependency named `a` could not be found and instance imports are not allowed

--- a/crates/wasm-compose/tests/compositions/disallow-imports/root.wat
+++ b/crates/wasm-compose/tests/compositions/disallow-imports/root.wat
@@ -1,0 +1,3 @@
+(component
+  (import "a" (instance))
+)


### PR DESCRIPTION
This PR adds a `no-imports` CLI option to `wasm-compose` that will treat a
missing dependency as an error rather than importing it as an instance in the
composed component.