### PR TITLE
Forcibly disable tail calls in wasm-smith generated modules

### DIFF
--- a/crates/wasm-smith/src/config.rs
+++ b/crates/wasm-smith/src/config.rs
@@ -578,7 +578,6 @@ impl<'a> Arbitrary<'a> for SwarmConfig {
             min_uleb_size: u.int_in_range(0..=5)?,
             bulk_memory_enabled: reference_types_enabled || u.arbitrary()?,
             reference_types_enabled,
-            tail_call_enabled: u.arbitrary()?,
             simd_enabled: u.arbitrary()?,
             multi_value_enabled: u.arbitrary()?,
             max_aliases: u.int_in_range(0..=MAX_MAXIMUM)?,
@@ -628,6 +627,7 @@ impl<'a> Arbitrary<'a> for SwarmConfig {
             threads_enabled: false,
             export_everything: false,
             disallow_traps: false,
+            tail_call_enabled: false,
         })
     }
 }

--- a/fuzz/fuzz_targets/no-traps.rs
+++ b/fuzz/fuzz_targets/no-traps.rs
@@ -25,7 +25,13 @@ fuzz_target!(|data: &[u8]| {
         Ok(m) => m,
         Err(_) => return,
     };
-    validate_module(config, &wasm_bytes);
+    validate_module(config.clone(), &wasm_bytes);
+
+    // Tail calls aren't implemented in wasmtime, so don't try to run them
+    // there.
+    if config.tail_call_enabled {
+        return;
+    }
 
     #[cfg(feature = "wasmtime")]
     {

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -16,6 +16,7 @@ pub fn generate_valid_module(
     config.threads_enabled = u.arbitrary()?;
     config.exceptions_enabled = u.arbitrary()?;
     config.canonicalize_nans = u.arbitrary()?;
+    config.tail_call_enabled = u.arbitrary()?;
 
     configure(&mut config, u)?;
 


### PR DESCRIPTION
Like other not-stable proposals such as `exceptions` or `memory64` leave this as off-by-default, even when configured via `SwarmConfig`.

For local fuzzing, however, it's implemented in this tooling suite so still attempt to enable it via the fuzz input.