### PR TITLE
Minor changes to naming in wasmparser/wasm-encoder

### DIFF
--- a/crates/wasm-encoder/src/core/code.rs
+++ b/crates/wasm-encoder/src/core/code.rs
@@ -340,16 +340,16 @@ pub enum Instruction<'a> {
     I64Load(MemArg),
     F32Load(MemArg),
     F64Load(MemArg),
-    I32Load8_S(MemArg),
-    I32Load8_U(MemArg),
-    I32Load16_S(MemArg),
-    I32Load16_U(MemArg),
-    I64Load8_S(MemArg),
-    I64Load8_U(MemArg),
-    I64Load16_S(MemArg),
-    I64Load16_U(MemArg),
-    I64Load32_S(MemArg),
-    I64Load32_U(MemArg),
+    I32Load8S(MemArg),
+    I32Load8U(MemArg),
+    I32Load16S(MemArg),
+    I32Load16U(MemArg),
+    I64Load8S(MemArg),
+    I64Load8U(MemArg),
+    I64Load16S(MemArg),
+    I64Load16U(MemArg),
+    I64Load32S(MemArg),
+    I64Load32U(MemArg),
     I32Store(MemArg),
     I64Store(MemArg),
     F32Store(MemArg),
@@ -361,9 +361,9 @@ pub enum Instruction<'a> {
     I64Store32(MemArg),
     MemorySize(u32),
     MemoryGrow(u32),
-    MemoryInit { mem: u32, data: u32 },
+    MemoryInit { mem: u32, segment: u32 },
     DataDrop(u32),
-    MemoryCopy { src: u32, dst: u32 },
+    MemoryCopy { src_mem: u32, dst_mem: u32 },
     MemoryFill(u32),
 
     // Numeric instructions.
@@ -516,29 +516,29 @@ pub enum Instruction<'a> {
 
     // Bulk memory instructions.
     TableInit { segment: u32, table: u32 },
-    ElemDrop { segment: u32 },
-    TableFill { table: u32 },
-    TableSet { table: u32 },
-    TableGet { table: u32 },
-    TableGrow { table: u32 },
-    TableSize { table: u32 },
-    TableCopy { src: u32, dst: u32 },
+    ElemDrop(u32),
+    TableFill(u32),
+    TableSet(u32),
+    TableGet(u32),
+    TableGrow(u32),
+    TableSize(u32),
+    TableCopy { src_table: u32, dst_table: u32 },
 
     // SIMD instructions.
-    V128Load { memarg: MemArg },
-    V128Load8x8S { memarg: MemArg },
-    V128Load8x8U { memarg: MemArg },
-    V128Load16x4S { memarg: MemArg },
-    V128Load16x4U { memarg: MemArg },
-    V128Load32x2S { memarg: MemArg },
-    V128Load32x2U { memarg: MemArg },
-    V128Load8Splat { memarg: MemArg },
-    V128Load16Splat { memarg: MemArg },
-    V128Load32Splat { memarg: MemArg },
-    V128Load64Splat { memarg: MemArg },
-    V128Load32Zero { memarg: MemArg },
-    V128Load64Zero { memarg: MemArg },
-    V128Store { memarg: MemArg },
+    V128Load(MemArg),
+    V128Load8x8S(MemArg),
+    V128Load8x8U(MemArg),
+    V128Load16x4S(MemArg),
+    V128Load16x4U(MemArg),
+    V128Load32x2S(MemArg),
+    V128Load32x2U(MemArg),
+    V128Load8Splat(MemArg),
+    V128Load16Splat(MemArg),
+    V128Load32Splat(MemArg),
+    V128Load64Splat(MemArg),
+    V128Load32Zero(MemArg),
+    V128Load64Zero(MemArg),
+    V128Store(MemArg),
     V128Load8Lane { memarg: MemArg, lane: Lane },
     V128Load16Lane { memarg: MemArg, lane: Lane },
     V128Load32Lane { memarg: MemArg, lane: Lane },
@@ -548,21 +548,21 @@ pub enum Instruction<'a> {
     V128Store32Lane { memarg: MemArg, lane: Lane },
     V128Store64Lane { memarg: MemArg, lane: Lane },
     V128Const(i128),
