### PR TITLE
wasm-encoder: Return Indices from builder functions where applicable

### DIFF
--- a/crates/wasm-encoder/README.md
+++ b/crates/wasm-encoder/README.md
@@ -36,12 +36,11 @@ let mut module = Module::new();
 let mut types = TypeSection::new();
 let params = vec![ValType::I32, ValType::I32];
 let results = vec![ValType::I32];
-types.function(params, results);
+let type_index = types.function(params, results);
 module.section(&types);
 
 // Encode the function section.
 let mut functions = FunctionSection::new();
-let type_index = 0;
 functions.function(type_index);
 module.section(&functions);
 

--- a/crates/wasm-encoder/src/component/aliases.rs
+++ b/crates/wasm-encoder/src/component/aliases.rs
@@ -106,10 +106,11 @@ impl ComponentAliasSection {
     }
 
     /// Define an alias to a component instance's export.
-    pub fn alias(&mut self, alias: Alias<'_>) -> &mut Self {
+    pub fn alias(&mut self, alias: Alias<'_>) -> u32 {
         alias.encode(&mut self.bytes);
+        let index = self.num_added;
         self.num_added += 1;
-        self
+        index
     }
 }
 

--- a/crates/wasm-encoder/src/component/canonicals.rs
+++ b/crates/wasm-encoder/src/component/canonicals.rs
@@ -83,7 +83,7 @@ impl CanonicalFunctionSection {
     }
 
     /// Define a function that will lift a core WebAssembly function to the canonical ABI.
-    pub fn lift<O>(&mut self, core_func_index: u32, type_index: u32, options: O) -> &mut Self
+    pub fn lift<O>(&mut self, core_func_index: u32, type_index: u32, options: O) -> u32
     where
         O: IntoIterator<Item = CanonicalOption>,
         O::IntoIter: ExactSizeIterator,
@@ -97,12 +97,14 @@ impl CanonicalFunctionSection {
             option.encode(&mut self.bytes);
         }
         type_index.encode(&mut self.bytes);
+
+        let index = self.num_added;
         self.num_added += 1;
-        self
+        index
     }
 
     /// Define a function that will lower a canonical ABI function to a core WebAssembly function.
-    pub fn lower<O>(&mut self, func_index: u32, options: O) -> &mut Self
+    pub fn lower<O>(&mut self, func_index: u32, options: O) -> u32
     where
         O: IntoIterator<Item = CanonicalOption>,
         O::IntoIter: ExactSizeIterator,
@@ -115,8 +117,10 @@ impl CanonicalFunctionSection {
         for option in options {
             option.encode(&mut self.bytes);
         }
+
+        let index = self.num_added;
         self.num_added += 1;
-        self
+        index
     }
 }
 

--- a/crates/wasm-encoder/src/component/exports.rs
+++ b/crates/wasm-encoder/src/component/exports.rs
@@ -92,13 +92,15 @@ impl ComponentExportSection {
         url: &str,
         kind: ComponentExportKind,
         index: u32,
-    ) -> &mut Self {
+    ) -> u32 {
         name.encode(&mut self.bytes);
         url.encode(&mut self.bytes);
         kind.encode(&mut self.bytes);
         index.encode(&mut self.bytes);
+
+        let index = self.num_added;
         self.num_added += 1;
-        self
+        index
     }
 }
 

