### PR TITLE
Implement export type ascription

### DIFF
--- a/crates/wasm-compose/src/encoding.rs
+++ b/crates/wasm-compose/src/encoding.rs
@@ -1225,7 +1225,7 @@ impl<'a> CompositionGraphEncoder<'a> {
                 }
             };
 
-            export_section.export(export_name, export_url, kind, index);
+            export_section.export(export_name, export_url, kind, index, None);
         }
 
         if !alias_section.is_empty() {

--- a/crates/wasm-compose/src/graph.rs
+++ b/crates/wasm-compose/src/graph.rs
@@ -272,6 +272,7 @@ impl<'a> Component<'a> {
                     url,
                     kind,
                     index,
+                    ty: None,
                 })?,
         ))
     }

--- a/crates/wasm-encoder/src/component.rs
+++ b/crates/wasm-encoder/src/component.rs
@@ -106,7 +106,7 @@ impl Component {
         Self {
             bytes: vec![
                 0x00, 0x61, 0x73, 0x6D, // magic (`\0asm`)
-                0x0b, 0x00, 0x01, 0x00, // version
+                0x0c, 0x00, 0x01, 0x00, // version
             ],
         }
     }

--- a/crates/wasm-encoder/src/component/exports.rs
+++ b/crates/wasm-encoder/src/component/exports.rs
@@ -2,7 +2,7 @@ use super::{
     COMPONENT_SORT, CORE_MODULE_SORT, CORE_SORT, FUNCTION_SORT, INSTANCE_SORT, TYPE_SORT,
     VALUE_SORT,
 };
-use crate::{encode_section, ComponentSection, ComponentSectionId, Encode};
+use crate::{encode_section, ComponentSection, ComponentSectionId, ComponentTypeRef, Encode};
 
 /// Represents the kind of an export from a WebAssembly component.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -56,7 +56,7 @@ impl Encode for ComponentExportKind {
 ///
 /// // This exports a function named "foo"
 /// let mut exports = ComponentExportSection::new();
-/// exports.export("foo", "", ComponentExportKind::Func, 0);
+/// exports.export("foo", "", ComponentExportKind::Func, 0, None);
 ///
 /// let mut component = Component::new();
 /// component.section(&exports);
@@ -92,11 +92,21 @@ impl ComponentExportSection {
         url: &str,
         kind: ComponentExportKind,
         index: u32,
+        ty: Option<ComponentTypeRef>,
     ) -> &mut Self {
         name.encode(&mut self.bytes);
         url.encode(&mut self.bytes);
         kind.encode(&mut self.bytes);
         index.encode(&mut self.bytes);
+        match ty {
+            Some(ty) => {
+                self.bytes.push(0x01);
+                ty.encode(&mut self.bytes);
+            }
+            None => {
+                self.bytes.push(0x00);
+            }
+        }
         self.num_added += 1;
         self
     }

--- a/crates/wasm-encoder/src/lib.rs
+++ b/crates/wasm-encoder/src/lib.rs
@@ -183,6 +183,6 @@ mod test {
     #[test]
     fn it_encodes_an_empty_component() {
         let bytes = Component::new().finish();
-        assert_eq!(bytes, [0x00, b'a', b's', b'm', 0x0b, 0x00, 0x01, 0x00]);
+        assert_eq!(bytes, [0x00, b'a', b's', b'm', 0x0c, 0x00, 0x01, 0x00]);
     }
 }

--- a/crates/wasmparser/src/parser.rs
+++ b/crates/wasmparser/src/parser.rs
@@ -19,7 +19,8 @@ pub(crate) const WASM_MODULE_VERSION: u16 = 0x1;
 //
 // * [????-??-??] 0xa - original version
 // * [2022-01-05] 0xb - `export` introduces an alias
-pub(crate) const WASM_COMPONENT_VERSION: u16 = 0xb;
+// * [2022-02-06] 0xc - `export` has an optional type ascribed to it
+pub(crate) const WASM_COMPONENT_VERSION: u16 = 0xc;
 
 /// The supported encoding formats for the parser.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -1166,7 +1167,7 @@ mod tests {
     fn parser_after_component_header() -> Parser {
         let mut p = Parser::default();
         assert_matches!(
-            p.parse(b"\0asm\x0b\0\x01\0", false),
+            p.parse(b"\0asm\x0c\0\x01\0", false),
             Ok(Chunk::Parsed {
                 consumed: 8,
                 payload: Payload::Version {

--- a/crates/wasmparser/src/readers/component/instances.rs
+++ b/crates/wasmparser/src/readers/component/instances.rs
@@ -144,6 +144,7 @@ impl<'a> FromReader<'a> for ComponentInstance<'a> {
                             url: "",
                             kind: reader.read()?,
                             index: reader.read()?,
+                            ty: None,
                         })
                     })
                     .collect::<Result<_>>()?,

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -1772,6 +1772,10 @@ impl Printer {
         }
         self.result.push(' ');
         self.print_component_external_kind(state, export.kind, export.index)?;
+        if let Some(ty) = &export.ty {
+            self.result.push(' ');
+            self.print_component_import_ty(state, &ty, false)?;
+        }
         self.end_group();
         Ok(())
     }

