### PR TITLE
wasmparser: split parsers for different elems

### DIFF
--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -130,8 +130,17 @@ fn read_all_wasm(wasm: &[u8]) -> Result<()> {
                             op?;
                         }
                     }
-                    for op in item.items.get_items_reader()? {
-                        op?;
+                    match item.items {
+                        wasmparser::ElementItems::Functions(r) => {
+                            for op in r {
+                                op?;
+                            }
+                        }
+                        wasmparser::ElementItems::Expressions(r) => {
+                            for op in r {
+                                op?;
+                            }
+                        }
                     }
                 }
             }

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -1116,18 +1116,21 @@ impl Printer {
                     self.print_const_expr_sugar(state, offset_expr, "offset")?;
                 }
             }
-            let mut items_reader = elem.items.get_items_reader()?;
             self.result.push(' ');
-            if items_reader.uses_exprs() {
-                self.print_valtype(elem.ty)?;
-            } else {
-                self.print_reftype(elem.ty)?;
-            }
-            for _ in 0..items_reader.get_count() {
-                self.result.push(' ');
-                match items_reader.read()? {
-                    ElementItem::Expr(expr) => self.print_const_expr_sugar(state, &expr, "item")?,
-                    ElementItem::Func(idx) => self.print_idx(&state.core.func_names, idx)?,
+            match elem.items {
+                ElementItems::Functions(mut reader) => {
+                    self.print_reftype(elem.ty)?;
+                    for _ in 0..reader.get_count() {
+                        self.result.push(' ');
+                        self.print_idx(&state.core.func_names, reader.read()?)?
+                    }
+                }
+                ElementItems::Expressions(mut reader) => {
+                    self.print_valtype(elem.ty)?;
+                    for _ in 0..reader.get_count() {
+                        self.result.push(' ');
+                        self.print_const_expr_sugar(state, &reader.read()?, "item")?
+                    }
                 }
             }
             self.end_group();

--- a/tests/dump/simple.wat.dump
+++ b/tests/dump/simple.wat.dump
@@ -35,11 +35,11 @@
  0x42 | 41 03       | i32_const value:3
  0x44 | 0b          | end
  0x45 | 01          | 1 items
- 0x46 | 00          | item Func(0)
+ 0x46 | 00          | item 0
  0x47 | 01 00 01    | element FuncRef passive, 1 items
- 0x4a | 00          | item Func(0)
+ 0x4a | 00          | item 0
  0x4b | 03 00 01    | element FuncRef declared 1 items
- 0x4e | 00          | item Func(0)
+ 0x4e | 00          | item 0
  0x4f | 0a 10       | code section
  0x51 | 03          | 3 count
 ============== func 1 ====================


### PR DESCRIPTION
Given an `elem`, whether it is going to contain function indices or constexprs is determined early on, and once determined, this won’t change.

The way wasmparser’s API was structured suggested that such change within a single element is in fact possible, which confused me every time I encountered this. By introducing two distinct readers for each kind of element items, this property is encoded in the API, much like it is in wasm_encoder.

Although unverified and not at all the focus of this PR, this change may also improve the performance of parsing items, as the branch checking for whether the item is an expression of a function is now outside of the loop by construction.