### PR TITLE
GC: wasmparser: Add (ref null? i31) type

### DIFF
--- a/crates/wasm-compose/src/encoding.rs
+++ b/crates/wasm-compose/src/encoding.rs
@@ -280,6 +280,7 @@ impl<'a> TypeEncoder<'a> {
             heap_type: match ty.heap_type() {
                 wasmparser::HeapType::Func => HeapType::Func,
                 wasmparser::HeapType::Extern => HeapType::Extern,
+                wasmparser::HeapType::I31 => HeapType::I31,
                 wasmparser::HeapType::TypedFunc(i) => HeapType::TypedFunc(i.into()),
             },
         }

--- a/crates/wasm-encoder/src/core/types.rs
+++ b/crates/wasm-encoder/src/core/types.rs
@@ -103,6 +103,8 @@ pub enum HeapType {
     Func,
     /// An extern reference. When nullable, equivalent to `externref`
     Extern,
+    /// An i31 reference. When nullable, equivalent to `i31ref`
+    I31,
     /// A reference to a particular index in a table.
     TypedFunc(u32),
 }
@@ -112,6 +114,7 @@ impl Encode for HeapType {
         match self {
             HeapType::Func => sink.push(0x70),
             HeapType::Extern => sink.push(0x6F),
+            HeapType::I31 => sink.push(0x6A),
             // Note that this is encoded as a signed type rather than unsigned
             // as it's decoded as an s33
             HeapType::TypedFunc(i) => i64::from(*i).encode(sink),

--- a/crates/wasm-mutate/src/module.rs
+++ b/crates/wasm-mutate/src/module.rs
@@ -87,6 +87,7 @@ pub fn map_ref_type(ref_ty: wasmparser::RefType) -> Result<RefType> {
         heap_type: match ref_ty.heap_type() {
             wasmparser::HeapType::Func => HeapType::Func,
             wasmparser::HeapType::Extern => HeapType::Extern,
+            wasmparser::HeapType::I31 => HeapType::I31,
             wasmparser::HeapType::TypedFunc(i) => HeapType::TypedFunc(i.into()),
         },
     })

--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -202,6 +202,7 @@ pub fn heapty(t: &mut dyn Translator, ty: &wasmparser::HeapType) -> Result<HeapT
     match ty {
         wasmparser::HeapType::Func => Ok(HeapType::Func),
         wasmparser::HeapType::Extern => Ok(HeapType::Extern),
+        wasmparser::HeapType::I31 => Ok(HeapType::I31),
         wasmparser::HeapType::TypedFunc(i) => {
             Ok(HeapType::TypedFunc(t.remap(Item::Type, (*i).into())?))
         }

--- a/crates/wasm-shrink/src/lib.rs
+++ b/crates/wasm-shrink/src/lib.rs
@@ -234,6 +234,7 @@ impl ShrinkRun {
             sign_extension: true,
             component_model: false,
             function_references: false,
+            gc: false,
 
             floats: true,
             memory_control: true,

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -1643,6 +1643,7 @@ fn convert_reftype(ty: wasmparser::RefType) -> RefType {
         heap_type: match ty.heap_type() {
             wasmparser::HeapType::Func => wasm_encoder::HeapType::Func,
             wasmparser::HeapType::Extern => wasm_encoder::HeapType::Extern,
+            wasmparser::HeapType::I31 => wasm_encoder::HeapType::I31,
             wasmparser::HeapType::TypedFunc(i) => wasm_encoder::HeapType::TypedFunc(i.into()),
         },
     }

--- a/crates/wasm-smith/tests/core.rs
+++ b/crates/wasm-smith/tests/core.rs
@@ -302,6 +302,7 @@ fn parser_features_from_config(config: &impl Config) -> WasmFeatures {
         component_model: false,
         function_references: false,
         memory_control: false,
+        gc: false,
     }
 }
 

--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -256,6 +256,7 @@ fn define_benchmarks(c: &mut Criterion) {
             sign_extension: true,
             function_references: true,
             memory_control: true,
+            gc: true,
         })
     }
 

