### PR TITLE
wasm-mutate: Fix removing table 0 when an element references it

### DIFF
--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -262,8 +262,10 @@ pub fn element(
                 &wasmparser::ValType::I32,
                 ConstExprKind::ElementOffset,
             )?;
+            let table_index = table_index.unwrap_or(0);
+            let table = t.remap(Item::Table, table_index)?;
             ElementMode::Active {
-                table: table_index.map(|i| t.remap(Item::Table, i)).transpose()?,
+                table: if table == 0 { None } else { Some(table) },
                 offset: &offset,
             }
         }


### PR DESCRIPTION
This fixes an accidental regression from #957 where wasm-mutate was removing table 0 even when an element segment implicitly referenced it by not having a table index listed.