### PR TITLE
Simplify API for parsing the name section

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,6 +86,7 @@ jobs:
       - run: cargo check --no-default-features --features objdump
       - run: cargo check --no-default-features --features strip
       - run: cargo check --no-default-features --features compose
+      - run: cargo check --no-default-features --features demangle
 
   doc:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,10 @@ regex = { version = "1.6.0", optional = true }
 # Dependencies of `compose`
 wasm-compose = { workspace = true, optional = true, features = ['cli'] }
 
+# Dependencies of `demangle`
+rustc-demangle = { version = "0.1.21", optional = true }
+cpp_demangle = { version = "0.4.0", optional = true }
+
 [dev-dependencies]
 serde_json = "1.0"
 tempfile = "3.1"
@@ -106,7 +110,19 @@ harness = false
 
 [features]
 # By default, all subcommands are built
-default = ['shrink', 'smith', 'mutate', 'validate', 'print', 'parse', 'dump', 'objdump', 'strip', 'compose']
+default = [
+  'shrink',
+  'smith',
+  'mutate',
+  'validate',
+  'print',
+  'parse',
+  'dump',
+  'objdump',
+  'strip',
+  'compose',
+  'demangle',
+]
 
 # Each subcommand is gated behind a feature and lists the dependencies it needs
 validate = ['wasmparser', 'rayon']
@@ -119,3 +135,4 @@ dump = ['wasmparser-dump']
 objdump = ['wasmparser']
 strip = ['wasm-encoder', 'wasmparser', 'regex']
 compose = ['wasm-compose']
+demangle = ['rustc-demangle', 'cpp_demangle', 'wasmparser', 'wasm-encoder']

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ programmatically as well:
 | Tool | Crate | Description |
 |------|------|------------|
 | `wasm-tools validate` | [wasmparser] | Validate a WebAssembly file |
-| `wasm-tools parser` | [wat] and [wast] | Translate the WebAssembly text format to binary |
+| `wasm-tools parse` | [wat] and [wast] | Translate the WebAssembly text format to binary |
 | `wasm-tools print` | [wasmprinter] | Translate the WebAssembly binary format to text |
 | `wasm-tools smith` | [wasm-smith] | Generate a "random" valid WebAssembly module |
 | `wasm-tools mutate` | [wasm-mutate] | Mutate an input wasm file into a new valid wasm file |
@@ -45,6 +45,8 @@ programmatically as well:
 | `wasm-tools dump` |   | Print debugging information about the binary format |
 | `wasm-tools objdump` |   | Print debugging information about section headers |
 | `wasm-tools strip` |   | Remove custom sections from a WebAssembly file |
+| `wasm-tools demangle` |   | Demangle Rust and C++ symbol names in the `name` section |
+| `wasm-tools compose` |   | Compose wasm components together |
 
 [wasmparser]: https://crates.io/crates/wasmparser
 [wat]: https://crates.io/crates/wat

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -2110,23 +2110,6 @@ impl<'a> BinaryReader<'a> {
         self.read_u32()
     }
 
