### PR TITLE
wasmparser: Use bit packing for `ValType` to represent larger typed func ref ranges

### DIFF
--- a/crates/wasm-compose/src/encoding.rs
+++ b/crates/wasm-compose/src/encoding.rs
@@ -269,14 +269,15 @@ impl<'a> TypeEncoder<'a> {
             wasmparser::ValType::F32 => ValType::F32,
             wasmparser::ValType::F64 => ValType::F64,
             wasmparser::ValType::V128 => ValType::V128,
-            wasmparser::ValType::Ref(ty) => ValType::Ref(Self::ref_type(ty)),
+            ty if ty.is_ref_type() => ValType::Ref(Self::ref_type(ty.as_ref_type().unwrap())),
+            _ => unreachable!(),
         }
     }
 
     fn ref_type(ty: wasmparser::RefType) -> RefType {
         RefType {
-            nullable: ty.nullable,
-            heap_type: match ty.heap_type {
+            nullable: ty.is_nullable(),
+            heap_type: match ty.heap_type() {
                 wasmparser::HeapType::Func => HeapType::Func,
                 wasmparser::HeapType::Extern => HeapType::Extern,
                 wasmparser::HeapType::TypedFunc(i) => HeapType::TypedFunc(i.into()),

--- a/crates/wasm-mutate/src/mutators/modify_const_exprs.rs
+++ b/crates/wasm-mutate/src/mutators/modify_const_exprs.rs
@@ -126,7 +126,8 @@ impl<'cfg, 'wasm> Translator for InitTranslator<'cfg, 'wasm> {
                 }),
                 T::FUNCREF => CE::ref_null(wasm_encoder::HeapType::Func),
                 T::EXTERNREF => CE::ref_null(wasm_encoder::HeapType::Extern),
-                T::Ref(_) => unimplemented!(),
+                ty if ty.is_ref_type() => unimplemented!(),
+                _ => unreachable!(),
             }
         } else {
             // FIXME: implement non-reducing mutations for constant expressions.

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -1626,21 +1626,22 @@ fn arbitrary_vec_u8(u: &mut Unstructured) -> Result<Vec<u8>> {
 
 /// Convert a wasmparser's `ValType` to a `wasm_encoder::ValType`.
 fn convert_type(parsed_type: wasmparser::ValType) -> ValType {
-    use wasmparser::ValType::*;
+    use wasmparser::ValType as V;
     match parsed_type {
-        I32 => ValType::I32,
-        I64 => ValType::I64,
-        F32 => ValType::F32,
-        F64 => ValType::F64,
-        V128 => ValType::V128,
-        Ref(ty) => ValType::Ref(convert_reftype(ty)),
+        V::I32 => ValType::I32,
+        V::I64 => ValType::I64,
+        V::F32 => ValType::F32,
+        V::F64 => ValType::F64,
+        V::V128 => ValType::V128,
+        ty if ty.is_ref_type() => ValType::Ref(convert_reftype(ty.as_ref_type().unwrap())),
+        _ => unreachable!(),
     }
 }
 
 fn convert_reftype(ty: wasmparser::RefType) -> RefType {
     wasm_encoder::RefType {
-        nullable: ty.nullable,
-        heap_type: match ty.heap_type {
+        nullable: ty.is_nullable(),
+        heap_type: match ty.heap_type() {
             wasmparser::HeapType::Func => wasm_encoder::HeapType::Func,
             wasmparser::HeapType::Extern => wasm_encoder::HeapType::Extern,
             wasmparser::HeapType::TypedFunc(i) => wasm_encoder::HeapType::TypedFunc(i.into()),

--- a/crates/wasm-smith/tests/core.rs
+++ b/crates/wasm-smith/tests/core.rs
@@ -151,7 +151,7 @@ fn smoke_test_imports_config() {
                                 *seen = true
                             }
                             (Some((seen, I::Table(t))), TypeRef::Table(tt))
-                                if *t == ValType::Ref(tt.element_type) =>
+                                if *t == tt.element_type.into() =>
                             {
                                 *seen = true
                             }
@@ -244,18 +244,18 @@ fn import_config(
     let mut config = SwarmConfig::arbitrary(u).expect("arbitrary swarm");
     config.exceptions_enabled = u.arbitrary().expect("exceptions enabled for swarm");
     let available = {
-        use {AvailableImportKind::*, ValType::*};
+        use {AvailableImportKind::*, ValType as V};
         vec![
-            ("env", "pi", Func(&[I32], &[])),
-            ("env", "pi2", Func(&[I32], &[])),
-            ("env", "pipi2", Func(&[I32, I32], &[])),
-            ("env", "po", Func(&[], &[I32])),
-            ("env", "pipo", Func(&[I32], &[I32])),
-            ("env", "popo", Func(&[], &[I32, I32])),
+            ("env", "pi", Func(&[V::I32], &[])),
+            ("env", "pi2", Func(&[V::I32], &[])),
+            ("env", "pipi2", Func(&[V::I32, V::I32], &[])),
+            ("env", "po", Func(&[], &[V::I32])),
+            ("env", "pipo", Func(&[V::I32], &[V::I32])),
+            ("env", "popo", Func(&[], &[V::I32, V::I32])),
             ("env", "mem", Memory),
-            ("env", "tbl", Table(ValType::FUNCREF)),
-            ("vars", "g", Global(I64)),
-            ("tags", "tag1", Tag(&[I32])),
+            ("env", "tbl", Table(V::FUNCREF)),
+            ("vars", "g", Global(V::I64)),
+            ("tags", "tag1", Tag(&[V::I32])),
         ]
     };
     config.available_imports = Some(

--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -4,10 +4,7 @@ use once_cell::unsync::Lazy;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
-use wasmparser::{
-    DataKind, ElementKind, HeapType, Parser, Payload, ValType, Validator, VisitOperator,
-    WasmFeatures,
-};
+use wasmparser::{DataKind, ElementKind, Parser, Payload, Validator, VisitOperator, WasmFeatures};
 
 /// A benchmark input.
 pub struct BenchmarkInput {

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -330,7 +330,6 @@ pub enum HeapType {
     Extern,
 }
 
-impl ValType {}
 
 impl<'a> FromReader<'a> for ValType {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -330,7 +330,6 @@ pub enum HeapType {
     Extern,
 }
 
-
 impl<'a> FromReader<'a> for ValType {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
         match reader.peek()? {

--- a/crates/wasmparser/src/resources.rs
+++ b/crates/wasmparser/src/resources.rs
@@ -240,11 +240,14 @@ pub trait WasmModuleResources {
         // Delegate to the generic value type validation which will have the
         // same validity checks.
         self.check_value_type(
-            RefType {
-                nullable: true,
-                heap_type,
-            }
-            .into(),
+            RefType::new(true, heap_type)
+                .ok_or_else(|| {
+                    BinaryReaderError::new(
+                        "heap type index beyond this crate's implementation limits",
+                        offset,
+                    )
+                })?
+                .into(),
             features,
             offset,
         )

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -261,10 +261,19 @@ impl WasmFeatures {
                     Err("floating-point support is disabled")
                 }
             }
-            ValType::Ref(r) => {
+            ValType::V128 => {
+                if self.simd {
+                    Ok(())
+                } else {
+                    Err("SIMD support is not enabled")
+                }
+            }
+            _ => {
+                assert!(ty.is_ref_type());
+                let r = ty.as_ref_type().unwrap();
                 if self.reference_types {
                     if !self.function_references {
-                        match (r.heap_type, r.nullable) {
+                        match (r.heap_type(), r.is_nullable()) {
                             (_, false) => {
                                 Err("function references required for non-nullable types")
                             }
@@ -278,13 +287,6 @@ impl WasmFeatures {
                     }
                 } else {
                     Err("reference types support is not enabled")
-                }
-            }
-            ValType::V128 => {
-                if self.simd {
-                    Ok(())
-                } else {
-                    Err("SIMD support is not enabled")
                 }
             }
         }

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -518,7 +518,7 @@ impl<'resources, R: WasmModuleResources> OperatorValidatorTemp<'_, 'resources, R
                         // ...but not any other types.
                         bail!(
                             self.offset,
-                            "type mismatche: expected {}, found heap type",
+                            "type mismatch: expected {}, found heap type",
                             ty_to_str(expected)
                         )
                     }

--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -1291,12 +1291,12 @@ impl ComponentDefinedType {
     }
 
     fn join_types(a: ValType, b: ValType) -> ValType {
-        use ValType::*;
+        use ValType as V;
 
         match (a, b) {
-            (I32, I32) | (I64, I64) | (F32, F32) | (F64, F64) => a,
-            (I32, F32) | (F32, I32) => I32,
-            (_, I64 | F64) | (I64 | F64, _) => I64,
+            (V::I32, V::I32) | (V::I64, V::I64) | (V::F32, V::F32) | (V::F64, V::F64) => a,
+            (V::I32, V::F32) | (V::F32, V::I32) => V::I32,
+            (_, V::I64 | V::F64) | (V::I64 | V::F64, _) => V::I64,
             _ => panic!("unexpected wasm type for canonical ABI"),
         }
     }

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -719,7 +719,8 @@ impl Printer {
             ValType::F32 => self.result.push_str("f32"),
             ValType::F64 => self.result.push_str("f64"),
             ValType::V128 => self.result.push_str("v128"),
-            ValType::Ref(rt) => self.print_reftype(rt)?,
+            ty if ty.is_ref_type() => self.print_reftype(ty.as_ref_type().unwrap())?,
+            _ => unreachable!(),
         }
         Ok(())
     }
@@ -731,10 +732,10 @@ impl Printer {
             self.result.push_str("externref");
         } else {
             self.result.push_str("(ref ");
-            if ty.nullable {
+            if ty.is_nullable() {
                 self.result.push_str("null ");
             }
-            self.print_heaptype(ty.heap_type)?;
+            self.print_heaptype(ty.heap_type())?;
             self.result.push_str(")");
         }
         Ok(())

--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -1007,7 +1007,7 @@ impl<'a> EncodingState<'a> {
         return ret;
 
         fn to_wasm_type(ty: &wasmparser::ValType) -> WasmType {
-            match ty {
+            match *ty {
                 wasmparser::ValType::I32 => WasmType::I32,
                 wasmparser::ValType::I64 => WasmType::I64,
                 wasmparser::ValType::F32 => WasmType::F32,

--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -474,8 +474,9 @@ impl<'a> Module<'a> {
 
     fn valty(&mut self, ty: ValType) {
         match ty {
-            ValType::Ref(r) => self.heapty(r.heap_type),
             ValType::I32 | ValType::I64 | ValType::F32 | ValType::F64 | ValType::V128 => {}
+            ty if ty.is_ref_type() => self.heapty(ty.as_ref_type().unwrap().heap_type()),
+            _ => unreachable!(),
         }
     }
 
@@ -1086,14 +1087,17 @@ impl Encoder {
             wasmparser::ValType::F32 => wasm_encoder::ValType::F32,
             wasmparser::ValType::F64 => wasm_encoder::ValType::F64,
             wasmparser::ValType::V128 => wasm_encoder::ValType::V128,
-            wasmparser::ValType::Ref(rt) => wasm_encoder::ValType::Ref(self.refty(rt)),
+            ty if ty.is_ref_type() => {
+                wasm_encoder::ValType::Ref(self.refty(ty.as_ref_type().unwrap()))
+            }
+            _ => unreachable!(),
         }
     }
 
     fn refty(&self, rt: wasmparser::RefType) -> wasm_encoder::RefType {
         wasm_encoder::RefType {
-            nullable: rt.nullable,
-            heap_type: self.heapty(rt.heap_type),
+            nullable: rt.is_nullable(),
+            heap_type: self.heapty(rt.heap_type()),
         }
     }
 

--- a/crates/wit-component/tests/components/default-export-sig-mismatch/error.txt
+++ b/crates/wit-component/tests/components/default-export-sig-mismatch/error.txt
@@ -1,1 +1,1 @@
-type mismatch for function `a`: expected `[I32, I32] -> [I32]` but found `[] -> []`
+type mismatch for function `a`: expected `[i32, i32] -> [i32]` but found `[] -> []`

--- a/crates/wit-component/tests/components/export-sig-mismatch/error.txt
+++ b/crates/wit-component/tests/components/export-sig-mismatch/error.txt
@@ -1,4 +1,4 @@
 failed to validate exported interface `foo`
 
 Caused by:
-    type mismatch for function `a`: expected `[I32, I32] -> [I32]` but found `[] -> []`
+    type mismatch for function `a`: expected `[i32, i32] -> [i32]` but found `[] -> []`

--- a/crates/wit-component/tests/components/import-sig-mismatch/error.txt
+++ b/crates/wit-component/tests/components/import-sig-mismatch/error.txt
@@ -1,4 +1,4 @@
 failed to validate import interface `foo`
 
 Caused by:
-    type mismatch for function `bar`: expected `[I32, I32] -> []` but found `[] -> []`
+    type mismatch for function `bar`: expected `[i32, i32] -> []` but found `[] -> []`

--- a/tests/cli/dump/alias2.wat.stdout
+++ b/tests/cli/dump/alias2.wat.stdout
@@ -131,13 +131,13 @@
    0x15c | 00          | [func 0] type 0
    0x15d | 04 04       | table section
    0x15f | 01          | 1 count
-   0x160 | 70 00 01    | [table 0] Table { ty: TableType { element_type: RefType { nullable: true, heap_type: Func }, initial: 1, maximum: None }, init: RefNull }
+   0x160 | 70 00 01    | [table 0] Table { ty: TableType { element_type: funcref, initial: 1, maximum: None }, init: RefNull }
    0x163 | 05 03       | memory section
    0x165 | 01          | 1 count
    0x166 | 00 01       | [memory 0] MemoryType { memory64: false, shared: false, initial: 1, maximum: None }
    0x168 | 06 04       | global section
    0x16a | 01          | 1 count
-   0x16b | 7f 00       | [global 0] GlobalType { content_type: I32, mutable: false }
+   0x16b | 7f 00       | [global 0] GlobalType { content_type: i32, mutable: false }
    0x16d | 0b          | end
    0x16e | 07 11       | export section
    0x170 | 04          | 4 count
@@ -168,9 +168,9 @@
          | 00         
    0x1ab | 00 01 32 02 | import [memory 0] Import { module: "", name: "2", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None }) }
          | 00 01      
-   0x1b1 | 00 01 33 03 | import [global 0] Import { module: "", name: "3", ty: Global(GlobalType { content_type: I32, mutable: false }) }
+   0x1b1 | 00 01 33 03 | import [global 0] Import { module: "", name: "3", ty: Global(GlobalType { content_type: i32, mutable: false }) }
          | 7f 00      
-   0x1b7 | 00 01 34 01 | import [table 0] Import { module: "", name: "4", ty: Table(TableType { element_type: RefType { nullable: true, heap_type: Func }, initial: 1, maximum: None }) }
+   0x1b7 | 00 01 34 01 | import [table 0] Import { module: "", name: "4", ty: Table(TableType { element_type: funcref, initial: 1, maximum: None }) }
          | 70 00 01   
    0x1be | 00 0a       | custom section
    0x1c0 | 04 6e 61 6d | name: "name"

--- a/tests/cli/dump/blockty.wat.stdout
+++ b/tests/cli/dump/blockty.wat.stdout
@@ -3,11 +3,11 @@
   0x8 | 01 17       | type section
   0xa | 05          | 5 count
   0xb | 60 00 00    | [type 0] Func(FuncType { params: [], returns: [] })
-  0xe | 60 00 01 7f | [type 1] Func(FuncType { params: [], returns: [I32] })
- 0x12 | 60 01 7f 00 | [type 2] Func(FuncType { params: [I32], returns: [] })
- 0x16 | 60 01 7f 01 | [type 3] Func(FuncType { params: [I32], returns: [I32] })
+  0xe | 60 00 01 7f | [type 1] Func(FuncType { params: [], returns: [i32] })
+ 0x12 | 60 01 7f 00 | [type 2] Func(FuncType { params: [i32], returns: [] })
+ 0x16 | 60 01 7f 01 | [type 3] Func(FuncType { params: [i32], returns: [i32] })
       | 7f         
- 0x1b | 60 01 7f 02 | [type 4] Func(FuncType { params: [I32], returns: [I32, I32] })
+ 0x1b | 60 01 7f 02 | [type 4] Func(FuncType { params: [i32], returns: [i32, i32] })
       | 7f 7f      
  0x21 | 03 02       | func section
  0x23 | 01          | 1 count
@@ -19,7 +19,7 @@
  0x29 | 00          | 0 local blocks
  0x2a | 02 40       | block blockty:Empty
  0x2c | 0b          | end
- 0x2d | 02 7f       | block blockty:Type(I32)
+ 0x2d | 02 7f       | block blockty:Type(i32)
  0x2f | 0b          | end
  0x30 | 02 02       | block blockty:FuncType(2)
  0x32 | 0b          | end

--- a/tests/cli/dump/bundled.wat.stdout
+++ b/tests/cli/dump/bundled.wat.stdout
@@ -25,7 +25,7 @@
          | 01 00 00 00
     0x54 | 01 09       | type section
     0x56 | 01          | 1 count
-    0x57 | 60 04 7f 7f | [type 0] Func(FuncType { params: [I32, I32, I32, I32], returns: [I32] })
+    0x57 | 60 04 7f 7f | [type 0] Func(FuncType { params: [i32, i32, i32, i32], returns: [i32] })
          | 7f 7f 01 7f
     0x5f | 03 02       | func section
     0x61 | 01          | 1 count
@@ -61,7 +61,7 @@
          | 01 00 00 00
     0xa0 | 01 09       | type section
     0xa2 | 02          | 2 count
-    0xa3 | 60 02 7f 7f | [type 0] Func(FuncType { params: [I32, I32], returns: [] })
+    0xa3 | 60 02 7f 7f | [type 0] Func(FuncType { params: [i32, i32], returns: [] })
          | 00         
     0xa8 | 60 00 00    | [type 1] Func(FuncType { params: [], returns: [] })
     0xab | 02 12       | import section
@@ -103,9 +103,9 @@
          | 01 00 00 00
    0x101 | 01 0c       | type section
    0x103 | 02          | 2 count
-   0x104 | 60 02 7f 7f | [type 0] Func(FuncType { params: [I32, I32], returns: [] })
+   0x104 | 60 02 7f 7f | [type 0] Func(FuncType { params: [i32, i32], returns: [] })
          | 00         
-   0x109 | 60 03 7f 7f | [type 1] Func(FuncType { params: [I32, I32, I32], returns: [] })
+   0x109 | 60 03 7f 7f | [type 1] Func(FuncType { params: [i32, i32, i32], returns: [] })
          | 7f 00      
    0x10f | 02 12       | import section
    0x111 | 01          | 1 count

--- a/tests/cli/dump/module-types.wat.stdout
+++ b/tests/cli/dump/module-types.wat.stdout
@@ -2,7 +2,7 @@
       | 0c 00 01 00
   0x8 | 03 23       | core type section
   0xa | 01          | 1 count
-  0xb | 50 05 01 60 | [core type 0] Module([Type(Func(FuncType { params: [], returns: [] })), Import(Import { module: "", name: "f", ty: Func(0) }), Import(Import { module: "", name: "g", ty: Global(GlobalType { content_type: I32, mutable: false }) }), Import(Import { module: "", name: "t", ty: Table(TableType { element_type: RefType { nullable: true, heap_type: Func }, initial: 1, maximum: None }) }), Import(Import { module: "", name: "m", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None }) })])
+  0xb | 50 05 01 60 | [core type 0] Module([Type(Func(FuncType { params: [], returns: [] })), Import(Import { module: "", name: "f", ty: Func(0) }), Import(Import { module: "", name: "g", ty: Global(GlobalType { content_type: i32, mutable: false }) }), Import(Import { module: "", name: "t", ty: Table(TableType { element_type: funcref, initial: 1, maximum: None }) }), Import(Import { module: "", name: "m", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None }) })])
       | 00 00 00 00
       | 01 66 00 00
       | 00 00 01 67

--- a/tests/cli/dump/names.wat.stdout
+++ b/tests/cli/dump/names.wat.stdout
@@ -2,7 +2,7 @@
       | 01 00 00 00
   0x8 | 01 05       | type section
   0xa | 01          | 1 count
-  0xb | 60 01 7f 00 | [type 0] Func(FuncType { params: [I32], returns: [] })
+  0xb | 60 01 7f 00 | [type 0] Func(FuncType { params: [i32], returns: [] })
   0xf | 03 02       | func section
  0x11 | 01          | 1 count
  0x12 | 00          | [func 0] type 0
@@ -11,7 +11,7 @@
 ============== func 0 ====================
  0x16 | 04          | size of function
  0x17 | 01          | 1 local blocks
- 0x18 | 01 7c       | 1 locals of type F64
+ 0x18 | 01 7c       | 1 locals of type f64
  0x1a | 0b          | end
  0x1b | 00 1c       | custom section
  0x1d | 04 6e 61 6d | name: "name"

--- a/tests/cli/dump/select.wat.stdout
+++ b/tests/cli/dump/select.wat.stdout
@@ -13,7 +13,7 @@
  0x16 | 00          | 0 local blocks
  0x17 | 1b          | select
  0x18 | 1c 00       | ??
- 0x1a | 1c 01 7f    | typed_select ty:I32
+ 0x1a | 1c 01 7f    | typed_select ty:i32
  0x1d | 1c 02       | ??
  0x1f | 7f          | i64_div_s
  0x20 | 7f          | i64_div_s

--- a/tests/cli/dump/simple.wat.stdout
+++ b/tests/cli/dump/simple.wat.stdout
@@ -2,7 +2,7 @@
       | 01 00 00 00
   0x8 | 01 08       | type section
   0xa | 02          | 2 count
-  0xb | 60 01 7f 00 | [type 0] Func(FuncType { params: [I32], returns: [] })
+  0xb | 60 01 7f 00 | [type 0] Func(FuncType { params: [i32], returns: [] })
   0xf | 60 00 00    | [type 1] Func(FuncType { params: [], returns: [] })
  0x12 | 02 07       | import section
  0x14 | 01          | 1 count
@@ -15,13 +15,13 @@
  0x20 | 01          | [func 3] type 1
  0x21 | 04 04       | table section
  0x23 | 01          | 1 count
- 0x24 | 70 00 01    | [table 0] Table { ty: TableType { element_type: RefType { nullable: true, heap_type: Func }, initial: 1, maximum: None }, init: RefNull }
+ 0x24 | 70 00 01    | [table 0] Table { ty: TableType { element_type: funcref, initial: 1, maximum: None }, init: RefNull }
  0x27 | 05 03       | memory section
  0x29 | 01          | 1 count
  0x2a | 00 01       | [memory 0] MemoryType { memory64: false, shared: false, initial: 1, maximum: None }
  0x2c | 06 06       | global section
  0x2e | 01          | 1 count
- 0x2f | 7f 00       | [global 0] GlobalType { content_type: I32, mutable: false }
+ 0x2f | 7f 00       | [global 0] GlobalType { content_type: i32, mutable: false }
  0x31 | 41 00       | i32_const value:0
  0x33 | 0b          | end
  0x34 | 07 05       | export section
@@ -31,14 +31,14 @@
  0x3d | 00          | start function 0
  0x3e | 09 0f       | element section
  0x40 | 03          | 3 count
- 0x41 | 00          | element RefType { nullable: true, heap_type: Func } table[0]
+ 0x41 | 00          | element funcref table[0]
  0x42 | 41 03       | i32_const value:3
  0x44 | 0b          | end
  0x45 | 01          | 1 items
  0x46 | 00          | item 0
- 0x47 | 01 00 01    | element RefType { nullable: true, heap_type: Func } passive, 1 items
+ 0x47 | 01 00 01    | element funcref passive, 1 items
  0x4a | 00          | item 0
- 0x4b | 03 00 01    | element RefType { nullable: true, heap_type: Func } declared 1 items
+ 0x4b | 03 00 01    | element funcref declared 1 items
  0x4e | 00          | item 0
  0x4f | 0a 10       | code section
  0x51 | 03          | 3 count
@@ -49,12 +49,12 @@
 ============== func 2 ====================
  0x55 | 04          | size of function
  0x56 | 01          | 1 local blocks
- 0x57 | 01 7f       | 1 locals of type I32
+ 0x57 | 01 7f       | 1 locals of type i32
  0x59 | 0b          | end
 ============== func 3 ====================
  0x5a | 06          | size of function
  0x5b | 01          | 1 local blocks
- 0x5c | 01 7f       | 1 locals of type I32
+ 0x5c | 01 7f       | 1 locals of type i32
  0x5e | 41 00       | i32_const value:0
  0x60 | 0b          | end
  0x61 | 0b 0a       | data section

--- a/tests/local/component-model/adapt.wast
+++ b/tests/local/component-model/adapt.wast
@@ -260,7 +260,7 @@
     (core instance $i (instantiate $m))
     (func (export "foo") (canon lift (core func $i "foo")))
   )
-  "lowered parameter types `[]` do not match parameter types `[I32]`")
+  "lowered parameter types `[]` do not match parameter types `[i32]`")
 
 (assert_invalid
   (component
@@ -268,7 +268,7 @@
     (core instance $i (instantiate $m))
     (func (export "foo") (canon lift (core func $i "foo")))
   )
-  "lowered result types `[]` do not match result types `[I32]`")
+  "lowered result types `[]` do not match result types `[i32]`")
 
 (assert_invalid
   (component


### PR DESCRIPTION
@peterhuene flagging you for review on this, but if you aren't comfortable reviewing it, I can wait till @alexcrichton gets back.

It is unfortunate we can't exhaustively match on `ValType` anymore, but I don't think that is really on the table with the bit packing we need to do for newer Wasm proposals like typed function references and wasm GC. The interesting changes are in `crates/wasmparser/src/readers/core/types.rs` which is where the bitpacking is happening. A little in `operators.rs` as well. Everything else is pretty much just mechanical.

-------------

`ValType`, `RefType`, and `MaybeType` now all fit in the same `u32` without any reshuffling of data, and we can represent typed function references with type indices of up to `crate::limits::MAX_WASM_TYPES` (actually more than that, even, but reaching that limit is all that matters).

Fixes #924

This seems to have improved validation performance around 5% to 9%, but parsing performance seems to have remained unchanged:

```
parse/tests             time:   [2.4162 ms 2.4326 ms 2.4530 ms]
                        change: [-1.3401% -0.5631% +0.4134%] (p = 0.20 > 0.05)
                        No change in performance detected.
Found 16 outliers among 100 measurements (16.00%)
  8 (8.00%) high mild
  8 (8.00%) high severe

validate/tests          time:   [8.2957 ms 8.3357 ms 8.3819 ms]
                        change: [-0.3539% +0.4333% +1.1407%] (p = 0.27 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) high mild
  4 (4.00%) high severe

validate/spidermonkey   time:   [42.028 ms 42.238 ms 42.489 ms]
                        change: [-8.9480% -7.6998% -6.6868%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe

parse/spidermonkey      time:   [22.575 ms 22.657 ms 22.747 ms]
                        change: [+0.3717% +0.9542% +1.4750%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  9 (9.00%) high mild
  2 (2.00%) high severe

Benchmarking validate/pulldown-cmark: Warming up for 3.0000 s
validate/pulldown-cmark time:   [1.7002 ms 1.7051 ms 1.7106 ms]
                        change: [-6.5367% -5.7188% -4.8981%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe

parse/pulldown-cmark    time:   [903.17 us 905.99 us 909.15 us]
                        change: [-2.1947% -0.1003% +1.7054%] (p = 0.93 > 0.05)
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

validate/lots-of-types  time:   [958.59 us 966.84 us 977.31 us]
                        change: [-1.7668% -0.4678% +0.8039%] (p = 0.48 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  4 (4.00%) high mild
  7 (7.00%) high severe

parse/lots-of-types     time:   [213.53 us 214.65 us 215.92 us]
                        change: [-1.6417% +0.1719% +2.7420%] (p = 0.90 > 0.05)
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe

validate/bz2            time:   [698.34 us 701.03 us 704.05 us]
                        change: [-9.4043% -8.5635% -7.7976%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  6 (6.00%) high mild
  7 (7.00%) high severe

parse/bz2               time:   [367.78 us 369.73 us 371.90 us]
                        change: [-0.4934% +0.7747% +2.0745%] (p = 0.23 > 0.05)
                        No change in performance detected.
Found 10 outliers among 100 measurements (10.00%)
  7 (7.00%) high mild
  3 (3.00%) high severe

Benchmarking validate/intgemm-simd: Warming up for 3.0000 s
validate/intgemm-simd   time:   [1.5229 ms 1.5322 ms 1.5436 ms]
                        change: [-7.5339% -6.2622% -4.9607%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  4 (4.00%) high mild
  6 (6.00%) high severe

parse/intgemm-simd      time:   [746.34 us 748.77 us 751.52 us]
                        change: [-1.0841% -0.1432% +0.8056%] (p = 0.78 > 0.05)
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  8 (8.00%) high mild
  4 (4.00%) high severe
```