### PR TITLE
Bump crate versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-tools"
-version = "1.0.17"
+version = "1.0.18"
 authors = ["The Wasmtime Project Developers"]
 edition.workspace = true
 description = "CLI tools for interoperating with WebAssembly files"
@@ -42,16 +42,16 @@ wasmtime = { version = "3.0.0", default-features = false, features = ['cranelift
 url = "2.3.1"
 
 wasm-encoder = { version = "0.21.0", path = "crates/wasm-encoder"}
-wasm-compose = { version = "0.2.2", path = "crates/wasm-compose"}
-wasm-mutate = { version = "0.2.14", path = "crates/wasm-mutate" }
-wasm-shrink = { version = "0.1.15", path = "crates/wasm-shrink" }
-wasm-smith = { version = "0.11.11", path = "crates/wasm-smith" }
-wasmparser = { version = "0.97.0", path = "crates/wasmparser" }
-wasmparser-dump = { version = "0.1.13", path = "crates/dump" }
-wasmprinter = { version = "0.2.46", path = "crates/wasmprinter" }
-wast = { version = "51.0.0", path = "crates/wast" }
-wat = { version = "1.0.53", path = "crates/wat" }
-wit-component = { version = "0.4.0", path = "crates/wit-component" }
+wasm-compose = { version = "0.2.3", path = "crates/wasm-compose"}
+wasm-mutate = { version = "0.2.15", path = "crates/wasm-mutate" }
+wasm-shrink = { version = "0.1.16", path = "crates/wasm-shrink" }
+wasm-smith = { version = "0.11.12", path = "crates/wasm-smith" }
+wasmparser = { version = "0.98.0", path = "crates/wasmparser" }
+wasmparser-dump = { version = "0.1.14", path = "crates/dump" }
+wasmprinter = { version = "0.2.47", path = "crates/wasmprinter" }
+wast = { version = "52.0.0", path = "crates/wast" }
+wat = { version = "1.0.54", path = "crates/wat" }
+wit-component = { version = "0.4.2", path = "crates/wit-component" }
 wit-parser = { version = "0.4.0", path = "crates/wit-parser" }
 
 [dependencies]

--- a/crates/dump/Cargo.toml
+++ b/crates/dump/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser-dump"
-version = "0.1.13"
+version = "0.1.14"
 authors = ["The Wasmtime Project Developers"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasm-compose/Cargo.toml
+++ b/crates/wasm-compose/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-compose"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors = ["Peter Huene <peter@huene.dev>"]
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasm-mutate/Cargo.toml
+++ b/crates/wasm-mutate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-mutate"
-version = "0.2.14"
+version = "0.2.15"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-mutate"

--- a/crates/wasm-shrink/Cargo.toml
+++ b/crates/wasm-shrink/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-shrink"
 name = "wasm-shrink"
-version = "0.1.15"
+version = "0.1.16"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "wasm-smith"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-smith"
-version = "0.11.11"
+version = "0.11.12"
 exclude = ["/benches/corpus"]
 
 [[bench]]

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.97.0"
+version = "0.98.0"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser"

--- a/crates/wasmprinter/Cargo.toml
+++ b/crates/wasmprinter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmprinter"
-version = "0.2.46"
+version = "0.2.47"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wast"
-version = "51.0.0"
+version = "52.0.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wat/Cargo.toml
+++ b/crates/wat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wat"
-version = "1.0.53"
+version = "1.0.54"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wit-component/Cargo.toml
+++ b/crates/wit-component/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-component"
 authors = ["Peter Huene <peter@huene.dev>"]
-version = "0.4.1"
+version = "0.4.2"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"


### PR DESCRIPTION
Not a large release, pushing out these changes:

* https://github.com/bytecodealliance/wasm-tools/pull/882
* https://github.com/bytecodealliance/wasm-tools/pull/883
* https://github.com/bytecodealliance/wasm-tools/pull/880