### PR TITLE
Bump versions of wasm-tools crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-tools"
-version = "1.0.14"
+version = "1.0.15"
 authors = ["The Wasmtime Project Developers"]
 edition.workspace = true
 description = "CLI tools for interoperating with WebAssembly files"
@@ -39,17 +39,17 @@ rayon = "1.3"
 serde = { version = "1.0.137", features = ["derive"] }
 wasmtime = "1.0.0"
 
-wasm-encoder = { version = "0.19.1", path = "crates/wasm-encoder"}
-wasm-compose = { version = "0.2.0", path = "crates/wasm-compose"}
-wasm-mutate = { version = "0.2.11", path = "crates/wasm-mutate" }
-wasm-shrink = { version = "0.1.13", path = "crates/wasm-shrink" }
-wasm-smith = { version = "0.11.8", path = "crates/wasm-smith" }
-wasmparser = { version = "0.94.0", path = "crates/wasmparser" }
-wasmparser-dump = { version = "0.1.11", path = "crates/dump" }
-wasmprinter = { version = "0.2.43", path = "crates/wasmprinter" }
-wast = { version = "49.0.0", path = "crates/wast" }
-wat = { version = "1.0.51", path = "crates/wat" }
-wit-component = { version = "0.3.0", path = "crates/wit-component" }
+wasm-encoder = { version = "0.20.0", path = "crates/wasm-encoder"}
+wasm-compose = { version = "0.2.1", path = "crates/wasm-compose"}
+wasm-mutate = { version = "0.2.12", path = "crates/wasm-mutate" }
+wasm-shrink = { version = "0.1.14", path = "crates/wasm-shrink" }
+wasm-smith = { version = "0.11.9", path = "crates/wasm-smith" }
+wasmparser = { version = "0.95.0", path = "crates/wasmparser" }
+wasmparser-dump = { version = "0.1.12", path = "crates/dump" }
+wasmprinter = { version = "0.2.44", path = "crates/wasmprinter" }
+wast = { version = "50.0.0", path = "crates/wast" }
+wat = { version = "1.0.52", path = "crates/wat" }
+wit-component = { version = "0.3.1", path = "crates/wit-component" }
 wit-parser = { version = "0.3.0", path = "crates/wit-parser" }
 
 [dependencies]

--- a/crates/dump/Cargo.toml
+++ b/crates/dump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser-dump"
-version = "0.1.11"
+version = "0.1.12"
 authors = ["The Wasmtime Project Developers"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasm-compose/Cargo.toml
+++ b/crates/wasm-compose/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-compose"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors = ["Peter Huene <peter@huene.dev>"]
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasm-encoder/Cargo.toml
+++ b/crates/wasm-encoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-encoder"
-version = "0.19.1"
+version = "0.20.0"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasm-mutate/Cargo.toml
+++ b/crates/wasm-mutate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-mutate"
-version = "0.2.11"
+version = "0.2.12"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-mutate"

--- a/crates/wasm-shrink/Cargo.toml
+++ b/crates/wasm-shrink/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-shrink"
 name = "wasm-shrink"
-version = "0.1.13"
+version = "0.1.14"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "wasm-smith"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-smith"
-version = "0.11.8"
+version = "0.11.9"
 exclude = ["/benches/corpus"]
 
 [[bench]]

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.94.0"
+version = "0.95.0"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser"

--- a/crates/wasmprinter/Cargo.toml
+++ b/crates/wasmprinter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmprinter"
-version = "0.2.43"
+version = "0.2.44"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wast"
-version = "49.0.0"
+version = "50.0.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wat/Cargo.toml
+++ b/crates/wat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wat"
-version = "1.0.51"
+version = "1.0.52"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wit-component/Cargo.toml
+++ b/crates/wit-component/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-component"
 authors = ["Peter Huene <peter@huene.dev>"]
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 
 [dependencies]


### PR DESCRIPTION
Primarily also release the `wit-parser` and `wit-component` crates to crates.io.