### PR TITLE
Fix Windows CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
-    - run: rustup update stable && rustup default stable
+    - run: rustup update stable --no-self-update && rustup default stable
     - uses: bytecodealliance/wasmtime/.github/actions/binary-compatible-builds@v4.0.0
       with:
         name: ${{ matrix.build }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-tools"
-version = "1.0.22"
+version = "1.0.21"
 authors = ["The Wasmtime Project Developers"]
 edition.workspace = true
 description = "CLI tools for interoperating with WebAssembly files"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-tools"
-version = "1.0.21"
+version = "1.0.22"
 authors = ["The Wasmtime Project Developers"]
 edition.workspace = true
 description = "CLI tools for interoperating with WebAssembly files"


### PR DESCRIPTION
Also bump the version of the `wasm-tools` umbrella crate to trigger CI again.