### PR TITLE
Bump crate versions for publication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-tools"
-version = "1.0.24"
+version = "1.0.25"
 authors = ["The Wasmtime Project Developers"]
 edition.workspace = true
 description = "CLI tools for interoperating with WebAssembly files"
@@ -42,18 +42,18 @@ wasmtime = { version = "3.0.0", default-features = false, features = ['cranelift
 url = "2.0.0"
 pretty_assertions = "1.3.0"
 
-wasm-encoder = { version = "0.24.0", path = "crates/wasm-encoder"}
-wasm-compose = { version = "0.2.8", path = "crates/wasm-compose"}
-wasm-metadata = { version = "0.2.0", path = "crates/wasm-metadata" }
-wasm-mutate = { version = "0.2.19", path = "crates/wasm-mutate" }
-wasm-shrink = { version = "0.1.20", path = "crates/wasm-shrink" }
-wasm-smith = { version = "0.12.3", path = "crates/wasm-smith" }
-wasmparser = { version = "0.101.0", path = "crates/wasmparser" }
-wasmprinter = { version = "0.2.51", path = "crates/wasmprinter" }
-wast = { version = "54.0.0", path = "crates/wast" }
-wat = { version = "1.0.59", path = "crates/wat" }
-wit-component = { version = "0.7.0", path = "crates/wit-component" }
-wit-parser = { version = "0.6.1", path = "crates/wit-parser" }
+wasm-encoder = { version = "0.24.1", path = "crates/wasm-encoder"}
+wasm-compose = { version = "0.2.9", path = "crates/wasm-compose"}
+wasm-metadata = { version = "0.3.0", path = "crates/wasm-metadata" }
+wasm-mutate = { version = "0.2.20", path = "crates/wasm-mutate" }
+wasm-shrink = { version = "0.1.21", path = "crates/wasm-shrink" }
+wasm-smith = { version = "0.12.4", path = "crates/wasm-smith" }
+wasmparser = { version = "0.101.1", path = "crates/wasmparser" }
+wasmprinter = { version = "0.2.52", path = "crates/wasmprinter" }
+wast = { version = "54.0.1", path = "crates/wast" }
+wat = { version = "1.0.60", path = "crates/wat" }
+wit-component = { version = "0.7.1", path = "crates/wit-component" }
+wit-parser = { version = "0.6.2", path = "crates/wit-parser" }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/wasm-compose/Cargo.toml
+++ b/crates/wasm-compose/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-compose"
-version = "0.2.8"
+version = "0.2.9"
 edition.workspace = true
 authors = ["Peter Huene <peter@huene.dev>"]
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasm-encoder/Cargo.toml
+++ b/crates/wasm-encoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-encoder"
-version = "0.24.0"
+version = "0.24.1"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasm-metadata/Cargo.toml
+++ b/crates/wasm-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-metadata"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-metadata"

--- a/crates/wasm-mutate/Cargo.toml
+++ b/crates/wasm-mutate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-mutate"
-version = "0.2.19"
+version = "0.2.20"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-mutate"

--- a/crates/wasm-shrink/Cargo.toml
+++ b/crates/wasm-shrink/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-shrink"
 name = "wasm-shrink"
-version = "0.1.20"
+version = "0.1.21"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "wasm-smith"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-smith"
-version = "0.12.3"
+version = "0.12.4"
 exclude = ["/benches/corpus"]
 
 [[bench]]

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.101.0"
+version = "0.101.1"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser"

--- a/crates/wasmprinter/Cargo.toml
+++ b/crates/wasmprinter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmprinter"
-version = "0.2.51"
+version = "0.2.52"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wast"
-version = "54.0.0"
+version = "54.0.1"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wat/Cargo.toml
+++ b/crates/wat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wat"
-version = "1.0.59"
+version = "1.0.60"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wit-component/Cargo.toml
+++ b/crates/wit-component/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-component"
 authors = ["Peter Huene <peter@huene.dev>"]
-version = "0.7.0"
+version = "0.7.1"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"

--- a/crates/wit-parser/Cargo.toml
+++ b/crates/wit-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-parser"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"


### PR DESCRIPTION
bump `wasm-mutate-stats` 0.1.0 => 0.1.0
bump `wit-parser-fuzz` 0.0.1 => 0.0.1
bump `wasm-tools-c-api` 0.1.1 => 0.1.1
bump `wasmparser` 0.101.0 => 0.101.1
bump `wasm-encoder` 0.24.0 => 0.24.1
bump `wasmprinter` 0.2.51 => 0.2.52
bump `wast` 54.0.0 => 54.0.1
bump `wat` 1.0.59 => 1.0.60
bump `wasm-smith` 0.12.3 => 0.12.4
bump `wasm-mutate` 0.2.19 => 0.2.20
bump `wasm-shrink` 0.1.20 => 0.1.21
bump `wasm-compose` 0.2.8 => 0.2.9
bump `wit-parser` 0.6.1 => 0.6.2
bump `wasm-metadata` 0.2.0 => 0.3.0
bump `wit-component` 0.7.0 => 0.7.1
bump `wasm-tools` 1.0.24 => 1.0.25