### PR TITLE
Update Wasmtime and turn some features off

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ num_cpus = "1.13"
 rand = { version = "0.8.4", features = ["small_rng"] }
 rayon = "1.3"
 serde = { version = "1.0.137", features = ["derive"] }
-wasmtime = "1.0.0"
+wasmtime = { version = "3.0.0", default-features = false, features = ['cranelift'] }
 
 wasm-encoder = { version = "0.20.0", path = "crates/wasm-encoder"}
 wasm-compose = { version = "0.2.1", path = "crates/wasm-compose"}

--- a/fuzz/fuzz_targets/no-traps.rs
+++ b/fuzz/fuzz_targets/no-traps.rs
@@ -75,10 +75,8 @@ fuzz_target!(|data: &[u8]| {
             // Allow stack overflow since this generally can't be protected
             // against as it's an implementation detail of cranelift we could
             // expose regardless of the limits placed on the function.
-            if let Some(trap) = err.downcast_ref::<wasmtime::Trap>() {
-                if let Some(wasmtime::TrapCode::StackOverflow) = trap.trap_code() {
-                    return;
-                }
+            if let Some(wasmtime::Trap::StackOverflow) = err.downcast_ref::<wasmtime::Trap>() {
+                return;
             }
 
             let s = err.to_string();


### PR DESCRIPTION
This is intended to fix build failures on oss-fuzz stemming from a recent update to `zstd-sys` which includes the `-flto=thin` flag by default that is apparently not compatible with the oss-fuzz builders. This both updates Wasmtime and turns off the `cache` feature so the `zstd-sys` crate is not pulled in.