### PR TITLE
wasm-compose: update example for latest cargo-component.

### DIFF
--- a/crates/wasm-compose/example/middleware/Cargo.toml
+++ b/crates/wasm-compose/example/middleware/Cargo.toml
@@ -12,7 +12,7 @@ wit-bindgen-guest-rust = { git = "https://github.com/bytecodealliance/wit-bindge
 crate-type = ["cdylib"]
 
 [package.metadata.component]
-direct-interface-export = "service"
+direct-export = "service"
 
 [package.metadata.component.imports]
 backend = "../service.wit"

--- a/crates/wasm-compose/example/middleware/src/lib.rs
+++ b/crates/wasm-compose/example/middleware/src/lib.rs
@@ -1,5 +1,8 @@
+use bindings::{
+    backend,
+    service::{Error, Request, Response, Service},
+};
 use flate2::{write::GzEncoder, Compression};
-use service::{Error, Request, Response, Service};
 use std::io::Write;
 
 struct Component;
@@ -50,4 +53,4 @@ impl Service for Component {
     }
 }
 
-service::export!(Component);
+bindings::export!(Component);

--- a/crates/wasm-compose/example/server/Cargo.toml
+++ b/crates/wasm-compose/example/server/Cargo.toml
@@ -9,6 +9,6 @@ async-std = { version = "1.12.0", features = ["attributes"] }
 clap = { version = "3.2.16", features = ["derive"] }
 driftwood = "0.0.6"
 tide = "0.16.0"
-wasmtime = { version = "2.0.0", features = ["component-model"] }
+wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", rev = "b61e678", features = ["component-model"] }
 
 [workspace]

--- a/crates/wasm-compose/example/service/Cargo.toml
+++ b/crates/wasm-compose/example/service/Cargo.toml
@@ -11,7 +11,7 @@ wit-bindgen-guest-rust = { git = "https://github.com/bytecodealliance/wit-bindge
 crate-type = ["cdylib"]
 
 [package.metadata.component]
-direct-interface-export = "service"
+direct-export = "service"
 
 [package.metadata.component.exports]
 service = "../service.wit"

--- a/crates/wasm-compose/example/service/src/lib.rs
+++ b/crates/wasm-compose/example/service/src/lib.rs
@@ -1,4 +1,4 @@
-use service::{Error, Request, Response, Service};
+use bindings::service::{Error, Request, Response, Service};
 use std::str;
 
 struct Component;
@@ -27,4 +27,4 @@ impl Service for Component {
     }
 }
 
-service::export!(Component);
+bindings::export!(Component);


### PR DESCRIPTION
This PR updates the `wasm-compose` example given the latest cargo-component, which itself is based off of the latest out of wasm-tools and wit-bindgen.

The server in the example needed to update to a more recent wasmtime as a result (specifically, one that supports type exports from component/instance types).