### PR TITLE
wit-component: lazily allocate adapter stack when appropriate

### DIFF
--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -1,9 +1,12 @@
 use self::bitvec::BitVec;
 use anyhow::{bail, Result};
 use indexmap::{IndexMap, IndexSet};
-use std::collections::HashMap;
-use std::mem;
-use wasm_encoder::{Encode, EntityType};
+use std::{
+    collections::{HashMap, HashSet},
+    mem,
+    ops::Deref,
+};
+use wasm_encoder::{Encode, EntityType, Instruction};
 use wasmparser::*;
 
 const PAGE_SIZE: i32 = 64 * 1024;
@@ -100,6 +103,55 @@ fn realloc_via_memory_grow() -> wasm_encoder::Function {
     func.instruction(&LocalGet(4));
     func.instruction(&I32Const(16));
     func.instruction(&I32Shl);
+    func.instruction(&End);
+
+    func
+}
+
+#[repr(i32)]
+#[non_exhaustive]
+enum AllocationState {
+    StackUnallocated,
+    StackAllocating,
+    StackAllocated,
+}
+
+fn allocate_stack_via_realloc(
+    realloc_index: u32,
+    sp: u32,
+    allocation_state: Option<u32>,
+) -> wasm_encoder::Function {
+    use wasm_encoder::Instruction::*;
+
+    let mut func = wasm_encoder::Function::new([]);
+
+    if let Some(allocation_state) = allocation_state {
+        // This means we're lazily allocating the stack, keeping track of state via `$allocation_state`
+        func.instruction(&GlobalGet(allocation_state));
+        func.instruction(&I32Const(AllocationState::StackUnallocated as _));
+        func.instruction(&I32Eq);
+        func.instruction(&If(wasm_encoder::BlockType::Empty));
+        func.instruction(&I32Const(AllocationState::StackAllocating as _));
+        func.instruction(&GlobalSet(allocation_state));
+        // We could also set `sp` to zero here to ensure the yet-to-be-allocated stack is empty.  However, we
+        // assume it defaults to zero anyway, in which case setting it would be redundant.
+    }
+
+    func.instruction(&I32Const(0));
+    func.instruction(&I32Const(0));
+    func.instruction(&I32Const(8));
+    func.instruction(&I32Const(PAGE_SIZE));
+    func.instruction(&Call(realloc_index));
+    func.instruction(&I32Const(PAGE_SIZE));
+    func.instruction(&I32Add);
+    func.instruction(&GlobalSet(sp));
+
+    if let Some(allocation_state) = allocation_state {
+        func.instruction(&I32Const(AllocationState::StackAllocated as _));
+        func.instruction(&GlobalSet(allocation_state));
+        func.instruction(&End);
+    }
+
     func.instruction(&End);
 
     func
@@ -576,7 +628,14 @@ impl<'a> Module<'a> {
             type_index
         };
 
-        let sp = self.find_stack_pointer()?;
+        let add_empty_type = |types: &mut wasm_encoder::TypeSection| {
+            let type_index = types.len();
+            types.function([], []);
+            type_index
+        };
+
+        let sp = self.find_mut_i32_global("__stack_pointer")?;
+        let allocation_state = self.find_mut_i32_global("allocation_state")?;
 
         let mut func_names = Vec::new();
 
@@ -614,7 +673,33 @@ impl<'a> Module<'a> {
             }
         }
 
