### PR TITLE
Implement latest component model spec.

### DIFF
--- a/crates/wasm-compose/Cargo.toml
+++ b/crates/wasm-compose/Cargo.toml
@@ -22,6 +22,7 @@ log = { workspace = true }
 serde_yaml = "0.8.26"
 clap = { workspace = true, optional = true }
 smallvec = "1.10.0"
+heck = "0.4.0"
 
 [features]
 default = []

--- a/crates/wasm-compose/src/composer.rs
+++ b/crates/wasm-compose/src/composer.rs
@@ -210,7 +210,7 @@ impl<'a> CompositionGraphBuilder<'a> {
         let (_, instance_id) = self.instances.get_index(instance).unwrap();
         let (_, component) = self.graph.get_component_of_instance(*instance_id).unwrap();
         match component.export_by_name(export) {
-            Some((export_index, kind, index)) if kind == ComponentExternalKind::Instance => {
+            Some((export_index, _, kind, index)) if kind == ComponentExternalKind::Instance => {
                 let export_ty = component.types.component_instance_at(index).unwrap();
                 if !ComponentInstanceType::is_subtype_of(export_ty, component.types(), ty, types) {
                     bail!("component `{path}` exports an instance named `{export}` but it is not compatible with import `{arg_name}` of component `{dependent_path}`",
@@ -234,7 +234,7 @@ impl<'a> CompositionGraphBuilder<'a> {
         r: InstanceImportRef,
     ) -> (&Component, &str, &ComponentInstanceType) {
         let component = self.graph.get_component(r.component).unwrap();
-        let (name, ty) = component.import(r.import).unwrap();
+        let (name, _, ty) = component.import(r.import).unwrap();
         match ty {
             ComponentTypeRef::Instance(index) => (
                 component,
@@ -310,7 +310,7 @@ impl<'a> CompositionGraphBuilder<'a> {
         let count = queue.len();
 
         // Push a dependency for every instance import
-        for (import, name, ty) in component.imports() {
+        for (import, name, _, ty) in component.imports() {
             match ty {
                 ComponentTypeRef::Instance(_) => {}
                 _ => bail!(

--- a/crates/wasm-compose/tests/compositions/complex-import/composed.wat
+++ b/crates/wasm-compose/tests/compositions/complex-import/composed.wat
@@ -146,7 +146,7 @@
       (export "u" (func (type 29)))
     )
   )
-  (import "$input" (component (;0;) (type 0)))
+  (import "input" (component (;0;) (type 0)))
   (import "b" (component (;1;) (type 1)))
   (import "a" (component (;2;) (type 2)))
   (instance (;0;) (instantiate 2))

--- a/crates/wasm-compose/tests/compositions/missing-explicit-dep/config.yml
+++ b/crates/wasm-compose/tests/compositions/missing-explicit-dep/config.yml
@@ -1,7 +1,2 @@
 dependencies:
   a: a.wat
-
-instantiations:
-  $input:
-    arguments:
-      '': a

--- a/crates/wasm-compose/tests/compositions/missing-explicit-dep/root.wat
+++ b/crates/wasm-compose/tests/compositions/missing-explicit-dep/root.wat
@@ -1,3 +1,3 @@
 (component
-  (import "" (instance))
+  (import "a" (instance))
 )

--- a/crates/wasm-compose/tests/compositions/not-instance-import/error.txt
+++ b/crates/wasm-compose/tests/compositions/not-instance-import/error.txt
@@ -1,1 +1,1 @@
-component `tests/compositions/not-instance-import/root.wat` has a non-instance import named ``
+component `tests/compositions/not-instance-import/root.wat` has a non-instance import named `a`

--- a/crates/wasm-compose/tests/compositions/not-instance-import/root.wat
+++ b/crates/wasm-compose/tests/compositions/not-instance-import/root.wat
@@ -1,3 +1,3 @@
 (component
-  (import "" (func))
+  (import "a" (func))
 )

--- a/crates/wasm-compose/tests/compositions/url-mismatch/b.wat
+++ b/crates/wasm-compose/tests/compositions/url-mismatch/b.wat
@@ -1,0 +1,3 @@
+(component
+  (import "a" "http://example.com/bar" (instance))
+)

--- a/crates/wasm-compose/tests/compositions/url-mismatch/error.txt
+++ b/crates/wasm-compose/tests/compositions/url-mismatch/error.txt
@@ -1,0 +1,1 @@
+cannot import instance with name `a` because import URL `http://example.com/foo` conflicts with `http://example.com/bar`

--- a/crates/wasm-compose/tests/compositions/url-mismatch/root.wat
+++ b/crates/wasm-compose/tests/compositions/url-mismatch/root.wat
@@ -1,0 +1,4 @@
+(component
+  (import "a" "http://example.com/foo" (instance))
+  (import "b" (instance))
+)

--- a/crates/wasm-encoder/src/component/exports.rs
+++ b/crates/wasm-encoder/src/component/exports.rs
@@ -56,7 +56,7 @@ impl Encode for ComponentExportKind {
 ///
 /// // This exports a function named "foo"
 /// let mut exports = ComponentExportSection::new();
-/// exports.export("foo", ComponentExportKind::Func, 0);
+/// exports.export("foo", "", ComponentExportKind::Func, 0);
 ///
 /// let mut component = Component::new();
 /// component.section(&exports);
@@ -86,8 +86,15 @@ impl ComponentExportSection {
     }
 
     /// Define an export in the export section.
-    pub fn export(&mut self, name: &str, kind: ComponentExportKind, index: u32) -> &mut Self {
+    pub fn export(
+        &mut self,
+        name: &str,
+        url: &str,
+        kind: ComponentExportKind,
+        index: u32,
+    ) -> &mut Self {
         name.encode(&mut self.bytes);
+        url.encode(&mut self.bytes);
         kind.encode(&mut self.bytes);
         index.encode(&mut self.bytes);
         self.num_added += 1;

--- a/crates/wasm-encoder/src/component/imports.rs
+++ b/crates/wasm-encoder/src/component/imports.rs
@@ -98,7 +98,7 @@ impl Encode for ComponentTypeRef {
 ///
 /// // This imports a function named `f` with the type defined above
 /// let mut imports = ComponentImportSection::new();
-/// imports.import("f", ComponentTypeRef::Func(0));
+/// imports.import("f", "", ComponentTypeRef::Func(0));
 ///
 /// let mut component = Component::new();
 /// component.section(&types);
@@ -129,8 +129,9 @@ impl ComponentImportSection {
     }
 
     /// Define an import in the component import section.
-    pub fn import(&mut self, name: &str, ty: ComponentTypeRef) -> &mut Self {
+    pub fn import(&mut self, name: &str, url: &str, ty: ComponentTypeRef) -> &mut Self {
         name.encode(&mut self.bytes);
+        url.encode(&mut self.bytes);
         ty.encode(&mut self.bytes);
         self.num_added += 1;
         self

--- a/crates/wasm-encoder/src/component/types.rs
+++ b/crates/wasm-encoder/src/component/types.rs
@@ -245,18 +245,20 @@ impl ComponentType {
     }
 
     /// Defines an import in this component type.
-    pub fn import(&mut self, name: &str, ty: ComponentTypeRef) -> &mut Self {
+    pub fn import(&mut self, name: &str, url: &str, ty: ComponentTypeRef) -> &mut Self {
         self.bytes.push(0x03);
         name.encode(&mut self.bytes);
+        url.encode(&mut self.bytes);
         ty.encode(&mut self.bytes);
         self.num_added += 1;
         self
     }
 
     /// Defines an export in this component type.
-    pub fn export(&mut self, name: &str, ty: ComponentTypeRef) -> &mut Self {
+    pub fn export(&mut self, name: &str, url: &str, ty: ComponentTypeRef) -> &mut Self {
         self.bytes.push(0x04);
         name.encode(&mut self.bytes);
+        url.encode(&mut self.bytes);
         ty.encode(&mut self.bytes);
         self.num_added += 1;
         self
@@ -343,9 +345,10 @@ impl InstanceType {
     }
 
     /// Defines an export in this instance type.
-    pub fn export(&mut self, name: &str, ty: ComponentTypeRef) -> &mut Self {
+    pub fn export(&mut self, name: &str, url: &str, ty: ComponentTypeRef) -> &mut Self {
         self.bytes.push(0x04);
         name.encode(&mut self.bytes);
+        url.encode(&mut self.bytes);
         ty.encode(&mut self.bytes);
         self.num_added += 1;
         self

--- a/crates/wasm-smith/src/component.rs
+++ b/crates/wasm-smith/src/component.rs
@@ -13,6 +13,7 @@ use std::{
     rc::Rc,
 };
 use wasm_encoder::{ComponentTypeRef, ComponentValType, PrimitiveValType, TypeBounds, ValType};
+use wasmparser::types::KebabString;
 
 mod encode;
 
@@ -122,7 +123,10 @@ struct ComponentContext {
     num_imports: usize,
 
     // The set of names of imports we've generated thus far.
-    import_names: HashSet<String>,
+    import_names: HashSet<KebabString>,
+
+    // The set of URLs of imports we've generated thus far.
+    import_urls: HashSet<KebabString>,
 
     // This component's function index space.
     funcs: Vec<ComponentOrCoreFuncType>,
@@ -185,6 +189,7 @@ impl ComponentContext {
             component: Component::empty(),
             num_imports: 0,
             import_names: HashSet::default(),
+            import_urls: HashSet::default(),
             funcs: vec![],
             component_funcs: vec![],
             scalar_component_funcs: vec![],
@@ -1022,7 +1027,9 @@ impl ComponentBuilder {
     ) -> Result<Rc<ComponentType>> {
         let mut defs = vec![];
         let mut imports = HashSet::new();
+        let mut import_urls = HashSet::new();
         let mut exports = HashSet::new();
+        let mut export_urls = HashSet::new();
 
         self.with_types_scope(|me| {
             arbitrary_loop(u, 0, 100, |u| {
@@ -1034,8 +1041,13 @@ impl ComponentBuilder {
                 if me.current_type_scope().can_ref_type() && u.int_in_range::<u8>(0..=3)? == 0 {
                     if let Some(ty) = me.arbitrary_type_ref(u, true, true)? {
                         // Imports.
-                        let name = crate::unique_string(100, &mut imports, u)?;
-                        defs.push(ComponentTypeDef::Import(Import { name, ty }));
+                        let name = crate::unique_kebab_string(100, &mut imports, u)?;
+                        let url = if u.arbitrary()? {
+                            Some(crate::unique_url(100, &mut import_urls, u)?)
+                        } else {
+                            None
+                        };
+                        defs.push(ComponentTypeDef::Import(Import { name, url, ty }));
                         return Ok(true);
                     }
 
@@ -1043,7 +1055,8 @@ impl ComponentBuilder {
                 }
 
                 // Type definitions, exports, and aliases.
-                let def = me.arbitrary_instance_type_def(u, &mut exports, type_fuel)?;
+                let def =
+                    me.arbitrary_instance_type_def(u, &mut exports, &mut export_urls, type_fuel)?;
                 defs.push(def.into());
                 Ok(true)
             })
@@ -1059,6 +1072,7 @@ impl ComponentBuilder {
     ) -> Result<Rc<InstanceType>> {
         let mut defs = vec![];
         let mut exports = HashSet::new();
+        let mut export_urls = HashSet::new();
 
         self.with_types_scope(|me| {
             arbitrary_loop(u, 0, 100, |u| {
@@ -1067,7 +1081,12 @@ impl ComponentBuilder {
                     return Ok(false);
                 }
 
-                defs.push(me.arbitrary_instance_type_def(u, &mut exports, type_fuel)?);
+                defs.push(me.arbitrary_instance_type_def(
+                    u,
+                    &mut exports,
+                    &mut export_urls,
+                    type_fuel,
+                )?);
                 Ok(true)
             })
         })?;
@@ -1078,13 +1097,15 @@ impl ComponentBuilder {
     fn arbitrary_instance_type_def(
         &mut self,
         u: &mut Unstructured,
-        exports: &mut HashSet<String>,
+        exports: &mut HashSet<KebabString>,
+        export_urls: &mut HashSet<KebabString>,
         type_fuel: &mut u32,
     ) -> Result<InstanceTypeDecl> {
         let mut choices: Vec<
             fn(
                 &mut ComponentBuilder,
-                &mut HashSet<String>,
+                &mut HashSet<KebabString>,
+                &mut HashSet<KebabString>,
                 &mut Unstructured,
                 &mut u32,
             ) -> Result<InstanceTypeDecl>,
@@ -1092,9 +1113,14 @@ impl ComponentBuilder {
 
         // Export.
         if self.current_type_scope().can_ref_type() {
-            choices.push(|me, exports, u, _type_fuel| {
+            choices.push(|me, exports, export_urls, u, _type_fuel| {
                 Ok(InstanceTypeDecl::Export {
-                    name: crate::unique_string(100, exports, u)?,
+                    name: crate::unique_kebab_string(100, exports, u)?,
+                    url: if u.arbitrary()? {
+                        Some(crate::unique_url(100, export_urls, u)?)
+                    } else {
+                        None
+                    },
                     ty: me.arbitrary_type_ref(u, false, true)?.unwrap(),
                 })
             });
@@ -1106,7 +1132,7 @@ impl ComponentBuilder {
             .iter()
             .any(|scope| !scope.types.is_empty() || !scope.core_types.is_empty())
         {
-            choices.push(|me, _exports, u, _type_fuel| {
+            choices.push(|me, _exports, _export_urls, u, _type_fuel| {
                 let alias = me.arbitrary_outer_type_alias(u)?;
                 match &alias {
                     Alias::Outer {
@@ -1124,7 +1150,7 @@ impl ComponentBuilder {
         }
 
         // Core type definition.
-        choices.push(|me, _exports, u, type_fuel| {
+        choices.push(|me, _exports, _export_urls, u, type_fuel| {
             let ty = me.arbitrary_core_type(u, type_fuel)?;
             me.current_type_scope_mut().push_core(ty.clone());
             Ok(InstanceTypeDecl::CoreType(ty))
@@ -1132,7 +1158,7 @@ impl ComponentBuilder {
 
         // Type definition.
         if self.types.len() < self.config.max_nesting_depth() {
-            choices.push(|me, _exports, u, type_fuel| {
+            choices.push(|me, _exports, _export_urls, u, type_fuel| {
                 let ty = me.arbitrary_type(u, type_fuel)?;
                 me.current_type_scope_mut().push(ty.clone());
                 Ok(InstanceTypeDecl::Type(ty))
@@ -1140,7 +1166,7 @@ impl ComponentBuilder {
         }
 
         let f = u.choose(&choices)?;
-        f(self, exports, u, type_fuel)
+        f(self, exports, export_urls, u, type_fuel)
     }
 
     fn arbitrary_outer_core_type_alias(
@@ -1236,7 +1262,7 @@ impl ComponentBuilder {
                 return Ok(false);
             }
 
-            let name = crate::unique_non_empty_string(100, &mut names, u)?;
+            let name = crate::unique_kebab_string(100, &mut names, u)?;
             let ty = self.arbitrary_component_val_type(u)?;
 
             params.push((name, ty));
@@ -1260,10 +1286,10 @@ impl ComponentBuilder {
             let name = if results.is_empty() {
                 // Most of the time we should have a single, unnamed result.
                 u.ratio::<u8>(10, 100)?
-                    .then(|| crate::unique_non_empty_string(100, &mut names, u))
+                    .then(|| crate::unique_kebab_string(100, &mut names, u))
                     .transpose()?
             } else {
-                Some(crate::unique_non_empty_string(100, &mut names, u)?)
+                Some(crate::unique_kebab_string(100, &mut names, u)?)
             };
 
             let ty = self.arbitrary_component_val_type(u)?;
@@ -1332,7 +1358,7 @@ impl ComponentBuilder {
                 return Ok(false);
             }
 
-            let name = crate::unique_non_empty_string(100, &mut field_names, u)?;
+            let name = crate::unique_kebab_string(100, &mut field_names, u)?;
             let ty = self.arbitrary_component_val_type(u)?;
 
             fields.push((name, ty));
@@ -1354,7 +1380,7 @@ impl ComponentBuilder {
                 return Ok(false);
             }
 
-            let name = crate::unique_non_empty_string(100, &mut case_names, u)?;
+            let name = crate::unique_kebab_string(100, &mut case_names, u)?;
 
             let ty = u
                 .arbitrary::<bool>()?
@@ -1404,7 +1430,7 @@ impl ComponentBuilder {
                 return Ok(false);
             }
 
-            fields.push(crate::unique_non_empty_string(100, &mut field_names, u)?);
+            fields.push(crate::unique_kebab_string(100, &mut field_names, u)?);
             Ok(true)
         })?;
         Ok(FlagsType { fields })
@@ -1419,7 +1445,7 @@ impl ComponentBuilder {
                 return Ok(false);
             }
 
-            variants.push(crate::unique_non_empty_string(100, &mut variant_names, u)?);
+            variants.push(crate::unique_kebab_string(100, &mut variant_names, u)?);
             Ok(true)
         })?;
         Ok(EnumType { variants })
@@ -1484,13 +1510,13 @@ impl ComponentBuilder {
         }
     }
 
-    fn push_import(&mut self, name: String, ty: ComponentTypeRef) {
+    fn push_import(&mut self, name: KebabString, url: Option<String>, ty: ComponentTypeRef) {
         let nth = match self.ensure_section(
             |sec| matches!(sec, Section::Import(_)),
             || Section::Import(ImportSection { imports: vec![] }),
         ) {
             Section::Import(sec) => {
-                sec.imports.push(Import { name, ty });
+                sec.imports.push(Import { name, url, ty });
                 sec.imports.len() - 1
             }
             _ => unreachable!(),
@@ -1615,8 +1641,17 @@ impl ComponentBuilder {
             match self.arbitrary_type_ref(u, true, false)? {
                 Some(ty) => {
                     let name =
-                        crate::unique_string(100, &mut self.component_mut().import_names, u)?;
-                    self.push_import(name, ty);
+                        crate::unique_kebab_string(100, &mut self.component_mut().import_names, u)?;
+                    let url = if u.arbitrary()? {
+                        Some(crate::unique_url(
+                            100,
+                            &mut self.component_mut().import_urls,
+                            u,
+                        )?)
+                    } else {
+                        None
+                    };
+                    self.push_import(name, url, ty);
                     Ok(true)
                 }
                 None => Ok(false),
@@ -1838,7 +1873,7 @@ fn inverse_scalar_canonical_abi_for(
 
     for core_ty in &core_func_ty.params {
         params.push((
-            crate::unique_non_empty_string(100, &mut names, u)?,
+            crate::unique_kebab_string(100, &mut names, u)?,
             from_core_ty(u, *core_ty)?,
         ));
     }
@@ -1849,7 +1884,7 @@ fn inverse_scalar_canonical_abi_for(
         0 => Vec::new(),
         1 => vec![(
             if u.arbitrary()? {
-                Some(crate::unique_non_empty_string(100, &mut names, u)?)
+                Some(crate::unique_kebab_string(100, &mut names, u)?)
             } else {
                 None
             },
@@ -1994,7 +2029,11 @@ enum ComponentTypeDef {
     Type(Rc<Type>),
     Alias(Alias),
     Import(Import),
-    Export { name: String, ty: ComponentTypeRef },
+    Export {
+        name: KebabString,
+        url: Option<String>,
+        ty: ComponentTypeRef,
+    },
 }
 
 impl From<InstanceTypeDecl> for ComponentTypeDef {
@@ -2002,7 +2041,7 @@ impl From<InstanceTypeDecl> for ComponentTypeDef {
         match def {
             InstanceTypeDecl::CoreType(t) => Self::CoreType(t),
             InstanceTypeDecl::Type(t) => Self::Type(t),
-            InstanceTypeDecl::Export { name, ty } => Self::Export { name, ty },
+            InstanceTypeDecl::Export { name, url, ty } => Self::Export { name, url, ty },
             InstanceTypeDecl::Alias(a) => Self::Alias(a),
         }
     }
@@ -2018,13 +2057,17 @@ enum InstanceTypeDecl {
     CoreType(Rc<CoreType>),
     Type(Rc<Type>),
     Alias(Alias),
-    Export { name: String, ty: ComponentTypeRef },
+    Export {
+        name: KebabString,
+        url: Option<String>,
+        ty: ComponentTypeRef,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct FuncType {
-    params: Vec<(String, ComponentValType)>,
-    results: Vec<(Option<String>, ComponentValType)>,
+    params: Vec<(KebabString, ComponentValType)>,
+    results: Vec<(Option<KebabString>, ComponentValType)>,
 }
 
 impl FuncType {
@@ -2082,12 +2125,12 @@ enum DefinedType {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct RecordType {
-    fields: Vec<(String, ComponentValType)>,
+    fields: Vec<(KebabString, ComponentValType)>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct VariantType {
-    cases: Vec<(String, Option<ComponentValType>, Option<u32>)>,
+    cases: Vec<(KebabString, Option<ComponentValType>, Option<u32>)>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -2102,12 +2145,12 @@ struct TupleType {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct FlagsType {
-    fields: Vec<String>,
+    fields: Vec<KebabString>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct EnumType {
-    variants: Vec<String>,
+    variants: Vec<KebabString>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -2133,7 +2176,8 @@ struct ImportSection {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 struct Import {
-    name: String,
+    name: KebabString,
+    url: Option<String>,
     ty: ComponentTypeRef,
 }
 

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -14,6 +14,7 @@ exclude = ["benches/*.wasm"]
 
 [dependencies]
 indexmap = { workspace = true }
+url = "2.3.1"
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/wasmparser/src/readers/component/exports.rs
+++ b/crates/wasmparser/src/readers/component/exports.rs
@@ -23,6 +23,8 @@ pub enum ComponentExternalKind {
 pub struct ComponentExport<'a> {
     /// The name of the exported item.
     pub name: &'a str,
+    /// The optional URL of the exported item.
+    pub url: &'a str,
     /// The kind of the export.
     pub kind: ComponentExternalKind,
     /// The index of the exported item.
@@ -60,7 +62,7 @@ impl<'a> ComponentExportSectionReader<'a> {
     /// ```
     /// use wasmparser::ComponentExportSectionReader;
     ///
-    /// # let data: &[u8] = &[0x01, 0x03, b'f', b'o', b'o', 0x01, 0x00];
+    /// # let data: &[u8] = &[0x01, 0x03, b'f', b'o', b'o', 0x00, 0x01, 0x00];
     /// let mut reader = ComponentExportSectionReader::new(data, 0).unwrap();
     /// for _ in 0..reader.get_count() {
     ///     let export = reader.read().expect("export");

--- a/crates/wasmparser/src/readers/component/imports.rs
+++ b/crates/wasmparser/src/readers/component/imports.rs
@@ -43,6 +43,8 @@ pub enum ComponentTypeRef {
 pub struct ComponentImport<'a> {
     /// The name of the imported item.
     pub name: &'a str,
+    /// The optional URL of the imported item.
+    pub url: &'a str,
     /// The type reference for the import.
     pub ty: ComponentTypeRef,
 }
@@ -77,7 +79,7 @@ impl<'a> ComponentImportSectionReader<'a> {
     /// # Examples
     /// ```
     /// use wasmparser::ComponentImportSectionReader;
-    /// let data: &[u8] = &[0x01, 0x01, 0x41, 0x01, 0x66, 0x00, 0x00];
+    /// let data: &[u8] = &[0x01, 0x01, 0x41, 0x00, 0x01, 0x66, 0x00, 0x00];
     /// let mut reader = ComponentImportSectionReader::new(data, 0).unwrap();
     /// for _ in 0..reader.get_count() {
     ///     let import = reader.read().expect("import");

--- a/crates/wasmparser/src/readers/component/types.rs
+++ b/crates/wasmparser/src/readers/component/types.rs
@@ -234,6 +234,8 @@ pub enum ComponentTypeDeclaration<'a> {
     Export {
         /// The name of the export.
         name: &'a str,
+        /// The optional URL of the export.
+        url: &'a str,
         /// The type reference for the export.
         ty: ComponentTypeRef,
     },
@@ -254,6 +256,8 @@ pub enum InstanceTypeDeclaration<'a> {
     Export {
         /// The name of the export.
         name: &'a str,
+        /// The URL for the export.
+        url: &'a str,
         /// The type reference for the export.
         ty: ComponentTypeRef,
     },

--- a/crates/wasmparser/src/readers/core/names.rs
+++ b/crates/wasmparser/src/readers/core/names.rs
@@ -126,7 +126,7 @@ impl<'a> SectionReader for IndirectNameMap<'a> {
 
         let end = self.reader.position;
         Ok(IndirectNaming {
-            index: index,
+            index,
             names: NameMap::new(
                 &self.reader.buffer[start..end],
                 self.reader.original_offset + start,

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -1158,7 +1158,13 @@ impl Validator {
             |components, _, _, export, offset| {
                 let current = components.last_mut().unwrap();
                 let ty = current.export_to_entity_type(&export, offset)?;
-                current.add_export(export.name, ty, offset, false /* checked above */)
+                current.add_export(
+                    export.name,
+                    export.url,
+                    ty,
+                    offset,
+                    false, /* checked above */
+                )
             },
         )
     }

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -1207,7 +1207,7 @@ where
                 "type mismatch: select only takes integral types"
             )
         }
-        if ty1 != ty2 && ty1 != None && ty2 != None {
+        if ty1 != ty2 && ty1.is_some() && ty2.is_some() {
             bail!(
                 self.offset,
                 "type mismatch: select operands have different types"

--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -9,10 +9,13 @@ use crate::{
 use indexmap::{IndexMap, IndexSet};
 use std::{
     borrow::Borrow,
+    fmt,
     hash::{Hash, Hasher},
     mem,
+    ops::Deref,
     sync::Arc,
 };
+use url::Url;
 
 /// The maximum number of parameters in the canonical ABI that can be passed by value.
 ///
@@ -27,6 +30,193 @@ const MAX_FLAT_FUNC_RESULTS: usize = 1;
 
 /// The maximum lowered types, including a possible type for a return pointer parameter.
 const MAX_LOWERED_TYPES: usize = MAX_FLAT_FUNC_PARAMS + 1;
+
+/// Represents a kebab string slice used in validation.
+///
+/// This is a wrapper around `str` that ensures the slice is
+/// a valid kebab case string according to the component model
+/// specification.
+///
+/// It also provides an equality and hashing implementation
+/// that ignores ASCII case.
+#[derive(Debug, Eq)]
+#[repr(transparent)]
+pub struct KebabStr(str);
+
+impl KebabStr {
+    /// Creates a new kebab string slice.
+    ///
+    /// Returns `None` if the given string is not a valid kebab string.
+    pub fn new<'a>(s: impl AsRef<str> + 'a) -> Option<&'a Self> {
+        let s = Self::new_unchecked(s);
+        if s.is_kebab_case() {
+            Some(s)
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn new_unchecked<'a>(s: impl AsRef<str> + 'a) -> &'a Self {
+        // Safety: `KebabStr` is a transparent wrapper around `str`
+        // Therefore transmuting `&str` to `&KebabStr` is safe.
+        unsafe { std::mem::transmute::<_, &Self>(s.as_ref()) }
+    }
+
+    /// Gets the underlying string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Converts the slice to an owned string.
+    pub fn to_kebab_string(&self) -> KebabString {
+        KebabString(self.to_string())
+    }
+
+    fn is_kebab_case(&self) -> bool {
+        let mut lower = false;
+        let mut upper = false;
+        for c in self.chars() {
+            match c {
+                'a'..='z' if !lower && !upper => lower = true,
+                'A'..='Z' if !lower && !upper => upper = true,
+                'a'..='z' if lower => {}
+                'A'..='Z' if upper => {}
+                '0'..='9' if lower || upper => {}
+                '-' if lower || upper => {
+                    lower = false;
+                    upper = false;
+                }
+                _ => return false,
+            }
+        }
+
+        !self.is_empty() && !self.ends_with('-')
+    }
+}
+
+impl Deref for KebabStr {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl PartialEq for KebabStr {
+    fn eq(&self, other: &Self) -> bool {
+        if self.len() != other.len() {
+            return false;
+        }
+
+        self.chars()
+            .zip(other.chars())
+            .all(|(a, b)| a.to_ascii_lowercase() == b.to_ascii_lowercase())
+    }
+}
+
+impl PartialEq<KebabString> for KebabStr {
+    fn eq(&self, other: &KebabString) -> bool {
+        self.eq(other.as_kebab_str())
+    }
+}
+
+impl Hash for KebabStr {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.len().hash(state);
+
+        for b in self.chars() {
+            b.to_ascii_lowercase().hash(state);
+        }
+    }
+}
+
+impl fmt::Display for KebabStr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (self as &str).fmt(f)
+    }
+}
+
+impl ToOwned for KebabStr {
+    type Owned = KebabString;
+
+    fn to_owned(&self) -> Self::Owned {
+        self.to_kebab_string()
+    }
+}
+
+/// Represents an owned kebab string for validation.
+///
+/// This is a wrapper around `String` that ensures the string is
+/// a valid kebab case string according to the component model
+/// specification.
+///
+/// It also provides an equality and hashing implementation
+/// that ignores ASCII case.
+#[derive(Debug, Clone, Eq)]
+pub struct KebabString(String);
+
+impl KebabString {
+    /// Creates a new kebab string.
+    ///
+    /// Returns `None` if the given string is not a valid kebab string.
+    pub fn new(s: impl Into<String>) -> Option<Self> {
+        let s = s.into();
+        if KebabStr::new(&s).is_some() {
+            Some(Self(s))
+        } else {
+            None
+        }
+    }
+
+    /// Gets the underlying string.
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    /// Converts the kebab string to a kebab string slice.
+    pub fn as_kebab_str(&self) -> &KebabStr {
+        // Safety: internal string is always valid kebab-case
+        KebabStr::new_unchecked(self.as_str())
+    }
+}
+
+impl Deref for KebabString {
+    type Target = KebabStr;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_kebab_str()
+    }
+}
+
+impl Borrow<KebabStr> for KebabString {
+    fn borrow(&self) -> &KebabStr {
+        self.as_kebab_str()
+    }
+}
+
+impl PartialEq for KebabString {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_kebab_str().eq(other.as_kebab_str())
+    }
+}
+
+impl PartialEq<KebabStr> for KebabString {
+    fn eq(&self, other: &KebabStr) -> bool {
+        self.as_kebab_str().eq(other)
+    }
+}
+
+impl Hash for KebabString {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_kebab_str().hash(state)
+    }
+}
+
+impl fmt::Display for KebabString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_kebab_str().fmt(f)
+    }
+}
 
 /// A simple alloc-free list of types used for calculating lowered function signatures.
 pub(crate) struct LoweredTypes {
@@ -622,9 +812,9 @@ pub struct ComponentType {
     /// The effective type size for the component type.
     pub(crate) type_size: usize,
     /// The imports of the component type.
-    pub imports: IndexMap<String, ComponentEntityType>,
+    pub imports: IndexMap<KebabString, (Option<Url>, ComponentEntityType)>,
     /// The exports of the component type.
-    pub exports: IndexMap<String, ComponentEntityType>,
+    pub exports: IndexMap<KebabString, (Option<Url>, ComponentEntityType)>,
 }
 
 impl ComponentType {
@@ -639,11 +829,11 @@ impl ComponentType {
         // *more* than what this component type needs).
         // However, for imports, the check is reversed (i.e. it is okay
         // to import *less* than what this component type needs).
-        a.imports.iter().all(|(k, a)| match b.imports.get(k) {
-            Some(b) => ComponentEntityType::internal_is_subtype_of(b, bt, a, at),
+        a.imports.iter().all(|(k, (_, a))| match b.imports.get(k) {
+            Some((_, b)) => ComponentEntityType::internal_is_subtype_of(b, bt, a, at),
             None => false,
-        }) && b.exports.iter().all(|(k, b)| match a.exports.get(k) {
-            Some(a) => ComponentEntityType::internal_is_subtype_of(a, at, b, bt),
+        }) && b.exports.iter().all(|(k, (_, b))| match a.exports.get(k) {
+            Some((_, a)) => ComponentEntityType::internal_is_subtype_of(a, at, b, bt),
             None => false,
         })
     }
@@ -653,11 +843,11 @@ impl ComponentType {
 #[derive(Debug, Clone)]
 pub enum ComponentInstanceTypeKind {
     /// The instance type is from a definition.
-    Defined(IndexMap<String, ComponentEntityType>),
+    Defined(IndexMap<KebabString, (Option<Url>, ComponentEntityType)>),
     /// The instance type is the result of instantiating a component type.
     Instantiated(TypeId),
     /// The instance type is the result of instantiating from exported items.
-    Exports(IndexMap<String, ComponentEntityType>),
+    Exports(IndexMap<KebabString, (Option<Url>, ComponentEntityType)>),
 }
 
 /// Represents a type of a component instance.
@@ -671,14 +861,20 @@ pub struct ComponentInstanceType {
 
 impl ComponentInstanceType {
     /// Gets the exports of the instance type.
-    pub fn exports<'a>(&'a self, types: TypesRef<'a>) -> &'a IndexMap<String, ComponentEntityType> {
+    pub fn exports<'a>(
+        &'a self,
+        types: TypesRef<'a>,
+    ) -> impl ExactSizeIterator<Item = (&'a KebabStr, &'a Option<Url>, ComponentEntityType)> + Clone
+    {
         self.internal_exports(types.list)
+            .iter()
+            .map(|(n, (u, t))| (n.as_kebab_str(), u, *t))
     }
 
     pub(crate) fn internal_exports<'a>(
         &'a self,
         types: &'a TypeList,
-    ) -> &'a IndexMap<String, ComponentEntityType> {
+    ) -> &'a IndexMap<KebabString, (Option<Url>, ComponentEntityType)> {
         match &self.kind {
             ComponentInstanceTypeKind::Defined(exports)
             | ComponentInstanceTypeKind::Exports(exports) => exports,
@@ -701,8 +897,8 @@ impl ComponentInstanceType {
         // *more* than what this instance type needs).
         b.internal_exports(bt)
             .iter()
-            .all(|(k, b)| match exports.get(k) {
-                Some(a) => ComponentEntityType::internal_is_subtype_of(a, at, b, bt),
+            .all(|(k, (_, b))| match exports.get(k) {
+                Some((_, a)) => ComponentEntityType::internal_is_subtype_of(a, at, b, bt),
                 None => false,
             })
     }
@@ -714,9 +910,9 @@ pub struct ComponentFuncType {
     /// The effective type size for the component function type.
     pub(crate) type_size: usize,
     /// The function parameters.
-    pub params: Box<[(String, ComponentValType)]>,
+    pub params: Box<[(KebabString, ComponentValType)]>,
     /// The function's results.
-    pub results: Box<[(Option<String>, ComponentValType)]>,
+    pub results: Box<[(Option<KebabString>, ComponentValType)]>,
 }
 
 impl ComponentFuncType {
@@ -839,7 +1035,7 @@ pub struct VariantCase {
     /// The variant case type.
     pub ty: Option<ComponentValType>,
     /// The name of the variant case refined by this one.
-    pub refines: Option<String>,
+    pub refines: Option<KebabString>,
 }
 
 /// Represents a record type.
@@ -848,7 +1044,7 @@ pub struct RecordType {
     /// The effective type size for the record type.
     pub(crate) type_size: usize,
     /// The map of record fields.
-    pub fields: IndexMap<String, ComponentValType>,
+    pub fields: IndexMap<KebabString, ComponentValType>,
 }
 
 /// Represents a variant type.
@@ -857,7 +1053,7 @@ pub struct VariantType {
     /// The effective type size for the variant type.
     pub(crate) type_size: usize,
     /// The map of variant cases.
-    pub cases: IndexMap<String, VariantCase>,
+    pub cases: IndexMap<KebabString, VariantCase>,
 }
 
 /// Represents a tuple type.
@@ -892,9 +1088,9 @@ pub enum ComponentDefinedType {
     /// The type is a tuple.
     Tuple(TupleType),
     /// The type is a set of flags.
-    Flags(IndexSet<String>),
+    Flags(IndexSet<KebabString>),
     /// The type is an enumeration.
-    Enum(IndexSet<String>),
+    Enum(IndexSet<KebabString>),
     /// The type is a union.
     Union(UnionType),
     /// The type is an `option`.

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -1451,9 +1451,13 @@ impl Printer {
                         self.print_component_outer_alias(states, kind, count, index)?
                     }
                 },
-                ComponentTypeDeclaration::Export { name, ty } => {
+                ComponentTypeDeclaration::Export { name, url, ty } => {
                     self.start_group("export ");
                     self.print_str(name)?;
+                    if !url.is_empty() {
+                        self.result.push(' ');
+                        self.print_str(url)?;
+                    }
                     self.result.push(' ');
                     self.print_component_import_ty(states.last().unwrap(), &ty, false)?;
                     self.end_group();
@@ -1492,9 +1496,13 @@ impl Printer {
                         self.print_component_outer_alias(states, kind, count, index)?
                     }
                 },
-                InstanceTypeDeclaration::Export { name, ty } => {
+                InstanceTypeDeclaration::Export { name, url, ty } => {
                     self.start_group("export ");
                     self.print_str(name)?;
+                    if !url.is_empty() {
+                        self.result.push(' ');
+                        self.print_str(url)?;
+                    }
                     self.result.push(' ');
                     self.print_component_import_ty(states.last().unwrap(), &ty, false)?;
                     self.end_group();
@@ -1722,6 +1730,10 @@ impl Printer {
     ) -> Result<()> {
         self.start_group("import ");
         self.print_str(import.name)?;
+        if !import.url.is_empty() {
+            self.result.push(' ');
+            self.print_str(import.url)?;
+        }
         self.result.push(' ');
         self.print_component_import_ty(state, &import.ty, index)?;
         self.end_group();
@@ -1812,6 +1824,10 @@ impl Printer {
     ) -> Result<()> {
         self.start_group("export ");
         self.print_str(export.name)?;
+        if !export.url.is_empty() {
+            self.result.push(' ');
+            self.print_str(export.url)?;
+        }
         self.result.push(' ');
         self.print_component_external_kind(state, export.kind, export.index)?;
         self.end_group();

--- a/crates/wasmprinter/src/operator.rs
+++ b/crates/wasmprinter/src/operator.rs
@@ -207,7 +207,7 @@ macro_rules! define_visit {
     (kind $other:tt) => (OpKind::Normal);
 
     // How to print the payload of an instruction. There are a number of
-    // instrucitons that have special cases such as avoiding printing anything
+    // instructions that have special cases such as avoiding printing anything
     // when an index is 0 or similar. The final case in this list is the
     // catch-all which prints each payload individually based on the name of the
     // payload field.

--- a/crates/wast/src/component/component.rs
+++ b/crates/wast/src/component/component.rs
@@ -1,6 +1,5 @@
 use crate::annotation;
 use crate::component::*;
-use crate::core;
 use crate::kw;
 use crate::parser::{Parse, Parser, Result};
 use crate::token::Index;
@@ -261,7 +260,7 @@ pub struct NestedComponent<'a> {
     pub name: Option<NameAnnotation<'a>>,
     /// If present, inline export annotations which indicate names this
     /// definition should be exported under.
-    pub exports: core::InlineExport<'a>,
+    pub exports: InlineExport<'a>,
     /// What kind of component this was parsed as.
     pub kind: NestedComponentKind<'a>,
 }

--- a/crates/wast/src/component/expand.rs
+++ b/crates/wast/src/component/expand.rs
@@ -11,7 +11,7 @@ use std::mem;
 ///
 /// This expansion is intended to desugar the AST from various parsed constructs
 /// to bits and bobs amenable for name resolution as well as binary encoding.
-/// For example `(import "" (func))` is split into a type definition followed by
+/// For example `(import "i" (func))` is split into a type definition followed by
 /// the import referencing that type definition.
 ///
 /// Most forms of AST expansion happen in this file and afterwards the AST will
@@ -133,12 +133,13 @@ impl<'a> Expander<'a> {
     }
 
     fn expand_core_module(&mut self, module: &mut CoreModule<'a>) -> Option<ComponentField<'a>> {
-        for name in module.exports.names.drain(..) {
+        for (name, url) in module.exports.names.drain(..) {
             let id = gensym::fill(module.span, &mut module.id);
             self.component_fields_to_append
                 .push(ComponentField::Export(ComponentExport {
                     span: module.span,
                     name,
+                    url,
                     kind: ComponentExportKind::module(module.span, id),
                 }));
         }
@@ -150,6 +151,7 @@ impl<'a> Expander<'a> {
                 Some(ComponentField::Import(ComponentImport {
                     span: module.span,
                     name: import.name,
+                    url: import.url,
                     item: ItemSig {
                         span: module.span,
                         id: module.id,
@@ -176,12 +178,13 @@ impl<'a> Expander<'a> {
         &mut self,
         component: &mut NestedComponent<'a>,
     ) -> Option<ComponentField<'a>> {
-        for name in component.exports.names.drain(..) {
+        for (name, url) in component.exports.names.drain(..) {
             let id = gensym::fill(component.span, &mut component.id);
             self.component_fields_to_append
                 .push(ComponentField::Export(ComponentExport {
                     span: component.span,
                     name,
+                    url,
                     kind: ComponentExportKind::component(component.span, id),
                 }));
         }
@@ -195,6 +198,7 @@ impl<'a> Expander<'a> {
                 Some(ComponentField::Import(ComponentImport {
                     span: component.span,
                     name: import.name,
+                    url: import.url,
                     item: ItemSig {
                         span: component.span,
                         id: component.id,
@@ -207,12 +211,13 @@ impl<'a> Expander<'a> {
     }
 
     fn expand_instance(&mut self, instance: &mut Instance<'a>) -> Option<ComponentField<'a>> {
-        for name in instance.exports.names.drain(..) {
+        for (name, url) in instance.exports.names.drain(..) {
             let id = gensym::fill(instance.span, &mut instance.id);
             self.component_fields_to_append
                 .push(ComponentField::Export(ComponentExport {
                     span: instance.span,
                     name,
+                    url,
                     kind: ComponentExportKind::instance(instance.span, id),
                 }));
         }
@@ -222,6 +227,7 @@ impl<'a> Expander<'a> {
                 Some(ComponentField::Import(ComponentImport {
                     span: instance.span,
                     name: import.name,
+                    url: import.url,
                     item: ItemSig {
                         span: instance.span,
                         id: instance.id,
@@ -271,12 +277,13 @@ impl<'a> Expander<'a> {
     }
 
     fn expand_func(&mut self, func: &mut Func<'a>) -> Option<ComponentField<'a>> {
-        for name in func.exports.names.drain(..) {
+        for (name, url) in func.exports.names.drain(..) {
             let id = gensym::fill(func.span, &mut func.id);
             self.component_fields_to_append
                 .push(ComponentField::Export(ComponentExport {
                     span: func.span,
                     name,
+                    url,
                     kind: ComponentExportKind::func(func.span, id),
                 }));
         }
@@ -286,6 +293,7 @@ impl<'a> Expander<'a> {
                 Some(ComponentField::Import(ComponentImport {
                     span: func.span,
                     name: import.name,
+                    url: import.url,
                     item: ItemSig {
                         span: func.span,
                         id: func.id,

--- a/crates/wast/src/component/func.rs
+++ b/crates/wast/src/component/func.rs
@@ -1,5 +1,4 @@
 use crate::component::*;
-use crate::core;
 use crate::kw;
 use crate::parser::{Parse, Parser, Result};
 use crate::token::{Id, Index, LParen, NameAnnotation, Span};
@@ -80,7 +79,7 @@ pub struct Func<'a> {
     pub name: Option<NameAnnotation<'a>>,
     /// If present, inline export annotations which indicate names this
     /// definition should be exported under.
-    pub exports: core::InlineExport<'a>,
+    pub exports: InlineExport<'a>,
     /// The kind of function.
     pub kind: FuncKind<'a>,
 }

--- a/crates/wast/src/component/import.rs
+++ b/crates/wast/src/component/import.rs
@@ -11,6 +11,8 @@ pub struct ComponentImport<'a> {
     pub span: Span,
     /// The name of the item to import.
     pub name: &'a str,
+    /// The optional URL of the import.
+    pub url: Option<&'a str>,
     /// The item that's being imported.
     pub item: ItemSig<'a>,
 }
@@ -19,8 +21,14 @@ impl<'a> Parse<'a> for ComponentImport<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
         let span = parser.parse::<kw::import>()?.0;
         let name = parser.parse()?;
+        let url = parser.parse()?;
         let item = parser.parens(|p| p.parse())?;
-        Ok(ComponentImport { span, name, item })
+        Ok(ComponentImport {
+            span,
+            name,
+            url,
+            item,
+        })
     }
 }
 
@@ -112,17 +120,22 @@ impl<'a> Parse<'a> for TypeBounds<'a> {
 ///
 /// This is the same as `core::InlineImport` except only one string import is
 /// required.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct InlineImport<'a> {
     /// The name of the item being imported.
     pub name: &'a str,
+    /// The optional URL of the item being imported.
+    pub url: Option<&'a str>,
 }
 
 impl<'a> Parse<'a> for InlineImport<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
         parser.parens(|p| {
             p.parse::<kw::import>()?;
-            Ok(InlineImport { name: p.parse()? })
+            Ok(InlineImport {
+                name: p.parse()?,
+                url: p.parse()?,
+            })
         })
     }
 }

--- a/crates/wast/src/component/instance.rs
+++ b/crates/wast/src/component/instance.rs
@@ -168,7 +168,7 @@ pub struct Instance<'a> {
     pub name: Option<NameAnnotation<'a>>,
     /// If present, inline export annotations which indicate names this
     /// definition should be exported under.
-    pub exports: core::InlineExport<'a>,
+    pub exports: InlineExport<'a>,
     /// What kind of instance this is.
     pub kind: InstanceKind<'a>,
 }

--- a/crates/wast/src/component/module.rs
+++ b/crates/wast/src/component/module.rs
@@ -18,7 +18,7 @@ pub struct CoreModule<'a> {
     pub name: Option<NameAnnotation<'a>>,
     /// If present, inline export annotations which indicate names this
     /// definition should be exported under.
-    pub exports: core::InlineExport<'a>,
+    pub exports: InlineExport<'a>,
     /// What kind of module this is, be it an inline-defined or imported one.
     pub kind: CoreModuleKind<'a>,
 }

--- a/crates/wast/src/component/resolve.rs
+++ b/crates/wast/src/component/resolve.rs
@@ -425,7 +425,7 @@ impl<'a> Resolver<'a> {
                 }
             }
             ComponentDefinedType::List(l) => {
-                self.component_val_type(&mut *l.element)?;
+                self.component_val_type(&mut l.element)?;
             }
             ComponentDefinedType::Tuple(t) => {
                 for field in t.fields.iter_mut() {
@@ -438,7 +438,7 @@ impl<'a> Resolver<'a> {
                 }
             }
             ComponentDefinedType::Option(o) => {
-                self.component_val_type(&mut *o.element)?;
+                self.component_val_type(&mut o.element)?;
             }
             ComponentDefinedType::Result(r) => {
                 if let Some(ty) = &mut r.ok {

--- a/crates/wast/src/component/types.rs
+++ b/crates/wast/src/component/types.rs
@@ -740,6 +740,8 @@ pub struct ComponentExportType<'a> {
     pub span: Span,
     /// The name of this export.
     pub name: &'a str,
+    /// The optional URL of this export.
+    pub url: Option<&'a str>,
     /// The signature of the item.
     pub item: ItemSig<'a>,
 }
@@ -748,8 +750,14 @@ impl<'a> Parse<'a> for ComponentExportType<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
         let span = parser.parse::<kw::export>()?.0;
         let name = parser.parse()?;
+        let url = parser.parse()?;
         let item = parser.parens(|p| p.parse())?;
-        Ok(Self { span, name, item })
+        Ok(Self {
+            span,
+            name,
+            url,
+            item,
+        })
     }
 }
 

--- a/crates/wast/src/parser.rs
+++ b/crates/wast/src/parser.rs
@@ -84,7 +84,7 @@ use std::usize;
 /// nested items. It would be great to not return an error here, though!
 pub(crate) const MAX_PARENS_DEPTH: usize = 100;
 
-/// A top-level convenience parseing function that parss a `T` from `buf` and
+/// A top-level convenience parsing function that parses a `T` from `buf` and
 /// requires that all tokens in `buf` are consume.
 ///
 /// This generic parsing function can be used to parse any `T` implementing the
@@ -395,7 +395,7 @@ impl ParseBuffer<'_> {
             state = match (&token.0, state) {
                 // From nothing, a `(` starts the search for an annotation
                 (LParen(_), State::None) => State::LParen,
-                // ... otherwise in nothing we alwyas preserve that state.
+                // ... otherwise in nothing we always preserve that state.
                 (_, State::None) => State::None,
 
                 // If the previous state was an `LParen`, we may have an
@@ -763,10 +763,12 @@ impl<'a> Parser<'a> {
     /// right location in the input stream, and the `msg` here is arbitrary text
     /// used to associate with the error and indicate why it was generated.
     pub fn error(self, msg: impl fmt::Display) -> Error {
-        self.error_at(self.cursor().cur_span(), &msg)
+        self.error_at(self.cursor().cur_span(), msg)
     }
 
-    fn error_at(self, span: Span, msg: &dyn fmt::Display) -> Error {
+    /// Creates an error whose line/column information is pointing at the
+    /// given span.
+    pub fn error_at(self, span: Span, msg: impl fmt::Display) -> Error {
         Error::parse(span, self.buf.input, msg.to_string())
     }
 
@@ -961,7 +963,7 @@ impl<'a> Cursor<'a> {
     /// Same as [`Parser::error`], but works with the current token in this
     /// [`Cursor`] instead.
     pub fn error(&self, msg: impl fmt::Display) -> Error {
-        self.parser.error_at(self.cur_span(), &msg)
+        self.parser.error_at(self.cur_span(), msg)
     }
 
     /// Attempts to advance this cursor if the current token is a `(`.
@@ -1101,7 +1103,7 @@ impl<'a> Cursor<'a> {
     /// the current token is `Reserved` which starts with `@` and has a nonzero
     /// length for the following name.
     ///
-    /// Note that this will skip *unknown* annoations. Only pre-registered
+    /// Note that this will skip *unknown* annotations. Only pre-registered
     /// annotations will be returned here.
     ///
     /// This function will automatically skip over any comments, whitespace, or
@@ -1242,8 +1244,8 @@ impl<'a> Cursor<'a> {
         // figure out how many of them we can skip.
         loop {
             let (token, _) = self.parser.buf.tokens.get(self.cur)?;
-            // and otherwise we skip all comments/whitespace and otherwise
-            // get real intersted once a normal `Token` pops up.
+            // and otherwise we skip all comments/whitespace and only
+            // get interested once a normal `Token` pops up.
             match token {
                 Token::Whitespace(_) | Token::LineComment(_) | Token::BlockComment(_) => {
                     self.cur += 1

--- a/crates/wast/src/token.rs
+++ b/crates/wast/src/token.rs
@@ -350,7 +350,8 @@ impl Peek for &'_ [u8] {
 
 impl<'a> Parse<'a> for &'a str {
     fn parse(parser: Parser<'a>) -> Result<Self> {
-        str::from_utf8(parser.parse()?).map_err(|_| parser.error("malformed UTF-8 encoding"))
+        str::from_utf8(parser.parse()?)
+            .map_err(|_| parser.error_at(parser.prev_span(), "malformed UTF-8 encoding"))
     }
 }
 

--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -32,7 +32,7 @@ impl WorldPrinter {
             writeln!(&mut self.output, "}}\n")?;
         }
 
-        write!(&mut self.output, "world {} {{\n", world.name)?;
+        writeln!(&mut self.output, "world {} {{", world.name)?;
         for (name, _import) in world.imports.iter() {
             writeln!(&mut self.output, "import {name}: {name}")?;
         }
@@ -46,9 +46,9 @@ impl WorldPrinter {
         if let Some(default) = &world.default {
             writeln!(&mut self.output, "default export interface {{")?;
             self.print_interface(default)?;
-            write!(&mut self.output, "}}\n")?;
+            writeln!(&mut self.output, "}}")?;
         }
-        write!(&mut self.output, "}}\n")?;
+        writeln!(&mut self.output, "}}")?;
 
         self.declared.clear();
         Ok(std::mem::take(&mut self.output).into())

--- a/crates/wit-component/src/validation.rs
+++ b/crates/wit-component/src/validation.rs
@@ -168,7 +168,7 @@ pub fn validate_module<'a>(
                 assert!(prev.is_none());
             }
             None if adapters.contains(name) => {
-                let map = ret.adapters_required.entry(name).or_insert(IndexMap::new());
+                let map = ret.adapters_required.entry(name).or_default();
                 for (func, ty) in funcs {
                     let ty = types.func_type_at(*ty).unwrap();
                     map.insert(func, ty.clone());
@@ -425,7 +425,7 @@ fn validate_exported_interface(
                     wasm_sig_to_func_type(interface.wasm_signature(AbiVariant::GuestExport, f));
                 let ty = types.function_at(*func_index).unwrap();
                 if ty == &expected_ty {
-                    return Ok(());
+                    continue;
                 }
                 match export_name {
                     Some(name) => {

--- a/crates/wit-parser/src/ast/resolve.rs
+++ b/crates/wit-parser/src/ast/resolve.rs
@@ -52,7 +52,7 @@ impl Resolver {
                 if let Some(other) = worlds.next() {
                     return Err(Error {
                         span: other.name.span,
-                        msg: format!("too many worlds defined"),
+                        msg: "too many worlds defined".to_string(),
                     }
                     .into());
                 }
@@ -82,7 +82,7 @@ impl Resolver {
                     if ret.default.is_some() {
                         return Err(Error {
                             span: iface.span(),
-                            msg: format!("more than one default"),
+                            msg: "more than one default".to_string(),
                         }
                         .into());
                     }
@@ -122,7 +122,7 @@ impl Resolver {
     ) -> Result<Interface> {
         match kind {
             ast::ExternKind::Interface(_span, items) => {
-                self.resolve("", &items, &Default::default())
+                self.resolve("", items, &Default::default())
             }
             ast::ExternKind::Id(id) => lookup.get(&*id.name).cloned().ok_or_else(|| {
                 Error {
@@ -177,6 +177,7 @@ impl Resolver {
 
         Ok(Interface {
             name: name.to_string(),
+            url: None,
             docs: self.docs(docs),
             types: mem::take(&mut self.types),
             type_lookup: mem::take(&mut self.type_lookup),

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -74,6 +74,7 @@ impl World {
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct Interface {
     pub name: String,
+    pub url: Option<String>,
     pub docs: Docs,
     pub types: Arena<TypeDef>,
     pub type_lookup: HashMap<String, TypeId>,

--- a/tests/dump/alias.wat.dump
+++ b/tests/dump/alias.wat.dump
@@ -1,72 +1,74 @@
   0x0 | 00 61 73 6d | version 65546 (Component)
       | 0a 00 01 00
-  0x8 | 07 1d       | component type section
+  0x8 | 07 1f       | component type section
   0xa | 01          | 1 count
-  0xb | 42 04 01 40 | [type 0] Instance([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Export { name: "f1", ty: Func(0) }, Type(Func(ComponentFuncType { params: [("p1", Primitive(String))], results: Named([]) })), Export { name: "f2", ty: Func(1) }])
+  0xb | 42 04 01 40 | [type 0] Instance([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Export { name: "f1", url: "", ty: Func(0) }, Type(Func(ComponentFuncType { params: [("p1", Primitive(String))], results: Named([]) })), Export { name: "f2", url: "", ty: Func(1) }])
       | 00 01 00 04
-      | 02 66 31 01
-      | 00 01 40 01
-      | 02 70 31 73
-      | 01 00 04 02
-      | 66 32 01 01
- 0x27 | 0a 05       | component import section
- 0x29 | 01          | 1 count
- 0x2a | 01 69 05 00 | [instance 0] ComponentImport { name: "i", ty: Instance(0) }
- 0x2e | 06 13       | component alias section
- 0x30 | 03          | 3 count
- 0x31 | 01 00 00 02 | alias [func 0] InstanceExport { kind: Func, instance_index: 0, name: "f1" }
+      | 02 66 31 00
+      | 01 00 01 40
+      | 01 02 70 31
+      | 73 01 00 04
+      | 02 66 32 00
+      | 01 01      
+ 0x29 | 0a 06       | component import section
+ 0x2b | 01          | 1 count
+ 0x2c | 01 69 00 05 | [instance 0] ComponentImport { name: "i", url: "", ty: Instance(0) }
+      | 00         
+ 0x31 | 06 13       | component alias section
+ 0x33 | 03          | 3 count
+ 0x34 | 01 00 00 02 | alias [func 0] InstanceExport { kind: Func, instance_index: 0, name: "f1" }
       | 66 31      
- 0x37 | 01 00 00 02 | alias [func 1] InstanceExport { kind: Func, instance_index: 0, name: "f2" }
+ 0x3a | 01 00 00 02 | alias [func 1] InstanceExport { kind: Func, instance_index: 0, name: "f2" }
       | 66 32      
- 0x3d | 01 00 00 02 | alias [func 2] InstanceExport { kind: Func, instance_index: 0, name: "f1" }
+ 0x40 | 01 00 00 02 | alias [func 2] InstanceExport { kind: Func, instance_index: 0, name: "f1" }
       | 66 31      
- 0x43 | 08 05       | canonical function section
- 0x45 | 01          | 1 count
- 0x46 | 01 00 02 00 | [core func 0] Lower { func_index: 2, options: [] }
- 0x4a | 01 2b       | [core module 0] inline size
-   0x4c | 00 61 73 6d | version 1 (Module)
+ 0x46 | 08 05       | canonical function section
+ 0x48 | 01          | 1 count
+ 0x49 | 01 00 02 00 | [core func 0] Lower { func_index: 2, options: [] }
+ 0x4d | 01 2b       | [core module 0] inline size
+   0x4f | 00 61 73 6d | version 1 (Module)
         | 01 00 00 00
-   0x54 | 01 04       | type section
-   0x56 | 01          | 1 count
-   0x57 | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
-   0x5a | 03 02       | func section
-   0x5c | 01          | 1 count
-   0x5d | 00          | [func 0] type 0
-   0x5e | 07 06       | export section
-   0x60 | 01          | 1 count
-   0x61 | 02 66 33 00 | export Export { name: "f3", kind: Func, index: 0 }
+   0x57 | 01 04       | type section
+   0x59 | 01          | 1 count
+   0x5a | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
+   0x5d | 03 02       | func section
+   0x5f | 01          | 1 count
+   0x60 | 00          | [func 0] type 0
+   0x61 | 07 06       | export section
+   0x63 | 01          | 1 count
+   0x64 | 02 66 33 00 | export Export { name: "f3", kind: Func, index: 0 }
         | 00         
-   0x66 | 0a 04       | code section
-   0x68 | 01          | 1 count
+   0x69 | 0a 04       | code section
+   0x6b | 01          | 1 count
 ============== func 0 ====================
-   0x69 | 02          | size of function
-   0x6a | 00          | 0 local blocks
-   0x6b | 0b          | end
-   0x6c | 00 09       | custom section
-   0x6e | 04 6e 61 6d | name: "name"
+   0x6c | 02          | size of function
+   0x6d | 00          | 0 local blocks
+   0x6e | 0b          | end
+   0x6f | 00 09       | custom section
+   0x71 | 04 6e 61 6d | name: "name"
         | 65         
-   0x73 | 00 02       | module name
-   0x75 | 01 6d       | "m"
- 0x77 | 02 04       | core instance section
- 0x79 | 01          | 1 count
- 0x7a | 00 00 00    | [core instance 0] Instantiate { module_index: 0, args: [] }
- 0x7d | 06 0f       | component alias section
- 0x7f | 02          | 2 count
- 0x80 | 00 00 01 00 | alias [core func 1] CoreInstanceExport { kind: Func, instance_index: 0, name: "f3" }
+   0x76 | 00 02       | module name
+   0x78 | 01 6d       | "m"
+ 0x7a | 02 04       | core instance section
+ 0x7c | 01          | 1 count
+ 0x7d | 00 00 00    | [core instance 0] Instantiate { module_index: 0, args: [] }
+ 0x80 | 06 0f       | component alias section
+ 0x82 | 02          | 2 count
+ 0x83 | 00 00 01 00 | alias [core func 1] CoreInstanceExport { kind: Func, instance_index: 0, name: "f3" }
       | 02 66 33   
- 0x87 | 00 00 01 00 | alias [core func 2] CoreInstanceExport { kind: Func, instance_index: 0, name: "f3" }
+ 0x8a | 00 00 01 00 | alias [core func 2] CoreInstanceExport { kind: Func, instance_index: 0, name: "f3" }
       | 02 66 33   
- 0x8e | 00 26       | custom section
- 0x90 | 0e 63 6f 6d | name: "component-name"
+ 0x91 | 00 26       | custom section
+ 0x93 | 0e 63 6f 6d | name: "component-name"
       | 70 6f 6e 65
       | 6e 74 2d 6e
       | 61 6d 65   
- 0x9f | 01 06 00 11 | core module section
- 0xa3 | 01          | 1 count
- 0xa4 | 00 01 6d    | Naming { index: 0, name: "m" }
- 0xa7 | 01 06 00 12 | core instance section
- 0xab | 01          | 1 count
- 0xac | 00 01 6d    | Naming { index: 0, name: "m" }
- 0xaf | 01 05 05    | instance section
- 0xb2 | 01          | 1 count
- 0xb3 | 00 01 69    | Naming { index: 0, name: "i" }
+ 0xa2 | 01 06 00 11 | core module section
+ 0xa6 | 01          | 1 count
+ 0xa7 | 00 01 6d    | Naming { index: 0, name: "m" }
+ 0xaa | 01 06 00 12 | core instance section
+ 0xae | 01          | 1 count
+ 0xaf | 00 01 6d    | Naming { index: 0, name: "m" }
+ 0xb2 | 01 05 05    | instance section
+ 0xb5 | 01          | 1 count
+ 0xb6 | 00 01 69    | Naming { index: 0, name: "i" }

--- a/tests/dump/alias2.wat
+++ b/tests/dump/alias2.wat
@@ -1,48 +1,48 @@
 (component
   (type $t (instance
-    (export "1" (core module))
-    (export "2" (func))
-    (export "3" (value string))
-    (export "4" (instance))
-    (export "5" (component))
+    (export "a" (core module))
+    (export "b" (func))
+    (export "c" (value string))
+    (export "d" (instance))
+    (export "e" (component))
   ))
 
-  (import "" (instance $i (type $t)))
+  (import "a" (instance $i (type $t)))
 
   (component $c
-    (import "1" (core module))
-    (import "2" (func))
-    (import "3" (value string))
-    (import "4" (instance))
-    (import "5" (component))
+    (import "a" (core module))
+    (import "b" (func))
+    (import "c" (value string))
+    (import "d" (instance))
+    (import "e" (component))
   )
 
   (instance (instantiate $c
-    (with "1" (core module $i "1"))
-    (with "2" (func $i "2"))
-    (with "3" (value $i "4"))
-    (with "4" (instance $i "3"))
-    (with "5" (component $i "5"))
+    (with "a" (core module $i "a"))
+    (with "b" (func $i "b"))
+    (with "c" (value $i "c"))
+    (with "d" (instance $i "d"))
+    (with "e" (component $i "e"))
   ))
 
   (component $c2
-    (import "" (instance (type $t)))
+    (import "a" (instance (type $t)))
   )
 
-  (alias export $i "1" (core module $m))
-  (alias export $i "2" (func $f))
-  (alias export $i "3" (value $v))
-  (alias export $i "4" (instance $i2))
-  (alias export $i "5" (component $c3))
+  (alias export $i "a" (core module $m))
+  (alias export $i "b" (func $f))
+  (alias export $i "c" (value $v))
+  (alias export $i "d" (instance $i2))
+  (alias export $i "e" (component $c3))
 
   (instance
     (instantiate $c2
-      (with "" (instance
-        (export "1" (core module $m))
-        (export "2" (func $f))
-        (export "3" (value $v))
-        (export "4" (instance $i2))
-        (export "5" (component $c3))
+      (with "a" (instance
+        (export "a" (core module $m))
+        (export "b" (func $f))
+        (export "c" (value $v))
+        (export "d" (instance $i2))
+        (export "e" (component $c3))
       ))
     )
   )

--- a/tests/dump/alias2.wat.dump
+++ b/tests/dump/alias2.wat.dump
@@ -1,239 +1,246 @@
    0x0 | 00 61 73 6d | version 65546 (Component)
        | 0a 00 01 00
-   0x8 | 07 2b       | component type section
+   0x8 | 07 30       | component type section
    0xa | 01          | 1 count
-   0xb | 42 09 00 50 | [type 0] Instance([CoreType(Module([])), Export { name: "1", ty: Module(0) }, Type(Func(ComponentFuncType { params: [], results: Named([]) })), Export { name: "2", ty: Func(0) }, Export { name: "3", ty: Value(Primitive(String)) }, Type(Instance([])), Export { name: "4", ty: Instance(1) }, Type(Component([])), Export { name: "5", ty: Component(2) }])
-       | 00 04 01 31
-       | 00 11 00 01
-       | 40 00 01 00
-       | 04 01 32 01
-       | 00 04 01 33
-       | 02 73 01 42
-       | 00 04 01 34
+   0xb | 42 09 00 50 | [type 0] Instance([CoreType(Module([])), Export { name: "a", url: "", ty: Module(0) }, Type(Func(ComponentFuncType { params: [], results: Named([]) })), Export { name: "b", url: "", ty: Func(0) }, Export { name: "c", url: "", ty: Value(Primitive(String)) }, Type(Instance([])), Export { name: "d", url: "", ty: Instance(1) }, Type(Component([])), Export { name: "e", url: "", ty: Component(2) }])
+       | 00 04 01 61
+       | 00 00 11 00
+       | 01 40 00 01
+       | 00 04 01 62
+       | 00 01 00 04
+       | 01 63 00 02
+       | 73 01 42 00
+       | 04 01 64 00
        | 05 01 01 41
-       | 00 04 01 35
-       | 04 02      
-  0x35 | 0a 04       | component import section
-  0x37 | 01          | 1 count
-  0x38 | 00 05 00    | [instance 0] ComponentImport { name: "", ty: Instance(0) }
-  0x3b | 04 54       | [component 0] inline size
-    0x3d | 00 61 73 6d | version 65546 (Component)
+       | 00 04 01 65
+       | 00 04 02   
+  0x3a | 0a 06       | component import section
+  0x3c | 01          | 1 count
+  0x3d | 01 61 00 05 | [instance 0] ComponentImport { name: "a", url: "", ty: Instance(0) }
+       | 00         
+  0x42 | 04 59       | [component 0] inline size
+    0x44 | 00 61 73 6d | version 65546 (Component)
          | 0a 00 01 00
-    0x45 | 03 03       | core type section
-    0x47 | 01          | 1 count
-    0x48 | 50 00       | [core type 0] Module([])
-    0x4a | 0a 06       | component import section
-    0x4c | 01          | 1 count
-    0x4d | 01 31 00 11 | [module 0] ComponentImport { name: "1", ty: Module(0) }
+    0x4c | 03 03       | core type section
+    0x4e | 01          | 1 count
+    0x4f | 50 00       | [core type 0] Module([])
+    0x51 | 0a 07       | component import section
+    0x53 | 01          | 1 count
+    0x54 | 01 61 00 00 | [module 0] ComponentImport { name: "a", url: "", ty: Module(0) }
+         | 11 00      
+    0x5a | 07 05       | component type section
+    0x5c | 01          | 1 count
+    0x5d | 40 00 01 00 | [type 0] Func(ComponentFuncType { params: [], results: Named([]) })
+    0x61 | 0a 0b       | component import section
+    0x63 | 02          | 2 count
+    0x64 | 01 62 00 01 | [func 0] ComponentImport { name: "b", url: "", ty: Func(0) }
          | 00         
-    0x52 | 07 05       | component type section
-    0x54 | 01          | 1 count
-    0x55 | 40 00 01 00 | [type 0] Func(ComponentFuncType { params: [], results: Named([]) })
-    0x59 | 0a 09       | component import section
-    0x5b | 02          | 2 count
-    0x5c | 01 32 01 00 | [func 0] ComponentImport { name: "2", ty: Func(0) }
-    0x60 | 01 33 02 73 | [value 0] ComponentImport { name: "3", ty: Value(Primitive(String)) }
-    0x64 | 07 03       | component type section
-    0x66 | 01          | 1 count
-    0x67 | 42 00       | [type 1] Instance([])
-    0x69 | 0a 05       | component import section
-    0x6b | 01          | 1 count
-    0x6c | 01 34 05 01 | [instance 0] ComponentImport { name: "4", ty: Instance(1) }
-    0x70 | 07 03       | component type section
-    0x72 | 01          | 1 count
-    0x73 | 41 00       | [type 2] Component([])
-    0x75 | 0a 05       | component import section
-    0x77 | 01          | 1 count
-    0x78 | 01 35 04 02 | [component 0] ComponentImport { name: "5", ty: Component(2) }
-    0x7c | 00 13       | custom section
-    0x7e | 0e 63 6f 6d | name: "component-name"
+    0x69 | 01 63 00 02 | [value 0] ComponentImport { name: "c", url: "", ty: Value(Primitive(String)) }
+         | 73         
+    0x6e | 07 03       | component type section
+    0x70 | 01          | 1 count
+    0x71 | 42 00       | [type 1] Instance([])
+    0x73 | 0a 06       | component import section
+    0x75 | 01          | 1 count
+    0x76 | 01 64 00 05 | [instance 0] ComponentImport { name: "d", url: "", ty: Instance(1) }
+         | 01         
+    0x7b | 07 03       | component type section
+    0x7d | 01          | 1 count
+    0x7e | 41 00       | [type 2] Component([])
+    0x80 | 0a 06       | component import section
+    0x82 | 01          | 1 count
+    0x83 | 01 65 00 04 | [component 0] ComponentImport { name: "e", url: "", ty: Component(2) }
+         | 02         
+    0x88 | 00 13       | custom section
+    0x8a | 0e 63 6f 6d | name: "component-name"
          | 70 6f 6e 65
          | 6e 74 2d 6e
          | 61 6d 65   
-    0x8d | 00 02       | component name
-    0x8f | 01 63       | "c"
-  0x91 | 06 1b       | component alias section
-  0x93 | 05          | 5 count
-  0x94 | 00 11 00 00 | alias [module 0] InstanceExport { kind: Module, instance_index: 0, name: "1" }
-       | 01 31      
-  0x9a | 01 00 00 01 | alias [func 0] InstanceExport { kind: Func, instance_index: 0, name: "2" }
-       | 32         
-  0x9f | 02 00 00 01 | alias [value 0] InstanceExport { kind: Value, instance_index: 0, name: "4" }
-       | 34         
-  0xa4 | 05 00 00 01 | alias [instance 1] InstanceExport { kind: Instance, instance_index: 0, name: "3" }
-       | 33         
-  0xa9 | 04 00 00 01 | alias [component 1] InstanceExport { kind: Component, instance_index: 0, name: "5" }
-       | 35         
-  0xae | 05 19       | component instance section
-  0xb0 | 01          | 1 count
-  0xb1 | 00 00 05 01 | [instance 2] Instantiate { component_index: 0, args: [ComponentInstantiationArg { name: "1", kind: Module, index: 0 }, ComponentInstantiationArg { name: "2", kind: Func, index: 0 }, ComponentInstantiationArg { name: "3", kind: Value, index: 0 }, ComponentInstantiationArg { name: "4", kind: Instance, index: 1 }, ComponentInstantiationArg { name: "5", kind: Component, index: 1 }] }
-       | 31 00 11 00
-       | 01 32 01 00
-       | 01 33 02 00
-       | 01 34 05 01
-       | 01 35 04 01
-  0xc9 | 04 32       | [component 2] inline size
-    0xcb | 00 61 73 6d | version 65546 (Component)
+    0x99 | 00 02       | component name
+    0x9b | 01 63       | "c"
+  0x9d | 06 1b       | component alias section
+  0x9f | 05          | 5 count
+  0xa0 | 00 11 00 00 | alias [module 0] InstanceExport { kind: Module, instance_index: 0, name: "a" }
+       | 01 61      
+  0xa6 | 01 00 00 01 | alias [func 0] InstanceExport { kind: Func, instance_index: 0, name: "b" }
+       | 62         
+  0xab | 02 00 00 01 | alias [value 0] InstanceExport { kind: Value, instance_index: 0, name: "c" }
+       | 63         
+  0xb0 | 05 00 00 01 | alias [instance 1] InstanceExport { kind: Instance, instance_index: 0, name: "d" }
+       | 64         
+  0xb5 | 04 00 00 01 | alias [component 1] InstanceExport { kind: Component, instance_index: 0, name: "e" }
+       | 65         
+  0xba | 05 19       | component instance section
+  0xbc | 01          | 1 count
+  0xbd | 00 00 05 01 | [instance 2] Instantiate { component_index: 0, args: [ComponentInstantiationArg { name: "a", kind: Module, index: 0 }, ComponentInstantiationArg { name: "b", kind: Func, index: 0 }, ComponentInstantiationArg { name: "c", kind: Value, index: 0 }, ComponentInstantiationArg { name: "d", kind: Instance, index: 1 }, ComponentInstantiationArg { name: "e", kind: Component, index: 1 }] }
+       | 61 00 11 00
+       | 01 62 01 00
+       | 01 63 02 00
+       | 01 64 05 01
+       | 01 65 04 01
+  0xd5 | 04 34       | [component 2] inline size
+    0xd7 | 00 61 73 6d | version 65546 (Component)
          | 0a 00 01 00
-    0xd3 | 06 05       | component alias section
-    0xd5 | 01          | 1 count
-    0xd6 | 03 02 01 00 | alias [type 0] Outer { kind: Type, count: 1, index: 0 }
-    0xda | 0a 04       | component import section
-    0xdc | 01          | 1 count
-    0xdd | 00 05 00    | [instance 0] ComponentImport { name: "", ty: Instance(0) }
-    0xe0 | 00 1b       | custom section
-    0xe2 | 0e 63 6f 6d | name: "component-name"
+    0xdf | 06 05       | component alias section
+    0xe1 | 01          | 1 count
+    0xe2 | 03 02 01 00 | alias [type 0] Outer { kind: Type, count: 1, index: 0 }
+    0xe6 | 0a 06       | component import section
+    0xe8 | 01          | 1 count
+    0xe9 | 01 61 00 05 | [instance 0] ComponentImport { name: "a", url: "", ty: Instance(0) }
+         | 00         
+    0xee | 00 1b       | custom section
+    0xf0 | 0e 63 6f 6d | name: "component-name"
          | 70 6f 6e 65
          | 6e 74 2d 6e
          | 61 6d 65   
-    0xf1 | 00 03       | component name
-    0xf3 | 02 63 32    | "c2"
-    0xf6 | 01 05 03    | type section
-    0xf9 | 01          | 1 count
-    0xfa | 00 01 74    | Naming { index: 0, name: "t" }
-  0xfd | 06 1b       | component alias section
-  0xff | 05          | 5 count
- 0x100 | 00 11 00 00 | alias [module 1] InstanceExport { kind: Module, instance_index: 0, name: "1" }
-       | 01 31      
- 0x106 | 01 00 00 01 | alias [func 1] InstanceExport { kind: Func, instance_index: 0, name: "2" }
-       | 32         
- 0x10b | 02 00 00 01 | alias [value 1] InstanceExport { kind: Value, instance_index: 0, name: "3" }
-       | 33         
- 0x110 | 05 00 00 01 | alias [instance 3] InstanceExport { kind: Instance, instance_index: 0, name: "4" }
-       | 34         
- 0x115 | 04 00 00 01 | alias [component 3] InstanceExport { kind: Component, instance_index: 0, name: "5" }
-       | 35         
- 0x11a | 05 1e       | component instance section
- 0x11c | 02          | 2 count
- 0x11d | 01 05 01 31 | [instance 4] FromExports([ComponentExport { name: "1", kind: Module, index: 1 }, ComponentExport { name: "2", kind: Func, index: 1 }, ComponentExport { name: "3", kind: Value, index: 1 }, ComponentExport { name: "4", kind: Instance, index: 3 }, ComponentExport { name: "5", kind: Component, index: 3 }])
+    0xff | 00 03       | component name
+   0x101 | 02 63 32    | "c2"
+   0x104 | 01 05 03    | type section
+   0x107 | 01          | 1 count
+   0x108 | 00 01 74    | Naming { index: 0, name: "t" }
+ 0x10b | 06 1b       | component alias section
+ 0x10d | 05          | 5 count
+ 0x10e | 00 11 00 00 | alias [module 1] InstanceExport { kind: Module, instance_index: 0, name: "a" }
+       | 01 61      
+ 0x114 | 01 00 00 01 | alias [func 1] InstanceExport { kind: Func, instance_index: 0, name: "b" }
+       | 62         
+ 0x119 | 02 00 00 01 | alias [value 1] InstanceExport { kind: Value, instance_index: 0, name: "c" }
+       | 63         
+ 0x11e | 05 00 00 01 | alias [instance 3] InstanceExport { kind: Instance, instance_index: 0, name: "d" }
+       | 64         
+ 0x123 | 04 00 00 01 | alias [component 3] InstanceExport { kind: Component, instance_index: 0, name: "e" }
+       | 65         
+ 0x128 | 05 1f       | component instance section
+ 0x12a | 02          | 2 count
+ 0x12b | 01 05 01 61 | [instance 4] FromExports([ComponentExport { name: "a", url: "", kind: Module, index: 1 }, ComponentExport { name: "b", url: "", kind: Func, index: 1 }, ComponentExport { name: "c", url: "", kind: Value, index: 1 }, ComponentExport { name: "d", url: "", kind: Instance, index: 3 }, ComponentExport { name: "e", url: "", kind: Component, index: 3 }])
        | 00 11 01 01
-       | 32 01 01 01
-       | 33 02 01 01
-       | 34 05 03 01
-       | 35 04 03   
- 0x134 | 00 02 01 00 | [instance 5] Instantiate { component_index: 2, args: [ComponentInstantiationArg { name: "", kind: Instance, index: 4 }] }
-       | 05 04      
- 0x13a | 01 48       | [core module 2] inline size
-   0x13c | 00 61 73 6d | version 1 (Module)
+       | 62 01 01 01
+       | 63 02 01 01
+       | 64 05 03 01
+       | 65 04 03   
+ 0x142 | 00 02 01 01 | [instance 5] Instantiate { component_index: 2, args: [ComponentInstantiationArg { name: "a", kind: Instance, index: 4 }] }
+       | 61 05 04   
+ 0x149 | 01 48       | [core module 2] inline size
+   0x14b | 00 61 73 6d | version 1 (Module)
          | 01 00 00 00
-   0x144 | 01 04       | type section
-   0x146 | 01          | 1 count
-   0x147 | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
-   0x14a | 03 02       | func section
-   0x14c | 01          | 1 count
-   0x14d | 00          | [func 0] type 0
-   0x14e | 04 04       | table section
-   0x150 | 01          | 1 count
-   0x151 | 70 00 01    | [table 0] TableType { element_type: FuncRef, initial: 1, maximum: None }
-   0x154 | 05 03       | memory section
-   0x156 | 01          | 1 count
-   0x157 | 00 01       | [memory 0] MemoryType { memory64: false, shared: false, initial: 1, maximum: None }
-   0x159 | 06 04       | global section
+   0x153 | 01 04       | type section
+   0x155 | 01          | 1 count
+   0x156 | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
+   0x159 | 03 02       | func section
    0x15b | 01          | 1 count
-   0x15c | 7f 00       | [global 0] GlobalType { content_type: I32, mutable: false }
-   0x15e | 0b          | end
-   0x15f | 07 11       | export section
-   0x161 | 04          | 4 count
-   0x162 | 01 31 00 00 | export Export { name: "1", kind: Func, index: 0 }
-   0x166 | 01 32 02 00 | export Export { name: "2", kind: Memory, index: 0 }
-   0x16a | 01 33 03 00 | export Export { name: "3", kind: Global, index: 0 }
-   0x16e | 01 34 01 00 | export Export { name: "4", kind: Table, index: 0 }
-   0x172 | 0a 04       | code section
-   0x174 | 01          | 1 count
+   0x15c | 00          | [func 0] type 0
+   0x15d | 04 04       | table section
+   0x15f | 01          | 1 count
+   0x160 | 70 00 01    | [table 0] TableType { element_type: FuncRef, initial: 1, maximum: None }
+   0x163 | 05 03       | memory section
+   0x165 | 01          | 1 count
+   0x166 | 00 01       | [memory 0] MemoryType { memory64: false, shared: false, initial: 1, maximum: None }
+   0x168 | 06 04       | global section
+   0x16a | 01          | 1 count
+   0x16b | 7f 00       | [global 0] GlobalType { content_type: I32, mutable: false }
+   0x16d | 0b          | end
+   0x16e | 07 11       | export section
+   0x170 | 04          | 4 count
+   0x171 | 01 31 00 00 | export Export { name: "1", kind: Func, index: 0 }
+   0x175 | 01 32 02 00 | export Export { name: "2", kind: Memory, index: 0 }
+   0x179 | 01 33 03 00 | export Export { name: "3", kind: Global, index: 0 }
+   0x17d | 01 34 01 00 | export Export { name: "4", kind: Table, index: 0 }
+   0x181 | 0a 04       | code section
+   0x183 | 01          | 1 count
 ============== func 0 ====================
-   0x175 | 02          | size of function
-   0x176 | 00          | 0 local blocks
-   0x177 | 0b          | end
-   0x178 | 00 0a       | custom section
-   0x17a | 04 6e 61 6d | name: "name"
+   0x184 | 02          | size of function
+   0x185 | 00          | 0 local blocks
+   0x186 | 0b          | end
+   0x187 | 00 0a       | custom section
+   0x189 | 04 6e 61 6d | name: "name"
          | 65         
-   0x17f | 00 03       | module name
-   0x181 | 02 6d 31    | "m1"
- 0x184 | 01 35       | [core module 3] inline size
-   0x186 | 00 61 73 6d | version 1 (Module)
+   0x18e | 00 03       | module name
+   0x190 | 02 6d 31    | "m1"
+ 0x193 | 01 35       | [core module 3] inline size
+   0x195 | 00 61 73 6d | version 1 (Module)
          | 01 00 00 00
-   0x18e | 01 04       | type section
-   0x190 | 01          | 1 count
-   0x191 | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
-   0x194 | 02 19       | import section
-   0x196 | 04          | 4 count
-   0x197 | 00 01 31 00 | import [func 0] Import { module: "", name: "1", ty: Func(0) }
+   0x19d | 01 04       | type section
+   0x19f | 01          | 1 count
+   0x1a0 | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
+   0x1a3 | 02 19       | import section
+   0x1a5 | 04          | 4 count
+   0x1a6 | 00 01 31 00 | import [func 0] Import { module: "", name: "1", ty: Func(0) }
          | 00         
-   0x19c | 00 01 32 02 | import [memory 0] Import { module: "", name: "2", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None }) }
+   0x1ab | 00 01 32 02 | import [memory 0] Import { module: "", name: "2", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None }) }
          | 00 01      
-   0x1a2 | 00 01 33 03 | import [global 0] Import { module: "", name: "3", ty: Global(GlobalType { content_type: I32, mutable: false }) }
+   0x1b1 | 00 01 33 03 | import [global 0] Import { module: "", name: "3", ty: Global(GlobalType { content_type: I32, mutable: false }) }
          | 7f 00      
-   0x1a8 | 00 01 34 01 | import [table 0] Import { module: "", name: "4", ty: Table(TableType { element_type: FuncRef, initial: 1, maximum: None }) }
+   0x1b7 | 00 01 34 01 | import [table 0] Import { module: "", name: "4", ty: Table(TableType { element_type: FuncRef, initial: 1, maximum: None }) }
          | 70 00 01   
-   0x1af | 00 0a       | custom section
-   0x1b1 | 04 6e 61 6d | name: "name"
+   0x1be | 00 0a       | custom section
+   0x1c0 | 04 6e 61 6d | name: "name"
          | 65         
-   0x1b6 | 00 03       | module name
-   0x1b8 | 02 6d 32    | "m2"
- 0x1bb | 02 0a       | core instance section
- 0x1bd | 02          | 2 count
- 0x1be | 00 02 00    | [core instance 0] Instantiate { module_index: 2, args: [] }
- 0x1c1 | 00 03 01 00 | [core instance 1] Instantiate { module_index: 3, args: [InstantiationArg { name: "", kind: Instance, index: 0 }] }
+   0x1c5 | 00 03       | module name
+   0x1c7 | 02 6d 32    | "m2"
+ 0x1ca | 02 0a       | core instance section
+ 0x1cc | 02          | 2 count
+ 0x1cd | 00 02 00    | [core instance 0] Instantiate { module_index: 2, args: [] }
+ 0x1d0 | 00 03 01 00 | [core instance 1] Instantiate { module_index: 3, args: [InstantiationArg { name: "", kind: Instance, index: 0 }] }
        | 12 00      
- 0x1c7 | 06 19       | component alias section
- 0x1c9 | 04          | 4 count
- 0x1ca | 00 00 01 00 | alias [core func 0] CoreInstanceExport { kind: Func, instance_index: 0, name: "1" }
+ 0x1d6 | 06 19       | component alias section
+ 0x1d8 | 04          | 4 count
+ 0x1d9 | 00 00 01 00 | alias [core func 0] CoreInstanceExport { kind: Func, instance_index: 0, name: "1" }
        | 01 31      
- 0x1d0 | 00 02 01 00 | alias [core memory 0] CoreInstanceExport { kind: Memory, instance_index: 0, name: "2" }
+ 0x1df | 00 02 01 00 | alias [core memory 0] CoreInstanceExport { kind: Memory, instance_index: 0, name: "2" }
        | 01 32      
- 0x1d6 | 00 03 01 00 | alias [core global 0] CoreInstanceExport { kind: Global, instance_index: 0, name: "3" }
+ 0x1e5 | 00 03 01 00 | alias [core global 0] CoreInstanceExport { kind: Global, instance_index: 0, name: "3" }
        | 01 33      
- 0x1dc | 00 01 01 00 | alias [core table 0] CoreInstanceExport { kind: Table, instance_index: 0, name: "4" }
+ 0x1eb | 00 01 01 00 | alias [core table 0] CoreInstanceExport { kind: Table, instance_index: 0, name: "4" }
        | 01 34      
- 0x1e2 | 02 19       | core instance section
- 0x1e4 | 02          | 2 count
- 0x1e5 | 01 04 01 31 | [core instance 2] FromExports([Export { name: "1", kind: Func, index: 0 }, Export { name: "2", kind: Memory, index: 0 }, Export { name: "3", kind: Global, index: 0 }, Export { name: "4", kind: Table, index: 0 }])
+ 0x1f1 | 02 19       | core instance section
+ 0x1f3 | 02          | 2 count
+ 0x1f4 | 01 04 01 31 | [core instance 2] FromExports([Export { name: "1", kind: Func, index: 0 }, Export { name: "2", kind: Memory, index: 0 }, Export { name: "3", kind: Global, index: 0 }, Export { name: "4", kind: Table, index: 0 }])
        | 00 00 01 32
        | 02 00 01 33
        | 03 00 01 34
        | 01 00      
- 0x1f7 | 00 03 01 00 | [core instance 3] Instantiate { module_index: 3, args: [InstantiationArg { name: "", kind: Instance, index: 2 }] }
+ 0x206 | 00 03 01 00 | [core instance 3] Instantiate { module_index: 3, args: [InstantiationArg { name: "", kind: Instance, index: 2 }] }
        | 12 02      
- 0x1fd | 00 76       | custom section
- 0x1ff | 0e 63 6f 6d | name: "component-name"
+ 0x20c | 00 76       | custom section
+ 0x20e | 0e 63 6f 6d | name: "component-name"
        | 70 6f 6e 65
        | 6e 74 2d 6e
        | 61 6d 65   
- 0x20e | 01 06 00 00 | core func section
- 0x212 | 01          | 1 count
- 0x213 | 00 01 66    | Naming { index: 0, name: "f" }
- 0x216 | 01 06 00 01 | core table section
- 0x21a | 01          | 1 count
- 0x21b | 00 01 74    | Naming { index: 0, name: "t" }
- 0x21e | 01 06 00 02 | core memory section
- 0x222 | 01          | 1 count
- 0x223 | 00 01 6d    | Naming { index: 0, name: "m" }
- 0x226 | 01 06 00 03 | core global section
- 0x22a | 01          | 1 count
- 0x22b | 00 01 67    | Naming { index: 0, name: "g" }
- 0x22e | 01 0e 00 11 | core module section
- 0x232 | 03          | 3 count
- 0x233 | 01 01 6d    | Naming { index: 1, name: "m" }
- 0x236 | 02 02 6d 31 | Naming { index: 2, name: "m1" }
- 0x23a | 03 02 6d 32 | Naming { index: 3, name: "m2" }
- 0x23e | 01 06 00 12 | core instance section
- 0x242 | 01          | 1 count
- 0x243 | 00 01 69    | Naming { index: 0, name: "i" }
- 0x246 | 01 05 01    | func section
- 0x249 | 01          | 1 count
- 0x24a | 01 01 66    | Naming { index: 1, name: "f" }
- 0x24d | 01 05 02    | value section
- 0x250 | 01          | 1 count
- 0x251 | 01 01 76    | Naming { index: 1, name: "v" }
- 0x254 | 01 05 03    | type section
- 0x257 | 01          | 1 count
- 0x258 | 00 01 74    | Naming { index: 0, name: "t" }
- 0x25b | 01 0d 04    | component section
- 0x25e | 03          | 3 count
- 0x25f | 00 01 63    | Naming { index: 0, name: "c" }
- 0x262 | 02 02 63 32 | Naming { index: 2, name: "c2" }
- 0x266 | 03 02 63 33 | Naming { index: 3, name: "c3" }
- 0x26a | 01 09 05    | instance section
- 0x26d | 02          | 2 count
- 0x26e | 00 01 69    | Naming { index: 0, name: "i" }
- 0x271 | 03 02 69 32 | Naming { index: 3, name: "i2" }
+ 0x21d | 01 06 00 00 | core func section
+ 0x221 | 01          | 1 count
+ 0x222 | 00 01 66    | Naming { index: 0, name: "f" }
+ 0x225 | 01 06 00 01 | core table section
+ 0x229 | 01          | 1 count
+ 0x22a | 00 01 74    | Naming { index: 0, name: "t" }
+ 0x22d | 01 06 00 02 | core memory section
+ 0x231 | 01          | 1 count
+ 0x232 | 00 01 6d    | Naming { index: 0, name: "m" }
+ 0x235 | 01 06 00 03 | core global section
+ 0x239 | 01          | 1 count
+ 0x23a | 00 01 67    | Naming { index: 0, name: "g" }
+ 0x23d | 01 0e 00 11 | core module section
+ 0x241 | 03          | 3 count
+ 0x242 | 01 01 6d    | Naming { index: 1, name: "m" }
+ 0x245 | 02 02 6d 31 | Naming { index: 2, name: "m1" }
+ 0x249 | 03 02 6d 32 | Naming { index: 3, name: "m2" }
+ 0x24d | 01 06 00 12 | core instance section
+ 0x251 | 01          | 1 count
+ 0x252 | 00 01 69    | Naming { index: 0, name: "i" }
+ 0x255 | 01 05 01    | func section
+ 0x258 | 01          | 1 count
+ 0x259 | 01 01 66    | Naming { index: 1, name: "f" }
+ 0x25c | 01 05 02    | value section
+ 0x25f | 01          | 1 count
+ 0x260 | 01 01 76    | Naming { index: 1, name: "v" }
+ 0x263 | 01 05 03    | type section
+ 0x266 | 01          | 1 count
+ 0x267 | 00 01 74    | Naming { index: 0, name: "t" }
+ 0x26a | 01 0d 04    | component section
+ 0x26d | 03          | 3 count
+ 0x26e | 00 01 63    | Naming { index: 0, name: "c" }
+ 0x271 | 02 02 63 32 | Naming { index: 2, name: "c2" }
+ 0x275 | 03 02 63 33 | Naming { index: 3, name: "c3" }
+ 0x279 | 01 09 05    | instance section
+ 0x27c | 02          | 2 count
+ 0x27d | 00 01 69    | Naming { index: 0, name: "i" }
+ 0x280 | 03 02 69 32 | Naming { index: 3, name: "i2" }

--- a/tests/dump/bundled.wat
+++ b/tests/dump/bundled.wat
@@ -3,7 +3,7 @@
       (export "read" (func $read (param "len" u32) (result (list u8))))
       (export "write" (func $write (param "buf" (list u8)) (result u32)))
     ))
-  (import "wasi_file" (instance $real-wasi (type $WasiFile)))
+  (import "wasi-file" (instance $real-wasi (type $WasiFile)))
 
   (core module $libc
     (memory (export "mem") 0)
@@ -15,14 +15,14 @@
   (core instance $libc (instantiate $libc))
 
   (core module $CHILD
-    (import "wasi_file" "read" (func $wasi-file (param i32 i32)))
+    (import "wasi-file" "read" (func $wasi-file (param i32 i32)))
     (func $play (export "play")
       unreachable
     )
   )
 
   (core module $VIRTUALIZE
-    (import "wasi_file" "read" (func (param i32 i32)))
+    (import "wasi-file" "read" (func (param i32 i32)))
     (func (export "read") (param i32 i32)
       unreachable
     )
@@ -38,8 +38,8 @@
     )
   )
 
-  (core instance $virt-wasi (instantiate $VIRTUALIZE (with "wasi_file" (instance (export "read" (func $real-wasi-read))))))
-  (core instance $child (instantiate $CHILD (with "wasi_file" (instance $virt-wasi))))
+  (core instance $virt-wasi (instantiate $VIRTUALIZE (with "wasi-file" (instance (export "read" (func $real-wasi-read))))))
+  (core instance $child (instantiate $CHILD (with "wasi-file" (instance $virt-wasi))))
   (func (export "work")
     (canon lift (core func $child "play")
       (memory $libc "mem")

--- a/tests/dump/bundled.wat.dump
+++ b/tests/dump/bundled.wat.dump
@@ -1,231 +1,232 @@
    0x0 | 00 61 73 6d | version 65546 (Component)
        | 0a 00 01 00
-   0x8 | 07 2e       | component type section
+   0x8 | 07 30       | component type section
    0xa | 01          | 1 count
-   0xb | 42 06 01 70 | [type 0] Instance([Type(Defined(List(Primitive(U8)))), Type(Func(ComponentFuncType { params: [("len", Primitive(U32))], results: Unnamed(Type(0)) })), Export { name: "read", ty: Func(1) }, Type(Defined(List(Primitive(U8)))), Type(Func(ComponentFuncType { params: [("buf", Type(2))], results: Unnamed(Primitive(U32)) })), Export { name: "write", ty: Func(3) }])
+   0xb | 42 06 01 70 | [type 0] Instance([Type(Defined(List(Primitive(U8)))), Type(Func(ComponentFuncType { params: [("len", Primitive(U32))], results: Unnamed(Type(0)) })), Export { name: "read", url: "", ty: Func(1) }, Type(Defined(List(Primitive(U8)))), Type(Func(ComponentFuncType { params: [("buf", Type(2))], results: Unnamed(Primitive(U32)) })), Export { name: "write", url: "", ty: Func(3) }])
        | 7d 01 40 01
        | 03 6c 65 6e
        | 79 00 00 04
        | 04 72 65 61
-       | 64 01 01 01
-       | 70 7d 01 40
-       | 01 03 62 75
-       | 66 02 00 79
-       | 04 05 77 72
-       | 69 74 65 01
-       | 03         
-  0x38 | 0a 0d       | component import section
-  0x3a | 01          | 1 count
-  0x3b | 09 77 61 73 | [instance 0] ComponentImport { name: "wasi_file", ty: Instance(0) }
-       | 69 5f 66 69
-       | 6c 65 05 00
-  0x47 | 01 44       | [core module 0] inline size
-    0x49 | 00 61 73 6d | version 1 (Module)
+       | 64 00 01 01
+       | 01 70 7d 01
+       | 40 01 03 62
+       | 75 66 02 00
+       | 79 04 05 77
+       | 72 69 74 65
+       | 00 01 03   
+  0x3a | 0a 0e       | component import section
+  0x3c | 01          | 1 count
+  0x3d | 09 77 61 73 | [instance 0] ComponentImport { name: "wasi-file", url: "", ty: Instance(0) }
+       | 69 2d 66 69
+       | 6c 65 00 05
+       | 00         
+  0x4a | 01 44       | [core module 0] inline size
+    0x4c | 00 61 73 6d | version 1 (Module)
          | 01 00 00 00
-    0x51 | 01 09       | type section
-    0x53 | 01          | 1 count
-    0x54 | 60 04 7f 7f | [type 0] Func(FuncType { params: [I32, I32, I32, I32], returns: [I32] })
+    0x54 | 01 09       | type section
+    0x56 | 01          | 1 count
+    0x57 | 60 04 7f 7f | [type 0] Func(FuncType { params: [I32, I32, I32, I32], returns: [I32] })
          | 7f 7f 01 7f
-    0x5c | 03 02       | func section
-    0x5e | 01          | 1 count
-    0x5f | 00          | [func 0] type 0
-    0x60 | 05 03       | memory section
-    0x62 | 01          | 1 count
-    0x63 | 00 00       | [memory 0] MemoryType { memory64: false, shared: false, initial: 0, maximum: None }
-    0x65 | 07 11       | export section
-    0x67 | 02          | 2 count
-    0x68 | 03 6d 65 6d | export Export { name: "mem", kind: Memory, index: 0 }
+    0x5f | 03 02       | func section
+    0x61 | 01          | 1 count
+    0x62 | 00          | [func 0] type 0
+    0x63 | 05 03       | memory section
+    0x65 | 01          | 1 count
+    0x66 | 00 00       | [memory 0] MemoryType { memory64: false, shared: false, initial: 0, maximum: None }
+    0x68 | 07 11       | export section
+    0x6a | 02          | 2 count
+    0x6b | 03 6d 65 6d | export Export { name: "mem", kind: Memory, index: 0 }
          | 02 00      
-    0x6e | 07 72 65 61 | export Export { name: "realloc", kind: Func, index: 0 }
+    0x71 | 07 72 65 61 | export Export { name: "realloc", kind: Func, index: 0 }
          | 6c 6c 6f 63
          | 00 00      
-    0x78 | 0a 05       | code section
-    0x7a | 01          | 1 count
+    0x7b | 0a 05       | code section
+    0x7d | 01          | 1 count
 ============== func 0 ====================
-    0x7b | 03          | size of function
-    0x7c | 00          | 0 local blocks
-    0x7d | 00          | unreachable
-    0x7e | 0b          | end
-    0x7f | 00 0c       | custom section
-    0x81 | 04 6e 61 6d | name: "name"
+    0x7e | 03          | size of function
+    0x7f | 00          | 0 local blocks
+    0x80 | 00          | unreachable
+    0x81 | 0b          | end
+    0x82 | 00 0c       | custom section
+    0x84 | 04 6e 61 6d | name: "name"
          | 65         
-    0x86 | 00 05       | module name
-    0x88 | 04 6c 69 62 | "libc"
+    0x89 | 00 05       | module name
+    0x8b | 04 6c 69 62 | "libc"
          | 63         
-  0x8d | 02 04       | core instance section
-  0x8f | 01          | 1 count
-  0x90 | 00 00 00    | [core instance 0] Instantiate { module_index: 0, args: [] }
-  0x93 | 01 5f       | [core module 1] inline size
-    0x95 | 00 61 73 6d | version 1 (Module)
+  0x90 | 02 04       | core instance section
+  0x92 | 01          | 1 count
+  0x93 | 00 00 00    | [core instance 0] Instantiate { module_index: 0, args: [] }
+  0x96 | 01 5f       | [core module 1] inline size
+    0x98 | 00 61 73 6d | version 1 (Module)
          | 01 00 00 00
-    0x9d | 01 09       | type section
-    0x9f | 02          | 2 count
-    0xa0 | 60 02 7f 7f | [type 0] Func(FuncType { params: [I32, I32], returns: [] })
+    0xa0 | 01 09       | type section
+    0xa2 | 02          | 2 count
+    0xa3 | 60 02 7f 7f | [type 0] Func(FuncType { params: [I32, I32], returns: [] })
          | 00         
-    0xa5 | 60 00 00    | [type 1] Func(FuncType { params: [], returns: [] })
-    0xa8 | 02 12       | import section
-    0xaa | 01          | 1 count
-    0xab | 09 77 61 73 | import [func 0] Import { module: "wasi_file", name: "read", ty: Func(0) }
-         | 69 5f 66 69
+    0xa8 | 60 00 00    | [type 1] Func(FuncType { params: [], returns: [] })
+    0xab | 02 12       | import section
+    0xad | 01          | 1 count
+    0xae | 09 77 61 73 | import [func 0] Import { module: "wasi-file", name: "read", ty: Func(0) }
+         | 69 2d 66 69
          | 6c 65 04 72
          | 65 61 64 00
          | 00         
-    0xbc | 03 02       | func section
-    0xbe | 01          | 1 count
-    0xbf | 01          | [func 1] type 1
-    0xc0 | 07 08       | export section
-    0xc2 | 01          | 1 count
-    0xc3 | 04 70 6c 61 | export Export { name: "play", kind: Func, index: 1 }
+    0xbf | 03 02       | func section
+    0xc1 | 01          | 1 count
+    0xc2 | 01          | [func 1] type 1
+    0xc3 | 07 08       | export section
+    0xc5 | 01          | 1 count
+    0xc6 | 04 70 6c 61 | export Export { name: "play", kind: Func, index: 1 }
          | 79 00 01   
-    0xca | 0a 05       | code section
-    0xcc | 01          | 1 count
+    0xcd | 0a 05       | code section
+    0xcf | 01          | 1 count
 ============== func 1 ====================
-    0xcd | 03          | size of function
-    0xce | 00          | 0 local blocks
-    0xcf | 00          | unreachable
-    0xd0 | 0b          | end
-    0xd1 | 00 21       | custom section
-    0xd3 | 04 6e 61 6d | name: "name"
+    0xd0 | 03          | size of function
+    0xd1 | 00          | 0 local blocks
+    0xd2 | 00          | unreachable
+    0xd3 | 0b          | end
+    0xd4 | 00 21       | custom section
+    0xd6 | 04 6e 61 6d | name: "name"
          | 65         
-    0xd8 | 00 06       | module name
-    0xda | 05 43 48 49 | "CHILD"
+    0xdb | 00 06       | module name
+    0xdd | 05 43 48 49 | "CHILD"
          | 4c 44      
-    0xe0 | 01 12       | function section
-    0xe2 | 02          | 2 count
-    0xe3 | 00 09 77 61 | Naming { index: 0, name: "wasi-file" }
+    0xe3 | 01 12       | function section
+    0xe5 | 02          | 2 count
+    0xe6 | 00 09 77 61 | Naming { index: 0, name: "wasi-file" }
          | 73 69 2d 66
          | 69 6c 65   
-    0xee | 01 04 70 6c | Naming { index: 1, name: "play" }
+    0xf1 | 01 04 70 6c | Naming { index: 1, name: "play" }
          | 61 79      
-  0xf4 | 01 60       | [core module 2] inline size
-    0xf6 | 00 61 73 6d | version 1 (Module)
+  0xf7 | 01 60       | [core module 2] inline size
+    0xf9 | 00 61 73 6d | version 1 (Module)
          | 01 00 00 00
-    0xfe | 01 0c       | type section
-   0x100 | 02          | 2 count
-   0x101 | 60 02 7f 7f | [type 0] Func(FuncType { params: [I32, I32], returns: [] })
+   0x101 | 01 0c       | type section
+   0x103 | 02          | 2 count
+   0x104 | 60 02 7f 7f | [type 0] Func(FuncType { params: [I32, I32], returns: [] })
          | 00         
-   0x106 | 60 03 7f 7f | [type 1] Func(FuncType { params: [I32, I32, I32], returns: [] })
+   0x109 | 60 03 7f 7f | [type 1] Func(FuncType { params: [I32, I32, I32], returns: [] })
          | 7f 00      
-   0x10c | 02 12       | import section
-   0x10e | 01          | 1 count
-   0x10f | 09 77 61 73 | import [func 0] Import { module: "wasi_file", name: "read", ty: Func(0) }
-         | 69 5f 66 69
+   0x10f | 02 12       | import section
+   0x111 | 01          | 1 count
+   0x112 | 09 77 61 73 | import [func 0] Import { module: "wasi-file", name: "read", ty: Func(0) }
+         | 69 2d 66 69
          | 6c 65 04 72
          | 65 61 64 00
          | 00         
-   0x120 | 03 03       | func section
-   0x122 | 02          | 2 count
-   0x123 | 00          | [func 1] type 0
-   0x124 | 01          | [func 2] type 1
-   0x125 | 07 10       | export section
-   0x127 | 02          | 2 count
-   0x128 | 04 72 65 61 | export Export { name: "read", kind: Func, index: 1 }
+   0x123 | 03 03       | func section
+   0x125 | 02          | 2 count
+   0x126 | 00          | [func 1] type 0
+   0x127 | 01          | [func 2] type 1
+   0x128 | 07 10       | export section
+   0x12a | 02          | 2 count
+   0x12b | 04 72 65 61 | export Export { name: "read", kind: Func, index: 1 }
          | 64 00 01   
-   0x12f | 05 77 72 69 | export Export { name: "write", kind: Func, index: 2 }
+   0x132 | 05 77 72 69 | export Export { name: "write", kind: Func, index: 2 }
          | 74 65 00 02
-   0x137 | 0a 09       | code section
-   0x139 | 02          | 2 count
+   0x13a | 0a 09       | code section
+   0x13c | 02          | 2 count
 ============== func 1 ====================
-   0x13a | 03          | size of function
-   0x13b | 00          | 0 local blocks
-   0x13c | 00          | unreachable
-   0x13d | 0b          | end
+   0x13d | 03          | size of function
+   0x13e | 00          | 0 local blocks
+   0x13f | 00          | unreachable
+   0x140 | 0b          | end
 ============== func 2 ====================
-   0x13e | 03          | size of function
-   0x13f | 00          | 0 local blocks
-   0x140 | 00          | unreachable
-   0x141 | 0b          | end
-   0x142 | 00 12       | custom section
-   0x144 | 04 6e 61 6d | name: "name"
+   0x141 | 03          | size of function
+   0x142 | 00          | 0 local blocks
+   0x143 | 00          | unreachable
+   0x144 | 0b          | end
+   0x145 | 00 12       | custom section
+   0x147 | 04 6e 61 6d | name: "name"
          | 65         
-   0x149 | 00 0b       | module name
-   0x14b | 0a 56 49 52 | "VIRTUALIZE"
+   0x14c | 00 0b       | module name
+   0x14e | 0a 56 49 52 | "VIRTUALIZE"
          | 54 55 41 4c
          | 49 5a 45   
- 0x156 | 06 1d       | component alias section
- 0x158 | 03          | 3 count
- 0x159 | 01 00 00 04 | alias [func 0] InstanceExport { kind: Func, instance_index: 0, name: "read" }
+ 0x159 | 06 1d       | component alias section
+ 0x15b | 03          | 3 count
+ 0x15c | 01 00 00 04 | alias [func 0] InstanceExport { kind: Func, instance_index: 0, name: "read" }
        | 72 65 61 64
- 0x161 | 00 02 01 00 | alias [core memory 0] CoreInstanceExport { kind: Memory, instance_index: 0, name: "mem" }
+ 0x164 | 00 02 01 00 | alias [core memory 0] CoreInstanceExport { kind: Memory, instance_index: 0, name: "mem" }
        | 03 6d 65 6d
- 0x169 | 00 00 01 00 | alias [core func 0] CoreInstanceExport { kind: Func, instance_index: 0, name: "realloc" }
+ 0x16c | 00 00 01 00 | alias [core func 0] CoreInstanceExport { kind: Func, instance_index: 0, name: "realloc" }
        | 07 72 65 61
        | 6c 6c 6f 63
- 0x175 | 08 09       | canonical function section
- 0x177 | 01          | 1 count
- 0x178 | 01 00 00 02 | [core func 1] Lower { func_index: 0, options: [Memory(0), Realloc(0)] }
+ 0x178 | 08 09       | canonical function section
+ 0x17a | 01          | 1 count
+ 0x17b | 01 00 00 02 | [core func 1] Lower { func_index: 0, options: [Memory(0), Realloc(0)] }
        | 03 00 04 00
- 0x180 | 02 28       | core instance section
- 0x182 | 03          | 3 count
- 0x183 | 01 01 04 72 | [core instance 1] FromExports([Export { name: "read", kind: Func, index: 1 }])
+ 0x183 | 02 28       | core instance section
+ 0x185 | 03          | 3 count
+ 0x186 | 01 01 04 72 | [core instance 1] FromExports([Export { name: "read", kind: Func, index: 1 }])
        | 65 61 64 00
        | 01         
- 0x18c | 00 02 01 09 | [core instance 2] Instantiate { module_index: 2, args: [InstantiationArg { name: "wasi_file", kind: Instance, index: 1 }] }
+ 0x18f | 00 02 01 09 | [core instance 2] Instantiate { module_index: 2, args: [InstantiationArg { name: "wasi-file", kind: Instance, index: 1 }] }
        | 77 61 73 69
-       | 5f 66 69 6c
+       | 2d 66 69 6c
        | 65 12 01   
- 0x19b | 00 01 01 09 | [core instance 3] Instantiate { module_index: 1, args: [InstantiationArg { name: "wasi_file", kind: Instance, index: 2 }] }
+ 0x19e | 00 01 01 09 | [core instance 3] Instantiate { module_index: 1, args: [InstantiationArg { name: "wasi-file", kind: Instance, index: 2 }] }
        | 77 61 73 69
-       | 5f 66 69 6c
+       | 2d 66 69 6c
        | 65 12 02   
- 0x1aa | 07 05       | component type section
- 0x1ac | 01          | 1 count
- 0x1ad | 40 00 01 00 | [type 1] Func(ComponentFuncType { params: [], results: Named([]) })
- 0x1b1 | 06 1e       | component alias section
- 0x1b3 | 03          | 3 count
- 0x1b4 | 00 00 01 03 | alias [core func 2] CoreInstanceExport { kind: Func, instance_index: 3, name: "play" }
+ 0x1ad | 07 05       | component type section
+ 0x1af | 01          | 1 count
+ 0x1b0 | 40 00 01 00 | [type 1] Func(ComponentFuncType { params: [], results: Named([]) })
+ 0x1b4 | 06 1e       | component alias section
+ 0x1b6 | 03          | 3 count
+ 0x1b7 | 00 00 01 03 | alias [core func 2] CoreInstanceExport { kind: Func, instance_index: 3, name: "play" }
        | 04 70 6c 61
        | 79         
- 0x1bd | 00 02 01 00 | alias [core memory 1] CoreInstanceExport { kind: Memory, instance_index: 0, name: "mem" }
+ 0x1c0 | 00 02 01 00 | alias [core memory 1] CoreInstanceExport { kind: Memory, instance_index: 0, name: "mem" }
        | 03 6d 65 6d
- 0x1c5 | 00 00 01 00 | alias [core func 3] CoreInstanceExport { kind: Func, instance_index: 0, name: "realloc" }
+ 0x1c8 | 00 00 01 00 | alias [core func 3] CoreInstanceExport { kind: Func, instance_index: 0, name: "realloc" }
        | 07 72 65 61
        | 6c 6c 6f 63
- 0x1d1 | 08 0a       | canonical function section
- 0x1d3 | 01          | 1 count
- 0x1d4 | 00 00 02 02 | [func 1] Lift { core_func_index: 2, type_index: 1, options: [Memory(1), Realloc(3)] }
+ 0x1d4 | 08 0a       | canonical function section
+ 0x1d6 | 01          | 1 count
+ 0x1d7 | 00 00 02 02 | [func 1] Lift { core_func_index: 2, type_index: 1, options: [Memory(1), Realloc(3)] }
        | 03 01 04 03
        | 01         
- 0x1dd | 0b 08       | component export section
- 0x1df | 01          | 1 count
- 0x1e0 | 04 77 6f 72 | export ComponentExport { name: "work", kind: Func, index: 1 }
-       | 6b 01 01   
- 0x1e7 | 00 7c       | custom section
- 0x1e9 | 0e 63 6f 6d | name: "component-name"
+ 0x1e0 | 0b 09       | component export section
+ 0x1e2 | 01          | 1 count
+ 0x1e3 | 04 77 6f 72 | export ComponentExport { name: "work", url: "", kind: Func, index: 1 }
+       | 6b 00 01 01
+ 0x1eb | 00 7c       | custom section
+ 0x1ed | 0e 63 6f 6d | name: "component-name"
        | 70 6f 6e 65
        | 6e 74 2d 6e
        | 61 6d 65   
- 0x1f8 | 01 13 00 00 | core func section
- 0x1fc | 01          | 1 count
- 0x1fd | 01 0e 72 65 | Naming { index: 1, name: "real-wasi-read" }
+ 0x1fc | 01 13 00 00 | core func section
+ 0x200 | 01          | 1 count
+ 0x201 | 01 0e 72 65 | Naming { index: 1, name: "real-wasi-read" }
        | 61 6c 2d 77
        | 61 73 69 2d
        | 72 65 61 64
- 0x20d | 01 1c 00 11 | core module section
- 0x211 | 03          | 3 count
- 0x212 | 00 04 6c 69 | Naming { index: 0, name: "libc" }
+ 0x211 | 01 1c 00 11 | core module section
+ 0x215 | 03          | 3 count
+ 0x216 | 00 04 6c 69 | Naming { index: 0, name: "libc" }
        | 62 63      
- 0x218 | 01 05 43 48 | Naming { index: 1, name: "CHILD" }
+ 0x21c | 01 05 43 48 | Naming { index: 1, name: "CHILD" }
        | 49 4c 44   
- 0x21f | 02 0a 56 49 | Naming { index: 2, name: "VIRTUALIZE" }
+ 0x223 | 02 0a 56 49 | Naming { index: 2, name: "VIRTUALIZE" }
        | 52 54 55 41
        | 4c 49 5a 45
- 0x22b | 01 1b 00 12 | core instance section
- 0x22f | 03          | 3 count
- 0x230 | 00 04 6c 69 | Naming { index: 0, name: "libc" }
+ 0x22f | 01 1b 00 12 | core instance section
+ 0x233 | 03          | 3 count
+ 0x234 | 00 04 6c 69 | Naming { index: 0, name: "libc" }
        | 62 63      
- 0x236 | 02 09 76 69 | Naming { index: 2, name: "virt-wasi" }
+ 0x23a | 02 09 76 69 | Naming { index: 2, name: "virt-wasi" }
        | 72 74 2d 77
        | 61 73 69   
- 0x241 | 03 05 63 68 | Naming { index: 3, name: "child" }
+ 0x245 | 03 05 63 68 | Naming { index: 3, name: "child" }
        | 69 6c 64   
- 0x248 | 01 0c 03    | type section
- 0x24b | 01          | 1 count
- 0x24c | 00 08 57 61 | Naming { index: 0, name: "WasiFile" }
+ 0x24c | 01 0c 03    | type section
+ 0x24f | 01          | 1 count
+ 0x250 | 00 08 57 61 | Naming { index: 0, name: "WasiFile" }
        | 73 69 46 69
        | 6c 65      
- 0x256 | 01 0d 05    | instance section
- 0x259 | 01          | 1 count
- 0x25a | 00 09 72 65 | Naming { index: 0, name: "real-wasi" }
+ 0x25a | 01 0d 05    | instance section
+ 0x25d | 01          | 1 count
+ 0x25e | 00 09 72 65 | Naming { index: 0, name: "real-wasi" }
        | 61 6c 2d 77
        | 61 73 69   

--- a/tests/dump/component-expand-bundle2.wat
+++ b/tests/dump/component-expand-bundle2.wat
@@ -1,11 +1,11 @@
 (component
   (component $c
-    (core module (export ""))
+    (core module (export "e"))
   )
-  (component $c2 (import "" (component (import "" (core module)))))
+  (component $c2 (import "i" (component (import "i" (core module)))))
   (instance $C (instantiate $c))
-  (alias export $C "" (core module $m))
-  (instance (instantiate $c2 (with "" (instance
-    (export "" (core module $m))
+  (alias export $C "e" (core module $m))
+  (instance (instantiate $c2 (with "i" (instance
+    (export "e" (core module $m))
   ))))
 )

--- a/tests/dump/component-expand-bundle2.wat.dump
+++ b/tests/dump/component-expand-bundle2.wat.dump
@@ -1,64 +1,66 @@
   0x0 | 00 61 73 6d | version 65546 (Component)
       | 0a 00 01 00
-  0x8 | 04 2e       | [component 0] inline size
+  0x8 | 04 30       | [component 0] inline size
     0xa | 00 61 73 6d | version 65546 (Component)
         | 0a 00 01 00
    0x12 | 01 08       | [core module 0] inline size
      0x14 | 00 61 73 6d | version 1 (Module)
           | 01 00 00 00
-   0x1c | 0b 05       | component export section
+   0x1c | 0b 07       | component export section
    0x1e | 01          | 1 count
-   0x1f | 00 00 11 00 | export ComponentExport { name: "", kind: Module, index: 0 }
-   0x23 | 00 13       | custom section
-   0x25 | 0e 63 6f 6d | name: "component-name"
-        | 70 6f 6e 65
-        | 6e 74 2d 6e
-        | 61 6d 65   
-   0x34 | 00 02       | component name
-   0x36 | 01 63       | "c"
- 0x38 | 04 31       | [component 1] inline size
-   0x3a | 00 61 73 6d | version 65546 (Component)
-        | 0a 00 01 00
-   0x42 | 07 0b       | component type section
-   0x44 | 01          | 1 count
-   0x45 | 41 02 00 50 | [type 0] Component([CoreType(Module([])), Import(ComponentImport { name: "", ty: Module(0) })])
-        | 00 03 00 00
+   0x1f | 01 65 00 00 | export ComponentExport { name: "e", url: "", kind: Module, index: 0 }
         | 11 00      
-   0x4f | 0a 04       | component import section
-   0x51 | 01          | 1 count
-   0x52 | 00 04 00    | [component 0] ComponentImport { name: "", ty: Component(0) }
-   0x55 | 00 14       | custom section
-   0x57 | 0e 63 6f 6d | name: "component-name"
+   0x25 | 00 13       | custom section
+   0x27 | 0e 63 6f 6d | name: "component-name"
         | 70 6f 6e 65
         | 6e 74 2d 6e
         | 61 6d 65   
-   0x66 | 00 03       | component name
-   0x68 | 02 63 32    | "c2"
- 0x6b | 05 04       | component instance section
- 0x6d | 01          | 1 count
- 0x6e | 00 00 00    | [instance 0] Instantiate { component_index: 0, args: [] }
- 0x71 | 06 06       | component alias section
+   0x36 | 00 02       | component name
+   0x38 | 01 63       | "c"
+ 0x3a | 04 35       | [component 1] inline size
+   0x3c | 00 61 73 6d | version 65546 (Component)
+        | 0a 00 01 00
+   0x44 | 07 0d       | component type section
+   0x46 | 01          | 1 count
+   0x47 | 41 02 00 50 | [type 0] Component([CoreType(Module([])), Import(ComponentImport { name: "i", url: "", ty: Module(0) })])
+        | 00 03 01 69
+        | 00 00 11 00
+   0x53 | 0a 06       | component import section
+   0x55 | 01          | 1 count
+   0x56 | 01 69 00 04 | [component 0] ComponentImport { name: "i", url: "", ty: Component(0) }
+        | 00         
+   0x5b | 00 14       | custom section
+   0x5d | 0e 63 6f 6d | name: "component-name"
+        | 70 6f 6e 65
+        | 6e 74 2d 6e
+        | 61 6d 65   
+   0x6c | 00 03       | component name
+   0x6e | 02 63 32    | "c2"
+ 0x71 | 05 04       | component instance section
  0x73 | 01          | 1 count
- 0x74 | 00 11 00 00 | alias [module 0] InstanceExport { kind: Module, instance_index: 0, name: "" }
-      | 00         
- 0x79 | 05 0d       | component instance section
- 0x7b | 02          | 2 count
- 0x7c | 01 01 00 00 | [instance 1] FromExports([ComponentExport { name: "", kind: Module, index: 0 }])
-      | 11 00      
- 0x82 | 00 01 01 00 | [instance 2] Instantiate { component_index: 1, args: [ComponentInstantiationArg { name: "", kind: Instance, index: 1 }] }
-      | 05 01      
- 0x88 | 00 29       | custom section
- 0x8a | 0e 63 6f 6d | name: "component-name"
+ 0x74 | 00 00 00    | [instance 0] Instantiate { component_index: 0, args: [] }
+ 0x77 | 06 07       | component alias section
+ 0x79 | 01          | 1 count
+ 0x7a | 00 11 00 00 | alias [module 0] InstanceExport { kind: Module, instance_index: 0, name: "e" }
+      | 01 65      
+ 0x80 | 05 0f       | component instance section
+ 0x82 | 02          | 2 count
+ 0x83 | 01 01 01 65 | [instance 1] FromExports([ComponentExport { name: "e", url: "", kind: Module, index: 0 }])
+      | 00 11 00   
+ 0x8a | 00 01 01 01 | [instance 2] Instantiate { component_index: 1, args: [ComponentInstantiationArg { name: "i", kind: Instance, index: 1 }] }
+      | 69 05 01   
+ 0x91 | 00 29       | custom section
+ 0x93 | 0e 63 6f 6d | name: "component-name"
       | 70 6f 6e 65
       | 6e 74 2d 6e
       | 61 6d 65   
- 0x99 | 01 06 00 11 | core module section
- 0x9d | 01          | 1 count
- 0x9e | 00 01 6d    | Naming { index: 0, name: "m" }
- 0xa1 | 01 09 04    | component section
- 0xa4 | 02          | 2 count
- 0xa5 | 00 01 63    | Naming { index: 0, name: "c" }
- 0xa8 | 01 02 63 32 | Naming { index: 1, name: "c2" }
- 0xac | 01 05 05    | instance section
- 0xaf | 01          | 1 count
- 0xb0 | 00 01 43    | Naming { index: 0, name: "C" }
+ 0xa2 | 01 06 00 11 | core module section
+ 0xa6 | 01          | 1 count
+ 0xa7 | 00 01 6d    | Naming { index: 0, name: "m" }
+ 0xaa | 01 09 04    | component section
+ 0xad | 02          | 2 count
+ 0xae | 00 01 63    | Naming { index: 0, name: "c" }
+ 0xb1 | 01 02 63 32 | Naming { index: 1, name: "c2" }
+ 0xb5 | 01 05 05    | instance section
+ 0xb8 | 01          | 1 count
+ 0xb9 | 00 01 43    | Naming { index: 0, name: "C" }

--- a/tests/dump/component-inline-export-import.wat.dump
+++ b/tests/dump/component-inline-export-import.wat.dump
@@ -3,18 +3,18 @@
   0x8 | 07 03       | component type section
   0xa | 01          | 1 count
   0xb | 41 00       | [type 0] Component([])
-  0xd | 0a 04       | component import section
+  0xd | 0a 05       | component import section
   0xf | 01          | 1 count
- 0x10 | 00 04 00    | [component 0] ComponentImport { name: "", ty: Component(0) }
- 0x13 | 03 03       | core type section
- 0x15 | 01          | 1 count
- 0x16 | 50 00       | [core type 0] Module([])
- 0x18 | 0a 06       | component import section
- 0x1a | 01          | 1 count
- 0x1b | 01 61 00 11 | [module 0] ComponentImport { name: "a", ty: Module(0) }
-      | 00         
- 0x20 | 0b 09       | component export section
- 0x22 | 02          | 2 count
- 0x23 | 00 04 00    | export ComponentExport { name: "", kind: Component, index: 0 }
- 0x26 | 01 61 00 11 | export ComponentExport { name: "a", kind: Module, index: 0 }
-      | 00         
+ 0x10 | 00 00 04 00 | [component 0] ComponentImport { name: "", url: "", ty: Component(0) }
+ 0x14 | 03 03       | core type section
+ 0x16 | 01          | 1 count
+ 0x17 | 50 00       | [core type 0] Module([])
+ 0x19 | 0a 07       | component import section
+ 0x1b | 01          | 1 count
+ 0x1c | 01 61 00 00 | [module 0] ComponentImport { name: "a", url: "", ty: Module(0) }
+      | 11 00      
+ 0x22 | 0b 0b       | component export section
+ 0x24 | 02          | 2 count
+ 0x25 | 00 00 04 00 | export ComponentExport { name: "", url: "", kind: Component, index: 0 }
+ 0x29 | 01 61 00 00 | export ComponentExport { name: "a", url: "", kind: Module, index: 0 }
+      | 11 00      

--- a/tests/dump/component-inline-type.wat
+++ b/tests/dump/component-inline-type.wat
@@ -1,6 +1,6 @@
 (component
-  (import "" (component))
-  (import "" (core module))
-  (import "" (instance))
-  (import "" (func))
+  (import "a" (component))
+  (import "b" (core module))
+  (import "c" (instance))
+  (import "d" (func))
 )

--- a/tests/dump/component-inline-type.wat.dump
+++ b/tests/dump/component-inline-type.wat.dump
@@ -3,24 +3,28 @@
   0x8 | 07 03       | component type section
   0xa | 01          | 1 count
   0xb | 41 00       | [type 0] Component([])
-  0xd | 0a 04       | component import section
+  0xd | 0a 06       | component import section
   0xf | 01          | 1 count
- 0x10 | 00 04 00    | [component 0] ComponentImport { name: "", ty: Component(0) }
- 0x13 | 03 03       | core type section
- 0x15 | 01          | 1 count
- 0x16 | 50 00       | [core type 0] Module([])
- 0x18 | 0a 05       | component import section
- 0x1a | 01          | 1 count
- 0x1b | 00 00 11 00 | [module 0] ComponentImport { name: "", ty: Module(0) }
- 0x1f | 07 03       | component type section
- 0x21 | 01          | 1 count
- 0x22 | 42 00       | [type 1] Instance([])
- 0x24 | 0a 04       | component import section
- 0x26 | 01          | 1 count
- 0x27 | 00 05 01    | [instance 0] ComponentImport { name: "", ty: Instance(1) }
- 0x2a | 07 05       | component type section
- 0x2c | 01          | 1 count
- 0x2d | 40 00 01 00 | [type 2] Func(ComponentFuncType { params: [], results: Named([]) })
- 0x31 | 0a 04       | component import section
- 0x33 | 01          | 1 count
- 0x34 | 00 01 02    | [func 0] ComponentImport { name: "", ty: Func(2) }
+ 0x10 | 01 61 00 04 | [component 0] ComponentImport { name: "a", url: "", ty: Component(0) }
+      | 00         
+ 0x15 | 03 03       | core type section
+ 0x17 | 01          | 1 count
+ 0x18 | 50 00       | [core type 0] Module([])
+ 0x1a | 0a 07       | component import section
+ 0x1c | 01          | 1 count
+ 0x1d | 01 62 00 00 | [module 0] ComponentImport { name: "b", url: "", ty: Module(0) }
+      | 11 00      
+ 0x23 | 07 03       | component type section
+ 0x25 | 01          | 1 count
+ 0x26 | 42 00       | [type 1] Instance([])
+ 0x28 | 0a 06       | component import section
+ 0x2a | 01          | 1 count
+ 0x2b | 01 63 00 05 | [instance 0] ComponentImport { name: "c", url: "", ty: Instance(1) }
+      | 01         
+ 0x30 | 07 05       | component type section
+ 0x32 | 01          | 1 count
+ 0x33 | 40 00 01 00 | [type 2] Func(ComponentFuncType { params: [], results: Named([]) })
+ 0x37 | 0a 06       | component import section
+ 0x39 | 01          | 1 count
+ 0x3a | 01 64 00 01 | [func 0] ComponentImport { name: "d", url: "", ty: Func(2) }
+      | 02         

--- a/tests/dump/component-instance-type.wat.dump
+++ b/tests/dump/component-instance-type.wat.dump
@@ -1,22 +1,23 @@
   0x0 | 00 61 73 6d | version 65546 (Component)
       | 0a 00 01 00
-  0x8 | 07 25       | component type section
+  0x8 | 07 28       | component type section
   0xa | 01          | 1 count
-  0xb | 42 03 01 40 | [type 0] Instance([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Type(Component([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Alias(Outer { kind: Type, count: 1, index: 0 }), Import(ComponentImport { name: "1", ty: Func(0) }), Export { name: "1", ty: Func(1) }])), Export { name: "c5", ty: Component(1) }])
+  0xb | 42 03 01 40 | [type 0] Instance([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Type(Component([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Alias(Outer { kind: Type, count: 1, index: 0 }), Import(ComponentImport { name: "1", url: "", ty: Func(0) }), Export { name: "1", url: "", ty: Func(1) }])), Export { name: "c5", url: "", ty: Component(1) }])
       | 00 01 00 01
       | 41 04 01 40
       | 00 01 00 02
       | 03 02 01 00
-      | 03 01 31 01
-      | 00 04 01 31
-      | 01 01 04 02
-      | 63 35 04 01
- 0x2f | 00 1a       | custom section
- 0x31 | 0e 63 6f 6d | name: "component-name"
+      | 03 01 31 00
+      | 01 00 04 01
+      | 31 00 01 01
+      | 04 02 63 35
+      | 00 04 01   
+ 0x32 | 00 1a       | custom section
+ 0x34 | 0e 63 6f 6d | name: "component-name"
       | 70 6f 6e 65
       | 6e 74 2d 6e
       | 61 6d 65   
- 0x40 | 01 09 03    | type section
- 0x43 | 01          | 1 count
- 0x44 | 00 05 6f 75 | Naming { index: 0, name: "outer" }
+ 0x43 | 01 09 03    | type section
+ 0x46 | 01          | 1 count
+ 0x47 | 00 05 6f 75 | Naming { index: 0, name: "outer" }
       | 74 65 72   

--- a/tests/dump/component-linking.wat
+++ b/tests/dump/component-linking.wat
@@ -1,25 +1,25 @@
 (component
-  (import "" (instance $i
-    (export "1" (core module))
-    (export "2" (func))
-    (export "3" (value string))
-    (export "4" (instance))
-    (export "5" (component))
+  (import "a" (instance $i
+    (export "a" (core module))
+    (export "b" (func))
+    (export "c" (value string))
+    (export "d" (instance))
+    (export "e" (component))
   ))
 
   (component $c
-    (import "1" (core module))
-    (import "2" (func))
-    (import "3" (value string))
-    (import "4" (instance))
-    (import "5" (component))
+    (import "a" (core module))
+    (import "b" (func))
+    (import "c" (value string))
+    (import "d" (instance))
+    (import "e" (component))
   )
 
   (instance (instantiate $c
-    (with "1" (core module $i "1"))
-    (with "2" (func $i "2"))
-    (with "3" (value $i "4"))
-    (with "4" (instance $i "3"))
-    (with "5" (component $i "5"))
+    (with "a" (core module $i "a"))
+    (with "b" (func $i "b"))
+    (with "c" (value $i "c"))
+    (with "d" (instance $i "d"))
+    (with "e" (component $i "e"))
   ))
 )

--- a/tests/dump/component-linking.wat.dump
+++ b/tests/dump/component-linking.wat.dump
@@ -1,85 +1,91 @@
   0x0 | 00 61 73 6d | version 65546 (Component)
       | 0a 00 01 00
-  0x8 | 07 2b       | component type section
+  0x8 | 07 30       | component type section
   0xa | 01          | 1 count
-  0xb | 42 09 00 50 | [type 0] Instance([CoreType(Module([])), Export { name: "1", ty: Module(0) }, Type(Func(ComponentFuncType { params: [], results: Named([]) })), Export { name: "2", ty: Func(0) }, Export { name: "3", ty: Value(Primitive(String)) }, Type(Instance([])), Export { name: "4", ty: Instance(1) }, Type(Component([])), Export { name: "5", ty: Component(2) }])
-      | 00 04 01 31
-      | 00 11 00 01
-      | 40 00 01 00
-      | 04 01 32 01
-      | 00 04 01 33
-      | 02 73 01 42
-      | 00 04 01 34
+  0xb | 42 09 00 50 | [type 0] Instance([CoreType(Module([])), Export { name: "a", url: "", ty: Module(0) }, Type(Func(ComponentFuncType { params: [], results: Named([]) })), Export { name: "b", url: "", ty: Func(0) }, Export { name: "c", url: "", ty: Value(Primitive(String)) }, Type(Instance([])), Export { name: "d", url: "", ty: Instance(1) }, Type(Component([])), Export { name: "e", url: "", ty: Component(2) }])
+      | 00 04 01 61
+      | 00 00 11 00
+      | 01 40 00 01
+      | 00 04 01 62
+      | 00 01 00 04
+      | 01 63 00 02
+      | 73 01 42 00
+      | 04 01 64 00
       | 05 01 01 41
-      | 00 04 01 35
-      | 04 02      
- 0x35 | 0a 04       | component import section
- 0x37 | 01          | 1 count
- 0x38 | 00 05 00    | [instance 0] ComponentImport { name: "", ty: Instance(0) }
- 0x3b | 04 54       | [component 0] inline size
-   0x3d | 00 61 73 6d | version 65546 (Component)
+      | 00 04 01 65
+      | 00 04 02   
+ 0x3a | 0a 06       | component import section
+ 0x3c | 01          | 1 count
+ 0x3d | 01 61 00 05 | [instance 0] ComponentImport { name: "a", url: "", ty: Instance(0) }
+      | 00         
+ 0x42 | 04 59       | [component 0] inline size
+   0x44 | 00 61 73 6d | version 65546 (Component)
         | 0a 00 01 00
-   0x45 | 03 03       | core type section
-   0x47 | 01          | 1 count
-   0x48 | 50 00       | [core type 0] Module([])
-   0x4a | 0a 06       | component import section
-   0x4c | 01          | 1 count
-   0x4d | 01 31 00 11 | [module 0] ComponentImport { name: "1", ty: Module(0) }
+   0x4c | 03 03       | core type section
+   0x4e | 01          | 1 count
+   0x4f | 50 00       | [core type 0] Module([])
+   0x51 | 0a 07       | component import section
+   0x53 | 01          | 1 count
+   0x54 | 01 61 00 00 | [module 0] ComponentImport { name: "a", url: "", ty: Module(0) }
+        | 11 00      
+   0x5a | 07 05       | component type section
+   0x5c | 01          | 1 count
+   0x5d | 40 00 01 00 | [type 0] Func(ComponentFuncType { params: [], results: Named([]) })
+   0x61 | 0a 0b       | component import section
+   0x63 | 02          | 2 count
+   0x64 | 01 62 00 01 | [func 0] ComponentImport { name: "b", url: "", ty: Func(0) }
         | 00         
-   0x52 | 07 05       | component type section
-   0x54 | 01          | 1 count
-   0x55 | 40 00 01 00 | [type 0] Func(ComponentFuncType { params: [], results: Named([]) })
-   0x59 | 0a 09       | component import section
-   0x5b | 02          | 2 count
-   0x5c | 01 32 01 00 | [func 0] ComponentImport { name: "2", ty: Func(0) }
-   0x60 | 01 33 02 73 | [value 0] ComponentImport { name: "3", ty: Value(Primitive(String)) }
-   0x64 | 07 03       | component type section
-   0x66 | 01          | 1 count
-   0x67 | 42 00       | [type 1] Instance([])
-   0x69 | 0a 05       | component import section
-   0x6b | 01          | 1 count
-   0x6c | 01 34 05 01 | [instance 0] ComponentImport { name: "4", ty: Instance(1) }
-   0x70 | 07 03       | component type section
-   0x72 | 01          | 1 count
-   0x73 | 41 00       | [type 2] Component([])
-   0x75 | 0a 05       | component import section
-   0x77 | 01          | 1 count
-   0x78 | 01 35 04 02 | [component 0] ComponentImport { name: "5", ty: Component(2) }
-   0x7c | 00 13       | custom section
-   0x7e | 0e 63 6f 6d | name: "component-name"
+   0x69 | 01 63 00 02 | [value 0] ComponentImport { name: "c", url: "", ty: Value(Primitive(String)) }
+        | 73         
+   0x6e | 07 03       | component type section
+   0x70 | 01          | 1 count
+   0x71 | 42 00       | [type 1] Instance([])
+   0x73 | 0a 06       | component import section
+   0x75 | 01          | 1 count
+   0x76 | 01 64 00 05 | [instance 0] ComponentImport { name: "d", url: "", ty: Instance(1) }
+        | 01         
+   0x7b | 07 03       | component type section
+   0x7d | 01          | 1 count
+   0x7e | 41 00       | [type 2] Component([])
+   0x80 | 0a 06       | component import section
+   0x82 | 01          | 1 count
+   0x83 | 01 65 00 04 | [component 0] ComponentImport { name: "e", url: "", ty: Component(2) }
+        | 02         
+   0x88 | 00 13       | custom section
+   0x8a | 0e 63 6f 6d | name: "component-name"
         | 70 6f 6e 65
         | 6e 74 2d 6e
         | 61 6d 65   
-   0x8d | 00 02       | component name
-   0x8f | 01 63       | "c"
- 0x91 | 06 1b       | component alias section
- 0x93 | 05          | 5 count
- 0x94 | 00 11 00 00 | alias [module 0] InstanceExport { kind: Module, instance_index: 0, name: "1" }
-      | 01 31      
- 0x9a | 01 00 00 01 | alias [func 0] InstanceExport { kind: Func, instance_index: 0, name: "2" }
-      | 32         
- 0x9f | 02 00 00 01 | alias [value 0] InstanceExport { kind: Value, instance_index: 0, name: "4" }
-      | 34         
- 0xa4 | 05 00 00 01 | alias [instance 1] InstanceExport { kind: Instance, instance_index: 0, name: "3" }
-      | 33         
- 0xa9 | 04 00 00 01 | alias [component 1] InstanceExport { kind: Component, instance_index: 0, name: "5" }
-      | 35         
- 0xae | 05 19       | component instance section
- 0xb0 | 01          | 1 count
- 0xb1 | 00 00 05 01 | [instance 2] Instantiate { component_index: 0, args: [ComponentInstantiationArg { name: "1", kind: Module, index: 0 }, ComponentInstantiationArg { name: "2", kind: Func, index: 0 }, ComponentInstantiationArg { name: "3", kind: Value, index: 0 }, ComponentInstantiationArg { name: "4", kind: Instance, index: 1 }, ComponentInstantiationArg { name: "5", kind: Component, index: 1 }] }
-      | 31 00 11 00
-      | 01 32 01 00
-      | 01 33 02 00
-      | 01 34 05 01
-      | 01 35 04 01
- 0xc9 | 00 1d       | custom section
- 0xcb | 0e 63 6f 6d | name: "component-name"
+   0x99 | 00 02       | component name
+   0x9b | 01 63       | "c"
+ 0x9d | 06 1b       | component alias section
+ 0x9f | 05          | 5 count
+ 0xa0 | 00 11 00 00 | alias [module 0] InstanceExport { kind: Module, instance_index: 0, name: "a" }
+      | 01 61      
+ 0xa6 | 01 00 00 01 | alias [func 0] InstanceExport { kind: Func, instance_index: 0, name: "b" }
+      | 62         
+ 0xab | 02 00 00 01 | alias [value 0] InstanceExport { kind: Value, instance_index: 0, name: "c" }
+      | 63         
+ 0xb0 | 05 00 00 01 | alias [instance 1] InstanceExport { kind: Instance, instance_index: 0, name: "d" }
+      | 64         
+ 0xb5 | 04 00 00 01 | alias [component 1] InstanceExport { kind: Component, instance_index: 0, name: "e" }
+      | 65         
+ 0xba | 05 19       | component instance section
+ 0xbc | 01          | 1 count
+ 0xbd | 00 00 05 01 | [instance 2] Instantiate { component_index: 0, args: [ComponentInstantiationArg { name: "a", kind: Module, index: 0 }, ComponentInstantiationArg { name: "b", kind: Func, index: 0 }, ComponentInstantiationArg { name: "c", kind: Value, index: 0 }, ComponentInstantiationArg { name: "d", kind: Instance, index: 1 }, ComponentInstantiationArg { name: "e", kind: Component, index: 1 }] }
+      | 61 00 11 00
+      | 01 62 01 00
+      | 01 63 02 00
+      | 01 64 05 01
+      | 01 65 04 01
+ 0xd5 | 00 1d       | custom section
+ 0xd7 | 0e 63 6f 6d | name: "component-name"
       | 70 6f 6e 65
       | 6e 74 2d 6e
       | 61 6d 65   
- 0xda | 01 05 04    | component section
- 0xdd | 01          | 1 count
- 0xde | 00 01 63    | Naming { index: 0, name: "c" }
- 0xe1 | 01 05 05    | instance section
- 0xe4 | 01          | 1 count
- 0xe5 | 00 01 69    | Naming { index: 0, name: "i" }
+ 0xe6 | 01 05 04    | component section
+ 0xe9 | 01          | 1 count
+ 0xea | 00 01 63    | Naming { index: 0, name: "c" }
+ 0xed | 01 05 05    | instance section
+ 0xf0 | 01          | 1 count
+ 0xf1 | 00 01 69    | Naming { index: 0, name: "i" }

--- a/tests/dump/import-modules.wat
+++ b/tests/dump/import-modules.wat
@@ -1,10 +1,10 @@
 (component
-  (import "" (core module $m1
+  (import "a" (core module $m1
     (import "" "f" (func))
   ))
   (core module $m2
     (func (export "f"))
   )
   (core instance $i1 (instantiate $m2))
-  (core instance $i2 (instantiate $m1 (with "" (instance $i1))))
+  (core instance $i2 (instantiate $m1 (with "a" (instance $i1))))
 )

--- a/tests/dump/import-modules.wat.dump
+++ b/tests/dump/import-modules.wat.dump
@@ -5,47 +5,48 @@
   0xb | 50 02 01 60 | [core type 0] Module([Type(Func(FuncType { params: [], returns: [] })), Import(Import { module: "", name: "f", ty: Func(0) })])
       | 00 00 00 00
       | 01 66 00 00
- 0x17 | 0a 05       | component import section
+ 0x17 | 0a 07       | component import section
  0x19 | 01          | 1 count
- 0x1a | 00 00 11 00 | [module 0] ComponentImport { name: "", ty: Module(0) }
- 0x1e | 01 2b       | [core module 1] inline size
-   0x20 | 00 61 73 6d | version 1 (Module)
+ 0x1a | 01 61 00 00 | [module 0] ComponentImport { name: "a", url: "", ty: Module(0) }
+      | 11 00      
+ 0x20 | 01 2b       | [core module 1] inline size
+   0x22 | 00 61 73 6d | version 1 (Module)
         | 01 00 00 00
-   0x28 | 01 04       | type section
-   0x2a | 01          | 1 count
-   0x2b | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
-   0x2e | 03 02       | func section
-   0x30 | 01          | 1 count
-   0x31 | 00          | [func 0] type 0
-   0x32 | 07 05       | export section
-   0x34 | 01          | 1 count
-   0x35 | 01 66 00 00 | export Export { name: "f", kind: Func, index: 0 }
-   0x39 | 0a 04       | code section
-   0x3b | 01          | 1 count
+   0x2a | 01 04       | type section
+   0x2c | 01          | 1 count
+   0x2d | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
+   0x30 | 03 02       | func section
+   0x32 | 01          | 1 count
+   0x33 | 00          | [func 0] type 0
+   0x34 | 07 05       | export section
+   0x36 | 01          | 1 count
+   0x37 | 01 66 00 00 | export Export { name: "f", kind: Func, index: 0 }
+   0x3b | 0a 04       | code section
+   0x3d | 01          | 1 count
 ============== func 0 ====================
-   0x3c | 02          | size of function
-   0x3d | 00          | 0 local blocks
-   0x3e | 0b          | end
-   0x3f | 00 0a       | custom section
-   0x41 | 04 6e 61 6d | name: "name"
+   0x3e | 02          | size of function
+   0x3f | 00          | 0 local blocks
+   0x40 | 0b          | end
+   0x41 | 00 0a       | custom section
+   0x43 | 04 6e 61 6d | name: "name"
         | 65         
-   0x46 | 00 03       | module name
-   0x48 | 02 6d 32    | "m2"
- 0x4b | 02 0a       | core instance section
- 0x4d | 02          | 2 count
- 0x4e | 00 01 00    | [core instance 0] Instantiate { module_index: 1, args: [] }
- 0x51 | 00 00 01 00 | [core instance 1] Instantiate { module_index: 0, args: [InstantiationArg { name: "", kind: Instance, index: 0 }] }
-      | 12 00      
- 0x57 | 00 29       | custom section
- 0x59 | 0e 63 6f 6d | name: "component-name"
+   0x48 | 00 03       | module name
+   0x4a | 02 6d 32    | "m2"
+ 0x4d | 02 0b       | core instance section
+ 0x4f | 02          | 2 count
+ 0x50 | 00 01 00    | [core instance 0] Instantiate { module_index: 1, args: [] }
+ 0x53 | 00 00 01 01 | [core instance 1] Instantiate { module_index: 0, args: [InstantiationArg { name: "a", kind: Instance, index: 0 }] }
+      | 61 12 00   
+ 0x5a | 00 29       | custom section
+ 0x5c | 0e 63 6f 6d | name: "component-name"
       | 70 6f 6e 65
       | 6e 74 2d 6e
       | 61 6d 65   
- 0x68 | 01 0b 00 11 | core module section
- 0x6c | 02          | 2 count
- 0x6d | 00 02 6d 31 | Naming { index: 0, name: "m1" }
- 0x71 | 01 02 6d 32 | Naming { index: 1, name: "m2" }
- 0x75 | 01 0b 00 12 | core instance section
- 0x79 | 02          | 2 count
- 0x7a | 00 02 69 31 | Naming { index: 0, name: "i1" }
- 0x7e | 01 02 69 32 | Naming { index: 1, name: "i2" }
+ 0x6b | 01 0b 00 11 | core module section
+ 0x6f | 02          | 2 count
+ 0x70 | 00 02 6d 31 | Naming { index: 0, name: "m1" }
+ 0x74 | 01 02 6d 32 | Naming { index: 1, name: "m2" }
+ 0x78 | 01 0b 00 12 | core instance section
+ 0x7c | 02          | 2 count
+ 0x7d | 00 02 69 31 | Naming { index: 0, name: "i1" }
+ 0x81 | 01 02 69 32 | Naming { index: 1, name: "i2" }

--- a/tests/dump/instance-expand.wat
+++ b/tests/dump/instance-expand.wat
@@ -3,5 +3,5 @@
     (export "" (func))
   ))
 
-  (import "" (instance (type $i)))
+  (import "a" (instance (type $i)))
 )

--- a/tests/dump/instance-expand.wat.dump
+++ b/tests/dump/instance-expand.wat.dump
@@ -1,18 +1,19 @@
   0x0 | 00 61 73 6d | version 65546 (Component)
       | 0a 00 01 00
-  0x8 | 07 0c       | component type section
+  0x8 | 07 0d       | component type section
   0xa | 01          | 1 count
-  0xb | 42 02 01 40 | [type 0] Instance([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Export { name: "", ty: Func(0) }])
+  0xb | 42 02 01 40 | [type 0] Instance([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Export { name: "", url: "", ty: Func(0) }])
       | 00 01 00 04
-      | 00 01 00   
- 0x16 | 0a 04       | component import section
- 0x18 | 01          | 1 count
- 0x19 | 00 05 00    | [instance 0] ComponentImport { name: "", ty: Instance(0) }
- 0x1c | 00 16       | custom section
- 0x1e | 0e 63 6f 6d | name: "component-name"
+      | 00 00 01 00
+ 0x17 | 0a 06       | component import section
+ 0x19 | 01          | 1 count
+ 0x1a | 01 61 00 05 | [instance 0] ComponentImport { name: "a", url: "", ty: Instance(0) }
+      | 00         
+ 0x1f | 00 16       | custom section
+ 0x21 | 0e 63 6f 6d | name: "component-name"
       | 70 6f 6e 65
       | 6e 74 2d 6e
       | 61 6d 65   
- 0x2d | 01 05 03    | type section
- 0x30 | 01          | 1 count
- 0x31 | 00 01 69    | Naming { index: 0, name: "i" }
+ 0x30 | 01 05 03    | type section
+ 0x33 | 01          | 1 count
+ 0x34 | 00 01 69    | Naming { index: 0, name: "i" }

--- a/tests/dump/instance-type.wat.dump
+++ b/tests/dump/instance-type.wat.dump
@@ -1,10 +1,10 @@
   0x0 | 00 61 73 6d | version 65546 (Component)
       | 0a 00 01 00
-  0x8 | 07 15       | component type section
+  0x8 | 07 17       | component type section
   0xa | 02          | 2 count
-  0xb | 42 02 01 40 | [type 0] Instance([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Export { name: "", ty: Func(0) }])
+  0xb | 42 02 01 40 | [type 0] Instance([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Export { name: "", url: "", ty: Func(0) }])
       | 00 01 00 04
-      | 00 01 00   
- 0x16 | 42 02 01 42 | [type 1] Instance([Type(Instance([])), Export { name: "", ty: Instance(0) }])
-      | 00 04 00 05
-      | 00         
+      | 00 00 01 00
+ 0x17 | 42 02 01 42 | [type 1] Instance([Type(Instance([])), Export { name: "", url: "", ty: Instance(0) }])
+      | 00 04 00 00
+      | 05 00      

--- a/tests/dump/instance-type2.wat.dump
+++ b/tests/dump/instance-type2.wat.dump
@@ -1,19 +1,19 @@
   0x0 | 00 61 73 6d | version 65546 (Component)
       | 0a 00 01 00
-  0x8 | 07 16       | component type section
+  0x8 | 07 18       | component type section
   0xa | 04          | 4 count
   0xb | 42 00       | [type 0] Instance([])
-  0xd | 42 01 04 00 | [type 1] Instance([Export { name: "", ty: Instance(0) }])
-      | 05 00      
- 0x13 | 42 00       | [type 2] Instance([])
- 0x15 | 42 02 02 03 | [type 3] Instance([Alias(Outer { kind: Type, count: 1, index: 2 }), Export { name: "", ty: Instance(0) }])
-      | 02 01 02 04
+  0xd | 42 01 04 00 | [type 1] Instance([Export { name: "", url: "", ty: Instance(0) }])
       | 00 05 00   
- 0x20 | 00 16       | custom section
- 0x22 | 0e 63 6f 6d | name: "component-name"
+ 0x14 | 42 00       | [type 2] Instance([])
+ 0x16 | 42 02 02 03 | [type 3] Instance([Alias(Outer { kind: Type, count: 1, index: 2 }), Export { name: "", url: "", ty: Instance(0) }])
+      | 02 01 02 04
+      | 00 00 05 00
+ 0x22 | 00 16       | custom section
+ 0x24 | 0e 63 6f 6d | name: "component-name"
       | 70 6f 6e 65
       | 6e 74 2d 6e
       | 61 6d 65   
- 0x31 | 01 05 03    | type section
- 0x34 | 01          | 1 count
- 0x35 | 02 01 78    | Naming { index: 2, name: "x" }
+ 0x33 | 01 05 03    | type section
+ 0x36 | 01          | 1 count
+ 0x37 | 02 01 78    | Naming { index: 2, name: "x" }

--- a/tests/dump/instantiate.wat.dump
+++ b/tests/dump/instantiate.wat.dump
@@ -3,30 +3,32 @@
   0x8 | 07 03       | component type section
   0xa | 01          | 1 count
   0xb | 41 00       | [type 0] Component([])
-  0xd | 0a 05       | component import section
+  0xd | 0a 06       | component import section
   0xf | 01          | 1 count
- 0x10 | 01 61 04 00 | [component 0] ComponentImport { name: "a", ty: Component(0) }
- 0x14 | 07 05       | component type section
- 0x16 | 01          | 1 count
- 0x17 | 40 00 01 00 | [type 1] Func(ComponentFuncType { params: [], results: Named([]) })
- 0x1b | 0a 05       | component import section
- 0x1d | 01          | 1 count
- 0x1e | 01 66 01 01 | [func 0] ComponentImport { name: "f", ty: Func(1) }
- 0x22 | 05 08       | component instance section
- 0x24 | 01          | 1 count
- 0x25 | 00 00 01 01 | [instance 0] Instantiate { component_index: 0, args: [ComponentInstantiationArg { name: "a", kind: Func, index: 0 }] }
+ 0x10 | 01 61 00 04 | [component 0] ComponentImport { name: "a", url: "", ty: Component(0) }
+      | 00         
+ 0x15 | 07 05       | component type section
+ 0x17 | 01          | 1 count
+ 0x18 | 40 00 01 00 | [type 1] Func(ComponentFuncType { params: [], results: Named([]) })
+ 0x1c | 0a 06       | component import section
+ 0x1e | 01          | 1 count
+ 0x1f | 01 66 00 01 | [func 0] ComponentImport { name: "f", url: "", ty: Func(1) }
+      | 01         
+ 0x24 | 05 08       | component instance section
+ 0x26 | 01          | 1 count
+ 0x27 | 00 00 01 01 | [instance 0] Instantiate { component_index: 0, args: [ComponentInstantiationArg { name: "a", kind: Func, index: 0 }] }
       | 61 01 00   
- 0x2c | 00 24       | custom section
- 0x2e | 0e 63 6f 6d | name: "component-name"
+ 0x2e | 00 24       | custom section
+ 0x30 | 0e 63 6f 6d | name: "component-name"
       | 70 6f 6e 65
       | 6e 74 2d 6e
       | 61 6d 65   
- 0x3d | 01 05 01    | func section
- 0x40 | 01          | 1 count
- 0x41 | 00 01 66    | Naming { index: 0, name: "f" }
- 0x44 | 01 05 04    | component section
- 0x47 | 01          | 1 count
- 0x48 | 00 01 63    | Naming { index: 0, name: "c" }
- 0x4b | 01 05 05    | instance section
- 0x4e | 01          | 1 count
- 0x4f | 00 01 61    | Naming { index: 0, name: "a" }
+ 0x3f | 01 05 01    | func section
+ 0x42 | 01          | 1 count
+ 0x43 | 00 01 66    | Naming { index: 0, name: "f" }
+ 0x46 | 01 05 04    | component section
+ 0x49 | 01          | 1 count
+ 0x4a | 00 01 63    | Naming { index: 0, name: "c" }
+ 0x4d | 01 05 05    | instance section
+ 0x50 | 01          | 1 count
+ 0x51 | 00 01 61    | Naming { index: 0, name: "a" }

--- a/tests/dump/instantiate2.wat
+++ b/tests/dump/instantiate2.wat
@@ -1,4 +1,4 @@
 (component
- (import "" (component $c (import "" (func))))
+ (import "a" (component $c (import "a" (func))))
  (instance (instantiate $c))
 )

--- a/tests/dump/instantiate2.wat.dump
+++ b/tests/dump/instantiate2.wat.dump
@@ -1,21 +1,23 @@
   0x0 | 00 61 73 6d | version 65546 (Component)
       | 0a 00 01 00
-  0x8 | 07 0c       | component type section
+  0x8 | 07 0e       | component type section
   0xa | 01          | 1 count
-  0xb | 41 02 01 40 | [type 0] Component([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Import(ComponentImport { name: "", ty: Func(0) })])
+  0xb | 41 02 01 40 | [type 0] Component([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Import(ComponentImport { name: "a", url: "", ty: Func(0) })])
       | 00 01 00 03
-      | 00 01 00   
- 0x16 | 0a 04       | component import section
- 0x18 | 01          | 1 count
- 0x19 | 00 04 00    | [component 0] ComponentImport { name: "", ty: Component(0) }
- 0x1c | 05 04       | component instance section
- 0x1e | 01          | 1 count
- 0x1f | 00 00 00    | [instance 0] Instantiate { component_index: 0, args: [] }
- 0x22 | 00 16       | custom section
- 0x24 | 0e 63 6f 6d | name: "component-name"
+      | 01 61 00 01
+      | 00         
+ 0x18 | 0a 06       | component import section
+ 0x1a | 01          | 1 count
+ 0x1b | 01 61 00 04 | [component 0] ComponentImport { name: "a", url: "", ty: Component(0) }
+      | 00         
+ 0x20 | 05 04       | component instance section
+ 0x22 | 01          | 1 count
+ 0x23 | 00 00 00    | [instance 0] Instantiate { component_index: 0, args: [] }
+ 0x26 | 00 16       | custom section
+ 0x28 | 0e 63 6f 6d | name: "component-name"
       | 70 6f 6e 65
       | 6e 74 2d 6e
       | 61 6d 65   
- 0x33 | 01 05 04    | component section
- 0x36 | 01          | 1 count
- 0x37 | 00 01 63    | Naming { index: 0, name: "c" }
+ 0x37 | 01 05 04    | component section
+ 0x3a | 01          | 1 count
+ 0x3b | 00 01 63    | Naming { index: 0, name: "c" }

--- a/tests/dump/module-types.wat
+++ b/tests/dump/module-types.wat
@@ -1,5 +1,5 @@
 (component
-  (import "" (core module $m
+  (import "a" (core module $m
     (import "" "f" (func))
     (import "" "g" (global i32))
     (import "" "t" (table 1 funcref))

--- a/tests/dump/module-types.wat.dump
+++ b/tests/dump/module-types.wat.dump
@@ -11,21 +11,22 @@
       | 70 00 01 00
       | 00 01 6d 02
       | 00 01      
- 0x2d | 0a 05       | component import section
+ 0x2d | 0a 07       | component import section
  0x2f | 01          | 1 count
- 0x30 | 00 00 11 00 | [module 0] ComponentImport { name: "", ty: Module(0) }
- 0x34 | 07 03       | component type section
- 0x36 | 01          | 1 count
- 0x37 | 42 00       | [type 0] Instance([])
- 0x39 | 00 22       | custom section
- 0x3b | 0e 63 6f 6d | name: "component-name"
+ 0x30 | 01 61 00 00 | [module 0] ComponentImport { name: "a", url: "", ty: Module(0) }
+      | 11 00      
+ 0x36 | 07 03       | component type section
+ 0x38 | 01          | 1 count
+ 0x39 | 42 00       | [type 0] Instance([])
+ 0x3b | 00 22       | custom section
+ 0x3d | 0e 63 6f 6d | name: "component-name"
       | 70 6f 6e 65
       | 6e 74 2d 6e
       | 61 6d 65   
- 0x4a | 01 06 00 11 | core module section
- 0x4e | 01          | 1 count
- 0x4f | 00 01 6d    | Naming { index: 0, name: "m" }
- 0x52 | 01 09 03    | type section
- 0x55 | 01          | 1 count
- 0x56 | 00 05 65 6d | Naming { index: 0, name: "empty" }
+ 0x4c | 01 06 00 11 | core module section
+ 0x50 | 01          | 1 count
+ 0x51 | 00 01 6d    | Naming { index: 0, name: "m" }
+ 0x54 | 01 09 03    | type section
+ 0x57 | 01          | 1 count
+ 0x58 | 00 05 65 6d | Naming { index: 0, name: "empty" }
       | 70 74 79   

--- a/tests/dump/nested-component.wat
+++ b/tests/dump/nested-component.wat
@@ -1,11 +1,11 @@
 
 (component
-  (component (import ""))
+  (component (import "a"))
 
   (component)
   (component)
 
-  (component (export "x"))
+  (component (export "a"))
 
   (component
     (component)
@@ -13,11 +13,11 @@
 
   (component
     (core module $m)
-    (import "" (func (param "p" string)))
+    (import "a" (func (param "p" string)))
     (export "a" (core module $m))
 
-    (instance (export "b") (import "")
-      (export "b" (func))
+    (instance (export "b") (import "b")
+      (export "a" (func))
     )
   )
 )

--- a/tests/dump/nested-component.wat.dump
+++ b/tests/dump/nested-component.wat.dump
@@ -3,65 +3,71 @@
   0x8 | 07 03       | component type section
   0xa | 01          | 1 count
   0xb | 41 00       | [type 0] Component([])
-  0xd | 0a 04       | component import section
+  0xd | 0a 06       | component import section
   0xf | 01          | 1 count
- 0x10 | 00 04 00    | [component 0] ComponentImport { name: "", ty: Component(0) }
- 0x13 | 04 08       | [component 1] inline size
-   0x15 | 00 61 73 6d | version 65546 (Component)
+ 0x10 | 01 61 00 04 | [component 0] ComponentImport { name: "a", url: "", ty: Component(0) }
+      | 00         
+ 0x15 | 04 08       | [component 1] inline size
+   0x17 | 00 61 73 6d | version 65546 (Component)
         | 0a 00 01 00
- 0x1d | 04 08       | [component 2] inline size
-   0x1f | 00 61 73 6d | version 65546 (Component)
+ 0x1f | 04 08       | [component 2] inline size
+   0x21 | 00 61 73 6d | version 65546 (Component)
         | 0a 00 01 00
- 0x27 | 04 08       | [component 3] inline size
-   0x29 | 00 61 73 6d | version 65546 (Component)
+ 0x29 | 04 08       | [component 3] inline size
+   0x2b | 00 61 73 6d | version 65546 (Component)
         | 0a 00 01 00
- 0x31 | 04 12       | [component 4] inline size
-   0x33 | 00 61 73 6d | version 65546 (Component)
+ 0x33 | 04 12       | [component 4] inline size
+   0x35 | 00 61 73 6d | version 65546 (Component)
         | 0a 00 01 00
-   0x3b | 04 08       | [component 0] inline size
-     0x3d | 00 61 73 6d | version 65546 (Component)
+   0x3d | 04 08       | [component 0] inline size
+     0x3f | 00 61 73 6d | version 65546 (Component)
           | 0a 00 01 00
- 0x45 | 04 6a       | [component 5] inline size
-   0x47 | 00 61 73 6d | version 65546 (Component)
+ 0x47 | 04 71       | [component 5] inline size
+   0x49 | 00 61 73 6d | version 65546 (Component)
         | 0a 00 01 00
-   0x4f | 01 13       | [core module 0] inline size
-     0x51 | 00 61 73 6d | version 1 (Module)
+   0x51 | 01 13       | [core module 0] inline size
+     0x53 | 00 61 73 6d | version 1 (Module)
           | 01 00 00 00
-     0x59 | 00 09       | custom section
-     0x5b | 04 6e 61 6d | name: "name"
+     0x5b | 00 09       | custom section
+     0x5d | 04 6e 61 6d | name: "name"
           | 65         
-     0x60 | 00 02       | module name
-     0x62 | 01 6d       | "m"
-   0x64 | 07 08       | component type section
-   0x66 | 01          | 1 count
-   0x67 | 40 01 01 70 | [type 0] Func(ComponentFuncType { params: [("p", Primitive(String))], results: Named([]) })
+     0x62 | 00 02       | module name
+     0x64 | 01 6d       | "m"
+   0x66 | 07 08       | component type section
+   0x68 | 01          | 1 count
+   0x69 | 40 01 01 70 | [type 0] Func(ComponentFuncType { params: [("p", Primitive(String))], results: Named([]) })
         | 73 01 00   
-   0x6e | 0a 04       | component import section
-   0x70 | 01          | 1 count
-   0x71 | 00 01 00    | [func 0] ComponentImport { name: "", ty: Func(0) }
-   0x74 | 0b 06       | component export section
-   0x76 | 01          | 1 count
-   0x77 | 01 61 00 11 | export ComponentExport { name: "a", kind: Module, index: 0 }
+   0x70 | 0a 06       | component import section
+   0x72 | 01          | 1 count
+   0x73 | 01 61 00 01 | [func 0] ComponentImport { name: "a", url: "", ty: Func(0) }
         | 00         
-   0x7c | 07 0d       | component type section
-   0x7e | 01          | 1 count
-   0x7f | 42 02 01 40 | [type 1] Instance([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Export { name: "b", ty: Func(0) }])
+   0x78 | 0b 07       | component export section
+   0x7a | 01          | 1 count
+   0x7b | 01 61 00 00 | export ComponentExport { name: "a", url: "", kind: Module, index: 0 }
+        | 11 00      
+   0x81 | 07 0e       | component type section
+   0x83 | 01          | 1 count
+   0x84 | 42 02 01 40 | [type 1] Instance([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Export { name: "a", url: "", ty: Func(0) }])
         | 00 01 00 04
-        | 01 62 01 00
-   0x8b | 0a 04       | component import section
-   0x8d | 01          | 1 count
-   0x8e | 00 05 01    | [instance 0] ComponentImport { name: "", ty: Instance(1) }
-   0x91 | 0b 05       | component export section
+        | 01 61 00 01
+        | 00         
+   0x91 | 0a 06       | component import section
    0x93 | 01          | 1 count
-   0x94 | 01 62 05 00 | export ComponentExport { name: "b", kind: Instance, index: 0 }
-   0x98 | 00 17       | custom section
-   0x9a | 0e 63 6f 6d | name: "component-name"
+   0x94 | 01 62 00 05 | [instance 0] ComponentImport { name: "b", url: "", ty: Instance(1) }
+        | 01         
+   0x99 | 0b 06       | component export section
+   0x9b | 01          | 1 count
+   0x9c | 01 62 00 05 | export ComponentExport { name: "b", url: "", kind: Instance, index: 0 }
+        | 00         
+   0xa1 | 00 17       | custom section
+   0xa3 | 0e 63 6f 6d | name: "component-name"
         | 70 6f 6e 65
         | 6e 74 2d 6e
         | 61 6d 65   
-   0xa9 | 01 06 00 11 | core module section
-   0xad | 01          | 1 count
-   0xae | 00 01 6d    | Naming { index: 0, name: "m" }
- 0xb1 | 0b 05       | component export section
- 0xb3 | 01          | 1 count
- 0xb4 | 01 78 04 03 | export ComponentExport { name: "x", kind: Component, index: 3 }
+   0xb2 | 01 06 00 11 | core module section
+   0xb6 | 01          | 1 count
+   0xb7 | 00 01 6d    | Naming { index: 0, name: "m" }
+ 0xba | 0b 06       | component export section
+ 0xbc | 01          | 1 count
+ 0xbd | 01 61 00 04 | export ComponentExport { name: "a", url: "", kind: Component, index: 3 }
+      | 03         

--- a/tests/local/component-model/adapt.wast
+++ b/tests/local/component-model/adapt.wast
@@ -73,35 +73,35 @@
 
 (assert_invalid
   (component
-    (import "" (func $f))
+    (import "i" (func $f))
     (core func (canon lower (func $f) string-encoding=utf8 string-encoding=utf16))
   )
   "canonical encoding option `utf8` conflicts with option `utf16`")
 
 (assert_invalid
   (component
-    (import "" (func $f))
+    (import "i" (func $f))
     (core func (canon lower (func $f) string-encoding=utf8 string-encoding=latin1+utf16))
   )
   "canonical encoding option `utf8` conflicts with option `latin1-utf16`")
 
 (assert_invalid
   (component
-    (import "" (func $f))
+    (import "i" (func $f))
     (core func (canon lower (func $f) string-encoding=utf16 string-encoding=latin1+utf16))
   )
   "canonical encoding option `utf16` conflicts with option `latin1-utf16`")
 
 (assert_invalid
   (component
-    (import "" (func $f))
+    (import "i" (func $f))
     (core func (canon lower (func $f) (memory 0)))
   )
   "memory index out of bounds")
 
 (assert_invalid
   (component
-    (import "" (func $f))
+    (import "i" (func $f))
     (core module $m (memory (export "memory") 1))
     (core instance $i (instantiate $m))
     (core func (canon lower (func $f) (memory $i "memory") (memory $i "memory")))
@@ -209,7 +209,7 @@
 
 (assert_invalid
   (component
-    (import "" (func $f (param "p1" string)))
+    (import "i" (func $f (param "p1" string)))
     (core module $m
       (memory (export "m") 1)
       (func (export "f") (result i32))
@@ -281,7 +281,7 @@
 
 (assert_invalid
   (component
-    (import "" (func $f))
+    (import "a" (func $f))
     (func (export "foo") (canon lift (core func $f)))
   )
   "unknown core func: failed to find name `$f`")

--- a/tests/local/component-model/alias.wast
+++ b/tests/local/component-model/alias.wast
@@ -28,7 +28,7 @@
 )
 
 (component
-  (import "" (core module $libc
+  (import "a" (core module $libc
     (export "memory" (memory 1))
     (export "table" (table 0 funcref))
     (export "func" (func))
@@ -60,18 +60,18 @@
 )
 
 (component
-  (import "" (instance $i
-    (export "1" (func))
-    (export "2" (core module))
-    (export "3" (instance))
+  (import "a" (instance $i
+    (export "a" (func))
+    (export "b" (core module))
+    (export "c" (instance))
   ))
-  (export "1" (func $i "1"))
-  (export "2" (core module $i "2"))
-  (export "3" (instance $i "3"))
+  (export "a" (func $i "a"))
+  (export "b" (core module $i "b"))
+  (export "c" (instance $i "c"))
 )
 
 (component
-  (import "" (core module $libc
+  (import "a" (core module $libc
     (export "memory" (memory 1))
     (export "table" (table 0 funcref))
     (export "func" (func))
@@ -79,7 +79,7 @@
     (export "global mut" (global (mut i64)))
   ))
 
-  (import "x" (core module $needs_libc
+  (import "b" (core module $needs_libc
     (import "" "memory" (memory 1))
     (import "" "table" (table 0 funcref))
     (import "" "func" (func))
@@ -99,44 +99,44 @@
 
 (assert_invalid
   (component
-    (import "" (instance (export "" (func))))
-    (export "" (core module 0 ""))
+    (import "a" (instance (export "a" (func))))
+    (export "a" (core module 0 "a"))
   )
-  "export `` for instance 0 is not a module")
+  "export `a` for instance 0 is not a module")
 
 (assert_invalid
   (component
     (component
-      (component (export ""))
+      (component (export "a"))
     )
     (instance (instantiate 0))
-    (export "" (core module 0 ""))
+    (export "a" (core module 0 "a"))
   )
-  "export `` for instance 0 is not a module")
+  "export `a` for instance 0 is not a module")
 
 (assert_invalid
   (component
-    (import "" (core module))
+    (import "a" (core module))
     (core instance (instantiate 0))
-    (alias core export 0 "" (core func))
+    (alias core export 0 "a" (core func))
   )
-  "core instance 0 has no export named ``")
+  "core instance 0 has no export named `a`")
 
 (assert_invalid
   (component
     (core module)
     (core instance (instantiate 0))
-    (alias core export 0 "" (core func))
+    (alias core export 0 "a" (core func))
   )
-  "core instance 0 has no export named ``")
+  "core instance 0 has no export named `a`")
 
 (assert_invalid
   (component
-    (import "" (component))
+    (import "a" (component))
     (instance (instantiate 0))
-    (alias export 0 "" (func))
+    (alias export 0 "a" (func))
   )
-  "instance 0 has no export named ``")
+  "instance 0 has no export named `a`")
 
 (assert_invalid
   (component
@@ -153,12 +153,12 @@
 (component $PARENT
   (type $t (func (result string)))
   (component
-    (import "" (func (type $t)))
+    (import "a" (func (type $t)))
   )
   (component
     (alias outer $PARENT $t (type $my_type))
     (alias outer 0 $my_type (type $my_type_again))
-    (import "" (func (type $my_type_again)))
+    (import "a" (func (type $my_type_again)))
   )
 )
 
@@ -174,7 +174,7 @@
         (import "b" (func $b (type $b)))
         (import "c" (func $c (type $c)))
 
-        (import "" (component $C
+        (import "d" (component $C
           (import "a" (func (result string)))
           (import "b" (func (result u32)))
           (import "c" (func (result s32)))
@@ -192,36 +192,36 @@
 
 ;; multiple projections in alias sugar
 (component $a
-  (import "" (instance $a
-    (export "b" (instance
-      (export "c" (instance
-        (export "d" (instance
-          (export "f" (func))
+  (import "a" (instance $a
+    (export "a" (instance
+      (export "a" (instance
+        (export "a" (instance
+          (export "a" (func))
         ))
       ))
     ))
   ))
 
-  (import "b" (component $b (import "" (func))))
+  (import "b" (component $b (import "a" (func))))
 
   (instance (instantiate $b
-    (with "" (func $a "b" "c" "d" "f"))
+    (with "a" (func $a "a" "a" "a" "a"))
   ))
 )
 
 ;; alias some constructs
 (component
-  (import "" (instance $foo (export "v" (value s32))))
+  (import "a" (instance $foo (export "v" (value s32))))
   (export "v" (value $foo "v"))
 )
 
 (component
-  (import "" (instance $foo (export "v" (component))))
+  (import "a" (instance $foo (export "v" (component))))
   (export "v" (component $foo "v"))
 )
 
 (component
-  (import "" (instance $foo (export "v" (core module))))
+  (import "a" (instance $foo (export "v" (core module))))
   (export "v" (core module $foo "v"))
 )
 
@@ -273,7 +273,7 @@
   "index out of bounds")
 
 (component
-  (import "" (instance $i
+  (import "a" (instance $i
      (export "x" (core module))
   ))
   ;; inline alias injection sugar works for module references
@@ -281,7 +281,7 @@
 )
 
 (component
-  (import "" (instance $i
+  (import "a" (instance $i
      (export "x" (component))
   ))
   ;; inline alias injection sugar works for component references

--- a/tests/local/component-model/big.wast
+++ b/tests/local/component-model/big.wast
@@ -1,5 +1,5 @@
 (component
-  (import "wasi:logging" (instance $logging
+  (import "wasi-logging" (instance $logging
     (export "log" (func (param "msg" string)))
   ))
   (import "libc" (core module $Libc
@@ -14,7 +14,7 @@
   (core module $Main
     (import "libc" "memory" (memory 1))
     (import "libc" "realloc" (func (param i32 i32 i32 i32) (result i32)))
-    (import "wasi:logging" "log" (func $log (param i32 i32)))
+    (import "wasi-logging" "log" (func $log (param i32 i32)))
     (func (export "run") (param i32 i32) (result i32)
       (local.get 0)
       (local.get 1)
@@ -24,7 +24,7 @@
   )
   (core instance $main (instantiate $Main
     (with "libc" (instance $libc))
-    (with "wasi:logging" (instance (export "log" (func $log))))
+    (with "wasi-logging" (instance (export "log" (func $log))))
   ))
   (func $run (param "in" string) (result string) (canon lift
     (core func $main "run")

--- a/tests/local/component-model/definedtypes.wast
+++ b/tests/local/component-model/definedtypes.wast
@@ -137,17 +137,17 @@
   "index out of bounds")
 
 (assert_invalid
-  (component (type (record (field "x" string) (field "x" u8))))
-  "duplicate field named `x` in record type")
+  (component (type (record (field "a-B-c-D" string) (field "A-b-C-d" u8))))
+  "record field name `A-b-C-d` conflicts with previous field name `a-B-c-D`")
 (assert_invalid
   (component (type (variant (case "x" s64) (case "x" s64))))
-  "duplicate case named `x` in variant type")
+  "variant case name `x` conflicts with previous case name `x`")
 (assert_invalid
-  (component (type (flags "x" "y" "x")))
-  "duplicate flag named `x`")
+  (component (type (flags "x" "y" "X")))
+  "flag name `X` conflicts with previous flag name `x`")
 (assert_invalid
-  (component (type (enum "x" "y" "x")))
-  "duplicate enum tag named `x`")
+  (component (type (enum "x" "y" "X")))
+  "enum tag name `X` conflicts with previous tag name `x`")
 
 (assert_invalid
   (component (type (record (field "" s32))))

--- a/tests/local/component-model/export.wast
+++ b/tests/local/component-model/export.wast
@@ -19,23 +19,49 @@
   "index out of bounds")
 
 (component
-  (import "1" (instance $i))
-  (import "2" (core module $m))
-  (import "3" (component $c))
-  (import "4" (value $v string))
-  (import "5" (func $f))
+  (import "a" (instance $i))
+  (import "b" (core module $m))
+  (import "c" (component $c))
+  (import "d" (value $v string))
+  (import "e" (func $f))
 
-  (export "1" (instance $i))
-  (export "2" (core module $m))
-  (export "3" (component $c))
-  (export "4" (value $v))
-  (export "5" (func $f))
+  (export "a" (instance $i))
+  (export "b" (core module $m))
+  (export "c" (component $c))
+  (export "d" (value $v))
+  (export "e" (func $f))
 )
 
 (assert_invalid
   (component
-    (import "" (value $v string))
-    (export "1" (value $v))
-    (export "2" (value $v))
+    (import "a" (value $v string))
+    (export "a" (value $v))
+    (export "b" (value $v))
   )
   "cannot be used more than once")
+
+
+(component
+  (import "a" (func))
+  (export "a" "https://example.com" (func 0))
+)
+
+;; Empty URLs are treated as no URL
+(component
+  (import "a" (func))
+  (export "a" "" (func 0))
+)
+
+(assert_invalid
+  (component
+    (import "a" (func))
+    (export "a" "foo" (func 0))
+  )
+  "relative URL without a base")
+
+(assert_invalid
+  (component
+    (import "a" "https://example.com" (func))
+    (import "b" "https://example.com" (func))
+  )
+  "duplicate import URL `https://example.com/`")

--- a/tests/local/component-model/func.wast
+++ b/tests/local/component-model/func.wast
@@ -1,15 +1,15 @@
 (component
-  (import "" (func (param "foo" string)))
-  (import "a" (func (param "foo" string) (param "bar" s32) (param "baz" u32)))
-  (import "b" (func (result "foo" (tuple))))
-  (import "c" (func (result "foo" string) (result "bar" s32) (result "baz" u32)))
+  (import "a" (func (param "foo" string)))
+  (import "b" (func (param "foo" string) (param "bar" s32) (param "baz" u32)))
+  (import "c" (func (result "foo" (tuple))))
+  (import "d" (func (result "foo" string) (result "bar" s32) (result "baz" u32)))
 )
 
 (component
-  (import "" (func))
-  (import "a" (func (param "p1" string)))
-  (import "b" (func (result u32)))
-  (import "c" (func (param "p1" bool) (result string)))
+  (import "a" (func))
+  (import "b" (func (param "p1" string)))
+  (import "c" (func (result u32)))
+  (import "d" (func (param "p1" bool) (result string)))
 )
 
 (assert_invalid
@@ -21,16 +21,16 @@
 
 (assert_invalid
   (component
-    (type (func (param "foo" string) (param "foo" u32)))
+    (type (func (param "foo" string) (param "FOO" u32)))
   )
-  "duplicate parameter name"
+  "function parameter name `FOO` conflicts with previous parameter name `foo`"
 )
 
 (assert_invalid
   (component
-    (type (func (result "foo" string) (result "foo" u32)))
+    (type (func (result "FOO" string) (result "foo" u32)))
   )
-  "duplicate result name"
+  "function result name `foo` conflicts with previous result name `FOO`"
 )
 
 (assert_invalid
@@ -49,7 +49,7 @@
 )
 
 (component
-  (import "" (func $log (param "msg" string)))
+  (import "a" (func $log (param "msg" string)))
   (core module $libc
     (memory (export "memory") 1)
   )
@@ -71,10 +71,10 @@
 
 (component
   (type $big (func
-    (param "1" u32) (param "2" u32) (param "3" u32) (param "4" u32) (param "5" u32)
-    (param "6" u32) (param "7" u32) (param "8" u32) (param "9" u32) (param "10" u32)
-    (param "11" u32) (param "12" u32) (param "13" u32) (param "14" u32) (param "15" u32)
-    (param "16" u32) (param "17" u32) (param "18" u32) (param "19" u32) (param "20" u32)
+    (param "p1" u32) (param "p2" u32) (param "p3" u32) (param "p4" u32) (param "p5" u32)
+    (param "p6" u32) (param "p7" u32) (param "p8" u32) (param "p9" u32) (param "p10" u32)
+    (param "p11" u32) (param "p12" u32) (param "p13" u32) (param "p14" u32) (param "p15" u32)
+    (param "p16" u32) (param "p17" u32) (param "p18" u32) (param "p19" u32) (param "p20" u32)
   ))
 
   (component $c
@@ -94,10 +94,10 @@
     (core instance $m (instantiate $m))
 
     (type $roundtrip (func
-      (param "1" u32) (param "2" u32) (param "3" u32) (param "4" u32) (param "5" u32)
-      (param "6" u32) (param "7" u32) (param "8" u32) (param "9" u32) (param "10" u32)
-      (param "11" u32) (param "12" u32) (param "13" u32) (param "14" u32) (param "15" u32)
-      (param "16" u32) (param "17" u32) (param "18" u32) (param "19" u32) (param "20" u32)
+      (param "p1" u32) (param "p2" u32) (param "p3" u32) (param "p4" u32) (param "p5" u32)
+      (param "p6" u32) (param "p7" u32) (param "p8" u32) (param "p9" u32) (param "p10" u32)
+      (param "p11" u32) (param "p12" u32) (param "p13" u32) (param "p14" u32) (param "p15" u32)
+      (param "p16" u32) (param "p17" u32) (param "p18" u32) (param "p19" u32) (param "p20" u32)
     ))
 
     (func $roundtrip (type $roundtrip)
@@ -110,7 +110,7 @@
 
 (assert_invalid
   (component
-    (import "" (func $log (result string)))
+    (import "a" (func $log (result string)))
     (core module $libc
       (memory (export "memory") 1)
     )

--- a/tests/local/component-model/import.wast
+++ b/tests/local/component-model/import.wast
@@ -2,11 +2,11 @@
   (import "a" (func))
   (import "b" (instance))
   (import "c" (instance
-    (export "" (func))
+    (export "a" (func))
   ))
   (import "d" (component
-    (import "" (core module))
-    (export "" (func))
+    (import "a" (core module))
+    (export "a" (func))
   ))
   (type $t (func))
   (import "e" (type (eq $t)))
@@ -15,21 +15,21 @@
 (assert_invalid
   (component
     (type $f (func))
-    (import "" (instance (type $f)))
+    (import "a" (instance (type $f)))
   )
   "type index 0 is not an instance type")
 
 (assert_invalid
   (component
     (core type $f (func))
-    (import "" (core module (type $f)))
+    (import "a" (core module (type $f)))
   )
   "core type index 0 is not a module type")
 
 (assert_invalid
   (component
     (type $f string)
-    (import "" (func (type $f)))
+    (import "a" (func (type $f)))
   )
   "type index 0 is not a function type")
 
@@ -69,23 +69,23 @@
 
 (assert_malformed
   (component quote
-    "(import \"\" (func))"
-    "(import \"\" (func))"
+    "(import \"a\" (func))"
+    "(import \"a\" (func))"
   )
-  "duplicate import name `` already defined")
+  "import name `a` conflicts with previous import name `a`")
 
 (assert_malformed
   (component quote
     "(type (component"
-      "(import \"\" (func))"
-      "(import \"\" (func))"
+      "(import \"a\" (func))"
+      "(import \"a\" (func))"
     "))"
   )
-  "duplicate import name `` already defined")
+  "import name `a` conflicts with previous import name `a`")
 
 (assert_invalid
   (component
-    (import "" (func (type 100)))
+    (import "a" (func (type 100)))
   )
   "type index out of bounds")
 
@@ -99,11 +99,33 @@
 
 (assert_invalid
   (component
-    (import "" (value string))
+    (import "a" (value string))
   )
   "value index 0 was not used as part of an instantiation, start function, or export")
 
 (component
-  (import "" (value string))
-  (export "" (value 0))
+  (import "a" (value string))
+  (export "a" (value 0))
 )
+
+(component
+  (import "a" "https://example.com" (func))
+)
+
+;; Empty URLs are treated as no URL
+(component
+  (import "a" "" (func))
+)
+
+(assert_invalid
+  (component
+    (import "a" "foo" (func))
+  )
+  "relative URL without a base")
+
+(assert_invalid
+  (component
+    (import "a" "https://example.com" (func))
+    (import "b" "https://example.com" (func))
+  )
+  "duplicate import URL `https://example.com/`")

--- a/tests/local/component-model/instance-type.wast
+++ b/tests/local/component-model/instance-type.wast
@@ -50,38 +50,38 @@
     ;; components
     (type $component_type (component))
     (export "c1" (component))
-    (export "c2" (component (import "" (func))))
-    (export "c3" (component (export "" (func))))
+    (export "c2" (component (import "i1" (func))))
+    (export "c3" (component (export "e1" (func))))
     (export "c4" (component (type $component_type)))
     (export "c5" (component
       (type $nested_func_type (func))
       (alias outer $outer $local_type (type $my_type))
-      (import "1" (func (type $nested_func_type)))
-      (import "2" (component))
-      (export "1" (func (type $my_type)))
-      (export "2" (component))
+      (import "i1" (func (type $nested_func_type)))
+      (import "i2" (component))
+      (export "e1" (func (type $my_type)))
+      (export "e2" (component))
     ))
   ))
 )
 
 ;; expand inline types
 (component
-  (type (instance (export "" (instance))))
+  (type (instance (export "a" (instance))))
 )
 
 ;; reference outer types
 (component
   (type (instance
     (type $t (instance))
-    (export "" (instance (type $t)))
+    (export "a" (instance (type $t)))
   ))
   (type $x (instance))
-  (type (instance (export "" (instance (type $x)))))
+  (type (instance (export "a" (instance (type $x)))))
 )
 
 ;; recursive
 (component
-  (type (instance (export "" (core module
+  (type (instance (export "a" (core module
     (type $functype (func))
 
     (export "a" (func))
@@ -178,15 +178,15 @@
 (assert_invalid
   (component
     (type (instance
-      (export "" (func))
-      (export "" (func)))))
-  "duplicate export name")
+      (export "a" (func))
+      (export "a" (func)))))
+  "export name `a` conflicts with previous export name `a`")
 
 (assert_invalid
   (component
     (type $t (func))
     (type (instance
-      (export "" (instance (type $t)))
+      (export "a" (instance (type $t)))
     )))
   "type index 0 is not an instance type")
 
@@ -194,7 +194,7 @@
   (component
     (core type $t (func))
     (type (instance
-      (export "" (core module (type $t)))
+      (export "a" (core module (type $t)))
     )))
   "core type index 0 is not a module type")
 
@@ -202,7 +202,7 @@
   (component
     (type $t (func))
     (type (instance
-      (export "" (core module (type $t)))
+      (export "a" (core module (type $t)))
     )))
   "unknown core type")
 
@@ -210,7 +210,7 @@
   (component
     (type $t (record (field "a" string)))
     (type (instance
-      (export "" (func (type $t)))
+      (export "a" (func (type $t)))
     )))
   "type index 0 is not a function type")
 
@@ -218,7 +218,7 @@
   (component
     (type $t (instance))
     (type (instance
-      (export "" (func (type $t)))
+      (export "a" (func (type $t)))
     )))
   "type index 0 is not a function type")
 
@@ -226,8 +226,8 @@
   (component
     (type $t (instance))
     (type (instance
-      (export "" (instance
-        (export "" (func (type $t)))
+      (export "a" (instance
+        (export "a" (func (type $t)))
       ))
     )))
   "type index 0 is not a function type")

--- a/tests/local/component-model/instantiate.wast
+++ b/tests/local/component-model/instantiate.wast
@@ -1,35 +1,35 @@
 (component
-  (import "" (core module $m))
+  (import "a" (core module $m))
   (core instance $a (instantiate $m))
 )
 
 (component
   (import "a" (func $i))
-  (import "" (component $c (import "a" (func))))
+  (import "b" (component $c (import "a" (func))))
   (instance (instantiate $c (with "a" (func $i))))
 )
 
 (component
   (import "a" (value $i string))
-  (import "" (component $c (import "a" (value string))))
+  (import "b" (component $c (import "a" (value string))))
   (instance (instantiate $c (with "a" (value $i))))
 )
 
 (component
   (import "a" (component $i))
-  (import "" (component $c (import "a" (component))))
+  (import "b" (component $c (import "a" (component))))
   (instance (instantiate $c (with "a" (component $i))))
 )
 
 (component
   (import "a" (core module $i))
-  (import "" (component $c (import "a" (core module))))
+  (import "b" (component $c (import "a" (core module))))
   (instance (instantiate $c (with "a" (core module $i))))
 )
 
 (component
   (import "a" (instance $i))
-  (import "" (component $c (import "a" (instance))))
+  (import "b" (component $c (import "a" (instance))))
   (instance (instantiate $c (with "a" (instance $i))))
 )
 
@@ -82,7 +82,7 @@
 
 (component
   (import "a" (component $m
-    (import "" (instance
+    (import "a" (instance
       (export "a" (core module))
     ))
   ))
@@ -91,7 +91,7 @@
   ))
   (instance $x (instantiate $m2))
 
-  (instance (instantiate $m (with "" (instance
+  (instance (instantiate $m (with "a" (instance
     (export "a" (core module $x "b"))
   ))))
 )
@@ -125,9 +125,9 @@
   
   ;; inline exports/imports
   (type $empty (instance))
-  (instance $d (import "i1") (type $empty))
-  (instance (import "i2"))
-  (instance (import "i3")
+  (instance $d (import "g") (type $empty))
+  (instance (import "h"))
+  (instance (import "i")
     (export "x" (func)))
   (instance (export "c") (export "d") (import "x"))
 )
@@ -144,7 +144,7 @@
   "unknown component")
 (assert_invalid
   (component
-    (import "" (core module))
+    (import "a" (core module))
     (core instance (instantiate 1))
   )
   "unknown module")
@@ -156,109 +156,109 @@
 )
 (assert_invalid
   (component
-    (import "" (core module $m (import "" "" (func))))
+    (import "a" (core module $m (import "" "" (func))))
     (core instance (instantiate $m))
   )
   "missing module instantiation argument")
 (assert_invalid
   (component
-    (import "" (component $m (import "" (func))))
+    (import "a" (component $m (import "a" (func))))
     (instance (instantiate $m))
   )
   "missing component instantiation argument")
 
 (assert_invalid
   (component
-    (import "" (component $m
-      (import "" (func))
+    (import "a" (component $m
+      (import "a" (func))
     ))
-    (import "i" (component $c))
-    (instance $i (instantiate $m (with "" (component $c))))
+    (import "b" (component $c))
+    (instance $i (instantiate $m (with "a" (component $c))))
   )
   "to be of type `function`")
 
 (component
-  (import "" (component $m
-    (import "" (func))
+  (import "a" (component $m
+    (import "a" (func))
   ))
-  (import "i" (func $f (result string)))
-  (instance $i (instantiate $m (with "" (func $f))))
+  (import "b" (func $f (result string)))
+  (instance $i (instantiate $m (with "a" (func $f))))
 )
 
 (assert_invalid
   (component
-    (import "" (component $m
-      (import "" (func))
+    (import "a" (component $m
+      (import "a" (func))
     ))
-    (import "i" (func (param "i" string)))
-    (instance $i (instantiate $m (with "" (func 0))))
+    (import "b" (func (param "i" string)))
+    (instance $i (instantiate $m (with "a" (func 0))))
   )
   "function type mismatch")
 
 (assert_invalid
   (component
-    (import "" (component $m
-      (import "" (core module
+    (import "a" (component $m
+      (import "a" (core module
         (import "" "" (func))
       ))
     ))
-    (import "i" (core module $i
+    (import "b" (core module $i
       (import "" "" (global i32))
     ))
-    (instance $i (instantiate $m (with "" (core module $i))))
+    (instance $i (instantiate $m (with "a" (core module $i))))
   )
   "module type mismatch")
 
 (assert_invalid
   (component
-    (import "" (component $m
-      (import "" (core module))
+    (import "a" (component $m
+      (import "a" (core module))
     ))
-    (import "i" (core module $i
+    (import "b" (core module $i
       (import "" "foobar" (global i32))
     ))
-    (instance $i (instantiate $m (with "" (core module $i))))
+    (instance $i (instantiate $m (with "a" (core module $i))))
   )
   "module type mismatch")
 
 ;; it's ok to give a module with fewer imports
 (component
-  (import "" (component $m
-    (import "" (core module
+  (import "a" (component $m
+    (import "a" (core module
       (import "" "" (global i32))
       (import "" "f" (func))
     ))
   ))
-  (import "i" (core module $i
+  (import "b" (core module $i
     (import "" "" (global i32))
   ))
-  (instance $i (instantiate $m (with "" (core module $i))))
+  (instance $i (instantiate $m (with "a" (core module $i))))
 )
 
 ;; export subsets
 (component
-  (import "" (component $m
-    (import "" (core module
+  (import "a" (component $m
+    (import "a" (core module
       (export "" (func))
     ))
   ))
-  (import "i" (core module $i
+  (import "b" (core module $i
     (export "" (func))
     (export "a" (func))
   ))
-  (instance $i (instantiate $m (with "" (core module $i))))
+  (instance $i (instantiate $m (with "a" (core module $i))))
 )
 (component
-  (import "" (component $m
-    (import "" (instance
-      (export "" (func))
+  (import "a" (component $m
+    (import "a" (instance
+      (export "a" (func))
     ))
   ))
-  (import "a" (instance $i
-    (export "" (func))
+  (import "b" (instance $i
     (export "a" (func))
+    (export "b" (func))
   ))
-  (instance (instantiate $m (with "" (instance $i))))
+  (instance (instantiate $m (with "a" (instance $i))))
 )
 
 
@@ -441,20 +441,20 @@
     (component $m)
     (instance $i (instantiate $m))
     (instance (instantiate $m
-      (with "" (instance $i))
-      (with "" (instance $i))
+      (with "a" (instance $i))
+      (with "a" (instance $i))
     ))
   )
-  "duplicate component instantiation argument named ``")
+  "instantiation argument `a` conflicts with previous argument `a`")
 
 (assert_invalid
   (component
-    (component $c (import "" (func)))
+    (component $c (import "a" (func)))
     (instance (instantiate $c
-      (with "" (component $c))
+      (with "a" (component $c))
     ))
   )
-  "expected component instantiation argument `` to be of type `function`")
+  "expected component instantiation argument `a` to be of type `function`")
 
 (assert_invalid
   (component
@@ -505,24 +505,24 @@
   (component
     (component $c)
     (instance
-      (export "" (component $c))
-      (export "" (component $c))
+      (export "a" (component $c))
+      (export "a" (component $c))
     )
   )
-  "export name `` already defined")
+  "instance export name `a` conflicts with previous export name `a`")
 
 (component
-  (import "1" (instance $i))
-  (import "2" (func $f))
-  (import "3" (component $c))
-  (import "4" (core module $m))
-  (import "5" (value $v string))
+  (import "a" (instance $i))
+  (import "b" (func $f))
+  (import "c" (component $c))
+  (import "d" (core module $m))
+  (import "e" (value $v string))
   (instance
-    (export "1" (instance $i))
-    (export "2" (func $f))
-    (export "3" (component $c))
-    (export "4" (core module $m))
-    (export "5" (value $v))
+    (export "a" (instance $i))
+    (export "b" (func $f))
+    (export "c" (component $c))
+    (export "d" (core module $m))
+    (export "e" (value $v))
   )
 )
 
@@ -557,19 +557,19 @@
   (component
     (component $c)
     (instance $i (instantiate $c))
-    (export "" (instance $i ""))
+    (export "a" (instance $i "a"))
   )
-  "no export named ``")
+  "no export named `a`")
 
 (assert_invalid
   (component
-    (export "" (instance 100 ""))
+    (export "a" (instance 100 "a"))
   )
   "index out of bounds")
 
 (assert_invalid
   (component
-    (import "" (core module $libc
+    (import "a" (core module $libc
       (export "memory" (memory 1))
       (export "table" (table 0 funcref))
       (export "func" (func))

--- a/tests/local/component-model/module-link.wast
+++ b/tests/local/component-model/module-link.wast
@@ -28,7 +28,7 @@
   (component $B
     (type $Wasi (instance))
     (import "wasi" (instance $wasi (type $Wasi)))
-    (import "A:1.x" (component $A
+    (import "a1-x" (component $A
       (import "wasi" (instance (type $Wasi)))
       (export "a" (func))
     ))
@@ -51,7 +51,7 @@
     (import "wasi" (instance $wasi (type $Wasi)))
     (instance $b (instantiate $B
       (with "wasi" (instance $wasi))
-      (with "A:1.x" (component $A)))
+      (with "a1-x" (component $A)))
     )
     (export "b" (func $b "b"))
   )
@@ -59,7 +59,7 @@
   (component $C 
     (type $Wasi (instance)) 
     (import "wasi" (instance $wasi (type $Wasi))) 
-    (import "B:1.x" (component $B 
+    (import "b1-x" (component $B 
       (import "wasi" (instance $wasi (type $Wasi))) 
       (export "b" (func)) 
     )) 
@@ -71,7 +71,7 @@
     (import "wasi" (instance $wasi (type $Wasi))) 
     (instance $c (instantiate $C
       (with "wasi" (instance $wasi)) 
-      (with "B:1.x" (component $B_wrap)) 
+      (with "b1-x" (component $B_wrap)) 
     )) 
     (export "c" (func $c "c")) 
   ) 
@@ -79,7 +79,7 @@
   (component $D 
     (type $Wasi (instance)) 
     (import "wasi" (instance $wasi (type $Wasi))) 
-    (import "C:1.x" (component $C 
+    (import "c1-x" (component $C 
       (import "wasi" (instance $wasi (type $Wasi))) 
       (export "c" (func)) 
     )) 
@@ -89,7 +89,7 @@
 
   (instance $d (instantiate $D 
     (with "wasi" (instance $wasi)) 
-    (with "C:1.x" (component $C_wrap)) 
+    (with "c1-x" (component $C_wrap)) 
   )) 
 
   (export "d" (func $d "d")) 

--- a/tests/local/component-model/naming.wast
+++ b/tests/local/component-model/naming.wast
@@ -1,0 +1,102 @@
+(assert_invalid
+  (component
+    (func (import "a"))
+    (component)
+    (instance (instantiate 0 (with "NotKebab-Case" (func 0))))
+  )
+  "instantiation argument name `NotKebab-Case` is not in kebab case"
+)
+
+(assert_invalid
+  (component
+    (import "f" (func))
+    (instance (export "1" (func 0)))
+  )
+  "instance export name `1` is not in kebab case"
+)
+
+(assert_invalid
+  (component
+    (instance)
+    (alias export 0 "Xml" (func))
+  )
+  "alias export name `Xml` is not in kebab case"
+)
+
+(assert_invalid
+  (component
+    (type (flags "a-1-c"))
+  )
+  "flag name `a-1-c` is not in kebab case"
+)
+
+(assert_invalid
+  (component
+    (type (enum "NevEr"))
+  )
+  "enum tag name `NevEr` is not in kebab case"
+)
+
+(assert_invalid
+  (component
+    (type (record (field "GoNnA" string)))
+  )
+  "record field name `GoNnA` is not in kebab case"
+)
+
+(assert_invalid
+  (component
+    (type (variant (case "GIVe" string)))
+  )
+  "variant case name `GIVe` is not in kebab case"
+)
+
+
+(assert_invalid
+  (component
+    (type (func (param "yOu" string)))
+  )
+  "function parameter name `yOu` is not in kebab case"
+)
+
+(assert_invalid
+  (component
+    (type (func (result "uP" string)))
+  )
+  "function result name `uP` is not in kebab case"
+)
+
+(assert_invalid
+  (component
+    (type (component (export "NevEr" (func))))
+  )
+  "export name `NevEr` is not in kebab case"
+)
+
+(assert_invalid
+  (component
+    (type (component (import "GonnA" (func))))
+  )
+  "import name `GonnA` is not in kebab case"
+)
+
+(assert_invalid
+  (component
+    (type (instance (export "lET" (func))))
+  )
+  "export name `lET` is not in kebab case"
+)
+
+(assert_invalid
+  (component
+    (instance (export "YoU"))
+  )
+  "export name `YoU` is not in kebab case"
+)
+
+(assert_invalid
+  (component
+    (instance (import "DOWn"))
+  )
+  "import name `DOWn` is not in kebab case"
+)

--- a/tests/local/component-model/nested-modules.wast
+++ b/tests/local/component-model/nested-modules.wast
@@ -1,5 +1,5 @@
 (component
-  (import "" (core module))
+  (import "i1" (core module))
 
   (core module)
   (core module)
@@ -12,14 +12,14 @@
 
   (component
     (core module $m)
-    (import "" (func (param "p" string)))
+    (import "a" (func (param "p" string)))
     (export "a" (core module $m))
   )
 )
 
 ;; does the `import` use the type annotation specified later?
 (component
-  (import "" (core module))
+  (import "a" (core module))
   (core type (module))
 )
 
@@ -37,11 +37,12 @@
 ;; typecheck the module code section correctly
 (component
   (core module
-    (func (export "")))
-  (import "" (core module))
+    (func (export ""))
+  )
+  (import "a" (core module))
   (core module
-    (func (export "") (result i32)
-      i32.const 5))
-  (import "b" (instance (export "" (core module))))
-  (alias export 0 "" (core module))
+    (func (export "") (result i32) i32.const 5)
+  )
+  (import "b" (instance (export "a" (core module))))
+  (alias export 0 "a" (core module))
 )

--- a/tests/local/component-model/start.wast
+++ b/tests/local/component-model/start.wast
@@ -1,72 +1,72 @@
 
 (assert_invalid
   (component
-    (import "" (func $f (param "1" string)))
+    (import "a" (func $f (param "p1" string)))
     (start $f)
   )
   "start function requires 1 arguments")
 
 (assert_invalid
   (component
-    (import "" (func $f (param "p" string)))
-    (import "v" (value $v string))
+    (import "a" (func $f (param "p" string)))
+    (import "b" (value $v string))
     (start $f (value $v) (value $v))
   )
   "start function requires 1 arguments")
 
 (assert_invalid
   (component
-    (import "" (func $f (param "1" string) (param "2" string)))
-    (import "v" (value $v string))
+    (import "a" (func $f (param "p1" string) (param "p2" string)))
+    (import "b" (value $v string))
     (start $f (value $v) (value $v))
   )
   "cannot be used more than once")
 
 (assert_invalid
   (component
-    (import "" (func $f (param "x" string) (param "y" string)))
-    (import "v" (value $v string))
-    (import "v2" (value $v2 u32))
+    (import "a" (func $f (param "x" string) (param "y" string)))
+    (import "b" (value $v string))
+    (import "c" (value $v2 u32))
     (start $f (value $v) (value $v2))
   )
   "type mismatch for component start function argument 1")
 
 (component
-  (import "" (func $f (param "z" string) (param "a" string)))
-  (import "v" (value $v string))
-  (import "v2" (value $v2 string))
+  (import "a" (func $f (param "z" string) (param "a" string)))
+  (import "b" (value $v string))
+  (import "c" (value $v2 string))
   (start $f (value $v) (value $v2))
 )
 
 (component
-  (import "" (func $f (result string)))
+  (import "a" (func $f (result string)))
   (start $f (result (value $a)))
   (export "a" (value $a))
 )
 
 (component
-  (import "" (func $f (param "a" string) (param "b" string) (result "c" s32) (result "d" s32)))
-  (import "v" (value $v string))
-  (import "v2" (value $v2 string))
+  (import "a" (func $f (param "a" string) (param "b" string) (result "c" s32) (result "d" s32)))
+  (import "b" (value $v string))
+  (import "c" (value $v2 string))
   (start $f (value $v) (value $v2) (result (value $c)) (result (value $d)))
-  (export "c" (value $c))
-  (export "d" (value $d))
+  (export "a" (value $c))
+  (export "b" (value $d))
 )
 
 (assert_invalid
   (component
-    (import "" (func $f (param "a" string) (param "b" string) (result "c" s32) (result "d" s32)))
-    (import "v" (value $v string))
-    (import "v2" (value $v2 string))
+    (import "a" (func $f (param "a" string) (param "b" string) (result "c" s32) (result "d" s32)))
+    (import "b" (value $v string))
+    (import "c" (value $v2 string))
     (start $f (value $v) (value $v2) (result (value $c)))
-    (export "c" (value $c))
+    (export "a" (value $c))
   )
   "component start function has a result count of 1 but the function type has a result count of 2"
 )
 
 (assert_invalid
   (component
-    (import "" (func $f))
+    (import "a" (func $f))
     (start $f)
     (start $f)
   )
@@ -82,9 +82,10 @@
     "\00"             ;; parameters, 0 count
     "\01\00"          ;; results, named, 0 count
 
-    "\0a\04"          ;; import section, 4 bytes large
+    "\0a\06"          ;; import section, 5 bytes large
     "\01"             ;; 1 count
-    "\00"             ;; name = ""
+    "\01a"            ;; name = "a"
+    "\00"             ;; url = ""
     "\01\00"          ;; type = func ($type 0)
 
     "\09\06"          ;; start section, 6 bytes large
@@ -104,9 +105,10 @@
     "\00"             ;; parameters, 0 count
     "\01\00"          ;; results, named, 0 count
 
-    "\0a\04"          ;; import section, 4 bytes large
+    "\0a\06"          ;; import section, 5 bytes large
     "\01"             ;; 1 count
-    "\00"             ;; name = ""
+    "\01a"            ;; name = "a"
+    "\00"             ;; url = ""
     "\01\00"          ;; type = func ($type 0)
 
     "\09\04"          ;; start section, 4 bytes large

--- a/tests/local/component-model/types.wast
+++ b/tests/local/component-model/types.wast
@@ -1,21 +1,21 @@
 (assert_invalid
   (component
     (type $t (instance))
-    (import "" (func (type $t)))
+    (import "a" (func (type $t)))
   )
   "type index 0 is not a function type")
 
 (assert_invalid
   (component
     (core type $t (func))
-    (import "" (core module (type $t)))
+    (import "a" (core module (type $t)))
   )
   "core type index 0 is not a module type")
 
 (assert_invalid
   (component
     (type $t (func))
-    (import "" (instance (type $t)))
+    (import "a" (instance (type $t)))
   )
   "type index 0 is not an instance type")
 
@@ -23,7 +23,7 @@
   (component
     (type $t (func))
     (type (component
-      (import "" (instance (type $t)))
+      (import "a" (instance (type $t)))
     ))
   )
   "type index 0 is not an instance type")
@@ -32,7 +32,7 @@
   (component
     (core type $t (func))
     (type (component
-      (import "" (core module (type $t)))
+      (import "a" (core module (type $t)))
     ))
   )
   "core type index 0 is not a module type")
@@ -41,27 +41,27 @@
   (component
     (type $t (instance))
     (type (component
-      (import "" (func (type $t)))
+      (import "a" (func (type $t)))
     ))
   )
   "type index 0 is not a function type")
 
 (assert_invalid
   (component
-    (export "" (core module 0))
+    (export "a" (core module 0))
   )
   "module index out of bounds")
 
 (assert_invalid
   (component
-    (export "" (instance 0))
+    (export "a" (instance 0))
   )
   "instance index out of bounds")
 
 (assert_invalid
   (component
     (core type (module
-      (export "" (func (type 0)))
+      (export "a" (func (type 0)))
     ))
   )
   "type index out of bounds")
@@ -69,11 +69,11 @@
 (assert_invalid
   (component
     (core type (module
-      (export "" (func))
-      (export "" (func))
+      (export "a" (func))
+      (export "a" (func))
     ))
   )
-  "export name `` already defined")
+  "export name `a` already defined")
 
 (assert_invalid
   (component
@@ -95,7 +95,7 @@
 (assert_invalid
   (component
     (type (component
-      (export "" (func (type 0)))
+      (export "a" (func (type 0)))
     ))
   )
   "type index out of bounds")
@@ -103,20 +103,20 @@
 (assert_invalid
   (component
     (type (component
-      (export "" (func))
-      (export "" (func))
+      (export "a" (func))
+      (export "A" (func))
     ))
   )
-  "export name `` already defined")
+  "export name `A` conflicts with previous export name `a`")
 
 (assert_invalid
   (component
     (type (component
-      (import "" (func))
-      (import "" (func))
+      (import "A" (func))
+      (import "a" (func))
     ))
   )
-  "duplicate import name")
+  "import name `a` conflicts with previous import name `A`")
 
 (assert_invalid
   (component $c
@@ -191,11 +191,11 @@
 (assert_invalid
   (component
     (type (instance
-      (export "" (func))
-      (export "" (func))
+      (export "foo-BAR-baz" (func))
+      (export "FOO-bar-BAZ" (func))
     ))
   )
-  "export name `` already defined")
+  "export name `FOO-bar-BAZ` conflicts with previous export name `foo-BAR-baz`")
 
 (assert_invalid
   (component $c
@@ -278,14 +278,14 @@
 (component
   (type (instance
     (type string)
-    (export "" (type (eq 0)))
+    (export "a" (type (eq 0)))
   ))
 )
 
 (component
   (type (component
     (type string)
-    (import "" (type (eq 0)))
-    (export "" (type (eq 0)))
+    (import "a" (type (eq 0)))
+    (export "a" (type (eq 0)))
   ))
 )

--- a/tests/local/component-model/very-nested.wast
+++ b/tests/local/component-model/very-nested.wast
@@ -12,14 +12,14 @@
       )
       (component
         (export "q**")
-        (export "00AGGGGle $$qq")
+        (export "dojgn-ejs9-nd188")
       )
       (component
         (export "q")
       )
       (component
         (export "c 3@E*******************")
-        (import "01AGGGGle*$$qq")
+        (import "sdg-q12")
       )
       (component
         (export "c t.*************")
@@ -29,35 +29,35 @@
         )
         (component
           (export "q**")
-          (export "00AGGGGle $$qq")
+          (export "dojgn-ejs9-nd188")
         )
         (component
           (export "q")
         )
         (component
           (export "c 3@E*******************")
-          (import "00AGGGGle*$$qq")
+          (import "bsdew2-sdbsdb")
         )
         (component
           (export "c=t.*************")
           (export "00AG")
           (component
-            (export "c 3@EGGyGG$qq**")
-            (export "00AGGGGle $$qq")
+            (export "alskgn-mbnaj4-a33i5nf")
+            (export "dojgn-ejs9-nd188")
           )
           (component
             (export "q")
           )
           (component
             (export "c 3@E*******************")
-            (import "00AGGGGl$$qq")
+            (import "jsjsjs")
           )
           (component
             (export "q")
           )
           (component
             (export "c 3@E*******************")
-            (import "00AGGGGi64x2.splatle*$$qq")
+            (import "anonmm-x23foinas-ASDOJASD")
           )
           (component
             (export "c t.****0*********")
@@ -67,39 +67,39 @@
             )
             (component
               (export "q**")
-              (export "00AGGGGle $$qq")
+              (export "dojgn-ejs9-nd188")
             )
             (component
               (export "q")
             )
             (component
               (export "c 3@E*******************")
-              (import "00AGGGGle*$$qq")
+              (import "bsdew2-sdbsdb")
             )
             (component
               (export "c=t.*************")
               (export "00AG")
               (component
-                (export "c 3@EGGyGG$qq**")
-                (export "00AGGGGle $$qq")
+                (export "alskgn-mbnaj4-a33i5nf")
+                (export "dojgn-ejs9-nd188")
               )
               (component
                 (export "q")
               )
               (component
-                (export "c 6Ǻ*******************")
-                (import "00AGGG^Glllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllle*$$qq")
+                (export "afhinds-T39OIDN-f1jsj11")
+                (import "sf-gqo3ngin23ogin13g-bvcad")
               )
               (component
-                (export "c EGGyGG$qq**")
-                (export "15AGGG.Gle '$$qq")
+                (export "EGG-y-GG-qq")
+                (export "agds-ASF-TT-yy")
               )
               (component
                 (export "q")
               )
               (component
                 (export "b 3@E*******************")
-                (import "00AGGGGle*$$qq")
+                (import "bsdew2-sdbsdb")
               )
               (component
                 (export "c 0.*************")
@@ -112,14 +112,14 @@
             )
             (component
               (export "c 3@E*********GG$qq**")
-              (export "00AGGGGle $$qq")
+              (export "dojgn-ejs9-nd188")
             )
             (component
               (export "q")
             )
             (component
               (export "c 3@E************[******")
-              (import "00AGGGGle*$$qq")
+              (import "bsdew2-sdbsdb")
             )
             (component
               (export "c t.*************")
@@ -135,7 +135,7 @@
             (import "00e*$$qq")
           )
           (component
-            (export "c EGGyGG$qq**")
+            (export "EGG-y-GG-qq")
             (export "0+AGGG.Gle $$qq")
           )
           (component
@@ -162,7 +162,7 @@
           (export "c t.*")
           (component
             (export "c 3@EGGGG$qq**")
-            (export "00AGGGGle*$$qq")
+            (export "bsdew2-sdbsdb")
           )
           (component
             (export "c t.********)*eleo &m Nx2GGGGle*$$qq")
@@ -184,7 +184,7 @@
         )
         (component
           (export "c 3@E*******************")
-          (import "01AGGGGle*$$qq")
+          (import "sdg-q12")
         )
         (component
           (export "c t.*************")
@@ -194,40 +194,40 @@
           )
           (component
             (export "q**")
-            (export "00AGGGGle $$qq")
+            (export "dojgn-ejs9-nd188")
           )
           (component
             (export "q")
           )
           (component
             (export "c 3@E*******************")
-            (import "00AGGGGle*$$qq")
+            (import "bsdew2-sdbsdb")
           )
           (component
             (export "c=t.*************")
             (export "00AG")
             (component
-              (export "c 3@EGGyGG$qq**")
-              (export "00AGGGGle $$qq")
+              (export "alskgn-mbnaj4-a33i5nf")
+              (export "dojgn-ejs9-nd188")
             )
             (component
               (export "q")
             )
             (component
               (export "c 3@E*******************")
-              (import "00AGGGGl$$qq")
+              (import "jsjsjs")
             )
             (component
               (export "q")
             )
             (component
               (export "c 3@E*******************")
-              (import "00AGGGGle*$$qq")
+              (import "bsdew2-sdbsdb")
             )
             (component
               (export "c t.*************")
               (export "0*************")
-              (import "00AGGGGle*$$qq")
+              (import "bsdew2-sdbsdb")
             )
             (component
               (export "c t.*************")
@@ -241,14 +241,14 @@
               )
               (component
                 (export "q**")
-                (export "00AGGGGle $$qq")
+                (export "dojgn-ejs9-nd188")
               )
               (component
                 (export "q")
               )
               (component
                 (export "c 3@E*******************")
-                (import "01AGGGGle*$$qq")
+                (import "sdg-q12")
               )
               (component
                 (export "c t.*************")
@@ -258,35 +258,35 @@
                 )
                 (component
                   (export "q**")
-                  (export "00AGGGGle $$qq")
+                  (export "dojgn-ejs9-nd188")
                 )
                 (component
                   (export "q")
                 )
                 (component
                   (export "c 3@E*******************")
-                  (import "00AGGGGle*$$qq")
+                  (import "bsdew2-sdbsdb")
                 )
                 (component
                   (export "c=t.*************")
                   (export "00AG")
                   (component
-                    (export "c 3@EGGyGG$qq**")
-                    (export "00AGGGGle $$qq")
+                    (export "alskgn-mbnaj4-a33i5nf")
+                    (export "dojgn-ejs9-nd188")
                   )
                   (component
                     (export "q")
                   )
                   (component
                     (export "c 3@E*******************")
-                    (import "00AGGGGl$$qq")
+                    (import "jsjsjs")
                   )
                   (component
                     (export "q")
                   )
                   (component
                     (export "c 3@E*******************")
-                    (import "00AGGGGi64x2.splatle*$$qq")
+                    (import "anonmm-x23foinas-ASDOJASD")
                   )
                   (component
                     (export "c t.****0*********")
@@ -296,39 +296,39 @@
                     )
                     (component
                       (export "q**")
-                      (export "00AGGGGle $$qq")
+                      (export "dojgn-ejs9-nd188")
                     )
                     (component
                       (export "q")
                     )
                     (component
                       (export "c 3@E*******************")
-                      (import "00AGGGGle*$$qq")
+                      (import "bsdew2-sdbsdb")
                     )
                     (component
                       (export "c=t.*************")
                       (export "00AG")
                       (component
-                        (export "c 3@EGGyGG$qq**")
-                        (export "00AGGGGle $$qq")
+                        (export "alskgn-mbnaj4-a33i5nf")
+                        (export "dojgn-ejs9-nd188")
                       )
                       (component
                         (export "q")
                       )
                       (component
-                        (export "c 6Ǻ*******************")
-                        (import "00AGGG^Glllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllle*$$qq")
+                        (export "afhinds-T39OIDN-f1jsj11")
+                        (import "sf-gqo3ngin23ogin13g-bvcad")
                       )
                       (component
-                        (export "c EGGyGG$qq**")
-                        (export "15AGGG.Gle '$$qq")
+                        (export "EGG-y-GG-qq")
+                        (export "agds-ASF-TT-yy")
                       )
                       (component
                         (export "q")
                       )
                       (component
                         (export "b 3@E*******************")
-                        (import "00AGGGGle*$$qq")
+                        (import "bsdew2-sdbsdb")
                       )
                       (component
                         (export "c 0.*************")
@@ -341,14 +341,14 @@
                     )
                     (component
                       (export "c 3@E*********GG$qq**")
-                      (export "00AGGGGle $$qq")
+                      (export "dojgn-ejs9-nd188")
                     )
                     (component
                       (export "q")
                     )
                     (component
                       (export "c 3@E************[******")
-                      (import "00AGGGGle*$$qq")
+                      (import "bsdew2-sdbsdb")
                     )
                     (component
                       (export "c t.*************")
@@ -364,7 +364,7 @@
                     (import "00e*$$qq")
                   )
                   (component
-                    (export "c EGGyGG$qq**")
+                    (export "EGG-y-GG-qq")
                     (export "0+AGGG.Gle $$qq")
                   )
                   (component
@@ -391,7 +391,7 @@
                   (export "c .t*")
                   (component
                     (export "c 3@EGGGG$qq**")
-                    (export "00AGGGGle*$$qq")
+                    (export "bsdew2-sdbsdb")
                   )
                   (component
                     (export "c t.********)*eleo &m Nx2GGGGle*$$qq")
@@ -413,7 +413,7 @@
                 )
                 (component
                   (export "c 3@E*******************")
-                  (import "01AGGGGle*$$qq")
+                  (import "sdg-q12")
                 )
                 (component
                   (export "c t.*************")
@@ -423,35 +423,35 @@
                   )
                   (component
                     (export "q**")
-                    (export "00AGGGGle $$qq")
+                    (export "dojgn-ejs9-nd188")
                   )
                   (component
                     (export "q")
                   )
                   (component
                     (export "c 3@E*******************")
-                    (import "00AGGGGle*$$qq")
+                    (import "bsdew2-sdbsdb")
                   )
                   (component
                     (export "c=t.*************")
                     (export "00AG")
                     (component
-                      (export "c 3@EGGyGG$qq**")
-                      (export "00AGGGGle $$qq")
+                      (export "alskgn-mbnaj4-a33i5nf")
+                      (export "dojgn-ejs9-nd188")
                     )
                     (component
                       (export "q")
                     )
                     (component
                       (export "c 3@E*******************")
-                      (import "00AGGGGl$$qq")
+                      (import "jsjsjs")
                     )
                     (component
                       (export "q")
                     )
                     (component
                       (export "c 3@E*******************")
-                      (import "00AGGGGle*$$qq")
+                      (import "bsdew2-sdbsdb")
                     )
                     (component
                       (export "c t.*************")
@@ -461,31 +461,31 @@
                       )
                       (component
                         (export "q**")
-                        (export "00AGGGGle $$qq")
+                        (export "dojgn-ejs9-nd188")
                       )
                       (component
                         (export "q")
                       )
                       (component
                         (export "c 3@E*******************")
-                        (import "00AGGGGle*$$qq")
+                        (import "bsdew2-sdbsdb")
                       )
                       (component
                         (export "c=t.*************")
                         (export "00AG")
                         (component
-                          (export "c 3@EGGyGG$qq**")
-                          (export "00AGGGGle $$qq")
+                          (export "alskgn-mbnaj4-a33i5nf")
+                          (export "dojgn-ejs9-nd188")
                         )
                         (component
                           (export "q")
                         )
                         (component
-                          (export "c 6Ǻ*******************")
-                          (import "00AGGG^Glllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllle*$$qq")
+                          (export "afhinds-T39OIDN-f1jsj11")
+                          (import "sf-gqo3ngin23ogin13g-bvcad")
                         )
                         (component
-                          (export "c EGGyGG$qq**")
+                          (export "EGG-y-GG-qq")
                           (export "00AGGG.Gle '$$qq")
                         )
                         (component
@@ -493,7 +493,7 @@
                         )
                         (component
                           (export "b 3@E*******************")
-                          (import "00AGGGGle*$$qq")
+                          (import "bsdew2-sdbsdb")
                         )
                         (component
                           (export "c 0.*************")
@@ -506,14 +506,14 @@
                       )
                       (component
                         (export "c 3@E*********GG$qq**")
-                        (export "00AGGGGle $$qq")
+                        (export "dojgn-ejs9-nd188")
                       )
                       (component
                         (export "q")
                       )
                       (component
                         (export "c 3@E************[******")
-                        (import "00AGGGGle*$$qq")
+                        (import "bsdew2-sdbsdb")
                       )
                       (component
                         (export "c t.*************")
@@ -529,7 +529,7 @@
                       (import "00e*$$qq")
                     )
                     (component
-                      (export "c EGGyGG$qq**")
+                      (export "EGG-y-GG-qq")
                       (export "00AGGG.Gle $$qq")
                     )
                     (component
@@ -537,7 +537,7 @@
                     )
                     (component
                       (export "c 3@E*******************")
-                      (import "00AGGGGle*$$qq")
+                      (import "bsdew2-sdbsdb")
                     )
                     (component
                       (export "c *****")
@@ -551,14 +551,14 @@
                       )
                       (component
                         (export "q**")
-                        (export "00AGGGGle $$qq")
+                        (export "dojgn-ejs9-nd188")
                       )
                       (component
                         (export "q")
                       )
                       (component
                         (export "c 3@E*******************")
-                        (import "01AGGGGle*$$qq")
+                        (import "sdg-q12")
                       )
                       (component
                         (export "c t.*************")
@@ -568,35 +568,35 @@
                         )
                         (component
                           (export "q**")
-                          (export "00AGGGGle $$qq")
+                          (export "dojgn-ejs9-nd188")
                         )
                         (component
                           (export "q")
                         )
                         (component
                           (export "c 3@E*******************")
-                          (import "00AGGGGle*$$qq")
+                          (import "bsdew2-sdbsdb")
                         )
                         (component
                           (export "c=t.*************")
                           (export "00AG")
                           (component
-                            (export "c 3@EGGyGG$qq**")
-                            (export "00AGGGGle $$qq")
+                            (export "alskgn-mbnaj4-a33i5nf")
+                            (export "dojgn-ejs9-nd188")
                           )
                           (component
                             (export "q")
                           )
                           (component
                             (export "c 3@E*******************")
-                            (import "00AGGGGl$$qq")
+                            (import "jsjsjs")
                           )
                           (component
                             (export "q")
                           )
                           (component
                             (export "c 3@E*******************")
-                            (import "00AGGGGi64x2.splatle*$$qq")
+                            (import "anonmm-x23foinas-ASDOJASD")
                           )
                           (component
                             (export "c t.****0*********")
@@ -606,39 +606,39 @@
                             )
                             (component
                               (export "q**")
-                              (export "00AGGGGle $$qq")
+                              (export "dojgn-ejs9-nd188")
                             )
                             (component
                               (export "q")
                             )
                             (component
                               (export "c 3@E*******************")
-                              (import "00AGGGGle*$$qq")
+                              (import "bsdew2-sdbsdb")
                             )
                             (component
                               (export "c=t.*************")
                               (export "00AG")
                               (component
-                                (export "c 3@EGGyGG$qq**")
-                                (export "00AGGGGle $$qq")
+                                (export "alskgn-mbnaj4-a33i5nf")
+                                (export "dojgn-ejs9-nd188")
                               )
                               (component
                                 (export "q")
                               )
                               (component
-                                (export "c 6Ǻ*******************")
-                                (import "00AGGG^Glllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllle*$$qq")
+                                (export "afhinds-T39OIDN-f1jsj11")
+                                (import "sf-gqo3ngin23ogin13g-bvcad")
                               )
                               (component
-                                (export "c EGGyGG$qq**")
-                                (export "15AGGG.Gle '$$qq")
+                                (export "EGG-y-GG-qq")
+                                (export "agds-ASF-TT-yy")
                               )
                               (component
                                 (export "q")
                               )
                               (component
                                 (export "b 3@E*******************")
-                                (import "00AGGGGle*$$qq")
+                                (import "bsdew2-sdbsdb")
                               )
                               (component
                                 (export "c 0.*************")
@@ -651,14 +651,14 @@
                             )
                             (component
                               (export "c 3@E*********GG$qq**")
-                              (export "00AGGGGle $$qq")
+                              (export "dojgn-ejs9-nd188")
                             )
                             (component
                               (export "q")
                             )
                             (component
                               (export "c 3@E************[******")
-                              (import "00AGGGGle*$$qq")
+                              (import "bsdew2-sdbsdb")
                             )
                             (component
                               (export "c t.*************")
@@ -674,7 +674,7 @@
                             (import "00e*$$qq")
                           )
                           (component
-                            (export "c EGGyGG$qq**")
+                            (export "EGG-y-GG-qq")
                             (export "0+AGGG.Gle $$qq")
                           )
                           (component
@@ -701,7 +701,7 @@
                           (export "c t.*")
                           (component
                             (export "c 3@EGGGG$qq**")
-                            (export "00AGGGGle*$$qq")
+                            (export "bsdew2-sdbsdb")
                           )
                           (component
                             (export "c t.********)*eleo &m Nx2GGGGle*$$qq")
@@ -723,7 +723,7 @@
                         )
                         (component
                           (export "c 3@E*******************")
-                          (import "01AGGGGle*$$qq")
+                          (import "sdg-q12")
                         )
                         (component
                           (export "c t.*************")
@@ -733,40 +733,40 @@
                           )
                           (component
                             (export "q**")
-                            (export "00AGGGGle $$qq")
+                            (export "dojgn-ejs9-nd188")
                           )
                           (component
                             (export "q")
                           )
                           (component
                             (export "c 3@E*******************")
-                            (import "00AGGGGle*$$qq")
+                            (import "bsdew2-sdbsdb")
                           )
                           (component
                             (export "c=t.*************")
                             (export "00AG")
                             (component
-                              (export "c 3@EGGyGG$qq**")
-                              (export "00AGGGGle $$qq")
+                              (export "alskgn-mbnaj4-a33i5nf")
+                              (export "dojgn-ejs9-nd188")
                             )
                             (component
                               (export "q")
                             )
                             (component
                               (export "c 3@E*******************")
-                              (import "00AGGGGl$$qq")
+                              (import "jsjsjs")
                             )
                             (component
                               (export "q")
                             )
                             (component
                               (export "c 3@E*******************")
-                              (import "00AGGGGle*$$qq")
+                              (import "bsdew2-sdbsdb")
                             )
                             (component
                               (export "c t.*************")
                               (export "0*************")
-                              (import "00AGGGGle*$$qq")
+                              (import "bsdew2-sdbsdb")
                             )
                             (component
                               (export "c t.*************")
@@ -780,14 +780,14 @@
                               )
                               (component
                                 (export "q**")
-                                (export "00AGGGGle $$qq")
+                                (export "dojgn-ejs9-nd188")
                               )
                               (component
                                 (export "q")
                               )
                               (component
                                 (export "c 3@E*******************")
-                                (import "01AGGGGle*$$qq")
+                                (import "sdg-q12")
                               )
                               (component
                                 (export "c t.*************")
@@ -797,35 +797,35 @@
                                 )
                                 (component
                                   (export "q**")
-                                  (export "00AGGGGle $$qq")
+                                  (export "dojgn-ejs9-nd188")
                                 )
                                 (component
                                   (export "q")
                                 )
                                 (component
                                   (export "c 3@E*******************")
-                                  (import "00AGGGGle*$$qq")
+                                  (import "bsdew2-sdbsdb")
                                 )
                                 (component
                                   (export "c=t.*************")
                                   (export "00AG")
                                   (component
-                                    (export "c 3@EGGyGG$qq**")
-                                    (export "00AGGGGle $$qq")
+                                    (export "alskgn-mbnaj4-a33i5nf")
+                                    (export "dojgn-ejs9-nd188")
                                   )
                                   (component
                                     (export "q")
                                   )
                                   (component
                                     (export "c 3@E*******************")
-                                    (import "00AGGGGl$$qq")
+                                    (import "jsjsjs")
                                   )
                                   (component
                                     (export "q")
                                   )
                                   (component
                                     (export "c 3@E*******************")
-                                    (import "00AGGGGi64x2.splatle*$$qq")
+                                    (import "anonmm-x23foinas-ASDOJASD")
                                   )
                                   (component
                                     (export "c t.****0*********")
@@ -835,39 +835,39 @@
                                     )
                                     (component
                                       (export "q**")
-                                      (export "00AGGGGle $$qq")
+                                      (export "dojgn-ejs9-nd188")
                                     )
                                     (component
                                       (export "q")
                                     )
                                     (component
                                       (export "c 3@E*******************")
-                                      (import "00AGGGGle*$$qq")
+                                      (import "bsdew2-sdbsdb")
                                     )
                                     (component
                                       (export "c=t.*************")
                                       (export "00AG")
                                       (component
-                                        (export "c 3@EGGyGG$qq**")
-                                        (export "00AGGGGle $$qq")
+                                        (export "alskgn-mbnaj4-a33i5nf")
+                                        (export "dojgn-ejs9-nd188")
                                       )
                                       (component
                                         (export "q")
                                       )
                                       (component
-                                        (export "c 6Ǻ*******************")
-                                        (import "00AGGG^Glllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllle*$$qq")
+                                        (export "afhinds-T39OIDN-f1jsj11")
+                                        (import "sf-gqo3ngin23ogin13g-bvcad")
                                       )
                                       (component
-                                        (export "c EGGyGG$qq**")
-                                        (export "15AGGG.Gle '$$qq")
+                                        (export "EGG-y-GG-qq")
+                                        (export "agds-ASF-TT-yy")
                                       )
                                       (component
                                         (export "q")
                                       )
                                       (component
                                         (export "b 3@E*******************")
-                                        (import "00AGGGGle*$$qq")
+                                        (import "bsdew2-sdbsdb")
                                       )
                                       (component
                                         (export "c 0.*************")
@@ -880,14 +880,14 @@
                                     )
                                     (component
                                       (export "c 3@E*********GG$qq**")
-                                      (export "00AGGGGle $$qq")
+                                      (export "dojgn-ejs9-nd188")
                                     )
                                     (component
                                       (export "q")
                                     )
                                     (component
                                       (export "c 3@E************[******")
-                                      (import "00AGGGGle*$$qq")
+                                      (import "bsdew2-sdbsdb")
                                     )
                                     (component
                                       (export "c t.*************")
@@ -903,7 +903,7 @@
                                     (import "00e*$$qq")
                                   )
                                   (component
-                                    (export "c EGGyGG$qq**")
+                                    (export "EGG-y-GG-qq")
                                     (export "0+AGGG.Gle $$qq")
                                   )
                                   (component
@@ -930,7 +930,7 @@
                                   (export "c .t*")
                                   (component
                                     (export "c 3@EGGGG$qq**")
-                                    (export "00AGGGGle*$$qq")
+                                    (export "bsdew2-sdbsdb")
                                   )
                                   (component
                                     (export "c t.********)*eleo &m Nx2GGGGle*$$qq")
@@ -952,7 +952,7 @@
                                 )
                                 (component
                                   (export "c 3@E*******************")
-                                  (import "01AGGGGle*$$qq")
+                                  (import "sdg-q12")
                                 )
                                 (component
                                   (export "c t.*************")
@@ -962,35 +962,35 @@
                                   )
                                   (component
                                     (export "q**")
-                                    (export "00AGGGGle $$qq")
+                                    (export "dojgn-ejs9-nd188")
                                   )
                                   (component
                                     (export "q")
                                   )
                                   (component
                                     (export "c 3@E*******************")
-                                    (import "00AGGGGle*$$qq")
+                                    (import "bsdew2-sdbsdb")
                                   )
                                   (component
                                     (export "c=t.*************")
                                     (export "00AG")
                                     (component
-                                      (export "c 3@EGGyGG$qq**")
-                                      (export "00AGGGGle $$qq")
+                                      (export "alskgn-mbnaj4-a33i5nf")
+                                      (export "dojgn-ejs9-nd188")
                                     )
                                     (component
                                       (export "q")
                                     )
                                     (component
                                       (export "c 3@E*******************")
-                                      (import "00AGGGGl$$qq")
+                                      (import "jsjsjs")
                                     )
                                     (component
                                       (export "q")
                                     )
                                     (component
                                       (export "c 3@E*******************")
-                                      (import "00AGGGGle*$$qq")
+                                      (import "bsdew2-sdbsdb")
                                     )
                                     (component
                                       (export "c t.*************")
@@ -1000,31 +1000,31 @@
                                       )
                                       (component
                                         (export "q**")
-                                        (export "00AGGGGle $$qq")
+                                        (export "dojgn-ejs9-nd188")
                                       )
                                       (component
                                         (export "q")
                                       )
                                       (component
                                         (export "c 3@E*******************")
-                                        (import "00AGGGGle*$$qq")
+                                        (import "bsdew2-sdbsdb")
                                       )
                                       (component
                                         (export "c=t.*************")
                                         (export "00AG")
                                         (component
-                                          (export "c 3@EGGyGG$qq**")
-                                          (export "00AGGGGle $$qq")
+                                          (export "alskgn-mbnaj4-a33i5nf")
+                                          (export "dojgn-ejs9-nd188")
                                         )
                                         (component
                                           (export "q")
                                         )
                                         (component
-                                          (export "c 6Ǻ*******************")
-                                          (import "00AGGG^Glllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllle*$$qq")
+                                          (export "afhinds-T39OIDN-f1jsj11")
+                                          (import "sf-gqo3ngin23ogin13g-bvcad")
                                         )
                                         (component
-                                          (export "c EGGyGG$qq**")
+                                          (export "EGG-y-GG-qq")
                                           (export "00AGGG.Gle '$$qq")
                                         )
                                         (component
@@ -1032,7 +1032,7 @@
                                         )
                                         (component
                                           (export "b 3@E*******************")
-                                          (import "00AGGGGle*$$qq")
+                                          (import "bsdew2-sdbsdb")
                                         )
                                         (component
                                           (export "c 0.*************")
@@ -1045,14 +1045,14 @@
                                       )
                                       (component
                                         (export "c 3@E*********GG$qq**")
-                                        (export "00AGGGGle $$qq")
+                                        (export "dojgn-ejs9-nd188")
                                       )
                                       (component
                                         (export "q")
                                       )
                                       (component
                                         (export "c 3@E************[******")
-                                        (import "00AGGGGle*$$qq")
+                                        (import "bsdew2-sdbsdb")
                                       )
                                       (component
                                         (export "c t.*************")
@@ -1068,7 +1068,7 @@
                                       (import "00e*$$qq")
                                     )
                                     (component
-                                      (export "c EGGyGG$qq**")
+                                      (export "EGG-y-GG-qq")
                                       (export "00AGGG.Gle $$qq")
                                     )
                                     (component
@@ -1076,7 +1076,7 @@
                                     )
                                     (component
                                       (export "c 3@E*******************")
-                                      (import "00AGGGGle*$$qq")
+                                      (import "bsdew2-sdbsdb")
                                     )
                                     (component
                                       (export "c 1.*************")
@@ -1089,7 +1089,7 @@
                                   )
                                   (component
                                     (export "c 4@E****\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*****GG$qq**")
-                                    (export "00AGGGGle $$qq")
+                                    (export "dojgn-ejs9-nd188")
                                   )
                                   (component
                                     (export "q")
@@ -1120,7 +1120,7 @@
                                 (component
                                   (export "c t.*************")
                                   (export "00AGGGGl4@E****\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*****GG$qq**")
-                                  (export "00AGGGGle $$qq")
+                                  (export "dojgn-ejs9-nd188")
                                 )
                                 (component
                                   (export "q")
@@ -1164,31 +1164,31 @@
                               )
                               (component
                                 (export "q**")
-                                (export "00AGGGGle $$qq")
+                                (export "dojgn-ejs9-nd188")
                               )
                               (component
                                 (export "q")
                               )
                               (component
                                 (export "c 3@E*******************")
-                                (import "00AGGGGle*$$qq")
+                                (import "bsdew2-sdbsdb")
                               )
                               (component
                                 (export "c=t.*************")
                                 (export "00AG")
                                 (component
-                                  (export "c 3@EGGyGG$qq**")
-                                  (export "00AGGGGle $$qq")
+                                  (export "alskgn-mbnaj4-a33i5nf")
+                                  (export "dojgn-ejs9-nd188")
                                 )
                                 (component
                                   (export "q")
                                 )
                                 (component
-                                  (export "c 6Ǻ*******************")
-                                  (import "00AGGG^Glllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllle*$$qq")
+                                  (export "afhinds-T39OIDN-f1jsj11")
+                                  (import "sf-gqo3ngin23ogin13g-bvcad")
                                 )
                                 (component
-                                  (export "c EGGyGG$qq**")
+                                  (export "EGG-y-GG-qq")
                                   (export "00AGGG.Gle '$$qq")
                                 )
                                 (component
@@ -1196,7 +1196,7 @@
                                 )
                                 (component
                                   (export "b 3@E*******************")
-                                  (import "00AGGGGle*$$qq")
+                                  (import "bsdew2-sdbsdb")
                                 )
                                 (component
                                   (export "c 0.*************")
@@ -1209,14 +1209,14 @@
                               )
                               (component
                                 (export "c 3@E*********GG$qq**")
-                                (export "00AGGGGle $$qq")
+                                (export "dojgn-ejs9-nd188")
                               )
                               (component
                                 (export "q")
                               )
                               (component
                                 (export "c 3@E************[******")
-                                (import "00AGGGGle*$$qq")
+                                (import "bsdew2-sdbsdb")
                               )
                               (component
                                 (export "c t.*************")
@@ -1232,7 +1232,7 @@
                               (import "00e*$$qq")
                             )
                             (component
-                              (export "c EGGyGG$qq**")
+                              (export "EGG-y-GG-qq")
                               (export "00AGGG.Gle $$qq")
                             )
                             (component
@@ -1240,7 +1240,7 @@
                             )
                             (component
                               (export "c 3@E*******************")
-                              (import "00AGGGGle*$$qq")
+                              (import "bsdew2-sdbsdb")
                             )
                             (component
                               (export "c 1.*************")
@@ -1253,7 +1253,7 @@
                           )
                           (component
                             (export "c 4@E****\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*****GG$qq**")
-                            (export "00AGGGGle $$qq")
+                            (export "dojgn-ejs9-nd188")
                           )
                           (component
                             (export "q")
@@ -1284,7 +1284,7 @@
                         (component
                           (export "c t.*************")
                           (export "00AGGGGl4@E****\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*****GG$qq**")
-                          (export "00AGGGGle $$qq")
+                          (export "dojgn-ejs9-nd188")
                         )
                         (component
                           (export "q")
@@ -1332,7 +1332,7 @@
                   )
                   (component
                     (export "c 4@E****\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*****GG$qq**")
-                    (export "00AGGGGle $$qq")
+                    (export "dojgn-ejs9-nd188")
                   )
                   (component
                     (export "q")
@@ -1363,7 +1363,7 @@
                 (component
                   (export "c t.*************")
                   (export "00AGGGGl4@E****\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*****GG$qq**")
-                  (export "00AGGGGle $$qq")
+                  (export "dojgn-ejs9-nd188")
                 )
                 (component
                   (export "q")
@@ -1407,31 +1407,31 @@
               )
               (component
                 (export "q**")
-                (export "00AGGGGle $$qq")
+                (export "dojgn-ejs9-nd188")
               )
               (component
                 (export "q")
               )
               (component
                 (export "c 3@E*******************")
-                (import "00AGGGGle*$$qq")
+                (import "bsdew2-sdbsdb")
               )
               (component
                 (export "c=t.*************")
                 (export "00AG")
                 (component
-                  (export "c 3@EGGyGG$qq**")
-                  (export "00AGGGGle $$qq")
+                  (export "alskgn-mbnaj4-a33i5nf")
+                  (export "dojgn-ejs9-nd188")
                 )
                 (component
                   (export "q")
                 )
                 (component
-                  (export "c 6Ǻ*******************")
-                  (import "00AGGG^Glllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllllle*$$qq")
+                  (export "afhinds-T39OIDN-f1jsj11")
+                  (import "sf-gqo3ngin23ogin13g-bvcad")
                 )
                 (component
-                  (export "c EGGyGG$qq**")
+                  (export "EGG-y-GG-qq")
                   (export "00AGGG.Gle '$$qq")
                 )
                 (component
@@ -1439,7 +1439,7 @@
                 )
                 (component
                   (export "b 3@E*******************")
-                  (import "00AGGGGle*$$qq")
+                  (import "bsdew2-sdbsdb")
                 )
                 (component
                   (export "c 0.*************")
@@ -1452,14 +1452,14 @@
               )
               (component
                 (export "c 3@E*********GG$qq**")
-                (export "00AGGGGle $$qq")
+                (export "dojgn-ejs9-nd188")
               )
               (component
                 (export "q")
               )
               (component
                 (export "c 3@E************[******")
-                (import "00AGGGGle*$$qq")
+                (import "bsdew2-sdbsdb")
               )
               (component
                 (export "c t.*************")
@@ -1475,7 +1475,7 @@
               (import "00e*$$qq")
             )
             (component
-              (export "c EGGyGG$qq**")
+              (export "EGG-y-GG-qq")
               (export "00AGGG.Gle $$qq")
             )
             (component
@@ -1483,7 +1483,7 @@
             )
             (component
               (export "c 3@E*******************")
-              (import "00AGGGGle*$$qq")
+              (import "bsdew2-sdbsdb")
             )
             (component
               (export "c 1.*************")
@@ -1496,7 +1496,7 @@
           )
           (component
             (export "c 4@E****\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*****GG$qq**")
-            (export "00AGGGGle $$qq")
+            (export "dojgn-ejs9-nd188")
           )
           (component
             (export "q")
@@ -1527,7 +1527,7 @@
         (component
           (export "c t.*************")
           (export "00AGGGGl4@E****\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\*****GG$qq**")
-          (export "00AGGGGle $$qq")
+          (export "dojgn-ejs9-nd188")
         )
         (component
           (export "q")
@@ -1562,126 +1562,126 @@
       (component)
     )
   )
-  "duplicate export name")
+  "conflicts with previous export name")
 
 (assert_invalid
   (component
     (type $m0 (component))
     (type $m1 (component
-      (import "1" (component (type $m0)))
-      (import "2" (component (type $m0)))
-      (import "3" (component (type $m0)))
-      (import "4" (component (type $m0)))
-      (import "5" (component (type $m0)))
-      (import "6" (component (type $m0)))
-      (import "7" (component (type $m0)))
-      (import "8" (component (type $m0)))
-      (import "9" (component (type $m0)))
-      (import "10" (component (type $m0)))
+      (import "i1" (component (type $m0)))
+      (import "i2" (component (type $m0)))
+      (import "i3" (component (type $m0)))
+      (import "i4" (component (type $m0)))
+      (import "i5" (component (type $m0)))
+      (import "i6" (component (type $m0)))
+      (import "i7" (component (type $m0)))
+      (import "i8" (component (type $m0)))
+      (import "i9" (component (type $m0)))
+      (import "i10" (component (type $m0)))
     ))
     (type $m2 (component
-      (import "1" (component (type $m1)))
-      (import "2" (component (type $m1)))
-      (import "3" (component (type $m1)))
-      (import "4" (component (type $m1)))
-      (import "5" (component (type $m1)))
-      (import "6" (component (type $m1)))
-      (import "7" (component (type $m1)))
-      (import "8" (component (type $m1)))
-      (import "9" (component (type $m1)))
-      (import "10" (component (type $m1)))
+      (import "i1" (component (type $m1)))
+      (import "i2" (component (type $m1)))
+      (import "i3" (component (type $m1)))
+      (import "i4" (component (type $m1)))
+      (import "i5" (component (type $m1)))
+      (import "i6" (component (type $m1)))
+      (import "i7" (component (type $m1)))
+      (import "i8" (component (type $m1)))
+      (import "i9" (component (type $m1)))
+      (import "i10" (component (type $m1)))
     ))
     (type $m3 (component
-      (import "1" (component (type $m2)))
-      (import "2" (component (type $m2)))
-      (import "3" (component (type $m2)))
-      (import "4" (component (type $m2)))
-      (import "5" (component (type $m2)))
-      (import "6" (component (type $m2)))
-      (import "7" (component (type $m2)))
-      (import "8" (component (type $m2)))
-      (import "9" (component (type $m2)))
-      (import "10" (component (type $m2)))
+      (import "i1" (component (type $m2)))
+      (import "i2" (component (type $m2)))
+      (import "i3" (component (type $m2)))
+      (import "i4" (component (type $m2)))
+      (import "i5" (component (type $m2)))
+      (import "i6" (component (type $m2)))
+      (import "i7" (component (type $m2)))
+      (import "i8" (component (type $m2)))
+      (import "i9" (component (type $m2)))
+      (import "i10" (component (type $m2)))
     ))
     (type $m4 (component
-      (import "1" (component (type $m3)))
-      (import "2" (component (type $m3)))
-      (import "3" (component (type $m3)))
-      (import "4" (component (type $m3)))
-      (import "5" (component (type $m3)))
-      (import "6" (component (type $m3)))
-      (import "7" (component (type $m3)))
-      (import "8" (component (type $m3)))
-      (import "9" (component (type $m3)))
-      (import "10" (component (type $m3)))
+      (import "i1" (component (type $m3)))
+      (import "i2" (component (type $m3)))
+      (import "i3" (component (type $m3)))
+      (import "i4" (component (type $m3)))
+      (import "i5" (component (type $m3)))
+      (import "i6" (component (type $m3)))
+      (import "i7" (component (type $m3)))
+      (import "i8" (component (type $m3)))
+      (import "i9" (component (type $m3)))
+      (import "i10" (component (type $m3)))
     ))
     (type $m5 (component
-      (import "1" (component (type $m4)))
-      (import "2" (component (type $m4)))
-      (import "3" (component (type $m4)))
-      (import "4" (component (type $m4)))
-      (import "5" (component (type $m4)))
-      (import "6" (component (type $m4)))
-      (import "7" (component (type $m4)))
-      (import "8" (component (type $m4)))
-      (import "9" (component (type $m4)))
-      (import "10" (component (type $m4)))
+      (import "i1" (component (type $m4)))
+      (import "i2" (component (type $m4)))
+      (import "i3" (component (type $m4)))
+      (import "i4" (component (type $m4)))
+      (import "i5" (component (type $m4)))
+      (import "i6" (component (type $m4)))
+      (import "i7" (component (type $m4)))
+      (import "i8" (component (type $m4)))
+      (import "i9" (component (type $m4)))
+      (import "i10" (component (type $m4)))
     ))
     (type $m6 (component
-      (import "1" (component (type $m5)))
-      (import "2" (component (type $m5)))
-      (import "3" (component (type $m5)))
-      (import "4" (component (type $m5)))
-      (import "5" (component (type $m5)))
-      (import "6" (component (type $m5)))
-      (import "7" (component (type $m5)))
-      (import "8" (component (type $m5)))
-      (import "9" (component (type $m5)))
-      (import "10" (component (type $m5)))
+      (import "i1" (component (type $m5)))
+      (import "i2" (component (type $m5)))
+      (import "i3" (component (type $m5)))
+      (import "i4" (component (type $m5)))
+      (import "i5" (component (type $m5)))
+      (import "i6" (component (type $m5)))
+      (import "i7" (component (type $m5)))
+      (import "i8" (component (type $m5)))
+      (import "i9" (component (type $m5)))
+      (import "i10" (component (type $m5)))
     ))
     (type $m7 (component
-      (import "1" (component (type $m6)))
-      (import "2" (component (type $m6)))
-      (import "3" (component (type $m6)))
-      (import "4" (component (type $m6)))
-      (import "5" (component (type $m6)))
-      (import "6" (component (type $m6)))
-      (import "7" (component (type $m6)))
-      (import "8" (component (type $m6)))
-      (import "9" (component (type $m6)))
-      (import "10" (component (type $m6)))
+      (import "i1" (component (type $m6)))
+      (import "i2" (component (type $m6)))
+      (import "i3" (component (type $m6)))
+      (import "i4" (component (type $m6)))
+      (import "i5" (component (type $m6)))
+      (import "i6" (component (type $m6)))
+      (import "i7" (component (type $m6)))
+      (import "i8" (component (type $m6)))
+      (import "i9" (component (type $m6)))
+      (import "i10" (component (type $m6)))
     ))
     (type $m8 (component
-      (import "1" (component (type $m7)))
-      (import "2" (component (type $m7)))
-      (import "3" (component (type $m7)))
-      (import "4" (component (type $m7)))
-      (import "5" (component (type $m7)))
-      (import "6" (component (type $m7)))
-      (import "7" (component (type $m7)))
-      (import "8" (component (type $m7)))
-      (import "9" (component (type $m7)))
-      (import "10" (component (type $m7)))
+      (import "i1" (component (type $m7)))
+      (import "i2" (component (type $m7)))
+      (import "i3" (component (type $m7)))
+      (import "i4" (component (type $m7)))
+      (import "i5" (component (type $m7)))
+      (import "i6" (component (type $m7)))
+      (import "i7" (component (type $m7)))
+      (import "i8" (component (type $m7)))
+      (import "i9" (component (type $m7)))
+      (import "i10" (component (type $m7)))
     ))
     (type $m9 (component
-      (import "1" (component (type $m8)))
-      (import "2" (component (type $m8)))
-      (import "3" (component (type $m8)))
-      (import "4" (component (type $m8)))
-      (import "5" (component (type $m8)))
-      (import "6" (component (type $m8)))
-      (import "7" (component (type $m8)))
-      (import "8" (component (type $m8)))
-      (import "9" (component (type $m8)))
-      (import "10" (component (type $m8)))
+      (import "i1" (component (type $m8)))
+      (import "i2" (component (type $m8)))
+      (import "i3" (component (type $m8)))
+      (import "i4" (component (type $m8)))
+      (import "i5" (component (type $m8)))
+      (import "i6" (component (type $m8)))
+      (import "i7" (component (type $m8)))
+      (import "i8" (component (type $m8)))
+      (import "i9" (component (type $m8)))
+      (import "i10" (component (type $m8)))
     ))
 
     (type $m (component
-      (import "" (component (type $m9)))
+      (import "a" (component (type $m9)))
     ))
     (import "a" (component $a (type $m9)))
     (import "b" (component $b (type $m)))
-    (instance (instantiate $b (with "" (component $a))))
+    (instance (instantiate $b (with "a" (component $a))))
   )
   "effective type size exceeds the limit")
 
@@ -1689,88 +1689,88 @@
   (component
     (component $m0)
     (component $m1
-      (instance (export "0") (instantiate $m0))
-      (instance (export "1") (instantiate $m0))
-      (instance (export "2") (instantiate $m0))
-      (instance (export "3") (instantiate $m0))
-      (instance (export "4") (instantiate $m0))
-      (instance (export "5") (instantiate $m0))
-      (instance (export "6") (instantiate $m0))
-      (instance (export "7") (instantiate $m0))
-      (instance (export "8") (instantiate $m0))
-      (instance (export "9") (instantiate $m0))
+      (instance (export "e0") (instantiate $m0))
+      (instance (export "e1") (instantiate $m0))
+      (instance (export "e2") (instantiate $m0))
+      (instance (export "e3") (instantiate $m0))
+      (instance (export "e4") (instantiate $m0))
+      (instance (export "e5") (instantiate $m0))
+      (instance (export "e6") (instantiate $m0))
+      (instance (export "e7") (instantiate $m0))
+      (instance (export "e8") (instantiate $m0))
+      (instance (export "e9") (instantiate $m0))
     )
     (component $m2
-      (instance (export "0") (instantiate $m1))
-      (instance (export "1") (instantiate $m1))
-      (instance (export "2") (instantiate $m1))
-      (instance (export "3") (instantiate $m1))
-      (instance (export "4") (instantiate $m1))
-      (instance (export "5") (instantiate $m1))
-      (instance (export "6") (instantiate $m1))
-      (instance (export "7") (instantiate $m1))
-      (instance (export "8") (instantiate $m1))
-      (instance (export "9") (instantiate $m1))
+      (instance (export "e0") (instantiate $m1))
+      (instance (export "e1") (instantiate $m1))
+      (instance (export "e2") (instantiate $m1))
+      (instance (export "e3") (instantiate $m1))
+      (instance (export "e4") (instantiate $m1))
+      (instance (export "e5") (instantiate $m1))
+      (instance (export "e6") (instantiate $m1))
+      (instance (export "e7") (instantiate $m1))
+      (instance (export "e8") (instantiate $m1))
+      (instance (export "e9") (instantiate $m1))
     )
     (component $m3
-      (instance (export "0") (instantiate $m2))
-      (instance (export "1") (instantiate $m2))
-      (instance (export "2") (instantiate $m2))
-      (instance (export "3") (instantiate $m2))
-      (instance (export "4") (instantiate $m2))
-      (instance (export "5") (instantiate $m2))
-      (instance (export "6") (instantiate $m2))
-      (instance (export "7") (instantiate $m2))
-      (instance (export "8") (instantiate $m2))
-      (instance (export "9") (instantiate $m2))
+      (instance (export "e0") (instantiate $m2))
+      (instance (export "e1") (instantiate $m2))
+      (instance (export "e2") (instantiate $m2))
+      (instance (export "e3") (instantiate $m2))
+      (instance (export "e4") (instantiate $m2))
+      (instance (export "e5") (instantiate $m2))
+      (instance (export "e6") (instantiate $m2))
+      (instance (export "e7") (instantiate $m2))
+      (instance (export "e8") (instantiate $m2))
+      (instance (export "e9") (instantiate $m2))
     )
     (component $m4
-      (instance (export "0") (instantiate $m3))
-      (instance (export "1") (instantiate $m3))
-      (instance (export "2") (instantiate $m3))
-      (instance (export "3") (instantiate $m3))
-      (instance (export "4") (instantiate $m3))
-      (instance (export "5") (instantiate $m3))
-      (instance (export "6") (instantiate $m3))
-      (instance (export "7") (instantiate $m3))
-      (instance (export "8") (instantiate $m3))
-      (instance (export "9") (instantiate $m3))
+      (instance (export "e0") (instantiate $m3))
+      (instance (export "e1") (instantiate $m3))
+      (instance (export "e2") (instantiate $m3))
+      (instance (export "e3") (instantiate $m3))
+      (instance (export "e4") (instantiate $m3))
+      (instance (export "e5") (instantiate $m3))
+      (instance (export "e6") (instantiate $m3))
+      (instance (export "e7") (instantiate $m3))
+      (instance (export "e8") (instantiate $m3))
+      (instance (export "e9") (instantiate $m3))
     )
     (component $m5
-      (instance (export "0") (instantiate $m4))
-      (instance (export "1") (instantiate $m4))
-      (instance (export "2") (instantiate $m4))
-      (instance (export "3") (instantiate $m4))
-      (instance (export "4") (instantiate $m4))
-      (instance (export "5") (instantiate $m4))
-      (instance (export "6") (instantiate $m4))
-      (instance (export "7") (instantiate $m4))
-      (instance (export "8") (instantiate $m4))
-      (instance (export "9") (instantiate $m4))
+      (instance (export "e0") (instantiate $m4))
+      (instance (export "e1") (instantiate $m4))
+      (instance (export "e2") (instantiate $m4))
+      (instance (export "e3") (instantiate $m4))
+      (instance (export "e4") (instantiate $m4))
+      (instance (export "e5") (instantiate $m4))
+      (instance (export "e6") (instantiate $m4))
+      (instance (export "e7") (instantiate $m4))
+      (instance (export "e8") (instantiate $m4))
+      (instance (export "e9") (instantiate $m4))
     )
     (component $m6
-      (instance (export "0") (instantiate $m5))
-      (instance (export "1") (instantiate $m5))
-      (instance (export "2") (instantiate $m5))
-      (instance (export "3") (instantiate $m5))
-      (instance (export "4") (instantiate $m5))
-      (instance (export "5") (instantiate $m5))
-      (instance (export "6") (instantiate $m5))
-      (instance (export "7") (instantiate $m5))
-      (instance (export "8") (instantiate $m5))
-      (instance (export "9") (instantiate $m5))
+      (instance (export "e0") (instantiate $m5))
+      (instance (export "e1") (instantiate $m5))
+      (instance (export "e2") (instantiate $m5))
+      (instance (export "e3") (instantiate $m5))
+      (instance (export "e4") (instantiate $m5))
+      (instance (export "e5") (instantiate $m5))
+      (instance (export "e6") (instantiate $m5))
+      (instance (export "e7") (instantiate $m5))
+      (instance (export "e8") (instantiate $m5))
+      (instance (export "e9") (instantiate $m5))
     )
     (component $m7
-      (instance (export "0") (instantiate $m6))
-      (instance (export "1") (instantiate $m6))
-      (instance (export "2") (instantiate $m6))
-      (instance (export "3") (instantiate $m6))
-      (instance (export "4") (instantiate $m6))
-      (instance (export "5") (instantiate $m6))
-      (instance (export "6") (instantiate $m6))
-      (instance (export "7") (instantiate $m6))
-      (instance (export "8") (instantiate $m6))
-      (instance (export "9") (instantiate $m6))
+      (instance (export "e0") (instantiate $m6))
+      (instance (export "e1") (instantiate $m6))
+      (instance (export "e2") (instantiate $m6))
+      (instance (export "e3") (instantiate $m6))
+      (instance (export "e4") (instantiate $m6))
+      (instance (export "e5") (instantiate $m6))
+      (instance (export "e6") (instantiate $m6))
+      (instance (export "e7") (instantiate $m6))
+      (instance (export "e8") (instantiate $m6))
+      (instance (export "e9") (instantiate $m6))
     )
   )
   "effective type size exceeds the limit")
@@ -1782,58 +1782,58 @@
 
     ;; size(t1) == 10
     (type $t1 (record
-      (field "0" $t0)
-      (field "1" $t0)
-      (field "2" $t0)
-      (field "3" $t0)
-      (field "4" $t0)
-      (field "5" $t0)
-      (field "6" $t0)
-      (field "7" $t0)
-      (field "8" $t0)
-      (field "9" $t0)
+      (field "f0" $t0)
+      (field "f1" $t0)
+      (field "f2" $t0)
+      (field "f3" $t0)
+      (field "f4" $t0)
+      (field "f5" $t0)
+      (field "f6" $t0)
+      (field "f7" $t0)
+      (field "f8" $t0)
+      (field "f9" $t0)
     ))
 
     ;; size(t2) == 100
     (type $t2 (record
-      (field "0" $t1)
-      (field "1" $t1)
-      (field "2" $t1)
-      (field "3" $t1)
-      (field "4" $t1)
-      (field "5" $t1)
-      (field "6" $t1)
-      (field "7" $t1)
-      (field "8" $t1)
-      (field "9" $t1)
+      (field "f0" $t1)
+      (field "f1" $t1)
+      (field "f2" $t1)
+      (field "f3" $t1)
+      (field "f4" $t1)
+      (field "f5" $t1)
+      (field "f6" $t1)
+      (field "f7" $t1)
+      (field "f8" $t1)
+      (field "f9" $t1)
     ))
 
     ;; size(t3) == 1000
     (type $t3 (record
-      (field "0" $t2)
-      (field "1" $t2)
-      (field "2" $t2)
-      (field "3" $t2)
-      (field "4" $t2)
-      (field "5" $t2)
-      (field "6" $t2)
-      (field "7" $t2)
-      (field "8" $t2)
-      (field "9" $t2)
+      (field "f0" $t2)
+      (field "f1" $t2)
+      (field "f2" $t2)
+      (field "f3" $t2)
+      (field "f4" $t2)
+      (field "f5" $t2)
+      (field "f6" $t2)
+      (field "f7" $t2)
+      (field "f8" $t2)
+      (field "f9" $t2)
     ))
 
     ;; size(t4) == 10000
     (type $t4 (record
-      (field "0" $t3)
-      (field "1" $t3)
-      (field "2" $t3)
-      (field "3" $t3)
-      (field "4" $t3)
-      (field "5" $t3)
-      (field "6" $t3)
-      (field "7" $t3)
-      (field "8" $t3)
-      (field "9" $t3)
+      (field "f0" $t3)
+      (field "f1" $t3)
+      (field "f2" $t3)
+      (field "f3" $t3)
+      (field "f4" $t3)
+      (field "f5" $t3)
+      (field "f6" $t3)
+      (field "f7" $t3)
+      (field "f8" $t3)
+      (field "f9" $t3)
     ))
 
     (type $f (func

--- a/tests/local/component-model/virtualize.wast
+++ b/tests/local/component-model/virtualize.wast
@@ -54,20 +54,20 @@
       (export "read" (func $read (param "len" u32) (result (list u8))))
       (export "write" (func $write (param "buf" (list u8)) (result u32)))
     ))
-    (import "wasi_file" (instance $real-wasi (type $WasiFile)))
-    (import "./virtualize.wasm" (component $VIRTUALIZE
-      (import "wasi_file" (instance (type $WasiFile)))
+    (import "wasi-file" (instance $real-wasi (type $WasiFile)))
+    (import "virtualize" (component $VIRTUALIZE
+      (import "wasi-file" (instance (type $WasiFile)))
         (export "read" (func $read (param "len" u32) (result (list u8))))
         (export "write" (func $write (param "buf" (list u8)) (result u32)))
       ))
-      (import "./child.wasm" (component $CHILD
-        (import "wasi_file" (instance (type $WasiFile)))
+      (import "child" (component $CHILD
+        (import "wasi-file" (instance (type $WasiFile)))
         (export "play" (func $play))
       )
     )
 
-    (instance $virt-wasi (instantiate $VIRTUALIZE (with "wasi_file" (instance $real-wasi))))
-    (instance $child (instantiate $CHILD (with "wasi_file" (instance $virt-wasi))))
+    (instance $virt-wasi (instantiate $VIRTUALIZE (with "wasi-file" (instance $real-wasi))))
+    (instance $child (instantiate $CHILD (with "wasi-file" (instance $virt-wasi))))
 
     (export "work" (func $child "play"))
   )
@@ -77,19 +77,19 @@
       (export "read" (func $read (param "len" u32) (result (list u8))))
       (export "write" (func $write (param "buf" (list u8)) (result u32)))
     ))
-    (import "wasi_file" (instance $real-wasi (type $WasiFile)))
+    (import "wasi-file" (instance $real-wasi (type $WasiFile)))
 
     (core instance $libc (instantiate $libc))
 
     (core module $CHILD
-      (import "wasi_file" "read" (func $wasi-file (param i32 i32)))
+      (import "wasi-file" "read" (func $wasi-file (param i32 i32)))
       (func $play (export "play")
         unreachable
       )
     )
 
     (core module $VIRTUALIZE
-      (import "wasi_file" "read" (func (param i32 i32)))
+      (import "wasi-file" "read" (func (param i32 i32)))
       (func (export "read") (param i32 i32)
         unreachable
       )
@@ -105,8 +105,8 @@
       )
     )
 
-    (core instance $virt-wasi (instantiate $VIRTUALIZE (with "wasi_file" (instance (export "read" (func $real-wasi-read))))))
-    (core instance $child (instantiate $CHILD (with "wasi_file" (instance $virt-wasi))))
+    (core instance $virt-wasi (instantiate $VIRTUALIZE (with "wasi-file" (instance (export "read" (func $real-wasi-read))))))
+    (core instance $child (instantiate $CHILD (with "wasi-file" (instance $virt-wasi))))
     (func (export "work")
       (canon lift (core func $child "play")
         (memory $libc "mem")


### PR DESCRIPTION
This PR implements the latest changes to the component model spec:

* Adds a `URL` field to imports and exports.
* Adds validation of the `URL` field.
* Adds validation of various "names" such that they are kebab-cased.

Consequently, import and export names in components are no longer allowed to be empty,
which required fixes in many component model tests.