### PR TITLE
Improve `SectionLimited` iterator types

### DIFF
--- a/crates/wasmparser/src/readers.rs
+++ b/crates/wasmparser/src/readers.rs
@@ -205,10 +205,7 @@ where
     }
 }
 
-impl<'a, T> ExactSizeIterator for SectionLimitedIntoIter<'a, T>
-where
-    T: FromReader<'a>,
-{}
+impl<'a, T> ExactSizeIterator for SectionLimitedIntoIter<'a, T> where T: FromReader<'a> {}
 
 /// An iterator over a limited section iterator.
 pub struct SectionLimitedIntoIterWithOffsets<'a, T> {
@@ -231,10 +228,7 @@ where
     }
 }
 
-impl<'a, T> ExactSizeIterator for SectionLimitedIntoIterWithOffsets<'a, T>
-where
-    T: FromReader<'a>,
-{}
+impl<'a, T> ExactSizeIterator for SectionLimitedIntoIterWithOffsets<'a, T> where T: FromReader<'a> {}
 
 /// A trait implemented for subsections of another outer section.
 ///

--- a/crates/wasmparser/src/readers.rs
+++ b/crates/wasmparser/src/readers.rs
@@ -198,6 +198,11 @@ where
         self.remaining -= 1;
         Some(result)
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.remaining as usize;
+        (remaining, Some(remaining))
+    }
 }
 
 /// An iterator over a limited section iterator.

--- a/crates/wasmparser/src/readers.rs
+++ b/crates/wasmparser/src/readers.rs
@@ -205,6 +205,11 @@ where
     }
 }
 
+impl<'a, T> ExactSizeIterator for SectionLimitedIntoIter<'a, T>
+where
+    T: FromReader<'a>,
+{}
+
 /// An iterator over a limited section iterator.
 pub struct SectionLimitedIntoIterWithOffsets<'a, T> {
     iter: SectionLimitedIntoIter<'a, T>,
@@ -225,6 +230,11 @@ where
         self.iter.size_hint()
     }
 }
+
+impl<'a, T> ExactSizeIterator for SectionLimitedIntoIterWithOffsets<'a, T>
+where
+    T: FromReader<'a>,
+{}
 
 /// A trait implemented for subsections of another outer section.
 ///


### PR DESCRIPTION
This small PR adds `size_hint` impl to `SectionLimitedIntoIter` and implements `ExactSizeIterator` for both `SectionLimited` iterator types.