### PR TITLE
Fix some warnings on nightly Rust

### DIFF
--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -109,7 +109,7 @@ pub trait Translator {
     }
 
     fn remap(&mut self, item: Item, idx: u32) -> Result<u32> {
-        drop(item);
+        let _ = item;
         Ok(idx)
     }
 }

--- a/crates/wasmprinter/src/operator.rs
+++ b/crates/wasmprinter/src/operator.rs
@@ -217,7 +217,7 @@ macro_rules! define_visit {
             $self.table_index($table)?;
         }
         $self.type_index($ty)?;
-        drop($byte);
+        let _ = $byte;
     );
     (payload $self:ident ReturnCallIndirect $ty:ident $table:ident) => (
         if $table != 0 {

--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -1161,18 +1161,18 @@ macro_rules! define_encode {
         BrTable($arg.0, $arg.1)
     });
     (mk CallIndirect $ty:ident $table:ident $table_byte:ident) => ({
-        drop($table_byte);
+        let _ = $table_byte;
         CallIndirect { ty: $ty, table: $table }
     });
     (mk ReturnCallIndirect $ty:ident $table:ident) => (
         ReturnCallIndirect { ty: $ty, table: $table }
     );
     (mk MemorySize $mem:ident $mem_byte:ident) => ({
-        drop($mem_byte);
+        let _ = $mem_byte;
         MemorySize($mem)
     });
     (mk MemoryGrow $mem:ident $mem_byte:ident) => ({
-        drop($mem_byte);
+        let _ = $mem_byte;
         MemoryGrow($mem)
     });
     (mk I32Const $v:ident) => (I32Const($v));

--- a/crates/wit-parser/src/resolve.rs
+++ b/crates/wit-parser/src/resolve.rs
@@ -1456,7 +1456,7 @@ impl<'a> MergeMap<'a> {
                 }
             }
             (WorldItem::Function(from), WorldItem::Function(into)) => {
-                drop((from, into));
+                let _ = (from, into);
                 // FIXME: should assert an check that `from` structurally
                 // matches `into`
             }


### PR DESCRIPTION
Apparently upstream has decided that `drop(foo)` is not how one should ignore `foo`, instead it must be spelled `let _ = foo`