### PR TITLE
OperatorVisitor: qualify index param names

### DIFF
--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -292,8 +292,8 @@ pub fn op(t: &mut dyn Translator, op: &Operator<'_>) -> Result<Instruction<'stat
         O::Else => I::Else,
 
         O::Try { ty } => I::Try(t.translate_block_type(ty)?),
-        O::Catch { index } => I::Catch(t.remap(Item::Tag, *index)?),
-        O::Throw { index } => I::Throw(t.remap(Item::Tag, *index)?),
+        O::Catch { tag_index } => I::Catch(t.remap(Item::Tag, *tag_index)?),
+        O::Throw { tag_index } => I::Throw(t.remap(Item::Tag, *tag_index)?),
         O::Rethrow { relative_depth } => I::Rethrow(*relative_depth),
         O::End => I::End,
         O::Br { relative_depth } => I::Br(*relative_depth),
@@ -309,11 +309,11 @@ pub fn op(t: &mut dyn Translator, op: &Operator<'_>) -> Result<Instruction<'stat
         O::Return => I::Return,
         O::Call { function_index } => I::Call(t.remap(Item::Function, *function_index)?),
         O::CallIndirect {
-            index,
+            type_index,
             table_index,
             table_byte: _,
         } => I::CallIndirect {
-            ty: t.remap(Item::Type, *index)?,
+            ty: t.remap(Item::Type, *type_index)?,
             table: t.remap(Item::Table, *table_index)?,
         },
         O::Delegate { relative_depth } => I::Delegate(*relative_depth),

--- a/crates/wasmparser/src/lib.rs
+++ b/crates/wasmparser/src/lib.rs
@@ -123,8 +123,8 @@ macro_rules! for_each_operator {
             @mvp If { ty: $crate::BlockType } => visit_if
             @mvp Else => visit_else
             @exceptions Try { ty: $crate::BlockType } => visit_try
-            @exceptions Catch { index: u32 } => visit_catch
-            @exceptions Throw { index: u32 } => visit_throw
+            @exceptions Catch { tag_index: u32 } => visit_catch
+            @exceptions Throw { tag_index: u32 } => visit_throw
             @exceptions Rethrow { relative_depth: u32 } => visit_rethrow
             @mvp End => visit_end
             @mvp Br { relative_depth: u32 } => visit_br
@@ -132,9 +132,9 @@ macro_rules! for_each_operator {
             @mvp BrTable { table: $crate::BrTable<'a> } => visit_br_table
             @mvp Return => visit_return
             @mvp Call { function_index: u32 } => visit_call
-            @mvp CallIndirect { index: u32, table_index: u32, table_byte: u8 } => visit_call_indirect
+            @mvp CallIndirect { type_index: u32, table_index: u32, table_byte: u8 } => visit_call_indirect
             @tail_calls ReturnCall { function_index: u32 } => visit_return_call
-            @tail_calls ReturnCallIndirect { index: u32, table_index: u32 } => visit_return_call_indirect
+            @tail_calls ReturnCallIndirect { type_index: u32, table_index: u32 } => visit_return_call_indirect
             @exceptions Delegate { relative_depth: u32 } => visit_delegate
             @exceptions CatchAll => visit_catch_all
             @mvp Drop => visit_drop


### PR DESCRIPTION
This is intended to make it easier for implementers of this trait to figure what is what (admittedly `index` doesn’t say much when there are all kinds of indexable lists, and some entities deal with indices into multiple lists), especially if they’re using something like RLS’ auto-implement all methods or just reading the documentation.

With `type_index` and `tag_index` these parameters become self-documenting.