### PR TITLE
`wasmparser`: turn table index in the elements section into an `Option`

### DIFF
--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -263,7 +263,7 @@ pub fn element(
                 ConstExprKind::ElementOffset,
             )?;
             ElementMode::Active {
-                table: Some(t.remap(Item::Table, *table_index)?),
+                table: table_index.map(|i| t.remap(Item::Table, i)).transpose()?,
                 offset: &offset,
             }
         }

--- a/crates/wasmparser/src/readers/core/elements.rs
+++ b/crates/wasmparser/src/readers/core/elements.rs
@@ -40,7 +40,7 @@ pub enum ElementKind<'a> {
     /// The element segment is active.
     Active {
         /// The index of the table being initialized.
-        table_index: u32,
+        table_index: Option<u32>,
         /// The initial expression of the element segment.
         offset_expr: ConstExpr<'a>,
     },
@@ -91,9 +91,9 @@ impl<'a> FromReader<'a> for Element<'a> {
             }
         } else {
             let table_index = if flags & 0b010 == 0 {
-                0
+                None
             } else {
-                reader.read_var_u32()?
+                Some(reader.read_var_u32()?)
             };
             let offset_expr = reader.read()?;
             ElementKind::Active {

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -207,7 +207,7 @@ impl ModuleState {
                 table_index,
                 offset_expr,
             } => {
-                let table = self.module.table_at(table_index, offset)?;
+                let table = self.module.table_at(table_index.unwrap_or(0), offset)?;
                 if !self
                     .module
                     .matches(ValType::Ref(e.ty), ValType::Ref(table.element_type), types)

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -1134,9 +1134,10 @@ impl Printer {
                     table_index,
                     offset_expr,
                 } => {
-                    if *table_index != 0 {
+                    let table_index = table_index.unwrap_or(0);
+                    if table_index != 0 {
                         self.result.push_str(" (table ");
-                        self.print_idx(&state.core.table_names, *table_index)?;
+                        self.print_idx(&state.core.table_names, table_index)?;
                         self.result.push(')');
                     }
                     self.result.push(' ');

--- a/src/bin/wasm-tools/dump.rs
+++ b/src/bin/wasm-tools/dump.rs
@@ -171,7 +171,7 @@ impl<'a> Dump<'a> {
                             table_index,
                             offset_expr,
                         } => {
-                            write!(me.state, " table[{}]", table_index)?;
+                            write!(me.state, " table[{:?}]", table_index)?;
                             me.print(offset_expr.get_binary_reader().original_position())?;
                             me.print_ops(offset_expr.get_operators_reader())?;
                             write!(me.state, "{} items", item_count)?;

--- a/tests/cli/dump/simple.wat.stdout
+++ b/tests/cli/dump/simple.wat.stdout
@@ -31,7 +31,7 @@
  0x3d | 00          | start function 0
  0x3e | 09 0f       | element section
  0x40 | 03          | 3 count
- 0x41 | 00          | element RefType { nullable: true, heap_type: Func } table[0]
+ 0x41 | 00          | element RefType { nullable: true, heap_type: Func } table[None]
  0x42 | 41 03       | i32_const value:3
  0x44 | 0b          | end
  0x45 | 01          | 1 items


### PR DESCRIPTION
The `wasmparser` crate currently doesn't disambiguate between the two possible encodings of the table index in the elements section while `wasm-encoder` does. I'd like to be able to generate bit-exact `.wasm` blobs by parsing with `wasmparser` and piping everything to `wasm-encoder`, and this makes it impossible. So this PR makes `wasmparser` do what `wasm-encoder` does and store the index inside of an `Option`.