### PR TITLE
wit-component: expose dummy component generation

### DIFF
--- a/crates/wit-component/Cargo.toml
+++ b/crates/wit-component/Cargo.toml
@@ -20,11 +20,10 @@ anyhow = { workspace = true }
 log = "0.4.17"
 bitflags = "1.3.2"
 indexmap = { workspace = true }
+wat = { workspace = true }
 
 [dev-dependencies]
 wasmprinter = { workspace = true }
 glob = "0.3.0"
 pretty_assertions = "1.3.0"
 env_logger = { workspace = true }
-wat = { workspace = true }
-test-helpers = { path = 'test-helpers' }

--- a/crates/wit-component/fuzz/Cargo.toml
+++ b/crates/wit-component/fuzz/Cargo.toml
@@ -12,7 +12,6 @@ arbitrary = { workspace = true, features = ['derive'] }
 env_logger = { workspace = true }
 libfuzzer-sys = { workspace = true }
 log = { workspace = true }
-test-helpers = { path = '../test-helpers' }
 wasmprinter = { workspace = true }
 wit-component = { workspace = true }
 wit-parser = { workspace = true }

--- a/crates/wit-component/fuzz/fuzz_targets/roundtrip-wit.rs
+++ b/crates/wit-component/fuzz/fuzz_targets/roundtrip-wit.rs
@@ -31,7 +31,7 @@ fuzz_target!(|data: &[u8]| {
     let text_from_types_only = DocumentPrinter::default().print(&types_only_doc).unwrap();
     write_file("doc.types-only.wit", &text_from_types_only);
 
-    let dummy = test_helpers::dummy_module(&doc);
+    let dummy = dummy::dummy_module(&doc);
     write_file("doc.dummy.wasm", &dummy);
     let normal_binary = ComponentEncoder::default()
         .validate(true)

--- a/crates/wit-component/src/dummy.rs
+++ b/crates/wit-component/src/dummy.rs
@@ -1,6 +1,7 @@
 use wit_parser::abi::{AbiVariant, WasmType};
 use wit_parser::{Document, Function};
 
+/// Generate a dummy implementation core Wasm module for a given WIT document
 pub fn dummy_module(doc: &Document) -> Vec<u8> {
     let world = doc.default_world().unwrap();
     let world = &doc.worlds[world];

--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -52,8 +52,8 @@
 //! otherwise there's no way to run a `wasi_snapshot_preview1` module within the
 //! component model.
 
-use crate::builder::ComponentBuilder;
 use crate::dummy;
+use crate::builder::ComponentBuilder;
 use crate::metadata::{self, Bindgen, ModuleMetadata};
 use crate::{
     validation::{ValidatedModule, MAIN_MODULE_IMPORT_NAME},
@@ -1162,6 +1162,7 @@ impl ComponentEncoder {
 
     /// Add a document & synthesize a dummy module for this encoder.
     pub fn document_dummy(mut self, doc: Document, encoding: StringEncoding) -> Result<Self> {
+        self.dummy = true;
         let module = dummy::dummy_module(&doc);
         let (wasm, _) = metadata::decode(&module)?;
         self.module = wasm;

--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -52,8 +52,8 @@
 //! otherwise there's no way to run a `wasi_snapshot_preview1` module within the
 //! component model.
 
-use crate::dummy;
 use crate::builder::ComponentBuilder;
+use crate::dummy;
 use crate::metadata::{self, Bindgen, ModuleMetadata};
 use crate::{
     validation::{ValidatedModule, MAIN_MODULE_IMPORT_NAME},
@@ -1112,7 +1112,6 @@ pub struct ComponentEncoder {
     metadata: Bindgen,
     validate: bool,
     types_only: bool,
-    dummy: bool,
 
     // This is a map from the name of the adapter to a pair of:
     //
@@ -1162,7 +1161,6 @@ impl ComponentEncoder {
 
     /// Add a document & synthesize a dummy module for this encoder.
     pub fn document_dummy(mut self, doc: Document, encoding: StringEncoding) -> Result<Self> {
-        self.dummy = true;
         let module = dummy::dummy_module(&doc);
         let (wasm, _) = metadata::decode(&module)?;
         self.module = wasm;
@@ -1229,7 +1227,7 @@ impl ComponentEncoder {
         state.encode_imports()?;
 
         if self.types_only {
-            if self.dummy || !self.module.is_empty() {
+            if !self.module.is_empty() {
                 bail!("a module cannot be specified for a types-only encoding");
             }
 
@@ -1276,14 +1274,8 @@ impl ComponentEncoder {
                 }
             }
         } else {
-            if self.dummy {
-                if !self.module.is_empty() {
-                    bail!("a module cannot be specified for a dummy encoding");
-                }
-            } else {
-                if self.module.is_empty() {
-                    bail!("a module is required when encoding a component");
-                }
+            if self.module.is_empty() {
+                bail!("a module is required when encoding a component");
             }
 
             state.encode_core_modules();

--- a/crates/wit-component/src/lib.rs
+++ b/crates/wit-component/src/lib.rs
@@ -9,6 +9,7 @@ use wasm_encoder::CanonicalOption;
 
 mod builder;
 mod decoding;
+mod dummy;
 mod encoding;
 mod gc;
 mod printing;
@@ -18,6 +19,7 @@ pub use decoding::decode_world;
 pub use encoding::ComponentEncoder;
 pub use printing::*;
 
+pub use dummy::dummy_module;
 pub mod metadata;
 
 /// Supported string encoding formats.

--- a/crates/wit-component/test-helpers/Cargo.toml
+++ b/crates/wit-component/test-helpers/Cargo.toml
@@ -1,9 +1,0 @@
-[package]
-name = "test-helpers"
-version = "0.1.0"
-edition = "2021"
-publish = false
-
-[dependencies]
-wit-parser = { workspace = true }
-wat = { workspace = true }

--- a/crates/wit-component/tests/interfaces.rs
+++ b/crates/wit-component/tests/interfaces.rs
@@ -85,7 +85,7 @@ fn run_test(path: &Path) -> Result<()> {
     // recover the original `*.wit` interfaces from the component output.
 
     println!("test dummy module");
-    let module = test_helpers::dummy_module(&doc);
+    let module = wit_component::dummy_module(&doc);
     let bytes = ComponentEncoder::default()
         .module(&module)?
         .validate(true)


### PR DESCRIPTION
This exposes the dummy core Wasm component generation, which is useful for binding generation code independent of implementation.

Specifically, I'd like to expose this in order to enable JS binding generation via a similar approach to the wit-bindgen demo.