### PR TITLE
Make publish list topological

### DIFF
--- a/ci/publish.rs
+++ b/ci/publish.rs
@@ -26,8 +26,8 @@ use std::time::Duration;
 
 // Crates we care about publishing sorted topologically.
 const CRATES_TO_PUBLISH: &[&str] = &[
-    "wasmparser",
     "wasm-encoder",
+    "wasmparser",
     "wasmprinter",
     "wast",
     "wat",


### PR DESCRIPTION
The `wasmparser` crate now depends on `wasm-encoder` via dev-dependencies, so switch the order of publishing.