### PR TITLE
Reorder list of crates to publish

### DIFF
--- a/ci/publish.rs
+++ b/ci/publish.rs
@@ -37,8 +37,8 @@ const CRATES_TO_PUBLISH: &[&str] = &[
     "wasm-shrink",
     "wasm-compose",
     "wit-parser",
-    "wit-component",
     "wasm-metadata",
+    "wit-component",
     "wasm-tools",
 ];
 


### PR DESCRIPTION
The `wit-component` crate depends on `wasm-metadata`, so move reorder to ensure the items are listed in topological order.