### PR TITLE
feat: cabi_realloc_adapter

### DIFF
--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -1171,11 +1171,19 @@ impl<'a> EncodingState<'a> {
 
             let mut core_exports = Vec::new();
             for export_name in info.needs_core_exports.iter() {
+                let mut core_export_name = export_name.as_str();
+                // provide cabi_realloc_adapter as cabi_realloc to adapters
+                // if it exists
+                if export_name == "cabi_realloc" {
+                    if let Some(adapter_realloc) = self.info.info.adapter_realloc {
+                        core_export_name = adapter_realloc;
+                    }
+                }
                 let index = self.component.alias_core_item(
                     self.instance_index
                         .expect("adaptee index set at this point"),
                     ExportKind::Func,
-                    export_name,
+                    core_export_name,
                 );
                 core_exports.push((export_name.as_str(), ExportKind::Func, index));
             }

--- a/crates/wit-component/src/validation.rs
+++ b/crates/wit-component/src/validation.rs
@@ -71,6 +71,9 @@ pub struct ValidatedModule<'a> {
     /// Whether or not this module exported a `cabi_realloc` function.
     pub realloc: Option<&'a str>,
 
+    /// Whether or not this module exported a `cabi_realloc_adapter` function.
+    pub adapter_realloc: Option<&'a str>,
+
     /// The original metadata specified for this module.
     pub metadata: &'a ModuleMetadata,
 }
@@ -101,6 +104,7 @@ pub fn validate_module<'a>(
         adapters_required: Default::default(),
         has_memory: false,
         realloc: None,
+        adapter_realloc: None,
         metadata: &metadata.metadata,
     };
 
@@ -144,6 +148,9 @@ pub fn validate_module<'a>(
                                     || export.name == "canonical_abi_realloc"
                                 {
                                     ret.realloc = Some(export.name);
+                                }
+                                if export.name == "cabi_realloc_adapter" {
+                                    ret.adapter_realloc = Some(export.name);
                                 }
                                 continue;
                             }

--- a/crates/wit-component/tests/components/adapt-inject-stack-with-adapt-realloc/adapt-old.wat
+++ b/crates/wit-component/tests/components/adapt-inject-stack-with-adapt-realloc/adapt-old.wat
@@ -1,0 +1,76 @@
+(module
+  (import "new" "get-two" (func $get_two (param i32)))
+  (import "__main_module__" "cabi_realloc" (func $cabi_realloc (param i32 i32 i32 i32) (result i32)))
+  (import "env" "memory" (memory 0))
+
+  (global $__stack_pointer (mut i32) i32.const 0)
+  (global $some_other_mutable_global (mut i32) i32.const 0)
+
+  ;; `wit-component` should use this to track the status of a lazy stack
+  ;; allocation:
+  (global $allocation_state (mut i32) i32.const 0)
+
+  ;; This is a sample adapter which is adapting between ABI. This exact function
+  ;; signature is imported by `module.wat` and we're implementing it here with a
+  ;; canonical-abi function that returns two integers. The canonical ABI for
+  ;; returning two integers is different than the ABI of this function, hence
+  ;; the adapter here.
+  ;;
+  ;; The purpose of this test case is to exercise the `$__stack_pointer` global.
+  ;; The stack pointer here needs to be initialized to something valid for
+  ;; this adapter module which is done with an injected `start` function into
+  ;; this adapter module when it's bundled into a component.
+  (func (export "get_sum") (result i32)
+    (local i32 i32)
+
+    ;; `wit-component` should have injected a call to a function that allocates
+    ;; the stack and sets $allocation_state to 2
+    (if (i32.ne (global.get $allocation_state) (i32.const 2)) (unreachable))
+
+    ;; First, allocate a page using $cabi_realloc and write to it.  This tests
+    ;; that we can use the main module's allocator if present (or else a
+    ;; substitute synthesized by `wit-component`).
+    (local.set 0
+      (call $cabi_realloc
+        (i32.const 0)
+        (i32.const 0)
+        (i32.const 8)
+        (i32.const 65536)))
+
+    (i32.store (local.get 0) (i32.const 42))
+    (i32.store offset=65532 (local.get 0) (i32.const 42))
+
+    ;; Allocate 8 bytes of stack space for the two u32 return values. The
+    ;; original stack pointer is saved in local 0 and the stack frame for this
+    ;; function is saved in local 1.
+    global.get $__stack_pointer
+    local.tee 0
+    i32.const 8
+    i32.sub
+    local.tee 1
+    global.set $__stack_pointer
+
+    ;; Call the imported function which will return two u32 values into the
+    ;; return pointer specified here, our stack frame.
+    local.get 1
+    call $get_two
+
+    ;; Compute the result of this function by adding together the two return
+    ;; values.
+    (i32.add
+      (i32.load (local.get 1))
+      (i32.load offset=4 (local.get 1)))
+
+    ;; Test that if there is another mutable global in this module that it
+    ;; doesn't affect the detection of the stack pointer. This extra mutable
+    ;; global should not be initialized or tampered with as part of the
+    ;; initialize-the-stack-pointer injected function
+    (global.set $some_other_mutable_global (global.get $some_other_mutable_global))
+
+    ;; Restore the stack pointer to the value it was at prior to entering this
+    ;; function.
+    local.get 0
+    global.set $__stack_pointer
+  )
+
+)

