### PR TITLE
[wasm-smith] ⛽ Allow OutOfFuel traps during module instantiation

### DIFF
--- a/fuzz/fuzz_targets/no-traps.rs
+++ b/fuzz/fuzz_targets/no-traps.rs
@@ -79,6 +79,11 @@ fuzz_target!(|data: &[u8]| {
                 return;
             }
 
+            // Allow out of fuel on module instantiation
+            if let Some(wasmtime::Trap::OutOfFuel) = err.downcast_ref::<wasmtime::Trap>() {
+                return;
+            }
+
             let s = err.to_string();
             // Allow "nominal" traps such as running out of fuel and the
             // module trying to allocate more resources than we'd like to


### PR DESCRIPTION
Fixes #852. The following module was causing an out of fuel trap during instantiation:

```
(module
  (type (;0;) (func))
  (func (;0;) (type 0)
    call 0
  )
  (start 0)
)
```

Apparently during instantiation, the resulting error string is always "error while executing at wasm backtrace:" so to actually check for an OutOfFuel trap, we need to downcast the error to a wasmtime::Trap first.