### PR TITLE
Handle inline exports on types for components

### DIFF
--- a/crates/wast/src/component/expand.rs
+++ b/crates/wast/src/component/expand.rs
@@ -365,6 +365,17 @@ impl<'a> Expander<'a> {
             TypeDef::Component(t) => t.key().insert(self, index),
             TypeDef::Instance(t) => t.key().insert(self, index),
         }
+        for (name, url) in field.exports.names.drain(..) {
+            self.component_fields_to_append
+                .push(ComponentField::Export(ComponentExport {
+                    span: field.span,
+                    id: None,
+                    debug_name: None,
+                    name,
+                    url,
+                    kind: ComponentExportKind::ty(field.span, id),
+                }));
+        }
     }
 
     fn expand_func_ty(&mut self, ty: &mut ComponentFunctionType<'a>) {

--- a/crates/wast/src/component/export.rs
+++ b/crates/wast/src/component/export.rs
@@ -101,6 +101,14 @@ impl<'a> ComponentExportKind<'a> {
             export_names: Default::default(),
         })
     }
+
+    pub(crate) fn ty(span: Span, id: Id<'a>) -> Self {
+        Self::Type(ItemRef {
+            kind: kw::r#type(span),
+            idx: Index::Id(id),
+            export_names: Default::default(),
+        })
+    }
 }
 
 impl<'a> Parse<'a> for ComponentExportKind<'a> {

--- a/crates/wast/src/component/types.rs
+++ b/crates/wast/src/component/types.rs
@@ -133,7 +133,7 @@ pub struct Type<'a> {
     pub name: Option<NameAnnotation<'a>>,
     /// If present, inline export annotations which indicate names this
     /// definition should be exported under.
-    pub exports: core::InlineExport<'a>,
+    pub exports: InlineExport<'a>,
     /// The type definition.
     pub def: TypeDef<'a>,
 }

--- a/tests/local/component-model/inline-exports.wast
+++ b/tests/local/component-model/inline-exports.wast
@@ -1,0 +1,3 @@
+(component
+  (type (export "foo") u8)
+)

--- a/tests/snapshots/local/component-model/inline-exports.wast/0.print
+++ b/tests/snapshots/local/component-model/inline-exports.wast/0.print
@@ -1,0 +1,4 @@
+(component
+  (type (;0;) u8)
+  (export (;1;) "foo" (type 0))
+)


### PR DESCRIPTION
This was accidentally left out from text expanding.