### PR TITLE
Leverage Cargo workspace deduplication

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,6 +84,8 @@ jobs:
       - run: cargo check --no-default-features --features mutate
       - run: cargo check --no-default-features --features dump
       - run: cargo check --no-default-features --features objdump
+      - run: cargo check --no-default-features --features strip
+      - run: cargo check --no-default-features --features compose
 
   doc:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wasm-tools"
 version = "1.0.12"
 authors = ["The Wasmtime Project Developers"]
-edition = "2021"
+edition.workspace = true
 description = "CLI tools for interoperating with WebAssembly files"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://github.com/bytecodealliance/wasm-tools"
@@ -13,49 +13,82 @@ readme = "README.md"
 exclude = ['tests/wabt', 'tests/testsuite', 'publish.rs']
 
 [workspace]
-members = ['crates/c-api', 'fuzz', 'crates/wasm-encoder', 'crates/fuzz-stats', 'crates/wasm-mutate-stats']
+members = [
+  'crates/c-api',
+  'crates/fuzz-stats',
+  'crates/wasm-mutate-stats',
+  'fuzz',
+]
+
+[workspace.package]
+edition = '2021'
+
+[workspace.dependencies]
+anyhow = "1.0.58"
+arbitrary = "1.1.0"
+clap = { version = "3.2.7", features = ["derive"] }
+criterion = "0.3.3"
+env_logger = "0.9"
+indexmap = "1.9.1"
+leb128 = "0.2.4"
+libfuzzer-sys = "0.4.0"
+log = "0.4.17"
+num_cpus = "1.13"
+rand = { version = "0.8.4", features = ["small_rng"] }
+rayon = "1.3"
+serde = { version = "1.0.137", features = ["derive"] }
+wasmtime = "1.0.0"
+
+wasm-encoder = { version = "0.18.0", path = "crates/wasm-encoder"}
+wasm-compose = { version = "0.1.3", path = "crates/wasm-compose"}
+wasm-mutate = { version = "0.2.4", path = "crates/wasm-mutate" }
+wasm-shrink = { version = "0.1.6", path = "crates/wasm-shrink" }
+wasm-smith = { version = "0.11.2", path = "crates/wasm-smith" }
+wasmparser = { version = "0.92.0", path = "crates/wasmparser" }
+wasmparser-dump = { version = "0.1.4", path = "crates/dump" }
+wasmprinter = { version = "0.2.36", path = "crates/wasmprinter" }
+wast = { version = "47.0.1", path = "crates/wast" }
+wat = { version = "1.0.44", path = "crates/wat" }
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }
+env_logger = { workspace = true }
 atty = "0.2"
-env_logger = "0.9"
-log = "0.4"
-clap = { version = "3.1.8", features = ['derive'] }
+log = { workspace = true }
+clap = { workspace = true }
 tempfile = "3.2.0"
-wat = { path = "crates/wat", version = '1.0.49' }
+wat = { workspace = true }
 
 # Dependencies of `validate`
-wasmparser = { path = "crates/wasmparser", optional = true, version = '0.92.0' }
-rayon = { version = "1.0", optional = true }
+wasmparser = { workspace = true, optional = true }
+rayon = { workspace = true, optional = true }
 
 # Dependencies of `print`
-wasmprinter = { path = "crates/wasmprinter", version = '0.2.41' }
+wasmprinter = { workspace = true }
 
 # Dependencies of `smith`
-arbitrary = { version = "1.0.0", optional = true }
-serde = { version = "1", features = ['derive'], optional = true }
+arbitrary = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
 serde_json = { version = "1", optional = true }
-wasm-smith = { path = "crates/wasm-smith", features = ["_internal_cli"], optional = true, version = '0.11.6' }
+wasm-smith = { workspace = true, features = ["_internal_cli"], optional = true }
 
 # Dependencies of `shrink`
-wasm-shrink = { path = "crates/wasm-shrink", features = ["clap"], optional = true, version = '0.1.11' }
+wasm-shrink = { workspace = true, features = ["clap"], optional = true }
 is_executable = { version = "1.0.1", optional = true }
 
 # Dependencies of `mutate`
-wasm-mutate = { path = "crates/wasm-mutate", features = ["clap"], optional = true, version = '0.2.9' }
+wasm-mutate = { workspace = true, features = ["clap"], optional = true }
 
 # Dependencies of `dump`
-wasmparser-dump = { path = "crates/dump", optional = true, version = '0.1.9' }
+wasmparser-dump = { workspace = true, optional = true }
 
 # Dependencies of `strip`
-wasm-encoder = { path = "crates/wasm-encoder", optional = true, version = '0.18.0' }
+wasm-encoder = { workspace = true, optional = true }
 
 # Dependencies of `compose`
