### PR TITLE
wasmparser: avoid double counting data segments

### DIFF
--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -865,13 +865,7 @@ impl Validator {
             "data",
             |state, _, _, count, offset| {
                 state.data_segment_count = count;
-                check_max(
-                    state.module.data_count.unwrap_or(0) as usize,
-                    count,
-                    MAX_WASM_DATA_SEGMENTS,
-                    "data segments",
-                    offset,
-                )
+                check_max(0, count, MAX_WASM_DATA_SEGMENTS, "data segments", offset)
             },
             |state, features, types, d, offset| state.add_data_segment(d, features, types, offset),
         )


### PR DESCRIPTION
Per #756, this fixes the issue of double counting data segments when a data
count section is present.  Prior to this fix, a module containing more than
50,000 data segements would fail to validate if it had a data count section
since the count would be doubled and exceed `MAX_WASM_DATA_SEGMENTS`.

Signed-off-by: Joel Dice <joel.dice@fermyon.com>