### PR TITLE
wit-parser: Fix types leaking across interfaces

### DIFF
--- a/crates/wit-parser/src/ast/resolve.rs
+++ b/crates/wit-parser/src/ast/resolve.rs
@@ -35,7 +35,6 @@ impl Resolver {
         for interface in document.interfaces() {
             let name = &interface.name.name;
             let instance = self.resolve(name, &interface.items, &interface.docs)?;
-            *self = Resolver::default();
 
             if interface_map.insert(name.to_string(), instance).is_some() {
                 return Err(Error {
@@ -173,6 +172,8 @@ impl Resolver {
                 }
             }
         }
+
+        self.anon_types.clear();
 
         Ok(Interface {
             name: name.to_string(),

--- a/crates/wit-parser/tests/all.rs
+++ b/crates/wit-parser/tests/all.rs
@@ -116,6 +116,7 @@ impl Runner<'_> {
             }
         } else {
             let instance = result?;
+            test_world(&instance);
             to_json(&instance)
         };
 
@@ -378,4 +379,21 @@ fn to_json(world: &World) -> String {
     fn translate_optional_type(ty: Option<&wit_parser::Type>) -> Option<String> {
         ty.map(translate_type)
     }
+}
+
+fn test_world(world: &World) {
+    for (_, interface) in world.imports.iter() {
+        test_interface(interface);
+    }
+    for (_, interface) in world.exports.iter() {
+        test_interface(interface);
+    }
+    if let Some(default) = &world.default {
+        test_interface(default);
+    }
+}
+
+fn test_interface(interface: &Interface) {
+    let mut sizes = SizeAlign::default();
+    sizes.fill(interface);
 }

--- a/crates/wit-parser/tests/ui/shared-types.wit
+++ b/crates/wit-parser/tests/ui/shared-types.wit
@@ -1,0 +1,8 @@
+world foo {
+  import foo: interface {
+    a: func() -> list<u8>
+  }
+  default export interface {
+    a: func() -> tuple<list<u8>>
+  }
+}

--- a/crates/wit-parser/tests/ui/shared-types.wit.result
+++ b/crates/wit-parser/tests/ui/shared-types.wit.result
@@ -1,0 +1,50 @@
+{
+  "name": "foo",
+  "default": {
+    "types": [
+      {
+        "idx": 0,
+        "list": "u8"
+      },
+      {
+        "idx": 1,
+        "tuple": {
+          "types": [
+            "type-0"
+          ]
+        }
+      }
+    ],
+    "functions": [
+      {
+        "name": "a",
+        "params": [],
+        "results": [
+          "type-1"
+        ]
+      }
+    ]
+  },
+  "imports": [
+    [
+      "foo",
+      {
+        "types": [
+          {
+            "idx": 0,
+            "list": "u8"
+          }
+        ],
+        "functions": [
+          {
+            "name": "a",
+            "params": [],
+            "results": [
+              "type-0"
+            ]
+          }
+        ]
+      }
+    ]
+  ]
+}


### PR DESCRIPTION
This fixes an internal bug where types were accidentally leaking across interfaces, panicking when used. This commit fixes the issue by properly fixing the "reset the state" after resolution of each interface and then additionally adds some more testing per-interface to the `ui` tests.