### PR TITLE
feat: add `wit-deps`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,20 +27,39 @@ edition = '2021'
 [workspace.dependencies]
 anyhow = "1.0.58"
 arbitrary = "1.1.0"
+async-compression = { version = "0.3", default-features = false }
+async-std = { version = "1" } # this is only here to enable Windows support in `async-tar` transitively
+async-tar = { version = "0.4", default-features = false }
+async-trait = { version = "0.1", default-features = false }
+camino = { version = "1", default-features = false }
 clap = { version = "4.0.0", features = ["derive"] }
 criterion = "0.3.3"
+depit = { path = "./crates/depit" }
+directories = { version = "5", default-features = false }
 env_logger = "0.9"
+futures = { version = "0.3", default-features = false }
+github-build = { path = "./tests/github-build" }
+hex = { version = "0.4", default-features = false }
 indexmap = "1.9.1"
 leb128 = "0.2.4"
 libfuzzer-sys = "0.4.0"
 log = "0.4.17"
 num_cpus = "1.13"
+pretty_assertions = "1.3.0"
 rand = { version = "0.8.4", features = ["small_rng"] }
 rayon = "1.3"
+reqwest = { version = "0.11", default-features = false }
 serde = { version = "1.0.137", features = ["derive"] }
-wasmtime = { version = "3.0.0", default-features = false, features = ['cranelift'] }
+sha2 = { version = "0.10", default-features = false }
+tokio = { version = "1", default-features = false }
+tokio-stream = { version = "0.1", default-features = false }
+tokio-util = { version = "0.7", default-features = false }
+toml = { version = "0.7", default-features = false }
+tracing = { version = "0.1", default-features = false }
+tracing-subscriber = { version = "0.3", default-features = false }
 url = "2.0.0"
-pretty_assertions = "1.3.0"
+wasmtime = { version = "3.0.0", default-features = false, features = ['cranelift'] }
+wit-bindgen = { version = "0.4", default-features = false }
 
 wasm-encoder = { version = "0.25.0", path = "crates/wasm-encoder"}
 wasm-compose = { version = "0.2.11", path = "crates/wasm-compose"}
@@ -53,6 +72,7 @@ wasmprinter = { version = "0.2.54", path = "crates/wasmprinter" }
 wast = { version = "55.0.0", path = "crates/wast" }
 wat = { version = "1.0.61", path = "crates/wat" }
 wit-component = { version = "0.7.4", path = "crates/wit-component" }
+wit-deps = { version = "0.1.0", path = "crates/wit-deps"}
 wit-parser = { version = "0.6.4", path = "crates/wit-parser" }
 
 [dependencies]
@@ -103,12 +123,28 @@ wast = { workspace = true, optional = true }
 # Dependencies of `metadata`
 wasm-metadata = { workspace = true, features = ["clap"], optional = true }
 
+# Dependencies of `deps`
+camino = { workspace = true, optional = true }
+wit-deps = { workspace = true, optional = true }
+tokio = { workspace = true, features = ["io-std", "fs", "macros", "rt-multi-thread"], optional = true }
+tokio-util = { workspace = true, features = ["compat"], optional = true }
+toml = { workspace = true, features = ["display", "parse"], optional = true }
+tracing-subscriber = { workspace = true, features = ["ansi", "env-filter", "fmt", "json", "std"], optional = true }
+
 [dev-dependencies]
 serde_json = "1.0"
 tempfile = "3.1"
 diff = "0.1"
 wast = { path = 'crates/wast' }
 pretty_assertions = { workspace = true }
+
+# wit-deps dependencies
+wit-deps-build-rs-test = { path = 'tests/wit-deps-build-rs' } # building this dependency is a test in itself
+wit-bindgen = { workspace = true }
+
+[[bin]]
+name = "wit-deps"
+required-features = ["deps"]
 
 [[test]]
 name = "cli"
@@ -150,3 +186,4 @@ compose = ['wasm-compose']
 demangle = ['rustc-demangle', 'cpp_demangle', 'wasmparser', 'wasm-encoder']
 component = ['wit-component', 'wit-parser', 'wast', 'wasm-encoder', 'wasmparser']
 metadata = ['wasmparser', 'wasm-metadata', 'serde_json' ]
+deps = ['wit-deps', 'camino', 'tokio', 'tokio-util', 'toml', 'tracing-subscriber']

--- a/crates/wit-deps/Cargo.toml
+++ b/crates/wit-deps/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "wit-deps"
+version = "0.1.0"
+edition.workspace = true
+authors = ["Roman Volosatovs <rvolosatovs@riseup.net>"]
+license = "Apache-2.0 WITH LLVM-exception"
+readme = "README.md"
+repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-deps"
+homepage = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-deps"
+description = "A library for WIT dependency management"
+
+[dependencies]
+anyhow = { workspace = true, features = ["std"] }
+async-compression = { workspace = true, features = ["futures-io", "gzip"] }
+async-tar = { workspace = true }
+async-trait = { workspace = true }
+directories = { workspace = true }
+futures = { workspace = true, features = ["async-await", "std"] }
+hex = { workspace = true, features = ["alloc"] }
+reqwest = { workspace = true, features = ["rustls-tls", "stream"] }
+serde = { workspace = true, features = ["derive"] }
+sha2 = { workspace = true }
+tokio = { workspace = true, features = ["fs"] }
+tokio-stream = { workspace = true, features = ["fs"] }
+tokio-util = { workspace = true, features = ["compat"] }
+toml = { workspace = true, features = ["display", "parse", "preserve_order"] }
+tracing = { workspace = true, features = ["attributes"] }
+url = { workspace = true, features = ["serde"] }
+
+[target.'cfg(windows)'.dependencies]
+# Required for https://github.com/dignifiedquire/async-tar/pull/35
+async-std = { workspace = true, features = ["unstable"] }

--- a/crates/wit-deps/README.md
+++ b/crates/wit-deps/README.md
@@ -1,0 +1,53 @@
+# Description
+
+`wit-deps` is a simple WIT dependency manager binary and Rust library, which manages your `wit/deps`. It's main objective is to ensure that whatever is located in your `wit/deps` is consistent with your dependency manifest (default: `wit/deps.toml`) and dependency lock (default: `wit/deps.lock`).
+
+# Manifest
+
+A dependency manifest is a TOML-encoded table mapping dependency names to their source specifications. In it's simplest form, a source specification is a URL string of a gzipped tarball containing a directory tree with a `wit` subdirectory containing `wit` files.
+
+Example:
+
+```toml
+# wit/deps.toml
+http = "https://github.com/WebAssembly/wasi-http/archive/6c6855a7329fb040a48ecdbad1765be8e694416c.tar.gz"
+io = "https://github.com/rvolosatovs/wasi-io/archive/v0.1.0.tar.gz"
+logging = "https://github.com/WebAssembly/wasi-logging/archive/d106e59b25297d0496e6a5d221ad090e19c3aaa3.tar.gz"
+poll = "https://github.com/WebAssembly/wasi-poll/archive/3ff76670b0d43bc7c8a224c2e65880a963416835.tar.gz"
+random = "https://github.com/WebAssembly/wasi-random/archive/28970c50c3797c0087fa75a15e88bfa39b91e0a0.tar.gz"
+```
+
+A source specfication can also be a structure with the following fields:
+
+- `url` - same format as the URL string
+- `sha256` - (optional) hex-encoded sha256 digest of the contents of the URL
+- `sha512` (optional) hex-encoded sha512 digest of the contents of the URL
+
+Example:
+
+```toml
+# wit/deps.toml
+[logging]
+url = "https://github.com/WebAssembly/wasi-logging/archive/d106e59b25297d0496e6a5d221ad090e19c3aaa3.tar.gz"
+sha256 = "4bb4aeab99e7323b30d107aab78e88b2265c1598cc438bc5fbc0d16bb63e798f"
+sha512 = "13b52b59afd98dd4938e3a651fad631d41a2e84ce781df5d8957eded77a8e1ac4277e771a10225cd4a3a9eae369ed7e8fee6e26f9991a2caa7c97c4a758b1ae6"
+```
+
+# Usage
+
+Note, `wit-deps` assumes that it has full control over `wit/deps` and so it may delete and modify contents of `wit/deps` at any time!
+
+## Interactive
+
+Use `wit-deps` or `wit-deps lock` to populate `wit/deps` using  `wit/deps.toml` manifest and `wit/deps.lock` (will be created if it does not exist)
+
+## Rust
+
+Use `wit_deps::lock!` macro in `build.rs` of your project to automatically lock your `wit/deps`.
+
+See crate documentation for more advanced use cases
+
+# Design decisions
+
+- `wit-deps` is lazy by default and will only fetch/write when it absolutely has to
+- `wit-deps` assumes that result of fetching from a URL is deterministic, that is contents returned by GET of a URL `domain.com` must always return exactly the same contents. Note, that you can use `sha256` or `sha512` fields in your manifest entry to invalidate the cache in this case