--- a/crates/wast/src/component/binary.rs
+++ b/crates/wast/src/component/binary.rs
@@ -334,8 +334,13 @@ impl<'a> Encoder<'a> {
     fn encode_export(&mut self, export: &ComponentExport<'a>) {
         let name = get_name(&export.id, &export.debug_name);
         let (kind, index) = (&export.kind).into();
-        self.exports
-            .export(export.name, export.url.unwrap_or(""), kind, index);
+        self.exports.export(
+            export.name,
+            export.url.unwrap_or(""),
+            kind,
+            index,
+            export.ty.as_ref().map(|ty| (&ty.0.kind).into()),
+        );
         match &export.kind {
             ComponentExportKind::CoreModule(_) => self.core_module_names.push(name),
             ComponentExportKind::Func(_) => self.func_names.push(name),

--- a/crates/wast/src/component/expand.rs
+++ b/crates/wast/src/component/expand.rs
@@ -121,10 +121,13 @@ impl<'a> Expander<'a> {
                 self.expand_item_sig(&mut i.item);
                 None
             }
-            ComponentField::Start(_)
-            | ComponentField::Alias(_)
-            | ComponentField::Export(_)
-            | ComponentField::Custom(_) => None,
+            ComponentField::Export(e) => {
+                if let Some(sig) = &mut e.ty {
+                    self.expand_item_sig(&mut sig.0);
+                }
+                None
+            }
+            ComponentField::Start(_) | ComponentField::Alias(_) | ComponentField::Custom(_) => None,
         };
 
         if let Some(expanded) = expanded {
@@ -143,6 +146,7 @@ impl<'a> Expander<'a> {
                     name,
                     url,
                     kind: ComponentExportKind::module(module.span, id),
+                    ty: None,
                 }));
         }
         match &mut module.kind {
@@ -190,6 +194,7 @@ impl<'a> Expander<'a> {
                     name,
                     url,
                     kind: ComponentExportKind::component(component.span, id),
+                    ty: None,
                 }));
         }
         match &mut component.kind {
@@ -225,6 +230,7 @@ impl<'a> Expander<'a> {
                     name,
                     url,
                     kind: ComponentExportKind::instance(instance.span, id),
+                    ty: None,
                 }));
         }
         match &mut instance.kind {
@@ -293,6 +299,7 @@ impl<'a> Expander<'a> {
                     name,
                     url,
                     kind: ComponentExportKind::func(func.span, id),
+                    ty: None,
                 }));
         }
         match &mut func.kind {
@@ -374,6 +381,7 @@ impl<'a> Expander<'a> {
                     name,
                     url,
                     kind: ComponentExportKind::ty(field.span, id),
+                    ty: None,
                 }));
         }
     }

--- a/crates/wast/src/component/export.rs
+++ b/crates/wast/src/component/export.rs
@@ -1,4 +1,4 @@
-use super::ItemRef;
+use super::{ItemRef, ItemSigNoName};
 use crate::kw;
 use crate::parser::{Cursor, Parse, Parser, Peek, Result};
 use crate::token::{Id, Index, NameAnnotation, Span};
@@ -18,6 +18,8 @@ pub struct ComponentExport<'a> {
     pub url: Option<&'a str>,
     /// The kind of export.
     pub kind: ComponentExportKind<'a>,
+    /// The kind of export.
+    pub ty: Option<ItemSigNoName<'a>>,
 }
 
 impl<'a> Parse<'a> for ComponentExport<'a> {
@@ -28,6 +30,11 @@ impl<'a> Parse<'a> for ComponentExport<'a> {
         let name = parser.parse()?;
         let url = parser.parse()?;
         let kind = parser.parse()?;
+        let ty = if !parser.is_empty() {
+            Some(parser.parens(|p| p.parse())?)
+        } else {
+            None
+        };
         Ok(ComponentExport {
             span,
             id,
@@ -35,6 +42,7 @@ impl<'a> Parse<'a> for ComponentExport<'a> {
             name,
             url,
             kind,
+            ty,
         })
     }
 }

--- a/crates/wast/src/component/resolve.rs
+++ b/crates/wast/src/component/resolve.rs
@@ -164,7 +164,12 @@ impl<'a> Resolver<'a> {
             ComponentField::Func(_) => unreachable!("should be expanded already"),
             ComponentField::Start(s) => self.start(s),
             ComponentField::Import(i) => self.item_sig(&mut i.item),
-            ComponentField::Export(e) => self.export(&mut e.kind),
+            ComponentField::Export(e) => {
+                if let Some(ty) = &mut e.ty {
+                    self.item_sig(&mut ty.0)?;
+                }
+                self.export(&mut e.kind)
+            }
             ComponentField::Custom(_) => Ok(()),
         }
     }

