### PR TITLE
GC: wasmparser: storage types

### DIFF
--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -34,6 +34,17 @@ pub enum ValType {
     Ref(RefType),
 }
 
+/// Represents storage types introduced in the GC spec for array and struct fields.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum StorageType {
+    /// The storage type is i8.
+    I8,
+    /// The storage type is i16.
+    I16,
+    /// The storage type is a value type.
+    Val(ValType),
+}
+
 // The size of `ValType` is performance sensitive.
 const _: () = {
     assert!(std::mem::size_of::<ValType>() == 4);
@@ -74,6 +85,22 @@ impl ValType {
             0x7F | 0x7E | 0x7D | 0x7C | 0x7B | 0x70 | 0x6F | 0x6B | 0x6C | 0x6E | 0x65 | 0x69
             | 0x68 | 0x6D | 0x67 | 0x66 | 0x6A => true,
             _ => false,
+        }
+    }
+}
+
+impl<'a> FromReader<'a> for StorageType {
+    fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        match reader.peek()? {
+            0x7A => {
+                reader.position += 1;
+                Ok(StorageType::I8)
+            }
+            0x79 => {
+                reader.position += 1;
+                Ok(StorageType::I16)
+            }
+            _ => Ok(StorageType::Val(reader.read()?)),
         }
     }
 }
@@ -659,7 +686,7 @@ pub struct FuncType {
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct ArrayType {
     /// Array element type.
-    pub element_type: ValType,
+    pub element_type: StorageType,
     /// Are elements mutable.
     pub mutable: bool,
 }

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -513,7 +513,12 @@ impl Module {
                 Type::Func(t)
             }
             crate::Type::Array(t) => {
-                self.check_value_type(t.element_type, features, offset)?;
+                match t.element_type {
+                    crate::StorageType::I8 | crate::StorageType::I16 => {}
+                    crate::StorageType::Val(value_type) => {
+                        self.check_value_type(value_type, features, offset)?;
+                    }
+                };
                 Type::Array(t)
             }
         };

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -731,11 +731,20 @@ impl Printer {
         if ty.mutable {
             self.result.push_str("(mut ");
         }
-        self.print_valtype(ty.element_type)?;
+        self.print_storage_type(ty.element_type)?;
         if ty.mutable {
             self.result.push_str(")");
         }
         Ok(0)
+    }
+
+    fn print_storage_type(&mut self, ty: StorageType) -> Result<()> {
+        match ty {
+            StorageType::I8 => self.result.push_str("i8"),
+            StorageType::I16 => self.result.push_str("i16"),
+            StorageType::Val(val_type) => self.print_valtype(val_type)?,
+        }
+        Ok(())
     }
 
     fn print_valtype(&mut self, ty: ValType) -> Result<()> {

--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -480,6 +480,13 @@ impl<'a> Module<'a> {
         }
     }
 
+    fn storagety(&mut self, ty: StorageType) {
+        match ty {
+            StorageType::I8 | StorageType::I16 => {}
+            StorageType::Val(ty) => self.valty(ty),
+        }
+    }
+
     fn heapty(&mut self, ty: HeapType) {
         match ty {
             HeapType::Func
@@ -508,7 +515,7 @@ impl<'a> Module<'a> {
                     }
                 }
                 Type::Array(ty) => {
-                    me.valty(ty.element_type);
+                    me.storagety(ty.element_type);
                 }
             };
             Ok(())
@@ -577,7 +584,7 @@ impl<'a> Module<'a> {
                     }
                 }
                 Type::Array(ty) => {
-                    types.array(map.valty(ty.element_type), ty.mutable);
+                    types.array(map.storagety(ty.element_type), ty.mutable);
                 }
             }
         }
@@ -1104,6 +1111,14 @@ impl Encoder {
             wasmparser::ValType::F64 => wasm_encoder::ValType::F64,
             wasmparser::ValType::V128 => wasm_encoder::ValType::V128,
             wasmparser::ValType::Ref(rt) => wasm_encoder::ValType::Ref(self.refty(rt)),
+        }
+    }
+
+    fn storagety(&self, ty: StorageType) -> wasm_encoder::StorageType {
+        match ty {
+            StorageType::I8 => wasm_encoder::StorageType::I8,
+            StorageType::I16 => wasm_encoder::StorageType::I16,
+            StorageType::Val(ty) => wasm_encoder::StorageType::Val(self.valty(ty)),
         }
     }
 

--- a/tests/local/gc/gc-array-types.wat
+++ b/tests/local/gc/gc-array-types.wat
@@ -4,4 +4,6 @@
   (type $a (array i32))
   (type $b (array (mut i32)))
   (type $c (array (mut (ref null $b))))
+  (type $d (array i8))
+  (type $e (array (mut i16)))
 )

--- a/tests/snapshots/local/gc/gc-array-types.wat.print
+++ b/tests/snapshots/local/gc/gc-array-types.wat.print
@@ -2,4 +2,6 @@
   (type $a (;0;) (array i32))
   (type $b (;1;) (array (mut i32)))
   (type $c (;2;) (array (mut (ref null 1))))
+  (type $d (;3;) (array i8))
+  (type $e (;4;) (array (mut i16)))
 )


### PR DESCRIPTION
This builds on #1022 and adds support for packed storage types for array and struct fields.

A storage type is either a packed storage type (`i8`, `i16`) or a regular value type.