### PR TITLE
Fix validation of `ref.func` without function-references

### DIFF
--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -23,6 +23,7 @@ wat = { path = "../wat" }
 wast = { path = "../wast" }
 rayon = { workspace = true }
 once_cell = "1.13.0"
+wasm-encoder = { workspace = true }
 
 [[bench]]
 name = "benchmark"

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -2333,16 +2333,23 @@ where
         if !self.resources.is_function_referenced(function_index) {
             bail!(self.offset, "undeclared function reference");
         }
-        let heap_type = HeapType::TypedFunc(match type_index.try_into() {
-            Ok(packed) => packed,
-            Err(_) => {
-                bail!(self.offset, "type index of `ref.func` target too large")
-            }
-        });
-        self.push_operand(ValType::Ref(RefType {
-            nullable: false,
-            heap_type,
-        }))?;
+
+        // FIXME(#924) this should not be conditional based on enabled
+        // proposals.
+        if self.features.function_references {
+            let heap_type = HeapType::TypedFunc(match type_index.try_into() {
+                Ok(packed) => packed,
+                Err(_) => {
+                    bail!(self.offset, "type index of `ref.func` target too large")
+                }
+            });
+            self.push_operand(ValType::Ref(RefType {
+                nullable: false,
+                heap_type,
+            }))?;
+        } else {
+            self.push_operand(ValType::FUNCREF)?;
+        }
         Ok(())
     }
     fn visit_v128_load(&mut self, memarg: MemArg) -> Self::Output {

--- a/crates/wasmparser/tests/big-module.rs
+++ b/crates/wasmparser/tests/big-module.rs
@@ -1,0 +1,32 @@
+use wasm_encoder::*;
+#[test]
+fn big_type_indices() {
+    const N: u32 = 100_000;
+    let mut module = Module::new();
+    let mut types = TypeSection::new();
+    for _ in 0..N {
+        types.function([], []);
+    }
+    module.section(&types);
+    let mut funcs = FunctionSection::new();
+    funcs.function(N - 1);
+    module.section(&funcs);
+
+    let mut elems = ElementSection::new();
+    elems.declared(RefType::FUNCREF, Elements::Functions(&[0]));
+    module.section(&elems);
+
+    let mut code = CodeSection::new();
+    let mut body = Function::new([]);
+    body.instruction(&Instruction::RefFunc(0));
+    body.instruction(&Instruction::Drop);
+    body.instruction(&Instruction::End);
+    code.function(&body);
+    module.section(&code);
+
+    let wasm = module.finish();
+
+    wasmparser::Validator::default()
+        .validate_all(&wasm)
+        .unwrap();
+}


### PR DESCRIPTION
This fixes the validation of the `ref.func` instruction when a module with many types is validated to not run into the limitation of #924.