-        for (_, func) in self.live_funcs() {
+        let lazy_stack_init_index =
+            if sp.is_some() && allocation_state.is_some() && main_module_realloc.is_some() {
+                // We have a stack pointer, a `cabi_realloc` function from the main module, and a global variable for
+                // keeping track of (and short-circuiting) reentrance.  That means we can (and should) do lazy stack
+                // allocation.
+                let index = num_func_imports + funcs.len();
+
+                // Tell the function remapper we're reserving a slot for our extra function:
+                map.funcs.next += 1;
+
+                funcs.function(add_empty_type(&mut types));
+
+                Some(index)
+            } else {
+                None
+            };
+
+        let exported_funcs = self
+            .exports
+            .values()
+            .filter_map(|export| match export.kind {
+                ExternalKind::Func => Some(export.index),
+                _ => None,
+            })
+            .collect::<HashSet<_>>();
+
+        for (i, func) in self.live_funcs() {
             let mut body = match &func.def {
                 Definition::Import(..) => continue,
                 Definition::Local(body) => body.get_binary_reader(),
@@ -625,28 +710,40 @@ impl<'a> Module<'a> {
                 let ty = body.read()?;
                 locals.push((cnt, valty(ty)));
             }
-            let mut func = wasm_encoder::Function::new(locals);
+            // Prepend an `allocate_stack` call to all exports if we're lazily allocating the stack.
+            if let (Some(lazy_stack_init_index), true) =
+                (lazy_stack_init_index, exported_funcs.contains(&i))
+            {
+                Instruction::Call(lazy_stack_init_index).encode(&mut map.buf);
+            }
             let bytes = map.operators(body)?;
+            let mut func = wasm_encoder::Function::new(locals);
             func.raw(bytes);
             code.function(&func);
         }
 
-        if sp.is_some() && realloc_index.is_none() {
-            // The main module does _not_ export a realloc function, nor does the adapter import it, but we need a
-            // function to allocate some stack space, so we'll add one here.
+        if lazy_stack_init_index.is_some() {
+            code.function(&allocate_stack_via_realloc(
+                realloc_index.unwrap(),
+                sp.unwrap(),
+                allocation_state,
+            ));
+        }
+
+        if sp.is_some() && (realloc_index.is_none() || allocation_state.is_none()) {
+            // Either the main module does _not_ export a realloc function, or it is not safe to use for stack
+            // allocation because we have no way to short-circuit reentrance, so we'll use `memory.grow` instead.
             realloc_index = Some(num_func_imports + funcs.len());
             funcs.function(add_realloc_type(&mut types));
             code.function(&realloc_via_memory_grow());
         }
 
-        // Inject a start function to initialize the stack pointer which will be
-        // local to this module. This only happens if a memory is preserved and
-        // a stack pointer global is found.
+        // Inject a start function to initialize the stack pointer which will be local to this module. This only
+        // happens if a memory is preserved, a stack pointer global is found, and we're not doing lazy stack
+        // allocation.
         let mut start = None;
-        if let Some(sp) = sp {
+        if let (Some(sp), None) = (sp, lazy_stack_init_index) {
             if num_memories > 0 {
-                use wasm_encoder::Instruction::*;
-
                 // If there are any memories or any mutable globals there must be
                 // precisely one of each as otherwise we don't know how to filter
                 // down to the right one.
@@ -665,19 +762,12 @@ impl<'a> Module<'a> {
                     types.len() - 1
                 });
                 funcs.function(empty_type);
-                func_names.push((function_index, "initialize_stack_pointer"));
-
-                let mut func = wasm_encoder::Function::new([]);
-                func.instruction(&I32Const(0));
-                func.instruction(&I32Const(0));
-                func.instruction(&I32Const(8));
-                func.instruction(&I32Const(PAGE_SIZE));
-                func.instruction(&Call(realloc_index.unwrap()));
-                func.instruction(&I32Const(PAGE_SIZE));
-                func.instruction(&I32Add);
-                func.instruction(&GlobalSet(sp));
-                func.instruction(&End);
-                code.function(&func);
+                func_names.push((function_index, "allocate_stack"));
+                code.function(&allocate_stack_via_realloc(
+                    realloc_index.unwrap(),
+                    sp,
+                    allocation_state,
+                ));
 
                 start = Some(wasm_encoder::StartSection { function_index });
             }
@@ -788,8 +878,14 @@ impl<'a> Module<'a> {
             section.push(code);
             subsection.encode(&mut section);
         };
-        if let (Some(realloc_index), None) = (realloc_index, main_module_realloc) {
+        if let (Some(realloc_index), true) = (
+            realloc_index,
+            main_module_realloc.is_none() || allocation_state.is_none(),
+        ) {
             func_names.push((realloc_index, "realloc_via_memory_grow"));
+        }
+        if let Some(lazy_stack_init_index) = lazy_stack_init_index {
+            func_names.push((lazy_stack_init_index, "allocate_stack"));
         }
         encode_subsection(0x01, &func_names);
         encode_subsection(0x07, &global_names);
@@ -806,38 +902,28 @@ impl<'a> Module<'a> {
         Ok(ret.finish())
     }
 
-    fn find_stack_pointer(&self) -> Result<Option<u32>> {
-        let mutable_i32_globals = self
+    fn find_mut_i32_global(&self, name: &str) -> Result<Option<u32>> {
+        let matches = &self
             .live_globals()
-            .filter(|(_, g)| g.ty.mutable && g.ty.content_type == ValType::I32)
-            .collect::<Vec<_>>();
-
-        // If there are no 32-bit mutable globals then there's definitely no
-        // stack pointer in this module
-        if mutable_i32_globals.is_empty() {
-            return Ok(None);
-        }
-
-        // If there are some mutable 32-bit globals then there's currently no
-        // great way of determining which is the stack pointer. For now a hack
-        // is used where we use the name section to find the name that LLVM
-        // injects. This hopefully can be improved in the future.
-        let stack_pointers = mutable_i32_globals
-            .iter()
-            .filter_map(|(i, _)| {
-                let name = *self.global_names.get(i)?;
-                if name == "__stack_pointer" {
-                    Some(*i)
+            .filter_map(|(i, g)| {
+                if g.ty.mutable
+                    && g.ty.content_type == ValType::I32
+                    && *self.global_names.get(&i)? == name
+                {
+                    Some(i)
                 } else {
                     None
                 }
             })
             .collect::<Vec<_>>();
 
-        match stack_pointers.len() {
-            0 => Ok(None),
-            1 => Ok(Some(stack_pointers[0])),
-            n => bail!("found {n} globals that look like the stack pointer"),
+        match matches.deref() {
+            [] => Ok(None),
+            [i] => Ok(Some(*i)),
+            _ => bail!(
+                "found {} mutable i32 globals with name {name}",
+                matches.len()
+            ),
         }
     }
 }
@@ -924,7 +1010,6 @@ struct Encoder {
 
 impl Encoder {
     fn operators(&mut self, mut reader: BinaryReader<'_>) -> Result<Vec<u8>> {
-        assert!(self.buf.is_empty());
         while !reader.eof() {
             reader.visit_operator(self)?;
         }

--- a/crates/wit-component/tests/components/adapt-inject-stack-with-realloc-no-state/adapt-old.wit
+++ b/crates/wit-component/tests/components/adapt-inject-stack-with-realloc-no-state/adapt-old.wit
@@ -1,0 +1,5 @@
+default world brave-new-world {
+  import new: interface {
+    get-two: func() -> (a: u32, b: u32)
+  }
+}

--- a/crates/wit-component/tests/components/adapt-inject-stack-with-realloc-no-state/component.wat
+++ b/crates/wit-component/tests/components/adapt-inject-stack-with-realloc-no-state/component.wat
@@ -48,21 +48,27 @@
   )
   (core module (;1;)
     (type (;0;) (func (param i32)))
-    (type (;1;) (func (result i32)))
-    (type (;2;) (func (param i32 i32 i32 i32) (result i32)))
-    (type (;3;) (func))
+    (type (;1;) (func (param i32 i32 i32 i32) (result i32)))
+    (type (;2;) (func (result i32)))
+    (type (;3;) (func (param i32 i32 i32 i32) (result i32)))
+    (type (;4;) (func))
     (import "env" "memory" (memory (;0;) 0))
     (import "new" "get-two" (func $get_two (;0;) (type 0)))
-    (import "__main_module__" "cabi_realloc" (func $cabi_realloc (;1;) (type 2)))
-    (func (;2;) (type 1) (result i32)
+    (import "__main_module__" "cabi_realloc" (func $cabi_realloc (;1;) (type 1)))
+    (func (;2;) (type 2) (result i32)
       (local i32 i32)
-      call $allocate_stack
-      global.get $allocation_state
-      i32.const 2
-      i32.ne
-      if ;; label = @1
-        unreachable
-      end
+      i32.const 0
+      i32.const 0
+      i32.const 8
+      i32.const 65536
+      call $cabi_realloc
+      local.set 0
+      local.get 0
+      i32.const 42
+      i32.store
+      local.get 0
+      i32.const 42
+      i32.store offset=65532
       global.get $__stack_pointer
       local.tee 0
       i32.const 8
@@ -81,29 +87,52 @@
       local.get 0
       global.set $__stack_pointer
     )
-    (func $allocate_stack (;3;) (type 3)
-      global.get $allocation_state
+    (func $realloc_via_memory_grow (;3;) (type 3) (param i32 i32 i32 i32) (result i32)
+      (local i32)
       i32.const 0
+      local.get 0
+      i32.ne
+      if ;; label = @1
+        unreachable
+      end
+      i32.const 0
+      local.get 1
+      i32.ne
+      if ;; label = @1
+        unreachable
+      end
+      i32.const 65536
+      local.get 3
+      i32.ne
+      if ;; label = @1
+        unreachable
+      end
+      i32.const 1
+      memory.grow
+      local.tee 4
+      i32.const -1
       i32.eq
       if ;; label = @1
-        i32.const 1
-        global.set $allocation_state
-        i32.const 0
-        i32.const 0
-        i32.const 8
-        i32.const 65536
-        call $cabi_realloc
-        i32.const 65536
-        i32.add
-        global.set $__stack_pointer
-        i32.const 2
-        global.set $allocation_state
+        unreachable
       end
+      local.get 4
+      i32.const 16
+      i32.shl
+    )
+    (func $allocate_stack (;4;) (type 4)
+      i32.const 0
+      i32.const 0
+      i32.const 8
+      i32.const 65536
+      call $realloc_via_memory_grow
+      i32.const 65536
+      i32.add
+      global.set $__stack_pointer
     )
     (global $__stack_pointer (;0;) (mut i32) i32.const 0)
     (global $some_other_mutable_global (;1;) (mut i32) i32.const 0)
-    (global $allocation_state (;2;) (mut i32) i32.const 0)
     (export "get_sum" (func 2))
+    (start $allocate_stack)
   )
   (core module (;2;)
     (type (;0;) (func (param i32)))

--- a/crates/wit-component/tests/components/adapt-inject-stack-with-realloc-no-state/component.wit
+++ b/crates/wit-component/tests/components/adapt-inject-stack-with-realloc-no-state/component.wit
@@ -1,0 +1,7 @@
+interface new {
+  get-two: func() -> (a: u32, b: u32)
+}
+
+default world component {
+  import new: self.new
+}

--- a/crates/wit-component/tests/components/adapt-inject-stack-with-realloc-no-state/module.wat
+++ b/crates/wit-component/tests/components/adapt-inject-stack-with-realloc-no-state/module.wat
@@ -1,0 +1,38 @@
+(module
+  (import "old" "get_sum" (func (result i32)))
+  ;; Minimal realloc which only accepts new, page-sized allocations:
+  (func $cabi_realloc (param i32 i32 i32 i32) (result i32)
+    (local i32)
+    i32.const 0
+    local.get 0
+    i32.ne
+    if
+      unreachable
+    end
+    i32.const 0
+    local.get 1
+    i32.ne
+    if
+      unreachable
+    end
+    i32.const 65536
+    local.get 3
+    i32.ne
+    if
+      unreachable
+    end
+    i32.const 1
+    memory.grow
+    local.tee 4
+    i32.const -1
+    i32.eq
+    if
+      unreachable
+    end
+    local.get 4
+    i32.const 16
+    i32.shl
+  )
+  (memory (export "memory") 1)
+  (export "cabi_realloc" (func $cabi_realloc))
+)

--- a/crates/wit-component/tests/components/adapt-inject-stack-with-realloc-no-state/module.wit
+++ b/crates/wit-component/tests/components/adapt-inject-stack-with-realloc-no-state/module.wit
@@ -1,0 +1,1 @@
+default world empty {}

--- a/crates/wit-component/tests/components/adapt-inject-stack-with-realloc/adapt-old.wat
+++ b/crates/wit-component/tests/components/adapt-inject-stack-with-realloc/adapt-old.wat
@@ -6,6 +6,10 @@
   (global $__stack_pointer (mut i32) i32.const 0)
   (global $some_other_mutable_global (mut i32) i32.const 0)
 
+  ;; `wit-component` should use this to track the status of a lazy stack
+  ;; allocation:
+  (global $allocation_state (mut i32) i32.const 0)
+
   ;; This is a sample adapter which is adapting between ABI. This exact function
   ;; signature is imported by `module.wat` and we're implementing it here with a
   ;; canonical-abi function that returns two integers. The canonical ABI for
@@ -18,6 +22,10 @@
   ;; this adapter module when it's bundled into a component.
   (func (export "get_sum") (result i32)
     (local i32 i32)
+
+    ;; `wit-component` should have injected a call to a function that allocates
+    ;; the stack and sets $allocation_state to 2
+    (if (i32.ne (global.get $allocation_state) (i32.const 2)) (unreachable))
 
     ;; First, allocate a page using $cabi_realloc and write to it.  This tests
     ;; that we can use the main module's allocator if present (or else a

--- a/crates/wit-component/tests/components/adapt-inject-stack-with-realloc/component.wat
+++ b/crates/wit-component/tests/components/adapt-inject-stack-with-realloc/component.wat
@@ -50,13 +50,19 @@
     (type (;0;) (func (param i32)))
     (type (;1;) (func (param i32 i32 i32 i32) (result i32)))
     (type (;2;) (func (result i32)))
-    (type (;3;) (func (param i32 i32 i32 i32) (result i32)))
-    (type (;4;) (func))
+    (type (;3;) (func))
     (import "env" "memory" (memory (;0;) 0))
     (import "new" "get-two" (func $get_two (;0;) (type 0)))
     (import "__main_module__" "cabi_realloc" (func $cabi_realloc (;1;) (type 1)))
     (func (;2;) (type 2) (result i32)
       (local i32 i32)
+      call $allocate_stack
+      global.get $allocation_state
+      i32.const 2
+      i32.ne
+      if ;; label = @1
+        unreachable
+      end
       i32.const 0
       i32.const 0
       i32.const 8
@@ -87,52 +93,29 @@
       local.get 0
       global.set $__stack_pointer
     )
-    (func $realloc_via_memory_grow (;3;) (type 3) (param i32 i32 i32 i32) (result i32)
-      (local i32)
+    (func $allocate_stack (;3;) (type 3)
+      global.get $allocation_state
       i32.const 0
-      local.get 0
-      i32.ne
-      if ;; label = @1
-        unreachable
-      end
-      i32.const 0
-      local.get 1
-      i32.ne
-      if ;; label = @1
-        unreachable
-      end
-      i32.const 65536
-      local.get 3
-      i32.ne
-      if ;; label = @1
-        unreachable
-      end
-      i32.const 1
-      memory.grow
-      local.tee 4
-      i32.const -1
       i32.eq
       if ;; label = @1
-        unreachable
+        i32.const 1
+        global.set $allocation_state
+        i32.const 0
+        i32.const 0
+        i32.const 8
+        i32.const 65536
+        call $cabi_realloc
+        i32.const 65536
+        i32.add
+        global.set $__stack_pointer
+        i32.const 2
+        global.set $allocation_state
       end
-      local.get 4
-      i32.const 16
-      i32.shl
-    )
-    (func $allocate_stack (;4;) (type 4)
-      i32.const 0
-      i32.const 0
-      i32.const 8
-      i32.const 65536
-      call $realloc_via_memory_grow
-      i32.const 65536
-      i32.add
-      global.set $__stack_pointer
     )
     (global $__stack_pointer (;0;) (mut i32) i32.const 0)
     (global $some_other_mutable_global (;1;) (mut i32) i32.const 0)
+    (global $allocation_state (;2;) (mut i32) i32.const 0)
     (export "get_sum" (func 2))
-    (start $allocate_stack)
   )
   (core module (;2;)
     (type (;0;) (func (param i32)))

--- a/crates/wit-component/tests/components/adapt-inject-stack-with-realloc/component.wat
+++ b/crates/wit-component/tests/components/adapt-inject-stack-with-realloc/component.wat
@@ -50,7 +50,8 @@
     (type (;0;) (func (param i32)))
     (type (;1;) (func (param i32 i32 i32 i32) (result i32)))
     (type (;2;) (func (result i32)))
-    (type (;3;) (func))
+    (type (;3;) (func (param i32 i32 i32 i32) (result i32)))
+    (type (;4;) (func))
     (import "env" "memory" (memory (;0;) 0))
     (import "new" "get-two" (func $get_two (;0;) (type 0)))
     (import "__main_module__" "cabi_realloc" (func $cabi_realloc (;1;) (type 1)))
@@ -86,12 +87,44 @@
       local.get 0
       global.set $__stack_pointer
     )
-    (func $initialize_stack_pointer (;3;) (type 3)
+    (func $realloc_via_memory_grow (;3;) (type 3) (param i32 i32 i32 i32) (result i32)
+      (local i32)
+      i32.const 0
+      local.get 0
+      i32.ne
+      if ;; label = @1
+        unreachable
+      end
+      i32.const 0
+      local.get 1
+      i32.ne
+      if ;; label = @1
+        unreachable
+      end
+      i32.const 65536
+      local.get 3
+      i32.ne
+      if ;; label = @1
+        unreachable
+      end
+      i32.const 1
+      memory.grow
+      local.tee 4
+      i32.const -1
+      i32.eq
+      if ;; label = @1
+        unreachable
+      end
+      local.get 4
+      i32.const 16
+      i32.shl
+    )
+    (func $allocate_stack (;4;) (type 4)
       i32.const 0
       i32.const 0
       i32.const 8
       i32.const 65536
-      call $cabi_realloc
+      call $realloc_via_memory_grow
       i32.const 65536
       i32.add
       global.set $__stack_pointer
@@ -99,7 +132,7 @@
     (global $__stack_pointer (;0;) (mut i32) i32.const 0)
     (global $some_other_mutable_global (;1;) (mut i32) i32.const 0)
     (export "get_sum" (func 2))
-    (start $initialize_stack_pointer)
+    (start $allocate_stack)
   )
   (core module (;2;)
     (type (;0;) (func (param i32)))

--- a/crates/wit-component/tests/components/adapt-inject-stack-with-reallocing-adapter/component.wat
+++ b/crates/wit-component/tests/components/adapt-inject-stack-with-reallocing-adapter/component.wat
@@ -50,7 +50,8 @@
     (type (;0;) (func (param i32)))
     (type (;1;) (func (result i32)))
     (type (;2;) (func (param i32 i32 i32 i32) (result i32)))
-    (type (;3;) (func))
+    (type (;3;) (func (param i32 i32 i32 i32) (result i32)))
+    (type (;4;) (func))
     (import "env" "memory" (memory (;0;) 0))
     (import "new" "get-two" (func $get_two (;0;) (type 0)))
     (import "__main_module__" "cabi_realloc" (func $cabi_realloc (;1;) (type 2)))
@@ -74,12 +75,44 @@
       local.get 0
       global.set $__stack_pointer
     )
-    (func $initialize_stack_pointer (;3;) (type 3)
+    (func $realloc_via_memory_grow (;3;) (type 3) (param i32 i32 i32 i32) (result i32)
+      (local i32)
+      i32.const 0
+      local.get 0
+      i32.ne
+      if ;; label = @1
+        unreachable
+      end
+      i32.const 0
+      local.get 1
+      i32.ne
+      if ;; label = @1
+        unreachable
+      end
+      i32.const 65536
+      local.get 3
+      i32.ne
+      if ;; label = @1
+        unreachable
+      end
+      i32.const 1
+      memory.grow
+      local.tee 4
+      i32.const -1
+      i32.eq
+      if ;; label = @1
+        unreachable
+      end
+      local.get 4
+      i32.const 16
+      i32.shl
+    )
+    (func $allocate_stack (;4;) (type 4)
       i32.const 0
       i32.const 0
       i32.const 8
       i32.const 65536
-      call $cabi_realloc
+      call $realloc_via_memory_grow
       i32.const 65536
       i32.add
       global.set $__stack_pointer
@@ -87,7 +120,7 @@
     (global $__stack_pointer (;0;) (mut i32) i32.const 0)
     (global $some_other_mutable_global (;1;) (mut i32) i32.const 0)
     (export "get_sum" (func 2))
-    (start $initialize_stack_pointer)
+    (start $allocate_stack)
   )
   (core module (;2;)
     (type (;0;) (func (param i32)))

--- a/crates/wit-component/tests/components/adapt-inject-stack/component.wat
+++ b/crates/wit-component/tests/components/adapt-inject-stack/component.wat
@@ -71,7 +71,7 @@
       i32.const 16
       i32.shl
     )
-    (func $initialize_stack_pointer (;3;) (type 3)
+    (func $allocate_stack (;3;) (type 3)
       i32.const 0
       i32.const 0
       i32.const 8
@@ -84,7 +84,7 @@
     (global $__stack_pointer (;0;) (mut i32) i32.const 0)
     (global $some_other_mutable_global (;1;) (mut i32) i32.const 0)
     (export "get_sum" (func 1))
-    (start $initialize_stack_pointer)
+    (start $allocate_stack)
   )
   (core module (;2;)
     (type (;0;) (func (param i32)))


### PR DESCRIPTION
Previously, I modified wit-component to use the main module `cabi_realloc` export to allocate the adapter stack when present. However,
https://github.com/bytecodealliance/preview2-prototyping/issues/78 pointed out that this can be problematic when `cabi_realloc` calls back into the adapter, e.g. as part of `__wasi_call_ctors`.  Such reentrance can either fail immediately because the function aliases have not yet been initialized or else recurse infinitely if the reentered function tries to allocate.

This commit introduces a new `allocation_state` global variable which, if found in an adapter, is used to facilitate lazy stack allocation. If this variable is available, wit-component instruments every function exported by the adapter with a call to a synthesized `allocate_stack` function which checks `allocation_state` and initiates allocation if it is zero, setting it immediately to one prior to calling `cabi_realloc`, thereby short-circuiting any recursion.  Once allocation is finished, `allocation_state` is set to two.

The adapter's responsibility is to also check `allocation_state` in any function it exports which is likely to be called from the main module's `cabi_realloc` function.  If it is zero or one, the function should return immediately (with whatever dummy return value is appropriate) without trying to use the stack or do an allocation.

Note that if the adapter does _not_ have an `allocation_state` global, we fall back to allocating the stack using memory.grow even if the main module has a `cabi_realloc` function.  This is because we can't be sure `cabi_realloc` won't try to reenter the adapter, and without `allocation_state` we have no way to notice and handle that case correctly.  Technically, we could add a synthetic global, but the adapter wouldn't know about it, so it would not know when to do the immediate dummy return discussed above.

Needless to say, this wit-component <-> adapter relationship has become pretty complicated, but that seems necessary in order to support existing, in-the-wild modules.

I'll follow this PR up with a corresponding one two the preview2Prototyping repo.

Signed-off-by: Joel Dice <joel.dice@fermyon.com>