### PR TITLE
wasmparser: Pack `RefType` into a `[u8; 3]`

### DIFF
--- a/crates/wasm-compose/src/encoding.rs
+++ b/crates/wasm-compose/src/encoding.rs
@@ -275,8 +275,8 @@ impl<'a> TypeEncoder<'a> {
 
     fn ref_type(ty: wasmparser::RefType) -> RefType {
         RefType {
-            nullable: ty.nullable,
-            heap_type: match ty.heap_type {
+            nullable: ty.is_nullable(),
+            heap_type: match ty.heap_type() {
                 wasmparser::HeapType::Func => HeapType::Func,
                 wasmparser::HeapType::Extern => HeapType::Extern,
                 wasmparser::HeapType::TypedFunc(i) => HeapType::TypedFunc(i.into()),

--- a/crates/wasm-mutate/src/module.rs
+++ b/crates/wasm-mutate/src/module.rs
@@ -81,10 +81,10 @@ pub fn map_type(tpe: wasmparser::ValType) -> Result<ValType> {
     }
 }
 
-pub fn map_ref_type(tpe: wasmparser::RefType) -> Result<RefType> {
+pub fn map_ref_type(ref_ty: wasmparser::RefType) -> Result<RefType> {
     Ok(RefType {
-        nullable: tpe.nullable,
-        heap_type: match tpe.heap_type {
+        nullable: ref_ty.is_nullable(),
+        heap_type: match ref_ty.heap_type() {
             wasmparser::HeapType::Func => HeapType::Func,
             wasmparser::HeapType::Extern => HeapType::Extern,
             wasmparser::HeapType::TypedFunc(i) => HeapType::TypedFunc(i.into()),

--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -193,8 +193,8 @@ pub fn ty(t: &mut dyn Translator, ty: &wasmparser::ValType) -> Result<ValType> {
 
 pub fn refty(t: &mut dyn Translator, ty: &wasmparser::RefType) -> Result<RefType> {
     Ok(RefType {
-        nullable: ty.nullable,
-        heap_type: t.translate_heapty(&ty.heap_type)?,
+        nullable: ty.is_nullable(),
+        heap_type: t.translate_heapty(&ty.heap_type())?,
     })
 }
 

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -1639,8 +1639,8 @@ fn convert_type(parsed_type: wasmparser::ValType) -> ValType {
 
 fn convert_reftype(ty: wasmparser::RefType) -> RefType {
     wasm_encoder::RefType {
-        nullable: ty.nullable,
-        heap_type: match ty.heap_type {
+        nullable: ty.is_nullable(),
+        heap_type: match ty.heap_type() {
             wasmparser::HeapType::Func => wasm_encoder::HeapType::Func,
             wasmparser::HeapType::Extern => wasm_encoder::HeapType::Extern,
             wasmparser::HeapType::TypedFunc(i) => wasm_encoder::HeapType::TypedFunc(i.into()),

--- a/crates/wasmparser/src/resources.rs
+++ b/crates/wasmparser/src/resources.rs
@@ -240,11 +240,14 @@ pub trait WasmModuleResources {
         // Delegate to the generic value type validation which will have the
         // same validity checks.
         self.check_value_type(
-            RefType {
-                nullable: true,
-                heap_type,
-            }
-            .into(),
+            RefType::new(true, heap_type)
+                .ok_or_else(|| {
+                    BinaryReaderError::new(
+                        "heap type index beyond this crate's implementation limits",
+                        offset,
+                    )
+                })?
+                .into(),
             features,
             offset,
         )

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -264,7 +264,7 @@ impl WasmFeatures {
             ValType::Ref(r) => {
                 if self.reference_types {
                     if !self.function_references {
-                        match (r.heap_type, r.nullable) {
+                        match (r.heap_type(), r.is_nullable()) {
                             (_, false) => {
                                 Err("function references required for non-nullable types")
                             }

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -151,7 +151,7 @@ impl ModuleState {
 
         match &table.init {
             TableInit::RefNull => {
-                if !table.ty.element_type.nullable {
+                if !table.ty.element_type.is_nullable() {
                     bail!(offset, "type mismatch: non-defaultable element type");
                 }
             }
@@ -247,7 +247,7 @@ impl ModuleState {
         match e.items {
             crate::ElementItems::Functions(reader) => {
                 let count = reader.count();
-                if !e.ty.nullable && count <= 0 {
+                if !e.ty.is_nullable() && count <= 0 {
                     return Err(BinaryReaderError::new(
                         "a non-nullable element must come with an initialization expression",
                         offset,
@@ -804,7 +804,7 @@ impl Module {
 
     fn check_ref_type(&self, ty: RefType, types: &TypeList, offset: usize) -> Result<()> {
         // Check that the heap type is valid
-        match ty.heap_type {
+        match ty.heap_type() {
             HeapType::Func | HeapType::Extern => (),
             HeapType::TypedFunc(type_index) => {
                 // Just check that the index is valid
@@ -817,8 +817,8 @@ impl Module {
     fn eq_valtypes(&self, ty1: ValType, ty2: ValType, types: &TypeList) -> bool {
         match (ty1, ty2) {
             (ValType::Ref(rt1), ValType::Ref(rt2)) => {
-                rt1.nullable == rt2.nullable
-                    && match (rt1.heap_type, rt2.heap_type) {
+                rt1.is_nullable() == rt2.is_nullable()
+                    && match (rt1.heap_type(), rt2.heap_type()) {
                         (HeapType::Func, HeapType::Func) => true,
                         (HeapType::Extern, HeapType::Extern) => true,
                         (HeapType::TypedFunc(n1), HeapType::TypedFunc(n2)) => {
@@ -864,8 +864,8 @@ impl Module {
         };
 
         let matches_ref = |ty1: RefType, ty2: RefType, types: &TypeList| -> bool {
-            matches_heap(ty1.heap_type, ty2.heap_type, types)
-                && matches_null(ty1.nullable, ty2.nullable)
+            matches_heap(ty1.heap_type(), ty2.heap_type(), types)
+                && matches_null(ty1.is_nullable(), ty2.is_nullable())
         };
 
         match (ty1, ty2) {

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -173,6 +173,13 @@ impl From<ValType> for MaybeType {
     }
 }
 
+impl From<RefType> for MaybeType {
+    fn from(ty: RefType) -> MaybeType {
+        let ty: ValType = ty.into();
+        ty.into()
+    }
+}
+
 impl OperatorValidator {
     fn new(features: &WasmFeatures, allocs: OperatorValidatorAllocations) -> Self {
         let OperatorValidatorAllocations {
@@ -985,22 +992,14 @@ pub fn ty_to_str(ty: ValType) -> &'static str {
         ValType::V128 => "v128",
         ValType::FUNCREF => "funcref",
         ValType::EXTERNREF => "externref",
-        ValType::Ref(RefType {
-            nullable: false,
-            heap_type: HeapType::Func,
-        }) => "(ref func)",
-        ValType::Ref(RefType {
-            nullable: false,
-            heap_type: HeapType::Extern,
-        }) => "(ref extern)",
-        ValType::Ref(RefType {
-            nullable: false,
-            heap_type: HeapType::TypedFunc(_),
-        }) => "(ref $type)",
-        ValType::Ref(RefType {
-            nullable: true,
-            heap_type: HeapType::TypedFunc(_),
-        }) => "(ref null $type)",
+        ValType::Ref(rt) => match (rt.is_nullable(), rt.heap_type()) {
+            (false, HeapType::Func) => "(ref func)",
+            (true, HeapType::Func) => "funcref",
+            (false, HeapType::Extern) => "(ref extern)",
+            (true, HeapType::Extern) => "externref",
+            (false, HeapType::TypedFunc(_)) => "(ref $type)",
+            (true, HeapType::TypedFunc(_)) => "(ref null $type)",
+        },
     }
 }
 
@@ -1286,10 +1285,8 @@ where
         // If `None` is popped then that means a "bottom" type was popped which
         // is always considered equivalent to the `hty` tag.
         if let Some(rt) = self.pop_ref()? {
-            let expected = RefType {
-                nullable: true,
-                heap_type: hty,
-            };
+            let expected =
+                RefType::new(true, hty).expect("existing heap types should be within our limits");
             if !self
                 .resources
                 .matches(ValType::Ref(rt), ValType::Ref(expected))
@@ -2221,19 +2218,15 @@ where
     fn visit_ref_null(&mut self, heap_type: HeapType) -> Self::Output {
         self.resources
             .check_heap_type(heap_type, &self.features, self.offset)?;
-        self.push_operand(ValType::Ref(RefType {
-            nullable: true,
-            heap_type,
-        }))?;
+        self.push_operand(ValType::Ref(
+            RefType::new(true, heap_type).expect("existing heap types should be within our limits"),
+        ))?;
         Ok(())
     }
 
     fn visit_ref_as_non_null(&mut self) -> Self::Output {
         let ty = match self.pop_ref()? {
-            Some(ty) => MaybeType::Type(ValType::Ref(RefType {
-                nullable: false,
-                heap_type: ty.heap_type,
-            })),
+            Some(ty) => MaybeType::Type(ValType::Ref(ty.as_non_null())),
             None => MaybeType::HeapBot,
         };
         self.push_operand(ty)?;
@@ -2242,10 +2235,7 @@ where
     fn visit_br_on_null(&mut self, relative_depth: u32) -> Self::Output {
         let ty = match self.pop_ref()? {
             None => MaybeType::HeapBot,
-            Some(ty) => MaybeType::Type(ValType::Ref(RefType {
-                nullable: false,
-                heap_type: ty.heap_type,
-            })),
+            Some(ty) => MaybeType::Type(ValType::Ref(ty.as_non_null())),
         };
         let (ft, kind) = self.jump(relative_depth)?;
         for ty in self.label_types(ft, kind)?.rev() {
@@ -2271,10 +2261,7 @@ where
                 // Switch rt0, our popped type, to a non-nullable type and
                 // perform the match because if the branch is taken it's a
                 // non-null value.
-                let ty = RefType {
-                    nullable: false,
-                    heap_type: rt0.heap_type,
-                };
+                let ty = rt0.as_non_null();
                 if !self.resources.matches(ty.into(), rt1) {
                     bail!(
                         self.offset,
@@ -2318,16 +2305,11 @@ where
         // FIXME(#924) this should not be conditional based on enabled
         // proposals.
         if self.features.function_references {
-            let heap_type = HeapType::TypedFunc(match type_index.try_into() {
-                Ok(packed) => packed,
-                Err(_) => {
-                    bail!(self.offset, "type index of `ref.func` target too large")
-                }
-            });
-            self.push_operand(ValType::Ref(RefType {
-                nullable: false,
-                heap_type,
-            }))?;
+            let heap_type = HeapType::TypedFunc(type_index);
+            self.push_operand(
+                RefType::new(false, heap_type)
+                    .expect("our limits on number of types should fit into ref type"),
+            )?;
         } else {
             self.push_operand(ValType::FUNCREF)?;
         }

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -731,10 +731,10 @@ impl Printer {
             self.result.push_str("externref");
         } else {
             self.result.push_str("(ref ");
-            if ty.nullable {
+            if ty.is_nullable() {
                 self.result.push_str("null ");
             }
-            self.print_heaptype(ty.heap_type)?;
+            self.print_heaptype(ty.heap_type())?;
             self.result.push_str(")");
         }
         Ok(())

--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -474,7 +474,7 @@ impl<'a> Module<'a> {
 
     fn valty(&mut self, ty: ValType) {
         match ty {
-            ValType::Ref(r) => self.heapty(r.heap_type),
+            ValType::Ref(r) => self.heapty(r.heap_type()),
             ValType::I32 | ValType::I64 | ValType::F32 | ValType::F64 | ValType::V128 => {}
         }
     }
@@ -1092,8 +1092,8 @@ impl Encoder {
 
     fn refty(&self, rt: wasmparser::RefType) -> wasm_encoder::RefType {
         wasm_encoder::RefType {
-            nullable: rt.nullable,
-            heap_type: self.heapty(rt.heap_type),
+            nullable: rt.is_nullable(),
+            heap_type: self.heapty(rt.heap_type()),
         }
     }
 

--- a/tests/cli/dump/alias2.wat.stdout
+++ b/tests/cli/dump/alias2.wat.stdout
@@ -131,7 +131,7 @@
    0x15c | 00          | [func 0] type 0
    0x15d | 04 04       | table section
    0x15f | 01          | 1 count
-   0x160 | 70 00 01    | [table 0] Table { ty: TableType { element_type: RefType { nullable: true, heap_type: Func }, initial: 1, maximum: None }, init: RefNull }
+   0x160 | 70 00 01    | [table 0] Table { ty: TableType { element_type: funcref, initial: 1, maximum: None }, init: RefNull }
    0x163 | 05 03       | memory section
    0x165 | 01          | 1 count
    0x166 | 00 01       | [memory 0] MemoryType { memory64: false, shared: false, initial: 1, maximum: None }
@@ -170,7 +170,7 @@
          | 00 01      
    0x1b1 | 00 01 33 03 | import [global 0] Import { module: "", name: "3", ty: Global(GlobalType { content_type: I32, mutable: false }) }
          | 7f 00      
-   0x1b7 | 00 01 34 01 | import [table 0] Import { module: "", name: "4", ty: Table(TableType { element_type: RefType { nullable: true, heap_type: Func }, initial: 1, maximum: None }) }
+   0x1b7 | 00 01 34 01 | import [table 0] Import { module: "", name: "4", ty: Table(TableType { element_type: funcref, initial: 1, maximum: None }) }
          | 70 00 01   
    0x1be | 00 0a       | custom section
    0x1c0 | 04 6e 61 6d | name: "name"

--- a/tests/cli/dump/module-types.wat.stdout
+++ b/tests/cli/dump/module-types.wat.stdout
@@ -2,7 +2,7 @@
       | 0c 00 01 00
   0x8 | 03 23       | core type section
   0xa | 01          | 1 count
-  0xb | 50 05 01 60 | [core type 0] Module([Type(Func(FuncType { params: [], returns: [] })), Import(Import { module: "", name: "f", ty: Func(0) }), Import(Import { module: "", name: "g", ty: Global(GlobalType { content_type: I32, mutable: false }) }), Import(Import { module: "", name: "t", ty: Table(TableType { element_type: RefType { nullable: true, heap_type: Func }, initial: 1, maximum: None }) }), Import(Import { module: "", name: "m", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None }) })])
+  0xb | 50 05 01 60 | [core type 0] Module([Type(Func(FuncType { params: [], returns: [] })), Import(Import { module: "", name: "f", ty: Func(0) }), Import(Import { module: "", name: "g", ty: Global(GlobalType { content_type: I32, mutable: false }) }), Import(Import { module: "", name: "t", ty: Table(TableType { element_type: funcref, initial: 1, maximum: None }) }), Import(Import { module: "", name: "m", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None }) })])
       | 00 00 00 00
       | 01 66 00 00
       | 00 00 01 67

--- a/tests/cli/dump/simple.wat.stdout
+++ b/tests/cli/dump/simple.wat.stdout
@@ -15,7 +15,7 @@
  0x20 | 01          | [func 3] type 1
  0x21 | 04 04       | table section
  0x23 | 01          | 1 count
- 0x24 | 70 00 01    | [table 0] Table { ty: TableType { element_type: RefType { nullable: true, heap_type: Func }, initial: 1, maximum: None }, init: RefNull }
+ 0x24 | 70 00 01    | [table 0] Table { ty: TableType { element_type: funcref, initial: 1, maximum: None }, init: RefNull }
  0x27 | 05 03       | memory section
  0x29 | 01          | 1 count
  0x2a | 00 01       | [memory 0] MemoryType { memory64: false, shared: false, initial: 1, maximum: None }
@@ -31,14 +31,14 @@
  0x3d | 00          | start function 0
  0x3e | 09 0f       | element section
  0x40 | 03          | 3 count
- 0x41 | 00          | element RefType { nullable: true, heap_type: Func } table[None]
+ 0x41 | 00          | element funcref table[None]
  0x42 | 41 03       | i32_const value:3
  0x44 | 0b          | end
  0x45 | 01          | 1 items
  0x46 | 00          | item 0
- 0x47 | 01 00 01    | element RefType { nullable: true, heap_type: Func } passive, 1 items
+ 0x47 | 01 00 01    | element funcref passive, 1 items
  0x4a | 00          | item 0
- 0x4b | 03 00 01    | element RefType { nullable: true, heap_type: Func } declared 1 items
+ 0x4b | 03 00 01    | element funcref declared 1 items
  0x4e | 00          | item 0
  0x4f | 0a 10       | code section
  0x51 | 03          | 3 count


### PR DESCRIPTION
Fixes #924.

This does not have the validation speed ups that #970 has. Its performance delta is a little more amorphous: we have a couple small speed ups in parsing real world benchmarks but some slow downs on the lots-of-types synthetic benchmark.

Overall, I'm still inclined to go with this version over #970 because it is less disruptive to consumers of the crate and continues to allow the better ergonomics of exhaustive matching on `ValType`.

```
parse/tests             time:   [2.4281 ms 2.4392 ms 2.4521 ms]
                        change: [-2.2326% -1.1193% -0.1863%] (p = 0.03 < 0.05)
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) high mild
  4 (4.00%) high severe

validate/tests          time:   [8.2324 ms 8.2653 ms 8.3027 ms]
                        change: [-1.8686% -1.1821% -0.4847%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 16 outliers among 100 measurements (16.00%)
  8 (8.00%) high mild
  8 (8.00%) high severe

validate/spidermonkey   time:   [45.287 ms 45.443 ms 45.623 ms]
                        change: [-0.4603% +0.1749% +0.7378%] (p = 0.57 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

parse/spidermonkey      time:   [22.109 ms 22.239 ms 22.396 ms]
                        change: [-1.9989% -1.2525% -0.4325%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 12 outliers among 100 measurements (12.00%)
  7 (7.00%) high mild
  5 (5.00%) high severe

Benchmarking validate/pulldown-cmark: Warming up for 3.0000 s
validate/pulldown-cmark time:   [1.8312 ms 1.8472 ms 1.8651 ms]
                        change: [-0.1019% +0.8062% +1.5879%] (p = 0.08 > 0.05)
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  7 (7.00%) high mild
  2 (2.00%) high severe

parse/pulldown-cmark    time:   [883.62 us 888.87 us 895.30 us]
                        change: [-3.5930% -2.6022% -1.5580%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe

Benchmarking validate/lots-of-types: Warming up for 3.0000 s
validate/lots-of-types  time:   [981.43 us 987.44 us 994.30 us]
                        change: [+2.7850% +4.3651% +6.3771%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 13 outliers among 100 measurements (13.00%)
  6 (6.00%) high mild
  7 (7.00%) high severe

parse/lots-of-types     time:   [234.12 us 235.16 us 236.44 us]
                        change: [+5.5025% +7.6456% +9.4458%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 12 outliers among 100 measurements (12.00%)
  2 (2.00%) high mild
  10 (10.00%) high severe

validate/bz2            time:   [770.89 us 774.68 us 779.05 us]
                        change: [-3.2093% -0.6903% +1.4449%] (p = 0.60 > 0.05)
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) high mild
  4 (4.00%) high severe

parse/bz2               time:   [360.49 us 362.07 us 363.93 us]
                        change: [-4.7194% -2.3152% -0.5706%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe

Benchmarking validate/intgemm-simd: Warming up for 3.0000 s
validate/intgemm-simd   time:   [1.6264 ms 1.6409 ms 1.6576 ms]
                        change: [-4.3743% -0.1229% +4.3713%] (p = 0.96 > 0.05)
                        No change in performance detected.
Found 14 outliers among 100 measurements (14.00%)
  7 (7.00%) high mild
  7 (7.00%) high severe

parse/intgemm-simd      time:   [728.06 us 731.08 us 734.71 us]
                        change: [-2.7176% -1.9405% -1.0816%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) high mild
  8 (8.00%) high severe
```