### PR TITLE
wasm-encoder: Change the I64xLeS instruction encoding

### DIFF
--- a/crates/wasm-encoder/src/core/code.rs
+++ b/crates/wasm-encoder/src/core/code.rs
@@ -2331,7 +2331,7 @@ impl Encode for Instruction<'_> {
             }
             Instruction::I64x2LeS => {
                 sink.push(0xFD);
-                0xDDu32.encode(sink);
+                0xDAu32.encode(sink);
             }
             Instruction::I64x2GeS => {
                 sink.push(0xFD);


### PR DESCRIPTION
Change the `u32` field of the `I64x2LeS` instruction from `0xDD` to `0xDA` (decimal 218) to match the [spec](https://webassembly.github.io/spec/core/binary/instructions.html#vector-instructions).