### PR TITLE
Add Types{,Ref}::{imports,exports} getters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ arbitrary = "1.1.0"
 clap = { version = "4.0.0", features = ["derive"] }
 criterion = "0.3.3"
 env_logger = "0.9"
+hashbrown = { version = "0.12.3", default-features = false }
 indexmap = "1.9.1"
 leb128 = "0.2.4"
 libfuzzer-sys = "0.4.0"

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -14,6 +14,7 @@ exclude = ["benches/*.wasm"]
 
 [dependencies]
 indexmap = { workspace = true }
+hashbrown = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -48,6 +48,7 @@ fn test_validate() {
 mod component;
 mod core;
 mod func;
+mod importmap;
 mod operators;
 pub mod types;
 

--- a/crates/wasmparser/src/validator/importmap.rs
+++ b/crates/wasmparser/src/validator/importmap.rs
@@ -1,0 +1,133 @@
+use super::types::EntityType;
+use hashbrown::raw::RawTable;
+use std::collections::hash_map::RandomState;
+use std::hash::{BuildHasher, Hash, Hasher};
+
+/// An ordered map of the imports of a Wasm module.
+///
+/// It's possible for a Wasm module to have multiple imports with the same module/name pair, since
+/// the Wasm itself only refers to imports by their index. For example, the following is a
+/// perfectly legal module (represented in the [WebAssembly text format]):
+/// ```text
+/// (module
+///   (import "env" "" (func))
+///   (import "env" "" (func (param i32))))
+/// ```
+///
+/// As such, this type provides [`get()`][ImportMap::get] for retrieving the **first** import with
+/// a given module/name pair, as well as an [iterator](ImportMap::iter) that returns each import
+/// entry in the order they were declared in the original module.
+///
+/// [WebAssembly text format]: https://webassembly.github.io/spec/core/text/index.html
+pub struct ImportMap {
+    entries: Vec<(Key, EntityType)>,
+    table: RawTable<usize>,
+    builder: RandomState,
+}
+
+/// (module, name)
+type Key = (String, String);
+
+impl ImportMap {
+    pub(super) fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+            table: RawTable::new(),
+            builder: Default::default(),
+        }
+    }
+
+    fn hash(builder: &RandomState, key: (&str, &str)) -> u64 {
+        // BuildHasher::hash_one once stabilized?
+        let mut hasher = builder.build_hasher();
+        key.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    pub(super) fn add(&mut self, module: String, name: String, entity: EntityType) {
+        let index = self.entries.len();
+        self.entries.push(((module, name), entity));
+        let ((module, name), _) = &self.entries[index];
+
+        if let (hash, None) = self.get_index(module, name) {
+            self.table.insert(hash, index, |&index| {
+                let ((module, name), _) = &self.entries[index];
+                Self::hash(&self.builder, (&**module, &**name))
+            });
+        }
+    }
+
+    fn get_index(&self, module: &str, name: &str) -> (u64, Option<usize>) {
+        let key = (module, name);
+        let hash = Self::hash(&self.builder, key);
+        let index = self.table.get(hash, |&index| {
+            let ((module, name), _) = &self.entries[index];
+            key == (&**module, &**name)
+        });
+        (hash, index.copied())
+    }
+
+    /// Lookup an import given its module and name.
+    ///
+    /// Note that if there were multiple imports with the given module and name, only the first in
+    /// order of its declaration in the imports section will be returned.
+    pub fn get(&self, module: &str, name: &str) -> Option<EntityType> {
+        self.get_index(module, name).1.map(|i| self.entries[i].1)
+    }
+
+    /// Iterate over all the entries in this `ImportMap`.
+    ///
+    /// The iterator returns tuples of the module string, the name string, and the `EntityType` of
+    /// each import.
+    #[inline]
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = (&'_ str, &'_ str, EntityType)> {
+        self.into_iter()
+    }
+
+    /// Returns the total number of imports in the map.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns true if the map holds no imports.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl<'a> IntoIterator for &'a ImportMap {
+    type IntoIter = ImportMapIter<'a>;
+    type Item = <Self::IntoIter as Iterator>::Item;
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        ImportMapIter {
+            inner: self.entries.iter(),
+        }
+    }
+}
+
+/// An iterator over an `ImportMap`. See [`ImportMap::iter()`] for details.
+pub struct ImportMapIter<'a> {
+    inner: std::slice::Iter<'a, (Key, EntityType)>,
+}
+
+impl<'a> Iterator for ImportMapIter<'a> {
+    type Item = (&'a str, &'a str, EntityType);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(|((m, n), e)| (&**m, &**n, *e))
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.len(), Some(self.len()))
+    }
+}
+
+impl ExactSizeIterator for ImportMapIter<'_> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+}