-wasm-compose = { path = "crates/wasm-compose", optional = true, version = '0.1.3', features = ['cli'] }
+wasm-compose = { workspace = true, optional = true, features = ['cli'] }
 
 [dev-dependencies]
-anyhow = "1.0"
-getopts = "0.2"
 serde_json = "1.0"
 tempfile = "3.1"
 diff = "0.1"
@@ -83,5 +116,5 @@ shrink = ['wasm-shrink', 'is_executable']
 mutate = ['wasm-mutate']
 dump = ['wasmparser-dump']
 objdump = ['wasmparser']
-strip = ['wasm-encoder']
+strip = ['wasm-encoder', 'wasmparser']
 compose = ['wasm-compose']

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -3,7 +3,7 @@ name = "wasm-tools-c-api"
 authors = ["Addison Hart <tgr@tgrcode.com>"]
 categories = ["development-tools", "development-tools::testing", "wasm"]
 description = "C API to expose wasm-tools"
-edition = "2021"
+edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/c-api"
@@ -18,12 +18,12 @@ test = false
 doctest = false
 
 [dependencies]
-arbitrary = { version = "1.1.0", features = ["derive"] }
-wasmparser-dump = { version = "0.1.4", path = "../dump" }
-wasm-mutate = { version = "0.2.4", path = "../wasm-mutate" }
-wasm-shrink = { version = "0.1.6", path = "../wasm-shrink" }
-wasm-smith = { version = "0.11.2", path = "../wasm-smith" }
-wasmparser = { version = "0.92.0", path = "../wasmparser" }
-wasmprinter = { version = "0.2.36", path = "../wasmprinter" }
-wast = { version = "47.0.1", path = "../wast" }
-wat = { version = "1.0.44", path = "../wat" }
+arbitrary = { workspace = true, features = ["derive"] }
+wasmparser-dump = { workspace = true }
+wasm-mutate = { workspace = true }
+wasm-shrink = { workspace = true }
+wasm-smith = { workspace = true }
+wasmparser = { workspace = true }
+wasmprinter = { workspace = true }
+wast = { workspace = true }
+wat = { workspace = true }

--- a/crates/dump/Cargo.toml
+++ b/crates/dump/Cargo.toml
@@ -2,11 +2,11 @@
 name = "wasmparser-dump"
 version = "0.1.9"
 authors = ["The Wasmtime Project Developers"]
-edition = "2021"
+edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/dump"
 description = "Utility to dump debug information about the wasm binary format"
 
 [dependencies]
-anyhow = "1"
-wasmparser = { path = "../wasmparser", version = "0.92.0" }
+anyhow = { workspace = true }
+wasmparser = { workspace = true }

--- a/crates/fuzz-stats/Cargo.toml
+++ b/crates/fuzz-stats/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "fuzz-stats"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]
-anyhow = "1.0"
-arbitrary = "1.0"
-num_cpus = "1.13"
-rand = "0.8"
-wasm-smith = { path = '../wasm-smith' }
-wasmtime = "0.38.1"
+anyhow = { workspace = true }
+arbitrary = { workspace = true }
+num_cpus = { workspace = true }
+rand = { workspace = true }
+wasm-smith = { workspace = true }
+wasmtime = { workspace = true }
 
 [lib]
 doctest = false

--- a/crates/wasm-compose/Cargo.toml
+++ b/crates/wasm-compose/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wasm-compose"
 version = "0.1.3"
-edition = "2021"
+edition.workspace = true
 authors = ["Peter Huene <peter@huene.dev>"]
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
@@ -11,16 +11,16 @@ documentation = "https://docs.rs/wasm-compose"
 description = "A library for composing WebAssembly components."
 
 [dependencies]
-wat = { version = "1.0.49", path = "../wat" }
-wasm-encoder = { version = "0.18.0", path = "../wasm-encoder" }
-wasmparser = { version = "0.92.0", path = "../wasmparser" }
-indexmap = { version = "1.9.1", features = ["serde"] }
-anyhow = "1.0.58"
-serde = { version = "1.0.137", features = ["derive"] }
+wat = { workspace = true }
+wasm-encoder = { workspace = true }
+wasmparser = { workspace = true }
+indexmap = { workspace = true, features = ["serde"] }
+anyhow = { workspace = true }
+serde = { workspace = true }
 petgraph = "0.6.2"
-log = "0.4.17"
+log = { workspace = true }
 serde_yaml = "0.8.26"
-clap = { version = "3.2.7", features = ["derive"], optional = true }
+clap = { workspace = true, optional = true }
 
 [features]
 default = []
@@ -29,4 +29,4 @@ cli = ["clap"]
 [dev-dependencies]
 glob = "0.3.0"
 pretty_assertions = "1.2.1"
-wasmprinter = { version = "0.2.41", path = "../wasmprinter" }
+wasmprinter = { workspace = true }

