### PR TITLE
Improve validation error when component model feature not enabled

### DIFF
--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -534,8 +534,7 @@ impl Validator {
                 if !self.features.component_model {
                     bail!(
                         range.start,
-                        "unknown binary version: {num:#x}, \
-                         note: the WebAssembly component model feature is not enabled",
+                        "encoded as a component but the WebAssembly component model feature is not enabled",
                     );
                 }
                 if num == WASM_COMPONENT_VERSION {

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -534,7 +534,9 @@ impl Validator {
                 if !self.features.component_model {
                     bail!(
                         range.start,
-                        "encoded as a component but the WebAssembly component model feature is not enabled",
+                        "unknown binary version and encoding combination: {num:#x} and 0x1, \
+                        note: encoded as a component but the WebAssembly component model feature \
+                        is not enabled - enable the feature to allow component validation",
                     );
                 }
                 if num == WASM_COMPONENT_VERSION {

--- a/tests/local/missing-features/component-not-enabled.wast
+++ b/tests/local/missing-features/component-not-enabled.wast
@@ -3,4 +3,4 @@
     "\00asm"
     "\0a\00\01\00"
     )
-  "unknown binary version: 0xa, note: the WebAssembly component model feature is not enabled")
+  "encoded as a component but the WebAssembly component model feature is not enabled")

--- a/tests/local/missing-features/component-not-enabled.wast
+++ b/tests/local/missing-features/component-not-enabled.wast
@@ -3,4 +3,4 @@
     "\00asm"
     "\0a\00\01\00"
     )
-  "encoded as a component but the WebAssembly component model feature is not enabled")
+  "unknown binary version and encoding combination: 0xa and 0x1, note: encoded as a component but the WebAssembly component model feature is not enabled - enable the feature to allow component validation")

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -87,7 +87,12 @@ fn main() {
 /// then load up and test in parallel.
 fn find_tests() -> Vec<PathBuf> {
     let mut tests = Vec::new();
-    if !Path::new("tests/testsuite").exists() {
+    let test_suite = Path::new("tests/testsuite");
+    if !test_suite.exists()
+        || std::fs::read_dir(test_suite)
+            .map(|mut d| d.next().is_none())
+            .unwrap_or(true)
+    {
         panic!("submodules need to be checked out");
     }
     find_tests("tests/local".as_ref(), &mut tests);


### PR DESCRIPTION
This tripped me up as the previous error message made it sound like the version encoded in the binary was not a supported version, but it is. The only issue was that the validator did not have the right feature enabled. 