### PR TITLE
Add a `--skeleton` option to `wasm-tools print`

### DIFF
--- a/src/bin/wasm-tools/print.rs
+++ b/src/bin/wasm-tools/print.rs
@@ -11,6 +11,12 @@ pub struct Opts {
     /// as comments for debugging.
     #[clap(short, long)]
     print_offsets: bool,
+
+    /// Indicates that the "skeleton" of a module should be printed where items
+    /// such as function bodies, data segments, and element segments are
+    /// replaced with "..." instead of printing their actual contents.
+    #[clap(long)]
+    skeleton: bool,
 }
 
 impl Opts {
@@ -18,6 +24,7 @@ impl Opts {
         let wasm = self.io.parse_input_wasm()?;
         let mut printer = wasmprinter::Printer::new();
         printer.print_offsets(self.print_offsets);
+        printer.print_skeleton(self.skeleton);
         let wat = printer.print(&wasm)?;
         self.io.output(wasm_tools::Output::Wat(&wat))?;
         Ok(())

--- a/tests/cli/print-skeleton.wat
+++ b/tests/cli/print-skeleton.wat
@@ -1,0 +1,9 @@
+;; RUN: print --skeleton %
+
+(module
+  (memory 0)
+  (func $f unreachable)
+  (data (i32.const 0) "1234")
+  (table 1 funcref)
+  (elem (i32.const 0) func $f)
+)

--- a/tests/cli/print-skeleton.wat.stdout
+++ b/tests/cli/print-skeleton.wat.stdout
@@ -1,0 +1,8 @@
+(module
+  (type (;0;) (func))
+  (func $f (;0;) (type 0) ...)
+  (table (;0;) 1 funcref)
+  (memory (;0;) 0)
+  (elem (;0;) (i32.const 0) ...)
+  (data (;0;) (i32.const 0) ...)
+)


### PR DESCRIPTION
Often when debugging larger wasm files I want to skip the data segments, element segments, and often entire function bodies. This commit adds a debugging option `--skeleton` to skip printing all these "big" items to ideally only print the "shape" of a module for easier manual inspection. An example issue I'm using this with is #986.