### PR TITLE
Return error when demangling component

### DIFF
--- a/src/bin/wasm-tools/demangle.rs
+++ b/src/bin/wasm-tools/demangle.rs
@@ -35,6 +35,9 @@ impl Opts {
                         Err(e) => log::debug!("error parsing name section {e:?}"),
                     }
                 }
+                Version { encoding, .. } if *encoding == wasmparser::Encoding::Component => {
+                    bail!("demangling components is not supported");
+                }
                 _ => {}
             }
             if let Some((id, range)) = payload.as_section() {


### PR DESCRIPTION
`wasm-tools` will happily demangle a component and in the process convert it to an invalid core module.

I would add support for demangling components, but I wanted to check first whether the right approach is to more or less copy/paste the demangling code that currently handles just modules. I believe it wouldn't be possible to add support in the encoder for generically adding sections to either a component or a core module as sections are different depending on if they are embedded in a component or a core module. 