### PR TITLE
Add v128 equality to `mutate` fuzzer

### DIFF
--- a/fuzz/fuzz_targets/mutate.rs
+++ b/fuzz/fuzz_targets/mutate.rs
@@ -276,6 +276,9 @@ mod eval {
                 let m = f64::from_bits(*m);
                 assert!(o == m || (o.is_nan() && m.is_nan()));
             }
+            (wasmtime::Val::V128(o), wasmtime::Val::V128(m)) => {
+                assert_eq!(o, m)
+            }
             (wasmtime::Val::ExternRef(o), wasmtime::Val::ExternRef(m)) => {
                 assert_eq!(o.is_none(), m.is_none())
             }


### PR DESCRIPTION
Should fix a recent oss-fuzz issue where it found that simd turned on but didn't have equality here.