### PR TITLE
Add a function to extract a world from a document

### DIFF
--- a/crates/wit-component/tests/components.rs
+++ b/crates/wit-component/tests/components.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use pretty_assertions::assert_eq;
 use std::{fs, path::Path};
 use wasm_encoder::{Encode, Section};
@@ -99,11 +99,7 @@ fn read_core_module(path: &Path) -> Result<Vec<u8>> {
         UnresolvedPackage::parse_file(&interface)?,
         &Default::default(),
     )?;
-    let doc = *resolve.packages[pkg].documents.iter().next().unwrap().1;
-    let doc = &resolve.documents[doc];
-    let world = doc
-        .default_world
-        .ok_or_else(|| anyhow!("no default world specified"))?;
+    let world = resolve.select_world(pkg, None)?;
     let encoded = wit_component::metadata::encode(&resolve, world, StringEncoding::UTF8)?;
 
     let section = wasm_encoder::CustomSection {

--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -156,7 +156,7 @@ pub struct EmbedOpts {
     /// world`, or it can be a `foo/bar` name where `foo` names a document and
     /// `bar` names a world within that document.
     #[clap(short, long)]
-    world: String,
+    world: Option<String>,
 
     /// Don't read a core wasm module as input, instead generating a "dummy"
     /// module as a placeholder.
@@ -180,25 +180,7 @@ impl EmbedOpts {
             Some(self.io.parse_input_wasm()?)
         };
         let (resolve, id) = parse_wit(&self.wit)?;
-
-        let mut parts = self.world.split('/');
-        let doc = match parts.next() {
-            Some(name) => match resolve.packages[id].documents.get(name) {
-                Some(doc) => *doc,
-                None => bail!("no document named `{name}` in package"),
-            },
-            None => bail!("invalid `--world` argument"),
-        };
-        let world = match parts.next() {
-            Some(name) => match resolve.documents[doc].worlds.get(name) {
-                Some(world) => *world,
-                None => bail!("no world named `{name}` in document"),
-            },
-            None => match resolve.documents[doc].default_world {
-                Some(world) => world,
-                None => bail!("no default world found in document"),
-            },
-        };
+        let world = resolve.select_world(id, self.world.as_deref())?;
 
         let encoded = wit_component::metadata::encode(
             &resolve,


### PR DESCRIPTION
This pulls in bytecodealliance/wit-bindgen#494 as an "official" function to the `wit-parser` crate. I've written an analogue for that function in many locations so the hope is that all bindings generators can standardize on the necessary idioms by using this function. For example the Wasmtime bindings generator will want to update to use this as well.