### PR TITLE
Remove the `wit_component::ComponentInterfaces` type

### DIFF
--- a/crates/wit-component/src/decoding.rs
+++ b/crates/wit-component/src/decoding.rs
@@ -88,12 +88,11 @@ struct InterfaceDecoder<'a> {
 /// Decode the world described by the given component bytes.
 ///
 /// This function takes a binary component as input and will infer the
-/// `Interface` representation of its imports and exports. More-or-less this
-/// will infer the "world" from a binary component. The binary component at this
-/// time is either a "types only" component produced by `wit-component` or an
-/// actual output of `wit-component`.
+/// `World` representation of its imports and exports. The binary component at
+/// this time is either a "types only" component produced by `wit-component` or
+/// an actual output of `wit-component`.
 ///
-/// The returned interfaces represent the description of imports and exports
+/// The returned world represents the description of imports and exports
 /// from the component.
 ///
 /// This can fail if the input component is invalid or otherwise isn't of the

--- a/crates/wit-component/src/decoding.rs
+++ b/crates/wit-component/src/decoding.rs
@@ -85,7 +85,7 @@ struct InterfaceDecoder<'a> {
     name_map: IndexMap<PtrHash<'a, types::Type>, &'a str>,
 }
 
-/// Decode the interfaces imported and exported by a component.
+/// Decode the world described by the given component bytes.
 ///
 /// This function takes a binary component as input and will infer the
 /// `Interface` representation of its imports and exports. More-or-less this

--- a/crates/wit-component/src/decoding.rs
+++ b/crates/wit-component/src/decoding.rs
@@ -85,54 +85,6 @@ struct InterfaceDecoder<'a> {
     name_map: IndexMap<PtrHash<'a, types::Type>, &'a str>,
 }
 
-/// Parsed representation of interfaces found within a component.
-///
-/// This is more-or-less a "world" and will likely be replaced one day with a
-/// `wit-parser` representation of a world.
-#[derive(Clone, Default)]
-pub struct ComponentInterfaces {
-    /// The "default export" which is the interface directly exported from the
-    /// component at the top level.
-    pub default: Option<Interface>,
-    /// Imported interfaces, keyed by name, of the component.
-    pub imports: IndexMap<String, Interface>,
-    /// Exported interfaces, keyed by name, of the component.
-    pub exports: IndexMap<String, Interface>,
-}
-
-impl ComponentInterfaces {
-    /// Returns an iterator which visits all the exported interfaces, both named
-    /// and default. The second entry in each pair the export name of the
-    /// interface, or `None` if it's the default export interface.
-    pub fn exports(&self) -> impl Iterator<Item = (&Interface, Option<&str>)> + '_ {
-        self.exports
-            .iter()
-            .map(|(name, i)| (i, Some(name.as_str())))
-            .chain(self.default.iter().map(|i| (i, None)))
-    }
-
-    /// Converts back into a `wit_parser::World`
-    pub fn into_world(self, name: &str) -> wit_parser::World {
-        wit_parser::World {
-            imports: self.imports,
-            exports: self.exports,
-            default: self.default,
-            name: name.to_string(),
-            docs: Default::default(),
-        }
-    }
-}
-
-impl From<wit_parser::World> for ComponentInterfaces {
-    fn from(world: wit_parser::World) -> ComponentInterfaces {
-        ComponentInterfaces {
-            exports: world.exports,
-            imports: world.imports,
-            default: world.default,
-        }
-    }
-}
-
 /// Decode the interfaces imported and exported by a component.
 ///
 /// This function takes a binary component as input and will infer the
