### PR TITLE
Fix a timeout in roundtrip-wit fuzzing

### DIFF
--- a/fuzz/fuzz_targets/roundtrip-wit.rs
+++ b/fuzz/fuzz_targets/roundtrip-wit.rs
@@ -53,7 +53,9 @@ fuzz_target!(|data: &[u8]| {
         panic!("roundtrip wasm didn't match");
     }
 
-    for (id, _world) in resolve.worlds.iter() {
+    // If there's hundreds or thousands of worlds only work with the first few
+    // to avoid timing out this fuzzer with asan enabled.
+    for (id, _world) in resolve.worlds.iter().take(20) {
         let mut dummy = wit_component::dummy_module(&resolve, id);
         let metadata =
             wit_component::metadata::encode(&resolve, id, StringEncoding::UTF8, None).unwrap();


### PR DESCRIPTION
Looks like oss-fuzz found a timeout where there were a ton of worlds and this process took awhile, so only test the first few worlds which should be sufficient for coverage.