--- a/crates/wasm-encoder/src/component/imports.rs
+++ b/crates/wasm-encoder/src/component/imports.rs
@@ -94,7 +94,8 @@ impl Encode for ComponentTypeRef {
 ///       ("b", PrimitiveValType::String)
 ///     ]
 ///   )
-///   .result(PrimitiveValType::String);
+///   .result(PrimitiveValType::String)
+///   .finish();
 ///
 /// // This imports a function named `f` with the type defined above
 /// let mut imports = ComponentImportSection::new();
@@ -129,12 +130,14 @@ impl ComponentImportSection {
     }
 
     /// Define an import in the component import section.
-    pub fn import(&mut self, name: &str, url: &str, ty: ComponentTypeRef) -> &mut Self {
+    pub fn import(&mut self, name: &str, url: &str, ty: ComponentTypeRef) -> u32 {
         name.encode(&mut self.bytes);
         url.encode(&mut self.bytes);
         ty.encode(&mut self.bytes);
+
+        let index = self.num_added;
         self.num_added += 1;
-        self
+        index
     }
 }
 

--- a/crates/wasm-encoder/src/component/instances.rs
+++ b/crates/wasm-encoder/src/component/instances.rs
@@ -59,7 +59,7 @@ impl InstanceSection {
     }
 
     /// Define an instance by instantiating a core module.
-    pub fn instantiate<'a, A>(&mut self, module_index: u32, args: A) -> &mut Self
+    pub fn instantiate<'a, A>(&mut self, module_index: u32, args: A) -> u32
     where
         A: IntoIterator<Item = (&'a str, ModuleArg)>,
         A::IntoIter: ExactSizeIterator,
@@ -72,12 +72,14 @@ impl InstanceSection {
             name.encode(&mut self.bytes);
             arg.encode(&mut self.bytes);
         }
+
+        let index = self.num_added;
         self.num_added += 1;
-        self
+        index
     }
 
     /// Define an instance by exporting core WebAssembly items.
-    pub fn export_items<'a, E>(&mut self, exports: E) -> &mut Self
+    pub fn export_items<'a, E>(&mut self, exports: E) -> u32
     where
         E: IntoIterator<Item = (&'a str, ExportKind, u32)>,
         E::IntoIter: ExactSizeIterator,
@@ -90,8 +92,10 @@ impl InstanceSection {
             kind.encode(&mut self.bytes);
             index.encode(&mut self.bytes);
         }
+
+        let index = self.num_added;
         self.num_added += 1;
-        self
+        index
     }
 }
 
@@ -146,7 +150,7 @@ impl ComponentInstanceSection {
     }
 
     /// Define an instance by instantiating a component.
-    pub fn instantiate<'a, A>(&mut self, component_index: u32, args: A) -> &mut Self
+    pub fn instantiate<'a, A>(&mut self, component_index: u32, args: A) -> u32
     where
         A: IntoIterator<Item = (&'a str, ComponentExportKind, u32)>,
         A::IntoIter: ExactSizeIterator,
@@ -160,12 +164,13 @@ impl ComponentInstanceSection {
             kind.encode(&mut self.bytes);
             index.encode(&mut self.bytes);
         }
+        let index = self.num_added;
         self.num_added += 1;
-        self
+        index
     }
 
     /// Define an instance by exporting items.
-    pub fn export_items<'a, E>(&mut self, exports: E) -> &mut Self
+    pub fn export_items<'a, E>(&mut self, exports: E) -> u32
     where
         E: IntoIterator<Item = (&'a str, ComponentExportKind, u32)>,
         E::IntoIter: ExactSizeIterator,
@@ -178,8 +183,10 @@ impl ComponentInstanceSection {
             kind.encode(&mut self.bytes);
             index.encode(&mut self.bytes);
         }
+
+        let index = self.num_added;
         self.num_added += 1;
-        self
+        index
     }
 }
 

--- a/crates/wasm-encoder/src/core/code.rs
+++ b/crates/wasm-encoder/src/core/code.rs
@@ -14,10 +14,9 @@ use std::borrow::Cow;
 /// };
 ///
 /// let mut types = TypeSection::new();
-/// types.function(vec![], vec![ValType::I32]);
+/// let type_index = types.function(vec![], vec![ValType::I32]);
 ///
 /// let mut functions = FunctionSection::new();
-/// let type_index = 0;
 /// functions.function(type_index);
 ///
 /// let locals = vec![];
@@ -66,10 +65,11 @@ impl CodeSection {
     }
 
     /// Write a function body into this code section.
