### PR TITLE
FIX: Nop operation instead of unreachable

### DIFF
--- a/crates/wasm-mutate/src/mutators/codemotion/if_complement.rs
+++ b/crates/wasm-mutate/src/mutators/codemotion/if_complement.rs
@@ -52,7 +52,7 @@ impl IfComplementWriter {
             }
         } else {
             // Write an unreachable instruction
-            newfunc.instruction(&Instruction::Unreachable);
+            newfunc.instruction(&Instruction::Nop);
         }
         newfunc.instruction(&Instruction::Else);
         for ch in then {


### PR DESCRIPTION
This fixes #809.
Basically, unreachable does not preserve semantics of the original binary.