--- a/crates/wit-deps/src/cache.rs
+++ b/crates/wit-deps/src/cache.rs
@@ -1,0 +1,116 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context as _};
+use async_trait::async_trait;
+use futures::io::BufReader;
+use futures::{AsyncBufRead, AsyncWrite};
+use tokio::fs::{self, File, OpenOptions};
+use tokio_util::compat::{Compat, TokioAsyncReadCompatExt};
+use url::{Host, Url};
+
+/// Resource caching layer
+#[async_trait]
+pub trait Cache {
+    /// Type returned by the [Self::get] method
+    type Read: AsyncBufRead + Unpin;
+    /// Type returned by the [Self::insert] method
+    type Write: AsyncWrite + Unpin;
+
+    /// Returns an read handle for the entry from the cache associated with a given url
+    async fn get(&self, url: &Url) -> anyhow::Result<Option<Self::Read>>;
+
+    /// Returns a write handle for the entry associated with a given url
+    async fn insert(&self, url: &Url) -> anyhow::Result<Self::Write>;
+}
+
+/// Local caching layer
+#[derive(Clone, Debug)]
+pub struct Local<'a>(&'a Path);
+
+impl Local<'_> {
+    fn path(&self, url: &Url) -> impl AsRef<Path> {
+        let mut path = PathBuf::from(self.0);
+        match url.host() {
+            Some(Host::Ipv4(ip)) => {
+                path.push(ip.to_string());
+            }
+            Some(Host::Ipv6(ip)) => {
+                path.push(ip.to_string());
+            }
+            Some(Host::Domain(domain)) => {
+                path.push(domain);
+            }
+            None => {}
+        }
+        if let Some(segments) = url.path_segments() {
+            for seg in segments {
+                path.push(seg);
+            }
+        }
+        path
+    }
+}
+
+#[async_trait]
+impl Cache for Local<'_> {
+    type Read = BufReader<Compat<File>>;
+    type Write = Compat<File>;
+
+    async fn get(&self, url: &Url) -> anyhow::Result<Option<Self::Read>> {
+        match File::open(self.path(url)).await {
+            Ok(file) => Ok(Some(BufReader::new(file.compat()))),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => bail!("failed to lookup `{url}` in cache: {e}"),
+        }
+    }
+
+    async fn insert(&self, url: &Url) -> anyhow::Result<Self::Write> {
+        let path = self.path(url);
+        if let Some(parent) = path.as_ref().parent() {
+            fs::create_dir_all(parent)
+                .await
+                .context("failed to create directory")?;
+        }
+        OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(path)
+            .await
+            .map(TokioAsyncReadCompatExt::compat)
+            .context("failed to open file for writing")
+    }
+}
+
+impl<'a> From<&'a Path> for Local<'a> {
+    fn from(path: &'a Path) -> Self {
+        Self(path)
+    }
+}
+
+impl<'a> From<&'a str> for Local<'a> {
+    fn from(path: &'a str) -> Self {
+        Self::from(Path::new(path))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_path() {
+        assert_eq!(
+            Local::from("test")
+                .path(
+                    &"https://example.com/foo/bar.tar.gz"
+                        .parse()
+                        .expect("failed to parse URL")
+                )
+                .as_ref(),
+            Path::new("test")
+                .join("example.com")
+                .join("foo")
+                .join("bar.tar.gz")
+        );
+    }
+}

--- a/crates/wit-deps/src/digest.rs
+++ b/crates/wit-deps/src/digest.rs
@@ -1,0 +1,167 @@
+use core::fmt;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+
+use futures::{AsyncRead, AsyncWrite};
+use hex::FromHex;
+use serde::ser::SerializeStruct;
+use serde::{de, Deserialize, Serialize};
+use sha2::{Digest as _, Sha256, Sha512};
+
+/// A resource digest
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Digest {
+    /// Sha256 digest of a resource
+    pub sha256: [u8; 32],
+    /// Sha512 digest of a resource
+    pub sha512: [u8; 64],
+}
+
+impl<'de> Deserialize<'de> for Digest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: [&str; 2] = ["sha256", "sha512"];
+
+        struct Visitor;
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = Digest;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a resource digest")
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
+            where
+                V: de::MapAccess<'de>,
+            {
+                let mut sha256 = None;
+                let mut sha512 = None;
+                while let Some((k, v)) = map.next_entry::<String, String>()? {
+                    match k.as_ref() {
+                        "sha256" => {
+                            if sha256.is_some() {
+                                return Err(de::Error::duplicate_field("sha256"));
+                            }
+                            sha256 = FromHex::from_hex(v).map(Some).map_err(|e| {
+                                de::Error::custom(format!("invalid `sha256` field value: {e}"))
+                            })?;
+                        }
+                        "sha512" => {
+                            if sha512.is_some() {
+                                return Err(de::Error::duplicate_field("sha512"));
+                            }
+                            sha512 = FromHex::from_hex(v).map(Some).map_err(|e| {
+                                de::Error::custom(format!("invalid `sha512` field value: {e}"))
+                            })?;
+                        }
+                        k => return Err(de::Error::unknown_field(k, &FIELDS)),
+                    }
+                }
+                let sha256 = sha256.ok_or_else(|| de::Error::missing_field("sha256"))?;
+                let sha512 = sha512.ok_or_else(|| de::Error::missing_field("sha512"))?;
+                Ok(Digest { sha256, sha512 })
+            }
+        }
+        deserializer.deserialize_struct("Entry", &FIELDS, Visitor)
+    }
+}
+
+impl Serialize for Digest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("Digest", 2)?;
+        state.serialize_field("sha256", &hex::encode(self.sha256))?;
+        state.serialize_field("sha512", &hex::encode(self.sha512))?;
+        state.end()
+    }
+}
+
+/// A reader wrapper, which hashes the bytes read
+pub struct Reader<T> {
+    reader: T,
+    sha256: Sha256,
+    sha512: Sha512,
+}
+
+impl<T: AsyncRead + Unpin> AsyncRead for Reader<T> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.reader).poll_read(cx, buf).map_ok(|n| {
+            self.sha256.update(&buf[..n]);
+            self.sha512.update(&buf[..n]);
+            n
+        })
+    }
+}
+
+impl<T> From<T> for Reader<T> {
+    fn from(reader: T) -> Self {
+        Self {
+            reader,
+            sha256: Sha256::new(),
+            sha512: Sha512::new(),
+        }
+    }
+}
+
+impl<T> From<Reader<T>> for Digest {
+    fn from(hashed: Reader<T>) -> Self {
+        let sha256 = hashed.sha256.finalize().into();
+        let sha512 = hashed.sha512.finalize().into();
+        Self { sha256, sha512 }
+    }
+}
+
+/// A writer wrapper, which hashes the bytes written
+pub struct Writer<T> {
+    writer: T,
+    sha256: Sha256,
+    sha512: Sha512,
+}
+
+impl<T: AsyncWrite + Unpin> AsyncWrite for Writer<T> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.writer).poll_write(cx, buf).map_ok(|n| {
+            self.sha256.update(&buf[..n]);
+            self.sha512.update(&buf[..n]);
+            n
+        })
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.writer).poll_flush(cx)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.writer).poll_close(cx)
+    }
+}
+
+impl<T> From<T> for Writer<T> {
+    fn from(writer: T) -> Self {
+        Self {
+            writer,
+            sha256: Sha256::new(),
+            sha512: Sha512::new(),
+        }
+    }
+}
+
+impl<T> From<Writer<T>> for Digest {
+    fn from(hashed: Writer<T>) -> Self {
+        let sha256 = hashed.sha256.finalize().into();
+        let sha512 = hashed.sha512.finalize().into();
+        Self { sha256, sha512 }
+    }
+}

--- a/crates/wit-deps/src/lib.rs
+++ b/crates/wit-deps/src/lib.rs
@@ -1,0 +1,209 @@
+//! `wit-deps` core
+
+#![forbid(clippy::unwrap_used)]
+#![warn(clippy::pedantic)]
+#![warn(missing_docs)]
+
+mod cache;
+mod digest;
+mod lock;
+mod manifest;
+
+pub use cache::{Cache, Local as LocalCache};
+pub use digest::{Digest, Reader as DigestReader, Writer as DigestWriter};
+pub use lock::{Entry as LockEntry, Lock};
+pub use manifest::{Entry as ManifestEntry, Manifest};
+
+use std::collections::BTreeSet;
+use std::ffi::OsStr;
+use std::path::Path;
+
+use anyhow::{bail, Context};
+use directories::ProjectDirs;
+use futures::{AsyncRead, AsyncWrite, TryStreamExt};
+use tokio::fs;
+use tokio_stream::wrappers::ReadDirStream;
+use tracing::debug;
+
+/// WIT dependency identifier
+pub type Identifier = String;
+// TODO: Introduce a rich type with name validation
+//#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq)]
+//pub struct Identifier(String);
+
+fn is_wit(path: impl AsRef<Path>) -> bool {
+    path.as_ref()
+        .extension()
+        .map(|ext| ext.eq_ignore_ascii_case("wit"))
+        .unwrap_or_default()
+}
+
+/// Unpacks all WIT interfaces found within `wit` subtree of a tar archive read from `tar` to `dst`
+///
+/// # Errors
+///
+/// Returns and error if the operation fails
+pub async fn untar(tar: impl AsyncRead + Unpin, dst: impl AsRef<Path>) -> anyhow::Result<()> {
+    let dst = dst.as_ref();
+
+    match fs::remove_dir_all(dst).await {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => bail!("failed to remove `{}`: {e}", dst.display()),
+    };
+    fs::create_dir_all(dst)
+        .await
+        .with_context(|| format!("failed to create `{}`", dst.display()))?;
+
+    async_tar::Archive::new(tar)
+        .entries()
+        .context("failed to unpack archive metadata")?
+        .try_for_each(|mut e| async move {
+            let path = e.path()?;
+            let mut path = path.into_iter().map(OsStr::to_str);
+            match (path.next(), path.next(), path.next(), path.next()) {
+                (Some(Some("wit")), Some(Some(name)), None, None)
+                | (Some(_), Some(Some("wit")), Some(Some(name)), None)
+                    if is_wit(name) =>
+                {
+                    e.unpack(dst.join(name)).await?;
+                    Ok(())
+                }
+                _ => Ok(()),
+            }
+        })
+        .await
+        .context("failed to unpack archive")?;
+    Ok(())
+}
+
+/// Packages path into a `wit` subtree in deterministic `tar` archive and writes it to `dst`.
+///
+/// # Errors
+///
+/// Returns and error if the operation fails
+pub async fn tar<T>(path: impl AsRef<Path>, dst: T) -> std::io::Result<T>
+where
+    T: AsyncWrite + Sync + Send + Unpin,
+{
+    let path = path.as_ref();
+    let mut tar = async_tar::Builder::new(dst);
+    tar.mode(async_tar::HeaderMode::Deterministic);
+    let names = fs::read_dir(path)
+        .await
+        .map(ReadDirStream::new)?
+        .try_filter_map(|e| async move {
+            let name = e.file_name();
+            if !is_wit(&name) {
+                return Ok(None);
+            }
+            if e.file_type().await?.is_dir() {
+                return Ok(None);
+            }
+            Ok(Some(name))
+        })
+        .try_collect::<BTreeSet<_>>()
+        .await?;
+    for name in names {
+        tar.append_path_with_name(path.join(&name), Path::new("wit").join(name))
+            .await?;
+    }
+    tar.into_inner().await
+}
+
+/// Given a TOML-encoded manifest and optional TOML-encoded lock, ensures that the path pointed to by
+/// `deps` is in sync with the manifest and lock. This is a potentially destructive operation!
+/// Returns a lock if the lock passed to this function was either `None` or out-of-sync.
+///
+/// # Errors
+///
+/// Returns an error if anything in the pipeline fails
+pub async fn lock(
+    manifest: impl AsRef<str>,
+    lock: Option<impl AsRef<str>>,
+    deps: impl AsRef<Path>,
+    packages: impl IntoIterator<Item = &Identifier>,
+) -> anyhow::Result<Option<String>> {
+    let manifest: Manifest =
+        toml::from_str(manifest.as_ref()).context("failed to decode manifest")?;
+
+    let old_lock = lock
+        .as_ref()
+        .map(AsRef::as_ref)
+        .map(toml::from_str)
+        .transpose()
+        .context("failed to decode lock")?;
+
+    let dirs = ProjectDirs::from("", "", env!("CARGO_PKG_NAME"));
+    let cache = dirs.as_ref().map(ProjectDirs::cache_dir).map(|cache| {
+        debug!("using cache at `{}`", cache.display());
+        LocalCache::from(cache)
+    });
+
+    let deps = deps.as_ref();
+    let lock = manifest
+        .lock(deps, old_lock.as_ref(), cache.as_ref(), packages)
+        .await
+        .with_context(|| format!("failed to lock deps to `{}`", deps.display()))?;
+
+    match old_lock {
+        Some(old_lock) if lock == old_lock => Ok(None),
+        _ => {
+            let lock = toml::to_string(&lock).context("failed to encode lock")?;
+            Ok(Some(lock))
+        }
+    }
+}
+
+/// Like [lock](self::lock()), but reads and writes the lock under path specified in `lock`.
+///
+/// Returns `true` if the lock was updated and `false` otherwise.
+///
+/// # Errors
+///
+/// Returns an error if anything in the pipeline fails
+pub async fn lock_path(
+    manifest: impl AsRef<str>,
+    lock_path: impl AsRef<Path>,
+    deps: impl AsRef<Path>,
+    packages: impl IntoIterator<Item = &Identifier>,
+) -> anyhow::Result<bool> {
+    let lock_path = lock_path.as_ref();
+    let lock = match fs::read_to_string(&lock_path).await {
+        Ok(lock) => Some(lock),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+        Err(e) => bail!("failed to read lock at `{}`: {e}", lock_path.display()),
+    };
+    if let Some(lock) = self::lock(manifest, lock, deps, packages)
+        .await
+        .context("failed to lock dependencies")?
+    {
+        if let Some(parent) = lock_path.parent() {
+            fs::create_dir_all(parent).await.with_context(|| {
+                format!(
+                    "failed to create lock parent directory `{}`",
+                    parent.display()
+                )
+            })?;
+        }
+        fs::write(&lock_path, &lock)
+            .await
+            .with_context(|| format!("failed to write lock to `{}`", lock_path.display()))?;
+        Ok(true)
+    } else {
+        Ok(false)
+    }
+}
+
+/// Ensure dependency manifest, lock and dependencies are in sync
+#[macro_export]
+macro_rules! lock {
+    () => {
+        $crate::lock_path(
+            include_str!("wit/deps.toml"),
+            "wit/deps.lock",
+            "wit/deps",
+            None,
+        )
+    };
+}

