### PR TITLE
Don't generate WIT with the name `memory`

### DIFF
--- a/crates/wit-smith/src/generate.rs
+++ b/crates/wit-smith/src/generate.rs
@@ -198,11 +198,15 @@ impl Generator {
 
 impl<'a> InterfaceGenerator<'a> {
     fn new(gen: &'a Generator) -> InterfaceGenerator<'a> {
+        // Claim the name `memory` to avoid conflicting with the canonical ABI
+        // always using a linear memory named `memory`.
+        let mut unique_names = HashSet::new();
+        unique_names.insert("memory".to_string());
         InterfaceGenerator {
             gen,
             config: &gen.config,
             types_in_interface: Vec::new(),
-            unique_names: HashSet::new(),
+            unique_names,
         }
     }
 


### PR DESCRIPTION
This commit fixes a fuzzer-found issue in the `wit-smith` crate where if a function is called `memory` then it's not possible to feed such a WIT document through `wit-component` at this time. This is because linear memory is called `memory` and must be called that. Until this restriction is later lifted perhaps this claims the name `memory` early on to prevent any interface items from being named that.