--- a/crates/wasm-encoder/Cargo.toml
+++ b/crates/wasm-encoder/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wasm-encoder"
 version = "0.18.0"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
-edition = "2021"
+edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-encoder"
@@ -13,9 +13,9 @@ A low-level WebAssembly encoder.
 """
 
 [dependencies]
-leb128 = "0.2.4"
+leb128 = { workspace = true }
 
 [dev-dependencies]
-anyhow = "1.0.38"
+anyhow = { workspace = true }
 tempfile = "3.2.0"
 wasmparser = { path = "../wasmparser" }

--- a/crates/wasm-mutate-stats/Cargo.toml
+++ b/crates/wasm-mutate-stats/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "wasm-mutate-stats"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 publish = false
 
 [dependencies]
-anyhow = "1.0"
-arbitrary = "1.0"
-num_cpus = "1.13"
-rand = { version = "0.8.0", features = ["small_rng"] }
-wasm-mutate = { path = '../wasm-mutate' }
-wasmprinter = { path = '../wasmprinter' }
-wasmparser = { path = "../wasmparser" }
-wasmtime = "0.38.1"
-env_logger = "0.9"
+anyhow = { workspace = true }
+arbitrary = { workspace = true }
+num_cpus = { workspace = true }
+rand = { workspace = true }
+wasm-mutate = { workspace = true }
+wasmprinter = { workspace = true }
+wasmparser = { workspace = true }
+wasmtime = { workspace = true }
+env_logger = { workspace = true }
 itertools = "0.10.0"
-clap = { version = "3.0", features = ['derive'] }
-log = "0.4"
+clap = { workspace = true }
+log = { workspace = true }
 
 [lib]
 doctest = false

--- a/crates/wasm-mutate/Cargo.toml
+++ b/crates/wasm-mutate/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
 name = "wasm-mutate"
 version = "0.2.9"
-edition = "2021"
+edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-mutate"
 description = "A WebAssembly test case mutator"
 
 [dependencies]
-clap = { optional = true, version = "3.0", features = ['derive'] }
+clap = { workspace = true, optional = true }
 thiserror = "1.0.28"
-wasmparser = { version = "0.92.0", path = "../wasmparser" }
-wasm-encoder = { version = "0.18.0", path = "../wasm-encoder"}
-rand = { version = "0.8.0", features = ["small_rng"] }
-log = "0.4.14"
+wasmparser = { workspace = true }
+wasm-encoder = { workspace = true }
+rand = { workspace = true }
+log = { workspace = true }
 egg = "0.6.0"
 
 [dev-dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 wat = { path = "../wat" }
 wasmprinter = { path = "../wasmprinter" }
-env_logger = "0.9"
+env_logger = { workspace = true }

--- a/crates/wasm-shrink/Cargo.toml
+++ b/crates/wasm-shrink/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 categories = ["command-line-utilities", "development-tools", "development-tools::testing", "wasm"]
 description = "A WebAssembly test case shrinker"
-edition = "2021"
+edition.workspace = true
 keywords = ["reducer", "reduce", "bug", "crash"]
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "./README.md"
@@ -11,15 +11,15 @@ name = "wasm-shrink"
 version = "0.1.11"
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 blake3 = "1.2.0"
-log = "0.4"
-rand = { version = "0.8.4", features = ["small_rng"] }
-clap = { version = "3.0", optional = true, features = ['derive'] }
-wasm-mutate = { version = "0.2.9", path = "../wasm-mutate" }
-wasmparser = { version = "0.92.0", path = "../wasmparser" }
+log = { workspace = true }
+rand = { workspace = true }
+clap = { workspace = true, optional = true }
+wasm-mutate = { workspace = true }
+wasmparser = { workspace = true }
 
 [dev-dependencies]
-env_logger = "0.9"
+env_logger = { workspace = true }
 wasmprinter = { path = "../wasmprinter" }
 wat = { path = "../wat" }

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -3,7 +3,7 @@ authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 categories = ["command-line-utilities", "development-tools", "development-tools::testing", "wasm"]
 description = "A WebAssembly test case generator"
 documentation = "https://docs.rs/wasm-smith"
-edition = "2021"
+edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 name = "wasm-smith"
 readme = "./README.md"
@@ -16,18 +16,18 @@ name = "corpus"
 harness = false
 
 [dependencies]
-arbitrary = { version = "1.1.0", features = ["derive"] }
+arbitrary = { workspace = true, features = ["derive"] }
 flagset = "0.4"
-indexmap = "1.6"
-leb128 = "0.2.4"
-serde = { version = "1", features = ['derive'], optional = true }
-wasm-encoder = { version = "0.18.0", path = "../wasm-encoder" }
-wasmparser = { version = "0.92.0", path = "../wasmparser" }
+indexmap = { workspace = true }
+leb128 = { workspace = true }
+serde = { workspace = true, optional = true }
+wasm-encoder = { workspace = true }
+wasmparser = { workspace = true }
 
 [dev-dependencies]
-criterion = "0.3.3"
-libfuzzer-sys = "0.4.0"
-rand = { version = "0.8.0", features = ["small_rng"] }
+criterion = { workspace = true }
+libfuzzer-sys = { workspace = true }
+rand = { workspace = true }
 wasmprinter = { path = "../wasmprinter" }
 wat = { path = "../wat" }
 

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -9,19 +9,18 @@ keywords = ["parser", "WebAssembly", "wasm"]
 description = """
 A simple event-driven library for parsing WebAssembly binary files.
 """
-edition = "2021"
+edition.workspace = true
 exclude = ["benches/*.wasm"]
 
 [dependencies]
-indexmap = "1.8.0"
+indexmap = { workspace = true }
 
 [dev-dependencies]
-anyhow = "1.0"
-criterion = "0.3"
-getopts = "0.2"
+anyhow = { workspace = true }
+criterion = { workspace = true }
 wat = { path = "../wat" }
 wast = { path = "../wast" }
-rayon = "1.3"
+rayon = { workspace = true }
 wasmparser-dump = { path = "../dump" }
 once_cell = "1.13.0"
 

--- a/crates/wasmprinter/Cargo.toml
+++ b/crates/wasmprinter/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wasmprinter"
 version = "0.2.41"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-edition = "2021"
+edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmprinter"
@@ -13,13 +13,12 @@ Rust converter from the WebAssembly binary format to the text format.
 """
 
 [dependencies]