--- a/crates/wit-deps/src/lock.rs
+++ b/crates/wit-deps/src/lock.rs
@@ -1,0 +1,122 @@
+use crate::{tar, Digest, DigestWriter, Identifier};
+
+use core::ops::Deref;
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use anyhow::Context;
+use futures::io::sink;
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+/// WIT dependency [Lock] entry
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct Entry {
+    /// Resource URL
+    pub url: Url,
+    /// Resource digest
+    #[serde(flatten)]
+    pub digest: Digest,
+}
+
+impl Entry {
+    /// Create a new entry given a url and path containing the unpacked dependency
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if [`Self::digest`] of `path` fails
+    pub async fn new(url: Url, path: impl AsRef<Path>) -> anyhow::Result<Self> {
+        let digest = Self::digest(path)
+            .await
+            .context("failed to compute digest")?;
+        Ok(Self { url, digest })
+    }
+
+    /// Compute the digest of an entry from path
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if tar-encoding the path fails
+    pub async fn digest(path: impl AsRef<Path>) -> std::io::Result<Digest> {
+        tar(path, DigestWriter::from(sink())).await.map(Into::into)
+    }
+}
+
+/// WIT dependency lock mapping [Identifiers](Identifier) to [Entries](Entry)
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct Lock(BTreeMap<Identifier, Entry>);
+
+impl Deref for Lock {
+    type Target = BTreeMap<Identifier, Entry>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl FromIterator<(Identifier, Entry)> for Lock {
+    fn from_iter<T: IntoIterator<Item = (Identifier, Entry)>>(iter: T) -> Self {
+        Self(BTreeMap::from_iter(iter))
+    }
+}
+
+impl Extend<(Identifier, Entry)> for Lock {
+    fn extend<T: IntoIterator<Item = (Identifier, Entry)>>(&mut self, iter: T) {
+        self.0.extend(iter);
+    }
+}
+
+impl<const N: usize> From<[(Identifier, Entry); N]> for Lock {
+    fn from(entries: [(Identifier, Entry); N]) -> Self {
+        Self::from_iter(entries)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use anyhow::{ensure, Context};
+    use hex::FromHex;
+
+    const FOO_URL: &str = "https://example.com/baz";
+    const FOO_SHA256: &str = "9f86d081884c7d658a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08";
+    const FOO_SHA512: &str = "ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff";
+
+    #[test]
+    fn decode() -> anyhow::Result<()> {
+        fn assert_lock(lock: Lock) -> anyhow::Result<Lock> {
+            ensure!(
+                lock == Lock::from([(
+                    "foo".parse().expect("failed to `foo` parse identifier"),
+                    Entry {
+                        url: FOO_URL.parse().expect("failed to parse `foo` URL"),
+                        digest: Digest {
+                            sha256: FromHex::from_hex(FOO_SHA256)
+                                .expect("failed to decode `foo` sha256"),
+                            sha512: FromHex::from_hex(FOO_SHA512)
+                                .expect("failed to decode `foo` sha512"),
+                        },
+                    }
+                )])
+            );
+            Ok(lock)
+        }
+
+        let lock = toml::from_str(&format!(
+            r#"
+foo = {{ url = "{FOO_URL}", sha256 = "{FOO_SHA256}", sha512 = "{FOO_SHA512}" }}
+"#
+        ))
+        .context("failed to decode lock")
+        .and_then(assert_lock)?;
+
+        let lock = toml::to_string(&lock).context("failed to encode lock")?;
+        toml::from_str(&lock)
+            .context("failed to decode lock")
+            .and_then(assert_lock)?;
+
+        Ok(())
+    }
+}

--- a/crates/wit-deps/src/manifest.rs
+++ b/crates/wit-deps/src/manifest.rs
@@ -1,0 +1,409 @@
+use crate::{untar, Cache, Digest, DigestReader, Identifier, Lock, LockEntry};
+
+use core::borrow::Borrow;
+use core::convert::identity;
+use core::fmt;
+use core::ops::Deref;
+use core::str::FromStr;
+
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{bail, Context as _};
+use async_compression::futures::bufread::GzipDecoder;
+use futures::io::BufReader;
+use futures::lock::Mutex;
+use futures::{stream, AsyncWriteExt, StreamExt, TryStreamExt};
+use hex::FromHex;
+use serde::{de, Deserialize};
+use tokio::fs;
+use tracing::{debug, error, info, instrument, warn};
+use url::Url;
+
+/// WIT dependency [Manifest] entry
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum Entry {
+    /// Dependency specification expressed as a resource (typically, a gzipped tarball) URL
+    Url {
+        /// Resource URL
+        url: Url,
+        /// Optional sha256 digest of this resource
+        sha256: Option<[u8; 32]>,
+        /// Optional sha512 digest of this resource
+        sha512: Option<[u8; 64]>,
+    },
+    // TODO: Support semver queries
+}
+
+impl From<Url> for Entry {
+    fn from(url: Url) -> Self {
+        Self::Url {
+            url,
+            sha256: None,
+            sha512: None,
+        }
+    }
+}
+
+impl FromStr for Entry {
+    type Err = url::ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        s.parse::<Url>().map(Into::into)
+    }
+}
+
+impl<'de> Deserialize<'de> for Entry {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        const FIELDS: [&str; 3] = ["sha256", "sha512", "url"];
+
+        struct Visitor;
+        impl<'de> de::Visitor<'de> for Visitor {
+            type Value = Entry;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a WIT dependency manifest entry")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                value.parse().map_err(de::Error::custom)
+            }
+
+            fn visit_map<V>(self, mut map: V) -> Result<Self::Value, V::Error>
+            where
+                V: de::MapAccess<'de>,
+            {
+                let mut url = None;
+                let mut sha256 = None;
+                let mut sha512 = None;
+                while let Some((k, v)) = map.next_entry::<String, String>()? {
+                    match k.as_ref() {
+                        "sha256" => {
+                            if sha256.is_some() {
+                                return Err(de::Error::duplicate_field("sha256"));
+                            }
+                            sha256 = FromHex::from_hex(v).map(Some).map_err(|e| {
+                                de::Error::custom(format!("invalid `sha256` field value: {e}"))
+                            })?;
+                        }
+                        "sha512" => {
+                            if sha512.is_some() {
+                                return Err(de::Error::duplicate_field("sha512"));
+                            }
+                            sha512 = FromHex::from_hex(v).map(Some).map_err(|e| {
+                                de::Error::custom(format!("invalid `sha512` field value: {e}"))
+                            })?;
+                        }
+                        "url" => {
+                            if url.is_some() {
+                                return Err(de::Error::duplicate_field("url"));
+                            }
+                            url = v.parse().map(Some).map_err(|e| {
+                                de::Error::custom(format!("invalid `url` field value: {e}"))
+                            })?;
+                        }
+                        k => return Err(de::Error::unknown_field(k, &FIELDS)),
+                    }
+                }
+                let url = url.ok_or_else(|| de::Error::missing_field("url"))?;
+                Ok(Entry::Url {
+                    url,
+                    sha256,
+                    sha512,
+                })
+            }
+        }
+        deserializer.deserialize_struct("Entry", &FIELDS, Visitor)
+    }
+}
+
+fn source_matches(
+    digest: impl Into<Digest>,
+    sha256: Option<[u8; 32]>,
+    sha512: Option<[u8; 64]>,
+) -> bool {
+    let digest = digest.into();
+    sha256.map_or(true, |sha256| sha256 == digest.sha256)
+        && sha512.map_or(true, |sha512| sha512 == digest.sha512)
+}
+
+impl Entry {
+    #[instrument(level = "trace", skip(out, lock, cache))]
+    async fn lock(
+        self,
+        out: impl AsRef<Path>,
+        lock: Option<&LockEntry>,
+        cache: Option<&impl Cache>,
+    ) -> anyhow::Result<LockEntry> {
+        let out = out.as_ref();
+
+        match self {
+            Self::Url {
+                url,
+                sha256,
+                sha512,
+            } => {
+                if let Some(lock) = lock {
+                    match LockEntry::digest(out).await {
+                        Ok(digest) if digest == lock.digest && url == lock.url => {
+                            debug!("`{}` is already up-to-date, skip fetch", out.display());
+                            return Ok(LockEntry { url, digest });
+                        }
+                        Ok(digest) => {
+                            debug!(
+                                "`{}` is out-of-date (sha256: {})",
+                                out.display(),
+                                hex::encode(digest.sha256)
+                            );
+                        }
+                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                            debug!("locked dependency for `{url}` missing");
+                        }
+                        Err(e) => error!("failed to compute dependency digest for `{url}`: {e}"),
+                    }
+                }
+                let cache = if let Some(cache) = cache {
+                    match cache.get(&url).await {
+                        Err(e) => error!("failed to get `{url}` from cache: {e}"),
+                        Ok(None) => debug!("`{url}` not present in cache"),
+                        Ok(Some(tar_gz)) => {
+                            let mut hashed = DigestReader::from(tar_gz);
+                            match untar(GzipDecoder::new(BufReader::new(&mut hashed)), out).await {
+                                Ok(()) if source_matches(hashed, sha256, sha512) => {
+                                    debug!("unpacked `{url}` from cache");
+                                    return LockEntry::new(url, out).await;
+                                }
+                                Ok(()) => {
+                                    warn!("cache hash mismatch for `{url}`");
+                                    fs::remove_dir_all(out).await.with_context(|| {
+                                        format!("failed to remove `{}`", out.display())
+                                    })?;
+                                }
+                                Err(e) => {
+                                    error!("failed to unpack `{url}` contents from cache: {e}");
+                                }
+                            }
+                        }
+                    }
+                    if let Ok(cache) = cache.insert(&url).await {
+                        Some(cache)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+                let cache = Arc::new(Mutex::new(cache));
+                let digest = match url.scheme() {
+                    "http" | "https" => {
+                        info!("fetch `{url}` into `{}`", out.display());
+                        let res = reqwest::get(url.clone())
+                            .await
+                            .context("failed to GET")
+                            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?
+                            .error_for_status()
+                            .context("GET request failed")
+                            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+                        let tar_gz = res
+                            .bytes_stream()
+                            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+                            .then(|chunk| async {
+                                let chunk = chunk?;
+                                let mut cache = cache.lock().await;
+                                let cache_res = if let Some(w) = cache.as_mut().map(|w| async {
+                                    if let Err(e) = w.write(&chunk).await {
+                                        error!("failed to write chunk to cache: {e}");
+                                        if let Err(e) = w.close().await {
+                                            error!("failed to close cache writer: {e}");
+                                        }
+                                        return Err(e);
+                                    }
+                                    Ok(())
+                                }) {
+                                    Some(w.await)
+                                } else {
+                                    None
+                                }
+                                .transpose();
+                                if cache_res.is_err() {
+                                    // Drop the cache writer if a failure occurs
+                                    cache.take();
+                                }
+                                Ok(chunk)
+                            })
+                            .into_async_read();
+                        let mut hashed = DigestReader::from(Box::pin(tar_gz));
+                        untar(GzipDecoder::new(BufReader::new(&mut hashed)), out)
+                            .await
+                            .with_context(|| format!("failed to unpack contents of `{url}`"))?;
+                        Digest::from(hashed)
+                    }
+                    // TODO: Support `file`
+                    scheme => bail!("unsupported URL scheme `{scheme}`"),
+                };
+                if let Some(sha256) = sha256 {
+                    if digest.sha256 != sha256 {
+                        fs::remove_dir_all(out)
+                            .await
+                            .with_context(|| format!("failed to remove `{}`", out.display()))?;
+                        bail!(
+                            r#"sha256 hash mismatch for `{url}`
+got: {}
+expected: {}"#,
+                            hex::encode(digest.sha256),
+                            hex::encode(sha256),
+                        );
+                    }
+                }
+                if let Some(sha512) = sha512 {
+                    if digest.sha512 != sha512 {
+                        fs::remove_dir_all(out)
+                            .await
+                            .with_context(|| format!("failed to remove `{}`", out.display()))?;
+                        bail!(
+                            r#"sha512 hash mismatch for `{url}`
+got: {}
+expected: {}"#,
+                            hex::encode(digest.sha512),
+                            hex::encode(sha512),
+                        );
+                    }
+                }
+                LockEntry::new(url, out).await
+            }
+        }
+    }
+}
+
+/// WIT dependency manifest mapping [Identifiers](Identifier) to [Entries](Entry)
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq)]
+pub struct Manifest(HashMap<Identifier, Entry>);
+
+impl Manifest {
+    /// Lock the manifest populating `deps`
+    #[instrument(level = "trace", skip(deps, lock, cache, packages))]
+    pub async fn lock(
+        self,
+        deps: impl AsRef<Path>,
+        lock: Option<impl Borrow<Lock>>,
+        cache: Option<&impl Cache>,
+        packages: impl IntoIterator<Item = &Identifier>,
+    ) -> anyhow::Result<Lock> {
+        let lock = lock.as_ref().map(Borrow::borrow);
+        let deps = deps.as_ref();
+        let packages: HashSet<_> = packages.into_iter().collect();
+        if let Some(id) = packages.iter().find(|id| !self.contains_key(**id)) {
+            bail!("selected package `{id}` not found in manifest")
+        }
+        stream::iter(self.0.into_iter().map(|(id, entry)| async {
+            if packages.is_empty() || packages.contains(&id) {
+                let out = deps.join(&id);
+                let lock = lock.and_then(|lock| lock.get(&id));
+                let entry = entry
+                    .lock(out, lock, cache)
+                    .await
+                    .with_context(|| format!("failed to lock `{id}`"))?;
+                Ok((id, entry))
+            } else if let Some(Some(entry)) = lock.map(|lock| lock.get(&id)) {
+                Ok((id, entry.clone()))
+            } else {
+                debug!("locking unselected manifest package `{id}` missing from lock");
+                let entry = entry
+                    .lock(deps.join(&id), None, cache)
+                    .await
+                    .with_context(|| format!("failed to lock `{id}`"))?;
+                Ok((id, entry))
+            }
+        }))
+        .then(identity)
+        .try_collect()
+        .await
+    }
+}
+
+impl Deref for Manifest {
+    type Target = HashMap<Identifier, Entry>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl FromIterator<(Identifier, Entry)> for Manifest {
+    fn from_iter<T: IntoIterator<Item = (Identifier, Entry)>>(iter: T) -> Self {
+        Self(HashMap::from_iter(iter))
+    }
+}
+
+impl<const N: usize> From<[(Identifier, Entry); N]> for Manifest {
+    fn from(entries: [(Identifier, Entry); N]) -> Self {
+        Self::from_iter(entries)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FOO_URL: &str = "https://example.com/foo.tar.gz";
+
+    const BAR_URL: &str = "https://example.com/bar";
+    const BAR_SHA256: &str = "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08";
+
+    const BAZ_URL: &str = "http://127.0.0.1/baz";
+    const BAZ_SHA256: &str = "9f86d081884c7d658a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08";
+    const BAZ_SHA512: &str = "ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff";
+
+    #[test]
+    fn decode() -> anyhow::Result<()> {
+        let manifest: Manifest = toml::from_str(&format!(
+            r#"
+foo = "{FOO_URL}"
+bar = {{ url = "{BAR_URL}", sha256 = "{BAR_SHA256}" }}
+baz = {{ url = "{BAZ_URL}", sha256 = "{BAZ_SHA256}", sha512 = "{BAZ_SHA512}" }}
+"#
+        ))
+        .context("failed to decode manifest")?;
+        assert_eq!(
+            manifest,
+            Manifest::from([
+                (
+                    "foo".parse().expect("failed to parse `foo` identifier"),
+                    FOO_URL
+                        .parse()
+                        .expect("failed to parse `foo` entry from URL string"),
+                ),
+                (
+                    "bar".parse().expect("failed to parse `bar` identifier"),
+                    Entry::Url {
+                        url: BAR_URL.parse().expect("failed to parse `bar` URL"),
+                        sha256: FromHex::from_hex(BAR_SHA256)
+                            .map(Some)
+                            .expect("failed to decode `bar` sha256"),
+                        sha512: None,
+                    }
+                ),
+                (
+                    "baz".parse().expect("failed to `baz` parse identifier"),
+                    Entry::Url {
+                        url: BAZ_URL.parse().expect("failed to parse `baz` URL"),
+                        sha256: FromHex::from_hex(BAZ_SHA256)
+                            .map(Some)
+                            .expect("failed to decode `baz` sha256"),
+                        sha512: FromHex::from_hex(BAZ_SHA512)
+                            .map(Some)
+                            .expect("failed to decode `baz` sha512")
+                    }
+                )
+            ])
+        );
+        Ok(())
+    }
+}

--- a/examples/wit-deps/main.rs
+++ b/examples/wit-deps/main.rs
@@ -1,0 +1,6 @@
+wit_bindgen::generate!({
+    path: "examples/wit-deps/wit",
+    world: "world",
+});
+
+fn main() {}

--- a/examples/wit-deps/wit/deps.lock
+++ b/examples/wit-deps/wit/deps.lock
@@ -1,0 +1,24 @@
+[http]
+url = "https://github.com/WebAssembly/wasi-http/archive/6c6855a7329fb040a48ecdbad1765be8e694416c.tar.gz"
+sha256 = "1667921c63364722b0d23eb69023ede0cdace86ee9b4c6f7c4286b3a2dd8d635"
+sha512 = "9b2f225411d347d3e99276359d3ad98475e9fbee4b3fad0169060dc648a5efa3584a6a1db990607a4971c7e3c0026dc65f8e48fe2824f9553840bb46f3b389ae"
+
+[io]
+url = "https://github.com/rvolosatovs/wasi-io/archive/v0.1.0.tar.gz"
+sha256 = "50e907cde3a0b49b2358c564a10db26e3585a5466029baaecb00424dccea77a1"
+sha512 = "096953066bc1e690b90e01d0a8ed92650052184173df8dac1e24d2a277a6f864a078eca0d555fa2de0b38be1ba8ed25db7949a396f60c9a35def7ea956a66ff1"
+
+[logging]
+url = "https://github.com/WebAssembly/wasi-logging/archive/d106e59b25297d0496e6a5d221ad090e19c3aaa3.tar.gz"
+sha256 = "f378a2b6a36af096528ec5e7031da474990cecaec1949c663befc5066d719f6f"
+sha512 = "ba09307b12f5428c3058d878001c9fb15df21933c6203328f785d5009a4fc0cf304950271590d4146305a2d8b8988595f396d955961168cb6bfa7ea9af1cc362"
+
+[poll]
+url = "https://github.com/WebAssembly/wasi-poll/archive/3ff76670b0d43bc7c8a224c2e65880a963416835.tar.gz"
+sha256 = "065422b0ea6ccb2a9facc6b87b902eef110c53d76fc31f341a6bc8d0b0285b6a"
+sha512 = "19a55cd3072a19ae6a1774723a4962e7a155a5ce89a27175e8c76020efb4d00bc92ebb78427d92bcb8effd4f0d03ebf0a0daa747ecd981b8d31d5abc2ad86423"
+
+[random]
+url = "https://github.com/WebAssembly/wasi-random/archive/28970c50c3797c0087fa75a15e88bfa39b91e0a0.tar.gz"
+sha256 = "79b6417bb1ab3c82c241c56021e717f258e2a0b3ab94db93907ca11d7f92ed66"
+sha512 = "1e657ac56420e65bde75eabea920a605a0ff4adc6f2ba8b7cf1c37a603710449bc1a29568dda2b61c04ae9889d2b1a82b9935d4b9d573eb48a83e0ecf9cad591"

--- a/examples/wit-deps/wit/deps.toml
+++ b/examples/wit-deps/wit/deps.toml
@@ -1,0 +1,9 @@
+http = "https://github.com/WebAssembly/wasi-http/archive/6c6855a7329fb040a48ecdbad1765be8e694416c.tar.gz"
+io = "https://github.com/rvolosatovs/wasi-io/archive/v0.1.0.tar.gz" # this fork renames `streams` interface for compatiblity with wasi-snapshot-preview1
+poll = "https://github.com/WebAssembly/wasi-poll/archive/3ff76670b0d43bc7c8a224c2e65880a963416835.tar.gz"
+random = "https://github.com/WebAssembly/wasi-random/archive/28970c50c3797c0087fa75a15e88bfa39b91e0a0.tar.gz"
+
+[logging]
+url = "https://github.com/WebAssembly/wasi-logging/archive/d106e59b25297d0496e6a5d221ad090e19c3aaa3.tar.gz"
+sha256 = "4bb4aeab99e7323b30d107aab78e88b2265c1598cc438bc5fbc0d16bb63e798f"
+sha512 = "13b52b59afd98dd4938e3a651fad631d41a2e84ce781df5d8957eded77a8e1ac4277e771a10225cd4a3a9eae369ed7e8fee6e26f9991a2caa7c97c4a758b1ae6"

--- a/examples/wit-deps/wit/deps/http/incoming-handler.wit
+++ b/examples/wit-deps/wit/deps/http/incoming-handler.wit
@@ -1,0 +1,26 @@
+// The `wasi:http/incoming-handler` interface is meant to be exported by
+// components and called by the host in response to a new incoming HTTP
+// response.
+//
+//   NOTE: in Preview3, this interface will be merged with
+//   `wasi:http/outgoing-handler` into a single `wasi:http/handler` interface
+//   that takes a `request` parameter and returns a `response` result.
+//
+default interface incoming-handler {
+  use pkg.types.{incoming-request, response-outparam}
+
+  // The `handle` function takes an outparam instead of returning its response
+  // so that the component may stream its response while streaming any other
+  // request or response bodies. The callee MUST write a response to the
+  // `response-out` and then finish the response before returning. The caller
+  // is expected to start streaming the response once `set-response-outparam`
+  // is called and finish streaming the response when `drop-response-outparam`
+  // is called. The `handle` function is then allowed to continue executing
+  // any post-response logic before returning. While this post-response
+  // execution is taken off the critical path, since there is no return value,
+  // there is no way to report its success or failure.
+  handle: func(
+    request: incoming-request,
+    response-out: response-outparam
+  )
+}

--- a/examples/wit-deps/wit/deps/http/outgoing-handler.wit
+++ b/examples/wit-deps/wit/deps/http/outgoing-handler.wit
@@ -1,0 +1,18 @@
+// The `wasi:http/outgoing-handler` interface is meant to be imported by
+// components and implemented by the host.
+//
+//   NOTE: in Preview3, this interface will be merged with
+//   `wasi:http/outgoing-handler` into a single `wasi:http/handler` interface
+//   that takes a `request` parameter and returns a `response` result.
+//
+default interface outgoing-handler {
+  use pkg.types.{outgoing-request, request-options, future-incoming-response}
+
+  // The parameter and result types of the `handle` function allow the caller
+  // to concurrently stream the bodies of the outgoing request and the incoming
+  // response.
+  handle: func(
+    request: outgoing-request,
+    options: option<request-options>
+  ) -> future-incoming-response
+}

--- a/examples/wit-deps/wit/deps/http/proxy.wit
+++ b/examples/wit-deps/wit/deps/http/proxy.wit
@@ -1,0 +1,24 @@
+// The `wasi:http/proxy` world captures a widely-implementable intersection of
+// hosts that includes HTTP forward and reverse proxies. Components targeting
+// this world may concurrently stream in and out any number of incoming and
+// outgoing HTTP requests.
+default world proxy {
+  // HTTP proxies have access to time and randomness.
+  import random: random.random
+  // TODO: add `import wall-clock: clocks.wall-clock`
+  // TODO: add `import monotonic-clock: clocks.monotonic-clock`
+
+  // This is the default logging handler to use when user code simply wants to
+  // log to a developer-facing console (e.g., via `console.log()`).
+  import console: logging.logging
+
+  // This is the default handler to use when user code simply wants to make an
+  // HTTP request (e.g., via `fetch()`).
+  import default-outgoing-HTTP: pkg.outgoing-handler
+
+  // The host delivers incoming HTTP requests to a component by calling the
+  // `handle` function of this exported interface. A host may arbitrarily reuse
+  // or not reuse component instance when delivering incoming HTTP requests and
+  // thus a component must be able to handle 0..N calls to `handle`.
+  export HTTP: pkg.incoming-handler
+}

--- a/examples/wit-deps/wit/deps/http/types.wit
+++ b/examples/wit-deps/wit/deps/http/types.wit
@@ -1,0 +1,157 @@
+// The `wasi:http/types` interface is meant to be imported by components to
+// define the HTTP resource types and operations used by the component's
+// imported and exported interfaces.
+default interface types {
+  use io.streams.{input-stream, output-stream}
+  use poll.poll.{pollable}
+  
+  // This type corresponds to HTTP standard Methods.
+  variant method {
+    get,
+    head,
+    post,
+    put,
+    delete,
+    connect,
+    options,
+    trace,
+    patch,
+    other(string)
+  }
+
+  // This type corresponds to HTTP standard Related Schemes.
+  variant scheme {
+    HTTP,
+    HTTPS,
+    other(string)
+  }
+
+  // TODO: perhaps better align with HTTP semantics?
+  // This type enumerates the different kinds of errors that may occur when
+  // initially returning a response.
+  variant error {
+      invalid-url(string),
+      timeout-error(string),
+      protocol-error(string),
+      unexpected-error(string)
+  }
+
+  // This following block defines the `fields` resource which corresponds to
+  // HTTP standard Fields. Soon, when resource types are added, the `type
+  // fields = u32` type alias can be replaced by a proper `resource fields`
+  // definition containing all the functions using the method syntactic sugar.
+  type fields = u32
+  drop-fields: func(fields: fields)
+  new-fields: func(entries: list<tuple<string,string>>) -> fields
+  fields-get: func(fields: fields, name: string) -> list<string>
+  fields-set: func(fields: fields, name: string, value: list<string>)
+  fields-delete: func(fields: fields, name: string)
+  fields-append: func(fields: fields, name: string, value: string)
+  fields-entries: func(fields: fields) -> list<tuple<string,string>>
+  fields-clone: func(fields: fields) -> fields
+
+  type headers = fields
+  type trailers = fields
+
+  // The following block defines stream types which corresponds to the HTTP
+  // standard Contents and Trailers. With Preview3, all of these fields can be
+  // replaced by a stream<u8, option<trailers>>. In the interim, we need to
+  // build on separate resource types defined by `wasi:io/streams`. The
+  // `finish-` functions emulate the stream's result value and MUST be called
+  // exactly once after the final read/write from/to the stream before dropping
+  // the stream.
+  type incoming-stream = input-stream
+  type outgoing-stream = output-stream
+  finish-incoming-stream: func(s: incoming-stream) -> option<trailers>
+  finish-outgoing-stream: func(s: outgoing-stream, trailers: option<trailers>)
+
+  // The following block defines the `incoming-request` and `outgoing-request`
+  // resource types that correspond to HTTP standard Requests. Soon, when
+  // resource types are added, the `u32` type aliases can be replaced by
+  // proper `resource` type definitions containing all the functions as
+  // methods. Later, Preview2 will allow both types to be merged together into
+  // a single `request` type (that uses the single `stream` type mentioned
+  // above). The `consume` and `write` methods may only be called once (and
+  // return failure thereafter).
+  type incoming-request = u32
+  type outgoing-request = u32
+  drop-incoming-request: func(request: incoming-request)
+  drop-outgoing-request: func(request: outgoing-request)
+  incoming-request-method: func(request: incoming-request) -> method
+  incoming-request-path: func(request: incoming-request) -> string
+  incoming-request-query: func(request: incoming-request) -> string
+  incoming-request-scheme: func(request: incoming-request) -> option<scheme>
+  incoming-request-authority: func(request: incoming-request) -> string
+  incoming-request-headers: func(request: incoming-request) -> headers
+  incoming-request-consume: func(request: incoming-request) -> result<incoming-stream>
+  new-outgoing-request: func(
+    method: method,
+    path: string,
+    query: string,
+    scheme: option<scheme>,
+    authority: string,
+    headers: headers
+  ) -> outgoing-request
+  outgoing-request-write: func(request: outgoing-request) -> result<outgoing-stream>
+
+  // Additional optional parameters that can be set when making a request.
+  record request-options {
+    // The following timeouts are specific to the HTTP protocol and work
+    // independently of the overall timeouts passed to `io.poll.poll-oneoff`.
+
+    // The timeout for the initial connect.
+    connect-timeout-ms: option<u32>,
+
+    // The timeout for receiving the first byte of the response body.
+    first-byte-timeout-ms: option<u32>,
+
+    // The timeout for receiving the next chunk of bytes in the response body
+    // stream.
+    between-bytes-timeout-ms: option<u32>
+  }
+
+  // The following block defines a special resource type used by the
+  // `wasi:http/incoming-handler` interface. When resource types are added, this
+  // block can be replaced by a proper `resource response-outparam { ... }`
+  // definition. Later, with Preview3, the need for an outparam goes away entirely
+  // (the `wasi:http/handler` interface used for both incoming and outgoing can
+  // simply return a `stream`).
+  type response-outparam = u32
+  drop-response-outparam: func(response: response-outparam)
+  set-response-outparam: func(param: response-outparam, response: result<outgoing-response, error>) -> result
+
+  // This type corresponds to the HTTP standard Status Code.
+  type status-code = u16
+
+  // The following block defines the `incoming-response` and `outgoing-response`
+  // resource types that correspond to HTTP standard Responses. Soon, when
+  // resource types are added, the `u32` type aliases can be replaced by proper
+  // `resource` type definitions containing all the functions as methods. Later,
+  // Preview2 will allow both types to be merged together into a single `response`
+  // type (that uses the single `stream` type mentioned above). The `consume` and
+  // `write` methods may only be called once (and return failure thereafter).
+  type incoming-response = u32
+  type outgoing-response = u32
+  drop-incoming-response: func(response: incoming-response)
+  drop-outgoing-response: func(response: outgoing-response)
+  incoming-response-status: func(response: incoming-response) -> status-code
+  incoming-response-headers: func(response: incoming-response) -> headers
+  incoming-response-consume: func(response: incoming-response) -> result<incoming-stream>
+  new-outgoing-response: func(
+    status-code: status-code,
+    headers: headers
+  ) -> outgoing-response
+  outgoing-response-write: func(response: outgoing-response) -> result<outgoing-stream>
+
+  // The following block defines a special resource type used by the
+  // `wasi:http/outgoing-handler` interface to emulate
+  // `future<result<response, error>>` in advance of Preview3. Given a
+  // `future-incoming-response`, the client can call the non-blocking `get`
+  // method to get the result if it is available. If the result is not available,
+  // the client can call `listen` to get a `pollable` that can be passed to
+  // `io.poll.poll-oneoff`.
+  type future-incoming-response = u32
+  drop-future-incoming-response: func(f: future-incoming-response)
+  future-incoming-response-get: func(f: future-incoming-response) -> option<result<incoming-response, error>>
+  listen-to-future-incoming-response: func(f: future-incoming-response) -> pollable
+}

--- a/examples/wit-deps/wit/deps/io/streams.wit
+++ b/examples/wit-deps/wit/deps/io/streams.wit
@@ -1,0 +1,213 @@
+/// WASI I/O is an I/O abstraction API which is currently focused on providing
+/// stream types.
+///
+/// In the future, the component model is expected to add built-in stream types;
+/// when it does, they are expected to subsume this API.
+default interface io-streams {
+    use poll.poll.{pollable}
+
+    /// An error type returned from a stream operation. Currently this
+    /// doesn't provide any additional information.
+    record stream-error {}
+
+    /// An input bytestream. In the future, this will be replaced by handle
+    /// types.
+    ///
+    /// This conceptually represents a `stream<u8, _>`. It's temporary
+    /// scaffolding until component-model's async features are ready.
+    ///
+    /// `input-stream`s are *non-blocking* to the extent practical on underlying
+    /// platforms. I/O operations always return promptly; if fewer bytes are
+    /// promptly available than requested, they return the number of bytes promptly
+    /// available, which could even be zero. To wait for data to be available,
+    /// use the `subscribe-to-input-stream` function to obtain a `pollable` which
+    /// can be polled for using `wasi_poll`.
+    ///
+    /// And at present, it is a `u32` instead of being an actual handle, until
+    /// the wit-bindgen implementation of handles and resources is ready.
+    ///
+    /// This [represents a resource](https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources).
+    type input-stream = u32
+
+    /// Read bytes from a stream.
+    ///
+    /// This function returns a list of bytes containing the data that was
+    /// read, along with a bool which, when true, indicates that the end of the
+    /// stream was reached. The returned list will contain up to `len` bytes; it
+    /// may return fewer than requested, but not more.
+    ///
+    /// Once a stream has reached the end, subsequent calls to read or
+    /// `skip` will always report end-of-stream rather than producing more
+    /// data.
+    ///
+    /// If `len` is 0, it represents a request to read 0 bytes, which should
+    /// always succeed, assuming the stream hasn't reached its end yet, and
+    /// return an empty list.
+    ///
+    /// The len here is a `u64`, but some callees may not be able to allocate
+    /// a buffer as large as that would imply.
+    /// FIXME: describe what happens if allocation fails.
+    read: func(
+        this: input-stream,
+        /// The maximum number of bytes to read
+        len: u64
+    ) -> result<tuple<list<u8>, bool>, stream-error>
+
+    /// Read bytes from a stream, with blocking.
+    ///
+    /// This is similar to `read`, except that it blocks until at least one
+    /// byte can be read.
+    blocking-read: func(
+        this: input-stream,
+        /// The maximum number of bytes to read
+        len: u64
+    ) -> result<tuple<list<u8>, bool>, stream-error>
+
+    /// Skip bytes from a stream.
+    ///
+    /// This is similar to the `read` function, but avoids copying the
+    /// bytes into the instance.
+    ///
+    /// Once a stream has reached the end, subsequent calls to read or
+    /// `skip` will always report end-of-stream rather than producing more
+    /// data.
+    ///
+    /// This function returns the number of bytes skipped, along with a bool
+    /// indicating whether the end of the stream was reached. The returned
+    /// value will be at most `len`; it may be less.
+    skip: func(
+        this: input-stream,
+        /// The maximum number of bytes to skip.
+        len: u64,
+    ) -> result<tuple<u64, bool>, stream-error>
+
+    /// Skip bytes from a stream, with blocking.
+    ///
+    /// This is similar to `skip`, except that it blocks until at least one
+    /// byte can be consumed.
+    blocking-skip: func(
+        this: input-stream,
+        /// The maximum number of bytes to skip.
+        len: u64,
+    ) -> result<tuple<u64, bool>, stream-error>
+
+    /// Create a `pollable` which will resolve once either the specified stream
+    /// has bytes available to read or the other end of the stream has been
+    /// closed.
+    subscribe-to-input-stream: func(this: input-stream) -> pollable
+
+    /// Dispose of the specified `input-stream`, after which it may no longer
+    /// be used.
+    drop-input-stream: func(this: input-stream)
+
+    /// An output bytestream. In the future, this will be replaced by handle
+    /// types.
+    ///
+    /// This conceptually represents a `stream<u8, _>`. It's temporary
+    /// scaffolding until component-model's async features are ready.
+    ///
+    /// `output-stream`s are *non-blocking* to the extent practical on
+    /// underlying platforms. Except where specified otherwise, I/O operations also
+    /// always return promptly, after the number of bytes that can be written
+    /// promptly, which could even be zero. To wait for the stream to be ready to
+    /// accept data, the `subscribe-to-output-stream` function to obtain a
+    /// `pollable` which can be polled for using `wasi_poll`.
+    ///
+    /// And at present, it is a `u32` instead of being an actual handle, until
+    /// the wit-bindgen implementation of handles and resources is ready.
+    ///
+    /// This [represents a resource](https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources).
+    type output-stream = u32
+
+    /// Write bytes to a stream.
+    ///
+    /// This function returns a `u64` indicating the number of bytes from
+    /// `buf` that were written; it may be less than the full list.
+    write: func(
+        this: output-stream,
+        /// Data to write
+        buf: list<u8>
+    ) -> result<u64, stream-error>
+
+    /// Write bytes to a stream, with blocking.
+    ///
+    /// This is similar to `write`, except that it blocks until at least one
+    /// byte can be written.
+    blocking-write: func(
+        this: output-stream,
+        /// Data to write
+        buf: list<u8>
+    ) -> result<u64, stream-error>
+
+    /// Write multiple zero bytes to a stream.
+    ///
+    /// This function returns a `u64` indicating the number of zero bytes
+    /// that were written; it may be less than `len`.
+    write-zeroes: func(
+        this: output-stream,
+        /// The number of zero bytes to write
+        len: u64
+    ) -> result<u64, stream-error>
+
+    /// Write multiple zero bytes to a stream, with blocking.
+    ///
+    /// This is similar to `write-zeroes`, except that it blocks until at least
+    /// one byte can be written.
+    blocking-write-zeroes: func(
+        this: output-stream,
+        /// The number of zero bytes to write
+        len: u64
+    ) -> result<u64, stream-error>
+
+    /// Read from one stream and write to another.
+    ///
+    /// This function returns the number of bytes transferred; it may be less
+    /// than `len`.
+    ///
+    /// Unlike other I/O functions, this function blocks until all the data
+    /// read from the input stream has been written to the output stream.
+    splice: func(
+        this: output-stream,
+        /// The stream to read from
+        src: input-stream,
+        /// The number of bytes to splice
+        len: u64,
+    ) -> result<tuple<u64, bool>, stream-error>
+
+    /// Read from one stream and write to another, with blocking.
+    ///
+    /// This is similar to `splice`, except that it blocks until at least
+    /// one byte can be read.
+    blocking-splice: func(
+        this: output-stream,
+        /// The stream to read from
+        src: input-stream,
+        /// The number of bytes to splice
+        len: u64,
+    ) -> result<tuple<u64, bool>, stream-error>
+
+    /// Forward the entire contents of an input stream to an output stream.
+    ///
+    /// This function repeatedly reads from the input stream and writes
+    /// the data to the output stream, until the end of the input stream
+    /// is reached, or an error is encountered.
+    ///
+    /// Unlike other I/O functions, this function blocks until the end
+    /// of the input stream is seen and all the data has been written to
+    /// the output stream.
+    ///
+    /// This function returns the number of bytes transferred.
+    forward: func(
+        this: output-stream,
+        /// The stream to read from
+        src: input-stream
+    ) -> result<u64, stream-error>
+
+    /// Create a `pollable` which will resolve once either the specified stream
+    /// is ready to accept bytes or the other end of the stream has been closed.
+    subscribe-to-output-stream: func(this: output-stream) -> pollable
+
+    /// Dispose of the specified `output-stream`, after which it may no longer
+    /// be used.
+    drop-output-stream: func(this: output-stream)
+}

--- a/examples/wit-deps/wit/deps/io/world.wit
+++ b/examples/wit-deps/wit/deps/io/world.wit
@@ -1,0 +1,3 @@
+default world example-world {
+    import streams: pkg.streams
+}

--- a/examples/wit-deps/wit/deps/logging/logging.wit
+++ b/examples/wit-deps/wit/deps/logging/logging.wit
@@ -1,0 +1,32 @@
+/// WASI Logging is a logging API intended to let users emit log messages with
+/// simple priority levels and context values.
+default interface logging {
+    /// A log level, describing a kind of message.
+    enum level {
+       /// Describes messages about the values of variables and the flow of
+       /// control within a program.
+       trace,
+
+       /// Describes messages likely to be of interest to someone debugging a
+       /// program.
+       debug,
+
+       /// Describes messages likely to be of interest to someone monitoring a
+       /// program.
+       info,
+
+       /// Describes messages indicating hazardous situations.
+       warn,
+
+       /// Describes messages indicating serious errors.
+       error,
+    }
+
+    /// Emit a log message.
+    ///
+    /// A log message has a `level` describing what kind of message is being
+    /// sent, a context, which is an uninterpreted string meant to help
+    /// consumers group similar messages, and a string containing the message
+    /// text.
+    log: func(level: level, context: string, message: string)
+}

--- a/examples/wit-deps/wit/deps/logging/world.wit
+++ b/examples/wit-deps/wit/deps/logging/world.wit
@@ -1,0 +1,3 @@
+default world example-world {
+    import logging: pkg.logging
+}

--- a/examples/wit-deps/wit/deps/poll/poll.wit
+++ b/examples/wit-deps/wit/deps/poll/poll.wit
@@ -1,0 +1,39 @@
+/// A poll API intended to let users wait for I/O events on multiple handles
+/// at once.
+default interface poll {
+    /// A "pollable" handle.
+    ///
+    /// This is conceptually represents a `stream<_, _>`, or in other words,
+    /// a stream that one can wait on, repeatedly, but which does not itself
+    /// produce any data. It's temporary scaffolding until component-model's
+    /// async features are ready.
+    ///
+    /// And at present, it is a `u32` instead of being an actual handle, until
+    /// the wit-bindgen implementation of handles and resources is ready.
+    ///
+    /// `pollable` lifetimes are not automatically managed. Users must ensure
+    /// that they do not outlive the resource they reference.
+    ///
+    /// This [represents a resource](https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources).
+    type pollable = u32
+
+    /// Dispose of the specified `pollable`, after which it may no longer
+    /// be used.
+    drop-pollable: func(this: pollable)
+
+    /// Poll for completion on a set of pollables.
+    ///
+    /// The "oneoff" in the name refers to the fact that this function must do a
+    /// linear scan through the entire list of subscriptions, which may be
+    /// inefficient if the number is large and the same subscriptions are used
+    /// many times. In the future, this is expected to be obsoleted by the
+    /// component model async proposal, which will include a scalable waiting
+    /// facility.
+    ///
+    /// Note that the return type would ideally be `list<bool>`, but that would
+    /// be more difficult to polyfill given the current state of `wit-bindgen`.
+    /// See <https://github.com/bytecodealliance/preview2-prototyping/pull/11#issuecomment-1329873061>
+    /// for details.  For now, we use zero to mean "not ready" and non-zero to
+    /// mean "ready".
+    poll-oneoff: func(in: list<pollable>) -> list<u8>
+}

--- a/examples/wit-deps/wit/deps/poll/world.wit
+++ b/examples/wit-deps/wit/deps/poll/world.wit
@@ -1,0 +1,3 @@
+default world example-world {
+    import poll: pkg.poll
+}

--- a/examples/wit-deps/wit/deps/random/random.wit
+++ b/examples/wit-deps/wit/deps/random/random.wit
@@ -1,0 +1,42 @@
+/// WASI Random is a random data API.
+///
+/// It is intended to be portable at least between Unix-family platforms and
+/// Windows.
+default interface random {
+    /// Return `len` cryptographically-secure pseudo-random bytes.
+    ///
+    /// This function must produce data from an adequately seeded
+    /// cryptographically-secure pseudo-random number generator (CSPRNG), so it
+    /// must not block, from the perspective of the calling program, and the
+    /// returned data is always unpredictable.
+    ///
+    /// This function must always return fresh pseudo-random data. Deterministic
+    /// environments must omit this function, rather than implementing it with
+    /// deterministic data.
+    get-random-bytes: func(len: u64) -> list<u8>
+
+    /// Return a cryptographically-secure pseudo-random `u64` value.
+    ///
+    /// This function returns the same type of pseudo-random data as
+    /// `get-random-bytes`, represented as a `u64`.
+    get-random-u64: func() -> u64
+
+    /// Return a 128-bit value that may contain a pseudo-random value.
+    ///
+    /// The returned value is not required to be computed from a CSPRNG, and may
+    /// even be entirely deterministic. Host implementations are encouraged to
+    /// provide pseudo-random values to any program exposed to
+    /// attacker-controlled content, to enable DoS protection built into many
+    /// languages' hash-map implementations.
+    ///
+    /// This function is intended to only be called once, by a source language
+    /// to initialize Denial Of Service (DoS) protection in its hash-map
+    /// implementation.
+    ///
+    /// # Expected future evolution
+    ///
+    /// This will likely be changed to a value import, to prevent it from being
+    /// called multiple times and potentially used for purposes other than DoS
+    /// protection.
+    insecure-random: func() -> tuple<u64, u64>
+}

--- a/examples/wit-deps/wit/deps/random/world.wit
+++ b/examples/wit-deps/wit/deps/random/world.wit
@@ -1,0 +1,3 @@
+default world example-world {
+    import random: pkg.random
+}

--- a/examples/wit-deps/wit/world.wit
+++ b/examples/wit-deps/wit/world.wit
@@ -1,0 +1,5 @@
+default world example {
+    import http: http.incoming-handler
+    import logging: logging.logging
+    import random: random.random
+}

--- a/src/bin/wit-deps/main.rs
+++ b/src/bin/wit-deps/main.rs
@@ -1,0 +1,113 @@
+#![warn(clippy::pedantic)]
+
+use anyhow::Context;
+use camino::{Utf8Path, Utf8PathBuf};
+use clap::{Parser, Subcommand};
+use tokio::fs::{self, File};
+use tokio::io;
+use tokio_util::compat::TokioAsyncWriteCompatExt;
+use tracing_subscriber::prelude::*;
+use wit_deps::Identifier;
+
+#[derive(Debug, Parser)]
+#[command(author, version, about, long_about = None)]
+struct Cli {
+    /// Dependency output directory
+    #[arg(short, long, default_value = "wit/deps")]
+    deps: Utf8PathBuf,
+
+    /// Dependency manifest path
+    #[arg(short, long, default_value = "wit/deps.toml")]
+    manifest: Utf8PathBuf,
+
+    /// Dependency lock path
+    #[arg(short, long, default_value = "wit/deps.lock")]
+    lock: Utf8PathBuf,
+
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Lock dependencies
+    Lock {
+        /// Optional list of packages to lock
+        #[arg(short, long)]
+        package: Vec<Identifier>,
+    },
+    /// Write a deterministic tar containing the `wit` subdirectory for a package to stdout
+    Tar {
+        /// Package to archive
+        package: Identifier,
+
+        /// Optional output path, if not specified, the archive will be written to stdout
+        #[arg(short, long)]
+        output: Option<Utf8PathBuf>,
+    },
+}
+
+async fn lock(
+    manifest_path: impl AsRef<Utf8Path>,
+    lock_path: impl AsRef<Utf8Path>,
+    deps_path: impl AsRef<Utf8Path>,
+    packages: impl IntoIterator<Item = &Identifier>,
+) -> anyhow::Result<()> {
+    let manifest_path = manifest_path.as_ref();
+    let lock_path = lock_path.as_ref();
+    let deps_path = deps_path.as_ref();
+
+    let manifest = fs::read_to_string(&manifest_path)
+        .await
+        .with_context(|| format!("failed to read manifest at `{manifest_path}`"))?;
+    wit_deps::lock_path(manifest, lock_path, deps_path, packages)
+        .await
+        .context("failed to lock dependencies")?;
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::fmt::layer()
+                .compact()
+                .without_time()
+                .with_file(false)
+                .with_target(false)
+                .with_writer(std::io::stderr),
+        )
+        .with(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
+
+    let Cli {
+        deps: deps_path,
+        manifest: manifest_path,
+        lock: lock_path,
+        command,
+    } = Cli::parse();
+
+    match command {
+        None => lock(manifest_path, lock_path, deps_path, None).await,
+        Some(Command::Lock { package }) => {
+            lock(manifest_path, lock_path, deps_path, &package).await
+        }
+        Some(Command::Tar { package, output }) => {
+            lock(manifest_path, lock_path, &deps_path, [&package]).await?;
+            let package = deps_path.join(package);
+            if let Some(output) = output {
+                let output = File::create(&output)
+                    .await
+                    .with_context(|| format!("failed to create output path `{output}`"))?;
+                wit_deps::tar(package, output.compat_write()).await?;
+            } else {
+                wit_deps::tar(package, io::stdout().compat_write()).await?;
+            }
+            Ok(())
+        }
+    }
+}

--- a/tests/wit-deps-build-rs/.gitignore
+++ b/tests/wit-deps-build-rs/.gitignore
@@ -1,0 +1,1 @@
+/wit/deps

--- a/tests/wit-deps-build-rs/Cargo.toml
+++ b/tests/wit-deps-build-rs/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "wit-deps-build-rs-test"
+version = "0.0.0"
+description = "`wit-deps` build.rs `lock!` test"
+edition = "2021"
+
+[dependencies]
+wit-bindgen = { workspace = true, features = ["default"] }
+
+[build-dependencies]
+anyhow = { workspace = true, features = ["std"] }
+tokio = { workspace = true, features = ["fs", "macros", "rt-multi-thread"] }
+wit-deps = { workspace = true }

--- a/tests/wit-deps-build-rs/build.rs
+++ b/tests/wit-deps-build-rs/build.rs
@@ -1,0 +1,14 @@
+use anyhow::Context;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    wit_deps::lock!()
+        .await
+        .context("failed to lock WIT dependencies")?;
+
+    println!("cargo:rerun-if-changed=wit/deps");
+    println!("cargo:rerun-if-changed=wit/deps.lock");
+    println!("cargo:rerun-if-changed=wit/deps.toml");
+
+    Ok(())
+}

--- a/tests/wit-deps-build-rs/src/lib.rs
+++ b/tests/wit-deps-build-rs/src/lib.rs
@@ -1,0 +1,3 @@
+wit_bindgen::generate!({
+    world: "world",
+});

--- a/tests/wit-deps-build-rs/wit/deps.lock
+++ b/tests/wit-deps-build-rs/wit/deps.lock
@@ -1,0 +1,24 @@
+[http]
+url = "https://github.com/WebAssembly/wasi-http/archive/6c6855a7329fb040a48ecdbad1765be8e694416c.tar.gz"
+sha256 = "1667921c63364722b0d23eb69023ede0cdace86ee9b4c6f7c4286b3a2dd8d635"
+sha512 = "9b2f225411d347d3e99276359d3ad98475e9fbee4b3fad0169060dc648a5efa3584a6a1db990607a4971c7e3c0026dc65f8e48fe2824f9553840bb46f3b389ae"
+
+[io]
+url = "https://github.com/rvolosatovs/wasi-io/archive/v0.1.0.tar.gz"
+sha256 = "50e907cde3a0b49b2358c564a10db26e3585a5466029baaecb00424dccea77a1"
+sha512 = "096953066bc1e690b90e01d0a8ed92650052184173df8dac1e24d2a277a6f864a078eca0d555fa2de0b38be1ba8ed25db7949a396f60c9a35def7ea956a66ff1"
+
+[logging]
+url = "https://github.com/WebAssembly/wasi-logging/archive/d106e59b25297d0496e6a5d221ad090e19c3aaa3.tar.gz"
+sha256 = "f378a2b6a36af096528ec5e7031da474990cecaec1949c663befc5066d719f6f"
+sha512 = "ba09307b12f5428c3058d878001c9fb15df21933c6203328f785d5009a4fc0cf304950271590d4146305a2d8b8988595f396d955961168cb6bfa7ea9af1cc362"
+
+[poll]
+url = "https://github.com/WebAssembly/wasi-poll/archive/3ff76670b0d43bc7c8a224c2e65880a963416835.tar.gz"
+sha256 = "065422b0ea6ccb2a9facc6b87b902eef110c53d76fc31f341a6bc8d0b0285b6a"
+sha512 = "19a55cd3072a19ae6a1774723a4962e7a155a5ce89a27175e8c76020efb4d00bc92ebb78427d92bcb8effd4f0d03ebf0a0daa747ecd981b8d31d5abc2ad86423"
+
+[random]
+url = "https://github.com/WebAssembly/wasi-random/archive/28970c50c3797c0087fa75a15e88bfa39b91e0a0.tar.gz"
+sha256 = "79b6417bb1ab3c82c241c56021e717f258e2a0b3ab94db93907ca11d7f92ed66"
+sha512 = "1e657ac56420e65bde75eabea920a605a0ff4adc6f2ba8b7cf1c37a603710449bc1a29568dda2b61c04ae9889d2b1a82b9935d4b9d573eb48a83e0ecf9cad591"

--- a/tests/wit-deps-build-rs/wit/deps.toml
+++ b/tests/wit-deps-build-rs/wit/deps.toml
@@ -1,0 +1,5 @@
+http = "https://github.com/WebAssembly/wasi-http/archive/6c6855a7329fb040a48ecdbad1765be8e694416c.tar.gz"
+io = "https://github.com/rvolosatovs/wasi-io/archive/v0.1.0.tar.gz" # this fork renames `streams` interface for compatiblity with wasi-snapshot-preview1
+logging = "https://github.com/WebAssembly/wasi-logging/archive/d106e59b25297d0496e6a5d221ad090e19c3aaa3.tar.gz"
+poll = "https://github.com/WebAssembly/wasi-poll/archive/3ff76670b0d43bc7c8a224c2e65880a963416835.tar.gz"
+random = "https://github.com/WebAssembly/wasi-random/archive/28970c50c3797c0087fa75a15e88bfa39b91e0a0.tar.gz"

--- a/tests/wit-deps-build-rs/wit/world.wit
+++ b/tests/wit-deps-build-rs/wit/world.wit
@@ -1,0 +1,5 @@
+default world test {
+    import http: http.incoming-handler
+    import logging: logging.logging
+    import random: random.random
+}


### PR DESCRIPTION
Update 2:
I've also published the binary crate to https://crates.io/crates/depit-cli, so it's now possible to `cargo install depit-cli`

Update:
I've tagged `0.1.0` release of the binary https://github.com/rvolosatovs/depit/releases/tag/v0.1.0 and published the library to crates.io https://docs.rs/depit/latest/depit/

Original:

As suggested during BA SIG Registries call this week, integrating https://github.com/rvolosatovs/depit WIT dependency management library/binary that I have presented.

Library `cargo doc` documentation is available at https://rvolosatovs.github.io/depit/depit/index.html

Please see `README.md`, you can test the interactive usage e.g. on `examples/wit-deps`:
```
$ cd examples/wit-deps
$ rm -rf wit/deps.lock wit/deps
$ cargo run --features deps --bin wit-deps
```

Specify `RUST_LOG=debug` to see the location of the cache, e.g.:
```
$ RUST_LOG=debug cargo run --features deps --bin wit-deps
    Finished dev [unoptimized + debuginfo] target(s) in 0.22s
     Running `/home/rvolosatovs/src/github.com/bytecodealliance/wasm-tools/target/debug/wit-deps`
DEBUG using cache at `/home/rvolosatovs/.local/cache/wit-deps`
DEBUG `wit/deps/io` is already up-to-date, skip fetch
DEBUG `wit/deps/logging` is already up-to-date, skip fetch
DEBUG `wit/deps/http` is already up-to-date, skip fetch
DEBUG `wit/deps/poll` is already up-to-date, skip fetch
DEBUG `wit/deps/random` is already up-to-date, skip fetch
$ tree ~/.local/cache/wit-deps                           
/home/rvolosatovs/.local/cache/wit-deps
└── github.com
    ├── rvolosatovs
    │   └── wasi-io
    │       └── archive
    │           └── v0.1.0.tar.gz
    └── WebAssembly
        ├── wasi-http
        │   └── archive
        │       └── 6c6855a7329fb040a48ecdbad1765be8e694416c.tar.gz
        ├── wasi-logging
        │   └── archive
        │       └── d106e59b25297d0496e6a5d221ad090e19c3aaa3.tar.gz
        ├── wasi-poll
        │   └── archive
        │       └── 3ff76670b0d43bc7c8a224c2e65880a963416835.tar.gz
        └── wasi-random
            └── archive
                └── 28970c50c3797c0087fa75a15e88bfa39b91e0a0.tar.gz
```

I encourage you to try changing `wit/deps.lock` hashes, removing entries and/or corrupting the cache, e.g.:

```
$ echo 'test' > ~/.local/cache/wit-deps/github.com/WebAssembly/wasi-http/archive/6c6855a7329fb040a48ecdbad1765be8e694416c.tar.gz 
$ rm -rf wit/deps.lock wit/deps
$ cargo run --features deps --bin wit-deps
    Finished dev [unoptimized + debuginfo] target(s) in 0.20s
     Running `/home/rvolosatovs/src/github.com/bytecodealliance/wasm-tools/target/debug/wit-deps`
ERROR failed to unpack `https://github.com/WebAssembly/wasi-http/archive/6c6855a7329fb040a48ecdbad1765be8e694416c.tar.gz` contents from cache: failed to unpack archive
 INFO fetch `https://github.com/WebAssembly/wasi-http/archive/6c6855a7329fb040a48ecdbad1765be8e694416c.tar.gz` into `wit/deps/http`
```

What do maintainers think of this addition?
Are you happy with the proposed structure?
A question I would like to raise here, what to do about CI? In the original repository the project is reproducibly built and tested for for following targets (with accompanying OCI images) via https://github.com/NixOS/nix:
- aarch64-apple-darwin
- aarch64-unknown-linux-musl
- armv7-unknown-linux-musleabihf
- x86_64-apple-darwin
- x86_64-pc-windows-gnu
- x86_64-unknown-linux-musl

E.g. https://github.com/rvolosatovs/depit/actions/runs/4631705537 (feel free to fetch one of the artifacts and play with it)

There's also Nix integration https://github.com/rvolosatovs/depit/blob/131d72358e3fcd2bd9028b42e8d155c3c3af65f9/flake.nix#L32-L136, which any Nix project would require (`nix` builds everything in a sandbox and one can only get network access if the digest of the contents is known ahead-of-time).

I left Nix out of this PR, but I am happy to contribute either just basic Nix support for this repository or accompanying CI flows as well, e.g. https://github.com/rvolosatovs/depit/blob/131d72358e3fcd2bd9028b42e8d155c3c3af65f9/.github/workflows/depit.yml#L13-L85