### PR TITLE
Update wat/wast READMEs

### DIFF
--- a/crates/wast/README.md
+++ b/crates/wast/README.md
@@ -29,7 +29,7 @@ types to parse anything that looks like a WebAssembly s-expression.
 * Need to parse a `*.wat` file?
 * Need to parse a `*.wast` file?
 * Need to run test suite assertions from the official wasm test suite?
-* Want to write an extension do the WebAssembly text format?
+* Want to write an extension to the WebAssembly text format?
 
 If you'd like to do any of the above this crate might be right for you! You may
 also want to check out the `wat` crate which provides a much more stable

--- a/crates/wat/README.md
+++ b/crates/wat/README.md
@@ -42,16 +42,16 @@ let wat = r#"
 let binary = wat::parse_str(wat)?;
 ```
 
-## Low-level parsing
+## AST Representation
 
-This repository and project also aims to provide low-level parsing support for
-the WAT and WAST formats. Effectively, if you've got an s-expression lookalike
-that you'd like to parse, you should be able to parse it!
+The `wat` crate does not expose an AST as its goal is to provide a
+forever-stable interface against the `wast` crate. Using `wat` is suitable when
+all you want to do is translate from text-to-binary, for example parsing the
+input of a CLI program into the WebAssembly binary format.
 
-The `wat` crate does not support this because it strives to provide strong
-API-level stability guarantees, but the `wast` crate has all the
-low-level details and is the implementation of the `wast` crate. Be sure to
-[check out its `README.md`](../wast/README.md) for more information.
+If instead you're interested in working with the AST of a text file or otherwise
+adding your own parsing to the text format you'll want to take a look at the
+[`wast` crate](../wast/README.md).
 
 ## Stability and WebAssembly Features
 


### PR DESCRIPTION
Clarify a few things in the `wat` README and fix a typo in `wast`.

Closes #797