### PR TITLE
Updates to wast for the GC proposal

### DIFF
--- a/crates/wast/src/core/binary.rs
+++ b/crates/wast/src/core/binary.rs
@@ -238,7 +238,7 @@ impl<'a> Encode for HeapType<'a> {
             HeapType::Extern => e.push(0x6f),
             HeapType::Any => e.push(0x6e),
             HeapType::Eq => e.push(0x6d),
-            HeapType::Data => e.push(0x67),
+            HeapType::Struct => e.push(0x67),
             HeapType::Array => e.push(0x66),
             HeapType::I31 => e.push(0x6a),
             HeapType::Index(index) => {
@@ -266,10 +266,10 @@ impl<'a> Encode for RefType<'a> {
                 nullable: true,
                 heap: HeapType::Eq,
             } => e.push(0x6d),
-            // The 'dataref' binary abbreviation
+            // The 'structref' binary abbreviation
             RefType {
                 nullable: true,
-                heap: HeapType::Data,
+                heap: HeapType::Struct,
             } => e.push(0x67),
             // The 'i31ref' binary abbreviation
             RefType {

--- a/crates/wast/src/core/expr.rs
+++ b/crates/wast/src/core/expr.rs
@@ -606,8 +606,8 @@ instructions! {
         ArrayGetS(Index<'a>) : [0xfb, 0x14] : "array.get_s",
         ArrayGetU(Index<'a>) : [0xfb, 0x15] : "array.get_u",
         ArraySet(Index<'a>) : [0xfb, 0x16] : "array.set",
-        ArrayLen(Index<'a>) : [0xfb, 0x17] : "array.len",
         ArrayCopy(ArrayCopy<'a>) : [0xfb, 0x18] : "array.copy",
+        ArrayLen : [0xfb, 0x19] : "array.len",
 
         // gc proposal, i31
         I31New : [0xfb, 0x20] : "i31.new",
@@ -640,6 +640,10 @@ instructions! {
         BrOnNonData(Index<'a>) : [0xfb, 0x64] : "br_on_non_data",
         BrOnNonI31(Index<'a>) : [0xfb, 0x65] : "br_on_non_i31",
         BrOnNonArray(Index<'a>) : [0xfb, 0x67] : "br_on_non_array",
+
+        // gc proposal extern/any coercion operations
+        ExternInternalize : [0xfb, 0x70] : "extern.internalize",
+        ExternExternalize : [0xfb, 0x71] : "extern.externalize",
 
         I32Const(i32) : [0x41] : "i32.const",
         I64Const(i64) : [0x42] : "i64.const",

--- a/crates/wast/src/core/resolve/names.rs
+++ b/crates/wast/src/core/resolve/names.rs
@@ -587,8 +587,7 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
             }
 
             RefTest(i) | RefCast(i) | StructNew(i) | StructNewDefault(i) | ArrayNew(i)
-            | ArrayNewDefault(i) | ArrayGet(i) | ArrayGetS(i) | ArrayGetU(i) | ArraySet(i)
-            | ArrayLen(i) => {
+            | ArrayNewDefault(i) | ArrayGet(i) | ArrayGetS(i) | ArrayGetU(i) | ArraySet(i) => {
                 self.resolver.resolve(i, Ns::Type)?;
             }
 

--- a/crates/wast/src/core/types.rs
+++ b/crates/wast/src/core/types.rs
@@ -72,8 +72,8 @@ pub enum HeapType<'a> {
     /// A reference that has an identity that can be compared: eqref. This is
     /// part of the GC proposal.
     Eq,
-    /// A reference to a GC object. This is part of the GC proposal.
-    Data,
+    /// A reference to a GC struct. This is part of the GC proposal.
+    Struct,
     /// A reference to a GC array. This is part of the GC proposal.
     Array,
     /// An unboxed 31-bit integer: i31ref. This may be going away if there is no common
@@ -99,9 +99,9 @@ impl<'a> Parse<'a> for HeapType<'a> {
         } else if l.peek::<kw::eq>() {
             parser.parse::<kw::eq>()?;
             Ok(HeapType::Eq)
-        } else if l.peek::<kw::data>() {
-            parser.parse::<kw::data>()?;
-            Ok(HeapType::Data)
+        } else if l.peek::<kw::r#struct>() {
+            parser.parse::<kw::r#struct>()?;
+            Ok(HeapType::Struct)
         } else if l.peek::<kw::array>() {
             parser.parse::<kw::array>()?;
             Ok(HeapType::Array)
@@ -122,7 +122,7 @@ impl<'a> Peek for HeapType<'a> {
             || kw::r#extern::peek(cursor)
             || kw::any::peek(cursor)
             || kw::eq::peek(cursor)
-            || kw::data::peek(cursor)
+            || kw::r#struct::peek(cursor)
             || kw::array::peek(cursor)
             || kw::i31::peek(cursor)
             || (LParen::peek(cursor) && kw::r#type::peek2(cursor))
@@ -173,11 +173,11 @@ impl<'a> RefType<'a> {
         }
     }
 
-    /// An `dataref` as an abbreviation for `(ref null data)`.
-    pub fn data() -> Self {
+    /// An `structref` as an abbreviation for `(ref null struct)`.
+    pub fn r#struct() -> Self {
         RefType {
             nullable: true,
-            heap: HeapType::Data,
+            heap: HeapType::Struct,
         }
     }
 
@@ -216,9 +216,9 @@ impl<'a> Parse<'a> for RefType<'a> {
         } else if l.peek::<kw::eqref>() {
             parser.parse::<kw::eqref>()?;
             Ok(RefType::eq())
-        } else if l.peek::<kw::dataref>() {
-            parser.parse::<kw::dataref>()?;
-            Ok(RefType::data())
+        } else if l.peek::<kw::structref>() {
+            parser.parse::<kw::structref>()?;
+            Ok(RefType::r#struct())
         } else if l.peek::<kw::arrayref>() {
             parser.parse::<kw::arrayref>()?;
             Ok(RefType::array())
@@ -258,7 +258,7 @@ impl<'a> Peek for RefType<'a> {
             || kw::externref::peek(cursor)
             || kw::anyref::peek(cursor)
             || kw::eqref::peek(cursor)
-            || kw::dataref::peek(cursor)
+            || kw::structref::peek(cursor)
             || kw::arrayref::peek(cursor)
             || kw::i31ref::peek(cursor)
             || (LParen::peek(cursor) && kw::r#ref::peek2(cursor))

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -396,7 +396,6 @@ pub mod kw {
     custom_keyword!(code);
     custom_keyword!(component);
     custom_keyword!(data);
-    custom_keyword!(dataref);
     custom_keyword!(declare);
     custom_keyword!(delegate);
     custom_keyword!(r#do = "do");
@@ -461,7 +460,6 @@ pub mod kw {
     custom_keyword!(result);
     custom_keyword!(shared);
     custom_keyword!(start);
-    custom_keyword!(r#struct = "struct");
     custom_keyword!(sub);
     custom_keyword!(table);
     custom_keyword!(then);
@@ -498,6 +496,8 @@ pub mod kw {
     custom_keyword!(string_utf8 = "string-encoding=utf8");
     custom_keyword!(string_utf16 = "string-encoding=utf16");
     custom_keyword!(string_latin1_utf16 = "string-encoding=latin1+utf16");
+    custom_keyword!(r#struct = "struct");
+    custom_keyword!(structref);
     custom_keyword!(realloc);
     custom_keyword!(post_return = "post-return");
     custom_keyword!(with);


### PR DESCRIPTION
Three misc updates that are needed for SpiderMonkey's prototype of the GC proposal.

  1. dataref is gone, there is now structref re-using the binary encoding of datarefr
  2. extern.{internalize, externalize} are new instructions
  3. array.len no longer has a type immediate, and has a new encoding

There are other changes in the latest V8 milestone we're tracking, but we're not ready to support them yet.