@@ -146,7 +98,7 @@ impl From<wit_parser::World> for ComponentInterfaces {
 ///
 /// This can fail if the input component is invalid or otherwise isn't of the
 /// expected shape. At this time not all component shapes are supported here.
-pub fn decode_component_interfaces(bytes: &[u8]) -> Result<ComponentInterfaces> {
+pub fn decode_world(name: &str, bytes: &[u8]) -> Result<World> {
     let info = ComponentInfo::new(bytes)?;
     let mut imports = IndexMap::new();
     let mut exports = IndexMap::new();
@@ -224,7 +176,9 @@ pub fn decode_component_interfaces(bytes: &[u8]) -> Result<ComponentInterfaces> 
         Some(InterfaceDecoder::new(&info).decode(default.iter().map(|(n, t)| (*n, *t)))?)
     };
 
-    Ok(ComponentInterfaces {
+    Ok(World {
+        name: name.to_string(),
+        docs: Default::default(),
         imports,
         exports,
         default,

--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -2167,7 +2167,7 @@ impl ComponentEncoder {
     /// Add a "world" of interfaces (exports/imports/default) to this encoder
     /// to configure what's being imported/exported.
     ///
-    /// The string encoding of the specified interface set is supplied here as
+    /// The string encoding of the specified world is supplied here as
     /// well.
     pub fn world(mut self, world: World, encoding: StringEncoding) -> Result<Self> {
         self.metadata.merge(BindgenMetadata::new(world, encoding))?;

--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -58,7 +58,7 @@ use crate::{
         validate_adapter_module, validate_module, ValidatedAdapter, ValidatedModule,
         MAIN_MODULE_IMPORT_NAME,
     },
-    ComponentInterfaces, StringEncoding,
+    StringEncoding,
 };
 use anyhow::{anyhow, bail, Context, Result};
 use indexmap::{map::Entry, IndexMap, IndexSet};
@@ -69,7 +69,7 @@ use wasmparser::{FuncType, Validator, WasmFeatures};
 use wit_parser::{
     abi::{AbiVariant, WasmSignature, WasmType},
     Enum, Flags, Function, FunctionKind, Interface, Params, Record, Result_, Results, Tuple, Type,
-    TypeDef, TypeDefKind, Union, Variant,
+    TypeDef, TypeDefKind, Union, Variant, World,
 };
 
 const INDIRECT_TABLE_NAME: &str = "$imports";
@@ -1300,7 +1300,7 @@ impl<'a> EncodingState<'a> {
         instance_index: u32,
         realloc_index: Option<u32>,
     ) -> Result<()> {
-        for (export, export_name) in metadata.interfaces.exports() {
+        for (export, export_name) in metadata.world.exports() {
             let mut interface_exports = Vec::new();
 
             // Make sure all named types are present in the exported instance
@@ -2169,13 +2169,8 @@ impl ComponentEncoder {
     ///
     /// The string encoding of the specified interface set is supplied here as
     /// well.
-    pub fn interfaces(
-        mut self,
-        interfaces: ComponentInterfaces,
-        encoding: StringEncoding,
-    ) -> Result<Self> {
-        self.metadata
-            .merge(BindgenMetadata::new(interfaces, encoding))?;
+    pub fn world(mut self, world: World, encoding: StringEncoding) -> Result<Self> {
+        self.metadata.merge(BindgenMetadata::new(world, encoding))?;
         Ok(self)
     }
 
@@ -2225,15 +2220,11 @@ impl ComponentEncoder {
         let mut state = EncodingState::default();
         let mut types = TypeEncoder::default();
         let mut imports = ImportEncoder::default();
-        types.encode_func_types(self.metadata.interfaces.exports().map(|p| p.0))?;
-        types.encode_instance_imports(
-            &self.metadata.interfaces.imports,
-            info.as_ref(),
-            &mut imports,
-        )?;
+        types.encode_func_types(self.metadata.world.exports().map(|p| p.0))?;
+        types.encode_instance_imports(&self.metadata.world.imports, info.as_ref(), &mut imports)?;
 
         for (_name, (_, metadata)) in self.adapters.iter() {
-            types.encode_func_types(metadata.interfaces.exports().map(|p| p.0))?;
+            types.encode_func_types(metadata.world.exports().map(|p| p.0))?;
         }
 
         if self.types_only {
@@ -2248,7 +2239,7 @@ impl ComponentEncoder {
             // itself.
             let mut raw_exports = Vec::new();
             let mut default_exports = Vec::new();
-            for (interface, name) in self.metadata.interfaces.exports() {
+            for (interface, name) in self.metadata.world.exports() {
                 match name {
                     Some(name) => {
                         let index = types
@@ -2310,13 +2301,13 @@ impl ComponentEncoder {
                     .context("failed to validate the imports of the minimized adapter module")?;
                 state.encode_core_adapter_module(name, &wasm);
                 for (name, required) in info.required_imports.iter() {
-                    let interface = &metadata.interfaces.imports[*name];
+                    let interface = &metadata.world.imports[*name];
                     types.encode_instance_import(name, interface, Some(required), &mut imports)?;
                 }
                 imports.adapters.insert(name, info);
             }
 
-            for (interface, _default) in self.metadata.interfaces.exports() {
+            for (interface, _default) in self.metadata.world.exports() {
                 types.encode_interface_named_types(interface)?;
             }
 
@@ -2332,7 +2323,7 @@ impl ComponentEncoder {
                 state.realloc_index,
             )?;
             for (name, (_, metadata)) in self.adapters.iter() {
-                if metadata.interfaces.exports().count() == 0 {
+                if metadata.world.exports().count() == 0 {
                     continue;
                 }
                 state.encode_exports(
@@ -2373,7 +2364,7 @@ fn required_adapter_exports(
             required.insert(name.to_string(), ty.clone());
         }
     }
-    for (interface, name) in metadata.interfaces.exports() {
+    for (interface, name) in metadata.world.exports() {
         for func in interface.functions.iter() {
             let name = func.core_export_name(name);
             let ty = interface.wasm_signature(AbiVariant::GuestExport, func);

--- a/crates/wit-component/src/lib.rs
+++ b/crates/wit-component/src/lib.rs
@@ -13,7 +13,7 @@ mod gc;
 mod printing;
 mod validation;
 
-pub use decoding::{decode_component_interfaces, ComponentInterfaces};
+pub use decoding::decode_world;
 pub use encoding::*;
 pub use printing::*;
 

--- a/crates/wit-component/src/validation.rs
+++ b/crates/wit-component/src/validation.rs
@@ -160,7 +160,7 @@ pub fn validate_module<'a>(
             bail!("module imports from an empty module name");
         }
 
-        match metadata.interfaces.imports.get(*name) {
+        match metadata.world.imports.get(*name) {
             Some(interface) => {
                 validate_imported_interface(interface, name, funcs, &types)?;
                 let funcs = funcs.into_iter().map(|(f, _ty)| *f).collect();
@@ -178,11 +178,11 @@ pub fn validate_module<'a>(
         }
     }
 
-    if let Some(interface) = &metadata.interfaces.default {
+    if let Some(interface) = &metadata.world.default {
         validate_exported_interface(interface, None, &export_funcs, &types)?;
     }
 
-    for (name, interface) in metadata.interfaces.exports.iter() {
+    for (name, interface) in metadata.world.exports.iter() {
         if name.is_empty() {
             bail!("cannot export an interface with an empty name");
         }
@@ -336,7 +336,7 @@ pub fn validate_adapter_module<'a>(
                 .extend(funcs.iter().map(|(name, _ty)| name.to_string()));
         } else {
             let interface = metadata
-                .interfaces
+                .world
                 .imports
                 .get(name)
                 .ok_or_else(|| anyhow!("adapter module imports unknown module `{name}`"))?;

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -69,6 +69,16 @@ impl World {
             }
         }
     }
+
+    /// Returns an iterator which visits all the exported interfaces, both named
+    /// and default. The second entry in each pair the export name of the
+    /// interface, or `None` if it's the default export interface.
+    pub fn exports(&self) -> impl Iterator<Item = (&Interface, Option<&str>)> + '_ {
+        self.exports
+            .iter()
+            .map(|(name, i)| (i, Some(name.as_str())))
+            .chain(self.default.iter().map(|i| (i, None)))
+    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq)]

--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use std::path::{Path, PathBuf};
 use wasm_tools::Output;
-use wit_component::{decode_component_interfaces, ComponentEncoder, StringEncoding, WorldPrinter};
+use wit_component::{decode_world, ComponentEncoder, StringEncoding, WorldPrinter};
 use wit_parser::World;
 
 /// WebAssembly wit-based component tooling.
@@ -122,7 +122,7 @@ impl NewOpts {
         if let Some(wit) = &self.wit {
             let encoding = self.encoding.unwrap_or(StringEncoding::UTF8);
             let world = World::parse_file(wit)?;
-            encoder = encoder.interfaces(world.into(), encoding)?;
+            encoder = encoder.world(world, encoding)?;
         }
 
         for (name, wasm) in self.adapters.iter() {
@@ -168,10 +168,7 @@ impl WitOpts {
             },
         };
 
-        let interfaces =
-            decode_component_interfaces(&bytes).context("failed to decode component")?;
-        let world = interfaces.into_world(name);
-
+        let world = decode_world(name, &bytes).context("failed to decode world")?;
         let mut printer = WorldPrinter::default();
         let output = printer.print(&world)?;
         self.io.output(Output::Wat(&output))?;


### PR DESCRIPTION
This was a temporary holdover until a `World` existed in `wit-parser`, which it now does, so remove the old type.