### PR TITLE
Fix wasm-encoder's encoding of element segments

### DIFF
--- a/crates/wasm-encoder/src/core/elements.rs
+++ b/crates/wasm-encoder/src/core/elements.rs
@@ -111,7 +111,7 @@ impl ElementSection {
             ElementMode::Active {
                 table: None,
                 offset,
-            } => {
+            } if segment.element_type == RefType::FUNCREF => {
                 (/* 0x00 | */expr_bit).encode(&mut self.bytes);
                 offset.encode(&mut self.bytes);
             }
@@ -123,12 +123,9 @@ impl ElementSection {
                     segment.element_type.encode(&mut self.bytes);
                 }
             }
-            ElementMode::Active {
-                table: Some(i),
-                offset,
-            } => {
+            ElementMode::Active { table, offset } => {
                 (0x02 | expr_bit).encode(&mut self.bytes);
-                i.encode(&mut self.bytes);
+                table.unwrap_or(0).encode(&mut self.bytes);
                 offset.encode(&mut self.bytes);
                 if expr_bit == 0 {
                     self.bytes.push(0x00); // elemkind == funcref


### PR DESCRIPTION
The `wasm-encoder` crate would incorrectly encode externref segments for table 0 with an encoding that only supports funcref types.