-    pub fn function(&mut self, func: &Function) -> &mut Self {
+    pub fn function(&mut self, func: &Function) -> u32 {
         func.encode(&mut self.bytes);
+        let index = self.num_added;
         self.num_added += 1;
-        self
+        index
     }
 
     /// Add a raw byte slice into this code section as a function body.
@@ -96,10 +96,11 @@ impl CodeSection {
     /// let mut encoder = wasm_encoder::CodeSection::new();
     /// encoder.raw(&code_section[body_range.start..body_range.end]);
     /// ```
-    pub fn raw(&mut self, data: &[u8]) -> &mut Self {
+    pub fn raw(&mut self, data: &[u8]) -> u32 {
         data.encode(&mut self.bytes);
+        let index = self.num_added;
         self.num_added += 1;
-        self
+        index
     }
 }
 

--- a/crates/wasm-encoder/src/core/data.rs
+++ b/crates/wasm-encoder/src/core/data.rs
@@ -13,7 +13,7 @@ use crate::{encode_section, encoding_size, ConstExpr, Encode, Section, SectionId
 /// };
 ///
 /// let mut memory = MemorySection::new();
-/// memory.memory(MemoryType {
+/// let memory_index = memory.memory(MemoryType {
 ///     minimum: 1,
 ///     maximum: None,
 ///     memory64: false,
@@ -21,7 +21,6 @@ use crate::{encode_section, encoding_size, ConstExpr, Encode, Section, SectionId
 /// });
 ///
 /// let mut data = DataSection::new();
-/// let memory_index = 0;
 /// let offset = ConstExpr::i32_const(42);
 /// let segment_data = b"hello";
 /// data.active(memory_index, &offset, segment_data.iter().copied());
@@ -81,7 +80,7 @@ impl DataSection {
     }
 
     /// Define a data segment.
-    pub fn segment<D>(&mut self, segment: DataSegment<D>) -> &mut Self
+    pub fn segment<D>(&mut self, segment: DataSegment<D>) -> u32
     where
         D: IntoIterator<Item = u8>,
         D::IntoIter: ExactSizeIterator,
@@ -111,12 +110,13 @@ impl DataSection {
         data.len().encode(&mut self.bytes);
         self.bytes.extend(data);
 
+        let index = self.num_added;
         self.num_added += 1;
-        self
+        index
     }
 
     /// Define an active data segment.
-    pub fn active<D>(&mut self, memory_index: u32, offset: &ConstExpr, data: D) -> &mut Self
+    pub fn active<D>(&mut self, memory_index: u32, offset: &ConstExpr, data: D) -> u32
     where
         D: IntoIterator<Item = u8>,
         D::IntoIter: ExactSizeIterator,
@@ -133,7 +133,7 @@ impl DataSection {
     /// Define a passive data segment.
     ///
     /// Passive data segments are part of the bulk memory proposal.
-    pub fn passive<D>(&mut self, data: D) -> &mut Self
+    pub fn passive<D>(&mut self, data: D) -> u32
     where
         D: IntoIterator<Item = u8>,
         D::IntoIter: ExactSizeIterator,
@@ -145,10 +145,11 @@ impl DataSection {
     }
 
     /// Copy an already-encoded data segment into this data section.
-    pub fn raw(&mut self, already_encoded_data_segment: &[u8]) -> &mut Self {
+    pub fn raw(&mut self, already_encoded_data_segment: &[u8]) -> u32 {
         self.bytes.extend_from_slice(already_encoded_data_segment);
+        let index = self.num_added;
         self.num_added += 1;
-        self
+        index
     }
 }
 

--- a/crates/wasm-encoder/src/core/exports.rs
+++ b/crates/wasm-encoder/src/core/exports.rs
@@ -63,12 +63,13 @@ impl ExportSection {
     }
 
     /// Define an export in the export section.
-    pub fn export(&mut self, name: &str, kind: ExportKind, index: u32) -> &mut Self {
+    pub fn export(&mut self, name: &str, kind: ExportKind, index: u32) -> u32 {
         name.encode(&mut self.bytes);
         kind.encode(&mut self.bytes);
         index.encode(&mut self.bytes);
+        let index = self.num_added;
         self.num_added += 1;
-        self
+        index
     }
 }
 

--- a/crates/wasm-encoder/src/core/functions.rs
+++ b/crates/wasm-encoder/src/core/functions.rs
@@ -43,10 +43,11 @@ impl FunctionSection {
     }
 
     /// Define a function in a module's function section.
-    pub fn function(&mut self, type_index: u32) -> &mut Self {
+    pub fn function(&mut self, type_index: u32) -> u32 {
         type_index.encode(&mut self.bytes);
+        let index = self.num_added;
         self.num_added += 1;
-        self
+        index
     }
 }
 

--- a/crates/wasm-encoder/src/core/globals.rs
+++ b/crates/wasm-encoder/src/core/globals.rs
@@ -46,18 +46,20 @@ impl GlobalSection {
     }
 
     /// Define a global.
-    pub fn global(&mut self, global_type: GlobalType, init_expr: &ConstExpr) -> &mut Self {
+    pub fn global(&mut self, global_type: GlobalType, init_expr: &ConstExpr) -> u32 {
         global_type.encode(&mut self.bytes);
         init_expr.encode(&mut self.bytes);
+        let index = self.num_added;
         self.num_added += 1;
-        self
+        index
     }
 
     /// Add a raw byte slice into this code section as a global.
-    pub fn raw(&mut self, data: &[u8]) -> &mut Self {
+    pub fn raw(&mut self, data: &[u8]) -> u32 {
         self.bytes.extend(data);
+        let index = self.num_added;
         self.num_added += 1;
-        self
+        index
     }
 }
 

--- a/crates/wasm-encoder/src/core/imports.rs
+++ b/crates/wasm-encoder/src/core/imports.rs
@@ -120,12 +120,13 @@ impl ImportSection {
     }
 
     /// Define an import in the import section.
-    pub fn import(&mut self, module: &str, field: &str, ty: impl Into<EntityType>) -> &mut Self {
+    pub fn import(&mut self, module: &str, field: &str, ty: impl Into<EntityType>) -> u32 {
         module.encode(&mut self.bytes);
         field.encode(&mut self.bytes);
         ty.into().encode(&mut self.bytes);
+        let index = self.num_added;
         self.num_added += 1;
-        self
+        index
     }
 }
 

--- a/crates/wasm-encoder/src/core/linking.rs
+++ b/crates/wasm-encoder/src/core/linking.rs
@@ -124,30 +124,32 @@ impl SymbolTable {
     ///
     /// The `name` must be omitted if `index` references an imported table and
     /// the `WASM_SYM_EXPLICIT_NAME` flag is not set.
-    pub fn function(&mut self, flags: u32, index: u32, name: Option<&str>) -> &mut Self {
+    pub fn function(&mut self, flags: u32, index: u32, name: Option<&str>) -> u32 {
         SYMTAB_FUNCTION.encode(&mut self.bytes);
         flags.encode(&mut self.bytes);
         index.encode(&mut self.bytes);
         if let Some(name) = name {
             name.encode(&mut self.bytes);
         }
+        let index = self.num_added;
         self.num_added += 1;
-        self
+        index
     }
 
     /// Define a global symbol in this symbol table.
     ///
     /// The `name` must be omitted if `index` references an imported table and
     /// the `WASM_SYM_EXPLICIT_NAME` flag is not set.
-    pub fn global(&mut self, flags: u32, index: u32, name: Option<&str>) -> &mut Self {
+    pub fn global(&mut self, flags: u32, index: u32, name: Option<&str>) -> u32 {
         SYMTAB_GLOBAL.encode(&mut self.bytes);
         flags.encode(&mut self.bytes);
         index.encode(&mut self.bytes);
         if let Some(name) = name {
             name.encode(&mut self.bytes);
         }
+        let index = self.num_added;
         self.num_added += 1;
-        self
+        index
     }
 
     // TODO: tags
@@ -156,15 +158,16 @@ impl SymbolTable {
     ///
     /// The `name` must be omitted if `index` references an imported table and
     /// the `WASM_SYM_EXPLICIT_NAME` flag is not set.
-    pub fn table(&mut self, flags: u32, index: u32, name: Option<&str>) -> &mut Self {
+    pub fn table(&mut self, flags: u32, index: u32, name: Option<&str>) -> u32 {
         SYMTAB_TABLE.encode(&mut self.bytes);
         flags.encode(&mut self.bytes);
         index.encode(&mut self.bytes);
         if let Some(name) = name {
             name.encode(&mut self.bytes);
         }
+        let index = self.num_added;
         self.num_added += 1;
-        self
+        index
     }
 
     /// Add a data symbol to this symbol table.
@@ -173,7 +176,7 @@ impl SymbolTable {
         flags: u32,
         name: &str,
         definition: Option<DataSymbolDefinition>,
-    ) -> &mut Self {
+    ) -> u32 {
         SYMTAB_DATA.encode(&mut self.bytes);
         flags.encode(&mut self.bytes);
         name.encode(&mut self.bytes);
@@ -182,8 +185,9 @@ impl SymbolTable {
             def.offset.encode(&mut self.bytes);
             def.size.encode(&mut self.bytes);
         }
+        let index = self.num_added;
         self.num_added += 1;
-        self
+        index
     }
 
     // TODO: sections

--- a/crates/wasm-encoder/src/core/memories.rs
+++ b/crates/wasm-encoder/src/core/memories.rs
@@ -45,10 +45,11 @@ impl MemorySection {
     }
 
     /// Define a memory.
-    pub fn memory(&mut self, memory_type: MemoryType) -> &mut Self {
+    pub fn memory(&mut self, memory_type: MemoryType) -> u32 {
         memory_type.encode(&mut self.bytes);
+        let index = self.num_added;
         self.num_added += 1;
-        self
+        index
     }
 }
 

--- a/crates/wasm-encoder/src/core/tables.rs
+++ b/crates/wasm-encoder/src/core/tables.rs
@@ -44,10 +44,11 @@ impl TableSection {
     }
 
     /// Define a table.
-    pub fn table(&mut self, table_type: TableType) -> &mut Self {
+    pub fn table(&mut self, table_type: TableType) -> u32 {
         table_type.encode(&mut self.bytes);
+        let index = self.num_added;
         self.num_added += 1;
-        self
+        index
     }
 }
 

--- a/crates/wasm-encoder/src/core/tags.rs
+++ b/crates/wasm-encoder/src/core/tags.rs
@@ -41,10 +41,11 @@ impl TagSection {
     }
 
     /// Define a tag.
-    pub fn tag(&mut self, tag_type: TagType) -> &mut Self {
+    pub fn tag(&mut self, tag_type: TagType) -> u32 {
         tag_type.encode(&mut self.bytes);
+        let index = self.num_added;
         self.num_added += 1;
-        self
+        index
     }
 }
 

--- a/crates/wasm-encoder/src/core/types.rs
+++ b/crates/wasm-encoder/src/core/types.rs
@@ -79,7 +79,7 @@ impl TypeSection {
     }
 
     /// Define a function type in this type section.
-    pub fn function<P, R>(&mut self, params: P, results: R) -> &mut Self
+    pub fn function<P, R>(&mut self, params: P, results: R) -> u32
     where
         P: IntoIterator<Item = ValType>,
         P::IntoIter: ExactSizeIterator,
@@ -94,8 +94,10 @@ impl TypeSection {
         self.bytes.extend(params.map(u8::from));
         results.len().encode(&mut self.bytes);
         self.bytes.extend(results.map(u8::from));
+
+        let index = self.num_added;
         self.num_added += 1;
-        self
+        index
     }
 }
 

--- a/crates/wasm-encoder/src/lib.rs
+++ b/crates/wasm-encoder/src/lib.rs
@@ -36,12 +36,11 @@
 //! let mut types = TypeSection::new();
 //! let params = vec![ValType::I32, ValType::I32];
 //! let results = vec![ValType::I32];
-//! types.function(params, results);
+//! let type_index = types.function(params, results);
 //! module.section(&types);
 //!
 //! // Encode the function section.
 //! let mut functions = FunctionSection::new();
-//! let type_index = 0;
 //! functions.function(type_index);
 //! module.section(&functions);
 //!


### PR DESCRIPTION
This refactor changes the returns of builder methods which create indexed entries (e.g. types) so that they return the index of the newly created entry. This means users don't need to otherwise calculate the value or know what it will be.

For example, the README no longer needs the line `let type_index = 0;` since it can be obtained when `types.function(...)` is called.
```rust
// Encode the type section.
let mut types = TypeSection::new();
let params = vec![ValType::I32, ValType::I32];
let results = vec![ValType::I32];
let type_index = types.function(params, results);
module.section(&types);

// Encode the function section.
let mut functions = FunctionSection::new();
functions.function(type_index);
module.section(&functions);
```