### PR TITLE
Remove the `Cell` for fuel in `wasm-mutate`

### DIFF
--- a/crates/wasm-mutate/src/lib.rs
+++ b/crates/wasm-mutate/src/lib.rs
@@ -26,7 +26,7 @@ use crate::mutators::{
 use info::ModuleInfo;
 use mutators::Mutator;
 use rand::{rngs::SmallRng, Rng, SeedableRng};
-use std::{cell::Cell, sync::Arc};
+use std::sync::Arc;
 
 #[cfg(feature = "clap")]
 use clap::Parser;
@@ -177,7 +177,7 @@ pub struct WasmMutate<'wasm> {
             parse(try_from_str = parse_fuel),
         )
     )]
-    fuel: Cell<u64>,
+    fuel: u64,
 
     /// Only perform size-reducing transformations on the Wasm module. This
     /// allows `wasm-mutate` to be used as a test case reducer.
@@ -197,8 +197,8 @@ pub struct WasmMutate<'wasm> {
 }
 
 #[cfg(feature = "clap")]
-fn parse_fuel(s: &str) -> Result<Cell<u64>, String> {
-    s.parse::<u64>().map(Cell::new).map_err(|s| s.to_string())
+fn parse_fuel(s: &str) -> Result<u64, String> {
+    s.parse::<u64>().map_err(|s| s.to_string())
 }
 
 impl Default for WasmMutate<'_> {
@@ -209,7 +209,7 @@ impl Default for WasmMutate<'_> {
             preserve_semantics: false,
             reduce: false,
             raw_mutate_func: None,
-            fuel: Cell::new(u64::MAX),
+            fuel: u64::MAX,
             rng: None,
             info: None,
         }
@@ -235,7 +235,7 @@ impl<'wasm> WasmMutate<'wasm> {
 
     /// Configure the fuel used during the mutation
     pub fn fuel(&mut self, fuel: u64) -> &mut Self {
-        self.fuel = Cell::new(fuel);
+        self.fuel = fuel;
         self
     }
 
@@ -269,12 +269,12 @@ impl<'wasm> WasmMutate<'wasm> {
         self
     }
 
-    pub(crate) fn consume_fuel(&self, qt: u64) -> Result<()> {
-        if qt > self.fuel.get() {
+    pub(crate) fn consume_fuel(&mut self, qt: u64) -> Result<()> {
+        if qt > self.fuel {
             log::info!("Out of fuel");
             return Err(Error::out_of_fuel());
         }
-        self.fuel.set(self.fuel.get() - qt);
+        self.fuel -= qt;
         Ok(())
     }
 

--- a/crates/wasm-mutate/src/mutators/peephole.rs
+++ b/crates/wasm-mutate/src/mutators/peephole.rs
@@ -272,6 +272,8 @@ impl PeepholeMutator {
                     .map(move |expr| {
                         log::trace!("Yielding expression:\n{}", expr.pretty(60));
 
+                        config.consume_fuel(1)?;
+
                         let mut newfunc = self.copy_locals(reader)?;
                         let needed_resources = Encoder::build_function(
                             config,
@@ -406,7 +408,6 @@ impl PeepholeMutator {
                             },
                         );
 
-                        config.consume_fuel(1)?;
                         Ok(module)
                     })
                     .map_while(|module: Result<Module>| match module {

--- a/crates/wasm-mutate/src/mutators/peephole.rs
+++ b/crates/wasm-mutate/src/mutators/peephole.rs
@@ -36,7 +36,7 @@ use self::{
 use super::{Mutator, OperatorAndByteOffset};
 use crate::{
     module::{map_type, PrimitiveTypeInfo},
-    Error, ModuleInfo, Result, WasmMutate,
+    Error, ErrorKind, ModuleInfo, Result, WasmMutate,
 };
 use egg::{Rewrite, Runner};
 use rand::{prelude::SmallRng, Rng};
@@ -229,8 +229,6 @@ impl PeepholeMutator {
                 // In theory this will return the Id of the operator eterm
                 let root = egraph.add_expr(&start);
                 let startcmp = start.clone();
-                // Since this construction is expensive then more fuel is consumed
-                let config4fuel = config.clone();
 
                 // If the number of nodes in the egraph is not large, then
                 // continue the search
@@ -407,10 +405,15 @@ impl PeepholeMutator {
                                 false
                             },
                         );
+
+                        config.consume_fuel(1)?;
                         Ok(module)
                     })
-                    // Consume fuel for each returned expression and it is expensive
-                    .take_while(move |_| config4fuel.consume_fuel(1).is_ok());
+                    .map_while(|module: Result<Module>| match module {
+                        Ok(module) => Some(Ok(module)),
+                        Err(e) if matches!(e.kind(), ErrorKind::OutOfFuel) => None,
+                        Err(e) => Some(Err(e)),
+                    });
 
                 return Ok(Box::new(iterator));
             }
@@ -633,8 +636,8 @@ mod tests {
                 (type (;0;) (func (result i32)))
                 (func (;0;) (type 0) (result i32)
                   (local i32 i32)
-                  i32.const -1985698784
-                  i32.const 1985698840
+                  i32.const 1697131274
+                  i32.const -1697131218
                   i32.add)
                 (export "exported_func" (func 0)))
             "#,

--- a/crates/wasm-mutate/src/mutators/snip_function.rs
+++ b/crates/wasm-mutate/src/mutators/snip_function.rs
@@ -24,7 +24,8 @@ impl Mutator for SnipMutator {
         let function_to_mutate = config.rng().gen_range(0..count);
         let ftype = config
             .info()
-            .get_functype_idx(function_to_mutate + config.info().num_imported_functions());
+            .get_functype_idx(function_to_mutate + config.info().num_imported_functions())
+            .clone();
 
         for i in 0..count {
             config.consume_fuel(1)?;
@@ -40,7 +41,7 @@ impl Mutator for SnipMutator {
             let locals = vec![];
             let mut f = Function::new(locals);
 
-            match ftype {
+            match &ftype {
                 TypeInfo::Func(t) => {
                     for primitive in t.returns.iter() {
                         match primitive {

--- a/crates/wasm-mutate/tests/tests.rs
+++ b/crates/wasm-mutate/tests/tests.rs
@@ -45,6 +45,7 @@ fn integration_test() {
             Ok(it) => it,
             Err(e) => match e.kind() {
                 ErrorKind::NoMutationsApplicable => continue,
+                ErrorKind::OutOfFuel => break,
                 _ => panic!("{}", e),
             },
         };


### PR DESCRIPTION
This commit removes the `Cell` used in fuel by taking `&mut self` instead of `&self`. Two locations needed to be updated to handle this mutability and weren't too hard to refactor.