### PR TITLE
Require 'alias core export' when aliasing core item

### DIFF
--- a/crates/wast/src/component/alias.rs
+++ b/crates/wast/src/component/alias.rs
@@ -4,17 +4,22 @@ use crate::parser::{Parse, Parser, Result};
 use crate::token::{Id, Index, NameAnnotation, Span};
 
 /// A inline alias for component exported items.
+///
+/// Handles both `core export` and `export` aliases
 #[derive(Debug)]
-pub struct InlineExportAlias<'a> {
+pub struct InlineExportAlias<'a, const CORE: bool> {
     /// The instance to alias the export from.
     pub instance: Index<'a>,
     /// The name of the export to alias.
     pub name: &'a str,
 }
 
-impl<'a> Parse<'a> for InlineExportAlias<'a> {
+impl<'a, const CORE: bool> Parse<'a> for InlineExportAlias<'a, CORE> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
         parser.parse::<kw::alias>()?;
+        if CORE {
+            parser.parse::<kw::core>()?;
+        }
         parser.parse::<kw::export>()?;
         let instance = parser.parse()?;
         let name = parser.parse()?;

--- a/crates/wast/src/component/func.rs
+++ b/crates/wast/src/component/func.rs
@@ -46,7 +46,7 @@ pub enum CoreFuncKind<'a> {
     /// The core function is defined in terms of aliasing a module instance export.
     ///
     /// The core function is actually a member of the core alias section.
-    Alias(InlineExportAlias<'a>),
+    Alias(InlineExportAlias<'a, true>),
 }
 
 impl<'a> Parse<'a> for CoreFuncKind<'a> {
@@ -128,7 +128,7 @@ pub enum FuncKind<'a> {
     /// The function is defined in terms of aliasing a component instance export.
     ///
     /// The function is actually a member of the alias section.
-    Alias(InlineExportAlias<'a>),
+    Alias(InlineExportAlias<'a, false>),
 }
 
 impl<'a> Parse<'a> for FuncKind<'a> {

--- a/crates/wast/tests/parse-fail/bad-core-func-alias.wat
+++ b/crates/wast/tests/parse-fail/bad-core-func-alias.wat
@@ -1,0 +1,7 @@
+(component
+  (core module $mod (func (export "fun")))
+  (core instance $inst (instantiate $mod))
+  (alias core export $inst "fun" (core func $fun1))
+  (core func $fun2 (alias core export $inst "fun"))
+  (core func $fun3 (alias export $inst "fun"))
+)

--- a/crates/wast/tests/parse-fail/bad-core-func-alias.wat.err
+++ b/crates/wast/tests/parse-fail/bad-core-func-alias.wat.err
@@ -1,0 +1,5 @@
+expected keyword `core`
+     --> tests/parse-fail/bad-core-func-alias.wat:6:27
+      |
+    6 |   (core func $fun3 (alias export $inst "fun"))
+      |                           ^

--- a/crates/wast/tests/parse-fail/bad-func-alias.wat
+++ b/crates/wast/tests/parse-fail/bad-func-alias.wat
@@ -1,0 +1,7 @@
+(component
+    (component $comp)
+    (instance $inst (instantiate $comp))
+    (func $alias1 (alias export $inst "fun"))
+    (alias export $inst "fun" (func $alias2))
+    (alias export $inst "fun" (core func $alias3))
+)

--- a/crates/wast/tests/parse-fail/bad-func-alias.wat.err
+++ b/crates/wast/tests/parse-fail/bad-func-alias.wat.err
@@ -1,0 +1,5 @@
+unexpected token, expected `module`
+     --> tests/parse-fail/bad-func-alias.wat:6:37
+      |
+    6 |     (alias export $inst "fun" (core func $alias3))
+      |                                     ^

--- a/tests/cli/dump/alias.wat
+++ b/tests/cli/dump/alias.wat
@@ -16,6 +16,6 @@
   )
 
   (core instance $m (instantiate $m))
-  (core func (alias export $m "f3"))
+  (core func (alias core export $m "f3"))
   (alias core export $m "f3" (core func))
 )


### PR DESCRIPTION
Fixes #996 

When aliasing a core item "alias core export" is now required as per the spec description.