### PR TITLE
Change the canonical ABI name of for top level functions in worlds

### DIFF
--- a/crates/wit-component/src/dummy.rs
+++ b/crates/wit-component/src/dummy.rs
@@ -11,7 +11,7 @@ pub fn dummy_module(resolve: &Resolve, world: WorldId) -> Vec<u8> {
             WorldItem::Function(func) => {
                 let sig = resolve.wasm_signature(AbiVariant::GuestImport, func);
 
-                wat.push_str(&format!("(import \"\" \"{}\" (func", func.name));
+                wat.push_str(&format!("(import \"$root\" \"{}\" (func", func.name));
                 push_tys(&mut wat, "param", &sig.params);
                 push_tys(&mut wat, "result", &sig.results);
                 wat.push_str("))\n");

--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -54,7 +54,7 @@
 
 use crate::builder::ComponentBuilder;
 use crate::metadata::{self, Bindgen, ModuleMetadata};
-use crate::validation::{ValidatedModule, MAIN_MODULE_IMPORT_NAME};
+use crate::validation::{ValidatedModule, BARE_FUNC_MODULE_NAME, MAIN_MODULE_IMPORT_NAME};
 use crate::StringEncoding;
 use anyhow::{anyhow, bail, Context, Result};
 use indexmap::IndexMap;
@@ -544,7 +544,7 @@ impl<'a> EncodingState<'a> {
         shims: &Shims<'_>,
         metadata: &ModuleMetadata,
     ) -> u32 {
-        let interface = if core_wasm_name.is_empty() {
+        let interface = if core_wasm_name == BARE_FUNC_MODULE_NAME {
             None
         } else {
             Some(core_wasm_name)
@@ -723,7 +723,7 @@ impl<'a> EncodingState<'a> {
         // For all interfaces imported into the main module record all of their
         // indirect lowerings into `Shims`.
         for core_wasm_name in info.required_imports.keys() {
-            let import_name = if core_wasm_name.is_empty() {
+            let import_name = if *core_wasm_name == BARE_FUNC_MODULE_NAME {
                 None
             } else {
                 Some(*core_wasm_name)
@@ -1163,7 +1163,7 @@ impl<'a> Shims<'a> {
         metadata: &ModuleMetadata,
         sigs: &mut Vec<WasmSignature>,
     ) {
-        let interface = if core_wasm_module.is_empty() {
+        let interface = if core_wasm_module == BARE_FUNC_MODULE_NAME {
             None
         } else {
             Some(core_wasm_module)

--- a/crates/wit-component/src/encoding/world.rs
+++ b/crates/wit-component/src/encoding/world.rs
@@ -1,6 +1,7 @@
 use super::{ComponentEncoder, RequiredOptions};
 use crate::validation::{
     validate_adapter_module, validate_module, ValidatedAdapter, ValidatedModule,
+    BARE_FUNC_MODULE_NAME,
 };
 use anyhow::{Context, Result};
 use indexmap::{IndexMap, IndexSet};
@@ -189,7 +190,7 @@ impl<'a> ComponentWorld<'a> {
             let empty = IndexSet::new();
             match item {
                 WorldItem::Function(func) => {
-                    let required = required.get("").unwrap_or(&empty);
+                    let required = required.get(BARE_FUNC_MODULE_NAME).unwrap_or(&empty);
                     // If this function isn't actually required then skip it
                     if !required.contains(name) {
                         return Ok(());
@@ -294,7 +295,7 @@ impl<'a> ComponentWorld<'a> {
         for (name, item) in resolve.worlds[world].imports.iter() {
             match item {
                 WorldItem::Function(func) => {
-                    let required = match required.get("") {
+                    let required = match required.get(BARE_FUNC_MODULE_NAME) {
                         Some(set) => set,
                         None => continue,
                     };

--- a/crates/wit-component/src/metadata.rs
+++ b/crates/wit-component/src/metadata.rs
@@ -32,6 +32,7 @@
 //!   binary form. This is the encoding of a package into wasm, and the bound
 //!   world for the bindings is specified from the prior strings.
 
+use crate::validation::BARE_FUNC_MODULE_NAME;
 use crate::{DecodedWasm, StringEncoding};
 use anyhow::{bail, Context, Result};
 use indexmap::IndexMap;
@@ -265,7 +266,7 @@ impl ModuleMetadata {
                 WorldItem::Function(_) => {
                     let prev = ret
                         .import_encodings
-                        .insert((String::new(), name.clone()), encoding);
+                        .insert((BARE_FUNC_MODULE_NAME.to_string(), name.clone()), encoding);
                     assert!(prev.is_none());
                 }
                 WorldItem::Interface(i) => {

--- a/crates/wit-component/tests/components.rs
+++ b/crates/wit-component/tests/components.rs
@@ -120,12 +120,19 @@ fn assert_output(contents: &str, path: &Path) -> Result<()> {
     if std::env::var_os("BLESS").is_some() {
         fs::write(path, contents)?;
     } else {
-        assert_eq!(
-            fs::read_to_string(path)?.replace("\r\n", "\n").trim(),
-            contents.trim(),
-            "failed baseline comparison ({})",
-            path.display(),
-        );
+        match fs::read_to_string(path) {
+            Ok(expected) => {
+                assert_eq!(
+                    expected.replace("\r\n", "\n").trim(),
+                    contents.trim(),
+                    "failed baseline comparison ({})",
+                    path.display(),
+                );
+            }
+            Err(_) => {
+                panic!("expected {path:?} to contain\n{contents}");
+            }
+        }
     }
     Ok(())
 }

--- a/crates/wit-component/tests/components/bare-funcs/component.wat
+++ b/crates/wit-component/tests/components/bare-funcs/component.wat
@@ -8,8 +8,8 @@
     (type (;1;) (func (param i32)))
     (type (;2;) (func (param i32 i32) (result i32)))
     (type (;3;) (func (param i32 i32 i32 i32) (result i32)))
-    (import "" "foo" (func (;0;) (type 0)))
-    (import "" "bar" (func (;1;) (type 1)))
+    (import "$root" "foo" (func (;0;) (type 0)))
+    (import "$root" "bar" (func (;1;) (type 1)))
     (func (;2;) (type 0))
     (func (;3;) (type 2) (param i32 i32) (result i32)
       unreachable
@@ -29,13 +29,13 @@
   )
   (core module (;1;)
     (type (;0;) (func (param i32)))
-    (func $indirect--bar (;0;) (type 0) (param i32)
+    (func $indirect-$root-bar (;0;) (type 0) (param i32)
       local.get 0
       i32.const 0
       call_indirect (type 0)
     )
     (table (;0;) 1 1 funcref)
-    (export "0" (func $indirect--bar))
+    (export "0" (func $indirect-$root-bar))
     (export "$imports" (table 0))
   )
   (core module (;2;)
@@ -52,7 +52,7 @@
     (export "foo" (func 1))
   )
   (core instance (;2;) (instantiate 0
-      (with "" (instance 1))
+      (with "$root" (instance 1))
     )
   )
   (alias core export 2 "memory" (core memory (;0;)))

--- a/crates/wit-component/tests/components/bare-funcs/module.wat
+++ b/crates/wit-component/tests/components/bare-funcs/module.wat
@@ -1,6 +1,6 @@
 (module
-  (import "" "foo" (func))
-  (import "" "bar" (func (param i32)))
+  (import "$root" "foo" (func))
+  (import "$root" "bar" (func (param i32)))
 
   (func (export "baz"))
 

--- a/crates/wit-component/tests/components/empty-module-import/module.wat
+++ b/crates/wit-component/tests/components/empty-module-import/module.wat
@@ -1,3 +1,3 @@
 (module
-  (import "" "foo" (func))
+  (import "$root" "foo" (func))
 )


### PR DESCRIPTION
For a WIT world of the form:

    world foo {
        import foo: func()
    }

previously this would require a core wasm module along the lines of:

    (module
        (import "" "foo" (func))
    )

where notably the module name of the import was the empty string, indicating that it was corresponding to a root-level function. Unfortunately, though, LLVM doesn't easily support this from guest languages. For example this Rust program:

    #[link(wasm_import_module = "")]
    extern "C" {
        fn foo();
    }

    #[no_mangle]
    pub unsafe extern "C" fn e() {
        foo();
    }

generates a wasm module that looks like:

    (module
      (type (;0;) (func))
      (import "env" "foo" (func $_ZN3foo3foo17hc95a7373bc5389c2E (;0;) (type 0)))
      ;; ..
    )

Note here how the `""` empty string was replaced by `env`, the default if nothing else is specified. While this is probably an LLVM bug that should be fixed the timescale of that is long enough that it's not really worth persisting this idiom, so this PR switches the expected module name of root-level function imports to be `$root` now instead of the empty string. This gets LLVM to work and preserves the property that the module name can't otherwise clash with a valid interface name.