### PR TITLE
preserve `cabi_post_` exports when appropriate

### DIFF
--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -35,6 +35,13 @@ pub fn run(
     }
     let mut not_required = IndexSet::new();
     for name in module.exports.keys().copied() {
+        // If we need `name` then we also need cabi_post_`name`:
+        let name = if let Some(suffix) = name.strip_prefix("cabi_post_") {
+            suffix
+        } else {
+            name
+        };
+
         if !required.contains_key(name) && !always_keep(name) {
             not_required.insert(name);
         }
@@ -620,7 +627,8 @@ impl<'a> Module<'a> {
         // afterwards actually map the body of all functions so the `map` of all
         // index mappings is fully populated before instructions are mapped.
 
-        let is_realloc = |m, n| m == "__main_module__" && n == "cabi_realloc";
+        let is_realloc =
+            |m, n| m == "__main_module__" && matches!(n, "canonical_abi_realloc" | "cabi_realloc");
 
         let (imported, local) =
             self.live_funcs()

--- a/crates/wit-component/tests/components/adapt-export-with-post-return/adapt-old.wat
+++ b/crates/wit-component/tests/components/adapt-export-with-post-return/adapt-old.wat
@@ -1,0 +1,33 @@
+;; This example represents adapting modules which use an early version of the
+;; canonical ABI, back when `cabi_realloc` was named `canonical_abi_realloc` and
+;; had a friend named `canonical_abi_free`.  Such modules are pretty easy to
+;; adapt since the adapter can use the main module's allocator for both lowering
+;; and post-return functions.
+;;
+;; See https://github.com/fermyon/spin-componentize for a real-world example.
+
+(module
+  (import "__main_module__" "canonical_abi_realloc" (func $realloc (param i32 i32 i32 i32) (result i32)))
+  (import "__main_module__" "canonical_abi_free" (func $free (param i32 i32 i32)))
+  (import "env" "memory" (memory 0))
+  (global $__stack_pointer (mut i32) i32.const 0)
+  (global $allocation_state (mut i32) i32.const 0)
+
+  (func (export "new#foo") (result i32)
+    ;; This is a dummy, non-working implementation, just to make gc.rs do what
+    ;; we want, which is to treat this adapter as if it uses the main module's
+    ;; allocator to allocate and free memory.
+
+    global.get $__stack_pointer
+    global.get $allocation_state
+    (call $realloc (i32.const 0) (i32.const 0) (i32.const 0) (i32.const 0))
+    unreachable
+  )
+
+  (func (export "cabi_post_new#foo") (param i32)
+    ;; another dummy implementation
+
+    (call $free (i32.const 0) (i32.const 0) (i32.const 0))
+    unreachable
+  )
+)

--- a/crates/wit-component/tests/components/adapt-export-with-post-return/adapt-old.wit
+++ b/crates/wit-component/tests/components/adapt-export-with-post-return/adapt-old.wit
@@ -1,0 +1,7 @@
+interface new {
+  foo: func() -> string
+}
+
+default world brave-new-world {
+  export new: self.new
+}

--- a/crates/wit-component/tests/components/adapt-export-with-post-return/component.wat
+++ b/crates/wit-component/tests/components/adapt-export-with-post-return/component.wat
@@ -1,0 +1,95 @@
+(component
+  (core module (;0;)
+    (type (;0;) (func (param i32 i32 i32 i32) (result i32)))
+    (type (;1;) (func (param i32 i32 i32)))
+    (func (;0;) (type 0) (param i32 i32 i32 i32) (result i32)
+      unreachable
+    )
+    (func (;1;) (type 1) (param i32 i32 i32)
+      unreachable
+    )
+    (memory (;0;) 1)
+    (export "canonical_abi_realloc" (func 0))
+    (export "canonical_abi_free" (func 1))
+    (export "memory" (memory 0))
+  )
+  (core module (;1;)
+    (type (;0;) (func (param i32 i32 i32 i32) (result i32)))
+    (type (;1;) (func (param i32 i32 i32)))
+    (type (;2;) (func (result i32)))
+    (type (;3;) (func (param i32)))
+    (type (;4;) (func))
+    (import "__main_module__" "canonical_abi_realloc" (func $realloc (;0;) (type 0)))
+    (import "__main_module__" "canonical_abi_free" (func $free (;1;) (type 1)))
+    (func (;2;) (type 2) (result i32)
+      call $allocate_stack
+      global.get $__stack_pointer
+      global.get $allocation_state
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      call $realloc
+      unreachable
+    )
+    (func (;3;) (type 3) (param i32)
+      call $allocate_stack
+      i32.const 0
+      i32.const 0
+      i32.const 0
+      call $free
+      unreachable
+    )
+    (func $allocate_stack (;4;) (type 4)
+      global.get $allocation_state
+      i32.const 0
+      i32.eq
+      if ;; label = @1
+        i32.const 1
+        global.set $allocation_state
+        i32.const 0
+        i32.const 0
+        i32.const 8
+        i32.const 65536
+        call $realloc
+        i32.const 65536
+        i32.add
+        global.set $__stack_pointer
+        i32.const 2
+        global.set $allocation_state
+      end
+    )
+    (global $__stack_pointer (;0;) (mut i32) i32.const 0)
+    (global $allocation_state (;1;) (mut i32) i32.const 0)
+    (export "new#foo" (func 2))
+    (export "cabi_post_new#foo" (func 3))
+  )
+  (core instance (;0;) (instantiate 0))
+  (alias core export 0 "memory" (core memory (;0;)))
+  (alias core export 0 "canonical_abi_realloc" (core func (;0;)))
+  (alias core export 0 "canonical_abi_realloc" (core func (;1;)))
+  (alias core export 0 "canonical_abi_free" (core func (;2;)))
+  (core instance (;1;)
+    (export "canonical_abi_realloc" (func 1))
+    (export "canonical_abi_free" (func 2))
+  )
+  (core instance (;2;) (instantiate 1
+      (with "__main_module__" (instance 1))
+    )
+  )
+  (type (;0;) (func (result string)))
+  (alias core export 2 "new#foo" (core func (;3;)))
+  (alias core export 2 "cabi_post_new#foo" (core func (;4;)))
+  (func (;0;) (type 0) (canon lift (core func 3) (memory 0) string-encoding=utf8 (post-return 4)))
+  (component (;0;)
+    (alias outer 1 0 (type (;0;)))
+    (import "import-foo" (func (;0;) (type 0)))
+    (type (;1;) (func (result string)))
+    (export (;1;) "foo" (func 0) (func (type 1)))
+  )
+  (instance (;0;) (instantiate 0
+      (with "import-foo" (func 0))
+    )
+  )
+  (export (;1;) "new" (instance 0))
+)

--- a/crates/wit-component/tests/components/adapt-export-with-post-return/component.wit
+++ b/crates/wit-component/tests/components/adapt-export-with-post-return/component.wit
@@ -1,0 +1,7 @@
+interface new {
+  foo: func() -> string
+}
+
+default world component {
+  export new: self.new
+}

--- a/crates/wit-component/tests/components/adapt-export-with-post-return/module.wat
+++ b/crates/wit-component/tests/components/adapt-export-with-post-return/module.wat
@@ -1,0 +1,9 @@
+(module
+  (func (export "canonical_abi_realloc") (param i32 i32 i32 i32) (result i32)
+    unreachable
+  )
+  (func (export "canonical_abi_free") (param i32 i32 i32)
+    unreachable
+  )
+  (memory (export "memory") 1)
+)

--- a/crates/wit-component/tests/components/adapt-export-with-post-return/module.wit
+++ b/crates/wit-component/tests/components/adapt-export-with-post-return/module.wit
@@ -1,0 +1,1 @@
+default world foo {}


### PR DESCRIPTION
Also, consider `canonical_abi_realloc` import equivalent to `cabi_realloc` when scanning adapter imports.  This helps when adapting older modules.