### PR TITLE
Bump wit-component's major version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-tools"
-version = "1.0.32"
+version = "1.0.33"
 authors = ["The Wasmtime Project Developers"]
 edition.workspace = true
 description = "CLI tools for interoperating with WebAssembly files"
@@ -43,7 +43,7 @@ url = "2.0.0"
 pretty_assertions = "1.3.0"
 
 wasm-encoder = { version = "0.27.0", path = "crates/wasm-encoder"}
-wasm-compose = { version = "0.2.14", path = "crates/wasm-compose"}
+wasm-compose = { version = "0.2.15", path = "crates/wasm-compose"}
 wasm-metadata = { version = "0.6.0", path = "crates/wasm-metadata" }
 wasm-mutate = { version = "0.2.25", path = "crates/wasm-mutate" }
 wasm-shrink = { version = "0.1.26", path = "crates/wasm-shrink" }
@@ -52,9 +52,9 @@ wasmparser = { version = "0.105.0", path = "crates/wasmparser" }
 wasmprinter = { version = "0.2.57", path = "crates/wasmprinter" }
 wast = { version = "58.0.0", path = "crates/wast" }
 wat = { version = "1.0.64", path = "crates/wat" }
-wit-component = { version = "0.8.3", path = "crates/wit-component" }
+wit-component = { version = "0.9.0", path = "crates/wit-component" }
 wit-parser = { version = "0.7.1", path = "crates/wit-parser" }
-wit-smith = { version = "0.1.2", path = "crates/wit-smith" }
+wit-smith = { version = "0.1.3", path = "crates/wit-smith" }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/wasm-compose/Cargo.toml
+++ b/crates/wasm-compose/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-compose"
-version = "0.2.14"
+version = "0.2.15"
 edition.workspace = true
 authors = ["Peter Huene <peter@huene.dev>"]
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wit-component/Cargo.toml
+++ b/crates/wit-component/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-component"
 authors = ["Peter Huene <peter@huene.dev>"]
-version = "0.8.3"
+version = "0.9.0"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"

--- a/crates/wit-smith/Cargo.toml
+++ b/crates/wit-smith/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 name = "wit-smith"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-smith"
-version = "0.1.2"
+version = "0.1.3"
 
 [dependencies]
 arbitrary = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
I forgot this in #1025 and otherwise installs of `wit-bindgen` are not working at this time since the 0.8 track of wit-component is using 0.5 of wasm-metadata resulting in duplicate version errors.