### PR TITLE
feat: add trace-level log to verbose.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,8 @@ impl GeneralOpts {
         let default = match self.verbose {
             0 => "warn",
             1 => "info",
-            _ => "debug",
+            2 => "debug",
+            _ => "trace",
         };
 
         env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(default))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use termcolor::{Ansi, ColorChoice, NoColor, StandardStream, WriteColor};
 
 #[derive(clap::Parser)]
 pub struct GeneralOpts {
-    /// Use verbose output (-vv very verbose output).
+    /// Use verbose output (-v info, -vv debug, -vvv trace).
     #[clap(long = "verbose", short = 'v', action = clap::ArgAction::Count)]
     verbose: u8,
 


### PR DESCRIPTION
This is a small change to add trace-level log to "verbose" flag. To see trace logs, you can do `wasm-tools <command> -vvv`. 