### PR TITLE
Install git in aarch64 container

### DIFF
--- a/ci/docker/aarch64-linux/Dockerfile
+++ b/ci/docker/aarch64-linux/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-RUN apt-get update -y && apt-get install -y gcc gcc-aarch64-linux-gnu ca-certificates
+RUN apt-get update -y && apt-get install -y gcc gcc-aarch64-linux-gnu ca-certificates git
 
 ENV PATH=$PATH:/rust/bin
 ENV CARGO_BUILD_TARGET=aarch64-unknown-linux-gnu


### PR DESCRIPTION
This'll give a more descriptive `--version` from the aarch64 binaries.