### PR TITLE
Add a `-d` flag to `wasm-tools strip`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ wasmparser-dump = { workspace = true, optional = true }
 
 # Dependencies of `strip`
 wasm-encoder = { workspace = true, optional = true }
+regex = { version = "1.6.0", optional = true }
 
 # Dependencies of `compose`
 wasm-compose = { workspace = true, optional = true, features = ['cli'] }
@@ -116,5 +117,5 @@ shrink = ['wasm-shrink', 'is_executable']
 mutate = ['wasm-mutate']
 dump = ['wasmparser-dump']
 objdump = ['wasmparser']
-strip = ['wasm-encoder', 'wasmparser']
+strip = ['wasm-encoder', 'wasmparser', 'regex']
 compose = ['wasm-compose']


### PR DESCRIPTION
No real reason for doing this but when I was thinking about this while ago I figured it would be easy to strip only some sections vs others as opposed to only an all-or-nothing toggle.