### PR TITLE
GC: wasmprinter: Print shorthand i31ref type alias

### DIFF
--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -732,17 +732,18 @@ impl Printer {
     }
 
     fn print_reftype(&mut self, ty: RefType) -> Result<()> {
-        if ty == RefType::FUNCREF {
-            self.result.push_str("funcref");
-        } else if ty == RefType::EXTERNREF {
-            self.result.push_str("externref");
-        } else {
-            self.result.push_str("(ref ");
-            if ty.is_nullable() {
-                self.result.push_str("null ");
+        match ty {
+            RefType::FUNCREF => self.result.push_str("funcref"),
+            RefType::EXTERNREF => self.result.push_str("externref"),
+            RefType::I31REF => self.result.push_str("i31ref"),
+            _ => {
+                self.result.push_str("(ref ");
+                if ty.is_nullable() {
+                    self.result.push_str("null ");
+                }
+                self.print_heaptype(ty.heap_type())?;
+                self.result.push_str(")");
             }
-            self.print_heaptype(ty.heap_type())?;
-            self.result.push_str(")");
         }
         Ok(())
     }

--- a/tests/snapshots/local/gc/gc-i31.wat.print
+++ b/tests/snapshots/local/gc/gc-i31.wat.print
@@ -1,7 +1,7 @@
 (module
   (type (;0;) (func (result i32)))
   (func $f (;0;) (type 0) (result i32)
-    (local $a (ref i31)) (local $b (ref null i31)) (local $c (ref null i31))
+    (local $a (ref i31)) (local $b i31ref) (local $c i31ref)
     unreachable
   )
 )


### PR DESCRIPTION
For consistency with funcref and externref.

Follow-up for https://github.com/bytecodealliance/wasm-tools/pull/1004#discussion_r1180675039