### PR TITLE
Rename HeapType::TypedFunc(u32) to Indexed(u32)

### DIFF
--- a/crates/wasm-compose/src/encoding.rs
+++ b/crates/wasm-compose/src/encoding.rs
@@ -288,7 +288,7 @@ impl<'a> TypeEncoder<'a> {
                 wasmparser::HeapType::Struct => HeapType::Struct,
                 wasmparser::HeapType::Array => HeapType::Array,
                 wasmparser::HeapType::I31 => HeapType::I31,
-                wasmparser::HeapType::TypedFunc(i) => HeapType::TypedFunc(i.into()),
+                wasmparser::HeapType::Indexed(i) => HeapType::Indexed(i.into()),
             },
         }
     }

--- a/crates/wasm-encoder/src/core/types.rs
+++ b/crates/wasm-encoder/src/core/types.rs
@@ -120,8 +120,8 @@ pub enum HeapType {
     Array,
     /// The i31 heap type.
     I31,
-    /// Function of the type at the given index.
-    TypedFunc(u32),
+    /// User defined type at the given index.
+    Indexed(u32),
 }
 
 impl Encode for HeapType {
@@ -139,7 +139,7 @@ impl Encode for HeapType {
             HeapType::I31 => sink.push(0x6A),
             // Note that this is encoded as a signed type rather than unsigned
             // as it's decoded as an s33
-            HeapType::TypedFunc(i) => i64::from(*i).encode(sink),
+            HeapType::Indexed(i) => i64::from(*i).encode(sink),
         }
     }
 }

--- a/crates/wasm-mutate/src/module.rs
+++ b/crates/wasm-mutate/src/module.rs
@@ -98,7 +98,7 @@ pub fn map_ref_type(ref_ty: wasmparser::RefType) -> Result<RefType> {
             wasmparser::HeapType::Struct => HeapType::Struct,
             wasmparser::HeapType::Array => HeapType::Array,
             wasmparser::HeapType::I31 => HeapType::I31,
-            wasmparser::HeapType::TypedFunc(i) => HeapType::TypedFunc(i.into()),
+            wasmparser::HeapType::Indexed(i) => HeapType::Indexed(i.into()),
         },
     })
 }

--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -211,8 +211,8 @@ pub fn heapty(t: &mut dyn Translator, ty: &wasmparser::HeapType) -> Result<HeapT
         wasmparser::HeapType::Struct => Ok(HeapType::Struct),
         wasmparser::HeapType::Array => Ok(HeapType::Array),
         wasmparser::HeapType::I31 => Ok(HeapType::I31),
-        wasmparser::HeapType::TypedFunc(i) => {
-            Ok(HeapType::TypedFunc(t.remap(Item::Type, (*i).into())?))
+        wasmparser::HeapType::Indexed(i) => {
+            Ok(HeapType::Indexed(t.remap(Item::Type, (*i).into())?))
         }
     }
 }

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -1654,7 +1654,7 @@ fn convert_reftype(ty: wasmparser::RefType) -> RefType {
             wasmparser::HeapType::Struct => HeapType::Struct,
             wasmparser::HeapType::Array => HeapType::Array,
             wasmparser::HeapType::I31 => HeapType::I31,
-            wasmparser::HeapType::TypedFunc(i) => HeapType::TypedFunc(i.into()),
+            wasmparser::HeapType::Indexed(i) => HeapType::Indexed(i.into()),
         },
     }
 }

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -192,8 +192,8 @@ impl Debug for RefType {
             (false, HeapType::Extern) => write!(f, "(ref extern)"),
             (true, HeapType::Func) => write!(f, "funcref"),
             (false, HeapType::Func) => write!(f, "(ref func)"),
-            (true, HeapType::TypedFunc(idx)) => write!(f, "(ref null {idx})"),
-            (false, HeapType::TypedFunc(idx)) => write!(f, "(ref {idx})"),
+            (true, HeapType::Indexed(idx)) => write!(f, "(ref null {idx})"),
+            (false, HeapType::Indexed(idx)) => write!(f, "(ref {idx})"),
         }
     }
 }
