### PR TITLE
GC: wasmparser: Add user defined array types

### DIFF
--- a/crates/wasm-compose/src/encoding.rs
+++ b/crates/wasm-compose/src/encoding.rs
@@ -468,19 +468,15 @@ impl<'a> TypeEncoder<'a> {
         let ty = self.0.type_from_id(id).unwrap();
 
         match ty {
-            wasmparser::types::Type::Func(_) | wasmparser::types::Type::Instance(_) => {
+            Type::Func(_) | Type::Array(_) | Type::Instance(_) => {
                 unreachable!()
             }
-            wasmparser::types::Type::Module(_) => self.module_type(encodable, types, id),
-            wasmparser::types::Type::Component(_) => self.component_type(encodable, types, id),
-            wasmparser::types::Type::ComponentInstance(_) => {
-                self.component_instance_type(encodable, types, id)
-            }
-            wasmparser::types::Type::ComponentFunc(_) => {
-                self.component_func_type(encodable, types, id)
-            }
-            wasmparser::types::Type::Defined(_) => self.defined_type(encodable, types, id),
-            wasmparser::types::Type::Resource(_) => unimplemented!(),
+            Type::Module(_) => self.module_type(encodable, types, id),
+            Type::Component(_) => self.component_type(encodable, types, id),
+            Type::ComponentInstance(_) => self.component_instance_type(encodable, types, id),
+            Type::ComponentFunc(_) => self.component_func_type(encodable, types, id),
+            Type::Defined(_) => self.defined_type(encodable, types, id),
+            Type::Resource(_) => unimplemented!(),
         }
     }
 

--- a/crates/wasm-encoder/src/core/types.rs
+++ b/crates/wasm-encoder/src/core/types.rs
@@ -201,6 +201,18 @@ impl TypeSection {
         self.num_added += 1;
         self
     }
+
+    /// Define an array type in this type section.
+    pub fn array<T>(&mut self, ty: T, mutable: bool) -> &mut Self
+    where
+        T: Into<ValType>,
+    {
+        self.bytes.push(0x5e);
+        ty.into().encode(&mut self.bytes);
+        self.bytes.push(mutable as u8);
+        self.num_added += 1;
+        self
+    }
 }
 
 impl Encode for TypeSection {

--- a/crates/wasm-mutate/src/module.rs
+++ b/crates/wasm-mutate/src/module.rs
@@ -66,7 +66,7 @@ impl TryFrom<wasmparser::Type> for TypeInfo {
                     .map(|&t| PrimitiveTypeInfo::from(t))
                     .collect(),
             })),
-            wasmparser::Type::Array(ft) => {
+            wasmparser::Type::Array(_) => {
                 unimplemented!("Array and struct types are not supported yet.")
             }
         }

--- a/crates/wasm-mutate/src/module.rs
+++ b/crates/wasm-mutate/src/module.rs
@@ -66,7 +66,9 @@ impl TryFrom<wasmparser::Type> for TypeInfo {
                     .map(|&t| PrimitiveTypeInfo::from(t))
                     .collect(),
             })),
-            _ => unimplemented!("Array and struct types are not supported yet."),
+            wasmparser::Type::Array(ft) => {
+                unimplemented!("Array and struct types are not supported yet.")
+            }
         }
     }
 }

--- a/crates/wasm-mutate/src/module.rs
+++ b/crates/wasm-mutate/src/module.rs
@@ -66,6 +66,7 @@ impl TryFrom<wasmparser::Type> for TypeInfo {
                     .map(|&t| PrimitiveTypeInfo::from(t))
                     .collect(),
             })),
+            _ => unimplemented!("Array and struct types are not supported yet."),
         }
     }
 }

--- a/crates/wasm-mutate/src/mutators/add_type.rs
+++ b/crates/wasm-mutate/src/mutators/add_type.rs
@@ -72,6 +72,7 @@ impl Mutator for AddTypeMutator {
                             .collect::<Result<Vec<_>, _>>()?;
                         types.function(params, results);
                     }
+                    _ => unimplemented!("Array and struct types are not supported yet."),
                 }
             }
             // And then add our new type.

--- a/crates/wasm-mutate/src/mutators/add_type.rs
+++ b/crates/wasm-mutate/src/mutators/add_type.rs
@@ -72,7 +72,9 @@ impl Mutator for AddTypeMutator {
                             .collect::<Result<Vec<_>, _>>()?;
                         types.function(params, results);
                     }