--- a/crates/wasmparser/src/lib.rs
+++ b/crates/wasmparser/src/lib.rs
@@ -49,6 +49,7 @@
 /// - `@threads`: [Wasm `threads` proposal]
 /// - `@simd`: [Wasm `simd` proposal]
 /// - `@relaxed_simd`: [Wasm `relaxed-simd` proposal]
+/// - `@gc`: [Wasm `gc` proposal]
 ///
 /// [Wasm `expection-handling` proposal]:
 /// https://github.com/WebAssembly/exception-handling
@@ -76,6 +77,9 @@
 ///
 /// [Wasm `relaxed-simd` proposal]:
 /// https://github.com/WebAssembly/relaxed-simd
+///
+/// [Wasm `gc` proposal]:
+/// https://github.com/WebAssembly/gc
 ///
 /// ```
 /// macro_rules! define_visit_operator {

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -71,7 +71,7 @@ impl ValType {
 
     pub(crate) fn is_valtype_byte(byte: u8) -> bool {
         match byte {
-            0x7F | 0x7E | 0x7D | 0x7C | 0x7B | 0x70 | 0x6F | 0x6B | 0x6C => true,
+            0x7F | 0x7E | 0x7D | 0x7C | 0x7B | 0x70 | 0x6F | 0x6B | 0x6C | 0x6A => true,
             _ => false,
         }
     }
@@ -100,7 +100,7 @@ impl<'a> FromReader<'a> for ValType {
                 reader.position += 1;
                 Ok(ValType::V128)
             }
-            0x70 | 0x6F | 0x6B | 0x6C => Ok(ValType::Ref(reader.read()?)),
+            0x70 | 0x6F | 0x6B | 0x6C | 0x6A => Ok(ValType::Ref(reader.read()?)),
             _ => bail!(reader.original_position(), "invalid value type"),
         }
     }
