### PR TITLE
Add a few more references for `addr2line`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,6 +90,7 @@ jobs:
       - run: cargo check --no-default-features --features component
       - run: cargo check --no-default-features --features metadata
       - run: cargo check --no-default-features --features wit-smith
+      - run: cargo check --no-default-features --features addr2line
 
   doc:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ programmatically as well:
 | `wasm-tools component embed` |  | Embed a `component-type` custom section in a core wasm binary |
 | `wasm-tools metadata show` |  [wasm-metadata] | Show name and producer metadata in a component or module |
 | `wasm-tools metadata add` |  | Add name or producer metadata to a component or module |
+| `wasm-tools addr2line` |  | Translate wasm offsets to filename/line numbers with DWARF |
 
 [wasmparser]: https://crates.io/crates/wasmparser
 [wat]: https://crates.io/crates/wat


### PR DESCRIPTION
* Add a check on CI that `addr2line` builds in isolation.
* Add a mention in the README of the new subcommand.