-                    _ => unimplemented!("Array and struct types are not supported yet."),
+                    wasmparser::Type::Array(_) => {
+                        unimplemented!("Array and struct types are not supported yet.")
+                    }
                 }
             }
             // And then add our new type.

--- a/crates/wasm-mutate/src/mutators/add_type.rs
+++ b/crates/wasm-mutate/src/mutators/add_type.rs
@@ -2,7 +2,7 @@
 
 use super::Mutator;
 use crate::module::map_type;
-use crate::Result;
+use crate::{Error, Result};
 use rand::Rng;
 use std::iter;
 
@@ -73,7 +73,7 @@ impl Mutator for AddTypeMutator {
                         types.function(params, results);
                     }
                     wasmparser::Type::Array(_) => {
-                        unimplemented!("Array and struct types are not supported yet.")
+                        return Err(Error::unsupported("Array types are not supported yet."));
                     }
                 }
             }

--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -1,3 +1,4 @@
+use crate::mutators::Item::Type;
 use crate::{Error, Result};
 use wasm_encoder::*;
 use wasmparser::{DataKind, ElementKind, FunctionBody, Global, Operator, Type};
@@ -137,7 +138,7 @@ pub fn type_def(t: &mut dyn Translator, ty: Type, s: &mut TypeSection) -> Result
             );
             Ok(())
         }
-        _ => unimplemented!("Array and struct types are not supported yet."),
+        Type::Array(_) => unimplemented!("Array and struct types are not supported yet."),
     }
 }
 

--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -1,4 +1,3 @@
-use crate::mutators::Item::Type;
 use crate::{Error, Result};
 use wasm_encoder::*;
 use wasmparser::{DataKind, ElementKind, FunctionBody, Global, Operator, Type};

--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -137,6 +137,7 @@ pub fn type_def(t: &mut dyn Translator, ty: Type, s: &mut TypeSection) -> Result
             );
             Ok(())
         }
+        _ => unimplemented!("Array and struct types are not supported yet."),
     }
 }
 

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -609,6 +609,9 @@ impl Module {
                     new_types.push(Type::Func(Rc::clone(&func_type)));
                     new_index
                 }