--- a/crates/wit-component/src/builder.rs
+++ b/crates/wit-component/src/builder.rs
@@ -122,7 +122,7 @@ impl ComponentBuilder {
     }
 
     pub fn export(&mut self, name: &str, url: &str, kind: ComponentExportKind, idx: u32) -> u32 {
-        self.exports().export(name, url, kind, idx);
+        self.exports().export(name, url, kind, idx, None);
         match kind {
             ComponentExportKind::Type => inc(&mut self.types),
             ComponentExportKind::Func => inc(&mut self.funcs),

--- a/tests/cli/dump/alias.wat.stdout
+++ b/tests/cli/dump/alias.wat.stdout
@@ -1,5 +1,5 @@
-  0x0 | 00 61 73 6d | version 11 (Component)
-      | 0b 00 01 00
+  0x0 | 00 61 73 6d | version 12 (Component)
+      | 0c 00 01 00
   0x8 | 07 1f       | component type section
   0xa | 01          | 1 count
   0xb | 42 04 01 40 | [type 0] Instance([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Export { name: "f1", url: "", ty: Func(0) }, Type(Func(ComponentFuncType { params: [("p1", Primitive(String))], results: Named([]) })), Export { name: "f2", url: "", ty: Func(1) }])

--- a/tests/cli/dump/alias2.wat.stdout
+++ b/tests/cli/dump/alias2.wat.stdout
@@ -1,5 +1,5 @@
-   0x0 | 00 61 73 6d | version 11 (Component)
-       | 0b 00 01 00
+   0x0 | 00 61 73 6d | version 12 (Component)
+       | 0c 00 01 00
    0x8 | 07 30       | component type section
    0xa | 01          | 1 count
    0xb | 42 09 00 50 | [type 0] Instance([CoreType(Module([])), Export { name: "a", url: "", ty: Module(0) }, Type(Func(ComponentFuncType { params: [], results: Named([]) })), Export { name: "b", url: "", ty: Func(0) }, Export { name: "c", url: "", ty: Value(Primitive(String)) }, Type(Instance([])), Export { name: "d", url: "", ty: Instance(1) }, Type(Component([])), Export { name: "e", url: "", ty: Component(2) }])
@@ -19,8 +19,8 @@
   0x3d | 01 61 00 05 | [instance 0] ComponentImport { name: "a", url: "", ty: Instance(0) }
        | 00         
   0x42 | 04 59       | [component 0] inline size
-    0x44 | 00 61 73 6d | version 11 (Component)
-         | 0b 00 01 00
+    0x44 | 00 61 73 6d | version 12 (Component)
+         | 0c 00 01 00
     0x4c | 03 03       | core type section
     0x4e | 01          | 1 count
     0x4f | 50 00       | [core type 0] Module([])
@@ -79,8 +79,8 @@
        | 01 64 05 01
        | 01 65 04 01
   0xd5 | 04 34       | [component 2] inline size
-    0xd7 | 00 61 73 6d | version 11 (Component)
-         | 0b 00 01 00
+    0xd7 | 00 61 73 6d | version 12 (Component)
+         | 0c 00 01 00
     0xdf | 06 05       | component alias section
     0xe1 | 01          | 1 count
     0xe2 | 03 02 01 00 | alias [type 0] Outer { kind: Type, count: 1, index: 0 }
@@ -112,7 +112,7 @@
        | 65         
  0x128 | 05 1f       | component instance section
  0x12a | 02          | 2 count
- 0x12b | 01 05 01 61 | [instance 4] FromExports([ComponentExport { name: "a", url: "", kind: Module, index: 1 }, ComponentExport { name: "b", url: "", kind: Func, index: 1 }, ComponentExport { name: "c", url: "", kind: Value, index: 1 }, ComponentExport { name: "d", url: "", kind: Instance, index: 3 }, ComponentExport { name: "e", url: "", kind: Component, index: 3 }])
+ 0x12b | 01 05 01 61 | [instance 4] FromExports([ComponentExport { name: "a", url: "", kind: Module, index: 1, ty: None }, ComponentExport { name: "b", url: "", kind: Func, index: 1, ty: None }, ComponentExport { name: "c", url: "", kind: Value, index: 1, ty: None }, ComponentExport { name: "d", url: "", kind: Instance, index: 3, ty: None }, ComponentExport { name: "e", url: "", kind: Component, index: 3, ty: None }])
        | 00 11 01 01
        | 62 01 01 01
        | 63 02 01 01

--- a/tests/cli/dump/bundled.wat.stdout
+++ b/tests/cli/dump/bundled.wat.stdout
@@ -1,5 +1,5 @@
-   0x0 | 00 61 73 6d | version 11 (Component)
-       | 0b 00 01 00
+   0x0 | 00 61 73 6d | version 12 (Component)
+       | 0c 00 01 00
    0x8 | 07 30       | component type section
    0xa | 01          | 1 count
    0xb | 42 06 01 70 | [type 0] Instance([Type(Defined(List(Primitive(U8)))), Type(Func(ComponentFuncType { params: [("len", Primitive(U32))], results: Unnamed(Type(0)) })), Export { name: "read", url: "", ty: Func(1) }, Type(Defined(List(Primitive(U8)))), Type(Func(ComponentFuncType { params: [("buf", Type(2))], results: Unnamed(Primitive(U32)) })), Export { name: "write", url: "", ty: Func(3) }])
@@ -187,46 +187,47 @@
  0x1d7 | 00 00 02 02 | [func 1] Lift { core_func_index: 2, type_index: 1, options: [Memory(1), Realloc(3)] }
        | 03 01 04 03
        | 01         
- 0x1e0 | 0b 09       | component export section
+ 0x1e0 | 0b 0a       | component export section
  0x1e2 | 01          | 1 count
- 0x1e3 | 04 77 6f 72 | export ComponentExport { name: "work", url: "", kind: Func, index: 1 }
+ 0x1e3 | 04 77 6f 72 | export ComponentExport { name: "work", url: "", kind: Func, index: 1, ty: None }
        | 6b 00 01 01
- 0x1eb | 00 7c       | custom section
- 0x1ed | 0e 63 6f 6d | name: "component-name"
+       | 00         
+ 0x1ec | 00 7c       | custom section
+ 0x1ee | 0e 63 6f 6d | name: "component-name"
        | 70 6f 6e 65
        | 6e 74 2d 6e
        | 61 6d 65   
- 0x1fc | 01 13 00 00 | core func section
- 0x200 | 01          | 1 count
- 0x201 | 01 0e 72 65 | Naming { index: 1, name: "real-wasi-read" }
+ 0x1fd | 01 13 00 00 | core func section
+ 0x201 | 01          | 1 count
+ 0x202 | 01 0e 72 65 | Naming { index: 1, name: "real-wasi-read" }
        | 61 6c 2d 77
        | 61 73 69 2d
        | 72 65 61 64
- 0x211 | 01 1c 00 11 | core module section
- 0x215 | 03          | 3 count
- 0x216 | 00 04 6c 69 | Naming { index: 0, name: "libc" }
+ 0x212 | 01 1c 00 11 | core module section
+ 0x216 | 03          | 3 count
+ 0x217 | 00 04 6c 69 | Naming { index: 0, name: "libc" }
        | 62 63      
- 0x21c | 01 05 43 48 | Naming { index: 1, name: "CHILD" }
+ 0x21d | 01 05 43 48 | Naming { index: 1, name: "CHILD" }
        | 49 4c 44   
- 0x223 | 02 0a 56 49 | Naming { index: 2, name: "VIRTUALIZE" }
+ 0x224 | 02 0a 56 49 | Naming { index: 2, name: "VIRTUALIZE" }
        | 52 54 55 41
        | 4c 49 5a 45
- 0x22f | 01 1b 00 12 | core instance section
- 0x233 | 03          | 3 count
- 0x234 | 00 04 6c 69 | Naming { index: 0, name: "libc" }
+ 0x230 | 01 1b 00 12 | core instance section
+ 0x234 | 03          | 3 count
+ 0x235 | 00 04 6c 69 | Naming { index: 0, name: "libc" }
        | 62 63      
- 0x23a | 02 09 76 69 | Naming { index: 2, name: "virt-wasi" }
+ 0x23b | 02 09 76 69 | Naming { index: 2, name: "virt-wasi" }
        | 72 74 2d 77
        | 61 73 69   
- 0x245 | 03 05 63 68 | Naming { index: 3, name: "child" }
+ 0x246 | 03 05 63 68 | Naming { index: 3, name: "child" }
        | 69 6c 64   
- 0x24c | 01 0c 03    | type section
- 0x24f | 01          | 1 count
- 0x250 | 00 08 57 61 | Naming { index: 0, name: "WasiFile" }
+ 0x24d | 01 0c 03    | type section
+ 0x250 | 01          | 1 count
+ 0x251 | 00 08 57 61 | Naming { index: 0, name: "WasiFile" }
        | 73 69 46 69
        | 6c 65      
- 0x25a | 01 0d 05    | instance section
- 0x25d | 01          | 1 count
- 0x25e | 00 09 72 65 | Naming { index: 0, name: "real-wasi" }
+ 0x25b | 01 0d 05    | instance section
+ 0x25e | 01          | 1 count
+ 0x25f | 00 09 72 65 | Naming { index: 0, name: "real-wasi" }
        | 61 6c 2d 77
        | 61 73 69   

--- a/tests/cli/dump/component-expand-bundle.wat.stdout
+++ b/tests/cli/dump/component-expand-bundle.wat.stdout
@@ -1,5 +1,5 @@
-  0x0 | 00 61 73 6d | version 11 (Component)
-      | 0b 00 01 00
+  0x0 | 00 61 73 6d | version 12 (Component)
+      | 0c 00 01 00
   0x8 | 01 29       | [core module 0] inline size
     0xa | 00 61 73 6d | version 1 (Module)
         | 01 00 00 00

--- a/tests/cli/dump/component-expand-bundle2.wat.stdout
+++ b/tests/cli/dump/component-expand-bundle2.wat.stdout
@@ -1,66 +1,66 @@
-  0x0 | 00 61 73 6d | version 11 (Component)
-      | 0b 00 01 00
-  0x8 | 04 30       | [component 0] inline size
-    0xa | 00 61 73 6d | version 11 (Component)
-        | 0b 00 01 00
+  0x0 | 00 61 73 6d | version 12 (Component)
+      | 0c 00 01 00
+  0x8 | 04 31       | [component 0] inline size
+    0xa | 00 61 73 6d | version 12 (Component)
+        | 0c 00 01 00
    0x12 | 01 08       | [core module 0] inline size
      0x14 | 00 61 73 6d | version 1 (Module)
           | 01 00 00 00
-   0x1c | 0b 07       | component export section
+   0x1c | 0b 08       | component export section
    0x1e | 01          | 1 count
-   0x1f | 01 65 00 00 | export ComponentExport { name: "e", url: "", kind: Module, index: 0 }
-        | 11 00      
-   0x25 | 00 13       | custom section
-   0x27 | 0e 63 6f 6d | name: "component-name"
+   0x1f | 01 65 00 00 | export ComponentExport { name: "e", url: "", kind: Module, index: 0, ty: None }
+        | 11 00 00   
+   0x26 | 00 13       | custom section
+   0x28 | 0e 63 6f 6d | name: "component-name"
         | 70 6f 6e 65
         | 6e 74 2d 6e
         | 61 6d 65   
-   0x36 | 00 02       | component name
-   0x38 | 01 63       | "c"
- 0x3a | 04 35       | [component 1] inline size
-   0x3c | 00 61 73 6d | version 11 (Component)
-        | 0b 00 01 00
-   0x44 | 07 0d       | component type section
-   0x46 | 01          | 1 count
-   0x47 | 41 02 00 50 | [type 0] Component([CoreType(Module([])), Import(ComponentImport { name: "i", url: "", ty: Module(0) })])
+   0x37 | 00 02       | component name
+   0x39 | 01 63       | "c"
+ 0x3b | 04 35       | [component 1] inline size
+   0x3d | 00 61 73 6d | version 12 (Component)
+        | 0c 00 01 00
+   0x45 | 07 0d       | component type section
+   0x47 | 01          | 1 count
+   0x48 | 41 02 00 50 | [type 0] Component([CoreType(Module([])), Import(ComponentImport { name: "i", url: "", ty: Module(0) })])
         | 00 03 01 69
         | 00 00 11 00
-   0x53 | 0a 06       | component import section
-   0x55 | 01          | 1 count
-   0x56 | 01 69 00 04 | [component 0] ComponentImport { name: "i", url: "", ty: Component(0) }
+   0x54 | 0a 06       | component import section
+   0x56 | 01          | 1 count
+   0x57 | 01 69 00 04 | [component 0] ComponentImport { name: "i", url: "", ty: Component(0) }
         | 00         
-   0x5b | 00 14       | custom section
-   0x5d | 0e 63 6f 6d | name: "component-name"
+   0x5c | 00 14       | custom section
+   0x5e | 0e 63 6f 6d | name: "component-name"
         | 70 6f 6e 65
         | 6e 74 2d 6e
         | 61 6d 65   
-   0x6c | 00 03       | component name
-   0x6e | 02 63 32    | "c2"
- 0x71 | 05 04       | component instance section
- 0x73 | 01          | 1 count
- 0x74 | 00 00 00    | [instance 0] Instantiate { component_index: 0, args: [] }
- 0x77 | 06 07       | component alias section
- 0x79 | 01          | 1 count
- 0x7a | 00 11 00 00 | alias [module 0] InstanceExport { kind: Module, instance_index: 0, name: "e" }
+   0x6d | 00 03       | component name
+   0x6f | 02 63 32    | "c2"
+ 0x72 | 05 04       | component instance section
+ 0x74 | 01          | 1 count
+ 0x75 | 00 00 00    | [instance 0] Instantiate { component_index: 0, args: [] }
+ 0x78 | 06 07       | component alias section
+ 0x7a | 01          | 1 count
+ 0x7b | 00 11 00 00 | alias [module 0] InstanceExport { kind: Module, instance_index: 0, name: "e" }
       | 01 65      
- 0x80 | 05 0f       | component instance section
- 0x82 | 02          | 2 count
- 0x83 | 01 01 01 65 | [instance 1] FromExports([ComponentExport { name: "e", url: "", kind: Module, index: 0 }])
+ 0x81 | 05 0f       | component instance section
+ 0x83 | 02          | 2 count
+ 0x84 | 01 01 01 65 | [instance 1] FromExports([ComponentExport { name: "e", url: "", kind: Module, index: 0, ty: None }])
       | 00 11 00   
- 0x8a | 00 01 01 01 | [instance 2] Instantiate { component_index: 1, args: [ComponentInstantiationArg { name: "i", kind: Instance, index: 1 }] }
+ 0x8b | 00 01 01 01 | [instance 2] Instantiate { component_index: 1, args: [ComponentInstantiationArg { name: "i", kind: Instance, index: 1 }] }
       | 69 05 01   
- 0x91 | 00 29       | custom section
- 0x93 | 0e 63 6f 6d | name: "component-name"
+ 0x92 | 00 29       | custom section
+ 0x94 | 0e 63 6f 6d | name: "component-name"
       | 70 6f 6e 65
       | 6e 74 2d 6e
       | 61 6d 65   
- 0xa2 | 01 06 00 11 | core module section
- 0xa6 | 01          | 1 count
- 0xa7 | 00 01 6d    | Naming { index: 0, name: "m" }
- 0xaa | 01 09 04    | component section
- 0xad | 02          | 2 count
- 0xae | 00 01 63    | Naming { index: 0, name: "c" }
- 0xb1 | 01 02 63 32 | Naming { index: 1, name: "c2" }
- 0xb5 | 01 05 05    | instance section
- 0xb8 | 01          | 1 count
- 0xb9 | 00 01 43    | Naming { index: 0, name: "C" }
+ 0xa3 | 01 06 00 11 | core module section
+ 0xa7 | 01          | 1 count
+ 0xa8 | 00 01 6d    | Naming { index: 0, name: "m" }
+ 0xab | 01 09 04    | component section
+ 0xae | 02          | 2 count
+ 0xaf | 00 01 63    | Naming { index: 0, name: "c" }
+ 0xb2 | 01 02 63 32 | Naming { index: 1, name: "c2" }
+ 0xb6 | 01 05 05    | instance section
+ 0xb9 | 01          | 1 count
+ 0xba | 00 01 43    | Naming { index: 0, name: "C" }

--- a/tests/cli/dump/component-inline-export-import.wat.stdout
+++ b/tests/cli/dump/component-inline-export-import.wat.stdout
@@ -1,5 +1,5 @@
-  0x0 | 00 61 73 6d | version 11 (Component)
-      | 0b 00 01 00
+  0x0 | 00 61 73 6d | version 12 (Component)
+      | 0c 00 01 00
   0x8 | 07 03       | component type section
   0xa | 01          | 1 count
   0xb | 41 00       | [type 0] Component([])
@@ -13,8 +13,9 @@
  0x1b | 01          | 1 count
  0x1c | 01 61 00 00 | [module 0] ComponentImport { name: "a", url: "", ty: Module(0) }
       | 11 00      
- 0x22 | 0b 0b       | component export section
+ 0x22 | 0b 0d       | component export section
  0x24 | 02          | 2 count
- 0x25 | 00 00 04 00 | export ComponentExport { name: "", url: "", kind: Component, index: 0 }
- 0x29 | 01 61 00 00 | export ComponentExport { name: "a", url: "", kind: Module, index: 0 }
-      | 11 00      
+ 0x25 | 00 00 04 00 | export ComponentExport { name: "", url: "", kind: Component, index: 0, ty: None }
+      | 00         
+ 0x2a | 01 61 00 00 | export ComponentExport { name: "a", url: "", kind: Module, index: 0, ty: None }
+      | 11 00 00   

--- a/tests/cli/dump/component-inline-type.wat.stdout
+++ b/tests/cli/dump/component-inline-type.wat.stdout
@@ -1,5 +1,5 @@
-  0x0 | 00 61 73 6d | version 11 (Component)
-      | 0b 00 01 00
+  0x0 | 00 61 73 6d | version 12 (Component)
+      | 0c 00 01 00
   0x8 | 07 03       | component type section
   0xa | 01          | 1 count
   0xb | 41 00       | [type 0] Component([])

--- a/tests/cli/dump/component-instance-type.wat.stdout
+++ b/tests/cli/dump/component-instance-type.wat.stdout
@@ -1,5 +1,5 @@
-  0x0 | 00 61 73 6d | version 11 (Component)
-      | 0b 00 01 00
+  0x0 | 00 61 73 6d | version 12 (Component)
+      | 0c 00 01 00
   0x8 | 07 28       | component type section
   0xa | 01          | 1 count
   0xb | 42 03 01 40 | [type 0] Instance([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Type(Component([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Alias(Outer { kind: Type, count: 1, index: 0 }), Import(ComponentImport { name: "1", url: "", ty: Func(0) }), Export { name: "1", url: "", ty: Func(1) }])), Export { name: "c5", url: "", ty: Component(1) }])

--- a/tests/cli/dump/component-linking.wat.stdout
+++ b/tests/cli/dump/component-linking.wat.stdout
@@ -1,5 +1,5 @@
-  0x0 | 00 61 73 6d | version 11 (Component)
-      | 0b 00 01 00
+  0x0 | 00 61 73 6d | version 12 (Component)
+      | 0c 00 01 00
   0x8 | 07 30       | component type section
   0xa | 01          | 1 count
   0xb | 42 09 00 50 | [type 0] Instance([CoreType(Module([])), Export { name: "a", url: "", ty: Module(0) }, Type(Func(ComponentFuncType { params: [], results: Named([]) })), Export { name: "b", url: "", ty: Func(0) }, Export { name: "c", url: "", ty: Value(Primitive(String)) }, Type(Instance([])), Export { name: "d", url: "", ty: Instance(1) }, Type(Component([])), Export { name: "e", url: "", ty: Component(2) }])
@@ -19,8 +19,8 @@
  0x3d | 01 61 00 05 | [instance 0] ComponentImport { name: "a", url: "", ty: Instance(0) }
       | 00         
  0x42 | 04 59       | [component 0] inline size
-   0x44 | 00 61 73 6d | version 11 (Component)
-        | 0b 00 01 00
+   0x44 | 00 61 73 6d | version 12 (Component)
+        | 0c 00 01 00
    0x4c | 03 03       | core type section
    0x4e | 01          | 1 count
    0x4f | 50 00       | [core type 0] Module([])

--- a/tests/cli/dump/component-outer-alias.wat.stdout
+++ b/tests/cli/dump/component-outer-alias.wat.stdout
@@ -1,5 +1,5 @@
-  0x0 | 00 61 73 6d | version 11 (Component)
-      | 0b 00 01 00
+  0x0 | 00 61 73 6d | version 12 (Component)
+      | 0c 00 01 00
   0x8 | 07 0e       | component type section
   0xa | 02          | 2 count
   0xb | 73          | [type 0] Defined(Primitive(String))
@@ -7,8 +7,8 @@
       | 02 01 00 01
       | 40 00 00 00
  0x18 | 04 2e       | [component 0] inline size
-   0x1a | 00 61 73 6d | version 11 (Component)
-        | 0b 00 01 00
+   0x1a | 00 61 73 6d | version 12 (Component)
+        | 0c 00 01 00
    0x22 | 06 05       | component alias section
    0x24 | 01          | 1 count
    0x25 | 03 02 01 00 | alias [type 0] Outer { kind: Type, count: 1, index: 0 }
@@ -24,8 +24,8 @@
    0x44 | 01          | 1 count
    0x45 | 00 01 74    | Naming { index: 0, name: "t" }
  0x48 | 04 32       | [component 1] inline size
-   0x4a | 00 61 73 6d | version 11 (Component)
-        | 0b 00 01 00
+   0x4a | 00 61 73 6d | version 12 (Component)
+        | 0c 00 01 00
    0x52 | 06 05       | component alias section
    0x54 | 01          | 1 count
    0x55 | 03 02 01 00 | alias [type 0] Outer { kind: Type, count: 1, index: 0 }
@@ -45,8 +45,8 @@
  0x7e | 01          | 1 count
  0x7f | 7d          | [type 2] Defined(Primitive(U8))
  0x80 | 04 33       | [component 2] inline size
-   0x82 | 00 61 73 6d | version 11 (Component)
-        | 0b 00 01 00
+   0x82 | 00 61 73 6d | version 12 (Component)
+        | 0c 00 01 00
    0x8a | 06 05       | component alias section
    0x8c | 01          | 1 count
    0x8d | 03 02 01 02 | alias [type 0] Outer { kind: Type, count: 1, index: 2 }

--- a/tests/cli/dump/import-modules.wat.stdout
+++ b/tests/cli/dump/import-modules.wat.stdout
@@ -1,5 +1,5 @@
-  0x0 | 00 61 73 6d | version 11 (Component)
-      | 0b 00 01 00
+  0x0 | 00 61 73 6d | version 12 (Component)
+      | 0c 00 01 00
   0x8 | 03 0d       | core type section
   0xa | 01          | 1 count
   0xb | 50 02 01 60 | [core type 0] Module([Type(Func(FuncType { params: [], returns: [] })), Import(Import { module: "", name: "f", ty: Func(0) })])

--- a/tests/cli/dump/instance-expand.wat.stdout
+++ b/tests/cli/dump/instance-expand.wat.stdout
@@ -1,5 +1,5 @@
-  0x0 | 00 61 73 6d | version 11 (Component)
-      | 0b 00 01 00
+  0x0 | 00 61 73 6d | version 12 (Component)
+      | 0c 00 01 00
   0x8 | 07 0d       | component type section
   0xa | 01          | 1 count
   0xb | 42 02 01 40 | [type 0] Instance([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Export { name: "", url: "", ty: Func(0) }])

--- a/tests/cli/dump/instance-type.wat.stdout
+++ b/tests/cli/dump/instance-type.wat.stdout
@@ -1,5 +1,5 @@
-  0x0 | 00 61 73 6d | version 11 (Component)
-      | 0b 00 01 00
+  0x0 | 00 61 73 6d | version 12 (Component)
+      | 0c 00 01 00
   0x8 | 07 17       | component type section
   0xa | 02          | 2 count
   0xb | 42 02 01 40 | [type 0] Instance([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Export { name: "", url: "", ty: Func(0) }])

--- a/tests/cli/dump/instance-type2.wat.stdout
+++ b/tests/cli/dump/instance-type2.wat.stdout
@@ -1,5 +1,5 @@
-  0x0 | 00 61 73 6d | version 11 (Component)
-      | 0b 00 01 00
+  0x0 | 00 61 73 6d | version 12 (Component)
+      | 0c 00 01 00
   0x8 | 07 18       | component type section
   0xa | 04          | 4 count
   0xb | 42 00       | [type 0] Instance([])

--- a/tests/cli/dump/instantiate.wat.stdout
+++ b/tests/cli/dump/instantiate.wat.stdout
@@ -1,5 +1,5 @@
-  0x0 | 00 61 73 6d | version 11 (Component)
-      | 0b 00 01 00
+  0x0 | 00 61 73 6d | version 12 (Component)
+      | 0c 00 01 00
   0x8 | 07 03       | component type section
   0xa | 01          | 1 count
   0xb | 41 00       | [type 0] Component([])

--- a/tests/cli/dump/instantiate2.wat.stdout
+++ b/tests/cli/dump/instantiate2.wat.stdout
@@ -1,5 +1,5 @@
-  0x0 | 00 61 73 6d | version 11 (Component)
-      | 0b 00 01 00
+  0x0 | 00 61 73 6d | version 12 (Component)
+      | 0c 00 01 00
   0x8 | 07 0e       | component type section
   0xa | 01          | 1 count
   0xb | 41 02 01 40 | [type 0] Component([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Import(ComponentImport { name: "a", url: "", ty: Func(0) })])

--- a/tests/cli/dump/module-types.wat.stdout
+++ b/tests/cli/dump/module-types.wat.stdout
@@ -1,5 +1,5 @@
-  0x0 | 00 61 73 6d | version 11 (Component)
-      | 0b 00 01 00
+  0x0 | 00 61 73 6d | version 12 (Component)
+      | 0c 00 01 00
   0x8 | 03 23       | core type section
   0xa | 01          | 1 count
   0xb | 50 05 01 60 | [core type 0] Module([Type(Func(FuncType { params: [], returns: [] })), Import(Import { module: "", name: "f", ty: Func(0) }), Import(Import { module: "", name: "g", ty: Global(GlobalType { content_type: I32, mutable: false }) }), Import(Import { module: "", name: "t", ty: Table(TableType { element_type: FuncRef, initial: 1, maximum: None }) }), Import(Import { module: "", name: "m", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None }) })])

