### PR TITLE
Implement a `component-name` custom section

### DIFF
--- a/crates/dump/src/lib.rs
+++ b/crates/dump/src/lib.rs
@@ -401,6 +401,14 @@ impl<'a> Dump<'a> {
                         while !iter.eof() {
                             self.print_custom_name_section(iter.read()?, iter.original_position())?;
                         }
+                    } else if c.name() == "component-name" {
+                        let mut iter = ComponentNameSectionReader::new(c.data(), c.data_offset())?;
+                        while !iter.eof() {
+                            self.print_custom_component_name_section(
+                                iter.read()?,
+                                iter.original_position(),
+                            )?;
+                        }
                     } else {
                         self.print_byte_header()?;
                         for _ in 0..NBYTES {
@@ -473,6 +481,39 @@ impl<'a> Dump<'a> {
             Name::Element(n) => self.print_name_map("element", n)?,
             Name::Data(n) => self.print_name_map("data", n)?,
             Name::Unknown { ty, range, .. } => {
+                write!(self.state, "unknown names: {}", ty)?;
+                self.print(range.start)?;
+                self.print(end)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn print_custom_component_name_section(
+        &mut self,
+        name: ComponentName<'_>,
+        end: usize,
+    ) -> Result<()> {
+        match name {
+            ComponentName::Component { name, name_range } => {
+                write!(self.state, "component name")?;
+                self.print(name_range.start)?;
+                write!(self.state, "{:?}", name)?;
+                self.print(name_range.end)?;
+            }
+            ComponentName::CoreFuncs(n) => self.print_name_map("core func", n)?,
+            ComponentName::CoreTables(n) => self.print_name_map("core table", n)?,
+            ComponentName::CoreGlobals(n) => self.print_name_map("core global", n)?,
+            ComponentName::CoreMemories(n) => self.print_name_map("core memory", n)?,
+            ComponentName::CoreInstances(n) => self.print_name_map("core instance", n)?,
+            ComponentName::CoreModules(n) => self.print_name_map("core module", n)?,
+            ComponentName::CoreTypes(n) => self.print_name_map("core type", n)?,
+            ComponentName::Types(n) => self.print_name_map("type", n)?,
+            ComponentName::Instances(n) => self.print_name_map("instance", n)?,
+            ComponentName::Components(n) => self.print_name_map("component", n)?,
+            ComponentName::Funcs(n) => self.print_name_map("func", n)?,
+            ComponentName::Values(n) => self.print_name_map("value", n)?,
+            ComponentName::Unknown { ty, range, .. } => {
                 write!(self.state, "unknown names: {}", ty)?;
                 self.print(range.start)?;
                 self.print(end)?;

--- a/crates/wasm-encoder/src/component.rs
+++ b/crates/wasm-encoder/src/component.rs
@@ -5,6 +5,7 @@ mod exports;
 mod imports;
 mod instances;
 mod modules;
+mod names;
 mod start;
 mod types;
 
@@ -15,6 +16,7 @@ pub use self::exports::*;
 pub use self::imports::*;
 pub use self::instances::*;
 pub use self::modules::*;
+pub use self::names::*;
 pub use self::start::*;
 pub use self::types::*;
 

--- a/crates/wasm-encoder/src/component/names.rs
+++ b/crates/wasm-encoder/src/component/names.rs
@@ -1,0 +1,143 @@
+use super::*;
+use crate::{encoding_size, CustomSection, Encode, ExportKind, NameMap, SectionId};
+
+/// Encoding for the `component-name` custom section which assigns
+/// human-readable names to items within a component.
+#[derive(Clone, Debug, Default)]
+pub struct ComponentNameSection {
+    bytes: Vec<u8>,
+}
+
+enum Subsection {
+    Component,
+    Decls,
+}
+
+impl ComponentNameSection {
+    /// Creates a new blank `name` custom section.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Appends a component name subsection to this section.
+    ///
+    /// This will indicate that the name of the entire component should be the
+    /// `name` specified. Note that this should be encoded first before other
+    /// subsections.
+    pub fn component(&mut self, name: &str) {
+        let len = encoding_size(u32::try_from(name.len()).unwrap());
+        self.subsection_header(Subsection::Component, len + name.len());
+        name.encode(&mut self.bytes);
+    }
+
+    /// Appends a decls name subsection to name core functions within the
+    /// component.
+    pub fn core_funcs(&mut self, names: &NameMap) {
+        self.core_decls(ExportKind::Func as u8, names)
+    }
+
+    /// Appends a decls name subsection to name core tables within the
+    /// component.
+    pub fn core_tables(&mut self, names: &NameMap) {
+        self.core_decls(ExportKind::Table as u8, names)
+    }
+
+    /// Appends a decls name subsection to name core memories within the
+    /// component.
+    pub fn core_memories(&mut self, names: &NameMap) {
+        self.core_decls(ExportKind::Memory as u8, names)
+    }
+
+    /// Appends a decls name subsection to name core globals within the
+    /// component.
+    pub fn core_globals(&mut self, names: &NameMap) {
+        self.core_decls(ExportKind::Global as u8, names)
+    }
+
+    /// Appends a decls name subsection to name core types within the
+    /// component.
+    pub fn core_types(&mut self, names: &NameMap) {
+        self.core_decls(CORE_TYPE_SORT, names)
+    }
+
+    /// Appends a decls name subsection to name core modules within the
+    /// component.
+    pub fn core_modules(&mut self, names: &NameMap) {
+        self.core_decls(CORE_MODULE_SORT, names)
+    }
+
+    /// Appends a decls name subsection to name core instances within the
+    /// component.
+    pub fn core_instances(&mut self, names: &NameMap) {
+        self.core_decls(CORE_INSTANCE_SORT, names)
+    }
+
+    /// Appends a decls name subsection to name component functions within the
+    /// component.
+    pub fn funcs(&mut self, names: &NameMap) {
+        self.component_decls(FUNCTION_SORT, names)
+    }
+
+    /// Appends a decls name subsection to name component values within the
+    /// component.
+    pub fn values(&mut self, names: &NameMap) {
+        self.component_decls(VALUE_SORT, names)
+    }
+
+    /// Appends a decls name subsection to name component type within the
+    /// component.
+    pub fn types(&mut self, names: &NameMap) {
+        self.component_decls(TYPE_SORT, names)
+    }
+
+    /// Appends a decls name subsection to name components within the
+    /// component.
+    pub fn components(&mut self, names: &NameMap) {
+        self.component_decls(COMPONENT_SORT, names)
+    }
+
+    /// Appends a decls name subsection to name component instances within the
+    /// component.
+    pub fn instances(&mut self, names: &NameMap) {
+        self.component_decls(INSTANCE_SORT, names)
+    }
+
+    fn component_decls(&mut self, kind: u8, names: &NameMap) {
+        self.subsection_header(Subsection::Decls, 1 + names.size());
+        self.bytes.push(kind);
+        names.encode(&mut self.bytes);
+    }
+
+    fn core_decls(&mut self, kind: u8, names: &NameMap) {
+        self.subsection_header(Subsection::Decls, 2 + names.size());
+        self.bytes.push(CORE_SORT);
+        self.bytes.push(kind);
+        names.encode(&mut self.bytes);
+    }
+
+    fn subsection_header(&mut self, id: Subsection, len: usize) {
+        self.bytes.push(id as u8);
+        len.encode(&mut self.bytes);
+    }
+
+    /// Returns whether this section is empty, or nothing has been encoded.
+    pub fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
+}
+
+impl Encode for ComponentNameSection {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        CustomSection {
+            name: "component-name",
+            data: &self.bytes,
+        }
+        .encode(sink);
+    }
+}
+
+impl ComponentSection for ComponentNameSection {
+    fn id(&self) -> u8 {
+        SectionId::Custom.into()
+    }
+}

--- a/crates/wasm-encoder/src/core/exports.rs
+++ b/crates/wasm-encoder/src/core/exports.rs
@@ -5,28 +5,23 @@ use crate::{encode_section, Encode, Section, SectionId};
 
 /// Represents the kind of an export from a WebAssembly module.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
 pub enum ExportKind {
     /// The export is a function.
-    Func,
+    Func = CORE_FUNCTION_SORT,
     /// The export is a table.
-    Table,
+    Table = CORE_TABLE_SORT,
     /// The export is a memory.
-    Memory,
+    Memory = CORE_MEMORY_SORT,
     /// The export is a global.
-    Global,
+    Global = CORE_GLOBAL_SORT,
     /// The export is a tag.
-    Tag,
+    Tag = CORE_TAG_SORT,
 }
 
 impl Encode for ExportKind {
     fn encode(&self, sink: &mut Vec<u8>) {
-        sink.push(match self {
-            Self::Func => CORE_FUNCTION_SORT,
-            Self::Table => CORE_TABLE_SORT,
-            Self::Memory => CORE_MEMORY_SORT,
-            Self::Global => CORE_GLOBAL_SORT,
-            Self::Tag => CORE_TAG_SORT,
-        });
+        sink.push(*self as u8);
     }
 }
 

--- a/crates/wasm-encoder/src/core/names.rs
+++ b/crates/wasm-encoder/src/core/names.rs
@@ -199,8 +199,13 @@ impl NameMap {
         self.count += 1;
     }
 
-    fn size(&self) -> usize {
+    pub(crate) fn size(&self) -> usize {
         encoding_size(self.count) + self.bytes.len()
+    }
+
+    /// Returns whether no names have been added to this map.
+    pub fn is_empty(&self) -> bool {
+        self.count == 0
     }
 }
 

--- a/crates/wasmparser/src/readers/component.rs
+++ b/crates/wasmparser/src/readers/component.rs
@@ -3,6 +3,7 @@ mod canonicals;
 mod exports;
 mod imports;
 mod instances;
+mod names;
 mod start;
 mod types;
 
@@ -11,5 +12,6 @@ pub use self::canonicals::*;
 pub use self::exports::*;
 pub use self::imports::*;
 pub use self::instances::*;
+pub use self::names::*;
 pub use self::start::*;
 pub use self::types::*;

--- a/crates/wasmparser/src/readers/component/names.rs
+++ b/crates/wasmparser/src/readers/component/names.rs
@@ -1,0 +1,164 @@
+use crate::{BinaryReader, BinaryReaderError, NameMap, Result, SectionIterator, SectionReader};
+use std::ops::Range;
+
+/// Represents a name read from the names custom section.
+#[derive(Clone)]
+#[allow(missing_docs)]
+pub enum ComponentName<'a> {
+    Component {
+        name: &'a str,
+        name_range: Range<usize>,
+    },
+    CoreFuncs(NameMap<'a>),
+    CoreGlobals(NameMap<'a>),
+    CoreMemories(NameMap<'a>),
+    CoreTables(NameMap<'a>),
+    CoreModules(NameMap<'a>),
+    CoreInstances(NameMap<'a>),
+    CoreTypes(NameMap<'a>),
+    Types(NameMap<'a>),
+    Instances(NameMap<'a>),
+    Components(NameMap<'a>),
+    Funcs(NameMap<'a>),
+    Values(NameMap<'a>),
+
+    /// An unknown [name subsection](https://webassembly.github.io/spec/core/appendix/custom.html#subsections).
+    Unknown {
+        /// The identifier for this subsection.
+        ty: u8,
+        /// The contents of this subsection.
+        data: &'a [u8],
+        /// The range of bytes, relative to the start of the original data
+        /// stream, that the contents of this subsection reside in.
+        range: Range<usize>,
+    },
+}
+
+/// A reader for the name custom section of a WebAssembly module.
+pub struct ComponentNameSectionReader<'a> {
+    reader: BinaryReader<'a>,
+}
+
+impl<'a> ComponentNameSectionReader<'a> {
+    /// Constructs a new `ComponentNameSectionReader` from the given data and offset.
+    pub fn new(data: &'a [u8], offset: usize) -> Result<ComponentNameSectionReader<'a>> {
+        Ok(ComponentNameSectionReader {
+            reader: BinaryReader::new_with_offset(data, offset),
+        })
+    }
+
+    fn verify_section_end(&self, end: usize) -> Result<()> {
+        if self.reader.buffer.len() < end {
+            return Err(BinaryReaderError::new(
+                "component name entry extends past end of the code section",
+                self.reader.original_offset + self.reader.buffer.len(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Determines if the reader is at the end of the section.
+    pub fn eof(&self) -> bool {
+        self.reader.eof()
+    }
+
+    /// Gets the original position of the section reader.
+    pub fn original_position(&self) -> usize {
+        self.reader.original_position()
+    }
+
+    /// Reads a name from the section.
+    pub fn read(&mut self) -> Result<ComponentName<'a>> {
+        let subsection_id = self.reader.read_u7()?;
+        let payload_len = self.reader.read_var_u32()? as usize;
+        let payload_start = self.reader.position;
+        let payload_end = payload_start + payload_len;
+        self.verify_section_end(payload_end)?;
+        let offset = self.reader.original_offset + payload_start;
+        let data = &self.reader.buffer[payload_start..payload_end];
+        self.reader.skip_to(payload_end);
+        let mut reader = BinaryReader::new_with_offset(data, offset);
+
+        Ok(match subsection_id {
+            0 => {
+                let name = reader.read_string()?;
+                if !reader.eof() {
+                    return Err(BinaryReaderError::new(
+                        "trailing data at the end of a name",
+                        reader.original_position(),
+                    ));
+                }
+                ComponentName::Component {
+                    name,
+                    name_range: offset..offset + reader.position,
+                }
+            }
+            1 => {
+                let ctor: fn(NameMap<'a>) -> ComponentName<'a> = match reader.read_u8()? {
+                    0x00 => match reader.read_u8()? {
+                        0x00 => ComponentName::CoreFuncs,
+                        0x01 => ComponentName::CoreTables,
+                        0x02 => ComponentName::CoreMemories,
+                        0x03 => ComponentName::CoreGlobals,
+                        0x10 => ComponentName::CoreTypes,
+                        0x11 => ComponentName::CoreModules,
+                        0x12 => ComponentName::CoreInstances,
+                        _ => {
+                            return Ok(ComponentName::Unknown {
+                                ty: 1,
+                                data,
+                                range: offset..offset + payload_len,
+                            });
+                        }
+                    },
+                    0x01 => ComponentName::Funcs,
+                    0x02 => ComponentName::Values,
+                    0x03 => ComponentName::Types,
+                    0x04 => ComponentName::Components,
+                    0x05 => ComponentName::Instances,
+                    _ => {
+                        return Ok(ComponentName::Unknown {
+                            ty: 1,
+                            data,
+                            range: offset..offset + payload_len,
+                        });
+                    }
+                };
+                ctor(NameMap::new(
+                    reader.remaining_buffer(),
+                    reader.original_position(),
+                )?)
+            }
+            ty => ComponentName::Unknown {
+                ty,
+                data,
+                range: offset..offset + payload_len,
+            },
+        })
+    }
+}
+
+impl<'a> SectionReader for ComponentNameSectionReader<'a> {
+    type Item = ComponentName<'a>;
+    fn read(&mut self) -> Result<Self::Item> {
+        ComponentNameSectionReader::read(self)
+    }
+    fn eof(&self) -> bool {
+        ComponentNameSectionReader::eof(self)
+    }
+    fn original_position(&self) -> usize {
+        ComponentNameSectionReader::original_position(self)
+    }
+    fn range(&self) -> Range<usize> {
+        self.reader.range()
+    }
+}
+
+impl<'a> IntoIterator for ComponentNameSectionReader<'a> {
+    type Item = Result<ComponentName<'a>>;
+    type IntoIter = SectionIterator<ComponentNameSectionReader<'a>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        SectionIterator::new(self)
+    }
+}

--- a/crates/wast/src/component/binary.rs
+++ b/crates/wast/src/component/binary.rs
@@ -3,10 +3,10 @@ use crate::core;
 use crate::token::{Id, Index, NameAnnotation};
 use wasm_encoder::{
     CanonicalFunctionSection, ComponentAliasSection, ComponentDefinedTypeEncoder,
-    ComponentExportSection, ComponentImportSection, ComponentInstanceSection, ComponentSection,
-    ComponentSectionId, ComponentStartSection, ComponentTypeEncoder, ComponentTypeSection,
-    CoreTypeEncoder, CoreTypeSection, InstanceSection, NestedComponentSection, RawSection,
-    SectionId,
+    ComponentExportSection, ComponentImportSection, ComponentInstanceSection, ComponentNameSection,
+    ComponentSection, ComponentSectionId, ComponentStartSection, ComponentTypeEncoder,
+    ComponentTypeSection, CoreTypeEncoder, CoreTypeSection, InstanceSection, NameMap,
+    NestedComponentSection, RawSection, SectionId,
 };
 
 pub fn encode(component: &Component<'_>) -> Vec<u8> {
@@ -20,8 +20,8 @@ pub fn encode(component: &Component<'_>) -> Vec<u8> {
 
 fn encode_fields(
     // TODO: use the id and name for a future names section
-    _component_id: &Option<Id<'_>>,
-    _component_name: &Option<NameAnnotation<'_>>,
+    component_id: &Option<Id<'_>>,
+    component_name: &Option<NameAnnotation<'_>>,
     fields: &[ComponentField<'_>],
 ) -> wasm_encoder::Component {
     let mut e = Encoder::default();
@@ -46,10 +46,8 @@ fn encode_fields(
         }
     }
 
-    // FIXME(WebAssembly/component-model#14): once a name section is defined it
-    // should be encoded here.
-
     e.flush(None);
+    e.encode_names(component_id, component_name);
 
     e.component
 }
@@ -136,7 +134,7 @@ fn encode_defined_type(encoder: ComponentDefinedTypeEncoder, ty: &ComponentDefin
 }
 
 #[derive(Default)]
-struct Encoder {
+struct Encoder<'a> {
     component: wasm_encoder::Component,
     current_section_id: Option<u8>,
 
@@ -153,18 +151,34 @@ struct Encoder {
     funcs: CanonicalFunctionSection,
     imports: ComponentImportSection,
     exports: ComponentExportSection,
+
+    core_func_names: Vec<Option<&'a str>>,
+    core_table_names: Vec<Option<&'a str>>,
+    core_memory_names: Vec<Option<&'a str>>,
+    core_global_names: Vec<Option<&'a str>>,
+    core_type_names: Vec<Option<&'a str>>,
+    core_module_names: Vec<Option<&'a str>>,
+    core_instance_names: Vec<Option<&'a str>>,
+    func_names: Vec<Option<&'a str>>,
+    value_names: Vec<Option<&'a str>>,
+    type_names: Vec<Option<&'a str>>,
+    component_names: Vec<Option<&'a str>>,
+    instance_names: Vec<Option<&'a str>>,
 }
 
-impl Encoder {
+impl<'a> Encoder<'a> {
     fn encode_custom(&mut self, custom: &Custom) {
         // Flush any in-progress section before encoding the customs section
         self.flush(None);
         self.component.section(custom);
     }
 
-    fn encode_core_module(&mut self, module: &CoreModule) {
+    fn encode_core_module(&mut self, module: &CoreModule<'a>) {
         // Flush any in-progress section before encoding the module
         self.flush(None);
+
+        self.core_module_names
+            .push(get_name(&module.id, &module.name));
 
         match &module.kind {
             CoreModuleKind::Import { .. } => unreachable!("should be expanded already"),
@@ -179,7 +193,9 @@ impl Encoder {
         }
     }
 
-    fn encode_core_instance(&mut self, instance: &CoreInstance) {
+    fn encode_core_instance(&mut self, instance: &CoreInstance<'a>) {
+        self.core_instance_names
+            .push(get_name(&instance.id, &instance.name));
         match &instance.kind {
             CoreInstanceKind::Instantiate { module, args } => {
                 self.core_instances.instantiate(
@@ -198,12 +214,15 @@ impl Encoder {
         self.flush(Some(self.core_instances.id()));
     }
 
-    fn encode_core_type(&mut self, ty: &CoreType) {
+    fn encode_core_type(&mut self, ty: &CoreType<'a>) {
+        self.core_type_names.push(get_name(&ty.id, &ty.name));
         encode_core_type(self.core_types.ty(), &ty.def);
         self.flush(Some(self.core_types.id()));
     }
 
-    fn encode_component(&mut self, component: &NestedComponent) {
+    fn encode_component(&mut self, component: &NestedComponent<'a>) {
+        self.component_names
+            .push(get_name(&component.id, &component.name));
         // Flush any in-progress section before encoding the component
         self.flush(None);
 
@@ -220,7 +239,9 @@ impl Encoder {
         }
     }
 
-    fn encode_instance(&mut self, instance: &Instance) {
+    fn encode_instance(&mut self, instance: &Instance<'a>) {
+        self.instance_names
+            .push(get_name(&instance.id, &instance.name));
         match &instance.kind {
             InstanceKind::Import { .. } => unreachable!("should be expanded already"),
             InstanceKind::Instantiate { component, args } => {
@@ -243,27 +264,31 @@ impl Encoder {
         self.flush(Some(self.instances.id()));
     }
 
-    fn encode_alias(&mut self, alias: &Alias) {
+    fn encode_alias(&mut self, alias: &Alias<'a>) {
+        let name = get_name(&alias.id, &alias.name);
         match &alias.target {
             AliasTarget::Export {
                 instance,
-                name,
+                name: export_name,
                 kind,
             } => {
                 self.aliases
-                    .instance_export((*instance).into(), (*kind).into(), name);
+                    .instance_export((*instance).into(), (*kind).into(), export_name);
+                self.names_for_component_export_alias(*kind).push(name);
             }
             AliasTarget::CoreExport {
                 instance,
-                name,
+                name: export_name,
                 kind,
             } => {
                 self.aliases
-                    .core_instance_export((*instance).into(), (*kind).into(), name);
+                    .core_instance_export((*instance).into(), (*kind).into(), export_name);
+                self.names_for_core_export_alias(*kind).push(name);
             }
             AliasTarget::Outer { outer, index, kind } => {
                 self.aliases
                     .outer((*outer).into(), (*kind).into(), (*index).into());
+                self.names_for_component_outer_alias(*kind).push(name);
             }
         }
 
@@ -281,14 +306,17 @@ impl Encoder {
         });
     }
 
-    fn encode_type(&mut self, ty: &Type) {
+    fn encode_type(&mut self, ty: &Type<'a>) {
+        self.type_names.push(get_name(&ty.id, &ty.name));
         encode_type(self.types.ty(), &ty.def);
         self.flush(Some(self.types.id()));
     }
 
-    fn encode_canonical_func(&mut self, func: &CanonicalFunc) {
+    fn encode_canonical_func(&mut self, func: &CanonicalFunc<'a>) {
+        let name = get_name(&func.id, &func.name);
         match &func.kind {
             CanonicalFuncKind::Lift { ty, info } => {
+                self.func_names.push(name);
                 self.funcs.lift(
                     info.func.idx.into(),
                     ty.into(),
@@ -296,6 +324,7 @@ impl Encoder {
                 );
             }
             CanonicalFuncKind::Lower(info) => {
+                self.core_func_names.push(name);
                 self.funcs
                     .lower(info.func.idx.into(), info.opts.iter().map(Into::into));
             }
@@ -304,7 +333,9 @@ impl Encoder {
         self.flush(Some(self.funcs.id()));
     }
 
-    fn encode_import(&mut self, import: &ComponentImport) {
+    fn encode_import(&mut self, import: &ComponentImport<'a>) {
+        let name = get_name(&import.item.id, &import.item.name);
+        self.names_for_item_kind(&import.item.kind).push(name);
         self.imports.import(import.name, (&import.item.kind).into());
         self.flush(Some(self.imports.id()));
     }
@@ -372,6 +403,106 @@ impl Encoder {
 
         self.current_section_id = section_id
     }
+
+    fn encode_names(
+        &mut self,
+        component_id: &Option<Id<'_>>,
+        component_name: &Option<NameAnnotation<'_>>,
+    ) {
+        let mut names = ComponentNameSection::new();
+        if let Some(name) = get_name(component_id, component_name) {
+            names.component(name);
+        }
+
+        let mut funcs = |list: &[Option<&str>], append: fn(&mut ComponentNameSection, &NameMap)| {
+            let mut map = NameMap::new();
+            for (i, entry) in list.iter().enumerate() {
+                if let Some(name) = entry {
+                    map.append(i as u32, name);
+                }
+            }
+            if !map.is_empty() {
+                append(&mut names, &map);
+            }
+        };
+
+        funcs(&self.core_func_names, ComponentNameSection::core_funcs);
+        funcs(&self.core_table_names, ComponentNameSection::core_tables);
+        funcs(&self.core_memory_names, ComponentNameSection::core_memories);
+        funcs(&self.core_global_names, ComponentNameSection::core_globals);
+        funcs(&self.core_type_names, ComponentNameSection::core_types);
+        funcs(&self.core_module_names, ComponentNameSection::core_modules);
+        funcs(
+            &self.core_instance_names,
+            ComponentNameSection::core_instances,
+        );
+        funcs(&self.func_names, ComponentNameSection::funcs);
+        funcs(&self.value_names, ComponentNameSection::values);
+        funcs(&self.type_names, ComponentNameSection::types);
+        funcs(&self.component_names, ComponentNameSection::components);
+        funcs(&self.instance_names, ComponentNameSection::instances);
+
+        if !names.is_empty() {
+            self.component.section(&names);
+        }
+    }
+
+    fn names_for_component_export_alias(
+        &mut self,
+        kind: ComponentExportAliasKind,
+    ) -> &mut Vec<Option<&'a str>> {
+        match kind {
+            ComponentExportAliasKind::Func => &mut self.func_names,
+            ComponentExportAliasKind::CoreModule => &mut self.core_module_names,
+            ComponentExportAliasKind::Value => &mut self.value_names,
+            ComponentExportAliasKind::Type => &mut self.type_names,
+            ComponentExportAliasKind::Component => &mut self.component_names,
+            ComponentExportAliasKind::Instance => &mut self.instance_names,
+        }
+    }
+
+    fn names_for_component_outer_alias(
+        &mut self,
+        kind: ComponentOuterAliasKind,
+    ) -> &mut Vec<Option<&'a str>> {
+        match kind {
+            ComponentOuterAliasKind::CoreModule => &mut self.core_module_names,
+            ComponentOuterAliasKind::CoreType => &mut self.core_type_names,
+            ComponentOuterAliasKind::Component => &mut self.component_names,
+            ComponentOuterAliasKind::Type => &mut self.type_names,
+        }
+    }
+
+    fn names_for_core_export_alias(&mut self, kind: core::ExportKind) -> &mut Vec<Option<&'a str>> {
+        match kind {
+            core::ExportKind::Func => &mut self.core_func_names,
+            core::ExportKind::Global => &mut self.core_global_names,
+            core::ExportKind::Table => &mut self.core_table_names,
+            core::ExportKind::Memory => &mut self.core_memory_names,
+            core::ExportKind::Tag => unimplemented!(),
+        }
+    }
+
+    fn names_for_item_kind(&mut self, kind: &ItemSigKind) -> &mut Vec<Option<&'a str>> {
+        match kind {
+            ItemSigKind::CoreModule(_) => &mut self.core_module_names,
+            ItemSigKind::Func(_) => &mut self.func_names,
+            ItemSigKind::Component(_) => &mut self.component_names,
+            ItemSigKind::Instance(_) => &mut self.instance_names,
+            ItemSigKind::Value(_) => &mut self.value_names,
+            ItemSigKind::Type(_) => &mut self.type_names,
+        }
+    }
+}
+
+fn get_name<'a>(id: &Option<Id<'a>>, name: &Option<NameAnnotation<'a>>) -> Option<&'a str> {
+    name.as_ref().map(|n| n.name).or(id.and_then(|id| {
+        if id.is_gensym() {
+            None
+        } else {
+            Some(id.name())
+        }
+    }))
 }
 
 // This implementation is much like `wasm_encoder::CustomSection`, except

--- a/tests/dump/alias.wat.dump
+++ b/tests/dump/alias.wat.dump
@@ -56,3 +56,17 @@
       | 02 66 33   
  0x87 | 00 00 01 00 | alias [core func 2] CoreInstanceExport { kind: Func, instance_index: 0, name: "f3" }
       | 02 66 33   
+ 0x8e | 00 26       | custom section
+ 0x90 | 0e 63 6f 6d | name: "component-name"
+      | 70 6f 6e 65
+      | 6e 74 2d 6e
+      | 61 6d 65   
+ 0x9f | 01 06 00 11 | core module section
+ 0xa3 | 01          | 1 count
+ 0xa4 | 00 01 6d    | Naming { index: 0, name: "m" }
+ 0xa7 | 01 06 00 12 | core instance section
+ 0xab | 01          | 1 count
+ 0xac | 00 01 6d    | Naming { index: 0, name: "m" }
+ 0xaf | 01 05 05    | instance section
+ 0xb2 | 01          | 1 count
+ 0xb3 | 00 01 69    | Naming { index: 0, name: "i" }

--- a/tests/dump/alias2.wat.dump
+++ b/tests/dump/alias2.wat.dump
@@ -16,7 +16,7 @@
   0x35 | 0a 04       | component import section
   0x37 | 01          | 1 count
   0x38 | 00 05 00    | [instance 0] ComponentImport { name: "", ty: Instance(0) }
-  0x3b | 04 3f       | [component 0] inline size
+  0x3b | 04 54       | [component 0] inline size
     0x3d | 00 61 73 6d | version 65546 (Component)
          | 0a 00 01 00
     0x45 | 03 03       | core type section
@@ -45,135 +45,195 @@
     0x75 | 0a 05       | component import section
     0x77 | 01          | 1 count
     0x78 | 01 35 04 02 | [component 0] ComponentImport { name: "5", ty: Component(2) }
-  0x7c | 06 1b       | component alias section
-  0x7e | 05          | 5 count
-  0x7f | 00 11 00 00 | alias [module 0] InstanceExport { kind: Module, instance_index: 0, name: "1" }
+    0x7c | 00 13       | custom section
+    0x7e | 0e 63 6f 6d | name: "component-name"
+         | 70 6f 6e 65
+         | 6e 74 2d 6e
+         | 61 6d 65   
+    0x8d | 00 02       | component name
+    0x8f | 01 63       | "c"
+  0x91 | 06 1b       | component alias section
+  0x93 | 05          | 5 count
+  0x94 | 00 11 00 00 | alias [module 0] InstanceExport { kind: Module, instance_index: 0, name: "1" }
        | 01 31      
-  0x85 | 01 00 00 01 | alias [func 0] InstanceExport { kind: Func, instance_index: 0, name: "2" }
+  0x9a | 01 00 00 01 | alias [func 0] InstanceExport { kind: Func, instance_index: 0, name: "2" }
        | 32         
-  0x8a | 02 00 00 01 | alias [value 0] InstanceExport { kind: Value, instance_index: 0, name: "4" }
+  0x9f | 02 00 00 01 | alias [value 0] InstanceExport { kind: Value, instance_index: 0, name: "4" }
        | 34         
-  0x8f | 05 00 00 01 | alias [instance 1] InstanceExport { kind: Instance, instance_index: 0, name: "3" }
+  0xa4 | 05 00 00 01 | alias [instance 1] InstanceExport { kind: Instance, instance_index: 0, name: "3" }
        | 33         
-  0x94 | 04 00 00 01 | alias [component 1] InstanceExport { kind: Component, instance_index: 0, name: "5" }
+  0xa9 | 04 00 00 01 | alias [component 1] InstanceExport { kind: Component, instance_index: 0, name: "5" }
        | 35         
-  0x99 | 05 19       | component instance section
-  0x9b | 01          | 1 count
-  0x9c | 00 00 05 01 | [instance 2] Instantiate { component_index: 0, args: [ComponentInstantiationArg { name: "1", kind: Module, index: 0 }, ComponentInstantiationArg { name: "2", kind: Func, index: 0 }, ComponentInstantiationArg { name: "3", kind: Value, index: 0 }, ComponentInstantiationArg { name: "4", kind: Instance, index: 1 }, ComponentInstantiationArg { name: "5", kind: Component, index: 1 }] }
+  0xae | 05 19       | component instance section
+  0xb0 | 01          | 1 count
+  0xb1 | 00 00 05 01 | [instance 2] Instantiate { component_index: 0, args: [ComponentInstantiationArg { name: "1", kind: Module, index: 0 }, ComponentInstantiationArg { name: "2", kind: Func, index: 0 }, ComponentInstantiationArg { name: "3", kind: Value, index: 0 }, ComponentInstantiationArg { name: "4", kind: Instance, index: 1 }, ComponentInstantiationArg { name: "5", kind: Component, index: 1 }] }
        | 31 00 11 00
        | 01 32 01 00
        | 01 33 02 00
        | 01 34 05 01
        | 01 35 04 01
-  0xb4 | 04 15       | [component 2] inline size
-    0xb6 | 00 61 73 6d | version 65546 (Component)
+  0xc9 | 04 32       | [component 2] inline size
+    0xcb | 00 61 73 6d | version 65546 (Component)
          | 0a 00 01 00
-    0xbe | 06 05       | component alias section
-    0xc0 | 01          | 1 count
-    0xc1 | 03 02 01 00 | alias [type 0] Outer { kind: Type, count: 1, index: 0 }
-    0xc5 | 0a 04       | component import section
-    0xc7 | 01          | 1 count
-    0xc8 | 00 05 00    | [instance 0] ComponentImport { name: "", ty: Instance(0) }
-  0xcb | 06 1b       | component alias section
-  0xcd | 05          | 5 count
-  0xce | 00 11 00 00 | alias [module 1] InstanceExport { kind: Module, instance_index: 0, name: "1" }
+    0xd3 | 06 05       | component alias section
+    0xd5 | 01          | 1 count
+    0xd6 | 03 02 01 00 | alias [type 0] Outer { kind: Type, count: 1, index: 0 }
+    0xda | 0a 04       | component import section
+    0xdc | 01          | 1 count
+    0xdd | 00 05 00    | [instance 0] ComponentImport { name: "", ty: Instance(0) }
+    0xe0 | 00 1b       | custom section
+    0xe2 | 0e 63 6f 6d | name: "component-name"
+         | 70 6f 6e 65
+         | 6e 74 2d 6e
+         | 61 6d 65   
+    0xf1 | 00 03       | component name
+    0xf3 | 02 63 32    | "c2"
+    0xf6 | 01 05 03    | type section
+    0xf9 | 01          | 1 count
+    0xfa | 00 01 74    | Naming { index: 0, name: "t" }
+  0xfd | 06 1b       | component alias section
+  0xff | 05          | 5 count
+ 0x100 | 00 11 00 00 | alias [module 1] InstanceExport { kind: Module, instance_index: 0, name: "1" }
        | 01 31      
-  0xd4 | 01 00 00 01 | alias [func 1] InstanceExport { kind: Func, instance_index: 0, name: "2" }
+ 0x106 | 01 00 00 01 | alias [func 1] InstanceExport { kind: Func, instance_index: 0, name: "2" }
        | 32         
-  0xd9 | 02 00 00 01 | alias [value 1] InstanceExport { kind: Value, instance_index: 0, name: "3" }
+ 0x10b | 02 00 00 01 | alias [value 1] InstanceExport { kind: Value, instance_index: 0, name: "3" }
        | 33         
-  0xde | 05 00 00 01 | alias [instance 3] InstanceExport { kind: Instance, instance_index: 0, name: "4" }
+ 0x110 | 05 00 00 01 | alias [instance 3] InstanceExport { kind: Instance, instance_index: 0, name: "4" }
        | 34         
-  0xe3 | 04 00 00 01 | alias [component 3] InstanceExport { kind: Component, instance_index: 0, name: "5" }
+ 0x115 | 04 00 00 01 | alias [component 3] InstanceExport { kind: Component, instance_index: 0, name: "5" }
        | 35         
-  0xe8 | 05 1e       | component instance section
-  0xea | 02          | 2 count
-  0xeb | 01 05 01 31 | [instance 4] FromExports([ComponentExport { name: "1", kind: Module, index: 1 }, ComponentExport { name: "2", kind: Func, index: 1 }, ComponentExport { name: "3", kind: Value, index: 1 }, ComponentExport { name: "4", kind: Instance, index: 3 }, ComponentExport { name: "5", kind: Component, index: 3 }])
+ 0x11a | 05 1e       | component instance section
+ 0x11c | 02          | 2 count
+ 0x11d | 01 05 01 31 | [instance 4] FromExports([ComponentExport { name: "1", kind: Module, index: 1 }, ComponentExport { name: "2", kind: Func, index: 1 }, ComponentExport { name: "3", kind: Value, index: 1 }, ComponentExport { name: "4", kind: Instance, index: 3 }, ComponentExport { name: "5", kind: Component, index: 3 }])
        | 00 11 01 01
        | 32 01 01 01
        | 33 02 01 01
        | 34 05 03 01
        | 35 04 03   
- 0x102 | 00 02 01 00 | [instance 5] Instantiate { component_index: 2, args: [ComponentInstantiationArg { name: "", kind: Instance, index: 4 }] }
+ 0x134 | 00 02 01 00 | [instance 5] Instantiate { component_index: 2, args: [ComponentInstantiationArg { name: "", kind: Instance, index: 4 }] }
        | 05 04      
- 0x108 | 01 48       | [core module 2] inline size
-   0x10a | 00 61 73 6d | version 1 (Module)
+ 0x13a | 01 48       | [core module 2] inline size
+   0x13c | 00 61 73 6d | version 1 (Module)
          | 01 00 00 00
-   0x112 | 01 04       | type section
-   0x114 | 01          | 1 count
-   0x115 | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
-   0x118 | 03 02       | func section
-   0x11a | 01          | 1 count
-   0x11b | 00          | [func 0] type 0
-   0x11c | 04 04       | table section
-   0x11e | 01          | 1 count
-   0x11f | 70 00 01    | [table 0] TableType { element_type: FuncRef, initial: 1, maximum: None }
-   0x122 | 05 03       | memory section
-   0x124 | 01          | 1 count
-   0x125 | 00 01       | [memory 0] MemoryType { memory64: false, shared: false, initial: 1, maximum: None }
-   0x127 | 06 04       | global section
-   0x129 | 01          | 1 count
-   0x12a | 7f 00       | [global 0] GlobalType { content_type: I32, mutable: false }
-   0x12c | 0b          | end
-   0x12d | 07 11       | export section
-   0x12f | 04          | 4 count
-   0x130 | 01 31 00 00 | export Export { name: "1", kind: Func, index: 0 }
-   0x134 | 01 32 02 00 | export Export { name: "2", kind: Memory, index: 0 }
-   0x138 | 01 33 03 00 | export Export { name: "3", kind: Global, index: 0 }
-   0x13c | 01 34 01 00 | export Export { name: "4", kind: Table, index: 0 }
-   0x140 | 0a 04       | code section
-   0x142 | 01          | 1 count
+   0x144 | 01 04       | type section
+   0x146 | 01          | 1 count
+   0x147 | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
+   0x14a | 03 02       | func section
+   0x14c | 01          | 1 count
+   0x14d | 00          | [func 0] type 0
+   0x14e | 04 04       | table section
+   0x150 | 01          | 1 count
+   0x151 | 70 00 01    | [table 0] TableType { element_type: FuncRef, initial: 1, maximum: None }
+   0x154 | 05 03       | memory section
+   0x156 | 01          | 1 count
+   0x157 | 00 01       | [memory 0] MemoryType { memory64: false, shared: false, initial: 1, maximum: None }
+   0x159 | 06 04       | global section
+   0x15b | 01          | 1 count
+   0x15c | 7f 00       | [global 0] GlobalType { content_type: I32, mutable: false }
+   0x15e | 0b          | end
+   0x15f | 07 11       | export section
+   0x161 | 04          | 4 count
+   0x162 | 01 31 00 00 | export Export { name: "1", kind: Func, index: 0 }
+   0x166 | 01 32 02 00 | export Export { name: "2", kind: Memory, index: 0 }
+   0x16a | 01 33 03 00 | export Export { name: "3", kind: Global, index: 0 }
+   0x16e | 01 34 01 00 | export Export { name: "4", kind: Table, index: 0 }
+   0x172 | 0a 04       | code section
+   0x174 | 01          | 1 count
 ============== func 0 ====================
-   0x143 | 02          | size of function
-   0x144 | 00          | 0 local blocks
-   0x145 | 0b          | end
-   0x146 | 00 0a       | custom section
-   0x148 | 04 6e 61 6d | name: "name"
+   0x175 | 02          | size of function
+   0x176 | 00          | 0 local blocks
+   0x177 | 0b          | end
+   0x178 | 00 0a       | custom section
+   0x17a | 04 6e 61 6d | name: "name"
          | 65         
-   0x14d | 00 03       | module name
-   0x14f | 02 6d 31    | "m1"
- 0x152 | 01 35       | [core module 3] inline size
-   0x154 | 00 61 73 6d | version 1 (Module)
+   0x17f | 00 03       | module name
+   0x181 | 02 6d 31    | "m1"
+ 0x184 | 01 35       | [core module 3] inline size
+   0x186 | 00 61 73 6d | version 1 (Module)
          | 01 00 00 00
-   0x15c | 01 04       | type section
-   0x15e | 01          | 1 count
-   0x15f | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
-   0x162 | 02 19       | import section
-   0x164 | 04          | 4 count
-   0x165 | 00 01 31 00 | import [func 0] Import { module: "", name: "1", ty: Func(0) }
+   0x18e | 01 04       | type section
+   0x190 | 01          | 1 count
+   0x191 | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
+   0x194 | 02 19       | import section
+   0x196 | 04          | 4 count
+   0x197 | 00 01 31 00 | import [func 0] Import { module: "", name: "1", ty: Func(0) }
          | 00         
-   0x16a | 00 01 32 02 | import [memory 0] Import { module: "", name: "2", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None }) }
+   0x19c | 00 01 32 02 | import [memory 0] Import { module: "", name: "2", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None }) }
          | 00 01      
-   0x170 | 00 01 33 03 | import [global 0] Import { module: "", name: "3", ty: Global(GlobalType { content_type: I32, mutable: false }) }
+   0x1a2 | 00 01 33 03 | import [global 0] Import { module: "", name: "3", ty: Global(GlobalType { content_type: I32, mutable: false }) }
          | 7f 00      
-   0x176 | 00 01 34 01 | import [table 0] Import { module: "", name: "4", ty: Table(TableType { element_type: FuncRef, initial: 1, maximum: None }) }
+   0x1a8 | 00 01 34 01 | import [table 0] Import { module: "", name: "4", ty: Table(TableType { element_type: FuncRef, initial: 1, maximum: None }) }
          | 70 00 01   
-   0x17d | 00 0a       | custom section
-   0x17f | 04 6e 61 6d | name: "name"
+   0x1af | 00 0a       | custom section
+   0x1b1 | 04 6e 61 6d | name: "name"
          | 65         
-   0x184 | 00 03       | module name
-   0x186 | 02 6d 32    | "m2"
- 0x189 | 02 0a       | core instance section
- 0x18b | 02          | 2 count
- 0x18c | 00 02 00    | [core instance 0] Instantiate { module_index: 2, args: [] }
- 0x18f | 00 03 01 00 | [core instance 1] Instantiate { module_index: 3, args: [InstantiationArg { name: "", kind: Instance, index: 0 }] }
+   0x1b6 | 00 03       | module name
+   0x1b8 | 02 6d 32    | "m2"
+ 0x1bb | 02 0a       | core instance section
+ 0x1bd | 02          | 2 count
+ 0x1be | 00 02 00    | [core instance 0] Instantiate { module_index: 2, args: [] }
+ 0x1c1 | 00 03 01 00 | [core instance 1] Instantiate { module_index: 3, args: [InstantiationArg { name: "", kind: Instance, index: 0 }] }
        | 12 00      
- 0x195 | 06 19       | component alias section
- 0x197 | 04          | 4 count
- 0x198 | 00 00 01 00 | alias [core func 0] CoreInstanceExport { kind: Func, instance_index: 0, name: "1" }
+ 0x1c7 | 06 19       | component alias section
+ 0x1c9 | 04          | 4 count
+ 0x1ca | 00 00 01 00 | alias [core func 0] CoreInstanceExport { kind: Func, instance_index: 0, name: "1" }
        | 01 31      
- 0x19e | 00 02 01 00 | alias [core memory 0] CoreInstanceExport { kind: Memory, instance_index: 0, name: "2" }
+ 0x1d0 | 00 02 01 00 | alias [core memory 0] CoreInstanceExport { kind: Memory, instance_index: 0, name: "2" }
        | 01 32      
- 0x1a4 | 00 03 01 00 | alias [core global 0] CoreInstanceExport { kind: Global, instance_index: 0, name: "3" }
+ 0x1d6 | 00 03 01 00 | alias [core global 0] CoreInstanceExport { kind: Global, instance_index: 0, name: "3" }
        | 01 33      
- 0x1aa | 00 01 01 00 | alias [core table 0] CoreInstanceExport { kind: Table, instance_index: 0, name: "4" }
+ 0x1dc | 00 01 01 00 | alias [core table 0] CoreInstanceExport { kind: Table, instance_index: 0, name: "4" }
        | 01 34      
- 0x1b0 | 02 19       | core instance section
- 0x1b2 | 02          | 2 count
- 0x1b3 | 01 04 01 31 | [core instance 2] FromExports([Export { name: "1", kind: Func, index: 0 }, Export { name: "2", kind: Memory, index: 0 }, Export { name: "3", kind: Global, index: 0 }, Export { name: "4", kind: Table, index: 0 }])
+ 0x1e2 | 02 19       | core instance section
+ 0x1e4 | 02          | 2 count
+ 0x1e5 | 01 04 01 31 | [core instance 2] FromExports([Export { name: "1", kind: Func, index: 0 }, Export { name: "2", kind: Memory, index: 0 }, Export { name: "3", kind: Global, index: 0 }, Export { name: "4", kind: Table, index: 0 }])
        | 00 00 01 32
        | 02 00 01 33
        | 03 00 01 34
        | 01 00      
- 0x1c5 | 00 03 01 00 | [core instance 3] Instantiate { module_index: 3, args: [InstantiationArg { name: "", kind: Instance, index: 2 }] }
+ 0x1f7 | 00 03 01 00 | [core instance 3] Instantiate { module_index: 3, args: [InstantiationArg { name: "", kind: Instance, index: 2 }] }
        | 12 02      
+ 0x1fd | 00 76       | custom section
+ 0x1ff | 0e 63 6f 6d | name: "component-name"
+       | 70 6f 6e 65
+       | 6e 74 2d 6e
+       | 61 6d 65   
+ 0x20e | 01 06 00 00 | core func section
+ 0x212 | 01          | 1 count
+ 0x213 | 00 01 66    | Naming { index: 0, name: "f" }
+ 0x216 | 01 06 00 01 | core table section
+ 0x21a | 01          | 1 count
+ 0x21b | 00 01 74    | Naming { index: 0, name: "t" }
+ 0x21e | 01 06 00 02 | core memory section
+ 0x222 | 01          | 1 count
+ 0x223 | 00 01 6d    | Naming { index: 0, name: "m" }
+ 0x226 | 01 06 00 03 | core global section
+ 0x22a | 01          | 1 count
+ 0x22b | 00 01 67    | Naming { index: 0, name: "g" }
+ 0x22e | 01 0e 00 11 | core module section
+ 0x232 | 03          | 3 count
+ 0x233 | 01 01 6d    | Naming { index: 1, name: "m" }
+ 0x236 | 02 02 6d 31 | Naming { index: 2, name: "m1" }
+ 0x23a | 03 02 6d 32 | Naming { index: 3, name: "m2" }
+ 0x23e | 01 06 00 12 | core instance section
+ 0x242 | 01          | 1 count
+ 0x243 | 00 01 69    | Naming { index: 0, name: "i" }
+ 0x246 | 01 05 01    | func section
+ 0x249 | 01          | 1 count
+ 0x24a | 01 01 66    | Naming { index: 1, name: "f" }
+ 0x24d | 01 05 02    | value section
+ 0x250 | 01          | 1 count
+ 0x251 | 01 01 76    | Naming { index: 1, name: "v" }
+ 0x254 | 01 05 03    | type section
+ 0x257 | 01          | 1 count
+ 0x258 | 00 01 74    | Naming { index: 0, name: "t" }
+ 0x25b | 01 0d 04    | component section
+ 0x25e | 03          | 3 count
+ 0x25f | 00 01 63    | Naming { index: 0, name: "c" }
+ 0x262 | 02 02 63 32 | Naming { index: 2, name: "c2" }
+ 0x266 | 03 02 63 33 | Naming { index: 3, name: "c3" }
+ 0x26a | 01 09 05    | instance section
+ 0x26d | 02          | 2 count
+ 0x26e | 00 01 69    | Naming { index: 0, name: "i" }
+ 0x271 | 03 02 69 32 | Naming { index: 3, name: "i2" }

--- a/tests/dump/bundled.wat.dump
+++ b/tests/dump/bundled.wat.dump
@@ -190,3 +190,42 @@
  0x1df | 01          | 1 count
  0x1e0 | 04 77 6f 72 | export ComponentExport { name: "work", kind: Func, index: 1 }
        | 6b 01 01   
+ 0x1e7 | 00 7c       | custom section
+ 0x1e9 | 0e 63 6f 6d | name: "component-name"
+       | 70 6f 6e 65
+       | 6e 74 2d 6e
+       | 61 6d 65   
+ 0x1f8 | 01 13 00 00 | core func section
+ 0x1fc | 01          | 1 count
+ 0x1fd | 01 0e 72 65 | Naming { index: 1, name: "real-wasi-read" }
+       | 61 6c 2d 77
+       | 61 73 69 2d
+       | 72 65 61 64
+ 0x20d | 01 1c 00 11 | core module section
+ 0x211 | 03          | 3 count
+ 0x212 | 00 04 6c 69 | Naming { index: 0, name: "libc" }
+       | 62 63      
+ 0x218 | 01 05 43 48 | Naming { index: 1, name: "CHILD" }
+       | 49 4c 44   
+ 0x21f | 02 0a 56 49 | Naming { index: 2, name: "VIRTUALIZE" }
+       | 52 54 55 41
+       | 4c 49 5a 45
+ 0x22b | 01 1b 00 12 | core instance section
+ 0x22f | 03          | 3 count
+ 0x230 | 00 04 6c 69 | Naming { index: 0, name: "libc" }
+       | 62 63      
+ 0x236 | 02 09 76 69 | Naming { index: 2, name: "virt-wasi" }
+       | 72 74 2d 77
+       | 61 73 69   
+ 0x241 | 03 05 63 68 | Naming { index: 3, name: "child" }
+       | 69 6c 64   
+ 0x248 | 01 0c 03    | type section
+ 0x24b | 01          | 1 count
+ 0x24c | 00 08 57 61 | Naming { index: 0, name: "WasiFile" }
+       | 73 69 46 69
+       | 6c 65      
+ 0x256 | 01 0d 05    | instance section
+ 0x259 | 01          | 1 count
+ 0x25a | 00 09 72 65 | Naming { index: 0, name: "real-wasi" }
+       | 61 6c 2d 77
+       | 61 73 69   

--- a/tests/dump/component-expand-bundle.wat.dump
+++ b/tests/dump/component-expand-bundle.wat.dump
@@ -51,3 +51,18 @@
       | 00 00      
  0x6e | 00 01 01 00 | [core instance 2] Instantiate { module_index: 1, args: [InstantiationArg { name: "", kind: Instance, index: 1 }] }
       | 12 01      
+ 0x74 | 00 2b       | custom section
+ 0x76 | 0e 63 6f 6d | name: "component-name"
+      | 70 6f 6e 65
+      | 6e 74 2d 6e
+      | 61 6d 65   
+ 0x85 | 01 06 00 00 | core func section
+ 0x89 | 01          | 1 count
+ 0x8a | 00 01 66    | Naming { index: 0, name: "f" }
+ 0x8d | 01 0a 00 11 | core module section
+ 0x91 | 02          | 2 count
+ 0x92 | 00 01 6d    | Naming { index: 0, name: "m" }
+ 0x95 | 01 02 6d 32 | Naming { index: 1, name: "m2" }
+ 0x99 | 01 06 00 12 | core instance section
+ 0x9d | 01          | 1 count
+ 0x9e | 00 01 4d    | Naming { index: 0, name: "M" }

--- a/tests/dump/component-expand-bundle2.wat.dump
+++ b/tests/dump/component-expand-bundle2.wat.dump
@@ -1,6 +1,6 @@
   0x0 | 00 61 73 6d | version 65546 (Component)
       | 0a 00 01 00
-  0x8 | 04 19       | [component 0] inline size
+  0x8 | 04 2e       | [component 0] inline size
     0xa | 00 61 73 6d | version 65546 (Component)
         | 0a 00 01 00
    0x12 | 01 08       | [core module 0] inline size
@@ -9,27 +9,56 @@
    0x1c | 0b 05       | component export section
    0x1e | 01          | 1 count
    0x1f | 00 00 11 00 | export ComponentExport { name: "", kind: Module, index: 0 }
- 0x23 | 04 1b       | [component 1] inline size
-   0x25 | 00 61 73 6d | version 65546 (Component)
+   0x23 | 00 13       | custom section
+   0x25 | 0e 63 6f 6d | name: "component-name"
+        | 70 6f 6e 65
+        | 6e 74 2d 6e
+        | 61 6d 65   
+   0x34 | 00 02       | component name
+   0x36 | 01 63       | "c"
+ 0x38 | 04 31       | [component 1] inline size
+   0x3a | 00 61 73 6d | version 65546 (Component)
         | 0a 00 01 00
-   0x2d | 07 0b       | component type section
-   0x2f | 01          | 1 count
-   0x30 | 41 02 00 50 | [type 0] Component([CoreType(Module([])), Import(ComponentImport { name: "", ty: Module(0) })])
+   0x42 | 07 0b       | component type section
+   0x44 | 01          | 1 count
+   0x45 | 41 02 00 50 | [type 0] Component([CoreType(Module([])), Import(ComponentImport { name: "", ty: Module(0) })])
         | 00 03 00 00
         | 11 00      
-   0x3a | 0a 04       | component import section
-   0x3c | 01          | 1 count
-   0x3d | 00 04 00    | [component 0] ComponentImport { name: "", ty: Component(0) }
- 0x40 | 05 04       | component instance section
- 0x42 | 01          | 1 count
- 0x43 | 00 00 00    | [instance 0] Instantiate { component_index: 0, args: [] }
- 0x46 | 06 06       | component alias section
- 0x48 | 01          | 1 count
- 0x49 | 00 11 00 00 | alias [module 0] InstanceExport { kind: Module, instance_index: 0, name: "" }
+   0x4f | 0a 04       | component import section
+   0x51 | 01          | 1 count
+   0x52 | 00 04 00    | [component 0] ComponentImport { name: "", ty: Component(0) }
+   0x55 | 00 14       | custom section
+   0x57 | 0e 63 6f 6d | name: "component-name"
+        | 70 6f 6e 65
+        | 6e 74 2d 6e
+        | 61 6d 65   
+   0x66 | 00 03       | component name
+   0x68 | 02 63 32    | "c2"
+ 0x6b | 05 04       | component instance section
+ 0x6d | 01          | 1 count
+ 0x6e | 00 00 00    | [instance 0] Instantiate { component_index: 0, args: [] }
+ 0x71 | 06 06       | component alias section
+ 0x73 | 01          | 1 count
+ 0x74 | 00 11 00 00 | alias [module 0] InstanceExport { kind: Module, instance_index: 0, name: "" }
       | 00         
- 0x4e | 05 0d       | component instance section
- 0x50 | 02          | 2 count
- 0x51 | 01 01 00 00 | [instance 1] FromExports([ComponentExport { name: "", kind: Module, index: 0 }])
+ 0x79 | 05 0d       | component instance section
+ 0x7b | 02          | 2 count
+ 0x7c | 01 01 00 00 | [instance 1] FromExports([ComponentExport { name: "", kind: Module, index: 0 }])
       | 11 00      
- 0x57 | 00 01 01 00 | [instance 2] Instantiate { component_index: 1, args: [ComponentInstantiationArg { name: "", kind: Instance, index: 1 }] }
+ 0x82 | 00 01 01 00 | [instance 2] Instantiate { component_index: 1, args: [ComponentInstantiationArg { name: "", kind: Instance, index: 1 }] }
       | 05 01      
+ 0x88 | 00 29       | custom section
+ 0x8a | 0e 63 6f 6d | name: "component-name"
+      | 70 6f 6e 65
+      | 6e 74 2d 6e
+      | 61 6d 65   
+ 0x99 | 01 06 00 11 | core module section
+ 0x9d | 01          | 1 count
+ 0x9e | 00 01 6d    | Naming { index: 0, name: "m" }
+ 0xa1 | 01 09 04    | component section
+ 0xa4 | 02          | 2 count
+ 0xa5 | 00 01 63    | Naming { index: 0, name: "c" }
+ 0xa8 | 01 02 63 32 | Naming { index: 1, name: "c2" }
+ 0xac | 01 05 05    | instance section
+ 0xaf | 01          | 1 count
+ 0xb0 | 00 01 43    | Naming { index: 0, name: "C" }

--- a/tests/dump/component-instance-type.wat.dump
+++ b/tests/dump/component-instance-type.wat.dump
@@ -11,3 +11,12 @@
       | 00 04 01 31
       | 01 01 04 02
       | 63 35 04 01
+ 0x2f | 00 1a       | custom section
+ 0x31 | 0e 63 6f 6d | name: "component-name"
+      | 70 6f 6e 65
+      | 6e 74 2d 6e
+      | 61 6d 65   
+ 0x40 | 01 09 03    | type section
+ 0x43 | 01          | 1 count
+ 0x44 | 00 05 6f 75 | Naming { index: 0, name: "outer" }
+      | 74 65 72   

--- a/tests/dump/component-linking.wat.dump
+++ b/tests/dump/component-linking.wat.dump
@@ -16,7 +16,7 @@
  0x35 | 0a 04       | component import section
  0x37 | 01          | 1 count
  0x38 | 00 05 00    | [instance 0] ComponentImport { name: "", ty: Instance(0) }
- 0x3b | 04 3f       | [component 0] inline size
+ 0x3b | 04 54       | [component 0] inline size
    0x3d | 00 61 73 6d | version 65546 (Component)
         | 0a 00 01 00
    0x45 | 03 03       | core type section
@@ -45,23 +45,41 @@
    0x75 | 0a 05       | component import section
    0x77 | 01          | 1 count
    0x78 | 01 35 04 02 | [component 0] ComponentImport { name: "5", ty: Component(2) }
- 0x7c | 06 1b       | component alias section
- 0x7e | 05          | 5 count
- 0x7f | 00 11 00 00 | alias [module 0] InstanceExport { kind: Module, instance_index: 0, name: "1" }
+   0x7c | 00 13       | custom section
+   0x7e | 0e 63 6f 6d | name: "component-name"
+        | 70 6f 6e 65
+        | 6e 74 2d 6e
+        | 61 6d 65   
+   0x8d | 00 02       | component name
+   0x8f | 01 63       | "c"
+ 0x91 | 06 1b       | component alias section
+ 0x93 | 05          | 5 count
+ 0x94 | 00 11 00 00 | alias [module 0] InstanceExport { kind: Module, instance_index: 0, name: "1" }
       | 01 31      
- 0x85 | 01 00 00 01 | alias [func 0] InstanceExport { kind: Func, instance_index: 0, name: "2" }
+ 0x9a | 01 00 00 01 | alias [func 0] InstanceExport { kind: Func, instance_index: 0, name: "2" }
       | 32         
- 0x8a | 02 00 00 01 | alias [value 0] InstanceExport { kind: Value, instance_index: 0, name: "4" }
+ 0x9f | 02 00 00 01 | alias [value 0] InstanceExport { kind: Value, instance_index: 0, name: "4" }
       | 34         
- 0x8f | 05 00 00 01 | alias [instance 1] InstanceExport { kind: Instance, instance_index: 0, name: "3" }
+ 0xa4 | 05 00 00 01 | alias [instance 1] InstanceExport { kind: Instance, instance_index: 0, name: "3" }
       | 33         
- 0x94 | 04 00 00 01 | alias [component 1] InstanceExport { kind: Component, instance_index: 0, name: "5" }
+ 0xa9 | 04 00 00 01 | alias [component 1] InstanceExport { kind: Component, instance_index: 0, name: "5" }
       | 35         
- 0x99 | 05 19       | component instance section
- 0x9b | 01          | 1 count
- 0x9c | 00 00 05 01 | [instance 2] Instantiate { component_index: 0, args: [ComponentInstantiationArg { name: "1", kind: Module, index: 0 }, ComponentInstantiationArg { name: "2", kind: Func, index: 0 }, ComponentInstantiationArg { name: "3", kind: Value, index: 0 }, ComponentInstantiationArg { name: "4", kind: Instance, index: 1 }, ComponentInstantiationArg { name: "5", kind: Component, index: 1 }] }
+ 0xae | 05 19       | component instance section
+ 0xb0 | 01          | 1 count
+ 0xb1 | 00 00 05 01 | [instance 2] Instantiate { component_index: 0, args: [ComponentInstantiationArg { name: "1", kind: Module, index: 0 }, ComponentInstantiationArg { name: "2", kind: Func, index: 0 }, ComponentInstantiationArg { name: "3", kind: Value, index: 0 }, ComponentInstantiationArg { name: "4", kind: Instance, index: 1 }, ComponentInstantiationArg { name: "5", kind: Component, index: 1 }] }
       | 31 00 11 00
       | 01 32 01 00
       | 01 33 02 00
       | 01 34 05 01
       | 01 35 04 01
+ 0xc9 | 00 1d       | custom section
+ 0xcb | 0e 63 6f 6d | name: "component-name"
+      | 70 6f 6e 65
+      | 6e 74 2d 6e
+      | 61 6d 65   
+ 0xda | 01 05 04    | component section
+ 0xdd | 01          | 1 count
+ 0xde | 00 01 63    | Naming { index: 0, name: "c" }
+ 0xe1 | 01 05 05    | instance section
+ 0xe4 | 01          | 1 count
+ 0xe5 | 00 01 69    | Naming { index: 0, name: "i" }

--- a/tests/dump/component-outer-alias.wat.dump
+++ b/tests/dump/component-outer-alias.wat.dump
@@ -6,7 +6,7 @@
   0xc | 41 02 02 03 | [type 1] Component([Alias(Outer { kind: Type, count: 1, index: 0 }), Type(Func(ComponentFuncType { params: [], results: Unnamed(Type(0)) }))])
       | 02 01 00 01
       | 40 00 00 00
- 0x18 | 04 16       | [component 0] inline size
+ 0x18 | 04 2e       | [component 0] inline size
    0x1a | 00 61 73 6d | version 65546 (Component)
         | 0a 00 01 00
    0x22 | 06 05       | component alias section
@@ -15,26 +15,59 @@
    0x29 | 07 05       | component type section
    0x2b | 01          | 1 count
    0x2c | 40 00 00 00 | [type 1] Func(ComponentFuncType { params: [], results: Unnamed(Type(0)) })
- 0x30 | 04 1a       | [component 1] inline size
-   0x32 | 00 61 73 6d | version 65546 (Component)
+   0x30 | 00 16       | custom section
+   0x32 | 0e 63 6f 6d | name: "component-name"
+        | 70 6f 6e 65
+        | 6e 74 2d 6e
+        | 61 6d 65   
+   0x41 | 01 05 03    | type section
+   0x44 | 01          | 1 count
+   0x45 | 00 01 74    | Naming { index: 0, name: "t" }
+ 0x48 | 04 32       | [component 1] inline size
+   0x4a | 00 61 73 6d | version 65546 (Component)
         | 0a 00 01 00
-   0x3a | 06 05       | component alias section
-   0x3c | 01          | 1 count
-   0x3d | 03 02 01 00 | alias [type 0] Outer { kind: Type, count: 1, index: 0 }
-   0x41 | 07 09       | component type section
-   0x43 | 02          | 2 count
-   0x44 | 40 00 00 00 | [type 1] Func(ComponentFuncType { params: [], results: Unnamed(Type(0)) })
-   0x48 | 40 00 00 00 | [type 2] Func(ComponentFuncType { params: [], results: Unnamed(Type(0)) })
- 0x4c | 07 02       | component type section
- 0x4e | 01          | 1 count
- 0x4f | 7d          | [type 2] Defined(Primitive(U8))
- 0x50 | 04 1a       | [component 2] inline size
-   0x52 | 00 61 73 6d | version 65546 (Component)
+   0x52 | 06 05       | component alias section
+   0x54 | 01          | 1 count
+   0x55 | 03 02 01 00 | alias [type 0] Outer { kind: Type, count: 1, index: 0 }
+   0x59 | 07 09       | component type section
+   0x5b | 02          | 2 count
+   0x5c | 40 00 00 00 | [type 1] Func(ComponentFuncType { params: [], results: Unnamed(Type(0)) })
+   0x60 | 40 00 00 00 | [type 2] Func(ComponentFuncType { params: [], results: Unnamed(Type(0)) })
+   0x64 | 00 16       | custom section
+   0x66 | 0e 63 6f 6d | name: "component-name"
+        | 70 6f 6e 65
+        | 6e 74 2d 6e
+        | 61 6d 65   
+   0x75 | 01 05 03    | type section
+   0x78 | 01          | 1 count
+   0x79 | 00 01 74    | Naming { index: 0, name: "t" }
+ 0x7c | 07 02       | component type section
+ 0x7e | 01          | 1 count
+ 0x7f | 7d          | [type 2] Defined(Primitive(U8))
+ 0x80 | 04 33       | [component 2] inline size
+   0x82 | 00 61 73 6d | version 65546 (Component)
         | 0a 00 01 00
-   0x5a | 06 05       | component alias section
-   0x5c | 01          | 1 count
-   0x5d | 03 02 01 02 | alias [type 0] Outer { kind: Type, count: 1, index: 2 }
-   0x61 | 07 09       | component type section
-   0x63 | 02          | 2 count
-   0x64 | 40 00 00 00 | [type 1] Func(ComponentFuncType { params: [], results: Unnamed(Type(0)) })
-   0x68 | 40 00 00 00 | [type 2] Func(ComponentFuncType { params: [], results: Unnamed(Type(0)) })
+   0x8a | 06 05       | component alias section
+   0x8c | 01          | 1 count
+   0x8d | 03 02 01 02 | alias [type 0] Outer { kind: Type, count: 1, index: 2 }
+   0x91 | 07 09       | component type section
+   0x93 | 02          | 2 count
+   0x94 | 40 00 00 00 | [type 1] Func(ComponentFuncType { params: [], results: Unnamed(Type(0)) })
+   0x98 | 40 00 00 00 | [type 2] Func(ComponentFuncType { params: [], results: Unnamed(Type(0)) })
+   0x9c | 00 17       | custom section
+   0x9e | 0e 63 6f 6d | name: "component-name"
+        | 70 6f 6e 65
+        | 6e 74 2d 6e
+        | 61 6d 65   
+   0xad | 01 06 03    | type section
+   0xb0 | 01          | 1 count
+   0xb1 | 00 02 74 32 | Naming { index: 0, name: "t2" }
+ 0xb5 | 00 1a       | custom section
+ 0xb7 | 0e 63 6f 6d | name: "component-name"
+      | 70 6f 6e 65
+      | 6e 74 2d 6e
+      | 61 6d 65   
+ 0xc6 | 01 09 03    | type section
+ 0xc9 | 02          | 2 count
+ 0xca | 00 01 74    | Naming { index: 0, name: "t" }
+ 0xcd | 02 02 74 32 | Naming { index: 2, name: "t2" }

--- a/tests/dump/import-modules.wat.dump
+++ b/tests/dump/import-modules.wat.dump
@@ -36,3 +36,16 @@
  0x4e | 00 01 00    | [core instance 0] Instantiate { module_index: 1, args: [] }
  0x51 | 00 00 01 00 | [core instance 1] Instantiate { module_index: 0, args: [InstantiationArg { name: "", kind: Instance, index: 0 }] }
       | 12 00      
+ 0x57 | 00 29       | custom section
+ 0x59 | 0e 63 6f 6d | name: "component-name"
+      | 70 6f 6e 65
+      | 6e 74 2d 6e
+      | 61 6d 65   
+ 0x68 | 01 0b 00 11 | core module section
+ 0x6c | 02          | 2 count
+ 0x6d | 00 02 6d 31 | Naming { index: 0, name: "m1" }
+ 0x71 | 01 02 6d 32 | Naming { index: 1, name: "m2" }
+ 0x75 | 01 0b 00 12 | core instance section
+ 0x79 | 02          | 2 count
+ 0x7a | 00 02 69 31 | Naming { index: 0, name: "i1" }
+ 0x7e | 01 02 69 32 | Naming { index: 1, name: "i2" }

--- a/tests/dump/instance-expand.wat.dump
+++ b/tests/dump/instance-expand.wat.dump
@@ -8,3 +8,11 @@
  0x16 | 0a 04       | component import section
  0x18 | 01          | 1 count
  0x19 | 00 05 00    | [instance 0] ComponentImport { name: "", ty: Instance(0) }
+ 0x1c | 00 16       | custom section
+ 0x1e | 0e 63 6f 6d | name: "component-name"
+      | 70 6f 6e 65
+      | 6e 74 2d 6e
+      | 61 6d 65   
+ 0x2d | 01 05 03    | type section
+ 0x30 | 01          | 1 count
+ 0x31 | 00 01 69    | Naming { index: 0, name: "i" }

--- a/tests/dump/instance-type2.wat.dump
+++ b/tests/dump/instance-type2.wat.dump
@@ -9,3 +9,11 @@
  0x15 | 42 02 02 03 | [type 3] Instance([Alias(Outer { kind: Type, count: 1, index: 2 }), Export { name: "", ty: Instance(0) }])
       | 02 01 02 04
       | 00 05 00   
+ 0x20 | 00 16       | custom section
+ 0x22 | 0e 63 6f 6d | name: "component-name"
+      | 70 6f 6e 65
+      | 6e 74 2d 6e
+      | 61 6d 65   
+ 0x31 | 01 05 03    | type section
+ 0x34 | 01          | 1 count
+ 0x35 | 02 01 78    | Naming { index: 2, name: "x" }

--- a/tests/dump/instantiate.wat.dump
+++ b/tests/dump/instantiate.wat.dump
@@ -16,3 +16,17 @@
  0x24 | 01          | 1 count
  0x25 | 00 00 01 01 | [instance 0] Instantiate { component_index: 0, args: [ComponentInstantiationArg { name: "a", kind: Func, index: 0 }] }
       | 61 01 00   
+ 0x2c | 00 24       | custom section
+ 0x2e | 0e 63 6f 6d | name: "component-name"
+      | 70 6f 6e 65
+      | 6e 74 2d 6e
+      | 61 6d 65   
+ 0x3d | 01 05 01    | func section
+ 0x40 | 01          | 1 count
+ 0x41 | 00 01 66    | Naming { index: 0, name: "f" }
+ 0x44 | 01 05 04    | component section
+ 0x47 | 01          | 1 count
+ 0x48 | 00 01 63    | Naming { index: 0, name: "c" }
+ 0x4b | 01 05 05    | instance section
+ 0x4e | 01          | 1 count
+ 0x4f | 00 01 61    | Naming { index: 0, name: "a" }

--- a/tests/dump/instantiate2.wat.dump
+++ b/tests/dump/instantiate2.wat.dump
@@ -11,3 +11,11 @@
  0x1c | 05 04       | component instance section
  0x1e | 01          | 1 count
  0x1f | 00 00 00    | [instance 0] Instantiate { component_index: 0, args: [] }
+ 0x22 | 00 16       | custom section
+ 0x24 | 0e 63 6f 6d | name: "component-name"
+      | 70 6f 6e 65
+      | 6e 74 2d 6e
+      | 61 6d 65   
+ 0x33 | 01 05 04    | component section
+ 0x36 | 01          | 1 count
+ 0x37 | 00 01 63    | Naming { index: 0, name: "c" }

--- a/tests/dump/module-types.wat.dump
+++ b/tests/dump/module-types.wat.dump
@@ -17,3 +17,15 @@
  0x34 | 07 03       | component type section
  0x36 | 01          | 1 count
  0x37 | 42 00       | [type 0] Instance([])
+ 0x39 | 00 22       | custom section
+ 0x3b | 0e 63 6f 6d | name: "component-name"
+      | 70 6f 6e 65
+      | 6e 74 2d 6e
+      | 61 6d 65   
+ 0x4a | 01 06 00 11 | core module section
+ 0x4e | 01          | 1 count
+ 0x4f | 00 01 6d    | Naming { index: 0, name: "m" }
+ 0x52 | 01 09 03    | type section
+ 0x55 | 01          | 1 count
+ 0x56 | 00 05 65 6d | Naming { index: 0, name: "empty" }
+      | 70 74 79   

--- a/tests/dump/nested-component.wat.dump
+++ b/tests/dump/nested-component.wat.dump
@@ -21,7 +21,7 @@
    0x3b | 04 08       | [component 0] inline size
      0x3d | 00 61 73 6d | version 65546 (Component)
           | 0a 00 01 00
- 0x45 | 04 51       | [component 5] inline size
+ 0x45 | 04 6a       | [component 5] inline size
    0x47 | 00 61 73 6d | version 65546 (Component)
         | 0a 00 01 00
    0x4f | 01 13       | [core module 0] inline size
@@ -54,6 +54,14 @@
    0x91 | 0b 05       | component export section
    0x93 | 01          | 1 count
    0x94 | 01 62 05 00 | export ComponentExport { name: "b", kind: Instance, index: 0 }
- 0x98 | 0b 05       | component export section
- 0x9a | 01          | 1 count
- 0x9b | 01 78 04 03 | export ComponentExport { name: "x", kind: Component, index: 3 }
+   0x98 | 00 17       | custom section
+   0x9a | 0e 63 6f 6d | name: "component-name"
+        | 70 6f 6e 65
+        | 6e 74 2d 6e
+        | 61 6d 65   
+   0xa9 | 01 06 00 11 | core module section
+   0xad | 01          | 1 count
+   0xae | 00 01 6d    | Naming { index: 0, name: "m" }
+ 0xb1 | 0b 05       | component export section
+ 0xb3 | 01          | 1 count
+ 0xb4 | 01 78 04 03 | export ComponentExport { name: "x", kind: Component, index: 3 }


### PR DESCRIPTION
This commit is an implementation of WebAssembly/component-model#124 which defines a custom section for naming the items within a component.