### PR TITLE
Update filter for tag builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,7 @@
 name: Build
 on:
   push:
-    branches:
-      - main
     tags:
-      - 'wasm-tools-*'
   pull_request:
     branches:
     - main
@@ -24,6 +21,7 @@ jobs:
   build:
     name: Build wasm-tools
     runs-on: ${{ matrix.os }}
+    if: github.event_name != 'push' || startsWith(github.ref, 'refs/tags/wasm-tools-')
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Looks like if a tag filter is provided to GitHub Actions then when tags are pushed as a group if any tag doesn't match the filter then CI doesn't run at all. This means that the mass-push of tags for crates in this repo accidentally don't run CI to build the release binaries for the tag of `wasm-tools` itself.

This commit fixes the issue by updating the conditions for the `build.yml` workflow. This always runs on all tags now but the only job will be skipped unless it's a `wasm-tools` tag.