-    pub(crate) fn read_name_type(&mut self) -> Result<NameType> {
-        let code = self.read_u7()?;
-        match code {
-            0 => Ok(NameType::Module),
-            1 => Ok(NameType::Function),
-            2 => Ok(NameType::Local),
-            3 => Ok(NameType::Label),
-            4 => Ok(NameType::Type),
-            5 => Ok(NameType::Table),
-            6 => Ok(NameType::Memory),
-            7 => Ok(NameType::Global),
-            8 => Ok(NameType::Element),
-            9 => Ok(NameType::Data),
-            _ => Ok(NameType::Unknown(code)),
-        }
-    }
-
     pub(crate) fn read_linking_type(&mut self) -> Result<LinkingType> {
         let ty = self.read_var_u32()?;
         Ok(match ty {

--- a/fuzz/fuzz_targets/roundtrip.rs
+++ b/fuzz/fuzz_targets/roundtrip.rs
@@ -68,9 +68,7 @@ fn validate_name_section(wasm: &[u8]) -> wasmparser::Result<()> {
         };
         for section in reader {
             match section? {
-                Name::Module(n) => {
-                    n.get_name()?;
-                }
+                Name::Module { .. } => {}
                 Name::Function(n)
                 | Name::Type(n)
                 | Name::Table(n)
@@ -78,18 +76,14 @@ fn validate_name_section(wasm: &[u8]) -> wasmparser::Result<()> {
                 | Name::Global(n)
                 | Name::Element(n)
                 | Name::Data(n) => {
-                    let mut map = n.get_map()?;
-                    for _ in 0..map.get_count() {
-                        map.read()?;
+                    for name in n {
+                        name?;
                     }
                 }
                 Name::Local(n) | Name::Label(n) => {
-                    let mut reader = n.get_indirect_map()?;
-                    for _ in 0..reader.get_indirect_count() {
-                        let local_name = reader.read()?;
-                        let mut map = local_name.get_map()?;
-                        for _ in 0..map.get_count() {
-                            map.read()?;
+                    for name in n {
+                        for name in name?.names {
+                            name?;
                         }
                     }
                 }

--- a/src/bin/wasm-tools/demangle.rs
+++ b/src/bin/wasm-tools/demangle.rs
@@ -1,0 +1,100 @@
+use anyhow::{bail, Result};
+use wasm_encoder::{IndirectNameMap, NameMap, NameSection, RawSection};
+use wasmparser::{Name, NameSectionReader, Parser, Payload::*};
+
+/// Demangle Rust and C++ symbol names in the `name` section.
+///
+/// This command will detect a `name` section in a wasm executable and demangle
+/// any Rust and C++ symbol names found within it. Tooling for debugging a wasm
+/// module which otherwise uses the `name` section but doesn't run a demangler
+/// will use the demangled names since the `name` section will be replaced.
+#[derive(clap::Parser)]
+pub struct Opts {
+    #[clap(flatten)]
+    io: wasm_tools::InputOutput,
+
+    /// Output the text format of WebAssembly instead of the binary format.
+    #[clap(short = 't', long)]
+    wat: bool,
+}
+
+impl Opts {
+    pub fn run(&self) -> Result<()> {
+        let input = self.io.parse_input_wasm()?;
+        let mut module = wasm_encoder::Module::new();
+
+        for payload in Parser::new(0).parse_all(&input) {
+            let payload = payload?;
+            match &payload {
+                CustomSection(c) if c.name() == "name" => {
+                    match self.demangle(c.data(), c.data_offset()) {
+                        Ok(new_section) => {
+                            module.section(&new_section);
+                            continue;
+                        }
+                        Err(e) => log::debug!("error parsing name section {e:?}"),
+                    }
+                }
+                _ => {}
+            }
+            if let Some((id, range)) = payload.as_section() {
+                module.section(&RawSection {
+                    id,
+                    data: &input[range],
+                });
+            }
+        }
+
+        self.io.output(wasm_tools::Output::Wasm {
+            bytes: module.as_slice(),
+            wat: self.wat,
+        })?;
+        Ok(())
+    }
+
+    fn demangle(&self, section: &[u8], offset: usize) -> Result<NameSection> {
+        let mut new_section = NameSection::new();
+        for section in NameSectionReader::new(section, offset)? {
+            match section? {
+                Name::Module { name, .. } => new_section.module(name),
+                Name::Memory(names) => new_section.memories(&self.name_map(names)?),
+                Name::Global(names) => new_section.globals(&self.name_map(names)?),
+                Name::Function(names) => new_section.functions(&self.name_map(names)?),
+                Name::Type(names) => new_section.types(&self.name_map(names)?),
+                Name::Table(names) => new_section.tables(&self.name_map(names)?),
+                Name::Element(names) => new_section.elements(&self.name_map(names)?),
+                Name::Data(names) => new_section.data(&self.name_map(names)?),
+                Name::Local(names) => new_section.locals(&self.indirect_name_map(names)?),
+                Name::Label(names) => new_section.labels(&self.indirect_name_map(names)?),
+                Name::Unknown { .. } => bail!("unknown name section"),
+            }
+        }
+        Ok(new_section)
+    }
+
+    fn name_map(&self, names: wasmparser::NameMap<'_>) -> Result<NameMap> {
+        let mut ret = NameMap::new();
+        for naming in names {
+            let naming = naming?;
+            let name = match rustc_demangle::try_demangle(naming.name) {
+                Ok(name) => name.to_string(),
+                Err(_) => match cpp_demangle::Symbol::new(naming.name) {
+                    Ok(name) => name.to_string(),
+                    Err(_) => naming.name.to_string(),
+                },
+            };
+            ret.append(naming.index, &name);
+        }
+        Ok(ret)
+    }
+
+    fn indirect_name_map(&self, names: wasmparser::IndirectNameMap<'_>) -> Result<IndirectNameMap> {
+        let mut ret = IndirectNameMap::new();
+        for naming in names {
+            let naming = naming?;
+            let map = self.name_map(naming.names)?;
+            ret.append(naming.index, &map);
+        }
+        Ok(ret)
+    }
+}

--- a/src/bin/wasm-tools/main.rs
+++ b/src/bin/wasm-tools/main.rs
@@ -54,6 +54,7 @@ subcommands! {
     (objdump, "objdump")
     (strip, "strip")
     (compose, "compose")
+    (demangle, "demangle")
 }
 
 fn main() -> ExitCode {

--- a/tests/dump/blockty.wat.dump
+++ b/tests/dump/blockty.wat.dump
@@ -37,7 +37,7 @@
  0x43 | 00 12       | custom section
  0x45 | 04 6e 61 6d | name: "name"
       | 65         
- 0x4a | 04 0b       | type names
+ 0x4a | 04 0b       | type section
  0x4c | 02          | 2 count
  0x4d | 00 05 65 6d | Naming { index: 0, name: "empty" }
       | 70 74 79   

--- a/tests/dump/bundled.wat.dump
+++ b/tests/dump/bundled.wat.dump
@@ -90,7 +90,7 @@
     0xd8 | 00 06       | module name
     0xda | 05 43 48 49 | "CHILD"
          | 4c 44      
-    0xe0 | 01 12       | function names
+    0xe0 | 01 12       | function section
     0xe2 | 02          | 2 count
     0xe3 | 00 09 77 61 | Naming { index: 0, name: "wasi-file" }
          | 73 69 2d 66

--- a/tests/dump/names.wat.dump
+++ b/tests/dump/names.wat.dump
@@ -18,12 +18,12 @@
       | 65         
  0x22 | 00 04       | module name
  0x24 | 03 66 6f 6f | "foo"
- 0x28 | 01 04       | function names
+ 0x28 | 01 04       | function section
  0x2a | 01          | 1 count
  0x2b | 00 01 66    | Naming { index: 0, name: "f" }
- 0x2e | 02 09       | local names
+ 0x2e | 02 09       | local section
  0x30 | 01          | 1 count
- 0x31 | 00          | function 0 locals
+ 0x31 | 00          | function 0 local section
  0x32 | 02          | 2 count
  0x33 | 00 01 78    | Naming { index: 0, name: "x" }
  0x36 | 01 01 79    | Naming { index: 1, name: "y" }

--- a/tests/dump/try-delegate.wat.dump
+++ b/tests/dump/try-delegate.wat.dump
@@ -19,8 +19,8 @@
  0x1f | 00 0d       | custom section
  0x21 | 04 6e 61 6d | name: "name"
       | 65         
- 0x26 | 03 06       | label names
+ 0x26 | 03 06       | label section
  0x28 | 01          | 1 count
- 0x29 | 00          | function 0 labels
+ 0x29 | 00          | function 0 label section
  0x2a | 01          | 1 count
  0x2b | 00 01 6c    | Naming { index: 0, name: "l" }


### PR DESCRIPTION
This commit modernizes the API to parse the `name` section in `wasmparser`, notably leveraging existing traits and removing some indirection through extra structures. The intent is to enable iterator-based parsing similar to the rest of parsing items in this crate, meaning the same idioms can be used for the `name` section as all other sections.

At the same time this commit also adds a new subcommand I thought of recently as `wasm-tools demangle` which runs a Rust or C++ demangler over the `name` section. This is almost guaranteed to increase the size of the `name` section but it otherwise might be useful when interacting with tools that don't otherwise demangle names automatically, for example web or JS runtimes.