### PR TITLE
Bump some crate versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,12 +42,12 @@ wasmtime = { version = "3.0.0", default-features = false, features = ['cranelift
 
 wasm-encoder = { version = "0.20.0", path = "crates/wasm-encoder"}
 wasm-compose = { version = "0.2.1", path = "crates/wasm-compose"}
-wasm-mutate = { version = "0.2.12", path = "crates/wasm-mutate" }
+wasm-mutate = { version = "0.2.13", path = "crates/wasm-mutate" }
 wasm-shrink = { version = "0.1.14", path = "crates/wasm-shrink" }
-wasm-smith = { version = "0.11.9", path = "crates/wasm-smith" }
-wasmparser = { version = "0.95.0", path = "crates/wasmparser" }
+wasm-smith = { version = "0.11.10", path = "crates/wasm-smith" }
+wasmparser = { version = "0.96.0", path = "crates/wasmparser" }
 wasmparser-dump = { version = "0.1.12", path = "crates/dump" }
-wasmprinter = { version = "0.2.44", path = "crates/wasmprinter" }
+wasmprinter = { version = "0.2.45", path = "crates/wasmprinter" }
 wast = { version = "50.0.0", path = "crates/wast" }
 wat = { version = "1.0.52", path = "crates/wat" }
 wit-component = { version = "0.3.2", path = "crates/wit-component" }

--- a/crates/wasm-mutate/Cargo.toml
+++ b/crates/wasm-mutate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-mutate"
-version = "0.2.12"
+version = "0.2.13"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-mutate"

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "wasm-smith"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-smith"
-version = "0.11.9"
+version = "0.11.10"
 exclude = ["/benches/corpus"]
 
 [[bench]]

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.95.0"
+version = "0.96.0"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser"

--- a/crates/wasmprinter/Cargo.toml
+++ b/crates/wasmprinter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmprinter"
-version = "0.2.44"
+version = "0.2.45"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"


### PR DESCRIPTION
This specifically doesn't bump all crate versions as done by the `./publish` script since the `wit-{component,parser}` changes aren't ready for publication yet. Instead just some `wasmparser` changes along with fuzz fixes from `wasm-smith` are pushed out.