### PR TITLE
Colorize section name in `dump` output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ log = { workspace = true }
 clap = { workspace = true }
 tempfile = "3.2.0"
 wat = { workspace = true }
+termcolor = "1.2.0"
 
 # Dependencies of `validate`
 wasmparser = { workspace = true, optional = true }
@@ -110,7 +111,6 @@ wit-smith = { workspace = true, features = ["clap"], optional = true }
 # Dependencies of `addr2line`
 addr2line = { version = "0.20.0", optional = true }
 gimli = { version = "0.27.2", optional = true }
-termcolor = "1.2.0"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ wit-smith = { workspace = true, features = ["clap"], optional = true }
 # Dependencies of `addr2line`
 addr2line = { version = "0.20.0", optional = true }
 gimli = { version = "0.27.2", optional = true }
+termcolor = "1.2.0"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/src/bin/wasm-tools/objdump.rs
+++ b/src/bin/wasm-tools/objdump.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use termcolor::WriteColor;
 use std::io::Write;
 use std::ops::Range;
 use wasmparser::{Encoding, Parser, Payload::*};
@@ -90,7 +91,7 @@ struct IndexSpace {
 
 struct Printer {
     indices: Vec<IndexSpace>,
-    output: Box<dyn Write>,
+    output: Box<dyn WriteColor>,
 }
 
 impl Printer {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ use anyhow::{bail, Context, Result};
 use std::fs::File;
 use std::io::{BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
+use termcolor::{Ansi, ColorChoice, StandardStream, WriteColor};
 
 // Implements the verbosity flag for the CLI commands.
 #[derive(clap::Parser)]
@@ -48,6 +49,10 @@ pub struct InputOutput {
 
     #[clap(flatten)]
     verbosity: Verbosity,
+
+    /// Use colors in output.
+    #[clap(long = "color", short = 'c', action = clap::ArgAction::SetTrue)]
+    color: bool,
 }
 
 #[derive(clap::Parser)]
@@ -89,7 +94,8 @@ impl InputOutput {
         self.output.output(bytes)
     }
 
-    pub fn output_writer(&self) -> Result<Box<dyn Write>> {
+    pub fn output_writer(&self) -> Result<Box<dyn WriteColor>> {
+        assert!(self.color == false);
         self.output.output_writer()
     }
 
@@ -150,10 +156,10 @@ impl OutputArg {
         self.output.as_deref()
     }
 
-    pub fn output_writer(&self) -> Result<Box<dyn Write>> {
+    pub fn output_writer(&self) -> Result<Box<dyn WriteColor>> {
         match &self.output {
-            Some(output) => Ok(Box::new(BufWriter::new(File::create(&output)?))),
-            None => Ok(Box::new(std::io::stdout())),
+            Some(output) => Ok(Box::new(Ansi::new(BufWriter::new(File::create(&output)?)))),
+            None => Ok(Box::new(StandardStream::stdout(ColorChoice::Auto))),
         }
     }
 }


### PR DESCRIPTION
### Summary

- Related issue: #1020

This PR introduces `--color` option for enhancing the output by colorizing it, specifically for section names in `dump` output for now.

I implemented the feature basically as mentioned in the issue.
Also I'm open to new ideas for colorization, since I feel like it is not enough only section names are colored.

![image](https://github.com/bytecodealliance/wasm-tools/assets/9913176/88f762af-0666-4469-998b-c435814beb48)
