### PR TITLE
Bump crate versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-tools"
-version = "1.0.25"
+version = "1.0.26"
 authors = ["The Wasmtime Project Developers"]
 edition.workspace = true
 description = "CLI tools for interoperating with WebAssembly files"
@@ -42,18 +42,18 @@ wasmtime = { version = "3.0.0", default-features = false, features = ['cranelift
 url = "2.0.0"
 pretty_assertions = "1.3.0"
 
-wasm-encoder = { version = "0.24.1", path = "crates/wasm-encoder"}
-wasm-compose = { version = "0.2.9", path = "crates/wasm-compose"}
-wasm-metadata = { version = "0.3.0", path = "crates/wasm-metadata" }
-wasm-mutate = { version = "0.2.20", path = "crates/wasm-mutate" }
-wasm-shrink = { version = "0.1.21", path = "crates/wasm-shrink" }
-wasm-smith = { version = "0.12.4", path = "crates/wasm-smith" }
-wasmparser = { version = "0.101.1", path = "crates/wasmparser" }
-wasmprinter = { version = "0.2.52", path = "crates/wasmprinter" }
-wast = { version = "54.0.1", path = "crates/wast" }
-wat = { version = "1.0.60", path = "crates/wat" }
-wit-component = { version = "0.7.1", path = "crates/wit-component" }
-wit-parser = { version = "0.6.2", path = "crates/wit-parser" }
+wasm-encoder = { version = "0.25.0", path = "crates/wasm-encoder"}
+wasm-compose = { version = "0.2.10", path = "crates/wasm-compose"}
+wasm-metadata = { version = "0.3.1", path = "crates/wasm-metadata" }
+wasm-mutate = { version = "0.2.21", path = "crates/wasm-mutate" }
+wasm-shrink = { version = "0.1.22", path = "crates/wasm-shrink" }
+wasm-smith = { version = "0.12.5", path = "crates/wasm-smith" }
+wasmparser = { version = "0.102.0", path = "crates/wasmparser" }
+wasmprinter = { version = "0.2.53", path = "crates/wasmprinter" }
+wast = { version = "55.0.0", path = "crates/wast" }
+wat = { version = "1.0.61", path = "crates/wat" }
+wit-component = { version = "0.7.2", path = "crates/wit-component" }
+wit-parser = { version = "0.6.3", path = "crates/wit-parser" }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/wasm-compose/Cargo.toml
+++ b/crates/wasm-compose/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-compose"
-version = "0.2.9"
+version = "0.2.10"
 edition.workspace = true
 authors = ["Peter Huene <peter@huene.dev>"]
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasm-encoder/Cargo.toml
+++ b/crates/wasm-encoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-encoder"
-version = "0.24.1"
+version = "0.25.0"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasm-metadata/Cargo.toml
+++ b/crates/wasm-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-metadata"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-metadata"

--- a/crates/wasm-mutate/Cargo.toml
+++ b/crates/wasm-mutate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-mutate"
-version = "0.2.20"
+version = "0.2.21"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-mutate"

--- a/crates/wasm-shrink/Cargo.toml
+++ b/crates/wasm-shrink/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-shrink"
 name = "wasm-shrink"
-version = "0.1.21"
+version = "0.1.22"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "wasm-smith"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-smith"
-version = "0.12.4"
+version = "0.12.5"
 exclude = ["/benches/corpus"]
 
 [[bench]]

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.101.1"
+version = "0.102.0"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser"

--- a/crates/wasmprinter/Cargo.toml
+++ b/crates/wasmprinter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmprinter"
-version = "0.2.52"
+version = "0.2.53"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wast"
-version = "54.0.1"
+version = "55.0.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wat/Cargo.toml
+++ b/crates/wat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wat"
-version = "1.0.60"
+version = "1.0.61"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wit-component/Cargo.toml
+++ b/crates/wit-component/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-component"
 authors = ["Peter Huene <peter@huene.dev>"]
-version = "0.7.1"
+version = "0.7.2"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"

--- a/crates/wit-parser/Cargo.toml
+++ b/crates/wit-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-parser"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.6.2"
+version = "0.6.3"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"


### PR DESCRIPTION
`wasm-tools-c-api` 0.1.1 => 0.1.1
`wasm-mutate-stats` 0.1.0 => 0.1.0
`wit-parser-fuzz` 0.0.1 => 0.0.1
`wasmparser` 0.101.1 => 0.102.0
`wasm-encoder` 0.24.1 => 0.25.0
`wasmprinter` 0.2.52 => 0.2.53
`wast` 54.0.1 => 55.0.0
`wat` 1.0.60 => 1.0.61
`wasm-smith` 0.12.4 => 0.12.5
`wasm-mutate` 0.2.20 => 0.2.21
`wasm-shrink` 0.1.21 => 0.1.22
`wasm-compose` 0.2.9 => 0.2.10
`wit-parser` 0.6.2 => 0.6.3
`wasm-metadata` 0.3.0 => 0.3.1
`wit-component` 0.7.1 => 0.7.2
`wasm-tools` 1.0.25 => 1.0.26

Notably this includes #944 which updates relaxed-simd support and #946 which restricts WIT and the component model's overlapping imports/exports.