+                Some((wasmparser::Type::Array(_array_type), _index_store)) => {
+                    unimplemented!("Array and struct types are not supported yet.");
+                }
             };
             match &new_types[serialized_sig_idx - first_type_index] {
                 Type::Func(f) => Some((serialized_sig_idx as u32, Rc::clone(f))),

--- a/crates/wasm-smith/tests/core.rs
+++ b/crates/wasm-smith/tests/core.rs
@@ -132,7 +132,9 @@ fn smoke_test_imports_config() {
                     for ty in rdr {
                         match ty.unwrap() {
                             wasmparser::Type::Func(ft) => sig_types.push(ft),
-                            _ => unimplemented!("Array and struct types are not supported yet."),
+                            wasmparser::Type::Array(_) => {
+                                unimplemented!("Array and struct types are not supported yet.")
+                            }
                         }
                     }
                 } else if let wasmparser::Payload::ImportSection(rdr) = payload {

--- a/crates/wasm-smith/tests/core.rs
+++ b/crates/wasm-smith/tests/core.rs
@@ -132,6 +132,7 @@ fn smoke_test_imports_config() {
                     for ty in rdr {
                         match ty.unwrap() {
                             wasmparser::Type::Func(ft) => sig_types.push(ft),
+                            _ => unimplemented!("Array and struct types are not supported yet."),
                         }
                     }
                 } else if let wasmparser::Payload::ImportSection(rdr) = payload {

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -166,7 +166,6 @@ impl fmt::Display for ValType {
 //   0000 = none
 //   ```
 // - `(unused)` is unused sequence of bits
-// TODO (unused) is supposed to be zeroed out
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct RefType([u8; 3]);
 
@@ -341,7 +340,7 @@ impl RefType {
     /// Returns `None` when the type index is beyond this crate's implementation
     /// limits and therefore is not representable.
     pub const fn indexed_func(nullable: bool, index: u32) -> Option<Self> {
-        Self::indexed(nullable, HeapType::Func, index)
+        Self::indexed(nullable, Self::FUNC_KIND, index)
     }
 
     /// Create a reference to an array with the type at the given index.
@@ -349,7 +348,7 @@ impl RefType {
     /// Returns `None` when the type index is beyond this crate's implementation
     /// limits and therefore is not representable.
     pub const fn indexed_array(nullable: bool, index: u32) -> Option<Self> {
-        Self::indexed(nullable, HeapType::Array, index)
+        Self::indexed(nullable, Self::ARRAY_KIND, index)
     }
 
     /// Create a reference to a struct with the type at the given index.
@@ -357,7 +356,7 @@ impl RefType {
     /// Returns `None` when the type index is beyond this crate's implementation
     /// limits and therefore is not representable.
     pub const fn indexed_struct(nullable: bool, index: u32) -> Option<Self> {
-        Self::indexed(nullable, HeapType::Struct, index)
+        Self::indexed(nullable, Self::STRUCT_KIND, index)
     }
 
     /// Create a reference to a user defined type at the given index.
@@ -365,15 +364,7 @@ impl RefType {
     /// Returns `None` when the type index is beyond this crate's implementation
     /// limits and therefore is not representable, or when the heap type is not
     /// a typed array, struct or function.
-    const fn indexed(nullable: bool, heap_type: HeapType, index: u32) -> Option<Self> {
-        let kind = match heap_type {
-            HeapType::Func => Self::FUNC_KIND,
-            HeapType::Array => Self::ARRAY_KIND,
-            HeapType::Struct => Self::STRUCT_KIND,
-            _ => {
-                return None;
-            }
-        };
+    const fn indexed(nullable: bool, kind: u32, index: u32) -> Option<Self> {
         if Self::can_represent_type_index(index) {
             let nullable32 = Self::NULLABLE_BIT * nullable as u32;
             Some(RefType::from_u32(
@@ -566,7 +557,6 @@ impl fmt::Display for RefType {
 pub enum HeapType {
     /// User defined type at the given index.
     TypedFunc(u32),
-    // TODO rename TypedFunc to Indexed as there are more indexed types now: funcs, structs, arrays.
     /// Untyped (any) function.
     Func,
     /// External heap type.

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -550,8 +550,7 @@ impl fmt::Display for RefType {
 pub enum HeapType {
     /// User defined type at the given index.
     TypedFunc(u32),
-    // Indexed user defined type at the given index.
-    // Indexed(u32),
+    // TODO rename TypedFunc to Indexed as there are more indexed types now: funcs, structs, arrays.
     /// Untyped (any) function.
     Func,
     /// External heap type.

--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -744,7 +744,7 @@ impl ComponentState {
 
             // Core wasm constructs are always valid with respect to
             // exported types, since they have none.
-            Type::Module(_) | Type::Instance(_) | Type::Func(_) => true,
+            Type::Module(_) | Type::Instance(_) | Type::Func(_) | Type::Array(_) => true,
 
             // Resource types, in isolation, are always valid to import
             // or export since they're either attached to an import or

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -514,8 +514,7 @@ impl Module {
                 Type::Func(t)
             }
             crate::Type::Array(t) => {
-                // TODO check element type. Currently the check panics if the ref is not to a function type.
-                // self.check_revalue_type(t.element_type, features, types, offset)?;
+                self.check_value_type(t.element_type, features, types, offset)?;
                 Type::Array(t)
             }
         };
@@ -807,7 +806,7 @@ impl Module {
         Ok(())
     }
 
-    fn check_ref_type(&self, ty: RefType, types: &TypeList, offset: usize) -> Result<()> {
+    fn check_ref_type(&self, ty: RefType, _types: &TypeList, offset: usize) -> Result<()> {
         // Check that the heap type is valid
         match ty.heap_type() {
             HeapType::Func
@@ -822,7 +821,7 @@ impl Module {
             | HeapType::I31 => (),
             HeapType::TypedFunc(type_index) => {
                 // Just check that the index is valid
-                self.func_type_at(type_index.into(), types, offset)?;
+                self.type_at(type_index, offset)?;
             }
         }
         Ok(())

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -513,6 +513,11 @@ impl Module {
                 }
                 Type::Func(t)
             }
+            crate::Type::Array(t) => {
+                // TODO check element type. Currently the check panics if the ref is not to a function type.
+                // self.check_revalue_type(t.element_type, features, types, offset)?;
+                Type::Array(t)
+            }
         };
 
         if check_limit {

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -133,7 +133,7 @@ impl ModuleState {
         offset: usize,
     ) -> Result<()> {
         self.module
-            .check_global_type(&global.ty, features, types, offset)?;
+            .check_global_type(&global.ty, features, offset)?;
         self.check_const_expr(&global.init_expr, global.ty.content_type, features, types)?;
         self.module.assert_mut().globals.push(global.ty);
         Ok(())
@@ -146,8 +146,7 @@ impl ModuleState {
         types: &TypeList,
         offset: usize,
     ) -> Result<()> {
-        self.module
-            .check_table_type(&table.ty, features, types, offset)?;
+        self.module.check_table_type(&table.ty, features, offset)?;
 
         match &table.init {
             TableInit::RefNull => {
@@ -200,7 +199,7 @@ impl ModuleState {
         // don't check it here
         if e.ty != RefType::FUNCREF {
             self.module
-                .check_value_type(ValType::Ref(e.ty), features, types, offset)?;
+                .check_value_type(ValType::Ref(e.ty), features, offset)?;
         }
         match e.kind {
             ElementKind::Active {
@@ -503,7 +502,7 @@ impl Module {
         let ty = match ty {
             crate::Type::Func(t) => {
                 for ty in t.params().iter().chain(t.results()) {
-                    self.check_value_type(*ty, features, types, offset)?;
+                    self.check_value_type(*ty, features, offset)?;
                 }
                 if t.results().len() > 1 && !features.multi_value {
                     return Err(BinaryReaderError::new(
@@ -514,7 +513,7 @@ impl Module {
                 Type::Func(t)
             }
             crate::Type::Array(t) => {
-                self.check_value_type(t.element_type, features, types, offset)?;
+                self.check_value_type(t.element_type, features, offset)?;
                 Type::Array(t)
             }
         };
@@ -674,7 +673,7 @@ impl Module {
                 EntityType::Func(self.types[*type_index as usize])
             }
             TypeRef::Table(t) => {
-                self.check_table_type(t, features, types, offset)?;
+                self.check_table_type(t, features, offset)?;
                 EntityType::Table(*t)
             }
             TypeRef::Memory(t) => {
@@ -686,7 +685,7 @@ impl Module {
                 EntityType::Tag(self.types[t.func_type_idx as usize])
             }
             TypeRef::Global(t) => {
-                self.check_global_type(t, features, types, offset)?;
+                self.check_global_type(t, features, offset)?;
                 EntityType::Global(*t)
             }
         })
@@ -696,13 +695,12 @@ impl Module {
         &self,
         ty: &TableType,
         features: &WasmFeatures,
-        types: &TypeList,
         offset: usize,
     ) -> Result<()> {
         // the `funcref` value type is allowed all the way back to the MVP, so
         // don't check it here
         if ty.element_type != RefType::FUNCREF {
-            self.check_value_type(ValType::Ref(ty.element_type), features, types, offset)?
+            self.check_value_type(ValType::Ref(ty.element_type), features, offset)?
         }
 
         self.check_limits(ty.initial, ty.maximum, offset)?;
@@ -784,13 +782,7 @@ impl Module {
             .collect::<Result<_>>()
     }
 
-    fn check_value_type(
-        &self,
-        ty: ValType,
-        features: &WasmFeatures,
-        types: &TypeList,
-        offset: usize,
-    ) -> Result<()> {
+    fn check_value_type(&self, ty: ValType, features: &WasmFeatures, offset: usize) -> Result<()> {
         match features.check_value_type(ty) {
             Ok(()) => Ok(()),
             Err(e) => Err(BinaryReaderError::new(e, offset)),
@@ -799,14 +791,14 @@ impl Module {
         // We must check it if it's a reference.
         match ty {
             ValType::Ref(rt) => {
-                self.check_ref_type(rt, types, offset)?;
+                self.check_ref_type(rt, offset)?;
             }
             _ => (),
         }
         Ok(())
     }
 
-    fn check_ref_type(&self, ty: RefType, _types: &TypeList, offset: usize) -> Result<()> {
+    fn check_ref_type(&self, ty: RefType, offset: usize) -> Result<()> {
         // Check that the heap type is valid
         match ty.heap_type() {
             HeapType::Func
@@ -914,10 +906,9 @@ impl Module {
         &self,
         ty: &GlobalType,
         features: &WasmFeatures,
-        types: &TypeList,
         offset: usize,
     ) -> Result<()> {
-        self.check_value_type(ty.content_type, features, types, offset)
+        self.check_value_type(ty.content_type, features, offset)
     }
 
     fn check_limits<T>(&self, initial: T, maximum: Option<T>, offset: usize) -> Result<()>
@@ -1105,8 +1096,7 @@ impl WasmModuleResources for OperatorValidatorResources<'_> {
     }
 
     fn check_value_type(&self, t: ValType, features: &WasmFeatures, offset: usize) -> Result<()> {
-        self.module
-            .check_value_type(t, features, self.types, offset)
+        self.module.check_value_type(t, features, offset)
     }
 
     fn element_type_at(&self, at: u32) -> Option<RefType> {
@@ -1174,8 +1164,7 @@ impl WasmModuleResources for ValidatorResources {
     }
 
     fn check_value_type(&self, t: ValType, features: &WasmFeatures, offset: usize) -> Result<()> {
-        self.0
-            .check_value_type(t, features, self.0.snapshot.as_ref().unwrap(), offset)
+        self.0.check_value_type(t, features, offset)
     }
 
     fn element_type_at(&self, at: u32) -> Option<RefType> {

--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use crate::validator::names::{KebabName, KebabString};
 use crate::{
-    BinaryReaderError, Export, ExternalKind, FuncType, GlobalType, Import, MemoryType,
+    ArrayType, BinaryReaderError, Export, ExternalKind, FuncType, GlobalType, Import, MemoryType,
     PrimitiveValType, RefType, Result, TableType, TypeRef, ValType,
 };
 use indexmap::{IndexMap, IndexSet};
@@ -170,6 +170,8 @@ const _: () = {
 pub enum Type {
     /// The definition is for a core function type.
     Func(FuncType),
+    /// The definition is for a core array type.
+    Array(ArrayType),
     /// The definition is for a core module type.
     ///
     /// This variant is only supported when parsing a component.
@@ -205,6 +207,14 @@ impl Type {
     pub fn as_func_type(&self) -> Option<&FuncType> {
         match self {
             Self::Func(ty) => Some(ty),
+            _ => None,
+        }
+    }
+
+    /// Converts the type to an array type.
+    pub fn as_array_type(&self) -> Option<&ArrayType> {
+        match self {
+            Self::Array(ty) => Some(ty),
             _ => None,
         }
     }
@@ -268,6 +278,7 @@ impl Type {
     pub(crate) fn type_size(&self) -> u32 {
         match self {
             Self::Func(ty) => 1 + (ty.params().len() + ty.results().len()) as u32,
+            Self::Array(_) => 2, // 2 is a guess.
             Self::Module(ty) => ty.type_size,
             Self::Instance(ty) => ty.type_size,
             Self::Component(ty) => ty.type_size,
@@ -1777,7 +1788,7 @@ impl TypeAlloc {
     pub fn free_variables_type_id(&self, id: TypeId, set: &mut IndexSet<ResourceId>) {
         match &self[id] {
             // Core wasm constructs cannot reference resources.
-            Type::Func(_) | Type::Module(_) | Type::Instance(_) => {}
+            Type::Func(_) | Type::Array(_) | Type::Module(_) | Type::Instance(_) => {}
 
             // Recurse on the imports/exports of components, but remove the
             // imported and defined resources within the component itself.
@@ -1998,7 +2009,7 @@ pub(crate) trait Remap: Index<TypeId, Output = Type> {
         let ty = match &self[*id] {
             // Core wasm functions/modules/instances don't have resource types
             // in them.
-            Type::Func(_) | Type::Module(_) | Type::Instance(_) => return false,
+            Type::Func(_) | Type::Array(_) | Type::Module(_) | Type::Instance(_) => return false,
 
             Type::Component(i) => {
                 let mut tmp = i.clone();

--- a/tests/local/gc/gc-array-types-invalid.wast
+++ b/tests/local/gc/gc-array-types-invalid.wast
@@ -1,0 +1,8 @@
+;; --enable-gc
+
+(assert_invalid
+  (module
+    (type $a (array (mut (ref null 1000))))
+  )
+  "unknown type"
+)

--- a/tests/local/gc/gc-array-types.wat
+++ b/tests/local/gc/gc-array-types.wat
@@ -1,0 +1,7 @@
+;; --enable-gc
+
+(module
+  (type $a (array i32))
+  (type $b (array (mut i32)))
+  (type $c (array (mut (ref null $b))))
+)

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -153,7 +153,7 @@ fn skip_test(test: &Path, contents: &[u8]) -> bool {
         "gc/let.wat",
         "/proposals/gc/",
     ];
-    let test_path = test.to_str().unwrap();
+    let test_path = test.to_str().unwrap().replace("\\", "/"); // for windows paths
     if broken.iter().any(|x| test_path.contains(x)) {
         return true;
     }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -144,23 +144,17 @@ fn skip_test(test: &Path, contents: &[u8]) -> bool {
         "exception-handling/throw.wast",
         // This is an empty file which currently doesn't parse
         "multi-memory/memory_copy1.wast",
+        // the GC proposal isn't implemented yet
+        "gc/gc-array.wat",
+        "gc/gc-rec-sub.wat",
+        "gc/gc-ref.wat",
+        "gc/gc-ref-global-import.wat",
+        "gc/gc-struct.wat",
+        "gc/let.wat",
+        "/proposals/gc/",
     ];
-    if broken.iter().any(|x| test.ends_with(x)) {
-        return true;
-    }
-
-    // TODO: the gc proposal isn't implemented yet
-    if test.iter().any(|p| p == "gc") {
-        // selectively enable some tests
-        let implemented = &[
-            "gc-i31.wat",
-            "gc-heaptypes.wat",
-            "gc-array-types.wat",
-            "gc-array-types-invalid.wast",
-        ];
-        if implemented.iter().any(|x| test.ends_with(x)) {
-            return false;
-        }
+    let test_path = test.to_str().unwrap();
+    if broken.iter().any(|x| test_path.contains(x)) {
         return true;
     }
 

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -152,7 +152,7 @@ fn skip_test(test: &Path, contents: &[u8]) -> bool {
     // TODO: the gc proposal isn't implemented yet
     if test.iter().any(|p| p == "gc") {
         // selectively enable some tests
-        let implemented = &["gc-i31.wat", "gc-heaptypes.wat"];
+        let implemented = &["gc-i31.wat", "gc-heaptypes.wat", "gc-array-types.wat"];
         if implemented.iter().any(|x| test.ends_with(x)) {
             return false;
         }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -152,7 +152,12 @@ fn skip_test(test: &Path, contents: &[u8]) -> bool {
     // TODO: the gc proposal isn't implemented yet
     if test.iter().any(|p| p == "gc") {
         // selectively enable some tests
-        let implemented = &["gc-i31.wat", "gc-heaptypes.wat", "gc-array-types.wat"];
+        let implemented = &[
+            "gc-i31.wat",
+            "gc-heaptypes.wat",
+            "gc-array-types.wat",
+            "gc-array-types-invalid.wast",
+        ];
         if implemented.iter().any(|x| test.ends_with(x)) {
             return false;
         }
@@ -303,7 +308,7 @@ impl TestState {
     fn test_wast_directive(&self, test: &Path, directive: WastDirective, idx: usize) -> Result<()> {
         // Only test parsing and encoding of modules which wasmparser doesn't
         // support test (basically just test `wast`, nothing else)
-        let skip_verify = test.iter().any(|t| t == "gc")
+        let skip_verify =
             // This specific test contains a module along the lines of:
             //
             //  (module
@@ -316,7 +321,7 @@ impl TestState {
             // segment has a type of `funcref` which isn't compatible with the
             // table's type. The spec interpreter thinks this should validate,
             // however, and I'm not entirely sure why.
-            || test.ends_with("function-references/br_table.wast");
+            test.ends_with("function-references/br_table.wast");
 
         match directive {
             WastDirective::Wat(mut module) => {

--- a/tests/snapshots/local/gc/gc-array-types.wat.print
+++ b/tests/snapshots/local/gc/gc-array-types.wat.print
@@ -1,0 +1,5 @@
+(module
+  (type $a (;0;) (array i32))
+  (type $b (;1;) (array (mut i32)))
+  (type $c (;2;) (array (mut (ref null 1))))
+)


### PR DESCRIPTION
This adds basic support for user defined array types, for example:
```wat
  (type $a (array i32))
  (type $b (array (mut i32)))
  (type $c (array (mut (ref null $b))))
```
