### PR TITLE
chore(example): update example

### DIFF
--- a/crates/wasm-compose/example/README.md
+++ b/crates/wasm-compose/example/README.md
@@ -99,7 +99,7 @@ To build the `service` component, use `cargo component build`:
 
 ```sh
 cd service
-cargo component build --release --target wasm32-wasi
+cargo component build --release
 ```
 
 To build the `middleware` component, use `cargo component build`:

--- a/crates/wasm-compose/example/README.md
+++ b/crates/wasm-compose/example/README.md
@@ -87,7 +87,7 @@ Follow the [installation instructions](https://github.com/bytecodealliance/cargo
 to install `cargo component` locally.
 
 > *Note*: `cargo component` is under active development. This example has been tested
-> with git sha [`a5ed5e`](https://github.com/bytecodealliance/cargo-component/commit/a5ed5ea1694431ab019d7f768579808794e5e26d)
+> with git sha [`012daba`](https://github.com/bytecodealliance/cargo-component/commit/012daba27c48e1ce19b27f09730d51e9018f5135)
 > and may not work with other versions of `cargo component`.
 
 Additionally, it is assumed that `wasm-tools` has been installed from the
@@ -99,14 +99,14 @@ To build the `service` component, use `cargo component build`:
 
 ```sh
 cd service
-cargo component build --release
+cargo component build --release --target wasm32-wasi
 ```
 
 To build the `middleware` component, use `cargo component build`:
 
 ```sh
 cd middleware
-cargo component build --release
+cargo component build --release --target wasm32-wasi
 ```
 
 ## Running the server

--- a/crates/wasm-compose/example/README.md
+++ b/crates/wasm-compose/example/README.md
@@ -106,7 +106,7 @@ To build the `middleware` component, use `cargo component build`:
 
 ```sh
 cd middleware
-cargo component build --release --target wasm32-wasi
+cargo component build --release
 ```
 
 ## Running the server

--- a/crates/wasm-compose/example/middleware/Cargo.toml
+++ b/crates/wasm-compose/example/middleware/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 flate2 = "1.0.24"
-wit-bindgen = { version = "0.4.0", default_features = false }
+wit-bindgen = { version = "0.5.0", default_features = false }
 
 [lib]
 crate-type = ["cdylib"]

--- a/crates/wasm-compose/example/middleware/Cargo.toml
+++ b/crates/wasm-compose/example/middleware/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 flate2 = "1.0.24"
-wit-bindgen = { version = "0.3.0", default_features = false }
+wit-bindgen = { version = "0.4.0", default_features = false }
 
 [lib]
 crate-type = ["cdylib"]

--- a/crates/wasm-compose/example/server/Cargo.toml
+++ b/crates/wasm-compose/example/server/Cargo.toml
@@ -9,7 +9,8 @@ async-std = { version = "1.12.0", features = ["attributes"] }
 clap = { version = "3.2.23", features = ["derive"] }
 driftwood = "0.0.6"
 tide = "0.16.0"
-wasmtime = { version = "6.0.0", features = ["component-model"] }
-wasmtime-component-macro = "6.0.0"
+wasi-cap-std-sync = { git = "https://github.com/bytecodealliance/preview2-prototyping" }
+wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", rev = "299131ae2d6655c49138bfab2c4469650763ef3b", features = ["component-model"] }
+wasi-host = { git = "https://github.com/bytecodealliance/preview2-prototyping", package = "host" }
 
 [workspace]

--- a/crates/wasm-compose/example/server/Cargo.toml
+++ b/crates/wasm-compose/example/server/Cargo.toml
@@ -9,8 +9,8 @@ async-std = { version = "1.12.0", features = ["attributes"] }
 clap = { version = "3.2.23", features = ["derive"] }
 driftwood = "0.0.6"
 tide = "0.16.0"
-wasi-cap-std-sync = { git = "https://github.com/bytecodealliance/preview2-prototyping" }
+wasi-cap-std-sync = { git = "https://github.com/bytecodealliance/preview2-prototyping", rev = "0d5ca073d1131002d97c9f5984d388b55539950e" }
 wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", rev = "299131ae2d6655c49138bfab2c4469650763ef3b", features = ["component-model"] }
-wasi-host = { git = "https://github.com/bytecodealliance/preview2-prototyping", package = "host" }
+wasi-host = { git = "https://github.com/bytecodealliance/preview2-prototyping", package = "host", rev = "0d5ca073d1131002d97c9f5984d388b55539950e" }
 
 [workspace]

--- a/crates/wasm-compose/example/service/Cargo.toml
+++ b/crates/wasm-compose/example/service/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-wit-bindgen = { version = "0.3.0", default_features = false }
+wit-bindgen = { version = "0.4.0", default_features = false }
 
 [lib]
 crate-type = ["cdylib"]

--- a/crates/wasm-compose/example/service/Cargo.toml
+++ b/crates/wasm-compose/example/service/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-wit-bindgen = { version = "0.4.0", default_features = false }
+wit-bindgen = { version = "0.5.0", default_features = false }
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
~~I'm not sure that using `wasm32-unknown-unknown` is actually the best solution to get this working but I assume we can't use `wasm32-wasi` without doing something fancier with preview2-prototyping?~~

~~In any case, these are the changes I had to make to get the compose example working.~~

Updated to use latest version of `cargo-component` and compatible adapter.