### PR TITLE
Increase limits on component/module/instance types

### DIFF
--- a/crates/wasmparser/src/limits.rs
+++ b/crates/wasmparser/src/limits.rs
@@ -37,9 +37,9 @@ pub const MAX_WASM_BR_TABLE_SIZE: usize = MAX_WASM_FUNCTION_SIZE;
 
 // Component-related limits
 pub const MAX_WASM_MODULE_SIZE: usize = 1024 * 1024 * 1024; //= 1 GiB
-pub const MAX_WASM_MODULE_TYPE_DECLS: usize = 1000;
-pub const MAX_WASM_COMPONENT_TYPE_DECLS: usize = 1000;
-pub const MAX_WASM_INSTANCE_TYPE_DECLS: usize = 1000;
+pub const MAX_WASM_MODULE_TYPE_DECLS: usize = 100_000;
+pub const MAX_WASM_COMPONENT_TYPE_DECLS: usize = 100_000;
+pub const MAX_WASM_INSTANCE_TYPE_DECLS: usize = 100_000;
 pub const MAX_WASM_RECORD_FIELDS: usize = 1000;
 pub const MAX_WASM_VARIANT_CASES: usize = 1000;
 pub const MAX_WASM_TUPLE_TYPES: usize = 1000;


### PR DESCRIPTION
Currently these are limited to 1k declarations per type but that's not enough to hold the maximal 100k exports, so increase these limits to 100k. This isn't expected to have too much impact outside of increasing these limits.