### PR TITLE
Freeze field layout of `TypeId`

### DIFF
--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -142,6 +142,7 @@ fn push_primitive_wasm_types(ty: &PrimitiveValType, lowered_types: &mut LoweredT
 
 /// Represents a unique identifier for a type known to a [`crate::Validator`].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[repr(C)]
 pub struct TypeId {
     /// The index into the global list of types.
     pub(crate) index: usize,

--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -142,7 +142,7 @@ fn push_primitive_wasm_types(ty: &PrimitiveValType, lowered_types: &mut LoweredT
 
 /// Represents a unique identifier for a type known to a [`crate::Validator`].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[repr(C)]
+#[repr(C)] // use fixed field layout to ensure minimal size
 pub struct TypeId {
     /// The index into the global list of types.
     pub(crate) index: usize,


### PR DESCRIPTION
When compiling with `-Zrandomize-layout` the fields of `TypeId` can be rearranged in a way where the type becomes larger than 16 bytes which triggered a static assert.

Resolves: #1013