--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -1386,6 +1386,26 @@ impl<'a> TypesRef<'a> {
         }
     }
 
+    /// Gets the imports of this module.
+    ///
+    /// Returns `None` if this is a component.
+    pub fn imports(&self) -> Option<&'a IndexMap<(String, String), Vec<EntityType>>> {
+        match &self.kind {
+            TypesRefKind::Module(module) => Some(&module.imports),
+            TypesRefKind::Component(_) => None,
+        }
+    }
+
+    /// Gets the exports of this module.
+    ///
+    /// Returns `None` if this is a component.
+    pub fn exports(&self) -> Option<&'a IndexMap<String, EntityType>> {
+        match &self.kind {
+            TypesRefKind::Module(module) => Some(&module.exports),
+            TypesRefKind::Component(_) => None,
+        }
+    }
+
     /// Gets the entity type for the given import.
     pub fn entity_type_from_import(&self, import: &Import) -> Option<EntityType> {
         match &self.kind {
@@ -1733,6 +1753,20 @@ impl Types {
             TypesKind::Module(_) => 0,
             TypesKind::Component(component) => component.values.len(),
         }
+    }
+
+    /// Gets the imports of this module.
+    ///
+    /// Returns `None` if this is a component.
+    pub fn imports(&self) -> Option<&IndexMap<(String, String), Vec<EntityType>>> {
+        self.as_ref().imports()
+    }
+
+    /// Gets the exports of this module.
+    ///
+    /// Returns `None` if this is a component.
+    pub fn exports(&self) -> Option<&IndexMap<String, EntityType>> {
+        self.as_ref().exports()
     }
 
     /// Gets the entity type from the given import.

--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -14,6 +14,8 @@ use std::{
     sync::Arc,
 };
 
+pub use super::importmap::{ImportMap, ImportMapIter};
+
 /// The maximum number of parameters in the canonical ABI that can be passed by value.
 ///
 /// Functions that exceed this limit will instead pass parameters indirectly from
@@ -1389,7 +1391,7 @@ impl<'a> TypesRef<'a> {
     /// Gets the imports of this module.
     ///
     /// Returns `None` if this is a component.
-    pub fn imports(&self) -> Option<&'a IndexMap<(String, String), Vec<EntityType>>> {
+    pub fn imports(&self) -> Option<&'a ImportMap> {
         match &self.kind {
             TypesRefKind::Module(module) => Some(&module.imports),
             TypesRefKind::Component(_) => None,
@@ -1758,7 +1760,7 @@ impl Types {
     /// Gets the imports of this module.
     ///
     /// Returns `None` if this is a component.
-    pub fn imports(&self) -> Option<&IndexMap<(String, String), Vec<EntityType>>> {
+    pub fn imports(&self) -> Option<&ImportMap> {
         self.as_ref().imports()
     }
 


### PR DESCRIPTION
I'm not sure if there was a reason this wasn't a thing, but afaict `validator::core::exports::Module::exports/imports` is never accessed to get() at one of their entries, only ever to insert stuff into them. This seems like a missing piece of the API, sorta.