-    I8x16Shuffle { lanes: [Lane; 16] },
-    I8x16ExtractLaneS { lane: Lane },
-    I8x16ExtractLaneU { lane: Lane },
-    I8x16ReplaceLane { lane: Lane },
-    I16x8ExtractLaneS { lane: Lane },
-    I16x8ExtractLaneU { lane: Lane },
-    I16x8ReplaceLane { lane: Lane },
-    I32x4ExtractLane { lane: Lane },
-    I32x4ReplaceLane { lane: Lane },
-    I64x2ExtractLane { lane: Lane },
-    I64x2ReplaceLane { lane: Lane },
-    F32x4ExtractLane { lane: Lane },
-    F32x4ReplaceLane { lane: Lane },
-    F64x2ExtractLane { lane: Lane },
-    F64x2ReplaceLane { lane: Lane },
+    I8x16Shuffle([Lane; 16]),
+    I8x16ExtractLaneS(Lane),
+    I8x16ExtractLaneU(Lane),
+    I8x16ReplaceLane(Lane),
+    I16x8ExtractLaneS(Lane),
+    I16x8ExtractLaneU(Lane),
+    I16x8ReplaceLane(Lane),
+    I32x4ExtractLane(Lane),
+    I32x4ReplaceLane(Lane),
+    I64x2ExtractLane(Lane),
+    I64x2ReplaceLane(Lane),
+    F32x4ExtractLane(Lane),
+    F32x4ReplaceLane(Lane),
+    F64x2ExtractLane(Lane),
+    F64x2ReplaceLane(Lane),
     I8x16Swizzle,
     I8x16Splat,
     I16x8Splat,
@@ -784,73 +784,73 @@ pub enum Instruction<'a> {
     F32x4RelaxedDotBf16x8AddF32x4,
 
     // Atomic instructions (the threads proposal)
-    MemoryAtomicNotify { memarg: MemArg },
-    MemoryAtomicWait32 { memarg: MemArg },
-    MemoryAtomicWait64 { memarg: MemArg },
+    MemoryAtomicNotify(MemArg),
+    MemoryAtomicWait32(MemArg),
+    MemoryAtomicWait64(MemArg),
     AtomicFence,
