### PR TITLE
wasm-tools: update for latest component model changes.

### DIFF
--- a/crates/wasm-compose/src/encoding.rs
+++ b/crates/wasm-compose/src/encoding.rs
@@ -376,7 +376,7 @@ impl<'a> TypeEncoder<'a> {
             .iter()
             .map(|(name, ty)| {
                 (
-                    name.as_deref(),
+                    name.as_str(),
                     self.component_val_type(encodable, types, *ty),
                 )
             })
@@ -396,11 +396,7 @@ impl<'a> TypeEncoder<'a> {
         let index = encodable.type_count();
         let mut f = encodable.ty().function();
 
-        if params.len() == 1 && params[0].0.is_none() {
-            f.param(params[0].1);
-        } else {
-            f.params(params.into_iter().map(|(name, ty)| (name.unwrap(), ty)));
-        }
+        f.params(params);
 
         if results.len() == 1 && results[0].0.is_none() {
             f.result(results[0].1);

--- a/crates/wasm-compose/tests/compositions/component-not-valid/error.txt
+++ b/crates/wasm-compose/tests/compositions/component-not-valid/error.txt
@@ -1,4 +1,4 @@
 failed to validate WebAssembly component `tests/compositions/component-not-valid/root.wat`
 
 Caused by:
-    unknown core function 0: function index out of bounds (at offset 0x13)
+    unknown core function 0: function index out of bounds (at offset 0x12)

--- a/crates/wasm-compose/tests/compositions/conflict-on-import/b.wat
+++ b/crates/wasm-compose/tests/compositions/conflict-on-import/b.wat
@@ -1,3 +1,3 @@
 (component
-  (import "a" (instance (export "x" (func (param string)))))
+  (import "a" (instance (export "x" (func (param "x" string)))))
 )

--- a/crates/wasm-compose/tests/compositions/merged-import/b.wat
+++ b/crates/wasm-compose/tests/compositions/merged-import/b.wat
@@ -1,3 +1,3 @@
 (component
-  (import "a" (instance (export "a" (func (param string))) (export "c" (func (param u64)))))
+  (import "a" (instance (export "a" (func (param "x" string))) (export "c" (func (param "y" u64)))))
 )

--- a/crates/wasm-compose/tests/compositions/merged-import/composed.wat
+++ b/crates/wasm-compose/tests/compositions/merged-import/composed.wat
@@ -3,9 +3,9 @@
     (instance
       (type (;0;) (func))
       (export "b" (func (type 0)))
-      (type (;1;) (func (param u64)))
+      (type (;1;) (func (param "y" u64)))
       (export "c" (func (type 1)))
-      (type (;2;) (func (param string)))
+      (type (;2;) (func (param "x" string)))
       (export "a" (func (type 2)))
     )
   )
@@ -13,9 +13,9 @@
   (component (;0;)
     (type (;0;) 
       (instance
-        (type (;0;) (func (param string)))
+        (type (;0;) (func (param "x" string)))
         (export "a" (func (type 0)))
-        (type (;1;) (func (param u64)))
+        (type (;1;) (func (param "y" u64)))
         (export "c" (func (type 1)))
       )
     )
@@ -30,7 +30,7 @@
       (instance
         (type (;0;) (func))
         (export "b" (func (type 0)))
-        (type (;1;) (func (param u32)))
+        (type (;1;) (func (param "y" u32)))
         (export "c" (func (type 1)))
       )
     )

--- a/crates/wasm-compose/tests/compositions/merged-import/root.wat
+++ b/crates/wasm-compose/tests/compositions/merged-import/root.wat
@@ -1,4 +1,4 @@
 (component
-  (import "a" (instance (export "b" (func)) (export "c" (func (param u32)))))
+  (import "a" (instance (export "b" (func)) (export "c" (func (param "y" u32)))))
   (import "b" (instance))
 )

--- a/crates/wasm-encoder/src/component/types.rs
+++ b/crates/wasm-encoder/src/component/types.rs
@@ -380,20 +380,7 @@ impl<'a> ComponentFuncTypeEncoder<'a> {
         Self(sink)
     }
 
-    /// Defines a single unnamed parameter.
-    ///
-    /// This method cannot be used with `params`.
-    ///
-    /// Parameters must be defined before defining results.
-    pub fn param(&mut self, ty: impl Into<ComponentValType>) -> &mut Self {
-        self.0.push(0x00);
-        ty.into().encode(self.0);
-        self
-    }
-
     /// Defines named parameters.
-    ///
-    /// This method cannot be used with `param`.
     ///
     /// Parameters must be defined before defining results.
     pub fn params<'b, P, T>(&mut self, params: P) -> &mut Self
@@ -402,7 +389,6 @@ impl<'a> ComponentFuncTypeEncoder<'a> {
         P::IntoIter: ExactSizeIterator,
         T: Into<ComponentValType>,
     {
-        self.0.push(0x01);
         let params = params.into_iter();
         params.len().encode(self.0);
         for (name, ty) in params {

--- a/crates/wasm-smith/src/component.rs
+++ b/crates/wasm-smith/src/component.rs
@@ -1218,41 +1218,6 @@ impl ComponentBuilder {
         let mut results = Vec::new();
         let mut names = HashSet::new();
 
-        fn push(
-            b: &ComponentBuilder,
-            u: &mut Unstructured,
-            type_fuel: &mut u32,
-            names: &mut HashSet<String>,
-            items: &mut Vec<(Option<String>, ComponentValType)>,
-        ) -> Result<bool> {
-            *type_fuel = type_fuel.saturating_sub(1);
-            if *type_fuel == 0 {
-                return Ok(false);
-            }
-
-            // If the collection is empty (i.e. first push), then arbitrarily give it a name.
-            // Otherwise, all of the items must be named.
-            let name = if items.is_empty() {
-                // Most of the time we should have named parameters/results.
-                u.ratio::<u8>(99, 100)?
-                    .then(|| crate::unique_non_empty_string(100, names, u))
-                    .transpose()?
-            } else {
-                Some(crate::unique_non_empty_string(100, names, u)?)
-            };
-
-            let ty = b.arbitrary_component_val_type(u)?;
-
-            items.push((name, ty));
-
-            // There can be only one unnamed parameter/result.
-            if items.len() == 1 && items[0].0.is_none() {
-                return Ok(false);
-            }
-
-            Ok(true)
-        }
-
         // Note: parameters are currently limited to a maximum of 16
         // because any additional parameters will require indirect access
         // via a pointer argument; when this occurs, validation of any
@@ -1263,7 +1228,17 @@ impl ComponentBuilder {
         // we should increase this maximum to test indirect parameter
         // passing.
         arbitrary_loop(u, 0, 16, |u| {
-            push(self, u, type_fuel, &mut names, &mut params)
+            *type_fuel = type_fuel.saturating_sub(1);
+            if *type_fuel == 0 {
+                return Ok(false);
+            }
+
+            let name = crate::unique_non_empty_string(100, &mut names, u)?;
+            let ty = self.arbitrary_component_val_type(u)?;
+
+            params.push((name, ty));
+
+            Ok(true)
         })?;
 
         names.clear();
@@ -1272,7 +1247,32 @@ impl ComponentBuilder {
         // required. When the memory option is implemented, this restriction
         // should be relaxed.
         arbitrary_loop(u, 0, 1, |u| {
-            push(self, u, type_fuel, &mut names, &mut results)
+            *type_fuel = type_fuel.saturating_sub(1);
+            if *type_fuel == 0 {
+                return Ok(false);
+            }
+
+            // If the result list is empty (i.e. first push), then arbitrarily give
+            // the result a name. Otherwise, all of the subsequent items must be named.
+            let name = if results.is_empty() {
+                // Most of the time we should have a single, unnamed result.
+                u.ratio::<u8>(10, 100)?
+                    .then(|| crate::unique_non_empty_string(100, &mut names, u))
+                    .transpose()?
+            } else {
+                Some(crate::unique_non_empty_string(100, &mut names, u)?)
+            };
+
+            let ty = self.arbitrary_component_val_type(u)?;
+
+            results.push((name, ty));
+
+            // There can be only one unnamed result.
+            if results.len() == 1 && results[0].0.is_none() {
+                return Ok(false);
+            }
+
+            Ok(true)
         })?;
 
         Ok(Rc::new(FuncType { params, results }))
@@ -1835,11 +1835,7 @@ fn inverse_scalar_canonical_abi_for(
 
     for core_ty in &core_func_ty.params {
         params.push((
-            if core_func_ty.params.len() > 1 || u.arbitrary()? {
-                Some(crate::unique_non_empty_string(100, &mut names, u)?)
-            } else {
-                None
-            },
+            crate::unique_non_empty_string(100, &mut names, u)?,
             from_core_ty(u, *core_ty)?,
         ));
     }
@@ -2024,21 +2020,11 @@ enum InstanceTypeDef {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct FuncType {
-    params: Vec<(Option<String>, ComponentValType)>,
+    params: Vec<(String, ComponentValType)>,
     results: Vec<(Option<String>, ComponentValType)>,
 }
 
 impl FuncType {
-    fn unnamed_param_ty(&self) -> Option<ComponentValType> {
-        if self.params.len() == 1 {
-            let (name, ty) = &self.params[0];
-            if name.is_none() {
-                return Some(*ty);
-            }
-        }
-        None
-    }
-
     fn unnamed_result_ty(&self) -> Option<ComponentValType> {
         if self.results.len() == 1 {
             let (name, ty) = &self.results[0];

--- a/crates/wasm-smith/src/component/encode.rs
+++ b/crates/wasm-smith/src/component/encode.rs
@@ -159,16 +159,7 @@ impl Type {
             Self::Func(func_ty) => {
                 let mut f = enc.function();
 
-                if let Some(ty) = func_ty.unnamed_param_ty() {
-                    f.param(ty);
-                } else {
-                    f.params(
-                        func_ty
-                            .params
-                            .iter()
-                            .map(|(name, ty)| (name.as_deref().unwrap(), *ty)),
-                    );
-                }
+                f.params(func_ty.params.iter().map(|(name, ty)| (name.as_str(), *ty)));
 
                 if let Some(ty) = func_ty.unnamed_result_ty() {
                     f.result(ty);

--- a/crates/wasm-smith/src/lib.rs
+++ b/crates/wasm-smith/src/lib.rs
@@ -68,8 +68,7 @@ pub use crate::core::{
 use arbitrary::{Result, Unstructured};
 pub use component::{Component, ConfiguredComponent};
 pub use config::{Config, DefaultConfig, SwarmConfig};
-
-use std::{collections::HashSet, str};
+use std::{collections::HashSet, fmt::Write, str};
 
 /// Do something an arbitrary number of times.
 ///
@@ -132,7 +131,7 @@ pub(crate) fn unique_string(
 ) -> Result<String> {
     let mut name = limited_string(max_size, u)?;
     while names.contains(&name) {
-        name.push_str(&format!("{}", names.len()));
+        write!(&mut name, "{}", names.len()).unwrap();
     }
     names.insert(name.clone());
     Ok(name)
@@ -145,7 +144,6 @@ pub(crate) fn unique_non_empty_string(
 ) -> Result<String> {
     let mut s = unique_string(max_size, names, u)?;
     while s.is_empty() || names.contains(&s) {
-        use std::fmt::Write;
         write!(&mut s, "{}", names.len()).unwrap();
     }
     names.insert(s.clone());

--- a/crates/wasmparser/src/readers/component/types.rs
+++ b/crates/wasmparser/src/readers/component/types.rs
@@ -259,31 +259,25 @@ pub enum InstanceTypeDeclaration<'a> {
     },
 }
 
-/// Represents the vector of types in a component function's
-/// parameters or results.
+/// Represents the result type of a component function.
 #[derive(Debug, Clone)]
-pub enum TypeVec<'a> {
-    /// The type vector contains a single, unnamed type.
+pub enum ComponentFuncResult<'a> {
+    /// The function returns a singular, unnamed type.
     Unnamed(ComponentValType),
-    /// The type vector contains zero or more named types.
+    /// The function returns zero or more named types.
     Named(Box<[(&'a str, ComponentValType)]>),
 }
 
-impl TypeVec<'_> {
-    /// Gets the type vector's length.
-    pub fn len(&self) -> usize {
+impl ComponentFuncResult<'_> {
+    /// Gets the count of types returned by the function.
+    pub fn type_count(&self) -> usize {
         match self {
             Self::Unnamed(_) => 1,
             Self::Named(vec) => vec.len(),
         }
     }
 
-    /// Determines if the type vector is empty.
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// Iterates over the types in the type vector.
+    /// Iterates over the types returned by the function.
     pub fn iter(&self) -> impl Iterator<Item = (Option<&str>, &ComponentValType)> {
         enum Either<L, R> {
             Left(L),
@@ -316,9 +310,9 @@ impl TypeVec<'_> {
 #[derive(Debug, Clone)]
 pub struct ComponentFuncType<'a> {
     /// The function parameters.
-    pub params: TypeVec<'a>,
-    /// The function results.
-    pub results: TypeVec<'a>,
+    pub params: Box<[(&'a str, ComponentValType)]>,
+    /// The function result.
+    pub results: ComponentFuncResult<'a>,
 }
 
 /// Represents a case in a variant type.
@@ -392,7 +386,7 @@ impl<'a> ComponentTypeSectionReader<'a> {
     /// # Examples
     /// ```
     /// use wasmparser::ComponentTypeSectionReader;
-    /// let data: &[u8] = &[0x01, 0x40, 0x01, 0x01, 0x03, b'f', b'o', b'o', 0x73, 0x00, 0x73];
+    /// let data: &[u8] = &[0x01, 0x40, 0x01, 0x03, b'f', b'o', b'o', 0x73, 0x00, 0x73];
     /// let mut reader = ComponentTypeSectionReader::new(data, 0).unwrap();
     /// for _ in 0..reader.get_count() {
     ///     let ty = reader.read().expect("type");
@@ -439,7 +433,7 @@ impl<'a> IntoIterator for ComponentTypeSectionReader<'a> {
     /// # Examples
     /// ```
     /// use wasmparser::ComponentTypeSectionReader;
-    /// let data: &[u8] = &[0x01, 0x40, 0x01, 0x01, 0x03, b'f', b'o', b'o', 0x73, 0x00, 0x73];
+    /// let data: &[u8] = &[0x01, 0x40, 0x01, 0x03, b'f', b'o', b'o', 0x73, 0x00, 0x73];
     /// let mut reader = ComponentTypeSectionReader::new(data, 0).unwrap();
     /// for ty in reader {
     ///     println!("Type {:?}", ty.expect("type"));

--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -863,21 +863,20 @@ impl ComponentState {
     ) -> Result<ComponentFuncType> {
         let mut type_size = 1;
 
-        let mut set = HashSet::with_capacity(std::cmp::max(ty.params.len(), ty.results.len()));
+        let mut set =
+            HashSet::with_capacity(std::cmp::max(ty.params.len(), ty.results.type_count()));
 
         let params = ty
             .params
             .iter()
             .map(|(name, ty)| {
-                if let Some(name) = name {
-                    Self::check_name(name, "function parameter", offset)?;
-                    if !set.insert(name) {
-                        return Err(BinaryReaderError::new("duplicate parameter name", offset));
-                    }
+                Self::check_name(name, "function parameter", offset)?;
+                if !set.insert(*name) {
+                    return Err(BinaryReaderError::new("duplicate parameter name", offset));
                 }
                 let ty = self.create_component_val_type(*ty, types, offset)?;
                 type_size = combine_type_sizes(type_size, ty.type_size(), offset)?;
-                Ok((name.map(ToOwned::to_owned), ty))
+                Ok((name.to_string(), ty))
             })
             .collect::<Result<_>>()?;
 

--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -706,7 +706,7 @@ pub struct ComponentFuncType {
     /// The effective type size for the component function type.
     pub(crate) type_size: usize,
     /// The function parameters.
-    pub params: Box<[(Option<String>, ComponentValType)]>,
+    pub params: Box<[(String, ComponentValType)]>,
     /// The function's results.
     pub results: Box<[(Option<String>, ComponentValType)]>,
 }

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -1628,10 +1628,8 @@ impl Printer {
         for (name, ty) in ty.params.iter() {
             self.result.push(' ');
             self.start_group("param ");
-            if let Some(name) = name {
-                self.print_str(name)?;
-                self.result.push(' ');
-            }
+            self.print_str(name)?;
+            self.result.push(' ');
             self.print_component_val_type(state, ty)?;
             self.end_group()
         }

--- a/crates/wast/src/component/binary.rs
+++ b/crates/wast/src/component/binary.rs
@@ -78,11 +78,7 @@ fn encode_type(encoder: ComponentTypeEncoder, ty: &TypeDef) {
         }
         TypeDef::Func(f) => {
             let mut encoder = encoder.function();
-            if f.params.len() == 1 && f.params[0].name.is_none() {
-                encoder.param(&f.params[0].ty);
-            } else {
-                encoder.params(f.params.iter().map(|p| (p.name.unwrap_or(""), &p.ty)));
-            }
+            encoder.params(f.params.iter().map(|p| (p.name, &p.ty)));
 
             if f.results.len() == 1 && f.results[0].name.is_none() {
                 encoder.result(&f.results[0].ty);

--- a/crates/wast/src/component/types.rs
+++ b/crates/wast/src/component/types.rs
@@ -698,8 +698,8 @@ impl<'a> Parse<'a> for ComponentFunctionType<'a> {
 /// A parameter of a [`ComponentFunctionType`].
 #[derive(Debug)]
 pub struct ComponentFunctionParam<'a> {
-    /// An optionally-specified name of this parameter
-    pub name: Option<&'a str>,
+    /// The name of the parameter
+    pub name: &'a str,
     /// The type of the parameter.
     pub ty: ComponentValType<'a>,
 }

--- a/crates/wast/src/core/resolve/names.rs
+++ b/crates/wast/src/core/resolve/names.rs
@@ -646,9 +646,7 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
                 self.resolver.resolve(&mut a.src_array, Ns::Type)?;
             }
 
-            RefNull(ty) | CallRef(ty) | ReturnCallRef(ty) => {
-                self.resolver.resolve_heaptype(ty)?
-            }
+            RefNull(ty) | CallRef(ty) | ReturnCallRef(ty) => self.resolver.resolve_heaptype(ty)?,
 
             _ => {}
         }

--- a/crates/wat/src/lib.rs
+++ b/crates/wat/src/lib.rs
@@ -216,9 +216,9 @@ pub fn parse_str(wat: impl AsRef<str>) -> Result<Vec<u8>> {
 }
 
 fn _parse_str(wat: &str) -> Result<Vec<u8>> {
-    let buf = ParseBuffer::new(&wat).map_err(|e| Error::cvt(e, wat))?;
+    let buf = ParseBuffer::new(wat).map_err(|e| Error::cvt(e, wat))?;
     let mut ast = parser::parse::<wast::Wat>(&buf).map_err(|e| Error::cvt(e, wat))?;
-    Ok(ast.encode().map_err(|e| Error::cvt(e, wat))?)
+    ast.encode().map_err(|e| Error::cvt(e, wat))
 }
 
 /// A convenience type definition for `Result` where the error is [`Error`]

--- a/tests/dump/alias.wat
+++ b/tests/dump/alias.wat
@@ -1,7 +1,7 @@
 (component
   (import "i" (instance $i
     (export "f1" (func $f1))
-    (export "f2" (func $f2 (param string)))
+    (export "f2" (func $f2 (param "p1" string)))
   ))
 
   (func (alias export $i "f1"))

--- a/tests/dump/alias.wat.dump
+++ b/tests/dump/alias.wat.dump
@@ -1,58 +1,58 @@
   0x0 | 00 61 73 6d | version 65546 (Component)
       | 0a 00 01 00
-  0x8 | 07 1b       | component type section
+  0x8 | 07 1d       | component type section
   0xa | 01          | 1 count
-  0xb | 42 04 01 40 | [type 0] Instance([Type(Func(ComponentFuncType { params: Named([]), results: Named([]) })), Export { name: "f1", ty: Func(0) }, Type(Func(ComponentFuncType { params: Unnamed(Primitive(String)), results: Named([]) })), Export { name: "f2", ty: Func(1) }])
-      | 01 00 01 00
-      | 04 02 66 31
-      | 01 00 01 40
-      | 00 73 01 00
-      | 04 02 66 32
-      | 01 01      
- 0x25 | 0a 05       | component import section
- 0x27 | 01          | 1 count
- 0x28 | 01 69 05 00 | [instance 0] ComponentImport { name: "i", ty: Instance(0) }
- 0x2c | 06 13       | component alias section
- 0x2e | 03          | 3 count
- 0x2f | 01 00 00 02 | alias [func 0] InstanceExport { kind: Func, instance_index: 0, name: "f1" }
+  0xb | 42 04 01 40 | [type 0] Instance([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Export { name: "f1", ty: Func(0) }, Type(Func(ComponentFuncType { params: [("p1", Primitive(String))], results: Named([]) })), Export { name: "f2", ty: Func(1) }])
+      | 00 01 00 04
+      | 02 66 31 01
+      | 00 01 40 01
+      | 02 70 31 73
+      | 01 00 04 02
+      | 66 32 01 01
+ 0x27 | 0a 05       | component import section
+ 0x29 | 01          | 1 count
+ 0x2a | 01 69 05 00 | [instance 0] ComponentImport { name: "i", ty: Instance(0) }
+ 0x2e | 06 13       | component alias section
+ 0x30 | 03          | 3 count
+ 0x31 | 01 00 00 02 | alias [func 0] InstanceExport { kind: Func, instance_index: 0, name: "f1" }
       | 66 31      
- 0x35 | 01 00 00 02 | alias [func 1] InstanceExport { kind: Func, instance_index: 0, name: "f2" }
+ 0x37 | 01 00 00 02 | alias [func 1] InstanceExport { kind: Func, instance_index: 0, name: "f2" }
       | 66 32      
- 0x3b | 01 00 00 02 | alias [func 2] InstanceExport { kind: Func, instance_index: 0, name: "f1" }
+ 0x3d | 01 00 00 02 | alias [func 2] InstanceExport { kind: Func, instance_index: 0, name: "f1" }
       | 66 31      
- 0x41 | 08 05       | canonical function section
- 0x43 | 01          | 1 count
- 0x44 | 01 00 02 00 | [core func 0] Lower { func_index: 2, options: [] }
- 0x48 | 01 2b       | [core module 0] inline size
-   0x4a | 00 61 73 6d | version 1 (Module)
+ 0x43 | 08 05       | canonical function section
+ 0x45 | 01          | 1 count
+ 0x46 | 01 00 02 00 | [core func 0] Lower { func_index: 2, options: [] }
+ 0x4a | 01 2b       | [core module 0] inline size
+   0x4c | 00 61 73 6d | version 1 (Module)
         | 01 00 00 00
-   0x52 | 01 04       | type section
-   0x54 | 01          | 1 count
-   0x55 | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
-   0x58 | 03 02       | func section
-   0x5a | 01          | 1 count
-   0x5b | 00          | [func 0] type 0
-   0x5c | 07 06       | export section
-   0x5e | 01          | 1 count
-   0x5f | 02 66 33 00 | export Export { name: "f3", kind: Func, index: 0 }
+   0x54 | 01 04       | type section
+   0x56 | 01          | 1 count
+   0x57 | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
+   0x5a | 03 02       | func section
+   0x5c | 01          | 1 count
+   0x5d | 00          | [func 0] type 0
+   0x5e | 07 06       | export section
+   0x60 | 01          | 1 count
+   0x61 | 02 66 33 00 | export Export { name: "f3", kind: Func, index: 0 }
         | 00         
-   0x64 | 0a 04       | code section
-   0x66 | 01          | 1 count
+   0x66 | 0a 04       | code section
+   0x68 | 01          | 1 count
 ============== func 0 ====================
-   0x67 | 02          | size of function
-   0x68 | 00          | 0 local blocks
-   0x69 | 0b          | end
-   0x6a | 00 09       | custom section
-   0x6c | 04 6e 61 6d | name: "name"
+   0x69 | 02          | size of function
+   0x6a | 00          | 0 local blocks
+   0x6b | 0b          | end
+   0x6c | 00 09       | custom section
+   0x6e | 04 6e 61 6d | name: "name"
         | 65         
-   0x71 | 00 02       | module name
-   0x73 | 01 6d       | "m"
- 0x75 | 02 04       | core instance section
- 0x77 | 01          | 1 count
- 0x78 | 00 00 00    | [core instance 0] Instantiate { module_index: 0, args: [] }
- 0x7b | 06 0f       | component alias section
- 0x7d | 02          | 2 count
- 0x7e | 00 00 01 00 | alias [core func 1] CoreInstanceExport { kind: Func, instance_index: 0, name: "f3" }
+   0x73 | 00 02       | module name
+   0x75 | 01 6d       | "m"
+ 0x77 | 02 04       | core instance section
+ 0x79 | 01          | 1 count
+ 0x7a | 00 00 00    | [core instance 0] Instantiate { module_index: 0, args: [] }
+ 0x7d | 06 0f       | component alias section
+ 0x7f | 02          | 2 count
+ 0x80 | 00 00 01 00 | alias [core func 1] CoreInstanceExport { kind: Func, instance_index: 0, name: "f3" }
       | 02 66 33   
- 0x85 | 00 00 01 00 | alias [core func 2] CoreInstanceExport { kind: Func, instance_index: 0, name: "f3" }
+ 0x87 | 00 00 01 00 | alias [core func 2] CoreInstanceExport { kind: Func, instance_index: 0, name: "f3" }
       | 02 66 33   

--- a/tests/dump/alias2.wat.dump
+++ b/tests/dump/alias2.wat.dump
@@ -1,180 +1,179 @@
    0x0 | 00 61 73 6d | version 65546 (Component)
        | 0a 00 01 00
-   0x8 | 07 2c       | component type section
+   0x8 | 07 2b       | component type section
    0xa | 01          | 1 count
-   0xb | 42 09 00 50 | [type 0] Instance([CoreType(Module([])), Export { name: "1", ty: Module(0) }, Type(Func(ComponentFuncType { params: Named([]), results: Named([]) })), Export { name: "2", ty: Func(0) }, Export { name: "3", ty: Value(Primitive(String)) }, Type(Instance([])), Export { name: "4", ty: Instance(1) }, Type(Component([])), Export { name: "5", ty: Component(2) }])
+   0xb | 42 09 00 50 | [type 0] Instance([CoreType(Module([])), Export { name: "1", ty: Module(0) }, Type(Func(ComponentFuncType { params: [], results: Named([]) })), Export { name: "2", ty: Func(0) }, Export { name: "3", ty: Value(Primitive(String)) }, Type(Instance([])), Export { name: "4", ty: Instance(1) }, Type(Component([])), Export { name: "5", ty: Component(2) }])
        | 00 04 01 31
        | 00 11 00 01
-       | 40 01 00 01
-       | 00 04 01 32
-       | 01 00 04 01
-       | 33 02 73 01
-       | 42 00 04 01
-       | 34 05 01 01
-       | 41 00 04 01
-       | 35 04 02   
-  0x36 | 0a 04       | component import section
-  0x38 | 01          | 1 count
-  0x39 | 00 05 00    | [instance 0] ComponentImport { name: "", ty: Instance(0) }
-  0x3c | 04 40       | [component 0] inline size
-    0x3e | 00 61 73 6d | version 65546 (Component)
+       | 40 00 01 00
+       | 04 01 32 01
+       | 00 04 01 33
+       | 02 73 01 42
+       | 00 04 01 34
+       | 05 01 01 41
+       | 00 04 01 35
+       | 04 02      
+  0x35 | 0a 04       | component import section
+  0x37 | 01          | 1 count
+  0x38 | 00 05 00    | [instance 0] ComponentImport { name: "", ty: Instance(0) }
+  0x3b | 04 3f       | [component 0] inline size
+    0x3d | 00 61 73 6d | version 65546 (Component)
          | 0a 00 01 00
-    0x46 | 03 03       | core type section
-    0x48 | 01          | 1 count
-    0x49 | 50 00       | [core type 0] Module([])
-    0x4b | 0a 06       | component import section
-    0x4d | 01          | 1 count
-    0x4e | 01 31 00 11 | [module 0] ComponentImport { name: "1", ty: Module(0) }
+    0x45 | 03 03       | core type section
+    0x47 | 01          | 1 count
+    0x48 | 50 00       | [core type 0] Module([])
+    0x4a | 0a 06       | component import section
+    0x4c | 01          | 1 count
+    0x4d | 01 31 00 11 | [module 0] ComponentImport { name: "1", ty: Module(0) }
          | 00         
-    0x53 | 07 06       | component type section
-    0x55 | 01          | 1 count
-    0x56 | 40 01 00 01 | [type 0] Func(ComponentFuncType { params: Named([]), results: Named([]) })
-         | 00         
-    0x5b | 0a 09       | component import section
-    0x5d | 02          | 2 count
-    0x5e | 01 32 01 00 | [func 0] ComponentImport { name: "2", ty: Func(0) }
-    0x62 | 01 33 02 73 | [value 0] ComponentImport { name: "3", ty: Value(Primitive(String)) }
-    0x66 | 07 03       | component type section
-    0x68 | 01          | 1 count
-    0x69 | 42 00       | [type 1] Instance([])
-    0x6b | 0a 05       | component import section
-    0x6d | 01          | 1 count
-    0x6e | 01 34 05 01 | [instance 0] ComponentImport { name: "4", ty: Instance(1) }
-    0x72 | 07 03       | component type section
-    0x74 | 01          | 1 count
-    0x75 | 41 00       | [type 2] Component([])
-    0x77 | 0a 05       | component import section
-    0x79 | 01          | 1 count
-    0x7a | 01 35 04 02 | [component 0] ComponentImport { name: "5", ty: Component(2) }
-  0x7e | 06 1b       | component alias section
-  0x80 | 05          | 5 count
-  0x81 | 00 11 00 00 | alias [module 0] InstanceExport { kind: Module, instance_index: 0, name: "1" }
+    0x52 | 07 05       | component type section
+    0x54 | 01          | 1 count
+    0x55 | 40 00 01 00 | [type 0] Func(ComponentFuncType { params: [], results: Named([]) })
+    0x59 | 0a 09       | component import section
+    0x5b | 02          | 2 count
+    0x5c | 01 32 01 00 | [func 0] ComponentImport { name: "2", ty: Func(0) }
+    0x60 | 01 33 02 73 | [value 0] ComponentImport { name: "3", ty: Value(Primitive(String)) }
+    0x64 | 07 03       | component type section
+    0x66 | 01          | 1 count
+    0x67 | 42 00       | [type 1] Instance([])
+    0x69 | 0a 05       | component import section
+    0x6b | 01          | 1 count
+    0x6c | 01 34 05 01 | [instance 0] ComponentImport { name: "4", ty: Instance(1) }
+    0x70 | 07 03       | component type section
+    0x72 | 01          | 1 count
+    0x73 | 41 00       | [type 2] Component([])
+    0x75 | 0a 05       | component import section
+    0x77 | 01          | 1 count
+    0x78 | 01 35 04 02 | [component 0] ComponentImport { name: "5", ty: Component(2) }
+  0x7c | 06 1b       | component alias section
+  0x7e | 05          | 5 count
+  0x7f | 00 11 00 00 | alias [module 0] InstanceExport { kind: Module, instance_index: 0, name: "1" }
        | 01 31      
-  0x87 | 01 00 00 01 | alias [func 0] InstanceExport { kind: Func, instance_index: 0, name: "2" }
+  0x85 | 01 00 00 01 | alias [func 0] InstanceExport { kind: Func, instance_index: 0, name: "2" }
        | 32         
-  0x8c | 02 00 00 01 | alias [value 0] InstanceExport { kind: Value, instance_index: 0, name: "4" }
+  0x8a | 02 00 00 01 | alias [value 0] InstanceExport { kind: Value, instance_index: 0, name: "4" }
        | 34         
-  0x91 | 05 00 00 01 | alias [instance 1] InstanceExport { kind: Instance, instance_index: 0, name: "3" }
+  0x8f | 05 00 00 01 | alias [instance 1] InstanceExport { kind: Instance, instance_index: 0, name: "3" }
        | 33         
-  0x96 | 04 00 00 01 | alias [component 1] InstanceExport { kind: Component, instance_index: 0, name: "5" }
+  0x94 | 04 00 00 01 | alias [component 1] InstanceExport { kind: Component, instance_index: 0, name: "5" }
        | 35         
-  0x9b | 05 19       | component instance section
-  0x9d | 01          | 1 count
-  0x9e | 00 00 05 01 | [instance 2] Instantiate { component_index: 0, args: [ComponentInstantiationArg { name: "1", kind: Module, index: 0 }, ComponentInstantiationArg { name: "2", kind: Func, index: 0 }, ComponentInstantiationArg { name: "3", kind: Value, index: 0 }, ComponentInstantiationArg { name: "4", kind: Instance, index: 1 }, ComponentInstantiationArg { name: "5", kind: Component, index: 1 }] }
+  0x99 | 05 19       | component instance section
+  0x9b | 01          | 1 count
+  0x9c | 00 00 05 01 | [instance 2] Instantiate { component_index: 0, args: [ComponentInstantiationArg { name: "1", kind: Module, index: 0 }, ComponentInstantiationArg { name: "2", kind: Func, index: 0 }, ComponentInstantiationArg { name: "3", kind: Value, index: 0 }, ComponentInstantiationArg { name: "4", kind: Instance, index: 1 }, ComponentInstantiationArg { name: "5", kind: Component, index: 1 }] }
        | 31 00 11 00
        | 01 32 01 00
        | 01 33 02 00
        | 01 34 05 01
        | 01 35 04 01
-  0xb6 | 04 15       | [component 2] inline size
-    0xb8 | 00 61 73 6d | version 65546 (Component)
+  0xb4 | 04 15       | [component 2] inline size
+    0xb6 | 00 61 73 6d | version 65546 (Component)
          | 0a 00 01 00
-    0xc0 | 06 05       | component alias section
-    0xc2 | 01          | 1 count
-    0xc3 | 03 02 01 00 | alias [type 0] Outer { kind: Type, count: 1, index: 0 }
-    0xc7 | 0a 04       | component import section
-    0xc9 | 01          | 1 count
-    0xca | 00 05 00    | [instance 0] ComponentImport { name: "", ty: Instance(0) }
-  0xcd | 06 1b       | component alias section
-  0xcf | 05          | 5 count
-  0xd0 | 00 11 00 00 | alias [module 1] InstanceExport { kind: Module, instance_index: 0, name: "1" }
+    0xbe | 06 05       | component alias section
+    0xc0 | 01          | 1 count
+    0xc1 | 03 02 01 00 | alias [type 0] Outer { kind: Type, count: 1, index: 0 }
+    0xc5 | 0a 04       | component import section
+    0xc7 | 01          | 1 count
+    0xc8 | 00 05 00    | [instance 0] ComponentImport { name: "", ty: Instance(0) }
+  0xcb | 06 1b       | component alias section
+  0xcd | 05          | 5 count
+  0xce | 00 11 00 00 | alias [module 1] InstanceExport { kind: Module, instance_index: 0, name: "1" }
        | 01 31      
-  0xd6 | 01 00 00 01 | alias [func 1] InstanceExport { kind: Func, instance_index: 0, name: "2" }
+  0xd4 | 01 00 00 01 | alias [func 1] InstanceExport { kind: Func, instance_index: 0, name: "2" }
        | 32         
-  0xdb | 02 00 00 01 | alias [value 1] InstanceExport { kind: Value, instance_index: 0, name: "3" }
+  0xd9 | 02 00 00 01 | alias [value 1] InstanceExport { kind: Value, instance_index: 0, name: "3" }
        | 33         
-  0xe0 | 05 00 00 01 | alias [instance 3] InstanceExport { kind: Instance, instance_index: 0, name: "4" }
+  0xde | 05 00 00 01 | alias [instance 3] InstanceExport { kind: Instance, instance_index: 0, name: "4" }
        | 34         
-  0xe5 | 04 00 00 01 | alias [component 3] InstanceExport { kind: Component, instance_index: 0, name: "5" }
+  0xe3 | 04 00 00 01 | alias [component 3] InstanceExport { kind: Component, instance_index: 0, name: "5" }
        | 35         
-  0xea | 05 1e       | component instance section
-  0xec | 02          | 2 count
-  0xed | 01 05 01 31 | [instance 4] FromExports([ComponentExport { name: "1", kind: Module, index: 1 }, ComponentExport { name: "2", kind: Func, index: 1 }, ComponentExport { name: "3", kind: Value, index: 1 }, ComponentExport { name: "4", kind: Instance, index: 3 }, ComponentExport { name: "5", kind: Component, index: 3 }])
+  0xe8 | 05 1e       | component instance section
+  0xea | 02          | 2 count
+  0xeb | 01 05 01 31 | [instance 4] FromExports([ComponentExport { name: "1", kind: Module, index: 1 }, ComponentExport { name: "2", kind: Func, index: 1 }, ComponentExport { name: "3", kind: Value, index: 1 }, ComponentExport { name: "4", kind: Instance, index: 3 }, ComponentExport { name: "5", kind: Component, index: 3 }])
        | 00 11 01 01
        | 32 01 01 01
        | 33 02 01 01
        | 34 05 03 01
        | 35 04 03   
- 0x104 | 00 02 01 00 | [instance 5] Instantiate { component_index: 2, args: [ComponentInstantiationArg { name: "", kind: Instance, index: 4 }] }
+ 0x102 | 00 02 01 00 | [instance 5] Instantiate { component_index: 2, args: [ComponentInstantiationArg { name: "", kind: Instance, index: 4 }] }
        | 05 04      
- 0x10a | 01 48       | [core module 2] inline size
-   0x10c | 00 61 73 6d | version 1 (Module)
+ 0x108 | 01 48       | [core module 2] inline size
+   0x10a | 00 61 73 6d | version 1 (Module)
          | 01 00 00 00
-   0x114 | 01 04       | type section
-   0x116 | 01          | 1 count
-   0x117 | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
-   0x11a | 03 02       | func section
-   0x11c | 01          | 1 count
-   0x11d | 00          | [func 0] type 0
-   0x11e | 04 04       | table section
-   0x120 | 01          | 1 count
-   0x121 | 70 00 01    | [table 0] TableType { element_type: FuncRef, initial: 1, maximum: None }
-   0x124 | 05 03       | memory section
-   0x126 | 01          | 1 count
-   0x127 | 00 01       | [memory 0] MemoryType { memory64: false, shared: false, initial: 1, maximum: None }
-   0x129 | 06 04       | global section
-   0x12b | 01          | 1 count
-   0x12c | 7f 00       | [global 0] GlobalType { content_type: I32, mutable: false }
-   0x12e | 0b          | end
-   0x12f | 07 11       | export section
-   0x131 | 04          | 4 count
-   0x132 | 01 31 00 00 | export Export { name: "1", kind: Func, index: 0 }
-   0x136 | 01 32 02 00 | export Export { name: "2", kind: Memory, index: 0 }
-   0x13a | 01 33 03 00 | export Export { name: "3", kind: Global, index: 0 }
-   0x13e | 01 34 01 00 | export Export { name: "4", kind: Table, index: 0 }
-   0x142 | 0a 04       | code section
-   0x144 | 01          | 1 count
+   0x112 | 01 04       | type section
+   0x114 | 01          | 1 count
+   0x115 | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
+   0x118 | 03 02       | func section
+   0x11a | 01          | 1 count
+   0x11b | 00          | [func 0] type 0
+   0x11c | 04 04       | table section
+   0x11e | 01          | 1 count
+   0x11f | 70 00 01    | [table 0] TableType { element_type: FuncRef, initial: 1, maximum: None }
+   0x122 | 05 03       | memory section
+   0x124 | 01          | 1 count
+   0x125 | 00 01       | [memory 0] MemoryType { memory64: false, shared: false, initial: 1, maximum: None }
+   0x127 | 06 04       | global section
+   0x129 | 01          | 1 count
+   0x12a | 7f 00       | [global 0] GlobalType { content_type: I32, mutable: false }
+   0x12c | 0b          | end
+   0x12d | 07 11       | export section
+   0x12f | 04          | 4 count
+   0x130 | 01 31 00 00 | export Export { name: "1", kind: Func, index: 0 }
+   0x134 | 01 32 02 00 | export Export { name: "2", kind: Memory, index: 0 }
+   0x138 | 01 33 03 00 | export Export { name: "3", kind: Global, index: 0 }
+   0x13c | 01 34 01 00 | export Export { name: "4", kind: Table, index: 0 }
+   0x140 | 0a 04       | code section
+   0x142 | 01          | 1 count
 ============== func 0 ====================
-   0x145 | 02          | size of function
-   0x146 | 00          | 0 local blocks
-   0x147 | 0b          | end
-   0x148 | 00 0a       | custom section
-   0x14a | 04 6e 61 6d | name: "name"
+   0x143 | 02          | size of function
+   0x144 | 00          | 0 local blocks
+   0x145 | 0b          | end
+   0x146 | 00 0a       | custom section
+   0x148 | 04 6e 61 6d | name: "name"
          | 65         
-   0x14f | 00 03       | module name
-   0x151 | 02 6d 31    | "m1"
- 0x154 | 01 35       | [core module 3] inline size
-   0x156 | 00 61 73 6d | version 1 (Module)
+   0x14d | 00 03       | module name
+   0x14f | 02 6d 31    | "m1"
+ 0x152 | 01 35       | [core module 3] inline size
+   0x154 | 00 61 73 6d | version 1 (Module)
          | 01 00 00 00
-   0x15e | 01 04       | type section
-   0x160 | 01          | 1 count
-   0x161 | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
-   0x164 | 02 19       | import section
-   0x166 | 04          | 4 count
-   0x167 | 00 01 31 00 | import [func 0] Import { module: "", name: "1", ty: Func(0) }
+   0x15c | 01 04       | type section
+   0x15e | 01          | 1 count
+   0x15f | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
+   0x162 | 02 19       | import section
+   0x164 | 04          | 4 count
+   0x165 | 00 01 31 00 | import [func 0] Import { module: "", name: "1", ty: Func(0) }
          | 00         
-   0x16c | 00 01 32 02 | import [memory 0] Import { module: "", name: "2", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None }) }
+   0x16a | 00 01 32 02 | import [memory 0] Import { module: "", name: "2", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None }) }
          | 00 01      
-   0x172 | 00 01 33 03 | import [global 0] Import { module: "", name: "3", ty: Global(GlobalType { content_type: I32, mutable: false }) }
+   0x170 | 00 01 33 03 | import [global 0] Import { module: "", name: "3", ty: Global(GlobalType { content_type: I32, mutable: false }) }
          | 7f 00      
-   0x178 | 00 01 34 01 | import [table 0] Import { module: "", name: "4", ty: Table(TableType { element_type: FuncRef, initial: 1, maximum: None }) }
+   0x176 | 00 01 34 01 | import [table 0] Import { module: "", name: "4", ty: Table(TableType { element_type: FuncRef, initial: 1, maximum: None }) }
          | 70 00 01   
-   0x17f | 00 0a       | custom section
-   0x181 | 04 6e 61 6d | name: "name"
+   0x17d | 00 0a       | custom section
+   0x17f | 04 6e 61 6d | name: "name"
          | 65         
-   0x186 | 00 03       | module name
-   0x188 | 02 6d 32    | "m2"
- 0x18b | 02 0a       | core instance section
- 0x18d | 02          | 2 count
- 0x18e | 00 02 00    | [core instance 0] Instantiate { module_index: 2, args: [] }
- 0x191 | 00 03 01 00 | [core instance 1] Instantiate { module_index: 3, args: [InstantiationArg { name: "", kind: Instance, index: 0 }] }
+   0x184 | 00 03       | module name
+   0x186 | 02 6d 32    | "m2"
+ 0x189 | 02 0a       | core instance section
+ 0x18b | 02          | 2 count
+ 0x18c | 00 02 00    | [core instance 0] Instantiate { module_index: 2, args: [] }
+ 0x18f | 00 03 01 00 | [core instance 1] Instantiate { module_index: 3, args: [InstantiationArg { name: "", kind: Instance, index: 0 }] }
        | 12 00      
- 0x197 | 06 19       | component alias section
- 0x199 | 04          | 4 count
- 0x19a | 00 00 01 00 | alias [core func 0] CoreInstanceExport { kind: Func, instance_index: 0, name: "1" }
+ 0x195 | 06 19       | component alias section
+ 0x197 | 04          | 4 count
+ 0x198 | 00 00 01 00 | alias [core func 0] CoreInstanceExport { kind: Func, instance_index: 0, name: "1" }
        | 01 31      
- 0x1a0 | 00 02 01 00 | alias [core memory 0] CoreInstanceExport { kind: Memory, instance_index: 0, name: "2" }
+ 0x19e | 00 02 01 00 | alias [core memory 0] CoreInstanceExport { kind: Memory, instance_index: 0, name: "2" }
        | 01 32      
- 0x1a6 | 00 03 01 00 | alias [core global 0] CoreInstanceExport { kind: Global, instance_index: 0, name: "3" }
+ 0x1a4 | 00 03 01 00 | alias [core global 0] CoreInstanceExport { kind: Global, instance_index: 0, name: "3" }
        | 01 33      
- 0x1ac | 00 01 01 00 | alias [core table 0] CoreInstanceExport { kind: Table, instance_index: 0, name: "4" }
+ 0x1aa | 00 01 01 00 | alias [core table 0] CoreInstanceExport { kind: Table, instance_index: 0, name: "4" }
        | 01 34      
- 0x1b2 | 02 19       | core instance section
- 0x1b4 | 02          | 2 count
- 0x1b5 | 01 04 01 31 | [core instance 2] FromExports([Export { name: "1", kind: Func, index: 0 }, Export { name: "2", kind: Memory, index: 0 }, Export { name: "3", kind: Global, index: 0 }, Export { name: "4", kind: Table, index: 0 }])
+ 0x1b0 | 02 19       | core instance section
+ 0x1b2 | 02          | 2 count
+ 0x1b3 | 01 04 01 31 | [core instance 2] FromExports([Export { name: "1", kind: Func, index: 0 }, Export { name: "2", kind: Memory, index: 0 }, Export { name: "3", kind: Global, index: 0 }, Export { name: "4", kind: Table, index: 0 }])
        | 00 00 01 32
        | 02 00 01 33
        | 03 00 01 34
        | 01 00      
- 0x1c7 | 00 03 01 00 | [core instance 3] Instantiate { module_index: 3, args: [InstantiationArg { name: "", kind: Instance, index: 2 }] }
+ 0x1c5 | 00 03 01 00 | [core instance 3] Instantiate { module_index: 3, args: [InstantiationArg { name: "", kind: Instance, index: 2 }] }
        | 12 02      

--- a/tests/dump/bundled.wat
+++ b/tests/dump/bundled.wat
@@ -1,7 +1,7 @@
 (component
   (type $WasiFile (instance
-      (export "read" (func $read (param u32) (result (list u8))))
-      (export "write" (func $write (param (list u8)) (result u32)))
+      (export "read" (func $read (param "len" u32) (result (list u8))))
+      (export "write" (func $write (param "buf" (list u8)) (result u32)))
     ))
   (import "wasi_file" (instance $real-wasi (type $WasiFile)))
 

--- a/tests/dump/bundled.wat.dump
+++ b/tests/dump/bundled.wat.dump
@@ -1,191 +1,192 @@
    0x0 | 00 61 73 6d | version 65546 (Component)
        | 0a 00 01 00
-   0x8 | 07 26       | component type section
+   0x8 | 07 2e       | component type section
    0xa | 01          | 1 count
-   0xb | 42 06 01 70 | [type 0] Instance([Type(Defined(List(Primitive(U8)))), Type(Func(ComponentFuncType { params: Unnamed(Primitive(U32)), results: Unnamed(Type(0)) })), Export { name: "read", ty: Func(1) }, Type(Defined(List(Primitive(U8)))), Type(Func(ComponentFuncType { params: Unnamed(Type(2)), results: Unnamed(Primitive(U32)) })), Export { name: "write", ty: Func(3) }])
-       | 7d 01 40 00
+   0xb | 42 06 01 70 | [type 0] Instance([Type(Defined(List(Primitive(U8)))), Type(Func(ComponentFuncType { params: [("len", Primitive(U32))], results: Unnamed(Type(0)) })), Export { name: "read", ty: Func(1) }, Type(Defined(List(Primitive(U8)))), Type(Func(ComponentFuncType { params: [("buf", Type(2))], results: Unnamed(Primitive(U32)) })), Export { name: "write", ty: Func(3) }])
+       | 7d 01 40 01
+       | 03 6c 65 6e
        | 79 00 00 04
        | 04 72 65 61
        | 64 01 01 01
        | 70 7d 01 40
-       | 00 02 00 79
+       | 01 03 62 75
+       | 66 02 00 79
        | 04 05 77 72
        | 69 74 65 01
        | 03         
-  0x30 | 0a 0d       | component import section
-  0x32 | 01          | 1 count
-  0x33 | 09 77 61 73 | [instance 0] ComponentImport { name: "wasi_file", ty: Instance(0) }
+  0x38 | 0a 0d       | component import section
+  0x3a | 01          | 1 count
+  0x3b | 09 77 61 73 | [instance 0] ComponentImport { name: "wasi_file", ty: Instance(0) }
        | 69 5f 66 69
        | 6c 65 05 00
-  0x3f | 01 44       | [core module 0] inline size
-    0x41 | 00 61 73 6d | version 1 (Module)
+  0x47 | 01 44       | [core module 0] inline size
+    0x49 | 00 61 73 6d | version 1 (Module)
          | 01 00 00 00
-    0x49 | 01 09       | type section
-    0x4b | 01          | 1 count
-    0x4c | 60 04 7f 7f | [type 0] Func(FuncType { params: [I32, I32, I32, I32], returns: [I32] })
+    0x51 | 01 09       | type section
+    0x53 | 01          | 1 count
+    0x54 | 60 04 7f 7f | [type 0] Func(FuncType { params: [I32, I32, I32, I32], returns: [I32] })
          | 7f 7f 01 7f
-    0x54 | 03 02       | func section
-    0x56 | 01          | 1 count
-    0x57 | 00          | [func 0] type 0
-    0x58 | 05 03       | memory section
-    0x5a | 01          | 1 count
-    0x5b | 00 00       | [memory 0] MemoryType { memory64: false, shared: false, initial: 0, maximum: None }
-    0x5d | 07 11       | export section
-    0x5f | 02          | 2 count
-    0x60 | 03 6d 65 6d | export Export { name: "mem", kind: Memory, index: 0 }
+    0x5c | 03 02       | func section
+    0x5e | 01          | 1 count
+    0x5f | 00          | [func 0] type 0
+    0x60 | 05 03       | memory section
+    0x62 | 01          | 1 count
+    0x63 | 00 00       | [memory 0] MemoryType { memory64: false, shared: false, initial: 0, maximum: None }
+    0x65 | 07 11       | export section
+    0x67 | 02          | 2 count
+    0x68 | 03 6d 65 6d | export Export { name: "mem", kind: Memory, index: 0 }
          | 02 00      
-    0x66 | 07 72 65 61 | export Export { name: "realloc", kind: Func, index: 0 }
+    0x6e | 07 72 65 61 | export Export { name: "realloc", kind: Func, index: 0 }
          | 6c 6c 6f 63
          | 00 00      
-    0x70 | 0a 05       | code section
-    0x72 | 01          | 1 count
+    0x78 | 0a 05       | code section
+    0x7a | 01          | 1 count
 ============== func 0 ====================
-    0x73 | 03          | size of function
-    0x74 | 00          | 0 local blocks
-    0x75 | 00          | unreachable
-    0x76 | 0b          | end
-    0x77 | 00 0c       | custom section
-    0x79 | 04 6e 61 6d | name: "name"
+    0x7b | 03          | size of function
+    0x7c | 00          | 0 local blocks
+    0x7d | 00          | unreachable
+    0x7e | 0b          | end
+    0x7f | 00 0c       | custom section
+    0x81 | 04 6e 61 6d | name: "name"
          | 65         
-    0x7e | 00 05       | module name
-    0x80 | 04 6c 69 62 | "libc"
+    0x86 | 00 05       | module name
+    0x88 | 04 6c 69 62 | "libc"
          | 63         
-  0x85 | 02 04       | core instance section
-  0x87 | 01          | 1 count
-  0x88 | 00 00 00    | [core instance 0] Instantiate { module_index: 0, args: [] }
-  0x8b | 01 5f       | [core module 1] inline size
-    0x8d | 00 61 73 6d | version 1 (Module)
+  0x8d | 02 04       | core instance section
+  0x8f | 01          | 1 count
+  0x90 | 00 00 00    | [core instance 0] Instantiate { module_index: 0, args: [] }
+  0x93 | 01 5f       | [core module 1] inline size
+    0x95 | 00 61 73 6d | version 1 (Module)
          | 01 00 00 00
-    0x95 | 01 09       | type section
-    0x97 | 02          | 2 count
-    0x98 | 60 02 7f 7f | [type 0] Func(FuncType { params: [I32, I32], returns: [] })
+    0x9d | 01 09       | type section
+    0x9f | 02          | 2 count
+    0xa0 | 60 02 7f 7f | [type 0] Func(FuncType { params: [I32, I32], returns: [] })
          | 00         
-    0x9d | 60 00 00    | [type 1] Func(FuncType { params: [], returns: [] })
-    0xa0 | 02 12       | import section
-    0xa2 | 01          | 1 count
-    0xa3 | 09 77 61 73 | import [func 0] Import { module: "wasi_file", name: "read", ty: Func(0) }
+    0xa5 | 60 00 00    | [type 1] Func(FuncType { params: [], returns: [] })
+    0xa8 | 02 12       | import section
+    0xaa | 01          | 1 count
+    0xab | 09 77 61 73 | import [func 0] Import { module: "wasi_file", name: "read", ty: Func(0) }
          | 69 5f 66 69
          | 6c 65 04 72
          | 65 61 64 00
          | 00         
-    0xb4 | 03 02       | func section
-    0xb6 | 01          | 1 count
-    0xb7 | 01          | [func 1] type 1
-    0xb8 | 07 08       | export section
-    0xba | 01          | 1 count
-    0xbb | 04 70 6c 61 | export Export { name: "play", kind: Func, index: 1 }
+    0xbc | 03 02       | func section
+    0xbe | 01          | 1 count
+    0xbf | 01          | [func 1] type 1
+    0xc0 | 07 08       | export section
+    0xc2 | 01          | 1 count
+    0xc3 | 04 70 6c 61 | export Export { name: "play", kind: Func, index: 1 }
          | 79 00 01   
-    0xc2 | 0a 05       | code section
-    0xc4 | 01          | 1 count
+    0xca | 0a 05       | code section
+    0xcc | 01          | 1 count
 ============== func 1 ====================
-    0xc5 | 03          | size of function
-    0xc6 | 00          | 0 local blocks
-    0xc7 | 00          | unreachable
-    0xc8 | 0b          | end
-    0xc9 | 00 21       | custom section
-    0xcb | 04 6e 61 6d | name: "name"
+    0xcd | 03          | size of function
+    0xce | 00          | 0 local blocks
+    0xcf | 00          | unreachable
+    0xd0 | 0b          | end
+    0xd1 | 00 21       | custom section
+    0xd3 | 04 6e 61 6d | name: "name"
          | 65         
-    0xd0 | 00 06       | module name
-    0xd2 | 05 43 48 49 | "CHILD"
+    0xd8 | 00 06       | module name
+    0xda | 05 43 48 49 | "CHILD"
          | 4c 44      
-    0xd8 | 01 12       | function names
-    0xda | 02          | 2 count
-    0xdb | 00 09 77 61 | Naming { index: 0, name: "wasi-file" }
+    0xe0 | 01 12       | function names
+    0xe2 | 02          | 2 count
+    0xe3 | 00 09 77 61 | Naming { index: 0, name: "wasi-file" }
          | 73 69 2d 66
          | 69 6c 65   
-    0xe6 | 01 04 70 6c | Naming { index: 1, name: "play" }
+    0xee | 01 04 70 6c | Naming { index: 1, name: "play" }
          | 61 79      
-  0xec | 01 60       | [core module 2] inline size
-    0xee | 00 61 73 6d | version 1 (Module)
+  0xf4 | 01 60       | [core module 2] inline size
+    0xf6 | 00 61 73 6d | version 1 (Module)
          | 01 00 00 00
-    0xf6 | 01 0c       | type section
-    0xf8 | 02          | 2 count
-    0xf9 | 60 02 7f 7f | [type 0] Func(FuncType { params: [I32, I32], returns: [] })
+    0xfe | 01 0c       | type section
+   0x100 | 02          | 2 count
+   0x101 | 60 02 7f 7f | [type 0] Func(FuncType { params: [I32, I32], returns: [] })
          | 00         
-    0xfe | 60 03 7f 7f | [type 1] Func(FuncType { params: [I32, I32, I32], returns: [] })
+   0x106 | 60 03 7f 7f | [type 1] Func(FuncType { params: [I32, I32, I32], returns: [] })
          | 7f 00      
-   0x104 | 02 12       | import section
-   0x106 | 01          | 1 count
-   0x107 | 09 77 61 73 | import [func 0] Import { module: "wasi_file", name: "read", ty: Func(0) }
+   0x10c | 02 12       | import section
+   0x10e | 01          | 1 count
+   0x10f | 09 77 61 73 | import [func 0] Import { module: "wasi_file", name: "read", ty: Func(0) }
          | 69 5f 66 69
          | 6c 65 04 72
          | 65 61 64 00
          | 00         
-   0x118 | 03 03       | func section
-   0x11a | 02          | 2 count
-   0x11b | 00          | [func 1] type 0
-   0x11c | 01          | [func 2] type 1
-   0x11d | 07 10       | export section
-   0x11f | 02          | 2 count
-   0x120 | 04 72 65 61 | export Export { name: "read", kind: Func, index: 1 }
+   0x120 | 03 03       | func section
+   0x122 | 02          | 2 count
+   0x123 | 00          | [func 1] type 0
+   0x124 | 01          | [func 2] type 1
+   0x125 | 07 10       | export section
+   0x127 | 02          | 2 count
+   0x128 | 04 72 65 61 | export Export { name: "read", kind: Func, index: 1 }
          | 64 00 01   
-   0x127 | 05 77 72 69 | export Export { name: "write", kind: Func, index: 2 }
+   0x12f | 05 77 72 69 | export Export { name: "write", kind: Func, index: 2 }
          | 74 65 00 02
-   0x12f | 0a 09       | code section
-   0x131 | 02          | 2 count
+   0x137 | 0a 09       | code section
+   0x139 | 02          | 2 count
 ============== func 1 ====================
-   0x132 | 03          | size of function
-   0x133 | 00          | 0 local blocks
-   0x134 | 00          | unreachable
-   0x135 | 0b          | end
+   0x13a | 03          | size of function
+   0x13b | 00          | 0 local blocks
+   0x13c | 00          | unreachable
+   0x13d | 0b          | end
 ============== func 2 ====================
-   0x136 | 03          | size of function
-   0x137 | 00          | 0 local blocks
-   0x138 | 00          | unreachable
-   0x139 | 0b          | end
-   0x13a | 00 12       | custom section
-   0x13c | 04 6e 61 6d | name: "name"
+   0x13e | 03          | size of function
+   0x13f | 00          | 0 local blocks
+   0x140 | 00          | unreachable
+   0x141 | 0b          | end
+   0x142 | 00 12       | custom section
+   0x144 | 04 6e 61 6d | name: "name"
          | 65         
-   0x141 | 00 0b       | module name
-   0x143 | 0a 56 49 52 | "VIRTUALIZE"
+   0x149 | 00 0b       | module name
+   0x14b | 0a 56 49 52 | "VIRTUALIZE"
          | 54 55 41 4c
          | 49 5a 45   
- 0x14e | 06 1d       | component alias section
- 0x150 | 03          | 3 count
- 0x151 | 01 00 00 04 | alias [func 0] InstanceExport { kind: Func, instance_index: 0, name: "read" }
+ 0x156 | 06 1d       | component alias section
+ 0x158 | 03          | 3 count
+ 0x159 | 01 00 00 04 | alias [func 0] InstanceExport { kind: Func, instance_index: 0, name: "read" }
        | 72 65 61 64
- 0x159 | 00 02 01 00 | alias [core memory 0] CoreInstanceExport { kind: Memory, instance_index: 0, name: "mem" }
+ 0x161 | 00 02 01 00 | alias [core memory 0] CoreInstanceExport { kind: Memory, instance_index: 0, name: "mem" }
        | 03 6d 65 6d
- 0x161 | 00 00 01 00 | alias [core func 0] CoreInstanceExport { kind: Func, instance_index: 0, name: "realloc" }
+ 0x169 | 00 00 01 00 | alias [core func 0] CoreInstanceExport { kind: Func, instance_index: 0, name: "realloc" }
        | 07 72 65 61
        | 6c 6c 6f 63
- 0x16d | 08 09       | canonical function section
- 0x16f | 01          | 1 count
- 0x170 | 01 00 00 02 | [core func 1] Lower { func_index: 0, options: [Memory(0), Realloc(0)] }
+ 0x175 | 08 09       | canonical function section
+ 0x177 | 01          | 1 count
+ 0x178 | 01 00 00 02 | [core func 1] Lower { func_index: 0, options: [Memory(0), Realloc(0)] }
        | 03 00 04 00
- 0x178 | 02 28       | core instance section
- 0x17a | 03          | 3 count
- 0x17b | 01 01 04 72 | [core instance 1] FromExports([Export { name: "read", kind: Func, index: 1 }])
+ 0x180 | 02 28       | core instance section
+ 0x182 | 03          | 3 count
+ 0x183 | 01 01 04 72 | [core instance 1] FromExports([Export { name: "read", kind: Func, index: 1 }])
        | 65 61 64 00
        | 01         
- 0x184 | 00 02 01 09 | [core instance 2] Instantiate { module_index: 2, args: [InstantiationArg { name: "wasi_file", kind: Instance, index: 1 }] }
+ 0x18c | 00 02 01 09 | [core instance 2] Instantiate { module_index: 2, args: [InstantiationArg { name: "wasi_file", kind: Instance, index: 1 }] }
        | 77 61 73 69
        | 5f 66 69 6c
        | 65 12 01   
- 0x193 | 00 01 01 09 | [core instance 3] Instantiate { module_index: 1, args: [InstantiationArg { name: "wasi_file", kind: Instance, index: 2 }] }
+ 0x19b | 00 01 01 09 | [core instance 3] Instantiate { module_index: 1, args: [InstantiationArg { name: "wasi_file", kind: Instance, index: 2 }] }
        | 77 61 73 69
        | 5f 66 69 6c
        | 65 12 02   
- 0x1a2 | 07 06       | component type section
- 0x1a4 | 01          | 1 count
- 0x1a5 | 40 01 00 01 | [type 1] Func(ComponentFuncType { params: Named([]), results: Named([]) })
-       | 00         
- 0x1aa | 06 1e       | component alias section
- 0x1ac | 03          | 3 count
- 0x1ad | 00 00 01 03 | alias [core func 2] CoreInstanceExport { kind: Func, instance_index: 3, name: "play" }
+ 0x1aa | 07 05       | component type section
+ 0x1ac | 01          | 1 count
+ 0x1ad | 40 00 01 00 | [type 1] Func(ComponentFuncType { params: [], results: Named([]) })
+ 0x1b1 | 06 1e       | component alias section
+ 0x1b3 | 03          | 3 count
+ 0x1b4 | 00 00 01 03 | alias [core func 2] CoreInstanceExport { kind: Func, instance_index: 3, name: "play" }
        | 04 70 6c 61
        | 79         
- 0x1b6 | 00 02 01 00 | alias [core memory 1] CoreInstanceExport { kind: Memory, instance_index: 0, name: "mem" }
+ 0x1bd | 00 02 01 00 | alias [core memory 1] CoreInstanceExport { kind: Memory, instance_index: 0, name: "mem" }
        | 03 6d 65 6d
- 0x1be | 00 00 01 00 | alias [core func 3] CoreInstanceExport { kind: Func, instance_index: 0, name: "realloc" }
+ 0x1c5 | 00 00 01 00 | alias [core func 3] CoreInstanceExport { kind: Func, instance_index: 0, name: "realloc" }
        | 07 72 65 61
        | 6c 6c 6f 63
- 0x1ca | 08 0a       | canonical function section
- 0x1cc | 01          | 1 count
- 0x1cd | 00 00 02 02 | [func 1] Lift { core_func_index: 2, type_index: 1, options: [Memory(1), Realloc(3)] }
+ 0x1d1 | 08 0a       | canonical function section
+ 0x1d3 | 01          | 1 count
+ 0x1d4 | 00 00 02 02 | [func 1] Lift { core_func_index: 2, type_index: 1, options: [Memory(1), Realloc(3)] }
        | 03 01 04 03
        | 01         
- 0x1d6 | 0b 08       | component export section
- 0x1d8 | 01          | 1 count
- 0x1d9 | 04 77 6f 72 | export ComponentExport { name: "work", kind: Func, index: 1 }
+ 0x1dd | 0b 08       | component export section
+ 0x1df | 01          | 1 count
+ 0x1e0 | 04 77 6f 72 | export ComponentExport { name: "work", kind: Func, index: 1 }
        | 6b 01 01   

--- a/tests/dump/component-inline-type.wat.dump
+++ b/tests/dump/component-inline-type.wat.dump
@@ -18,10 +18,9 @@
  0x24 | 0a 04       | component import section
  0x26 | 01          | 1 count
  0x27 | 00 05 01    | [instance 0] ComponentImport { name: "", ty: Instance(1) }
- 0x2a | 07 06       | component type section
+ 0x2a | 07 05       | component type section
  0x2c | 01          | 1 count
- 0x2d | 40 01 00 01 | [type 2] Func(ComponentFuncType { params: Named([]), results: Named([]) })
-      | 00         
- 0x32 | 0a 04       | component import section
- 0x34 | 01          | 1 count
- 0x35 | 00 01 02    | [func 0] ComponentImport { name: "", ty: Func(2) }
+ 0x2d | 40 00 01 00 | [type 2] Func(ComponentFuncType { params: [], results: Named([]) })
+ 0x31 | 0a 04       | component import section
+ 0x33 | 01          | 1 count
+ 0x34 | 00 01 02    | [func 0] ComponentImport { name: "", ty: Func(2) }

--- a/tests/dump/component-instance-type.wat.dump
+++ b/tests/dump/component-instance-type.wat.dump
@@ -1,14 +1,13 @@
   0x0 | 00 61 73 6d | version 65546 (Component)
       | 0a 00 01 00
-  0x8 | 07 27       | component type section
+  0x8 | 07 25       | component type section
   0xa | 01          | 1 count
-  0xb | 42 03 01 40 | [type 0] Instance([Type(Func(ComponentFuncType { params: Named([]), results: Named([]) })), Type(Component([Type(Func(ComponentFuncType { params: Named([]), results: Named([]) })), Alias(Outer { kind: Type, count: 1, index: 0 }), Import(ComponentImport { name: "1", ty: Func(0) }), Export { name: "1", ty: Func(1) }])), Export { name: "c5", ty: Component(1) }])
-      | 01 00 01 00
-      | 01 41 04 01
-      | 40 01 00 01
-      | 00 02 03 02
-      | 01 00 03 01
-      | 31 01 00 04
-      | 01 31 01 01
-      | 04 02 63 35
-      | 04 01      
+  0xb | 42 03 01 40 | [type 0] Instance([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Type(Component([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Alias(Outer { kind: Type, count: 1, index: 0 }), Import(ComponentImport { name: "1", ty: Func(0) }), Export { name: "1", ty: Func(1) }])), Export { name: "c5", ty: Component(1) }])
+      | 00 01 00 01
+      | 41 04 01 40
+      | 00 01 00 02
+      | 03 02 01 00
+      | 03 01 31 01
+      | 00 04 01 31
+      | 01 01 04 02
+      | 63 35 04 01

--- a/tests/dump/component-linking.wat.dump
+++ b/tests/dump/component-linking.wat.dump
@@ -1,66 +1,65 @@
   0x0 | 00 61 73 6d | version 65546 (Component)
       | 0a 00 01 00
-  0x8 | 07 2c       | component type section
+  0x8 | 07 2b       | component type section
   0xa | 01          | 1 count
-  0xb | 42 09 00 50 | [type 0] Instance([CoreType(Module([])), Export { name: "1", ty: Module(0) }, Type(Func(ComponentFuncType { params: Named([]), results: Named([]) })), Export { name: "2", ty: Func(0) }, Export { name: "3", ty: Value(Primitive(String)) }, Type(Instance([])), Export { name: "4", ty: Instance(1) }, Type(Component([])), Export { name: "5", ty: Component(2) }])
+  0xb | 42 09 00 50 | [type 0] Instance([CoreType(Module([])), Export { name: "1", ty: Module(0) }, Type(Func(ComponentFuncType { params: [], results: Named([]) })), Export { name: "2", ty: Func(0) }, Export { name: "3", ty: Value(Primitive(String)) }, Type(Instance([])), Export { name: "4", ty: Instance(1) }, Type(Component([])), Export { name: "5", ty: Component(2) }])
       | 00 04 01 31
       | 00 11 00 01
-      | 40 01 00 01
-      | 00 04 01 32
-      | 01 00 04 01
-      | 33 02 73 01
-      | 42 00 04 01
-      | 34 05 01 01
-      | 41 00 04 01
-      | 35 04 02   
- 0x36 | 0a 04       | component import section
- 0x38 | 01          | 1 count
- 0x39 | 00 05 00    | [instance 0] ComponentImport { name: "", ty: Instance(0) }
- 0x3c | 04 40       | [component 0] inline size
-   0x3e | 00 61 73 6d | version 65546 (Component)
+      | 40 00 01 00
+      | 04 01 32 01
+      | 00 04 01 33
+      | 02 73 01 42
+      | 00 04 01 34
+      | 05 01 01 41
+      | 00 04 01 35
+      | 04 02      
+ 0x35 | 0a 04       | component import section
+ 0x37 | 01          | 1 count
+ 0x38 | 00 05 00    | [instance 0] ComponentImport { name: "", ty: Instance(0) }
+ 0x3b | 04 3f       | [component 0] inline size
+   0x3d | 00 61 73 6d | version 65546 (Component)
         | 0a 00 01 00
-   0x46 | 03 03       | core type section
-   0x48 | 01          | 1 count
-   0x49 | 50 00       | [core type 0] Module([])
-   0x4b | 0a 06       | component import section
-   0x4d | 01          | 1 count
-   0x4e | 01 31 00 11 | [module 0] ComponentImport { name: "1", ty: Module(0) }
+   0x45 | 03 03       | core type section
+   0x47 | 01          | 1 count
+   0x48 | 50 00       | [core type 0] Module([])
+   0x4a | 0a 06       | component import section
+   0x4c | 01          | 1 count
+   0x4d | 01 31 00 11 | [module 0] ComponentImport { name: "1", ty: Module(0) }
         | 00         
-   0x53 | 07 06       | component type section
-   0x55 | 01          | 1 count
-   0x56 | 40 01 00 01 | [type 0] Func(ComponentFuncType { params: Named([]), results: Named([]) })
-        | 00         
-   0x5b | 0a 09       | component import section
-   0x5d | 02          | 2 count
-   0x5e | 01 32 01 00 | [func 0] ComponentImport { name: "2", ty: Func(0) }
-   0x62 | 01 33 02 73 | [value 0] ComponentImport { name: "3", ty: Value(Primitive(String)) }
-   0x66 | 07 03       | component type section
-   0x68 | 01          | 1 count
-   0x69 | 42 00       | [type 1] Instance([])
-   0x6b | 0a 05       | component import section
-   0x6d | 01          | 1 count
-   0x6e | 01 34 05 01 | [instance 0] ComponentImport { name: "4", ty: Instance(1) }
-   0x72 | 07 03       | component type section
-   0x74 | 01          | 1 count
-   0x75 | 41 00       | [type 2] Component([])
-   0x77 | 0a 05       | component import section
-   0x79 | 01          | 1 count
-   0x7a | 01 35 04 02 | [component 0] ComponentImport { name: "5", ty: Component(2) }
- 0x7e | 06 1b       | component alias section
- 0x80 | 05          | 5 count
- 0x81 | 00 11 00 00 | alias [module 0] InstanceExport { kind: Module, instance_index: 0, name: "1" }
+   0x52 | 07 05       | component type section
+   0x54 | 01          | 1 count
+   0x55 | 40 00 01 00 | [type 0] Func(ComponentFuncType { params: [], results: Named([]) })
+   0x59 | 0a 09       | component import section
+   0x5b | 02          | 2 count
+   0x5c | 01 32 01 00 | [func 0] ComponentImport { name: "2", ty: Func(0) }
+   0x60 | 01 33 02 73 | [value 0] ComponentImport { name: "3", ty: Value(Primitive(String)) }
+   0x64 | 07 03       | component type section
+   0x66 | 01          | 1 count
+   0x67 | 42 00       | [type 1] Instance([])
+   0x69 | 0a 05       | component import section
+   0x6b | 01          | 1 count
+   0x6c | 01 34 05 01 | [instance 0] ComponentImport { name: "4", ty: Instance(1) }
+   0x70 | 07 03       | component type section
+   0x72 | 01          | 1 count
+   0x73 | 41 00       | [type 2] Component([])
+   0x75 | 0a 05       | component import section
+   0x77 | 01          | 1 count
+   0x78 | 01 35 04 02 | [component 0] ComponentImport { name: "5", ty: Component(2) }
+ 0x7c | 06 1b       | component alias section
+ 0x7e | 05          | 5 count
+ 0x7f | 00 11 00 00 | alias [module 0] InstanceExport { kind: Module, instance_index: 0, name: "1" }
       | 01 31      
- 0x87 | 01 00 00 01 | alias [func 0] InstanceExport { kind: Func, instance_index: 0, name: "2" }
+ 0x85 | 01 00 00 01 | alias [func 0] InstanceExport { kind: Func, instance_index: 0, name: "2" }
       | 32         
- 0x8c | 02 00 00 01 | alias [value 0] InstanceExport { kind: Value, instance_index: 0, name: "4" }
+ 0x8a | 02 00 00 01 | alias [value 0] InstanceExport { kind: Value, instance_index: 0, name: "4" }
       | 34         
- 0x91 | 05 00 00 01 | alias [instance 1] InstanceExport { kind: Instance, instance_index: 0, name: "3" }
+ 0x8f | 05 00 00 01 | alias [instance 1] InstanceExport { kind: Instance, instance_index: 0, name: "3" }
       | 33         
- 0x96 | 04 00 00 01 | alias [component 1] InstanceExport { kind: Component, instance_index: 0, name: "5" }
+ 0x94 | 04 00 00 01 | alias [component 1] InstanceExport { kind: Component, instance_index: 0, name: "5" }
       | 35         
- 0x9b | 05 19       | component instance section
- 0x9d | 01          | 1 count
- 0x9e | 00 00 05 01 | [instance 2] Instantiate { component_index: 0, args: [ComponentInstantiationArg { name: "1", kind: Module, index: 0 }, ComponentInstantiationArg { name: "2", kind: Func, index: 0 }, ComponentInstantiationArg { name: "3", kind: Value, index: 0 }, ComponentInstantiationArg { name: "4", kind: Instance, index: 1 }, ComponentInstantiationArg { name: "5", kind: Component, index: 1 }] }
+ 0x99 | 05 19       | component instance section
+ 0x9b | 01          | 1 count
+ 0x9c | 00 00 05 01 | [instance 2] Instantiate { component_index: 0, args: [ComponentInstantiationArg { name: "1", kind: Module, index: 0 }, ComponentInstantiationArg { name: "2", kind: Func, index: 0 }, ComponentInstantiationArg { name: "3", kind: Value, index: 0 }, ComponentInstantiationArg { name: "4", kind: Instance, index: 1 }, ComponentInstantiationArg { name: "5", kind: Component, index: 1 }] }
       | 31 00 11 00
       | 01 32 01 00
       | 01 33 02 00

--- a/tests/dump/component-outer-alias.wat.dump
+++ b/tests/dump/component-outer-alias.wat.dump
@@ -1,46 +1,40 @@
   0x0 | 00 61 73 6d | version 65546 (Component)
       | 0a 00 01 00
-  0x8 | 07 0f       | component type section
+  0x8 | 07 0e       | component type section
   0xa | 02          | 2 count
   0xb | 73          | [type 0] Defined(Primitive(String))
-  0xc | 41 02 02 03 | [type 1] Component([Alias(Outer { kind: Type, count: 1, index: 0 }), Type(Func(ComponentFuncType { params: Named([]), results: Unnamed(Type(0)) }))])
+  0xc | 41 02 02 03 | [type 1] Component([Alias(Outer { kind: Type, count: 1, index: 0 }), Type(Func(ComponentFuncType { params: [], results: Unnamed(Type(0)) }))])
       | 02 01 00 01
-      | 40 01 00 00
-      | 00         
- 0x19 | 04 17       | [component 0] inline size
-   0x1b | 00 61 73 6d | version 65546 (Component)
+      | 40 00 00 00
+ 0x18 | 04 16       | [component 0] inline size
+   0x1a | 00 61 73 6d | version 65546 (Component)
         | 0a 00 01 00
-   0x23 | 06 05       | component alias section
-   0x25 | 01          | 1 count
-   0x26 | 03 02 01 00 | alias [type 0] Outer { kind: Type, count: 1, index: 0 }
-   0x2a | 07 06       | component type section
-   0x2c | 01          | 1 count
-   0x2d | 40 01 00 00 | [type 1] Func(ComponentFuncType { params: Named([]), results: Unnamed(Type(0)) })
-        | 00         
- 0x32 | 04 1c       | [component 1] inline size
-   0x34 | 00 61 73 6d | version 65546 (Component)
+   0x22 | 06 05       | component alias section
+   0x24 | 01          | 1 count
+   0x25 | 03 02 01 00 | alias [type 0] Outer { kind: Type, count: 1, index: 0 }
+   0x29 | 07 05       | component type section
+   0x2b | 01          | 1 count
+   0x2c | 40 00 00 00 | [type 1] Func(ComponentFuncType { params: [], results: Unnamed(Type(0)) })
+ 0x30 | 04 1a       | [component 1] inline size
+   0x32 | 00 61 73 6d | version 65546 (Component)
         | 0a 00 01 00
-   0x3c | 06 05       | component alias section
-   0x3e | 01          | 1 count
-   0x3f | 03 02 01 00 | alias [type 0] Outer { kind: Type, count: 1, index: 0 }
-   0x43 | 07 0b       | component type section
-   0x45 | 02          | 2 count
-   0x46 | 40 01 00 00 | [type 1] Func(ComponentFuncType { params: Named([]), results: Unnamed(Type(0)) })
-        | 00         
-   0x4b | 40 01 00 00 | [type 2] Func(ComponentFuncType { params: Named([]), results: Unnamed(Type(0)) })
-        | 00         
- 0x50 | 07 02       | component type section
- 0x52 | 01          | 1 count
- 0x53 | 7d          | [type 2] Defined(Primitive(U8))
- 0x54 | 04 1c       | [component 2] inline size
-   0x56 | 00 61 73 6d | version 65546 (Component)
+   0x3a | 06 05       | component alias section
+   0x3c | 01          | 1 count
+   0x3d | 03 02 01 00 | alias [type 0] Outer { kind: Type, count: 1, index: 0 }
+   0x41 | 07 09       | component type section
+   0x43 | 02          | 2 count
+   0x44 | 40 00 00 00 | [type 1] Func(ComponentFuncType { params: [], results: Unnamed(Type(0)) })
+   0x48 | 40 00 00 00 | [type 2] Func(ComponentFuncType { params: [], results: Unnamed(Type(0)) })
+ 0x4c | 07 02       | component type section
+ 0x4e | 01          | 1 count
+ 0x4f | 7d          | [type 2] Defined(Primitive(U8))
+ 0x50 | 04 1a       | [component 2] inline size
+   0x52 | 00 61 73 6d | version 65546 (Component)
         | 0a 00 01 00
-   0x5e | 06 05       | component alias section
-   0x60 | 01          | 1 count
-   0x61 | 03 02 01 02 | alias [type 0] Outer { kind: Type, count: 1, index: 2 }
-   0x65 | 07 0b       | component type section
-   0x67 | 02          | 2 count
-   0x68 | 40 01 00 00 | [type 1] Func(ComponentFuncType { params: Named([]), results: Unnamed(Type(0)) })
-        | 00         
-   0x6d | 40 01 00 00 | [type 2] Func(ComponentFuncType { params: Named([]), results: Unnamed(Type(0)) })
-        | 00         
+   0x5a | 06 05       | component alias section
+   0x5c | 01          | 1 count
+   0x5d | 03 02 01 02 | alias [type 0] Outer { kind: Type, count: 1, index: 2 }
+   0x61 | 07 09       | component type section
+   0x63 | 02          | 2 count
+   0x64 | 40 00 00 00 | [type 1] Func(ComponentFuncType { params: [], results: Unnamed(Type(0)) })
+   0x68 | 40 00 00 00 | [type 2] Func(ComponentFuncType { params: [], results: Unnamed(Type(0)) })

--- a/tests/dump/instance-expand.wat.dump
+++ b/tests/dump/instance-expand.wat.dump
@@ -1,10 +1,10 @@
   0x0 | 00 61 73 6d | version 65546 (Component)
       | 0a 00 01 00
-  0x8 | 07 0d       | component type section
+  0x8 | 07 0c       | component type section
   0xa | 01          | 1 count
-  0xb | 42 02 01 40 | [type 0] Instance([Type(Func(ComponentFuncType { params: Named([]), results: Named([]) })), Export { name: "", ty: Func(0) }])
-      | 01 00 01 00
-      | 04 00 01 00
- 0x17 | 0a 04       | component import section
- 0x19 | 01          | 1 count
- 0x1a | 00 05 00    | [instance 0] ComponentImport { name: "", ty: Instance(0) }
+  0xb | 42 02 01 40 | [type 0] Instance([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Export { name: "", ty: Func(0) }])
+      | 00 01 00 04
+      | 00 01 00   
+ 0x16 | 0a 04       | component import section
+ 0x18 | 01          | 1 count
+ 0x19 | 00 05 00    | [instance 0] ComponentImport { name: "", ty: Instance(0) }

--- a/tests/dump/instance-type.wat.dump
+++ b/tests/dump/instance-type.wat.dump
@@ -1,10 +1,10 @@
   0x0 | 00 61 73 6d | version 65546 (Component)
       | 0a 00 01 00
-  0x8 | 07 16       | component type section
+  0x8 | 07 15       | component type section
   0xa | 02          | 2 count
-  0xb | 42 02 01 40 | [type 0] Instance([Type(Func(ComponentFuncType { params: Named([]), results: Named([]) })), Export { name: "", ty: Func(0) }])
-      | 01 00 01 00
-      | 04 00 01 00
- 0x17 | 42 02 01 42 | [type 1] Instance([Type(Instance([])), Export { name: "", ty: Instance(0) }])
+  0xb | 42 02 01 40 | [type 0] Instance([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Export { name: "", ty: Func(0) }])
+      | 00 01 00 04
+      | 00 01 00   
+ 0x16 | 42 02 01 42 | [type 1] Instance([Type(Instance([])), Export { name: "", ty: Instance(0) }])
       | 00 04 00 05
       | 00         

--- a/tests/dump/instantiate.wat.dump
+++ b/tests/dump/instantiate.wat.dump
@@ -6,14 +6,13 @@
   0xd | 0a 05       | component import section
   0xf | 01          | 1 count
  0x10 | 01 61 04 00 | [component 0] ComponentImport { name: "a", ty: Component(0) }
- 0x14 | 07 06       | component type section
+ 0x14 | 07 05       | component type section
  0x16 | 01          | 1 count
- 0x17 | 40 01 00 01 | [type 1] Func(ComponentFuncType { params: Named([]), results: Named([]) })
-      | 00         
- 0x1c | 0a 05       | component import section
- 0x1e | 01          | 1 count
- 0x1f | 01 66 01 01 | [func 0] ComponentImport { name: "f", ty: Func(1) }
- 0x23 | 05 08       | component instance section
- 0x25 | 01          | 1 count
- 0x26 | 00 00 01 01 | [instance 0] Instantiate { component_index: 0, args: [ComponentInstantiationArg { name: "a", kind: Func, index: 0 }] }
+ 0x17 | 40 00 01 00 | [type 1] Func(ComponentFuncType { params: [], results: Named([]) })
+ 0x1b | 0a 05       | component import section
+ 0x1d | 01          | 1 count
+ 0x1e | 01 66 01 01 | [func 0] ComponentImport { name: "f", ty: Func(1) }
+ 0x22 | 05 08       | component instance section
+ 0x24 | 01          | 1 count
+ 0x25 | 00 00 01 01 | [instance 0] Instantiate { component_index: 0, args: [ComponentInstantiationArg { name: "a", kind: Func, index: 0 }] }
       | 61 01 00   

--- a/tests/dump/instantiate2.wat.dump
+++ b/tests/dump/instantiate2.wat.dump
@@ -1,13 +1,13 @@
   0x0 | 00 61 73 6d | version 65546 (Component)
       | 0a 00 01 00
-  0x8 | 07 0d       | component type section
+  0x8 | 07 0c       | component type section
   0xa | 01          | 1 count
-  0xb | 41 02 01 40 | [type 0] Component([Type(Func(ComponentFuncType { params: Named([]), results: Named([]) })), Import(ComponentImport { name: "", ty: Func(0) })])
-      | 01 00 01 00
-      | 03 00 01 00
- 0x17 | 0a 04       | component import section
- 0x19 | 01          | 1 count
- 0x1a | 00 04 00    | [component 0] ComponentImport { name: "", ty: Component(0) }
- 0x1d | 05 04       | component instance section
- 0x1f | 01          | 1 count
- 0x20 | 00 00 00    | [instance 0] Instantiate { component_index: 0, args: [] }
+  0xb | 41 02 01 40 | [type 0] Component([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Import(ComponentImport { name: "", ty: Func(0) })])
+      | 00 01 00 03
+      | 00 01 00   
+ 0x16 | 0a 04       | component import section
+ 0x18 | 01          | 1 count
+ 0x19 | 00 04 00    | [component 0] ComponentImport { name: "", ty: Component(0) }
+ 0x1c | 05 04       | component instance section
+ 0x1e | 01          | 1 count
+ 0x1f | 00 00 00    | [instance 0] Instantiate { component_index: 0, args: [] }

--- a/tests/dump/nested-component.wat
+++ b/tests/dump/nested-component.wat
@@ -13,7 +13,7 @@
 
   (component
     (core module $m)
-    (import "" (func (param string)))
+    (import "" (func (param "p" string)))
     (export "a" (core module $m))
 
     (instance (export "b") (import "")

--- a/tests/dump/nested-component.wat.dump
+++ b/tests/dump/nested-component.wat.dump
@@ -21,7 +21,7 @@
    0x3b | 04 08       | [component 0] inline size
      0x3d | 00 61 73 6d | version 65546 (Component)
           | 0a 00 01 00
- 0x45 | 04 50       | [component 5] inline size
+ 0x45 | 04 51       | [component 5] inline size
    0x47 | 00 61 73 6d | version 65546 (Component)
         | 0a 00 01 00
    0x4f | 01 13       | [core module 0] inline size
@@ -32,29 +32,28 @@
           | 65         
      0x60 | 00 02       | module name
      0x62 | 01 6d       | "m"
-   0x64 | 07 06       | component type section
+   0x64 | 07 08       | component type section
    0x66 | 01          | 1 count
-   0x67 | 40 00 73 01 | [type 0] Func(ComponentFuncType { params: Unnamed(Primitive(String)), results: Named([]) })
+   0x67 | 40 01 01 70 | [type 0] Func(ComponentFuncType { params: [("p", Primitive(String))], results: Named([]) })
+        | 73 01 00   
+   0x6e | 0a 04       | component import section
+   0x70 | 01          | 1 count
+   0x71 | 00 01 00    | [func 0] ComponentImport { name: "", ty: Func(0) }
+   0x74 | 0b 06       | component export section
+   0x76 | 01          | 1 count
+   0x77 | 01 61 00 11 | export ComponentExport { name: "a", kind: Module, index: 0 }
         | 00         
-   0x6c | 0a 04       | component import section
-   0x6e | 01          | 1 count
-   0x6f | 00 01 00    | [func 0] ComponentImport { name: "", ty: Func(0) }
-   0x72 | 0b 06       | component export section
-   0x74 | 01          | 1 count
-   0x75 | 01 61 00 11 | export ComponentExport { name: "a", kind: Module, index: 0 }
-        | 00         
-   0x7a | 07 0e       | component type section
-   0x7c | 01          | 1 count
-   0x7d | 42 02 01 40 | [type 1] Instance([Type(Func(ComponentFuncType { params: Named([]), results: Named([]) })), Export { name: "b", ty: Func(0) }])
-        | 01 00 01 00
-        | 04 01 62 01
-        | 00         
-   0x8a | 0a 04       | component import section
-   0x8c | 01          | 1 count
-   0x8d | 00 05 01    | [instance 0] ComponentImport { name: "", ty: Instance(1) }
-   0x90 | 0b 05       | component export section
-   0x92 | 01          | 1 count
-   0x93 | 01 62 05 00 | export ComponentExport { name: "b", kind: Instance, index: 0 }
- 0x97 | 0b 05       | component export section
- 0x99 | 01          | 1 count
- 0x9a | 01 78 04 03 | export ComponentExport { name: "x", kind: Component, index: 3 }
+   0x7c | 07 0d       | component type section
+   0x7e | 01          | 1 count
+   0x7f | 42 02 01 40 | [type 1] Instance([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Export { name: "b", ty: Func(0) }])
+        | 00 01 00 04
+        | 01 62 01 00
+   0x8b | 0a 04       | component import section
+   0x8d | 01          | 1 count
+   0x8e | 00 05 01    | [instance 0] ComponentImport { name: "", ty: Instance(1) }
+   0x91 | 0b 05       | component export section
+   0x93 | 01          | 1 count
+   0x94 | 01 62 05 00 | export ComponentExport { name: "b", kind: Instance, index: 0 }
+ 0x98 | 0b 05       | component export section
+ 0x9a | 01          | 1 count
+ 0x9b | 01 78 04 03 | export ComponentExport { name: "x", kind: Component, index: 3 }

--- a/tests/local/component-model/adapt.wast
+++ b/tests/local/component-model/adapt.wast
@@ -1,5 +1,5 @@
 (component
-  (import "log" (func $log (param string)))
+  (import "log" (func $log (param "msg" string)))
   (core module $libc
     (memory (export "memory") 1)
     (func (export "canonical_abi_realloc") (param i32 i32 i32 i32) (result i32)
@@ -45,7 +45,7 @@
     ))
   ))
 
-  (func (export "log1") (param string)
+  (func (export "log1") (param "msg" string)
     (canon lift
       (core func $my_instance "log-utf8")
       string-encoding=utf8
@@ -53,7 +53,7 @@
       (realloc $realloc)
     )
   )
-  (func (export "log2") (param string)
+  (func (export "log2") (param "msg" string)
     (canon lift
       (core func $my_instance "log-utf16")
       string-encoding=utf16
@@ -61,7 +61,7 @@
       (realloc $realloc)
     )
   )
-  (func (export "log3") (param string)
+  (func (export "log3") (param "msg" string)
     (canon lift
       (core func $my_instance "log-compact-utf16")
       string-encoding=latin1+utf16
@@ -114,7 +114,7 @@
       (func (export "f") (param i32 i32))
     )
     (core instance $i (instantiate $m))
-    (func (param (list u8)) (canon lift (core func $i "f")))
+    (func (param "p1" (list u8)) (canon lift (core func $i "f")))
   )
   "canonical option `memory` is required")
 
@@ -125,7 +125,7 @@
       (func (export "f") (param i32 i32))
     )
     (core instance $i (instantiate $m))
-    (func (param (list u8))
+    (func (param "p1" (list u8))
       (canon lift (core func $i "f")
         (memory $i "m")
       )
@@ -141,7 +141,7 @@
       (func (export "r") (param i32 i32 i32 i32) (result i32))
     )
     (core instance $i (instantiate $m))
-    (func (param (list u8))
+    (func (param "p1" (list u8))
       (canon lift (core func $i "f")
         (memory $i "m")
         (realloc (func $i "r"))
@@ -159,7 +159,7 @@
       (func (export "r"))
     )
     (core instance $i (instantiate $m))
-    (func (param (list u8))
+    (func (param "p1" (list u8))
       (canon lift (core func $i "f")
         (memory $i "m")
         (realloc (func $i "r"))
@@ -209,7 +209,7 @@
 
 (assert_invalid
   (component
-    (import "" (func $f (param string)))
+    (import "" (func $f (param "p1" string)))
     (core module $m
       (memory (export "m") 1)
       (func (export "f") (result i32))

--- a/tests/local/component-model/alias.wast
+++ b/tests/local/component-model/alias.wast
@@ -1,7 +1,7 @@
 (component
   (import "i" (instance $i
     (export "f1" (func $f1))
-    (export "f2" (func $f2 (param string)))
+    (export "f2" (func $f2 (param "p1" string)))
   ))
   (export "run" (func $i "f1"))
 )
@@ -9,7 +9,7 @@
 (component
   (import "i" (component $c
     (export "f1" (func $f1))
-    (export "f2" (func $f2 (param string)))
+    (export "f2" (func $f2 (param "p1" string)))
   ))
   (instance $i (instantiate $c))
   (export "run" (func $i "f1"))

--- a/tests/local/component-model/big.wast
+++ b/tests/local/component-model/big.wast
@@ -1,6 +1,6 @@
 (component
   (import "wasi:logging" (instance $logging
-    (export "log" (func (param string)))
+    (export "log" (func (param "msg" string)))
   ))
   (import "libc" (core module $Libc
     (export "memory" (memory 1))
@@ -26,7 +26,7 @@
     (with "libc" (instance $libc))
     (with "wasi:logging" (instance (export "log" (func $log))))
   ))
-  (func $run (param string) (result string) (canon lift
+  (func $run (param "in" string) (result string) (canon lift
     (core func $main "run")
     (memory $libc "memory") (realloc (func $libc "realloc"))
   ))

--- a/tests/local/component-model/definedtypes.wast
+++ b/tests/local/component-model/definedtypes.wast
@@ -95,7 +95,7 @@
 (assert_invalid
   (component
     (type $t (func))
-    (type (func (param $t)))
+    (type (func (param "t" $t)))
   )
   "type index 0 is not a defined type")
 

--- a/tests/local/component-model/func.wast
+++ b/tests/local/component-model/func.wast
@@ -7,16 +7,9 @@
 
 (component
   (import "" (func))
-  (import "a" (func (param string)))
+  (import "a" (func (param "p1" string)))
   (import "b" (func (result u32)))
-  (import "c" (func (param bool) (result string)))
-)
-
-(assert_invalid
-  (component
-    (import "a" (func (param "foo" string) (param s32) (param "bar" u32)))
-  )
-  "function parameter name cannot be empty"
+  (import "c" (func (param "p1" bool) (result string)))
 )
 
 (assert_invalid
@@ -56,7 +49,7 @@
 )
 
 (component
-  (import "" (func $log (param string)))
+  (import "" (func $log (param "msg" string)))
   (core module $libc
     (memory (export "memory") 1)
   )
@@ -135,7 +128,7 @@
     )
     (core instance $i (instantiate $m))
 
-    (func (export "param-list") (param (list u8))
+    (func (export "param-list") (param "bytes" (list u8))
       (canon lift (core func $i "param-list") (memory $i "memory"))
     )
   )

--- a/tests/local/component-model/instance-type.wast
+++ b/tests/local/component-model/instance-type.wast
@@ -43,8 +43,8 @@
     (export "c" (func (@name "bar")))
     (export "d" (func $foo (@name "bar")))
     (export "e" (func (type $t)))
-    (export "f" (func (param string)))
-    (export "g" (func (param s32) (result u32)))
+    (export "f" (func (param "f" string)))
+    (export "g" (func (param "g" s32) (result u32)))
     (export "h" (func (type $t)))
 
     ;; components
@@ -135,15 +135,15 @@
   (type (component
     (import "a" (func))
     (import "b" (func (type $empty)))
-    (import "c" (func (param s32)))
-    (import "d" (func (param s32) (result s32)))
+    (import "c" (func (param "c" s32)))
+    (import "d" (func (param "d" s32) (result s32)))
 
     (import "h" (instance))
     (import "i" (instance (type $i)))
     (import "j" (instance
       (export "a" (func))
       (export "b" (func (type $empty)))
-      (export "c" (func (param s32)))
+      (export "c" (func (param "c" s32)))
     ))
 
     (import "k" (core module))
@@ -157,12 +157,12 @@
 
     (export "a" (func))
     (export "e" (func (type $empty)))
-    (export "f" (func (param s32)))
+    (export "f" (func (param "f" s32)))
 
     (export "g" (instance
       (export "a" (func))
       (export "b" (func (type $empty)))
-      (export "c" (func (param s32)))
+      (export "c" (func (param "c" s32)))
     ))
 
     (export "h" (core module

--- a/tests/local/component-model/instantiate.wast
+++ b/tests/local/component-model/instantiate.wast
@@ -190,7 +190,7 @@
     (import "" (component $m
       (import "" (func))
     ))
-    (import "i" (func (param string)))
+    (import "i" (func (param "i" string)))
     (instance $i (instantiate $m (with "" (func 0))))
   )
   "function type mismatch")

--- a/tests/local/component-model/nested-modules.wast
+++ b/tests/local/component-model/nested-modules.wast
@@ -12,7 +12,7 @@
 
   (component
     (core module $m)
-    (import "" (func (param string)))
+    (import "" (func (param "p" string)))
     (export "a" (core module $m))
   )
 )

--- a/tests/local/component-model/start.wast
+++ b/tests/local/component-model/start.wast
@@ -1,14 +1,14 @@
 
 (assert_invalid
   (component
-    (import "" (func $f (param string)))
+    (import "" (func $f (param "1" string)))
     (start $f)
   )
   "start function requires 1 arguments")
 
 (assert_invalid
   (component
-    (import "" (func $f (param string)))
+    (import "" (func $f (param "p" string)))
     (import "v" (value $v string))
     (start $f (value $v) (value $v))
   )
@@ -76,10 +76,10 @@
   (component binary
     "\00asm" "\0a\00\01\00"   ;; component header
 
-    "\07\06"          ;; type section, 6 bytes large
+    "\07\05"          ;; type section, 5 bytes large
     "\01"             ;; 1 count
     "\40"             ;; function
-    "\01\00"          ;; parameters, named, 0 count
+    "\00"             ;; parameters, 0 count
     "\01\00"          ;; results, named, 0 count
 
     "\0a\04"          ;; import section, 4 bytes large
@@ -98,10 +98,10 @@
   (component binary
     "\00asm" "\0a\00\01\00"   ;; component header
 
-    "\07\06"          ;; type section, 6 bytes large
+    "\07\05"          ;; type section, 5 bytes large
     "\01"             ;; 1 count
     "\40"             ;; function
-    "\01\00"          ;; parameters, named, 0 count
+    "\00"             ;; parameters, 0 count
     "\01\00"          ;; results, named, 0 count
 
     "\0a\04"          ;; import section, 4 bytes large

--- a/tests/local/component-model/string.wast
+++ b/tests/local/component-model/string.wast
@@ -19,7 +19,7 @@
   )
   (core instance $main (instantiate $Main (with "libc" (instance $libc))))
   (alias core export $main "start" (core func $main_func))
-  (func $start (param string) (result string)
+  (func $start (param "p1" string) (result string)
     (canon lift (core func $main_func)
       (memory $libc "memory")
       (realloc (func $libc "canonical_abi_realloc"))

--- a/tests/local/component-model/virtualize.wast
+++ b/tests/local/component-model/virtualize.wast
@@ -9,8 +9,8 @@
 
   (component $child
     (import "wasi-file" (instance $wasi-file
-      (export "read" (func $read (param u32) (result (list u8))))
-      (export "write" (func $write (param (list u8)) (result u32)))
+      (export "read" (func $read (param "count" u32) (result (list u8))))
+      (export "write" (func $write (param "bytes" (list u8)) (result u32)))
     ))
 
     (core instance $libc (instantiate $libc))
@@ -42,8 +42,8 @@
 
   (component $virtualize
     (import "wasi-file" (instance $wasi-file
-      (export "read" (func $read (param u32) (result (list u8))))
-      (export "write" (func $write (param (list u8)) (result u32)))
+      (export "read" (func $read (param "len" u32) (result (list u8))))
+      (export "write" (func $write (param "buf" (list u8)) (result u32)))
     ))
     (export "read" (func $wasi-file "read"))
     (export "write" (func $wasi-file "write"))
@@ -51,14 +51,14 @@
 
   (component
     (type $WasiFile (instance
-      (export "read" (func $read (param u32) (result (list u8))))
-      (export "write" (func $write (param (list u8)) (result u32)))
+      (export "read" (func $read (param "len" u32) (result (list u8))))
+      (export "write" (func $write (param "buf" (list u8)) (result u32)))
     ))
     (import "wasi_file" (instance $real-wasi (type $WasiFile)))
     (import "./virtualize.wasm" (component $VIRTUALIZE
       (import "wasi_file" (instance (type $WasiFile)))
-        (export "read" (func $read (param u32) (result (list u8))))
-        (export "write" (func $write (param (list u8)) (result u32)))
+        (export "read" (func $read (param "len" u32) (result (list u8))))
+        (export "write" (func $write (param "buf" (list u8)) (result u32)))
       ))
       (import "./child.wasm" (component $CHILD
         (import "wasi_file" (instance (type $WasiFile)))
@@ -74,8 +74,8 @@
 
   (component
     (type $WasiFile (instance
-      (export "read" (func $read (param u32) (result (list u8))))
-      (export "write" (func $write (param (list u8)) (result u32)))
+      (export "read" (func $read (param "len" u32) (result (list u8))))
+      (export "write" (func $write (param "buf" (list u8)) (result u32)))
     ))
     (import "wasi_file" (instance $real-wasi (type $WasiFile)))
 


### PR DESCRIPTION
This PR updates the tools for the latest component model spec changes.

Namely, it makes component function parameters always named.

See WebAssembly/component-model#108 for the spec change.