### PR TITLE
wasm-smith: fix two bugs in component generation

### DIFF
--- a/crates/wasm-smith/src/component.rs
+++ b/crates/wasm-smith/src/component.rs
@@ -729,6 +729,7 @@ impl ComponentBuilder {
                 "memory".into(),
                 crate::core::EntityType::Memory(self.arbitrary_core_memory_type(u)?),
             ));
+            exports.insert("memory".into());
             counts.memories += 1;
             has_memory = true;
         }

--- a/crates/wasm-smith/src/component.rs
+++ b/crates/wasm-smith/src/component.rs
@@ -1079,20 +1079,20 @@ impl ComponentBuilder {
         u: &mut Unstructured,
         exports: &mut HashSet<String>,
         type_fuel: &mut u32,
-    ) -> Result<InstanceTypeDef> {
+    ) -> Result<InstanceTypeDecl> {
         let mut choices: Vec<
             fn(
                 &mut ComponentBuilder,
                 &mut HashSet<String>,
                 &mut Unstructured,
                 &mut u32,
-            ) -> Result<InstanceTypeDef>,
+            ) -> Result<InstanceTypeDecl>,
         > = Vec::with_capacity(3);
 
         // Export.
         if self.current_type_scope().can_ref_type() {
             choices.push(|me, exports, u, _type_fuel| {
-                Ok(InstanceTypeDef::Export {
+                Ok(InstanceTypeDecl::Export {
                     name: crate::unique_string(100, exports, u)?,
                     ty: me.arbitrary_type_ref(u, false, true)?.unwrap(),
                 })
@@ -1118,7 +1118,7 @@ impl ComponentBuilder {
                     } => me.current_type_scope_mut().push_core(ty.clone()),
                     _ => unreachable!(),
                 };
-                Ok(InstanceTypeDef::Alias(alias))
+                Ok(InstanceTypeDecl::Alias(alias))
             });
         }
 
@@ -1126,15 +1126,17 @@ impl ComponentBuilder {
         choices.push(|me, _exports, u, type_fuel| {
             let ty = me.arbitrary_core_type(u, type_fuel)?;
             me.current_type_scope_mut().push_core(ty.clone());
-            Ok(InstanceTypeDef::CoreType(ty))
+            Ok(InstanceTypeDecl::CoreType(ty))
         });
 
         // Type definition.
-        choices.push(|me, _exports, u, type_fuel| {
-            let ty = me.arbitrary_type(u, type_fuel)?;
-            me.current_type_scope_mut().push(ty.clone());
-            Ok(InstanceTypeDef::Type(ty))
-        });
+        if self.types.len() < self.config.max_nesting_depth() {
+            choices.push(|me, _exports, u, type_fuel| {
+                let ty = me.arbitrary_type(u, type_fuel)?;
+                me.current_type_scope_mut().push(ty.clone());
+                Ok(InstanceTypeDecl::Type(ty))
+            });
+        }
 
         let f = u.choose(&choices)?;
         f(self, exports, u, type_fuel)
@@ -1998,24 +2000,24 @@ enum ComponentTypeDef {
     Export { name: String, ty: ComponentTypeRef },
 }
 
-impl From<InstanceTypeDef> for ComponentTypeDef {
-    fn from(def: InstanceTypeDef) -> Self {
+impl From<InstanceTypeDecl> for ComponentTypeDef {
+    fn from(def: InstanceTypeDecl) -> Self {
         match def {
-            InstanceTypeDef::CoreType(t) => Self::CoreType(t),
-            InstanceTypeDef::Type(t) => Self::Type(t),
-            InstanceTypeDef::Export { name, ty } => Self::Export { name, ty },
-            InstanceTypeDef::Alias(a) => Self::Alias(a),
+            InstanceTypeDecl::CoreType(t) => Self::CoreType(t),
+            InstanceTypeDecl::Type(t) => Self::Type(t),
+            InstanceTypeDecl::Export { name, ty } => Self::Export { name, ty },
+            InstanceTypeDecl::Alias(a) => Self::Alias(a),
         }
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct InstanceType {
-    defs: Vec<InstanceTypeDef>,
+    defs: Vec<InstanceTypeDecl>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-enum InstanceTypeDef {
+enum InstanceTypeDecl {
     CoreType(Rc<CoreType>),
     Type(Rc<Type>),
     Alias(Alias),

--- a/crates/wasm-smith/src/component/encode.rs
+++ b/crates/wasm-smith/src/component/encode.rs
@@ -220,30 +220,30 @@ impl Type {
                 let mut enc_inst_ty = wasm_encoder::InstanceType::new();
                 for def in &inst_ty.defs {
                     match def {
-                        InstanceTypeDef::CoreType(ty) => {
+                        InstanceTypeDecl::CoreType(ty) => {
                             ty.encode(enc_inst_ty.core_type());
                         }
-                        InstanceTypeDef::Type(ty) => {
+                        InstanceTypeDecl::Type(ty) => {
                             ty.encode(enc_inst_ty.ty());
                         }
-                        InstanceTypeDef::Export { name, ty } => {
+                        InstanceTypeDecl::Export { name, ty } => {
                             enc_inst_ty.export(name, *ty);
                         }
-                        InstanceTypeDef::Alias(Alias::Outer {
+                        InstanceTypeDecl::Alias(Alias::Outer {
                             count,
                             i,
                             kind: OuterAliasKind::Type(_),
                         }) => {
                             enc_inst_ty.alias_outer_type(*count, *i);
                         }
-                        InstanceTypeDef::Alias(Alias::Outer {
+                        InstanceTypeDecl::Alias(Alias::Outer {
                             count,
                             i,
                             kind: OuterAliasKind::CoreType(_),
                         }) => {
                             enc_inst_ty.alias_outer_core_type(*count, *i);
                         }
-                        InstanceTypeDef::Alias(_) => unreachable!(),
+                        InstanceTypeDecl::Alias(_) => unreachable!(),
                     }
                 }
                 enc.instance(&enc_inst_ty);


### PR DESCRIPTION
Two bugfixes in how `wasm-smith` generates components, and a renaming to match a change in the spec:

* when generating the typical `memory` export, add the name `"memory"` to the exports table.
* when generating type definitions, obey the max nesting depth setting.
* rename `InstanceTypeDef` to `InstanceTypeDecl`, to reflect the name found in https://github.com/WebAssembly/component-model/blob/main/design/mvp/Binary.md

Both of these bugs were found by manually enabling components (removing the `false &&` at https://github.com/bytecodealliance/wasm-tools/blob/main/fuzz/fuzz_targets/validate-valid-module.rs#L16) of the `fuzz/fuzz_targets/validate-valid-module.rs` fuzz target. That fuzz target now reliably discovers ways that component generation exceeds the type size limits in `wasmparser`. Component generation will require some pretty big refactoring to keep track of and obey these size limits, which I can't take on at this time.