### PR TITLE
wit-parser: re-enable use

### DIFF
--- a/crates/wit-parser/Cargo.toml
+++ b/crates/wit-parser/Cargo.toml
@@ -17,6 +17,7 @@ id-arena = "2"
 anyhow = { workspace = true }
 indexmap = { workspace = true }
 pulldown-cmark = { version = "0.8", default-features = false }
+topo_sort = "0.4"
 unicode-xid = "0.2.2"
 
 [dev-dependencies]


### PR DESCRIPTION
**WIP**

This PR temporarily re-enables `use` for the single-file `*.wit` scenario.
The implementation orders interfaces topologically and then processes
each interface's use dependencies in order.

As a concrete example, consider:

```wit
// service.wit

interface service-handler {
    use { request, response } from service-types
    use { error } from service-common

    f: func(req: request) -> result<response, error>
}

interface service-types {
    use { message, request, response } from service-common
}

interface service-common {
    record message {
        text: string
    }

    record request {
        mesg: message
    }

    record response {
        mesg: message,
        code: s32
    }

    enum error {
        ok,
        bad,
    }
}

world service {
    export handler: service-handler
}
```

Running `wasm-tools component new --types-only --wit service.wit -t -o service.wat` produces:

```
(component
  (type (;0;) (record (field "text" string)))
  (type (;1;) (record (field "mesg" 0)))
  (type (;2;) (record (field "mesg" 0) (field "code" s32)))
  (type (;3;) (enum "ok" "bad"))
  (type (;4;) (result 2 (error 3)))
  (type (;5;) (func (param "req" 1) (result 4)))
  (type (;6;)
    (instance
      (alias outer 1 0 (type (;0;)))
      (export "message" (type (eq 0)))
      (alias outer 1 1 (type (;1;)))
      (export "request" (type (eq 1)))
      (alias outer 1 2 (type (;2;)))
      (export "response" (type (eq 2)))
      (alias outer 1 3 (type (;3;)))
      (export "error" (type (eq 3)))
      (alias outer 1 5 (type (;4;)))
      (export "f" (func (type 4)))
    )
  )
  (export "handler" (type 6))
)
```


Signed-off-by: Brian H <brian.hardock@fermyon.com>