--- a/tests/cli/dump/nested-component.wat.stdout
+++ b/tests/cli/dump/nested-component.wat.stdout
@@ -1,5 +1,5 @@
-  0x0 | 00 61 73 6d | version 11 (Component)
-      | 0b 00 01 00
+  0x0 | 00 61 73 6d | version 12 (Component)
+      | 0c 00 01 00
   0x8 | 07 03       | component type section
   0xa | 01          | 1 count
   0xb | 41 00       | [type 0] Component([])
@@ -8,23 +8,23 @@
  0x10 | 01 61 00 04 | [component 0] ComponentImport { name: "a", url: "", ty: Component(0) }
       | 00         
  0x15 | 04 08       | [component 1] inline size
-   0x17 | 00 61 73 6d | version 11 (Component)
-        | 0b 00 01 00
+   0x17 | 00 61 73 6d | version 12 (Component)
+        | 0c 00 01 00
  0x1f | 04 08       | [component 2] inline size
-   0x21 | 00 61 73 6d | version 11 (Component)
-        | 0b 00 01 00
+   0x21 | 00 61 73 6d | version 12 (Component)
+        | 0c 00 01 00
  0x29 | 04 08       | [component 3] inline size
-   0x2b | 00 61 73 6d | version 11 (Component)
-        | 0b 00 01 00
+   0x2b | 00 61 73 6d | version 12 (Component)
+        | 0c 00 01 00
  0x33 | 04 12       | [component 4] inline size