--- a/crates/wit-component/tests/components/adapt-inject-stack-with-adapt-realloc/adapt-old.wit
+++ b/crates/wit-component/tests/components/adapt-inject-stack-with-adapt-realloc/adapt-old.wit
@@ -1,0 +1,5 @@
+default world brave-new-world {
+  import new: interface {
+    get-two: func() -> (a: u32, b: u32)
+  }
+}

--- a/crates/wit-component/tests/components/adapt-inject-stack-with-adapt-realloc/component.wat
+++ b/crates/wit-component/tests/components/adapt-inject-stack-with-adapt-realloc/component.wat
@@ -1,0 +1,161 @@
+(component
+  (type (;0;)
+    (instance
+      (type (;0;) (func (result "a" u32) (result "b" u32)))
+      (export (;0;) "get-two" (func (type 0)))
+    )
+  )
+  (import "new" (instance (;0;) (type 0)))
+  (core module (;0;)
+    (type (;0;) (func (result i32)))
+    (type (;1;) (func (param i32 i32 i32 i32) (result i32)))
+    (import "old" "get_sum" (func (;0;) (type 0)))
+    (func $cabi_realloc (;1;) (type 1) (param i32 i32 i32 i32) (result i32)
+      i32.const 123456789
+    )
+    (func $cabi_realloc_adapter (;2;) (type 1) (param i32 i32 i32 i32) (result i32)
+      i32.const 987654321
+    )
+    (memory (;0;) 1)
+    (export "memory" (memory 0))
+    (export "cabi_realloc" (func $cabi_realloc))
+    (export "cabi_realloc_adapter" (func $cabi_realloc_adapter))
+  )
+  (core module (;1;)
+    (type (;0;) (func (param i32)))
+    (type (;1;) (func (param i32 i32 i32 i32) (result i32)))
+    (type (;2;) (func (result i32)))
+    (type (;3;) (func))
+    (import "env" "memory" (memory (;0;) 0))
+    (import "new" "get-two" (func $get_two (;0;) (type 0)))
+    (import "__main_module__" "cabi_realloc" (func $cabi_realloc (;1;) (type 1)))
+    (func (;2;) (type 2) (result i32)
+      (local i32 i32)
+      call $allocate_stack
+      global.get $allocation_state
+      i32.const 2
+      i32.ne
+      if ;; label = @1
+        unreachable
+      end
+      i32.const 0
+      i32.const 0
+      i32.const 8
+      i32.const 65536
+      call $cabi_realloc
+      local.set 0
+      local.get 0
+      i32.const 42
+      i32.store
+      local.get 0
+      i32.const 42
+      i32.store offset=65532
+      global.get $__stack_pointer
+      local.tee 0
+      i32.const 8
+      i32.sub
+      local.tee 1
+      global.set $__stack_pointer
+      local.get 1
+      call $get_two
+      local.get 1
+      i32.load
+      local.get 1
+      i32.load offset=4
+      i32.add
+      global.get $some_other_mutable_global
+      global.set $some_other_mutable_global
+      local.get 0
+      global.set $__stack_pointer
+    )
+    (func $allocate_stack (;3;) (type 3)
+      global.get $allocation_state
+      i32.const 0
+      i32.eq
+      if ;; label = @1
+        i32.const 1
+        global.set $allocation_state
+        i32.const 0
+        i32.const 0
+        i32.const 8
+        i32.const 65536
+        call $cabi_realloc
+        i32.const 65536
+        i32.add
+        global.set $__stack_pointer
+        i32.const 2
+        global.set $allocation_state
+      end
+    )
+    (global $__stack_pointer (;0;) (mut i32) i32.const 0)
+    (global $some_other_mutable_global (;1;) (mut i32) i32.const 0)
+    (global $allocation_state (;2;) (mut i32) i32.const 0)
+    (export "get_sum" (func 2))
+  )
+  (core module (;2;)
+    (type (;0;) (func (param i32)))
+    (type (;1;) (func (result i32)))
+    (func $indirect-new-get-two (;0;) (type 0) (param i32)
+      local.get 0
+      i32.const 0
+      call_indirect (type 0)
+    )
+    (func $adapt-old-get_sum (;1;) (type 1) (result i32)
+      i32.const 1
+      call_indirect (type 1)
+    )
+    (table (;0;) 2 2 funcref)
+    (export "0" (func $indirect-new-get-two))
+    (export "1" (func $adapt-old-get_sum))
+    (export "$imports" (table 0))
+  )
+  (core module (;3;)
+    (type (;0;) (func (param i32)))
+    (type (;1;) (func (result i32)))
+    (import "" "0" (func (;0;) (type 0)))
+    (import "" "1" (func (;1;) (type 1)))
+    (import "" "$imports" (table (;0;) 2 2 funcref))
+    (elem (;0;) (i32.const 0) func 0 1)
+  )
+  (core instance (;0;) (instantiate 2))
+  (alias core export 0 "1" (core func (;0;)))
+  (core instance (;1;)
+    (export "get_sum" (func 0))
+  )
+  (core instance (;2;) (instantiate 0
+      (with "old" (instance 1))
+    )
+  )
+  (alias core export 2 "memory" (core memory (;0;)))
+  (alias core export 2 "cabi_realloc" (core func (;1;)))
+  (alias core export 2 "cabi_realloc_adapter" (core func (;2;)))
+  (core instance (;3;)
+    (export "cabi_realloc" (func 2))
+  )
+  (core instance (;4;)
+    (export "memory" (memory 0))
+  )
+  (alias core export 0 "0" (core func (;3;)))
+  (core instance (;5;)
+    (export "get-two" (func 3))
+  )
+  (core instance (;6;) (instantiate 1
+      (with "__main_module__" (instance 3))
+      (with "env" (instance 4))
+      (with "new" (instance 5))
+    )
+  )
+  (alias core export 0 "$imports" (core table (;0;)))
+  (alias export 0 "get-two" (func (;0;)))
+  (core func (;4;) (canon lower (func 0) (memory 0)))
+  (alias core export 6 "get_sum" (core func (;5;)))
+  (core instance (;7;)
+    (export "$imports" (table 0))
+    (export "0" (func 4))
+    (export "1" (func 5))
+  )
+  (core instance (;8;) (instantiate 3
+      (with "" (instance 7))
+    )
+  )
+)

