### PR TITLE
Fix parsing of `select`-with-results

### DIFF
--- a/crates/wast/src/core/expr.rs
+++ b/crates/wast/src/core/expr.rs
@@ -1872,9 +1872,10 @@ pub struct SelectTypes<'a> {
 
 impl<'a> Parse<'a> for SelectTypes<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
-        let mut tys = None;
+        let mut found = false;
+        let mut list = Vec::new();
         while parser.peek2::<kw::result>() {
-            let mut list = Vec::new();
+            found = true;
             parser.parens(|p| {
                 p.parse::<kw::result>()?;
                 while !p.is_empty() {
@@ -1882,8 +1883,9 @@ impl<'a> Parse<'a> for SelectTypes<'a> {
                 }
                 Ok(())
             })?;
-            tys = Some(list);
         }
-        Ok(SelectTypes { tys })
+        Ok(SelectTypes {
+            tys: if found { Some(list) } else { None },
+        })
     }
 }

--- a/tests/local/select-interesting.wat
+++ b/tests/local/select-interesting.wat
@@ -1,0 +1,2 @@
+(func (result i32) unreachable select (result i32) (result))
+(func (result i32) unreachable select (result i32) (result) select)

--- a/tests/snapshots/local/select-interesting.wat.print
+++ b/tests/snapshots/local/select-interesting.wat.print
@@ -1,0 +1,12 @@
+(module
+  (type (;0;) (func (result i32)))
+  (func (;0;) (type 0) (result i32)
+    unreachable
+    select (result i32)
+  )
+  (func (;1;) (type 0) (result i32)
+    unreachable
+    select (result i32)
+    select
+  )
+)


### PR DESCRIPTION
Previously multiple `(result)` blocks would erroneously discard the previously parsed result blocks, so this commit fixes the textual parsing of this instruction to collect all of the `(result)` blocks instead of only the final one.

Closes #870