### PR TITLE
Fix an un-expanded type in table init exprs

### DIFF
--- a/crates/wast/src/core/resolve/types.rs
+++ b/crates/wast/src/core/resolve/types.rs
@@ -103,8 +103,16 @@ impl<'a> Expander<'a> {
                 }
             },
 
-            ModuleField::Table(_)
-            | ModuleField::Memory(_)
+            ModuleField::Table(t) => match &mut t.kind {
+                TableKind::Normal { init_expr, .. } => {
+                    if let Some(expr) = init_expr {
+                        self.expand_expression(expr);
+                    }
+                }
+                TableKind::Import { .. } | TableKind::Inline { .. } => {}
+            },
+
+            ModuleField::Memory(_)
             | ModuleField::Start(_)
             | ModuleField::Export(_)
             | ModuleField::Custom(_) => {}

--- a/tests/local/invalid-init-expr.wast
+++ b/tests/local/invalid-init-expr.wast
@@ -1,0 +1,13 @@
+(assert_invalid
+  (module
+    (table funcref (elem (call_indirect)))
+  )
+  "non-constant operator")
+
+(assert_invalid
+  (module
+    (table 1 1 funcref (call_indirect))
+  )
+  ;; note that this error message will change when wasmparser implements the
+  ;; above feature
+  "invalid value type")


### PR DESCRIPTION
This fixes a recent fuzz-bug found from #823 where initialization expressions needed to be expanded before resolution.