### PR TITLE
Fix base case for wit-parser's variant alignment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-tools"
-version = "1.0.26"
+version = "1.0.27"
 authors = ["The Wasmtime Project Developers"]
 edition.workspace = true
 description = "CLI tools for interoperating with WebAssembly files"
@@ -52,8 +52,8 @@ wasmparser = { version = "0.102.0", path = "crates/wasmparser" }
 wasmprinter = { version = "0.2.53", path = "crates/wasmprinter" }
 wast = { version = "55.0.0", path = "crates/wast" }
 wat = { version = "1.0.61", path = "crates/wat" }
-wit-component = { version = "0.7.2", path = "crates/wit-component" }
-wit-parser = { version = "0.6.3", path = "crates/wit-parser" }
+wit-component = { version = "0.7.3", path = "crates/wit-component" }
+wit-parser = { version = "0.6.4", path = "crates/wit-parser" }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/wit-component/Cargo.toml
+++ b/crates/wit-component/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-component"
 authors = ["Peter Huene <peter@huene.dev>"]
-version = "0.7.2"
+version = "0.7.3"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"

--- a/crates/wit-parser/Cargo.toml
+++ b/crates/wit-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-parser"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.6.3"
+version = "0.6.4"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"

--- a/crates/wit-parser/src/sizealign.rs
+++ b/crates/wit-parser/src/sizealign.rs
@@ -111,7 +111,7 @@ impl SizeAlign {
     ) -> (usize, usize) {
         let (discrim_size, discrim_align) = int_size_align(tag);
         let mut case_size = 0;
-        let mut case_align = 0;
+        let mut case_align = 1;
         for ty in types {
             if let Some(ty) = ty {
                 case_size = case_size.max(self.size(ty));


### PR DESCRIPTION
This fixes a bug in #948 discovered by wit-bindgen's test suite which I forgot to run prior to landing it here. Historically much of the ABI code in `wit-parser` was tested by `wit-bindgen` but after the extraction there is no testing of it in this repository, so this is something we'll want to improve in the future.

This commit additionally includes a minor version bump for the wit-parser crate.