-   0x35 | 00 61 73 6d | version 11 (Component)
-        | 0b 00 01 00
+   0x35 | 00 61 73 6d | version 12 (Component)
+        | 0c 00 01 00
    0x3d | 04 08       | [component 0] inline size
-     0x3f | 00 61 73 6d | version 11 (Component)
-          | 0b 00 01 00
- 0x47 | 04 71       | [component 5] inline size
-   0x49 | 00 61 73 6d | version 11 (Component)
-        | 0b 00 01 00
+     0x3f | 00 61 73 6d | version 12 (Component)
+          | 0c 00 01 00
+ 0x47 | 04 73       | [component 5] inline size
+   0x49 | 00 61 73 6d | version 12 (Component)
+        | 0c 00 01 00
    0x51 | 01 13       | [core module 0] inline size
      0x53 | 00 61 73 6d | version 1 (Module)
           | 01 00 00 00
@@ -41,33 +41,33 @@
    0x72 | 01          | 1 count
    0x73 | 01 61 00 01 | [func 0] ComponentImport { name: "a", url: "", ty: Func(0) }
         | 00         
-   0x78 | 0b 07       | component export section
+   0x78 | 0b 08       | component export section
    0x7a | 01          | 1 count
-   0x7b | 01 61 00 00 | export ComponentExport { name: "a", url: "", kind: Module, index: 0 }
-        | 11 00      
-   0x81 | 07 0e       | component type section
-   0x83 | 01          | 1 count
-   0x84 | 42 02 01 40 | [type 1] Instance([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Export { name: "a", url: "", ty: Func(0) }])
+   0x7b | 01 61 00 00 | export ComponentExport { name: "a", url: "", kind: Module, index: 0, ty: None }
+        | 11 00 00   
+   0x82 | 07 0e       | component type section
+   0x84 | 01          | 1 count
+   0x85 | 42 02 01 40 | [type 1] Instance([Type(Func(ComponentFuncType { params: [], results: Named([]) })), Export { name: "a", url: "", ty: Func(0) }])
         | 00 01 00 04
         | 01 61 00 01
         | 00         
