### PR TITLE
VisitOperator: implement delegate from &mut VisitOperator

### DIFF
--- a/crates/wasmparser/src/readers/core/operators.rs
+++ b/crates/wasmparser/src/readers/core/operators.rs
@@ -326,3 +326,21 @@ pub trait VisitOperator<'a> {
 
     for_each_operator!(define_visit_operator);
 }
+
+macro_rules! define_visit_operator_delegate {
+    ($(@$proposal:ident $op:ident $({ $($arg:ident: $argty:ty),* })? => $visit:ident)*) => {
+        $(
+            fn $visit(&mut self $($(,$arg: $argty)*)?) -> Self::Output {
+                V::$visit(*self, $($($arg),*)?)
+            }
+        )*
+    }
+}
+
+impl<'a, 'b, V: VisitOperator<'a>> VisitOperator<'a> for &'b mut V {
+    type Output = V::Output;
+    fn visit_operator(&mut self, op: &Operator<'a>) -> Self::Output {
+        V::visit_operator(*self, op)
+    }
+    for_each_operator!(define_visit_operator_delegate);
+}


### PR DESCRIPTION
This allows generic code to work with both VisitOperators passed by value and by reference, without client code needing to implement a wrapping type that would act as a container for the reference.