### PR TITLE
Disable wasmtime execution in no-traps and mutate fuzzers

### DIFF
--- a/fuzz/fuzz_targets/mutate.rs
+++ b/fuzz/fuzz_targets/mutate.rs
@@ -130,6 +130,13 @@ mod eval {
     /// We should get identical results because we told `wasm-mutate` to preserve
     /// semantics.
     pub fn assert_same_evaluation(wasm: &[u8], mutated_wasm: &[u8]) {
+        // TODO: should re-enable this when the fuzzer works again, needs
+        // someone to invest energy into running this locally for a long time
+        // and then be on the hook for incoming oss-fuzz bugs.
+        if true {
+            return;
+        }
+
         let mut config = wasmtime::Config::default();
         config.cranelift_nan_canonicalization(true);
         config.consume_fuel(true);

--- a/fuzz/fuzz_targets/no-traps.rs
+++ b/fuzz/fuzz_targets/no-traps.rs
@@ -29,6 +29,13 @@ fuzz_target!(|data: &[u8]| {
 
     #[cfg(feature = "wasmtime")]
     {
+        // TODO: should re-enable this when the fuzzer works again, needs
+        // someone to invest energy into running this locally for a long time
+        // and then be on the hook for incoming oss-fuzz bugs.
+        if true {
+            return;
+        }
+
         // Configure the engine, module, and store
         let mut eng_conf = Config::new();
         eng_conf.wasm_memory64(true);


### PR DESCRIPTION
Lots of oss-fuzz bugs have been coming in for these fuzzers and I'm not personally up to fixing all the issues, so disable these until someone's on the hook for fixing the issues.