### PR TITLE
wasmparser: make `TypeId` hash differently for aliased types.

### DIFF
--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -1,16 +1,10 @@
-#[macro_use]
-extern crate criterion;
-
 use anyhow::Result;
-use criterion::Criterion;
+use criterion::{criterion_group, criterion_main, Criterion};
 use once_cell::unsync::Lazy;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
-use wasmparser::{
-    BlockType, BrTable, DataKind, ElementKind, Ieee32, Ieee64, MemArg, Parser, Payload, ValType,
-    Validator, VisitOperator, WasmFeatures, V128,
-};
+use wasmparser::{DataKind, ElementKind, Parser, Payload, Validator, VisitOperator, WasmFeatures};
 
 /// A benchmark input.
 pub struct BenchmarkInput {

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -58,7 +58,7 @@ pub enum Type {
 pub struct FuncType {
     /// The combined parameters and result types.
     params_results: Box<[ValType]>,
-    /// The number of paramter types.
+    /// The number of parameter types.
     len_params: usize,
 }
 

--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -87,6 +87,8 @@ impl ComponentState {
         current.core_types.push(TypeId {
             type_size: ty.type_size(),
             index: types.len(),
+            type_index: Some(current.core_types.len()),
+            is_core: true,
         });
         types.push(ty);
 
@@ -113,6 +115,8 @@ impl ComponentState {
         self.core_modules.push(TypeId {
             type_size: ty.type_size(),
             index: types.len(),
+            type_index: None,
+            is_core: true,
         });
 
         types.push(ty);
@@ -182,6 +186,8 @@ impl ComponentState {
         current.types.push(TypeId {
             type_size: ty.type_size(),
             index: types.len(),
+            type_index: Some(current.types.len()),
+            is_core: false,
         });
         types.push(ty);
 
@@ -327,6 +333,8 @@ impl ComponentState {
         self.core_funcs.push(TypeId {
             type_size: lowered_ty.type_size(),
             index: types.len(),
+            type_index: None,
+            is_core: true,
         });
 
         types.push(lowered_ty);
@@ -344,6 +352,8 @@ impl ComponentState {
         self.components.push(TypeId {
             type_size: ty.type_size(),
             index: types.len(),
+            type_index: None,
+            is_core: false,
         });
 
         types.push(ty);
@@ -1009,6 +1019,8 @@ impl ComponentState {
         let id = TypeId {
             type_size: ty.type_size(),
             index: types.len(),
+            type_index: None,
+            is_core: true,
         };
 
         types.push(ty);
@@ -1144,6 +1156,8 @@ impl ComponentState {
         let id = TypeId {
             type_size: ty.type_size(),
             index: types.len(),
+            type_index: None,
+            is_core: false,
         };
 
         types.push(ty);
@@ -1245,6 +1259,8 @@ impl ComponentState {
         let id = TypeId {
             type_size: ty.type_size(),
             index: types.len(),
+            type_index: None,
+            is_core: false,
         };
 
         types.push(ty);
@@ -1331,6 +1347,8 @@ impl ComponentState {
         let id = TypeId {
             type_size: ty.type_size(),
             index: types.len(),
+            type_index: None,
+            is_core: true,
         };
 
         types.push(ty);
@@ -1544,7 +1562,13 @@ impl ComponentState {
         let current = components.last_mut().unwrap();
         check_max(current.type_count(), 1, MAX_WASM_TYPES, "types", offset)?;
 
-        current.core_types.push(ty);
+        current.core_types.push(TypeId {
+            type_size: ty.type_size,
+            index: ty.index,
+            type_index: Some(current.core_types.len()),
+            is_core: true,
+        });
+
         Ok(())
     }
 
@@ -1555,7 +1579,13 @@ impl ComponentState {
         let current = components.last_mut().unwrap();
         check_max(current.type_count(), 1, MAX_WASM_TYPES, "types", offset)?;
 
-        current.types.push(ty);
+        current.types.push(TypeId {
+            type_size: ty.type_size,
+            index: ty.index,
+            type_index: Some(current.types.len()),
+            is_core: false,
+        });
+
         Ok(())
     }
 

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -481,6 +481,8 @@ impl Module {
         self.types.push(TypeId {
             type_size: ty.type_size(),
             index: types.len(),
+            type_index: Some(self.types.len()),
+            is_core: true,
         });
         types.push(ty);
         Ok(())

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -324,7 +324,7 @@ impl<R> Deref for OperatorValidatorTemp<'_, '_, R> {
 
 impl<R> DerefMut for OperatorValidatorTemp<'_, '_, R> {
     fn deref_mut(&mut self) -> &mut OperatorValidator {
-        &mut self.inner
+        self.inner
     }
 }
 

--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -141,6 +141,14 @@ pub struct TypeId {
     pub(crate) type_size: usize,
     /// The index into the global list of types.
     pub(crate) index: usize,
+    /// The original type index.
+    ///
+    /// This will be `None` for implicitly defined types, e.g. types for
+    /// modules definitions, component definitions, instantiations, and function
+    /// lowerings.
+    pub(crate) type_index: Option<usize>,
+    /// Whether or not the type is a core type.
+    pub(crate) is_core: bool,
 }
 
 /// A unified type definition for validating WebAssembly modules and components.


### PR DESCRIPTION
This PR adds the original type index (if there is one) to `TypeId`.

The intention for doing so is making `TypeId`'s `Hash` and `PartialEq`
implementations take into account type aliases. This allows consumers
of the validators's type information to disambiguate the aliasing when
necessary.