### PR TITLE
Fix a copy/paste mistake in add-function mutator

### DIFF
--- a/crates/wasm-mutate/src/mutators/add_function.rs
+++ b/crates/wasm-mutate/src/mutators/add_function.rs
@@ -67,7 +67,7 @@ impl Mutator for AddFunctionMutator {
                     func.instruction(&Instruction::RefNull(HeapType::Func));
                 }
                 PrimitiveTypeInfo::ExternRef => {
-                    func.instruction(&Instruction::RefNull(HeapType::Func));
+                    func.instruction(&Instruction::RefNull(HeapType::Extern));
                 }
                 PrimitiveTypeInfo::Empty => unreachable!(),
             }


### PR DESCRIPTION
This commit fixes an accidental fuzz bug from #701 as a copy/paste error.