-   0x91 | 0a 06       | component import section
-   0x93 | 01          | 1 count
-   0x94 | 01 62 00 05 | [instance 0] ComponentImport { name: "b", url: "", ty: Instance(1) }
+   0x92 | 0a 06       | component import section
+   0x94 | 01          | 1 count
+   0x95 | 01 62 00 05 | [instance 0] ComponentImport { name: "b", url: "", ty: Instance(1) }
         | 01         
-   0x99 | 0b 06       | component export section
-   0x9b | 01          | 1 count
-   0x9c | 01 62 00 05 | export ComponentExport { name: "b", url: "", kind: Instance, index: 0 }
-        | 00         
-   0xa1 | 00 17       | custom section
-   0xa3 | 0e 63 6f 6d | name: "component-name"
+   0x9a | 0b 07       | component export section
+   0x9c | 01          | 1 count
+   0x9d | 01 62 00 05 | export ComponentExport { name: "b", url: "", kind: Instance, index: 0, ty: None }
+        | 00 00      
+   0xa3 | 00 17       | custom section
+   0xa5 | 0e 63 6f 6d | name: "component-name"
         | 70 6f 6e 65
         | 6e 74 2d 6e
         | 61 6d 65   
-   0xb2 | 01 06 00 11 | core module section
-   0xb6 | 01          | 1 count
-   0xb7 | 00 01 6d    | Naming { index: 0, name: "m" }
- 0xba | 0b 06       | component export section
- 0xbc | 01          | 1 count
- 0xbd | 01 61 00 04 | export ComponentExport { name: "a", url: "", kind: Component, index: 3 }
-      | 03         
+   0xb4 | 01 06 00 11 | core module section
+   0xb8 | 01          | 1 count
+   0xb9 | 00 01 6d    | Naming { index: 0, name: "m" }
+ 0xbc | 0b 07       | component export section
+ 0xbe | 01          | 1 count
+ 0xbf | 01 61 00 04 | export ComponentExport { name: "a", url: "", kind: Component, index: 3, ty: None }
+      | 03 00      

