### PR TITLE
Fix wasm-encoder encodings for new relaxed instructions

### DIFF
--- a/crates/wasm-encoder/src/core/code.rs
+++ b/crates/wasm-encoder/src/core/code.rs
@@ -2397,15 +2397,15 @@ impl Encode for Instruction<'_> {
             }
             Instruction::I16x8DotI8x16I7x16S => {
                 sink.push(0xFD);
-                0x111u32.encode(sink);
+                0x112u32.encode(sink);
             }
             Instruction::I32x4DotI8x16I7x16AddS => {
                 sink.push(0xFD);
-                0x111u32.encode(sink);
+                0x113u32.encode(sink);
             }
             Instruction::F32x4RelaxedDotBf16x8AddF32x4 => {
                 sink.push(0xFD);
-                0x111u32.encode(sink);
+                0x114u32.encode(sink);
             }
 
             // Atmoic instructions from the thread proposal


### PR DESCRIPTION
Looks like a few copy/paste errors