@@ -306,15 +306,6 @@ impl RefType {
     const fn from_u32(x: u32) -> Self {
         debug_assert!(x & (0b11111111 << 24) == 0);
 
-        // if indexed, kind must be struct/array/func
-        debug_assert!(
-            x & Self::INDEXED_BIT == 0
-                || matches!(
-                    x & Self::KIND_MASK,
-                    Self::FUNC_KIND | Self::ARRAY_KIND | Self::STRUCT_KIND
-                )
-        );
-
         // if not indexed, type must be any/eq/i31/struct/array/func/extern/nofunc/noextern/none
         debug_assert!(
             x & Self::INDEXED_BIT != 0
@@ -382,7 +373,7 @@ impl RefType {
     pub const fn new(nullable: bool, heap_type: HeapType) -> Option<Self> {
         let nullable32 = Self::NULLABLE_BIT * nullable as u32;
         match heap_type {
-            HeapType::TypedFunc(index) => RefType::indexed_func(nullable, index),
+            HeapType::Indexed(index) => RefType::indexed(nullable, 0, index), // 0 bc we don't know the kind
             HeapType::Func => Some(Self::from_u32(nullable32 | Self::FUNC_TYPE)),
             HeapType::Extern => Some(Self::from_u32(nullable32 | Self::EXTERN_TYPE)),
             HeapType::Any => Some(Self::from_u32(nullable32 | Self::ANY_TYPE)),
@@ -408,7 +399,7 @@ impl RefType {
 
     /// If this is a reference to a typed function, get its type index.
     pub const fn type_index(&self) -> Option<u32> {
-        if self.is_typed_func_ref() {
+        if self.is_indexed_type_ref() {
             Some(self.as_u32() & Self::INDEX_MASK)
         } else {
             None
@@ -444,10 +435,7 @@ impl RefType {
     pub fn heap_type(&self) -> HeapType {
         let s = self.as_u32();
         if self.is_indexed_type_ref() {
-            match s & Self::KIND_MASK {
-                Self::FUNC_KIND => HeapType::TypedFunc(self.type_index().unwrap()),
-                _ => unreachable!(),
-            }
+            HeapType::Indexed(self.type_index().unwrap())
         } else {
             match s & Self::TYPE_MASK {
                 Self::FUNC_TYPE => HeapType::Func,
@@ -471,7 +459,7 @@ impl RefType {
         match (self.is_nullable(), self.heap_type()) {
             (true, HeapType::Func) => "funcref",
             (true, HeapType::Extern) => "externref",
-            (true, HeapType::TypedFunc(_)) => "(ref null $type)",
+            (true, HeapType::Indexed(_)) => "(ref null $type)",
             (true, HeapType::Any) => "anyref",
             (true, HeapType::None) => "nullref",
             (true, HeapType::NoExtern) => "nullexternref",
@@ -482,7 +470,7 @@ impl RefType {
             (true, HeapType::I31) => "i31ref",
             (false, HeapType::Func) => "(ref func)",
             (false, HeapType::Extern) => "(ref extern)",
-            (false, HeapType::TypedFunc(_)) => "(ref $type)",
+            (false, HeapType::Indexed(_)) => "(ref $type)",
             (false, HeapType::Any) => "(ref any)",
             (false, HeapType::None) => "(ref none)",
             (false, HeapType::NoExtern) => "(ref noextern)",
@@ -526,7 +514,7 @@ impl fmt::Display for RefType {
         let s = match (self.is_nullable(), self.heap_type()) {
             (true, HeapType::Func) => "funcref",
             (true, HeapType::Extern) => "externref",
-            (true, HeapType::TypedFunc(i)) => return write!(f, "(ref null {i})"),
+            (true, HeapType::Indexed(i)) => return write!(f, "(ref null {i})"),
             (true, HeapType::Any) => "anyref",
             (true, HeapType::None) => "nullref",
             (true, HeapType::NoExtern) => "nullexternref",
@@ -537,7 +525,7 @@ impl fmt::Display for RefType {
             (true, HeapType::I31) => "i31ref",
             (false, HeapType::Func) => "(ref func)",
             (false, HeapType::Extern) => "(ref extern)",
-            (false, HeapType::TypedFunc(i)) => return write!(f, "(ref {i})"),
+            (false, HeapType::Indexed(i)) => return write!(f, "(ref {i})"),
             (false, HeapType::Any) => "(ref any)",
             (false, HeapType::None) => "(ref none)",
             (false, HeapType::NoExtern) => "(ref noextern)",
@@ -556,7 +544,7 @@ impl fmt::Display for RefType {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum HeapType {
     /// User defined type at the given index.
-    TypedFunc(u32),
+    Indexed(u32),
     /// Untyped (any) function.
     Func,
     /// External heap type.
@@ -627,10 +615,10 @@ impl<'a> FromReader<'a> for HeapType {
                 let idx = match u32::try_from(reader.read_var_s33()?) {
                     Ok(idx) => idx,
                     Err(_) => {
-                        bail!(reader.original_position(), "invalid function heap type",);
+                        bail!(reader.original_position(), "invalid indexed ref heap type");
                     }
                 };
-                Ok(HeapType::TypedFunc(idx))
+                Ok(HeapType::Indexed(idx))
             }
         }
     }

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -271,7 +271,7 @@ impl WasmFeatures {
                             (_, false) => {
                                 Err("function references required for non-nullable types")
                             }
-                            (HeapType::TypedFunc(_), _) => {
+                            (HeapType::Indexed(_), _) => {
                                 Err("function references required for index reference types")
                             }
                             _ => Ok(()),

--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -1500,7 +1500,7 @@ impl ComponentState {
                         crate::OuterAliasKind::Type => {
                             let ty = if count == 0 {
                                 // Local alias, check the local module state
-                                state.type_at(index, offset)?
+                                state.type_id_at(index, offset)?
                             } else {
                                 // Otherwise, check the enclosing component state
                                 let component =

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -1272,14 +1272,14 @@ where
         Ok(())
     }
     fn visit_call_ref(&mut self, type_index: u32) -> Self::Output {
-        let hty = HeapType::TypedFunc(type_index);
+        let hty = HeapType::Indexed(type_index);
         self.resources
             .check_heap_type(hty, &self.features, self.offset)?;
         // If `None` is popped then that means a "bottom" type was popped which
         // is always considered equivalent to the `hty` tag.
         if let Some(rt) = self.pop_ref()? {
-            let expected =
-                RefType::new(true, hty).expect("existing heap types should be within our limits");
+            let expected = RefType::indexed_func(true, type_index)
+                .expect("existing heap types should be within our limits");
             if !self
                 .resources
                 .matches(ValType::Ref(rt), ValType::Ref(expected))
@@ -2291,9 +2291,8 @@ where
         // FIXME(#924) this should not be conditional based on enabled
         // proposals.
         if self.features.function_references {
-            let heap_type = HeapType::TypedFunc(type_index);
             self.push_operand(
-                RefType::new(false, heap_type)
+                RefType::indexed_func(false, type_index)
                     .expect("our limits on number of types should fit into ref type"),
             )?;
         } else {

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -789,7 +789,7 @@ impl Printer {
             HeapType::Struct => self.result.push_str("struct"),
             HeapType::Array => self.result.push_str("array"),
             HeapType::I31 => self.result.push_str("i31"),
-            HeapType::TypedFunc(i) => self.result.push_str(&format!("{}", u32::from(i))),
+            HeapType::Indexed(i) => self.result.push_str(&format!("{}", u32::from(i))),
         }
         Ok(())
     }

--- a/crates/wast/src/component/binary.rs
+++ b/crates/wast/src/component/binary.rs
@@ -589,7 +589,7 @@ impl From<core::HeapType<'_>> for wasm_encoder::HeapType {
         match r {
             core::HeapType::Func => Self::Func,
             core::HeapType::Extern => Self::Extern,
-            core::HeapType::Index(Index::Num(i, _)) => Self::TypedFunc(i),
+            core::HeapType::Index(Index::Num(i, _)) => Self::Indexed(i),
             core::HeapType::Index(_) => panic!("unresolved index"),
             core::HeapType::Any
             | core::HeapType::Eq

--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -492,7 +492,7 @@ impl<'a> Module<'a> {
             | HeapType::Struct
             | HeapType::Array
             | HeapType::I31 => {}
-            HeapType::TypedFunc(i) => self.ty(i.into()),
+            HeapType::Indexed(i) => self.ty(i.into()),
         }
     }
 
@@ -1126,8 +1126,8 @@ impl Encoder {
             HeapType::Struct => wasm_encoder::HeapType::Struct,
             HeapType::Array => wasm_encoder::HeapType::Array,
             HeapType::I31 => wasm_encoder::HeapType::I31,
-            HeapType::TypedFunc(idx) => {
-                wasm_encoder::HeapType::TypedFunc(self.types.remap(idx.into()).try_into().unwrap())
+            HeapType::Indexed(idx) => {
+                wasm_encoder::HeapType::Indexed(self.types.remap(idx.into()).try_into().unwrap())
             }
         }
     }


### PR DESCRIPTION
`HeapType::TypedFunc(u32)` has been (as of [typed references](https://github.com/WebAssembly/function-references) proposal) used to refer function types defined in the module.

It is parsed from `(ref null? {index})`. With introduction of new indexed types for GC, there's unfortunately no way to tell what type the index is pointing to while parsing: they used to be all `func` types, but now can also be `array`, `struct` and more.

Renaming HeapType::TypedFunc(u32) to Indexed(u32) reflects this change.

Summary of the changes:
- Match RefTypes where one or both has HeapType::Indexed.
- `RefType::new()` will now create indexed RefType with unknown kind.
- Use `RefType::indexed_func()` instead of `RefType::new()` for indexed func refs.
- Add `Self::ARRAY_KIND` to the list of matched RefType kinds - when getting HeapType of a RefType.
- Check if two indexed types are equal.