### PR TITLE
VisitOperator: implement delegates for Box<VisitOperator>

### DIFF
--- a/crates/wasmparser/src/readers/core/operators.rs
+++ b/crates/wasmparser/src/readers/core/operators.rs
@@ -331,16 +331,24 @@ macro_rules! define_visit_operator_delegate {
     ($(@$proposal:ident $op:ident $({ $($arg:ident: $argty:ty),* })? => $visit:ident)*) => {
         $(
             fn $visit(&mut self $($(,$arg: $argty)*)?) -> Self::Output {
-                V::$visit(*self, $($($arg),*)?)
+                V::$visit(&mut *self, $($($arg),*)?)
             }
         )*
     }
 }
 
-impl<'a, 'b, V: VisitOperator<'a>> VisitOperator<'a> for &'b mut V {
+impl<'a, 'b, V: VisitOperator<'a> + ?Sized> VisitOperator<'a> for &'b mut V {
     type Output = V::Output;
     fn visit_operator(&mut self, op: &Operator<'a>) -> Self::Output {
         V::visit_operator(*self, op)
+    }
+    for_each_operator!(define_visit_operator_delegate);
+}
+
+impl<'a, V: VisitOperator<'a> + ?Sized> VisitOperator<'a> for Box<V> {
+    type Output = V::Output;
+    fn visit_operator(&mut self, op: &Operator<'a>) -> Self::Output {
+        V::visit_operator(&mut *self, op)
     }
     for_each_operator!(define_visit_operator_delegate);
 }


### PR DESCRIPTION
This is also fine because `Box` implements `DerefMut`. Pretty useful for people (like me) who have a `Box<dyn VisitOperator>`, but can't use `&dyn` because of the borrowck limitations around how it handles HRTBs.