-    I32AtomicLoad { memarg: MemArg },
-    I64AtomicLoad { memarg: MemArg },
-    I32AtomicLoad8U { memarg: MemArg },
-    I32AtomicLoad16U { memarg: MemArg },
-    I64AtomicLoad8U { memarg: MemArg },
-    I64AtomicLoad16U { memarg: MemArg },
-    I64AtomicLoad32U { memarg: MemArg },
-    I32AtomicStore { memarg: MemArg },
-    I64AtomicStore { memarg: MemArg },
-    I32AtomicStore8 { memarg: MemArg },
-    I32AtomicStore16 { memarg: MemArg },
-    I64AtomicStore8 { memarg: MemArg },
-    I64AtomicStore16 { memarg: MemArg },
-    I64AtomicStore32 { memarg: MemArg },
-    I32AtomicRmwAdd { memarg: MemArg },
-    I64AtomicRmwAdd { memarg: MemArg },
-    I32AtomicRmw8AddU { memarg: MemArg },
-    I32AtomicRmw16AddU { memarg: MemArg },
-    I64AtomicRmw8AddU { memarg: MemArg },
-    I64AtomicRmw16AddU { memarg: MemArg },
-    I64AtomicRmw32AddU { memarg: MemArg },
-    I32AtomicRmwSub { memarg: MemArg },
-    I64AtomicRmwSub { memarg: MemArg },
-    I32AtomicRmw8SubU { memarg: MemArg },
-    I32AtomicRmw16SubU { memarg: MemArg },
-    I64AtomicRmw8SubU { memarg: MemArg },
-    I64AtomicRmw16SubU { memarg: MemArg },
-    I64AtomicRmw32SubU { memarg: MemArg },
-    I32AtomicRmwAnd { memarg: MemArg },
-    I64AtomicRmwAnd { memarg: MemArg },
-    I32AtomicRmw8AndU { memarg: MemArg },
-    I32AtomicRmw16AndU { memarg: MemArg },
-    I64AtomicRmw8AndU { memarg: MemArg },
-    I64AtomicRmw16AndU { memarg: MemArg },
-    I64AtomicRmw32AndU { memarg: MemArg },
-    I32AtomicRmwOr { memarg: MemArg },
-    I64AtomicRmwOr { memarg: MemArg },
-    I32AtomicRmw8OrU { memarg: MemArg },
-    I32AtomicRmw16OrU { memarg: MemArg },
-    I64AtomicRmw8OrU { memarg: MemArg },
-    I64AtomicRmw16OrU { memarg: MemArg },
-    I64AtomicRmw32OrU { memarg: MemArg },
-    I32AtomicRmwXor { memarg: MemArg },
-    I64AtomicRmwXor { memarg: MemArg },
-    I32AtomicRmw8XorU { memarg: MemArg },
-    I32AtomicRmw16XorU { memarg: MemArg },
-    I64AtomicRmw8XorU { memarg: MemArg },
-    I64AtomicRmw16XorU { memarg: MemArg },
-    I64AtomicRmw32XorU { memarg: MemArg },
-    I32AtomicRmwXchg { memarg: MemArg },
-    I64AtomicRmwXchg { memarg: MemArg },
-    I32AtomicRmw8XchgU { memarg: MemArg },
-    I32AtomicRmw16XchgU { memarg: MemArg },
-    I64AtomicRmw8XchgU { memarg: MemArg },
-    I64AtomicRmw16XchgU { memarg: MemArg },
-    I64AtomicRmw32XchgU { memarg: MemArg },
-    I32AtomicRmwCmpxchg { memarg: MemArg },
-    I64AtomicRmwCmpxchg { memarg: MemArg },
-    I32AtomicRmw8CmpxchgU { memarg: MemArg },
-    I32AtomicRmw16CmpxchgU { memarg: MemArg },
-    I64AtomicRmw8CmpxchgU { memarg: MemArg },
-    I64AtomicRmw16CmpxchgU { memarg: MemArg },
-    I64AtomicRmw32CmpxchgU { memarg: MemArg },
+    I32AtomicLoad(MemArg),
+    I64AtomicLoad(MemArg),
+    I32AtomicLoad8U(MemArg),
+    I32AtomicLoad16U(MemArg),
+    I64AtomicLoad8U(MemArg),
+    I64AtomicLoad16U(MemArg),
+    I64AtomicLoad32U(MemArg),
+    I32AtomicStore(MemArg),
+    I64AtomicStore(MemArg),
+    I32AtomicStore8(MemArg),
+    I32AtomicStore16(MemArg),
+    I64AtomicStore8(MemArg),
+    I64AtomicStore16(MemArg),
+    I64AtomicStore32(MemArg),
+    I32AtomicRmwAdd(MemArg),
+    I64AtomicRmwAdd(MemArg),
+    I32AtomicRmw8AddU(MemArg),
+    I32AtomicRmw16AddU(MemArg),
+    I64AtomicRmw8AddU(MemArg),
+    I64AtomicRmw16AddU(MemArg),
+    I64AtomicRmw32AddU(MemArg),
+    I32AtomicRmwSub(MemArg),
+    I64AtomicRmwSub(MemArg),
+    I32AtomicRmw8SubU(MemArg),
+    I32AtomicRmw16SubU(MemArg),
+    I64AtomicRmw8SubU(MemArg),
+    I64AtomicRmw16SubU(MemArg),
+    I64AtomicRmw32SubU(MemArg),
+    I32AtomicRmwAnd(MemArg),
+    I64AtomicRmwAnd(MemArg),
+    I32AtomicRmw8AndU(MemArg),
+    I32AtomicRmw16AndU(MemArg),
+    I64AtomicRmw8AndU(MemArg),
+    I64AtomicRmw16AndU(MemArg),
+    I64AtomicRmw32AndU(MemArg),
+    I32AtomicRmwOr(MemArg),
+    I64AtomicRmwOr(MemArg),
+    I32AtomicRmw8OrU(MemArg),
+    I32AtomicRmw16OrU(MemArg),
+    I64AtomicRmw8OrU(MemArg),
+    I64AtomicRmw16OrU(MemArg),
+    I64AtomicRmw32OrU(MemArg),
+    I32AtomicRmwXor(MemArg),
+    I64AtomicRmwXor(MemArg),
+    I32AtomicRmw8XorU(MemArg),
+    I32AtomicRmw16XorU(MemArg),
+    I64AtomicRmw8XorU(MemArg),
+    I64AtomicRmw16XorU(MemArg),
+    I64AtomicRmw32XorU(MemArg),
+    I32AtomicRmwXchg(MemArg),
+    I64AtomicRmwXchg(MemArg),
+    I32AtomicRmw8XchgU(MemArg),
+    I32AtomicRmw16XchgU(MemArg),
+    I64AtomicRmw8XchgU(MemArg),
+    I64AtomicRmw16XchgU(MemArg),
+    I64AtomicRmw32XchgU(MemArg),
+    I32AtomicRmwCmpxchg(MemArg),
+    I64AtomicRmwCmpxchg(MemArg),
+    I32AtomicRmw8CmpxchgU(MemArg),
+    I32AtomicRmw16CmpxchgU(MemArg),
+    I64AtomicRmw8CmpxchgU(MemArg),
+    I64AtomicRmw16CmpxchgU(MemArg),
+    I64AtomicRmw32CmpxchgU(MemArg),
 }
 
 impl Encode for Instruction<'_> {
@@ -949,11 +949,11 @@ impl Encode for Instruction<'_> {
                 sink.push(0x24);
                 g.encode(sink);
             }
