### PR TITLE
Fix some fuzz-discovered issues in WIT parsing and encoding

### DIFF
--- a/crates/wit-component/src/encoding/wit.rs
+++ b/crates/wit-component/src/encoding/wit.rs
@@ -84,6 +84,10 @@ impl Encoder<'_> {
                 assert!(first);
             }
         }
+        for (name, _world) in self.resolve.documents[doc].worlds.iter() {
+            let first = used_names.insert(name.clone());
+            assert!(first);
+        }
 
         // Encode all interfaces, foreign and local, into this component type.
         // Local interfaces get their functions defined as well and are

--- a/crates/wit-component/tests/interfaces/world-pkg-conflict.wat
+++ b/crates/wit-component/tests/interfaces/world-pkg-conflict.wat
@@ -1,0 +1,38 @@
+(component
+  (type (;0;)
+    (component
+      (type (;0;)
+        (instance
+          (type (;0;) u32)
+          (export (;1;) "t" (type (eq 0)))
+        )
+      )
+      (export (;0;) "a" "pkg:/bar/a" (instance (type 0)))
+    )
+  )
+  (export (;1;) "bar" "pkg:/bar" (type 0))
+  (type (;2;)
+    (component
+      (type (;0;)
+        (instance
+          (type (;0;) u32)
+          (export (;1;) "t" (type (eq 0)))
+        )
+      )
+      (import "a2" "pkg:/bar/a" (instance (type 0)))
+      (alias export 0 "t" (type (;1;)))
+      (type (;2;)
+        (instance
+          (alias outer 1 1 (type (;0;)))
+          (export (;1;) "t" (type (eq 0)))
+        )
+      )
+      (export (;0;) "foo" "pkg:/foo/foo" (instance (type 2)))
+      (type (;3;)
+        (component)
+      )
+      (export (;0;) "a" "pkg:/foo/a" (component (type 3)))
+    )
+  )
+  (export (;3;) "foo" "pkg:/foo" (type 2))
+)

--- a/crates/wit-component/tests/interfaces/world-pkg-conflict/bar.wit
+++ b/crates/wit-component/tests/interfaces/world-pkg-conflict/bar.wit
@@ -1,0 +1,3 @@
+default interface a {
+  type t = u32
+}

--- a/crates/wit-component/tests/interfaces/world-pkg-conflict/bar.wit.print
+++ b/crates/wit-component/tests/interfaces/world-pkg-conflict/bar.wit.print
@@ -1,0 +1,5 @@
+interface a {
+  type t = u32
+
+}
+

--- a/crates/wit-component/tests/interfaces/world-pkg-conflict/foo.wit
+++ b/crates/wit-component/tests/interfaces/world-pkg-conflict/foo.wit
@@ -1,0 +1,7 @@
+world a {
+
+}
+
+interface foo {
+  use pkg.bar.{t}
+}

--- a/crates/wit-component/tests/interfaces/world-pkg-conflict/foo.wit.print
+++ b/crates/wit-component/tests/interfaces/world-pkg-conflict/foo.wit.print
@@ -1,0 +1,6 @@
+interface foo {
+  use pkg.bar.a.{t}
+}
+
+world a {
+}

--- a/crates/wit-parser/src/resolve.rs
+++ b/crates/wit-parser/src/resolve.rs
@@ -1036,7 +1036,7 @@ impl Remap {
             let prev = world
                 .exports
                 .insert(name.clone(), WorldItem::Function(func));
-            if prev.is_some() {
+            if prev.is_some() || world.imports.contains_key(&name) {
                 bail!(Error {
                     msg: format!(
                         "export of function `{name}` shadows previously exported interface"

--- a/crates/wit-parser/tests/ui/parse-fail/world-implicit-import2.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/world-implicit-import2.wit
@@ -1,0 +1,9 @@
+interface foo {
+  type g = char
+}
+
+world w {
+  use self.foo.{g}
+
+  import foo: func() -> g
+}

--- a/crates/wit-parser/tests/ui/parse-fail/world-implicit-import2.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/world-implicit-import2.wit.result
@@ -1,0 +1,5 @@
+import of function `foo` shadows previously imported interface
+     --> tests/ui/parse-fail/world-implicit-import2.wit:8:10
+      |
+    8 |   import foo: func() -> g
+      |          ^--

--- a/crates/wit-parser/tests/ui/parse-fail/world-implicit-import3.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/world-implicit-import3.wit
@@ -1,0 +1,9 @@
+interface foo {
+  type g = char
+}
+
+world w {
+  use self.foo.{g}
+
+  export foo: func() -> g
+}

--- a/crates/wit-parser/tests/ui/parse-fail/world-implicit-import3.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/world-implicit-import3.wit.result
@@ -1,0 +1,5 @@
+export of function `foo` shadows previously exported interface
+     --> tests/ui/parse-fail/world-implicit-import3.wit:8:10
+      |
+    8 |   export foo: func() -> g
+      |          ^--

--- a/fuzz/fuzz_targets/roundtrip-wit.rs
+++ b/fuzz/fuzz_targets/roundtrip-wit.rs
@@ -27,6 +27,7 @@ fuzz_target!(|data: &[u8]| {
                 let err = e.to_string();
                 if err.contains("conflicts with a previous")
                     || err.contains("shadows previously imported")
+                    || err.contains("shadows previously exported")
                 {
                     return;
                 }


### PR DESCRIPTION
I'm not entirely sure why OSS-fuzz hasn't found these yet since it only took a minute or so locally to find these when I was fuzzing the `resources` branch. In any case good to get them fixed nonetheless.