### PR TITLE
Bump the version of wit-component

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-tools"
-version = "1.0.19"
+version = "1.0.20"
 authors = ["The Wasmtime Project Developers"]
 edition.workspace = true
 description = "CLI tools for interoperating with WebAssembly files"
@@ -51,7 +51,7 @@ wasmparser-dump = { version = "0.1.16", path = "crates/dump" }
 wasmprinter = { version = "0.2.49", path = "crates/wasmprinter" }
 wast = { version = "52.0.2", path = "crates/wast" }
 wat = { version = "1.0.56", path = "crates/wat" }
-wit-component = { version = "0.4.3", path = "crates/wit-component" }
+wit-component = { version = "0.4.4", path = "crates/wit-component" }
 wit-parser = { version = "0.4.1", path = "crates/wit-parser" }
 
 [dependencies]

--- a/crates/wit-component/Cargo.toml
+++ b/crates/wit-component/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-component"
 authors = ["Peter Huene <peter@huene.dev>"]
-version = "0.4.3"
+version = "0.4.4"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"


### PR DESCRIPTION
Publish the recent bug fixes and change for `$root` of top-level function imports.