### PR TITLE
mutate: Don't remove drop nodes when preserving semantics

### DIFF
--- a/crates/wasm-mutate/src/mutators/peephole/rules.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/rules.rs
@@ -313,7 +313,7 @@ impl PeepholeMutator {
         }
 
         // Mess with dropped subexpressions.
-        if !config.reduce {
+        if !config.reduce && !config.preserve_semantics {
             rules.extend(vec![
                 rewrite!(
                     "i32.drop-x";


### PR DESCRIPTION
This fixes a recent fuzz-bug found where removal of `(drop ?x)` would remove a side-effectful `?x` which isn't preserving of semantics.