### PR TITLE
Fix validation panic with unreachable code

### DIFF
--- a/fuzz/fuzz_targets/validate.rs
+++ b/fuzz/fuzz_targets/validate.rs
@@ -42,16 +42,15 @@ fuzz_target!(|data: &[u8]| {
     let use_maybe_invalid = byte3 & 0b0000_0100 != 0;
 
     let wasm = &data[3..];
-    if log::log_enabled!(log::Level::Debug) {
-        log::debug!("writing input to `test.wasm`");
-        std::fs::write("test.wasm", wasm).unwrap();
-    }
     if use_maybe_invalid {
         let mut u = Unstructured::new(wasm);
         if let Ok(module) = MaybeInvalidModule::arbitrary(&mut u) {
-            drop(validator.validate_all(&module.to_bytes()));
+            let wasm = module.to_bytes();
+            wasm_tools_fuzz::log_wasm(&wasm, "");
+            drop(validator.validate_all(&wasm));
         }
     } else {
+        wasm_tools_fuzz::log_wasm(wasm, "");
         drop(validator.validate_all(wasm));
     }
 });

--- a/tests/local/invalid-unreachable.wast
+++ b/tests/local/invalid-unreachable.wast
@@ -1,0 +1,11 @@
+(assert_invalid
+  (module
+    (func
+      unreachable
+      select
+      loop
+        i32x4.eq
+      end
+    )
+  )
+  "expected v128 but nothing on stack")


### PR DESCRIPTION
This fixes a fuzz-found regression from #701 where unreachable code could end up triggering a panic during validation.