### PR TITLE
feat: direct signature api

### DIFF
--- a/crates/wit-component/src/dummy.rs
+++ b/crates/wit-component/src/dummy.rs
@@ -9,7 +9,7 @@ pub fn dummy_module(resolve: &Resolve, world: WorldId) -> Vec<u8> {
     for (name, import) in world.imports.iter() {
         match import {
             WorldItem::Function(func) => {
-                let sig = resolve.wasm_signature(AbiVariant::GuestImport, func);
+                let sig = resolve.wasm_signature(Some(AbiVariant::GuestImport), func);
 
                 wat.push_str(&format!("(import \"$root\" \"{}\" (func", func.name));
                 push_tys(&mut wat, "param", &sig.params);
@@ -18,7 +18,7 @@ pub fn dummy_module(resolve: &Resolve, world: WorldId) -> Vec<u8> {
             }
             WorldItem::Interface(import) => {
                 for (_, func) in resolve.interfaces[*import].functions.iter() {
-                    let sig = resolve.wasm_signature(AbiVariant::GuestImport, func);
+                    let sig = resolve.wasm_signature(Some(AbiVariant::GuestImport), func);
 
                     wat.push_str(&format!("(import \"{name}\" \"{}\" (func", func.name));
                     push_tys(&mut wat, "param", &sig.params);
@@ -54,7 +54,7 @@ pub fn dummy_module(resolve: &Resolve, world: WorldId) -> Vec<u8> {
     return wat::parse_str(&wat).unwrap();
 
     fn push_func(wat: &mut String, name: &str, resolve: &Resolve, func: &Function) {
-        let sig = resolve.wasm_signature(AbiVariant::GuestExport, func);
+        let sig = resolve.wasm_signature(Some(AbiVariant::GuestExport), func);
         wat.push_str(&format!("(func (export \"{name}\")"));
         push_tys(wat, "param", &sig.params);
         push_tys(wat, "result", &sig.results);

--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -104,7 +104,7 @@ bitflags::bitflags! {
 
 impl RequiredOptions {
     fn for_import(resolve: &Resolve, func: &Function) -> RequiredOptions {
-        let sig = resolve.wasm_signature(AbiVariant::GuestImport, func);
+        let sig = resolve.wasm_signature(Some(AbiVariant::GuestImport), func);
         let mut ret = RequiredOptions::empty();
         // Lift the params and lower the results for imports
         ret.add_lift(TypeContents::for_types(
@@ -122,7 +122,7 @@ impl RequiredOptions {
     }
 
     fn for_export(resolve: &Resolve, func: &Function) -> RequiredOptions {
-        let sig = resolve.wasm_signature(AbiVariant::GuestExport, func);
+        let sig = resolve.wasm_signature(Some(AbiVariant::GuestExport), func);
         let mut ret = RequiredOptions::empty();
         // Lower the params and lift the results for exports
         ret.add_lower(TypeContents::for_types(

--- a/crates/wit-component/src/encoding/world.rs
+++ b/crates/wit-component/src/encoding/world.rs
@@ -119,7 +119,7 @@ impl<'a> ComponentWorld<'a> {
         }
         let mut add_func = |func: &Function, name: Option<&str>| {
             let name = func.core_export_name(name);
-            let ty = resolve.wasm_signature(AbiVariant::GuestExport, func);
+            let ty = resolve.wasm_signature(Some(AbiVariant::GuestExport), func);
             let prev = required.insert(
                 name.into_owned(),
                 wasmparser::FuncType::new(
@@ -241,7 +241,7 @@ impl<'a> ComponentWorld<'a> {
             if options.is_empty() {
                 interface.direct.push(DirectLowering { name: &func.name });
             } else {
-                let sig = resolve.wasm_signature(AbiVariant::GuestImport, func);
+                let sig = resolve.wasm_signature(Some(AbiVariant::GuestImport), func);
                 interface.indirect.push(IndirectLowering {
                     name: &func.name,
                     sig,

--- a/crates/wit-component/src/validation.rs
+++ b/crates/wit-component/src/validation.rs
@@ -469,7 +469,7 @@ fn validate_func(
     func: &Function,
     abi: AbiVariant,
 ) -> Result<()> {
-    let expected = wasm_sig_to_func_type(resolve.wasm_signature(abi, func));
+    let expected = wasm_sig_to_func_type(resolve.wasm_signature(Some(abi), func));
     if ty != &expected {
         bail!(
             "type mismatch for function `{}`: expected `{:?} -> {:?}` but found `{:?} -> {:?}`",


### PR DESCRIPTION
This makes a minor change to `wasm_signature` to support a form that provides the complete ABI signature for a function without the import / export call signature truncations when providing `None` in place of `AbiVariant`.

I found I needed this information in bindgen work and there was no other API available to just get the full untruncated core type, without a bunch of copying or reimplementation.

While I understand this change is slightly noisy, it is also in theory a negative diff (by character count at least!). I'm very much open to API suggestions as to how to better make this available, but as such a fundamental part of the component model it would be great to have easy access to this information.