### PR TITLE
[wast] Add support for final types.

### DIFF
--- a/crates/wast/src/component/expand.rs
+++ b/crates/wast/src/component/expand.rs
@@ -488,6 +488,7 @@ impl<'a> Expander<'a> {
                         name: None,
                         def: key.to_def(item.span),
                         parent: None,
+                        final_type: None,
                     }));
                     let idx = Index::Id(id);
                     t.index = Some(idx);

--- a/crates/wast/src/core/resolve/types.rs
+++ b/crates/wast/src/core/resolve/types.rs
@@ -218,6 +218,7 @@ impl<'a> Expander<'a> {
             name: None,
             def: key.to_def(span),
             parent: None,
+            final_type: None,
         }));
         let idx = Index::Id(id);
         key.insert(self, idx);

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -474,6 +474,7 @@ pub mod kw {
     custom_keyword!(shared);
     custom_keyword!(start);
     custom_keyword!(sub);
+    custom_keyword!(r#final = "final");
     custom_keyword!(table);
     custom_keyword!(then);
     custom_keyword!(r#try = "try");

--- a/tests/local/gc/gc-rec-sub.wat
+++ b/tests/local/gc/gc-rec-sub.wat
@@ -35,5 +35,8 @@
   (rec
     (type (sub $a (func)))
   )
+  (rec
+    (type (sub final $a (func)))
+  )
   (type (sub $a (func)))
 )


### PR DESCRIPTION
The GC proposal contains a final type: https://github.com/WebAssembly/gc/blob/main/proposals/gc/MVP.md#type-definitions

This commit add support for it in wast. All types are considered final unless the `sub` keyword is used.
A type marked `(sub final)` will be final.

We are currently implementing this at Mozilla (see https://bugzilla.mozilla.org/show_bug.cgi?id=1825088)