### PR TITLE
Fix encoding for GC rec.

### DIFF
--- a/crates/wast/src/core/binary.rs
+++ b/crates/wast/src/core/binary.rs
@@ -202,7 +202,7 @@ impl Encode for Rec<'_> {
             return;
         }
 
-        e.push(0x45);
+        e.push(0x4f);
         self.types.len().encode(e);
         for ty in &self.types {
             ty.encode(e);


### PR DESCRIPTION
Per https://github.com/WebAssembly/gc/blob/main/proposals/gc/MVP.md and v8/binaryen implementations, the `rec` needs to be encoded as 0x4f bytes (in spec text `-0x31`)

We don't test GC yet. I verified encoding with binaryen's wasm-dis.