### PR TITLE
Fix a panic in `wast` with components

### DIFF
--- a/crates/wast/src/component/component.rs
+++ b/crates/wast/src/component/component.rs
@@ -188,7 +188,7 @@ impl<'a> Parse<'a> for ComponentField<'a> {
                 return Ok(Self::Alias(parser.parse()?));
             }
             if parser.peek::<kw::r#type>() {
-                return Ok(Self::Type(parser.parse()?));
+                return Ok(Self::Type(Type::parse_maybe_with_inline_exports(parser)?));
             }
             if parser.peek::<kw::import>() {
                 return Ok(Self::Import(parser.parse()?));

--- a/tests/local/component-model/inline-exports.wast
+++ b/tests/local/component-model/inline-exports.wast
@@ -1,3 +1,7 @@
 (component
   (type (export "foo") u8)
 )
+
+(assert_malformed
+  (component quote "(type (component (type (export \"\") (func))))")
+  "unexpected token")


### PR DESCRIPTION
This commit fixes an issue in the `wast` crate where an inline export could be listed on a type definition in a type context in the component model. This caused a panic when converting to binary due to the inline export being unexpected.

This resolves the issue by disallowing inline exports in this context, instead only allowing it in the top-level component context.