--- a/crates/wit-component/tests/components/adapt-inject-stack-with-adapt-realloc/component.wit
+++ b/crates/wit-component/tests/components/adapt-inject-stack-with-adapt-realloc/component.wit
@@ -1,0 +1,7 @@
+interface new {
+  get-two: func() -> (a: u32, b: u32)
+}
+
+default world component {
+  import new: self.new
+}

--- a/crates/wit-component/tests/components/adapt-inject-stack-with-adapt-realloc/module.wat
+++ b/crates/wit-component/tests/components/adapt-inject-stack-with-adapt-realloc/module.wat
@@ -1,0 +1,12 @@
+(module
+  (import "old" "get_sum" (func (result i32)))
+  (func $cabi_realloc (param i32 i32 i32 i32) (result i32)
+    (i32.const 123456789)
+  )
+  (func $cabi_realloc_adapter (param i32 i32 i32 i32) (result i32)
+    (i32.const 987654321)
+  )
+  (memory (export "memory") 1)
+  (export "cabi_realloc" (func $cabi_realloc))
+  (export "cabi_realloc_adapter" (func $cabi_realloc_adapter))
+)

--- a/crates/wit-component/tests/components/adapt-inject-stack-with-adapt-realloc/module.wit
+++ b/crates/wit-component/tests/components/adapt-inject-stack-with-adapt-realloc/module.wit
@@ -1,0 +1,1 @@
+default world empty {}


### PR DESCRIPTION
This adds support for a core `cabi_realloc_adapter` function export as taking precedence over the `cabi_realloc` function export for the implementation of `cabi_realloc` that is provided back to the adapter itself when importing from the component.

This resolves https://github.com/bytecodealliance/preview2-prototyping/issues/145.