--- a/tests/local/component-model/export-ascription.wast
+++ b/tests/local/component-model/export-ascription.wast
@@ -1,0 +1,38 @@
+(component
+  (import "f" (func $f))
+  (export "f" (func $f) (func))
+)
+
+;; subtyping works
+(component
+  (import "f" (instance $i (export "f" (func))))
+  (export "f" (instance $i) (instance))
+)
+
+;; make sure subtyping works in the right direction
+(assert_invalid
+  (component
+    (import "f" (instance $i))
+    (export "f" (instance $i) (instance (export "f" (func))))
+  )
+  "ascribed type of export is not compatible")
+
+;; make sure the type is actually changed
+(assert_invalid
+  (component
+    (import "f" (func $f))
+
+    (component $c
+      (import "f" (instance $i (export "f" (func))))
+      (export "f" (instance $i) (instance))
+    )
+
+    (instance $c (instantiate $c (with "f" (instance (export "f" (func $f))))))
+
+    (component $consume
+      (import "arg" (instance $i (export "f" (func))))
+    )
+
+    (instance (instantiate $consume (with "arg" (instance $c "f"))))
+  )
+  "type mismatch for component instantiation argument `arg`")

--- a/tests/local/component-model/start.wast
+++ b/tests/local/component-model/start.wast
@@ -74,7 +74,7 @@
 
 (assert_invalid
   (component binary
-    "\00asm" "\0b\00\01\00"   ;; component header
+    "\00asm" "\0c\00\01\00"   ;; component header
 
     "\07\05"          ;; type section, 5 bytes large
     "\01"             ;; 1 count
@@ -97,7 +97,7 @@
 
 (assert_invalid
   (component binary
-    "\00asm" "\0b\00\01\00"   ;; component header
+    "\00asm" "\0c\00\01\00"   ;; component header
 
     "\07\05"          ;; type section, 5 bytes large
     "\01"             ;; 1 count

--- a/tests/snapshots/local/component-model/export-ascription.wast/0.print
+++ b/tests/snapshots/local/component-model/export-ascription.wast/0.print
@@ -1,0 +1,6 @@
+(component
+  (type (;0;) (func))
+  (import "f" (func $f (;0;) (type 0)))
+  (type (;1;) (func))
+  (export (;1;) "f" (func $f) (func (type 1)))
+)

--- a/tests/snapshots/local/component-model/export-ascription.wast/1.print
+++ b/tests/snapshots/local/component-model/export-ascription.wast/1.print
@@ -1,0 +1,13 @@
+(component
+  (type (;0;)
+    (instance
+      (type (;0;) (func))
+      (export (;0;) "f" (func (type 0)))
+    )
+  )
+  (import "f" (instance $i (;0;) (type 0)))
+  (type (;1;)
+    (instance)
+  )
+  (export (;1;) "f" (instance $i) (instance (type 1)))
+)


### PR DESCRIPTION
This commit implements the change described in
WebAssembly/component-model#155 and accounts for the update in WebAssembly/component-model#161. The internal plumbing for this change was relatively easy to implement and shouldn't cause too much of a burden even on Wasmtime as a consumer (it may not have to change at all). I'll be working on a follow-up for `wit-component` to use this new construct to fix the original underlying issue.