@@ -124,25 +124,53 @@ impl fmt::Display for ValType {
 ///
 /// The reference types proposal first introduced `externref` and `funcref`.
 ///
-/// The function refererences proposal introduced typed function references.
+/// The function references proposal introduced typed function references.
+///
+/// The GC proposal introduces heap types: any, eq, i31, struct, array, nofunc, noextern, none.
 //
-// This is a bitpacked enum that fits in a "u24" aka `[u8; 3]`. It has a two bit
-// discriminant distinguishing the following variants:
+// RefType is a bit-packed enum that fits in a `u24` aka `[u8; 3]`.
+// Note that its content is opaque (and subject to change), but its API is stable.
+// It has the following internal structure:
+// ```
+// [nullable:u1] [indexed==1:u1] [kind:u2] [index:u20]
+// [nullable:u1] [indexed==0:u1] [type:u4] [(unused):u18]
+// ```
+// , where
+// - `nullable` determines nullability of the ref
+// - `indexed` determines if the ref is of a dynamically defined type with an index (encoded in a following bit-packing section) or of a known fixed type
+// - `kind` determines what kind of indexed type the index is pointing to:
+//   ```
+//   10 = struct
+//   11 = array
+//   01 = function
+//   ```
+// - `index` is the type index
+// - `type` is an enumeration of known types:
+//   ```
+//   1111 = any
 //
-// `(ref null? <type_index>)`: [ 00:i2 nullable:i1 type_index:i21 ]
-//         `(ref null? func)`: [ 01:i2 nullable:i1                ]
-//       `(ref null? extern)`: [ 10:i2 nullable:i1                ]
-//                     unused: [ 11:i2                            ]
+//   1101 = eq
+//   1000 = i31
+//   1001 = struct
+//   1100 = array
 //
-// Note that we only technically need 20 bits for the type index to fit every
-// type index less than or equal to `crate::limits::MAX_WASM_TYPES`. So if we
-// ever need them, we have 2 bits available in that first variant.
+//   0101 = func
+//   0100 = nofunc
+//
+//   0011 = extern
+//   0010 = noextern
+//
+//   0000 = none
+//   ```
+// - `(unused)` is unused sequence of bits
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct RefType([u8; 3]);
 
 impl std::fmt::Debug for RefType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match (self.is_nullable(), self.heap_type()) {
+            (true, HeapType::I31) => write!(f, "i31ref"),
+            (false, HeapType::I31) => write!(f, "(ref i31)"),
             (true, HeapType::Extern) => write!(f, "externref"),
             (false, HeapType::Extern) => write!(f, "(ref extern)"),
             (true, HeapType::Func) => write!(f, "funcref"),
@@ -170,29 +198,46 @@ const _: () = {
     }
 
     assert!(can_roundtrip_index(crate::limits::MAX_WASM_TYPES as u32));
-    assert!(can_roundtrip_index(0b00000000_00011111_00000000_00000000));
+    assert!(can_roundtrip_index(0b00000000_00001111_00000000_00000000));
     assert!(can_roundtrip_index(0b00000000_00000000_11111111_00000000));
     assert!(can_roundtrip_index(0b00000000_00000000_00000000_11111111));
     assert!(can_roundtrip_index(0));
 };
 
 impl RefType {
-    const DISCRIMINANT_MASK: u32 = 0b11 << 22;
+    const NULLABLE_BIT: u32 = 1 << 23; // bit #23
+    const INDEXED_BIT: u32 = 1 << 22; // bit #22
 
-    const TYPED_FUNC_DISCRIMINANT: u32 = 0b00 << 22;
-    const ANY_FUNC_DISCRIMINANT: u32 = 0b01 << 22;
-    const EXTERN_DISCRIMINANT: u32 = 0b10 << 22;
+    const TYPE_MASK: u32 = 0b1111 << 18; // 4 bits #21-#18 (if `indexed == 0`)
+    const ANY_TYPE: u32 = 0b1111 << 18;
+    const EQ_TYPE: u32 = 0b1101 << 18;
+    const I31_TYPE: u32 = 0b1000 << 18;
+    const STRUCT_TYPE: u32 = 0b1001 << 18;
+    const ARRAY_TYPE: u32 = 0b1100 << 18;
+    const FUNC_TYPE: u32 = 0b0101 << 18;
+    const NOFUNC_TYPE: u32 = 0b0100 << 18;
+    const EXTERN_TYPE: u32 = 0b0011 << 18;
+    const NOEXTERN_TYPE: u32 = 0b0010 << 18;
+    const NONE_TYPE: u32 = 0b0000 << 18;
 
-    const NULLABLE_MASK: u32 = 1 << 21;
-    const INDEX_MASK: u32 = (1 << 21) - 1;
+    const KIND_MASK: u32 = 0b11 << 20; // 2 bits #21-#20 (if `indexed == 1`)
+    const STRUCT_KIND: u32 = 0b10 << 20;
+    const ARRAY_KIND: u32 = 0b11 << 20;
+    const FUNC_KIND: u32 = 0b01 << 20;
+
+    const INDEX_MASK: u32 = (1 << 20) - 1; // 20 bits #19-#0 (if `indexed == 1`)
 
     /// An nullable untyped function reference aka `(ref null func)` aka
     /// `funcref` aka `anyfunc`.
-    pub const FUNCREF: Self = RefType::from_u32(Self::ANY_FUNC_DISCRIMINANT | Self::NULLABLE_MASK);
+    pub const FUNCREF: Self = RefType::from_u32(Self::NULLABLE_BIT | Self::FUNC_TYPE);
 
     /// A nullable reference to an extern object aka `(ref null extern)` aka
     /// `externref`.
-    pub const EXTERNREF: Self = RefType::from_u32(Self::EXTERN_DISCRIMINANT | Self::NULLABLE_MASK);
+    pub const EXTERNREF: Self = RefType::from_u32(Self::NULLABLE_BIT | Self::EXTERN_TYPE);
+
+    /// A nullable reference to an i31 object aka `(ref null i31)` aka
+    /// `i31ref`.
+    pub const I31REF: Self = RefType::from_u32(Self::NULLABLE_BIT | Self::I31_TYPE);
 
     const fn can_represent_type_index(index: u32) -> bool {
         index & Self::INDEX_MASK == index
@@ -217,22 +262,45 @@ impl RefType {
     #[inline]
     const fn from_u32(x: u32) -> Self {
         debug_assert!(x & (0b11111111 << 24) == 0);
-        debug_assert!(matches!(
-            x & Self::DISCRIMINANT_MASK,
-            Self::ANY_FUNC_DISCRIMINANT | Self::TYPED_FUNC_DISCRIMINANT | Self::EXTERN_DISCRIMINANT
-        ));
+
+        // if indexed, kind must be struct/array/func
+        debug_assert!(
+            x & Self::INDEXED_BIT == 0
+                || matches!(
+                    x & Self::KIND_MASK,
+                    Self::FUNC_KIND | Self::ARRAY_KIND | Self::STRUCT_KIND
+                )
+        );
+
+        // if not indexed, type must be any/eq/i31/struct/array/func/extern/noextern/none
+        debug_assert!(
+            x & Self::INDEXED_BIT != 0
+                || matches!(
+                    x & Self::TYPE_MASK,
+                    Self::ANY_TYPE
+                        | Self::EQ_TYPE
+                        | Self::I31_TYPE
+                        | Self::STRUCT_TYPE
+                        | Self::ARRAY_TYPE
+                        | Self::FUNC_TYPE
+                        | Self::NOFUNC_TYPE
+                        | Self::EXTERN_TYPE
+                        | Self::NOEXTERN_TYPE
+                        | Self::NONE_TYPE
+                )
+        );
         RefType(Self::u32_to_u24(x))
     }
 
     /// Create a reference to a typed function with the type at the given index.
     ///
     /// Returns `None` when the type index is beyond this crate's implementation
-    /// limits and therfore is not representable.
+    /// limits and therefore is not representable.
     pub const fn typed_func(nullable: bool, index: u32) -> Option<Self> {
         if Self::can_represent_type_index(index) {
-            let nullable = if nullable { Self::NULLABLE_MASK } else { 0 };
+            let nullable32 = Self::NULLABLE_BIT * nullable as u32;
             Some(RefType::from_u32(
-                Self::TYPED_FUNC_DISCRIMINANT | nullable | index,
+                nullable32 | Self::INDEXED_BIT | Self::FUNC_KIND | index,
             ))
         } else {
             None
@@ -244,21 +312,23 @@ impl RefType {
     /// Returns `None` when the heap type's type index (if any) is beyond this
     /// crate's implementation limits and therfore is not representable.
     pub fn new(nullable: bool, heap_type: HeapType) -> Option<Self> {
-        let nullable32 = if nullable { Self::NULLABLE_MASK } else { 0 };
+        let nullable32 = Self::NULLABLE_BIT * nullable as u32;
         match heap_type {
             HeapType::TypedFunc(index) => RefType::typed_func(nullable, index),
-            HeapType::Func => Some(Self::from_u32(Self::ANY_FUNC_DISCRIMINANT | nullable32)),
-            HeapType::Extern => Some(Self::from_u32(Self::EXTERN_DISCRIMINANT | nullable32)),
+            HeapType::Func => Some(Self::from_u32(nullable32 | Self::FUNC_TYPE)),
+            HeapType::Extern => Some(Self::from_u32(nullable32 | Self::EXTERN_TYPE)),
+            HeapType::I31 => Some(Self::from_u32(nullable32 | Self::I31_TYPE)),
         }
-    }
-
-    const fn discriminant(&self) -> u32 {
-        self.as_u32() & Self::DISCRIMINANT_MASK
     }
 
     /// Is this a reference to a typed function?
     pub const fn is_typed_func_ref(&self) -> bool {
-        self.discriminant() == Self::TYPED_FUNC_DISCRIMINANT
+        self.is_indexed_type_ref() && self.as_u32() & Self::KIND_MASK == Self::FUNC_KIND
+    }
+
+    /// Is this a reference to an indexed type?
+    pub const fn is_indexed_type_ref(&self) -> bool {
+        self.as_u32() & Self::INDEXED_BIT != 0
     }
 
     /// If this is a reference to a typed function, get its type index.
@@ -272,31 +342,39 @@ impl RefType {
 
     /// Is this an untyped function reference aka `(ref null func)` aka `funcref` aka `anyfunc`?
     pub fn is_func_ref(&self) -> bool {
-        self.discriminant() == Self::ANY_FUNC_DISCRIMINANT
+        !self.is_indexed_type_ref() && self.as_u32() & Self::TYPE_MASK == Self::FUNC_TYPE
     }
 
     /// Is this a `(ref null extern)` aka `externref`?
     pub fn is_extern_ref(&self) -> bool {
-        self.discriminant() == Self::EXTERN_DISCRIMINANT
+        !self.is_indexed_type_ref() && self.as_u32() & Self::TYPE_MASK == Self::EXTERN_TYPE
     }
 
     /// Is this ref type nullable?
     pub const fn is_nullable(&self) -> bool {
-        self.as_u32() & Self::NULLABLE_MASK != 0
+        self.as_u32() & Self::NULLABLE_BIT != 0
     }
 
     /// Get the non-nullable version of this ref type.
     pub fn as_non_null(&self) -> Self {
-        Self::from_u32(self.as_u32() & !Self::NULLABLE_MASK)
+        Self::from_u32(self.as_u32() & !Self::NULLABLE_BIT)
     }
 
     /// Get the heap type that this is a reference to.
     pub fn heap_type(&self) -> HeapType {
-        match self.discriminant() {
-            Self::TYPED_FUNC_DISCRIMINANT => HeapType::TypedFunc(self.type_index().unwrap()),
-            Self::ANY_FUNC_DISCRIMINANT => HeapType::Func,
-            Self::EXTERN_DISCRIMINANT => HeapType::Extern,
-            _ => unreachable!(),
+        let s = self.as_u32();
+        if self.is_indexed_type_ref() {
+            match s & Self::KIND_MASK {
+                Self::FUNC_KIND => HeapType::TypedFunc(self.type_index().unwrap()),
+                _ => unreachable!(),
+            }
+        } else {
+            match s & Self::TYPE_MASK {
+                Self::FUNC_TYPE => HeapType::Func,
+                Self::EXTERN_TYPE => HeapType::Extern,
+                Self::I31_TYPE => HeapType::I31,
+                _ => unreachable!(),
+            }
         }
     }
 
@@ -307,9 +385,11 @@ impl RefType {
             (true, HeapType::Func) => "funcref",
             (true, HeapType::Extern) => "externref",
             (true, HeapType::TypedFunc(_)) => "(ref null $type)",
+            (true, HeapType::I31) => "i31ref",
             (false, HeapType::Func) => "(ref func)",
             (false, HeapType::Extern) => "(ref extern)",
             (false, HeapType::TypedFunc(_)) => "(ref $type)",
+            (false, HeapType::I31) => "(ref i31)",
         }
     }
 }
@@ -319,6 +399,7 @@ impl<'a> FromReader<'a> for RefType {
         match reader.read()? {
             0x70 => Ok(RefType::FUNCREF),
             0x6F => Ok(RefType::EXTERNREF),
+            0x6A => Ok(RefType::I31REF),
             byte @ (0x6B | 0x6C) => {
                 let nullable = byte == 0x6C;
                 let pos = reader.original_position();
@@ -338,9 +419,11 @@ impl fmt::Display for RefType {
             (true, HeapType::Func) => "funcref",
             (true, HeapType::Extern) => "externref",
             (true, HeapType::TypedFunc(i)) => return write!(f, "(ref null {i})"),
+            (true, HeapType::I31) => "i31ref",
             (false, HeapType::Func) => "(ref func)",
             (false, HeapType::Extern) => "(ref extern)",
             (false, HeapType::TypedFunc(i)) => return write!(f, "(ref {i})"),
+            (false, HeapType::I31) => "(ref i31)",
         };
         f.write_str(s)
     }
@@ -356,6 +439,19 @@ pub enum HeapType {
     Func,
     /// External heap type.
     Extern,
+    // /// The `any` heap type. The common supertype (a.k.a. top) of all internal types.
+    // Any,
+    // /// The `none` heap type. The common subtype (a.k.a. bottom) of all internal types.
+    // None,
+    // /// The `noextern` heap type. The common subtype (a.k.a. bottom) of all external types.
+    // NoExtern,
+    // /// The `nofunc` heap type. The common subtype (a.k.a. bottom) of all function types.
+    // NoFunc,
+    // /// The `eq` heap type. The common supertype of all referenceable types on which comparison
+    // /// (ref.eq) is allowed (this may include host-defined external types).
+    // Eq,
+    /// The i31 heap type.
+    I31,
 }
 
 impl<'a> FromReader<'a> for HeapType {
@@ -368,6 +464,10 @@ impl<'a> FromReader<'a> for HeapType {
             0x6F => {
                 reader.position += 1;
                 Ok(HeapType::Extern)
+            }
+            0x6A => {
+                reader.position += 1;
+                Ok(HeapType::I31)
             }
             _ => {
                 let idx = match u32::try_from(reader.read_var_s33()?) {

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -245,6 +245,8 @@ pub struct WasmFeatures {
     pub function_references: bool,
     /// The WebAssembly memory control proposal
     pub memory_control: bool,
+    /// The WebAssembly gc proposal
+    pub gc: bool,
 }
 
 impl WasmFeatures {
@@ -305,6 +307,7 @@ impl Default for WasmFeatures {
             component_model: false,
             function_references: false,
             memory_control: false,
+            gc: false,
 
             // On-by-default features (phase 4 or greater).
             mutable_global: true,

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -805,7 +805,7 @@ impl Module {
     fn check_ref_type(&self, ty: RefType, types: &TypeList, offset: usize) -> Result<()> {
         // Check that the heap type is valid
         match ty.heap_type() {
-            HeapType::Func | HeapType::Extern => (),
+            HeapType::Func | HeapType::Extern | HeapType::I31 => (),
             HeapType::TypedFunc(type_index) => {
                 // Just check that the index is valid
                 self.func_type_at(type_index.into(), types, offset)?;

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -751,6 +751,7 @@ impl Printer {
         match ty {
             HeapType::Func => self.result.push_str("func"),
             HeapType::Extern => self.result.push_str("extern"),
+            HeapType::I31 => self.result.push_str("i31"),
             HeapType::TypedFunc(i) => self.result.push_str(&format!("{}", u32::from(i))),
         }
         Ok(())

--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -482,7 +482,7 @@ impl<'a> Module<'a> {
 
     fn heapty(&mut self, ty: HeapType) {
         match ty {
-            HeapType::Func | HeapType::Extern => {}
+            HeapType::Func | HeapType::Extern | HeapType::I31 => {}
             HeapType::TypedFunc(i) => self.ty(i.into()),
         }
     }
@@ -1102,6 +1102,7 @@ impl Encoder {
         match ht {
             wasmparser::HeapType::Func => wasm_encoder::HeapType::Func,
             wasmparser::HeapType::Extern => wasm_encoder::HeapType::Extern,
+            wasmparser::HeapType::I31 => wasm_encoder::HeapType::I31,
             wasmparser::HeapType::TypedFunc(idx) => {
                 wasm_encoder::HeapType::TypedFunc(self.types.remap(idx.into()).try_into().unwrap())
             }

--- a/fuzz/fuzz_targets/validate.rs
+++ b/fuzz/fuzz_targets/validate.rs
@@ -38,8 +38,9 @@ fuzz_target!(|data: &[u8]| {
         sign_extension: (byte2 & 0b1000_0000) != 0,
         memory_control: (byte3 & 0b0000_0001) != 0,
         function_references: (byte3 & 0b0000_0010) != 0,
+        gc: (byte3 & 0b0000_0100) != 0,
     });
-    let use_maybe_invalid = byte3 & 0b0000_0100 != 0;
+    let use_maybe_invalid = byte3 & 0b0000_1000 != 0;
 
     let wasm = &data[3..];
     if use_maybe_invalid {

--- a/tests/local/gc/gc-i31.wat
+++ b/tests/local/gc/gc-i31.wat
@@ -1,0 +1,14 @@
+;; --enable-gc
+
+(module
+  (func $f (result i32)
+    (local $a (ref i31))
+    (local $b (ref null i31))
+    (local $c i31ref)
+
+    unreachable
+
+    ;; (local.set $a (i31.new (i32.const 42)))
+    ;; (i31.get_u (local.get $a))
+  )
+)

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -151,6 +151,10 @@ fn skip_test(test: &Path, contents: &[u8]) -> bool {
 
     // TODO: the gc proposal isn't implemented yet
     if test.iter().any(|p| p == "gc") {
+        // enable for gc/gc-i31.wat
+        if test.ends_with("gc/gc-i31.wat") {
+            return false;
+        }
         return true;
     }
 
@@ -569,6 +573,7 @@ impl TestState {
             mutable_global: true,
             function_references: true,
             memory_control: true,
+            gc: true,
         };
         for part in test.iter().filter_map(|t| t.to_str()) {
             match part {
@@ -583,6 +588,7 @@ impl TestState {
                     features.mutable_global = false;
                     features.bulk_memory = false;
                     features.function_references = false;
+                    features.gc = false;
                 }
                 "floats-disabled.wast" => features.floats = false,
                 "threads" => {
@@ -603,6 +609,7 @@ impl TestState {
                 "function-references" => features.function_references = true,
                 "relaxed-simd" => features.relaxed_simd = true,
                 "reference-types" => features.reference_types = true,
+                "gc" => features.gc = true,
                 _ => {}
             }
         }

--- a/tests/snapshots/local/gc/gc-i31.wat.print
+++ b/tests/snapshots/local/gc/gc-i31.wat.print
@@ -1,0 +1,7 @@
+(module
+  (type (;0;) (func (result i32)))
+  (func $f (;0;) (type 0) (result i32)
+    (local $a (ref i31)) (local $b (ref null i31)) (local $c (ref null i31))
+    unreachable
+  )
+)


### PR DESCRIPTION
Unboxed integers (`i31`) is the most trivial reference type added by the Wasm GC specification, and the easiest to parse 🙂

This PR adds and enables a roundtrip test to demonstrate support for all flavors of `i31` references.

Also, change RefType internal structure to represent types introduced by the GC spec as described below.

RefType is a bit-packed enum that fits in a `u24` aka `[u8; 3]`. 
Note that its content is opaque (and subject to change), but its API is stable. 
It has the following internal structure:
```
[nullable:u1] [indexed==1:u1] [kind:u2] [index:u20]
[nullable:u1] [indexed==0:u1] [type:u4] [(unused):u18]
```
, where 
- `nullable` determines nullability of the ref
- `indexed` determines if the ref is of a dynamically defined type with an index (encoded in a following bit-packing section) or of a known fixed type
- `kind` determines what kind of indexed type the index is pointing to:
  ```
  10 = struct
  11 = array
  01 = function
  ```
- `index` is the type index
- `type` is an enumeration of known types:
  ```
  1111 = any

  1101 = eq
  1000 = i31
  1001 = struct
  1100 = array

  0101 = func    
  0100 = nofunc  

  0011 = extern  
  0010 = noextern

  0000 = none
  ```
- `(unused)` is unused sequence of bits
