### PR TITLE
Relax the url package to ^2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ rand = { version = "0.8.4", features = ["small_rng"] }
 rayon = "1.3"
 serde = { version = "1.0.137", features = ["derive"] }
 wasmtime = { version = "3.0.0", default-features = false, features = ['cranelift'] }
-url = "2.3.1"
+url = "2.0.0"
 
 wasm-encoder = { version = "0.22.1", path = "crates/wasm-encoder"}
 wasm-compose = { version = "0.2.6", path = "crates/wasm-compose"}


### PR DESCRIPTION
The `url` package, included for wasm components, has an overly strict constraint that conflicts with a pinned dependency in the Firefox build. `cargo test --all` passes with `url = "=2.0.0"`, so it should hopefully be no problem to use `url = "2.0.0"` here instead.

cc @eqrion 