### PR TITLE
Fix references to imported types in the text format

### DIFF
--- a/crates/wit-parser/tests/ui/use.wit
+++ b/crates/wit-parser/tests/ui/use.wit
@@ -28,4 +28,6 @@ interface use-multiple {
 
 interface trailing-comma {
   use self.foo.{the-type,}
+
+  record the-foo { a: the-type }
 }


### PR DESCRIPTION
During the topological sorting of types there wasn't an entry in the
dependency array for imported types which ended up leading to errors
about the types not being defined when, in fact, they are defined!