-            Instruction::TableGet { table } => {
+            Instruction::TableGet(table) => {
                 sink.push(0x25);
                 table.encode(sink);
             }
-            Instruction::TableSet { table } => {
+            Instruction::TableSet(table) => {
                 sink.push(0x26);
                 table.encode(sink);
             }
@@ -975,43 +975,43 @@ impl Encode for Instruction<'_> {
                 sink.push(0x2B);
                 m.encode(sink);
             }
-            Instruction::I32Load8_S(m) => {
+            Instruction::I32Load8S(m) => {
                 sink.push(0x2C);
                 m.encode(sink);
             }
-            Instruction::I32Load8_U(m) => {
+            Instruction::I32Load8U(m) => {
                 sink.push(0x2D);
                 m.encode(sink);
             }
-            Instruction::I32Load16_S(m) => {
+            Instruction::I32Load16S(m) => {
                 sink.push(0x2E);
                 m.encode(sink);
             }
-            Instruction::I32Load16_U(m) => {
+            Instruction::I32Load16U(m) => {
                 sink.push(0x2F);
                 m.encode(sink);
             }
-            Instruction::I64Load8_S(m) => {
+            Instruction::I64Load8S(m) => {
                 sink.push(0x30);
                 m.encode(sink);
             }
-            Instruction::I64Load8_U(m) => {
+            Instruction::I64Load8U(m) => {
                 sink.push(0x31);
                 m.encode(sink);
             }
-            Instruction::I64Load16_S(m) => {
+            Instruction::I64Load16S(m) => {
                 sink.push(0x32);
                 m.encode(sink);
             }
-            Instruction::I64Load16_U(m) => {
+            Instruction::I64Load16U(m) => {
                 sink.push(0x33);
                 m.encode(sink);
             }
-            Instruction::I64Load32_S(m) => {
+            Instruction::I64Load32S(m) => {
                 sink.push(0x34);
                 m.encode(sink);
             }
-            Instruction::I64Load32_U(m) => {
+            Instruction::I64Load32U(m) => {
                 sink.push(0x35);
                 m.encode(sink);
             }
@@ -1059,10 +1059,10 @@ impl Encode for Instruction<'_> {
                 sink.push(0x40);
                 i.encode(sink);
             }
-            Instruction::MemoryInit { mem, data } => {
+            Instruction::MemoryInit { mem, segment } => {
                 sink.push(0xfc);
                 sink.push(0x08);
-                data.encode(sink);
+                segment.encode(sink);
                 mem.encode(sink);
             }
             Instruction::DataDrop(data) => {
@@ -1070,11 +1070,11 @@ impl Encode for Instruction<'_> {
                 sink.push(0x09);
                 data.encode(sink);
             }
-            Instruction::MemoryCopy { src, dst } => {
+            Instruction::MemoryCopy { src_mem, dst_mem } => {
                 sink.push(0xfc);
                 sink.push(0x0a);
-                dst.encode(sink);
-                src.encode(sink);
+                dst_mem.encode(sink);
+                src_mem.encode(sink);
             }
             Instruction::MemoryFill(mem) => {
                 sink.push(0xfc);
@@ -1281,90 +1281,93 @@ impl Encode for Instruction<'_> {
                 segment.encode(sink);
                 table.encode(sink);
             }
-            Instruction::ElemDrop { segment } => {
+            Instruction::ElemDrop(segment) => {
                 sink.push(0xfc);
                 sink.push(0x0d);
                 segment.encode(sink);
             }
-            Instruction::TableCopy { src, dst } => {
+            Instruction::TableCopy {
+                src_table,
+                dst_table,
+            } => {
                 sink.push(0xfc);
                 sink.push(0x0e);
-                dst.encode(sink);
-                src.encode(sink);
+                dst_table.encode(sink);
+                src_table.encode(sink);
             }
-            Instruction::TableGrow { table } => {
+            Instruction::TableGrow(table) => {
                 sink.push(0xfc);
                 sink.push(0x0f);
                 table.encode(sink);
             }
-            Instruction::TableSize { table } => {
+            Instruction::TableSize(table) => {
                 sink.push(0xfc);
                 sink.push(0x10);
                 table.encode(sink);
             }
-            Instruction::TableFill { table } => {
+            Instruction::TableFill(table) => {
                 sink.push(0xfc);
                 sink.push(0x11);
                 table.encode(sink);
             }
 
             // SIMD instructions.
-            Instruction::V128Load { memarg } => {
+            Instruction::V128Load(memarg) => {
                 sink.push(0xFD);
                 0x00u32.encode(sink);
                 memarg.encode(sink);
             }
-            Instruction::V128Load8x8S { memarg } => {
+            Instruction::V128Load8x8S(memarg) => {
                 sink.push(0xFD);
                 0x01u32.encode(sink);
                 memarg.encode(sink);
             }
-            Instruction::V128Load8x8U { memarg } => {
+            Instruction::V128Load8x8U(memarg) => {
                 sink.push(0xFD);
                 0x02u32.encode(sink);
                 memarg.encode(sink);
             }
-            Instruction::V128Load16x4S { memarg } => {
+            Instruction::V128Load16x4S(memarg) => {
                 sink.push(0xFD);
                 0x03u32.encode(sink);
                 memarg.encode(sink);
             }
-            Instruction::V128Load16x4U { memarg } => {
+            Instruction::V128Load16x4U(memarg) => {
                 sink.push(0xFD);
                 0x04u32.encode(sink);
                 memarg.encode(sink);
             }
-            Instruction::V128Load32x2S { memarg } => {
+            Instruction::V128Load32x2S(memarg) => {
                 sink.push(0xFD);
                 0x05u32.encode(sink);
                 memarg.encode(sink);
             }
-            Instruction::V128Load32x2U { memarg } => {
+            Instruction::V128Load32x2U(memarg) => {
                 sink.push(0xFD);
                 0x06u32.encode(sink);
                 memarg.encode(sink);
             }
-            Instruction::V128Load8Splat { memarg } => {
+            Instruction::V128Load8Splat(memarg) => {
                 sink.push(0xFD);
                 0x07u32.encode(sink);
                 memarg.encode(sink);
             }
-            Instruction::V128Load16Splat { memarg } => {
+            Instruction::V128Load16Splat(memarg) => {
                 sink.push(0xFD);
                 0x08u32.encode(sink);
                 memarg.encode(sink);
             }
-            Instruction::V128Load32Splat { memarg } => {
+            Instruction::V128Load32Splat(memarg) => {
                 sink.push(0xFD);
                 0x09u32.encode(sink);
                 memarg.encode(sink);
             }
-            Instruction::V128Load64Splat { memarg } => {
+            Instruction::V128Load64Splat(memarg) => {
                 sink.push(0xFD);
                 0x0Au32.encode(sink);
                 memarg.encode(sink);
             }
-            Instruction::V128Store { memarg } => {
+            Instruction::V128Store(memarg) => {
                 sink.push(0xFD);
                 0x0Bu32.encode(sink);
                 memarg.encode(sink);
@@ -1374,7 +1377,7 @@ impl Encode for Instruction<'_> {
                 0x0Cu32.encode(sink);
                 sink.extend(x.to_le_bytes().iter().copied());
             }
-            Instruction::I8x16Shuffle { lanes } => {
+            Instruction::I8x16Shuffle(lanes) => {
                 sink.push(0xFD);
                 0x0Du32.encode(sink);
                 assert!(lanes.iter().all(|l: &u8| *l < 32));
@@ -1408,85 +1411,85 @@ impl Encode for Instruction<'_> {
                 sink.push(0xFD);
                 0x14u32.encode(sink);
             }
-            Instruction::I8x16ExtractLaneS { lane } => {
+            Instruction::I8x16ExtractLaneS(lane) => {
                 sink.push(0xFD);
                 0x15u32.encode(sink);
                 assert!(lane < 16);
                 sink.push(lane);
             }
-            Instruction::I8x16ExtractLaneU { lane } => {
+            Instruction::I8x16ExtractLaneU(lane) => {
                 sink.push(0xFD);
                 0x16u32.encode(sink);
                 assert!(lane < 16);
                 sink.push(lane);
             }
-            Instruction::I8x16ReplaceLane { lane } => {
+            Instruction::I8x16ReplaceLane(lane) => {
                 sink.push(0xFD);
                 0x17u32.encode(sink);
                 assert!(lane < 16);
                 sink.push(lane);
             }
-            Instruction::I16x8ExtractLaneS { lane } => {
+            Instruction::I16x8ExtractLaneS(lane) => {
                 sink.push(0xFD);
                 0x18u32.encode(sink);
                 assert!(lane < 8);
                 sink.push(lane);
             }
-            Instruction::I16x8ExtractLaneU { lane } => {
+            Instruction::I16x8ExtractLaneU(lane) => {
                 sink.push(0xFD);
                 0x19u32.encode(sink);
                 assert!(lane < 8);
                 sink.push(lane);
             }
-            Instruction::I16x8ReplaceLane { lane } => {
+            Instruction::I16x8ReplaceLane(lane) => {
                 sink.push(0xFD);
                 0x1Au32.encode(sink);
                 assert!(lane < 8);
                 sink.push(lane);
             }
-            Instruction::I32x4ExtractLane { lane } => {
+            Instruction::I32x4ExtractLane(lane) => {
                 sink.push(0xFD);
                 0x1Bu32.encode(sink);
                 assert!(lane < 4);
                 sink.push(lane);
             }
-            Instruction::I32x4ReplaceLane { lane } => {
+            Instruction::I32x4ReplaceLane(lane) => {
                 sink.push(0xFD);
                 0x1Cu32.encode(sink);
                 assert!(lane < 4);
                 sink.push(lane);
             }
-            Instruction::I64x2ExtractLane { lane } => {
+            Instruction::I64x2ExtractLane(lane) => {
                 sink.push(0xFD);
                 0x1Du32.encode(sink);
                 assert!(lane < 2);
                 sink.push(lane);
             }
-            Instruction::I64x2ReplaceLane { lane } => {
+            Instruction::I64x2ReplaceLane(lane) => {
                 sink.push(0xFD);
                 0x1Eu32.encode(sink);
                 assert!(lane < 2);
                 sink.push(lane);
             }
-            Instruction::F32x4ExtractLane { lane } => {
+            Instruction::F32x4ExtractLane(lane) => {
                 sink.push(0xFD);
                 0x1Fu32.encode(sink);
                 assert!(lane < 4);
                 sink.push(lane);
             }
-            Instruction::F32x4ReplaceLane { lane } => {
+            Instruction::F32x4ReplaceLane(lane) => {
                 sink.push(0xFD);
                 0x20u32.encode(sink);
                 assert!(lane < 4);
                 sink.push(lane);
             }
-            Instruction::F64x2ExtractLane { lane } => {
+            Instruction::F64x2ExtractLane(lane) => {
                 sink.push(0xFD);
                 0x21u32.encode(sink);
                 assert!(lane < 2);
                 sink.push(lane);
             }
-            Instruction::F64x2ReplaceLane { lane } => {
+            Instruction::F64x2ReplaceLane(lane) => {
                 sink.push(0xFD);
                 0x22u32.encode(sink);
                 assert!(lane < 2);
@@ -2233,12 +2236,12 @@ impl Encode for Instruction<'_> {
                 sink.push(0xFD);
                 0x5Fu32.encode(sink);
             }
-            Instruction::V128Load32Zero { memarg } => {
+            Instruction::V128Load32Zero(memarg) => {
                 sink.push(0xFD);
                 0x5Cu32.encode(sink);
                 memarg.encode(sink);
             }
-            Instruction::V128Load64Zero { memarg } => {
+            Instruction::V128Load64Zero(memarg) => {
                 sink.push(0xFD);
                 0x5Du32.encode(sink);
                 memarg.encode(sink);
@@ -2409,17 +2412,17 @@ impl Encode for Instruction<'_> {
             }
 
             // Atmoic instructions from the thread proposal
-            Instruction::MemoryAtomicNotify { memarg } => {
+            Instruction::MemoryAtomicNotify(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x00);
                 memarg.encode(sink);
             }
-            Instruction::MemoryAtomicWait32 { memarg } => {
+            Instruction::MemoryAtomicWait32(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x01);
                 memarg.encode(sink);
             }
-            Instruction::MemoryAtomicWait64 { memarg } => {
+            Instruction::MemoryAtomicWait64(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x02);
                 memarg.encode(sink);
@@ -2429,317 +2432,317 @@ impl Encode for Instruction<'_> {
                 sink.push(0x03);
                 sink.push(0x00);
             }
-            Instruction::I32AtomicLoad { memarg } => {
+            Instruction::I32AtomicLoad(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x10);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicLoad { memarg } => {
+            Instruction::I64AtomicLoad(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x11);
                 memarg.encode(sink);
             }
-            Instruction::I32AtomicLoad8U { memarg } => {
+            Instruction::I32AtomicLoad8U(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x12);
                 memarg.encode(sink);
             }
-            Instruction::I32AtomicLoad16U { memarg } => {
+            Instruction::I32AtomicLoad16U(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x13);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicLoad8U { memarg } => {
+            Instruction::I64AtomicLoad8U(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x14);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicLoad16U { memarg } => {
+            Instruction::I64AtomicLoad16U(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x15);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicLoad32U { memarg } => {
+            Instruction::I64AtomicLoad32U(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x16);
                 memarg.encode(sink);
             }
-            Instruction::I32AtomicStore { memarg } => {
+            Instruction::I32AtomicStore(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x17);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicStore { memarg } => {
+            Instruction::I64AtomicStore(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x18);
                 memarg.encode(sink);
             }
-            Instruction::I32AtomicStore8 { memarg } => {
+            Instruction::I32AtomicStore8(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x19);
                 memarg.encode(sink);
             }
-            Instruction::I32AtomicStore16 { memarg } => {
+            Instruction::I32AtomicStore16(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x1A);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicStore8 { memarg } => {
+            Instruction::I64AtomicStore8(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x1B);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicStore16 { memarg } => {
+            Instruction::I64AtomicStore16(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x1C);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicStore32 { memarg } => {
+            Instruction::I64AtomicStore32(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x1D);
                 memarg.encode(sink);
             }
-            Instruction::I32AtomicRmwAdd { memarg } => {
+            Instruction::I32AtomicRmwAdd(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x1E);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicRmwAdd { memarg } => {
+            Instruction::I64AtomicRmwAdd(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x1F);
                 memarg.encode(sink);
             }
-            Instruction::I32AtomicRmw8AddU { memarg } => {
+            Instruction::I32AtomicRmw8AddU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x20);
                 memarg.encode(sink);
             }
-            Instruction::I32AtomicRmw16AddU { memarg } => {
+            Instruction::I32AtomicRmw16AddU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x21);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicRmw8AddU { memarg } => {
+            Instruction::I64AtomicRmw8AddU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x22);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicRmw16AddU { memarg } => {
+            Instruction::I64AtomicRmw16AddU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x23);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicRmw32AddU { memarg } => {
+            Instruction::I64AtomicRmw32AddU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x24);
                 memarg.encode(sink);
             }
-            Instruction::I32AtomicRmwSub { memarg } => {
+            Instruction::I32AtomicRmwSub(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x25);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicRmwSub { memarg } => {
+            Instruction::I64AtomicRmwSub(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x26);
                 memarg.encode(sink);
             }
-            Instruction::I32AtomicRmw8SubU { memarg } => {
+            Instruction::I32AtomicRmw8SubU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x27);
                 memarg.encode(sink);
             }
-            Instruction::I32AtomicRmw16SubU { memarg } => {
+            Instruction::I32AtomicRmw16SubU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x28);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicRmw8SubU { memarg } => {
+            Instruction::I64AtomicRmw8SubU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x29);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicRmw16SubU { memarg } => {
+            Instruction::I64AtomicRmw16SubU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x2A);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicRmw32SubU { memarg } => {
+            Instruction::I64AtomicRmw32SubU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x2B);
                 memarg.encode(sink);
             }
-            Instruction::I32AtomicRmwAnd { memarg } => {
+            Instruction::I32AtomicRmwAnd(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x2C);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicRmwAnd { memarg } => {
+            Instruction::I64AtomicRmwAnd(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x2D);
                 memarg.encode(sink);
             }
-            Instruction::I32AtomicRmw8AndU { memarg } => {
+            Instruction::I32AtomicRmw8AndU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x2E);
                 memarg.encode(sink);
             }
-            Instruction::I32AtomicRmw16AndU { memarg } => {
+            Instruction::I32AtomicRmw16AndU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x2F);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicRmw8AndU { memarg } => {
+            Instruction::I64AtomicRmw8AndU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x30);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicRmw16AndU { memarg } => {
+            Instruction::I64AtomicRmw16AndU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x31);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicRmw32AndU { memarg } => {
+            Instruction::I64AtomicRmw32AndU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x32);
                 memarg.encode(sink);
             }
-            Instruction::I32AtomicRmwOr { memarg } => {
+            Instruction::I32AtomicRmwOr(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x33);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicRmwOr { memarg } => {
+            Instruction::I64AtomicRmwOr(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x34);
                 memarg.encode(sink);
             }
-            Instruction::I32AtomicRmw8OrU { memarg } => {
+            Instruction::I32AtomicRmw8OrU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x35);
                 memarg.encode(sink);
             }
-            Instruction::I32AtomicRmw16OrU { memarg } => {
+            Instruction::I32AtomicRmw16OrU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x36);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicRmw8OrU { memarg } => {
+            Instruction::I64AtomicRmw8OrU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x37);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicRmw16OrU { memarg } => {
+            Instruction::I64AtomicRmw16OrU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x38);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicRmw32OrU { memarg } => {
+            Instruction::I64AtomicRmw32OrU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x39);
                 memarg.encode(sink);
             }
-            Instruction::I32AtomicRmwXor { memarg } => {
+            Instruction::I32AtomicRmwXor(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x3A);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicRmwXor { memarg } => {
+            Instruction::I64AtomicRmwXor(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x3B);
                 memarg.encode(sink);
             }
-            Instruction::I32AtomicRmw8XorU { memarg } => {
+            Instruction::I32AtomicRmw8XorU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x3C);
                 memarg.encode(sink);
             }
-            Instruction::I32AtomicRmw16XorU { memarg } => {
+            Instruction::I32AtomicRmw16XorU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x3D);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicRmw8XorU { memarg } => {
+            Instruction::I64AtomicRmw8XorU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x3E);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicRmw16XorU { memarg } => {
+            Instruction::I64AtomicRmw16XorU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x3F);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicRmw32XorU { memarg } => {
+            Instruction::I64AtomicRmw32XorU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x40);
                 memarg.encode(sink);
             }
-            Instruction::I32AtomicRmwXchg { memarg } => {
+            Instruction::I32AtomicRmwXchg(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x41);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicRmwXchg { memarg } => {
+            Instruction::I64AtomicRmwXchg(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x42);
                 memarg.encode(sink);
             }
-            Instruction::I32AtomicRmw8XchgU { memarg } => {
+            Instruction::I32AtomicRmw8XchgU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x43);
                 memarg.encode(sink);
             }
-            Instruction::I32AtomicRmw16XchgU { memarg } => {
+            Instruction::I32AtomicRmw16XchgU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x44);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicRmw8XchgU { memarg } => {
+            Instruction::I64AtomicRmw8XchgU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x45);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicRmw16XchgU { memarg } => {
+            Instruction::I64AtomicRmw16XchgU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x46);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicRmw32XchgU { memarg } => {
+            Instruction::I64AtomicRmw32XchgU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x47);
                 memarg.encode(sink);
             }
-            Instruction::I32AtomicRmwCmpxchg { memarg } => {
+            Instruction::I32AtomicRmwCmpxchg(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x48);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicRmwCmpxchg { memarg } => {
+            Instruction::I64AtomicRmwCmpxchg(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x49);
                 memarg.encode(sink);
             }
-            Instruction::I32AtomicRmw8CmpxchgU { memarg } => {
+            Instruction::I32AtomicRmw8CmpxchgU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x4A);
                 memarg.encode(sink);
             }
-            Instruction::I32AtomicRmw16CmpxchgU { memarg } => {
+            Instruction::I32AtomicRmw16CmpxchgU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x4B);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicRmw8CmpxchgU { memarg } => {
+            Instruction::I64AtomicRmw8CmpxchgU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x4C);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicRmw16CmpxchgU { memarg } => {
+            Instruction::I64AtomicRmw16CmpxchgU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x4D);
                 memarg.encode(sink);
             }
-            Instruction::I64AtomicRmw32CmpxchgU { memarg } => {
+            Instruction::I64AtomicRmw32CmpxchgU(memarg) => {
                 sink.push(0xFE);
                 sink.push(0x4E);
                 memarg.encode(sink);

--- a/crates/wasmparser/src/lib.rs
+++ b/crates/wasmparser/src/lib.rs
@@ -118,18 +118,18 @@ macro_rules! for_each_operator {
         $mac! {
             @mvp Unreachable => visit_unreachable
             @mvp Nop => visit_nop
-            @mvp Block { ty: $crate::BlockType } => visit_block
-            @mvp Loop { ty: $crate::BlockType } => visit_loop
-            @mvp If { ty: $crate::BlockType } => visit_if
+            @mvp Block { blockty: $crate::BlockType } => visit_block
+            @mvp Loop { blockty: $crate::BlockType } => visit_loop
+            @mvp If { blockty: $crate::BlockType } => visit_if
             @mvp Else => visit_else
-            @exceptions Try { ty: $crate::BlockType } => visit_try
+            @exceptions Try { blockty: $crate::BlockType } => visit_try
             @exceptions Catch { tag_index: u32 } => visit_catch
             @exceptions Throw { tag_index: u32 } => visit_throw
             @exceptions Rethrow { relative_depth: u32 } => visit_rethrow
             @mvp End => visit_end
             @mvp Br { relative_depth: u32 } => visit_br
             @mvp BrIf { relative_depth: u32 } => visit_br_if
-            @mvp BrTable { table: $crate::BrTable<'a> } => visit_br_table
+            @mvp BrTable { targets: $crate::BrTable<'a> } => visit_br_table
             @mvp Return => visit_return
             @mvp Call { function_index: u32 } => visit_call
             @mvp CallIndirect { type_index: u32, table_index: u32, table_byte: u8 } => visit_call_indirect
@@ -321,7 +321,7 @@ macro_rules! for_each_operator {
             // bulk memory https://github.com/WebAssembly/bulk-memory-operations/blob/master/proposals/bulk-memory-operations/Overview.md
             @bulk_memory MemoryInit { segment: u32, mem: u32 } => visit_memory_init
             @bulk_memory DataDrop { segment: u32 } => visit_data_drop
-            @bulk_memory MemoryCopy { dst: u32, src: u32 } => visit_memory_copy
+            @bulk_memory MemoryCopy { dst_mem: u32, src_mem: u32 } => visit_memory_copy
             @bulk_memory MemoryFill { mem: u32 } => visit_memory_fill
             @bulk_memory TableInit { segment: u32, table: u32 } => visit_table_init
             @bulk_memory ElemDrop { segment: u32 } => visit_elem_drop


### PR DESCRIPTION
I recently implemented a library which will translate from `wasmparser` instructions to `wasm-encoder` instructions using the `for_each_instruction!` macro to make it easier to convert between the two. This PR represents some updates to make the process easier such as:

* Renames instruction variants to match in both `wasmparser` and `wasm-encoder`.
* Changes all single-payload instructions in `wasm-encoder` to uniformly be represented as a tuple enum variant instead of some as a tuple variant and some as a struct variant.
* Changes struct-variant names in `wasm-encoder` to match the names in `wasmparser`.
* Some struct-variant names in `wasmparser` are now more descriptive in isolation, for example `dst_mem` instead of `dst`.

Overall this is mostly stylistic changes but it made writing such a macro much easier. I don't currently plan at this time to land the macro in this repository but as part of the `wit-component` tool it may be destined for this repository eventually which would provide a better check that this is compatible into the future.