### PR TITLE
Add force-merge option for adapters

### DIFF
--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -1497,7 +1497,13 @@ impl ComponentEncoder {
     /// wasm module specified by `bytes` imports. The `bytes` will then import
     /// `interface` and export functions to get imported from the module `name`
     /// in the core wasm that's being wrapped.
-    pub fn adapter(mut self, name: &str, bytes: &[u8]) -> Result<Self> {
+    ///
+    /// When merging components whose intersecting imports are known ahead of time
+    /// to have fully equivalent types, force_merge can be used to dedupe the
+    /// imports against eachother (for example shared WASI bindings).
+    /// No type checking is currently performed, so this will break components
+    /// when applied incorrectly.
+    pub fn adapter(mut self, name: &str, bytes: &[u8], force_merge: bool) -> Result<Self> {
         let (wasm, metadata) = metadata::decode(bytes)?;
         // Merge the adapter's document into our own document to have one large
         // document, and then afterwards merge worlds as well.
@@ -1518,7 +1524,7 @@ impl ComponentEncoder {
             .worlds[metadata.world.index()];
         self.metadata
             .resolve
-            .merge_worlds(world, self.metadata.world)
+            .merge_worlds(world, self.metadata.world, force_merge)
             .with_context(|| {
                 format!("failed to merge WIT world of adapter `{name}` into main package")
             })?;

--- a/crates/wit-component/src/metadata.rs
+++ b/crates/wit-component/src/metadata.rs
@@ -252,7 +252,7 @@ impl Bindgen {
             .context("failed to merge WIT package sets together")?
             .worlds[world.index()];
         self.resolve
-            .merge_worlds(world, self.world)
+            .merge_worlds(world, self.world, false)
             .context("failed to merge worlds from two documents")?;
 
         for (name, encoding) in export_encodings {

--- a/crates/wit-parser/src/resolve.rs
+++ b/crates/wit-parser/src/resolve.rs
@@ -421,7 +421,7 @@ impl Resolve {
     /// interface.
     ///
     /// This operation can fail if the imports/exports overlap.
-    pub fn merge_worlds(&mut self, from: WorldId, into: WorldId) -> Result<()> {
+    pub fn merge_worlds(&mut self, from: WorldId, into: WorldId, force_union: bool) -> Result<()> {
         let mut new_imports = Vec::new();
         let mut new_exports = Vec::new();
 
@@ -478,7 +478,9 @@ impl Resolve {
                 Some(into_import) => match (from_import, into_import) {
                     // If these imports, which have the same name, are of the
                     // same interface then union them together at this point.
-                    (WorldItem::Interface(from), WorldItem::Interface(into)) if from == into => {
+                    (WorldItem::Interface(from), WorldItem::Interface(into))
+                        if force_union || from == into =>
+                    {
                         continue
                     }
                     _ => bail!("duplicate import found for interface `{name}`"),

--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -111,7 +111,7 @@ impl NewOpts {
             .module(&wasm)?;
 
         for (name, wasm) in self.adapters.iter() {
-            encoder = encoder.adapter(name, wasm)?;
+            encoder = encoder.adapter(name, wasm, false)?;
         }
 
         let bytes = encoder


### PR DESCRIPTION
I've got a workflow where I'm adapting a preview1 component to preview2, where that component itself has world bindings to preview2 as well. The version APIs exactly match (so there should be type equality), but I'm getting the error:

```
     Error: failed to merge WIT world of adapter `wasi_snapshot_preview1` into main package

Caused by:
    duplicate import found for interface `environment`
```

This change adds a `force_merge` option to the adapter to inform that imports are known to be equivalent.