### PR TITLE
wasm-smith: Fix fuzzing errors

### DIFF
--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -1299,7 +1299,7 @@ impl Module {
                     // it will fit. Afterwards ensure that the offset of the
                     // data segment is in-bounds by clamping it to the
                     if self.config.disallow_traps() {
-                        let max_size = mem.minimum * 64 * 1024;
+                        let max_size = (u64::MAX / 64 / 1024).min(mem.minimum) * 64 * 1024;
                         init.truncate(max_size as usize);
                         let max_offset = max_size - init.len() as u64;
                         match &mut offset {

--- a/crates/wasm-smith/src/core/code_builder.rs
+++ b/crates/wasm-smith/src/core/code_builder.rs
@@ -4352,11 +4352,11 @@ fn memory_offset(u: &mut Unstructured, module: &Module, memory_index: u32) -> Re
         // work. 16 is the number of bytes of the largest load type (V128).
         (true, true) => {
             let no_trap_max = (i64::MAX - 16) as u64;
-            (min, no_trap_max, no_trap_max)
+            (min.min(no_trap_max), no_trap_max, no_trap_max)
         }
         (false, true) => {
             let no_trap_max = (i32::MAX - 16) as u64;
-            (min, no_trap_max, no_trap_max)
+            (min.min(no_trap_max), no_trap_max, no_trap_max)
         }
     };
 


### PR DESCRIPTION
These two wasm-smith errors popped up on oss-fuzz the other day:
- Crash with error "`arbitrary::Unstructured::int_in_range` requires a non-empty range" at src/core/code_builder.rs:4367
- Crash with error "attempt to multiply with overflow" at src/core.rs:1302

The first error occurred because we were providing a minimum memory offset value that was greater than the max mem offset value (due to how we clamp the max offset in non-trapping mode). To fix this, we can set the minimum to be equal to the max in this case (which will result in arbitrary choosing exactly that value as the memory offset).

The second error occurred because we were attempting to multiply the minimum memory by the page size, which was resulting in an overflow. To perform this calculation, we need to ensure that our arbitrary page count is <= `u64::MAX / (2^16)`