-anyhow = "1.0"
-wasmparser = { path = '../wasmparser', version = '0.92.0' }
+anyhow = { workspace = true }
+wasmparser = { workspace = true }
 
 [dev-dependencies]
 diff = "0.1"
-getopts = "0.2"
-rayon = "1.0"
+rayon = { workspace = true }
 tempfile = "3.0"
 wat = { path = "../wat" }
 wast = { path = "../wast" }

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wast"
 version = "47.0.1"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-edition = "2021"
+edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wast"
@@ -13,14 +13,14 @@ Customizable Rust parsers for the WebAssembly Text formats WAT and WAST
 """
 
 [dependencies]
-leb128 = "0.2"
+leb128 = { workspace = true }
 unicode-width = "0.1.9"
 memchr = "2.4.1"
-wasm-encoder = { version = "0.18.0", path = "../wasm-encoder" }
+wasm-encoder = { workspace = true }
 
 [dev-dependencies]
-anyhow = "1.0"
-rayon = "1.0"
+anyhow = { workspace = true }
+rayon = { workspace = true }
 wasmparser = { path = "../wasmparser" }
 wat = { path = "../wat" }
 

--- a/crates/wat/Cargo.toml
+++ b/crates/wat/Cargo.toml
@@ -2,7 +2,7 @@
 name = "wat"
 version = "1.0.49"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-edition = "2021"
+edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wat"
@@ -13,4 +13,4 @@ Rust parser for the WebAssembly Text format, WAT
 """
 
 [dependencies]
-wast = { path = '../wast', version = '47.0.0' }
+wast = { workspace = true }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -2,23 +2,23 @@
 name = "wasm-tools-fuzz"
 version = "0.0.1"
 publish = false
-edition = "2021"
+edition.workspace = true
 
 [package.metadata]
 cargo-fuzz = true
 
 [dependencies]
-anyhow = "1"
-arbitrary = "1"
-env_logger = "0.9"
-libfuzzer-sys = "0.4.0"
-log = "0.4"
+anyhow = { workspace = true }
+arbitrary = { workspace = true }
+env_logger = { workspace = true }
+libfuzzer-sys = { workspace = true }
+log = { workspace = true }
 tempfile = "3.0"
 wasm-mutate = { path = "../crates/wasm-mutate" }
 wasm-smith = { path = "../crates/wasm-smith" }
 wasmparser = { path = "../crates/wasmparser" }
 wasmprinter = { path = "../crates/wasmprinter" }
-wasmtime = { version = "0.38.1", optional = true }
+wasmtime = { workspace = true, optional = true }
 wast = { path = "../crates/wast" }
 wat = { path = "../crates/wat" }
 


### PR DESCRIPTION
This commit is similar to bytecodealliance/wasmtime#4905 but for this repository's family of crates. The goal here is to reduce the version-complexity of the manifests in this repository by moving dependencies specified in multiple places into the root `Cargo.toml` to only specify versions once. This helps ensure that this family of crates only use one version for all deps and additionally makes bumping versions easier.

This also goes through and updates `edition` markers to all reference the workspace so we can easily update the workspace of all crates in the future as well.