### PR TITLE
Disable float types with `floats = false`

### DIFF
--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -222,8 +222,7 @@ pub struct WasmFeatures {
     /// Whether or not floating-point instructions are enabled.
     ///
     /// This is enabled by default can be used to disallow floating-point
-    /// operators. Note that disabling this does not disable the `f32` and
-    /// `f64` wasm types, only the operators that work on them.
+    /// operators and types.
     ///
     /// This does not correspond to a WebAssembly proposal but is instead
     /// intended for embeddings which have stricter-than-usual requirements
@@ -248,7 +247,14 @@ pub struct WasmFeatures {
 impl WasmFeatures {
     pub(crate) fn check_value_type(&self, ty: ValType) -> Result<(), &'static str> {
         match ty {
-            ValType::I32 | ValType::I64 | ValType::F32 | ValType::F64 => Ok(()),
+            ValType::I32 | ValType::I64 => Ok(()),
+            ValType::F32 | ValType::F64 => {
+                if self.floats {
+                    Ok(())
+                } else {
+                    Err("floating-point support is disabled")
+                }
+            }
             ValType::FuncRef | ValType::ExternRef => {
                 if self.reference_types {
                     Ok(())

--- a/tests/local/missing-features/floats-disabled.wast
+++ b/tests/local/missing-features/floats-disabled.wast
@@ -1,0 +1,10 @@
+(assert_invalid
+  (module
+    (func (param f32))
+  )
+  "floating-point support is disabled")
+(assert_invalid
+  (module
+    (func (local f32))
+  )
+  "floating-point support is disabled")

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -552,6 +552,7 @@ impl TestState {
                     features.mutable_global = false;
                     features.bulk_memory = false;
                 }
+                "floats-disabled.wast" => features.floats = false,
                 "threads" => {
                     features.threads = true;
                     features.bulk_memory = false;


### PR DESCRIPTION
This commit updates the validator to reject the `f32` and `f64` types if the `WasmFeatures::floats` field is disabled.

Closes #909