### PR TITLE
Bump wit-{component,parser} crate versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-tools"
-version = "1.0.20"
+version = "1.0.21"
 authors = ["The Wasmtime Project Developers"]
 edition.workspace = true
 description = "CLI tools for interoperating with WebAssembly files"
@@ -51,8 +51,8 @@ wasmparser-dump = { version = "0.1.16", path = "crates/dump" }
 wasmprinter = { version = "0.2.49", path = "crates/wasmprinter" }
 wast = { version = "52.0.2", path = "crates/wast" }
 wat = { version = "1.0.56", path = "crates/wat" }
-wit-component = { version = "0.4.4", path = "crates/wit-component" }
-wit-parser = { version = "0.4.1", path = "crates/wit-parser" }
+wit-component = { version = "0.5.0", path = "crates/wit-component" }
+wit-parser = { version = "0.5.0", path = "crates/wit-parser" }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/wit-component/Cargo.toml
+++ b/crates/wit-component/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-component"
 authors = ["Peter Huene <peter@huene.dev>"]
-version = "0.4.4"
+version = "0.5.0"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"

--- a/crates/wit-parser/Cargo.toml
+++ b/crates/wit-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-parser"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.4.1"
+version = "0.5.0"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"


### PR DESCRIPTION
Account for changes made in #901 and do a major release for those crates. This'll also kick CI to test out the builds added in #897.