### PR TITLE
Only iterate the documents of `pkg` in `select_world`

### DIFF
--- a/crates/wit-parser/src/resolve.rs
+++ b/crates/wit-parser/src/resolve.rs
@@ -576,8 +576,8 @@ impl Resolve {
                 }
 
                 let mut unique_default_world = None;
-                for (_name, doc) in &self.documents {
-                    if let Some(default_world) = doc.default_world {
+                for (_name, doc) in &self.packages[pkg].documents {
+                    if let Some(default_world) = self.documents[*doc].default_world {
                         if unique_default_world.is_some() {
                             bail!("multiple default worlds found in package, one must be specified")
                         } else {


### PR DESCRIPTION
When multiple packages in a `Resolve` define default worlds, calling `select_world` with a `None` world value would unconditionally fail. This is because `select_world` was iterating all documents in `Resolve`, not just those defined by `pkg`. This PR fixes the bug by only iterating the documents of `pkg` in `Resolve` when a `None` default world is passed.