### PR TITLE
Use different stores in mutate fuzzer

### DIFF
--- a/crates/fuzz-stats/src/limits.rs
+++ b/crates/fuzz-stats/src/limits.rs
@@ -1,4 +1,6 @@
 use wasmtime::*;
+
+#[derive(Clone)]
 pub struct StoreLimits {
     pub remaining_memory: usize,
     pub oom: bool,


### PR DESCRIPTION
Otherwise the same limits are used for both stores which means that one instance may not hit the limits that another reaches. This ensures that both instances are run in isolation from each other to produce the same behavior.