### PR TITLE
Fix resolving memory names of `memory.discard` in text format

### DIFF
--- a/crates/wast/src/core/resolve/names.rs
+++ b/crates/wast/src/core/resolve/names.rs
@@ -413,7 +413,7 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
         }
 
         match instr {
-            MemorySize(i) | MemoryGrow(i) | MemoryFill(i) => {
+            MemorySize(i) | MemoryGrow(i) | MemoryFill(i) | MemoryDiscard(i) => {
                 self.resolver.resolve(&mut i.mem, Ns::Memory)?;
             }
             MemoryInit(i) => {

--- a/tests/local/memory-discard.wat
+++ b/tests/local/memory-discard.wat
@@ -1,7 +1,14 @@
 (module
-  (memory i32 2)
+  (memory $m i32 2)
 
   (func
     (memory.discard (i32.const 0) (i32.const 65536))
+  )
+  (func
+    (memory.discard $m (i32.const 0) (i32.const 65536))
+  )
+
+  (func
+    (memory.discard 0 (i32.const 0) (i32.const 65536))
   )
 )

--- a/tests/snapshots/local/memory-discard.wat.print
+++ b/tests/snapshots/local/memory-discard.wat.print
@@ -5,5 +5,15 @@
     i32.const 65536
     memory.discard
   )
-  (memory (;0;) 2)
+  (func (;1;) (type 0)
+    i32.const 0
+    i32.const 65536
+    memory.discard
+  )
+  (func (;2;) (type 0)
+    i32.const 0
+    i32.const 65536
+    memory.discard
+  )
+  (memory $m (;0;) 2)
 )


### PR DESCRIPTION
This fixes a fuzz bug that cropped up last night where `memory.discard` accidentally didn't resolve its memory name.