### PR TITLE
Support core wasm inputs to `wasm-tools component wit`

### DIFF
--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -21,7 +21,7 @@ use std::marker;
 use std::ops::Range;
 use std::str;
 
-const WASM_MAGIC_NUMBER: &[u8; 4] = b"\0asm";
+pub(crate) const WASM_MAGIC_NUMBER: &[u8; 4] = b"\0asm";
 
 /// A binary reader for WebAssembly modules.
 #[derive(Debug, Clone)]

--- a/crates/wit-component/src/metadata.rs
+++ b/crates/wit-component/src/metadata.rs
@@ -81,6 +81,12 @@ impl Default for Bindgen {
             exports: Default::default(),
             document,
         });
+        resolve.packages[package]
+            .documents
+            .insert("root".to_string(), document);
+        resolve.documents[document]
+            .worlds
+            .insert("root".to_string(), world);
         Bindgen {
             resolve,
             world,

--- a/tests/cli/print-core-wasm-wit.wit
+++ b/tests/cli/print-core-wasm-wit.wit
@@ -1,0 +1,9 @@
+// RUN: component embed --dummy % | component wit
+
+interface my-interface {
+  foo: func()
+}
+
+default world my-world {
+  import my-interface: self.my-interface
+}

--- a/tests/cli/print-core-wasm-wit.wit.stdout
+++ b/tests/cli/print-core-wasm-wit.wit.stdout
@@ -1,0 +1,3 @@
+world root {
+  import my-interface: print-core-wasm-wit.print-core-wasm-wit.my-interface
+}


### PR DESCRIPTION
In addition to printing out the WIT of packages and components, support reading core wasm modules for `component-type*` sections and printing out the WIT. The printout isn't great right now, but can hopefully improve over time.