### PR TITLE
Consolidate list-reading functions into `read_iter`

### DIFF
--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -158,7 +158,7 @@ fn read_all_wasm(wasm: &[u8]) -> Result<()> {
                 let mut reader = body.get_binary_reader();
                 for _ in 0..reader.read_var_u32()? {
                     reader.read_var_u32()?;
-                    reader.read_val_type()?;
+                    reader.read::<wasmparser::ValType>()?;
                 }
                 while !reader.eof() {
                     reader.visit_operator(&mut NopVisit)?;

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -17,6 +17,7 @@ use crate::{limits::*, *};
 use std::convert::TryInto;
 use std::error::Error;
 use std::fmt;
+use std::marker;
 use std::ops::Range;
 use std::str;
 
@@ -194,20 +195,6 @@ impl<'a> BinaryReader<'a> {
         Ok(b)
     }
 
-    /// Reads a core WebAssembly value type from the binary reader.
-    pub fn read_val_type(&mut self) -> Result<ValType> {
-        match Self::val_type_from_byte(self.peek()?) {
-            Some(ty) => {
-                self.position += 1;
-                Ok(ty)
-            }
-            None => Err(BinaryReaderError::new(
-                "invalid value type",
-                self.original_position(),
-            )),
-        }
-    }
-
     pub(crate) fn external_kind_from_byte(byte: u8, offset: usize) -> Result<ExternalKind> {
         match byte {
             0x00 => Ok(ExternalKind::Func),
@@ -219,25 +206,38 @@ impl<'a> BinaryReader<'a> {
         }
     }
 
-    pub(crate) fn read_type_vec(
-        &mut self,
-        max: usize,
-        desc: &str,
-    ) -> Result<Box<[(&'a str, ComponentValType)]>> {
-        let size = self.read_size(max, desc)?;
-        (0..size)
-            .map(|_| Ok((self.read_string()?, self.read()?)))
-            .collect::<Result<_>>()
-    }
-
-    // Reads a variable-length 32-bit size from the byte stream while checking
-    // against a limit.
-    pub(crate) fn read_size(&mut self, limit: usize, desc: &str) -> Result<usize> {
+    /// Reads a variable-length 32-bit size from the byte stream while checking
+    /// against a limit.
+    pub fn read_size(&mut self, limit: usize, desc: &str) -> Result<usize> {
+        let pos = self.original_position();
         let size = self.read_var_u32()? as usize;
         if size > limit {
-            bail!(self.original_position() - 4, "{desc} size is out of bounds");
+            bail!(pos, "{desc} size is out of bounds");
         }
         Ok(size)
+    }
+
+    /// Reads a variable-length 32-bit size from the byte stream while checking
+    /// against a limit.
+    ///
+    /// Then reads that many values of type `T` and returns them as an iterator.
+    ///
+    /// Note that regardless of how many items are read from the returned
+    /// iterator the items will still be parsed from this reader.
+    pub fn read_iter<'me, T>(
+        &'me mut self,
+        limit: usize,
+        desc: &str,
+    ) -> Result<BinaryReaderIter<'a, 'me, T>>
+    where
+        T: FromReader<'a>,
+    {
+        let size = self.read_size(limit, desc)?;
+        Ok(BinaryReaderIter {
+            remaining: size,
+            reader: self,
+            _marker: marker::PhantomData,
+        })
     }
 
     fn read_first_byte_and_var_u32(&mut self) -> Result<(u8, u32)> {
@@ -657,19 +657,6 @@ impl<'a> BinaryReader<'a> {
         Ok(self.buffer[self.position])
     }
 
-    fn val_type_from_byte(byte: u8) -> Option<ValType> {
-        match byte {
-            0x7F => Some(ValType::I32),
-            0x7E => Some(ValType::I64),
-            0x7D => Some(ValType::F32),
-            0x7C => Some(ValType::F64),
-            0x7B => Some(ValType::V128),
-            0x70 => Some(ValType::FuncRef),
-            0x6F => Some(ValType::ExternRef),
-            _ => None,
-        }
-    }
-
     fn read_block_type(&mut self) -> Result<BlockType> {
         let b = self.peek()?;
 
@@ -680,7 +667,7 @@ impl<'a> BinaryReader<'a> {
         }
 
         // Check for a block type of form [] -> [t].
-        if let Some(ty) = Self::val_type_from_byte(b) {
+        if let Some(ty) = ValType::from_byte(b) {
             self.position += 1;
             return Ok(BlockType::Type(ty));
         }
@@ -784,7 +771,7 @@ impl<'a> BinaryReader<'a> {
                         self.position,
                     ));
                 }
-                visitor.visit_typed_select(self.read_val_type()?)
+                visitor.visit_typed_select(self.read()?)
             }
 
             0x20 => visitor.visit_local_get(self.read_var_u32()?),
@@ -962,7 +949,7 @@ impl<'a> BinaryReader<'a> {
             0xc3 => visitor.visit_i64_extend16_s(),
             0xc4 => visitor.visit_i64_extend32_s(),
 
-            0xd0 => visitor.visit_ref_null(self.read_val_type()?),
+            0xd0 => visitor.visit_ref_null(self.read()?),
             0xd1 => visitor.visit_ref_is_null(),
             0xd2 => visitor.visit_ref_func(self.read_var_u32()?),
 
@@ -1621,4 +1608,47 @@ impl<'a> VisitOperator<'a> for OperatorFactory<'a> {
     type Output = Operator<'a>;
 
     for_each_operator!(define_visit_operator);
+}
+
+/// Iterator returned from [`BinaryReader::read_iter`].
+pub struct BinaryReaderIter<'a, 'me, T: FromReader<'a>> {
+    remaining: usize,
+    reader: &'me mut BinaryReader<'a>,
+    _marker: marker::PhantomData<T>,
+}
+
+impl<'a, T> Iterator for BinaryReaderIter<'a, '_, T>
+where
+    T: FromReader<'a>,
+{
+    type Item = Result<T>;
+
+    fn next(&mut self) -> Option<Result<T>> {
+        if self.remaining == 0 {
+            None
+        } else {
+            let ret = self.reader.read::<T>();
+            if ret.is_err() {
+                self.remaining = 0;
+            } else {
+                self.remaining -= 1;
+            }
+            Some(ret)
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
+impl<'a, T> Drop for BinaryReaderIter<'a, '_, T>
+where
+    T: FromReader<'a>,
+{
+    fn drop(&mut self) {
+        while self.next().is_some() {
+            // ...
+        }
+    }
 }

--- a/crates/wasmparser/src/readers.rs
+++ b/crates/wasmparser/src/readers.rs
@@ -47,6 +47,16 @@ impl<'a> FromReader<'a> for &'a str {
     }
 }
 
+impl<'a, T, U> FromReader<'a> for (T, U)
+where
+    T: FromReader<'a>,
+    U: FromReader<'a>,
+{
+    fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        Ok((reader.read()?, reader.read()?))
+    }
+}
+
 /// A generic structure for reading a section of a WebAssembly binary which has
 /// a limited number of items within it.
 ///

--- a/crates/wasmparser/src/readers/component/instances.rs
+++ b/crates/wasmparser/src/readers/component/instances.rs
@@ -55,15 +55,13 @@ impl<'a> FromReader<'a> for Instance<'a> {
         Ok(match reader.read_u8()? {
             0x00 => Instance::Instantiate {
                 module_index: reader.read_var_u32()?,
-                args: (0..reader
-                    .read_size(MAX_WASM_INSTANTIATION_ARGS, "core instantiation arguments")?)
-                    .map(|_| reader.read())
+                args: reader
+                    .read_iter(MAX_WASM_INSTANTIATION_ARGS, "core instantiation arguments")?
                     .collect::<Result<_>>()?,
             },
             0x01 => Instance::FromExports(
-                (0..reader
-                    .read_size(MAX_WASM_INSTANTIATION_EXPORTS, "core instantiation exports")?)
-                    .map(|_| reader.read())
+                reader
+                    .read_iter(MAX_WASM_INSTANTIATION_ARGS, "core instantiation arguments")?
                     .collect::<Result<_>>()?,
             ),
             x => return reader.invalid_leading_byte(x, "core instance"),
@@ -134,9 +132,8 @@ impl<'a> FromReader<'a> for ComponentInstance<'a> {
         Ok(match reader.read_u8()? {
             0x00 => ComponentInstance::Instantiate {
                 component_index: reader.read_var_u32()?,
-                args: (0..reader
-                    .read_size(MAX_WASM_INSTANTIATION_ARGS, "instantiation arguments")?)
-                    .map(|_| reader.read())
+                args: reader
+                    .read_iter(MAX_WASM_INSTANTIATION_ARGS, "instantiation arguments")?
                     .collect::<Result<_>>()?,
             },
             0x01 => ComponentInstance::FromExports(

--- a/crates/wasmparser/src/readers/component/start.rs
+++ b/crates/wasmparser/src/readers/component/start.rs
@@ -17,13 +17,14 @@ pub struct ComponentStartFunction {
 impl<'a> FromReader<'a> for ComponentStartFunction {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
         let func_index = reader.read_var_u32()?;
-        let size = reader.read_size(MAX_WASM_START_ARGS, "start function arguments")?;
+        let arguments = reader
+            .read_iter(MAX_WASM_START_ARGS, "start function arguments")?
+            .collect::<Result<_>>()?;
+        let results = reader.read_size(MAX_WASM_FUNCTION_RETURNS, "start function results")? as u32;
         Ok(ComponentStartFunction {
             func_index,
-            arguments: (0..size)
-                .map(|_| reader.read_var_u32())
-                .collect::<Result<_>>()?,
-            results: reader.read_size(MAX_WASM_FUNCTION_RETURNS, "start function results")? as u32,
+            arguments,
+            results,
         })
     }
 }

--- a/crates/wasmparser/src/readers/core/code.rs
+++ b/crates/wasmparser/src/readers/core/code.rs
@@ -135,8 +135,8 @@ impl<'a> LocalsReader<'a> {
 
     /// Reads an item from the reader.
     pub fn read(&mut self) -> Result<(u32, ValType)> {
-        let count = self.reader.read_var_u32()?;
-        let value_type = self.reader.read_val_type()?;
+        let count = self.reader.read()?;
+        let value_type = self.reader.read()?;
         Ok((count, value_type))
     }
 }

--- a/crates/wasmparser/src/readers/core/elements.rs
+++ b/crates/wasmparser/src/readers/core/elements.rs
@@ -104,7 +104,7 @@ impl<'a> FromReader<'a> for Element<'a> {
         let exprs = flags & 0b100 != 0;
         let ty = if flags & 0b011 != 0 {
             if exprs {
-                reader.read_val_type()?
+                reader.read()?
             } else {
                 match reader.read()? {
                     ExternalKind::Func => ValType::FuncRef,

--- a/crates/wasmparser/src/readers/core/globals.rs
+++ b/crates/wasmparser/src/readers/core/globals.rs
@@ -38,7 +38,7 @@ impl<'a> FromReader<'a> for Global<'a> {
 impl<'a> FromReader<'a> for GlobalType {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
         Ok(GlobalType {
-            content_type: reader.read_val_type()?,
+            content_type: reader.read()?,
             mutable: match reader.read_u8()? {
                 0x00 => false,
                 0x01 => true,

--- a/crates/wasmparser/src/readers/core/tables.rs
+++ b/crates/wasmparser/src/readers/core/tables.rs
@@ -20,7 +20,7 @@ pub type TableSectionReader<'a> = SectionLimited<'a, TableType>;
 
 impl<'a> FromReader<'a> for TableType {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
-        let element_type = reader.read_val_type()?;
+        let element_type = reader.read()?;
         let has_max = match reader.read_u8()? {
             0x00 => false,
             0x01 => true,
@@ -31,12 +31,8 @@ impl<'a> FromReader<'a> for TableType {
                 )
             }
         };
-        let initial = reader.read_var_u32()?;
-        let maximum = if has_max {
-            Some(reader.read_var_u32()?)
-        } else {
-            None
-        };
+        let initial = reader.read()?;
+        let maximum = if has_max { Some(reader.read()?) } else { None };
         Ok(TableType {
             element_type,
             initial,

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -44,6 +44,31 @@ impl ValType {
     pub fn is_reference_type(&self) -> bool {
         matches!(self, ValType::FuncRef | ValType::ExternRef)
     }
+
+    pub(crate) fn from_byte(byte: u8) -> Option<ValType> {
+        match byte {
+            0x7F => Some(ValType::I32),
+            0x7E => Some(ValType::I64),
+            0x7D => Some(ValType::F32),
+            0x7C => Some(ValType::F64),
+            0x7B => Some(ValType::V128),
+            0x70 => Some(ValType::FuncRef),
+            0x6F => Some(ValType::ExternRef),
+            _ => None,
+        }
+    }
+}
+
+impl<'a> FromReader<'a> for ValType {
+    fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        match ValType::from_byte(reader.peek()?) {
+            Some(ty) => {
+                reader.position += 1;
+                Ok(ty)
+            }
+            None => bail!(reader.original_position(), "invalid value type"),
+        }
+    }
 }
 
 /// Represents a type in a WebAssembly module.
@@ -204,15 +229,14 @@ impl<'a> FromReader<'a> for Type {
 
 impl<'a> FromReader<'a> for FuncType {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
-        let len_params = reader.read_size(MAX_WASM_FUNCTION_PARAMS, "function params")?;
-        let mut params_results = Vec::with_capacity(len_params);
-        for _ in 0..len_params {
-            params_results.push(reader.read_val_type()?);
-        }
-        let len_results = reader.read_size(MAX_WASM_FUNCTION_RETURNS, "function returns")?;
-        params_results.reserve(len_results);
-        for _ in 0..len_results {
-            params_results.push(reader.read_val_type()?);
+        let mut params_results = reader
+            .read_iter(MAX_WASM_FUNCTION_PARAMS, "function params")?
+            .collect::<Result<Vec<_>>>()?;
+        let len_params = params_results.len();
+        let results = reader.read_iter(MAX_WASM_FUNCTION_RETURNS, "function returns")?;
+        params_results.reserve(results.size_hint().0);
+        for result in results {
+            params_results.push(result?);
         }
         Ok(FuncType::from_raw_parts(params_results.into(), len_params))
     }

--- a/crates/wasmparser/src/validator/func.rs
+++ b/crates/wasmparser/src/validator/func.rs
@@ -107,8 +107,8 @@ impl<T: WasmModuleResources> FuncValidator<T> {
     pub fn read_locals(&mut self, reader: &mut BinaryReader<'_>) -> Result<()> {
         for _ in 0..reader.read_var_u32()? {
             let offset = reader.original_position();
-            let cnt = reader.read_var_u32()?;
-            let ty = reader.read_val_type()?;
+            let cnt = reader.read()?;
+            let ty = reader.read()?;
             self.define_locals(offset, cnt, ty)?;
         }
         Ok(())

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -881,7 +881,7 @@ impl Printer {
             for _ in 0..body.read_var_u32()? {
                 let offset = body.original_position();
                 let cnt = body.read_var_u32()?;
-                let ty = body.read_val_type()?;
+                let ty = body.read()?;
                 if MAX_LOCALS
                     .checked_sub(local_idx)
                     .and_then(|s| s.checked_sub(cnt))

--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -302,7 +302,7 @@ impl<'a> Module<'a> {
             let local_count = body.read_var_u32()?;
             for _ in 0..local_count {
                 body.read_var_u32()?;
-                body.read_val_type()?;
+                body.read::<ValType>()?;
             }
             me.operators(body)
         }));
@@ -480,7 +480,7 @@ impl<'a> Module<'a> {
             let mut locals = Vec::new();
             for _ in 0..body.read_var_u32()? {
                 let cnt = body.read_var_u32()?;
-                let ty = body.read_val_type()?;
+                let ty = body.read()?;
                 locals.push((cnt, valty(ty)));
             }
             let mut func = wasm_encoder::Function::new(locals);


### PR DESCRIPTION
This commit adds a new `BinaryReader::read_iter` method which is used to consolidate all list-reading methods into one. This cleans up some duplicate code in locations to read a size and then collect that many items onto a returned list.

In the process this also adds `FromReader<'a> for ValType`.