### PR TITLE
Cleanup skipping methods in `BinaryReader`

### DIFF
--- a/crates/wasm-mutate/src/mutators/codemotion.rs
+++ b/crates/wasm-mutate/src/mutators/codemotion.rs
@@ -74,7 +74,7 @@ impl CodemotionMutator {
 
         for fidx in (function_to_mutate..function_count).chain(0..function_to_mutate) {
             config.consume_fuel(1)?;
-            let reader = all_readers[fidx as usize];
+            let reader = all_readers[fidx as usize].clone();
             let mut operatorreader = reader.get_operators_reader()?;
             operatorreader.allow_memarg64(true);
 

--- a/crates/wasm-mutate/src/mutators/peephole.rs
+++ b/crates/wasm-mutate/src/mutators/peephole.rs
@@ -137,7 +137,7 @@ impl PeepholeMutator {
                 return Err(Error::no_mutations_applicable());
             }
 
-            let reader = readers[function_to_mutate as usize];
+            let reader = readers[function_to_mutate as usize].clone();
             let mut operatorreader = reader.get_operators_reader()?;
             operatorreader.allow_memarg64(true);
             let mut localsreader = reader.get_locals_reader()?;
@@ -272,7 +272,7 @@ impl PeepholeMutator {
 
                         config.consume_fuel(1)?;
 
-                        let mut newfunc = self.copy_locals(reader)?;
+                        let mut newfunc = self.copy_locals(reader.clone())?;
                         let needed_resources = Encoder::build_function(
                             config,
                             opcode_to_mutate,

--- a/crates/wasmparser/src/readers.rs
+++ b/crates/wasmparser/src/readers.rs
@@ -259,10 +259,7 @@ impl<'a, T> Subsections<'a, T> {
         T: Subsection<'a>,
     {
         let subsection_id = self.reader.read_u7()?;
-        let payload_len = self.reader.read_var_u32()? as usize;
-        let offset = self.reader.original_position();
-        let data = self.reader.read_bytes(payload_len)?;
-        let reader = BinaryReader::new_with_offset(data, offset);
+        let reader = self.reader.read_reader("unexpected end of section")?;
         T::from_reader(subsection_id, reader)
     }
 }

--- a/crates/wasmparser/src/readers/core/operators.rs
+++ b/crates/wasmparser/src/readers/core/operators.rs
@@ -129,13 +129,8 @@ pub struct OperatorsReader<'a> {
 }
 
 impl<'a> OperatorsReader<'a> {
-    pub(crate) fn new<'b>(data: &'a [u8], offset: usize) -> OperatorsReader<'b>
-    where
-        'a: 'b,
-    {
-        OperatorsReader {
-            reader: BinaryReader::new_with_offset(data, offset),
-        }
+    pub(crate) fn new(reader: BinaryReader<'a>) -> OperatorsReader<'a> {
+        OperatorsReader { reader }
     }
 
     /// Determines if the reader is at the end of the operators.
@@ -171,18 +166,12 @@ impl<'a> OperatorsReader<'a> {
     }
 
     /// Reads an operator from the reader.
-    pub fn read<'b>(&mut self) -> Result<Operator<'b>>
-    where
-        'a: 'b,
-    {
+    pub fn read(&mut self) -> Result<Operator<'a>> {
         self.reader.read_operator()
     }
 
     /// Converts to an iterator of operators paired with offsets.
-    pub fn into_iter_with_offsets<'b>(self) -> OperatorsIteratorWithOffsets<'b>
-    where
-        'a: 'b,
-    {
+    pub fn into_iter_with_offsets(self) -> OperatorsIteratorWithOffsets<'a> {
         OperatorsIteratorWithOffsets {
             reader: self,
             err: false,
@@ -190,10 +179,7 @@ impl<'a> OperatorsReader<'a> {
     }
 
     /// Reads an operator with its offset.
-    pub fn read_with_offset<'b>(&mut self) -> Result<(Operator<'b>, usize)>
-    where
-        'a: 'b,
-    {
+    pub fn read_with_offset(&mut self) -> Result<(Operator<'a>, usize)> {
         let pos = self.reader.original_position();
         Ok((self.read()?, pos))
     }

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -436,7 +436,7 @@ impl Validator {
             } => self.code_section_start(*count, range)?,
             CodeSectionEntry(body) => {
                 let func_validator = self.code_section_entry(body)?;
-                return Ok(ValidPayload::Func(func_validator, *body));
+                return Ok(ValidPayload::Func(func_validator, body.clone()));
             }
             DataSection(s) => self.data_section(s)?,
 


### PR DESCRIPTION
This commit consolidates and simplifies some methods around skipping data in a `BinaryReader`, typically to get a new reader to parse it later. Notably a field of `BinaryReader` is now private and there's less open-coding around the offsets and internal state management.