### PR TITLE
ci: add clippy job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,15 @@ jobs:
     - name: Install Rust
       run: rustup update stable && rustup default stable && rustup component add rustfmt
     - run: cargo fmt -- --check
+  
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Rust
+      run: rustup update stable && rustup default stable
+    - run: cargo clippy --all -- -D warnings
 
   fuzz:
     name: Fuzz

--- a/crates/wasm-compose/src/encoding.rs
+++ b/crates/wasm-compose/src/encoding.rs
@@ -288,7 +288,7 @@ impl<'a> TypeEncoder<'a> {
                 wasmparser::HeapType::Struct => HeapType::Struct,
                 wasmparser::HeapType::Array => HeapType::Array,
                 wasmparser::HeapType::I31 => HeapType::I31,
-                wasmparser::HeapType::Indexed(i) => HeapType::Indexed(i.into()),
+                wasmparser::HeapType::Indexed(i) => HeapType::Indexed(i),
             },
         }
     }

--- a/crates/wasm-compose/src/graph.rs
+++ b/crates/wasm-compose/src/graph.rs
@@ -1124,7 +1124,7 @@ mod test {
             validate: true,
         })?;
 
-        let wat = wasmprinter::print_bytes(&encoded)?;
+        let wat = wasmprinter::print_bytes(encoded)?;
         assert_eq!(r#"(component)"#, wat);
 
         Ok(())
@@ -1144,7 +1144,7 @@ mod test {
             validate: true,
         })?;
 
-        let wat = wasmprinter::print_bytes(&encoded)?.replace("\r\n", "\n");
+        let wat = wasmprinter::print_bytes(encoded)?.replace("\r\n", "\n");
         assert_eq!(
             r#"(component
   (type (;0;)
@@ -1173,7 +1173,7 @@ mod test {
             validate: true,
         })?;
 
-        let wat = wasmprinter::print_bytes(&encoded)?.replace("\r\n", "\n");
+        let wat = wasmprinter::print_bytes(encoded)?.replace("\r\n", "\n");
         assert_eq!(
             r#"(component
   (component (;0;))
@@ -1236,7 +1236,7 @@ mod test {
             validate: true,
         })?;
 
-        let wat = wasmprinter::print_bytes(&encoded)?.replace("\r\n", "\n");
+        let wat = wasmprinter::print_bytes(encoded)?.replace("\r\n", "\n");
         assert_eq!(
             r#"(component
   (type (;0;)

--- a/crates/wasm-compose/tests/compose.rs
+++ b/crates/wasm-compose/tests/compose.rs
@@ -94,10 +94,10 @@ fn component_composing() -> Result<()> {
         };
 
         if std::env::var_os("BLESS").is_some() {
-            fs::write(&baseline_path, output + "\n")?;
+            fs::write(baseline_path, output + "\n")?;
         } else {
             assert_eq!(
-                fs::read_to_string(&baseline_path)
+                fs::read_to_string(baseline_path)
                     .with_context(|| format!(
                         "failed to read component baseline `{}`",
                         baseline_path.display()

--- a/crates/wasm-encoder/src/component/names.rs
+++ b/crates/wasm-encoder/src/component/names.rs
@@ -128,7 +128,7 @@ impl ComponentNameSection {
     }
 
     /// View the encoded section as a CustomSection.
-    pub fn as_custom<'a>(&'a self) -> CustomSection<'a> {
+    pub fn as_custom(&self) -> CustomSection<'_> {
         CustomSection {
             name: "component-name".into(),
             data: Cow::Borrowed(&self.bytes),

--- a/crates/wasm-encoder/src/core/dump.rs
+++ b/crates/wasm-encoder/src/core/dump.rs
@@ -57,7 +57,7 @@ impl CoreDumpSection {
     }
 
     /// View the encoded section as a CustomSection.
-    fn as_custom<'a>(&'a self) -> CustomSection<'a> {
+    fn as_custom(&self) -> CustomSection<'_> {
         let mut data = vec![0];
         self.name.encode(&mut data);
         CustomSection {
@@ -267,7 +267,7 @@ impl CoreDumpStackSection {
     }
 
     /// View the encoded section as a CustomSection.
-    pub fn as_custom<'a>(&'a self) -> CustomSection<'a> {
+    pub fn as_custom(&self) -> CustomSection<'_> {
         let mut data = vec![0];
         self.name.encode(&mut data);
         self.count.encode(&mut data);

--- a/crates/wasm-encoder/src/core/elements.rs
+++ b/crates/wasm-encoder/src/core/elements.rs
@@ -102,7 +102,7 @@ impl ElementSection {
     }
 
     /// Define an element segment.
-    pub fn segment<'a>(&mut self, segment: ElementSegment<'a>) -> &mut Self {
+    pub fn segment(&mut self, segment: ElementSegment<'_>) -> &mut Self {
         let expr_bit = match segment.elements {
             Elements::Expressions(_) => 0b100u32,
             Elements::Functions(_) => 0b000u32,
@@ -184,7 +184,7 @@ impl ElementSection {
     /// Encode a passive element segment.
     ///
     /// Passive segments are part of the bulk memory proposal.
-    pub fn passive<'a>(&mut self, element_type: RefType, elements: Elements<'a>) -> &mut Self {
+    pub fn passive(&mut self, element_type: RefType, elements: Elements<'_>) -> &mut Self {
         self.segment(ElementSegment {
             mode: ElementMode::Passive,
             element_type,
@@ -195,7 +195,7 @@ impl ElementSection {
     /// Encode a declared element segment.
     ///
     /// Declared segments are part of the bulk memory proposal.
-    pub fn declared<'a>(&mut self, element_type: RefType, elements: Elements<'a>) -> &mut Self {
+    pub fn declared(&mut self, element_type: RefType, elements: Elements<'_>) -> &mut Self {
         self.segment(ElementSegment {
             mode: ElementMode::Declared,
             element_type,

--- a/crates/wasm-encoder/src/core/names.rs
+++ b/crates/wasm-encoder/src/core/names.rs
@@ -153,7 +153,7 @@ impl NameSection {
     }
 
     /// View the encoded section as a CustomSection.
-    pub fn as_custom<'a>(&'a self) -> CustomSection<'a> {
+    pub fn as_custom(&self) -> CustomSection<'_> {
         CustomSection {
             name: "name".into(),
             data: Cow::Borrowed(&self.bytes),

--- a/crates/wasm-encoder/src/core/producers.rs
+++ b/crates/wasm-encoder/src/core/producers.rs
@@ -25,6 +25,7 @@ use crate::{CustomSection, Encode, Section, SectionId};
 /// let wasm_bytes = module.finish();
 /// ```
 #[derive(Clone, Debug)]
+#[derive(Default)]
 pub struct ProducersSection {
     bytes: Vec<u8>,
     num_fields: u32,
@@ -47,14 +48,7 @@ impl ProducersSection {
     }
 }
 
-impl Default for ProducersSection {
-    fn default() -> Self {
-        Self {
-            bytes: Vec::new(),
-            num_fields: 0,
-        }
-    }
-}
+
 
 impl Encode for ProducersSection {
     fn encode(&self, sink: &mut Vec<u8>) {
@@ -78,6 +72,7 @@ impl Section for ProducersSection {
 
 /// The value of a field in the producers custom section
 #[derive(Clone, Debug)]
+#[derive(Default)]
 pub struct ProducersField {
     bytes: Vec<u8>,
     num_values: u32,
@@ -100,14 +95,7 @@ impl ProducersField {
     }
 }
 
-impl Default for ProducersField {
-    fn default() -> Self {
-        Self {
-            bytes: Vec::new(),
-            num_values: 0,
-        }
-    }
-}
+
 
 impl Encode for ProducersField {
     fn encode(&self, sink: &mut Vec<u8>) {

--- a/crates/wasm-encoder/src/core/producers.rs
+++ b/crates/wasm-encoder/src/core/producers.rs
@@ -24,8 +24,7 @@ use crate::{CustomSection, Encode, Section, SectionId};
 /// module.section(&producers);
 /// let wasm_bytes = module.finish();
 /// ```
-#[derive(Clone, Debug)]
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct ProducersSection {
     bytes: Vec<u8>,
     num_fields: u32,
@@ -48,8 +47,6 @@ impl ProducersSection {
     }
 }
 
-
-
 impl Encode for ProducersSection {
     fn encode(&self, sink: &mut Vec<u8>) {
         let mut data = Vec::new();
@@ -71,8 +68,7 @@ impl Section for ProducersSection {
 }
 
 /// The value of a field in the producers custom section
-#[derive(Clone, Debug)]
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct ProducersField {
     bytes: Vec<u8>,
     num_values: u32,
@@ -94,8 +90,6 @@ impl ProducersField {
         self
     }
 }
-
-
 
 impl Encode for ProducersField {
     fn encode(&self, sink: &mut Vec<u8>) {

--- a/crates/wasm-mutate-stats/src/bin/wasm-mutate-stats.rs
+++ b/crates/wasm-mutate-stats/src/bin/wasm-mutate-stats.rs
@@ -300,7 +300,6 @@ impl State {
         let generation_start = std::time::Instant::now();
 
         let threads = (0..self.corpus.len())
-            .into_iter()
             .map(|usize| {
                 let state = self.clone();
                 let artifact_folder = artifact_folders[usize].clone();

--- a/crates/wasm-mutate/tests/tests.rs
+++ b/crates/wasm-mutate/tests/tests.rs
@@ -6,9 +6,9 @@ fn validate(validator: &mut Validator, bytes: &[u8]) {
         Ok(_) => return,
         Err(e) => e,
     };
-    drop(std::fs::write("test.wasm", &bytes));
+    drop(std::fs::write("test.wasm", bytes));
     if let Ok(text) = wasmprinter::print_bytes(bytes) {
-        drop(std::fs::write("test.wat", &text));
+        drop(std::fs::write("test.wat", text));
     }
 
     panic!("Wasm failed to validate: {:?}", err);

--- a/crates/wasm-shrink/src/lib.rs
+++ b/crates/wasm-shrink/src/lib.rs
@@ -10,7 +10,7 @@ use rand::{rngs::SmallRng, Rng, SeedableRng};
 use wasm_mutate::WasmMutate;
 
 #[rustfmt::skip]
-static EMPTY_WASM: &'static [u8] = &[
+static EMPTY_WASM: &[u8] = &[
     // Magic.
     0x00, b'a', b's', b'm',
     // Version.

--- a/crates/wasm-shrink/tests/tests.rs
+++ b/crates/wasm-shrink/tests/tests.rs
@@ -44,7 +44,7 @@ fn shrink_to_empty_allowed() -> Result<()> {
 #[test]
 fn smoke_test() -> Result<()> {
     let info = WasmShrink::default().attempts(100).run(wasm(), |wasm| {
-        let wat = wasmprinter::print_bytes(&wasm)?;
+        let wat = wasmprinter::print_bytes(wasm)?;
         Ok(wat.contains("local.get"))
     })?;
 

--- a/crates/wasm-smith/src/component.rs
+++ b/crates/wasm-smith/src/component.rs
@@ -612,9 +612,9 @@ impl ComponentBuilder {
         Ok(Step::StillBuilding)
     }
 
-    fn arbitrary_type_ref<'a>(
+    fn arbitrary_type_ref(
         &self,
-        u: &mut Unstructured<'a>,
+        u: &mut Unstructured<'_>,
         for_import: bool,
         for_type_def: bool,
     ) -> Result<Option<ComponentTypeRef>> {

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -625,7 +625,7 @@ impl Module {
                     if self.funcs.len() >= self.config.max_funcs() {
                         continue;
                     } else if let Some((sig_idx, func_type)) = make_func_type(*sig_idx) {
-                        let entity = EntityType::Func(sig_idx as u32, Rc::clone(&func_type));
+                        let entity = EntityType::Func(sig_idx, Rc::clone(&func_type));
                         if type_size_budget < entity.size() {
                             continue;
                         }
@@ -828,7 +828,7 @@ impl Module {
         arbitrary_loop(
             u,
             self.config.min_tables() as usize,
-            self.config.max_tables() as usize,
+            self.config.max_tables(),
             |u| {
                 if !self.can_add_local_or_import_table() {
                     return Ok(false);
@@ -845,7 +845,7 @@ impl Module {
         arbitrary_loop(
             u,
             self.config.min_memories() as usize,
-            self.config.max_memories() as usize,
+            self.config.max_memories(),
             |u| {
                 if !self.can_add_local_or_import_memory() {
                     return Ok(false);
@@ -1002,7 +1002,7 @@ impl Module {
             return Ok(());
         }
 
-        let mut choices = Vec::with_capacity(self.funcs.len() as usize);
+        let mut choices = Vec::with_capacity(self.funcs.len());
 
         for (func_idx, ty) in self.funcs() {
             if ty.params.is_empty() && ty.results.is_empty() {
@@ -1654,7 +1654,7 @@ fn convert_reftype(ty: wasmparser::RefType) -> RefType {
             wasmparser::HeapType::Struct => HeapType::Struct,
             wasmparser::HeapType::Array => HeapType::Array,
             wasmparser::HeapType::I31 => HeapType::I31,
-            wasmparser::HeapType::Indexed(i) => HeapType::Indexed(i.into()),
+            wasmparser::HeapType::Indexed(i) => HeapType::Indexed(i),
         },
     }
 }

--- a/crates/wasm-smith/src/core/terminate.rs
+++ b/crates/wasm-smith/src/core/terminate.rs
@@ -1,5 +1,5 @@
 use super::*;
-use std::mem;
+
 use wasm_encoder::BlockType;
 
 impl Module {
@@ -52,7 +52,7 @@ impl Module {
             // recursion.
             check_fuel(&mut new_insts);
 
-            for inst in mem::replace(instrs, vec![]) {
+            for inst in std::mem::take(instrs) {
                 let is_loop = matches!(&inst, Instruction::Loop(_));
                 new_insts.push(inst);
 

--- a/crates/wasm-smith/tests/core.rs
+++ b/crates/wasm-smith/tests/core.rs
@@ -278,8 +278,7 @@ fn import_config(
             )
             "#,
         )
-        .unwrap()
-        .into(),
+        .unwrap(),
     );
     (config, available)
 }
@@ -314,9 +313,9 @@ fn validate(validator: &mut Validator, bytes: &[u8]) {
         Ok(_) => return,
         Err(e) => e,
     };
-    drop(std::fs::write("test.wasm", &bytes));
+    drop(std::fs::write("test.wasm", bytes));
     if let Ok(text) = wasmprinter::print_bytes(bytes) {
-        drop(std::fs::write("test.wat", &text));
+        drop(std::fs::write("test.wat", text));
     }
     panic!("wasm failed to validate {:?}", err);
 }

--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -5,7 +5,7 @@ use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 use wasmparser::{
-    DataKind, ElementKind, HeapType, Parser, Payload, ValType, Validator, VisitOperator,
+    DataKind, ElementKind, Parser, Payload, Validator, VisitOperator,
     WasmFeatures,
 };
 

--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -4,10 +4,7 @@ use once_cell::unsync::Lazy;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
-use wasmparser::{
-    DataKind, ElementKind, Parser, Payload, Validator, VisitOperator,
-    WasmFeatures,
-};
+use wasmparser::{DataKind, ElementKind, Parser, Payload, Validator, VisitOperator, WasmFeatures};
 
 /// A benchmark input.
 pub struct BenchmarkInput {

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -94,7 +94,7 @@ impl BinaryReaderError {
     }
 
     pub(crate) fn add_context(&mut self, mut context: String) {
-        context.push_str("\n");
+        context.push('\n');
         self.inner.message.insert_str(0, &context);
     }
 }
@@ -700,10 +700,10 @@ impl<'a> BinaryReader<'a> {
         match u32::try_from(idx) {
             Ok(idx) => Ok(BlockType::FuncType(idx)),
             Err(_) => {
-                return Err(BinaryReaderError::new(
+                Err(BinaryReaderError::new(
                     "invalid function type",
                     self.original_position(),
-                ));
+                ))
             }
         }
     }
@@ -758,7 +758,7 @@ impl<'a> BinaryReader<'a> {
         T: VisitOperator<'a>,
     {
         let pos = self.original_position();
-        let code = self.read_u8()? as u8;
+        let code = self.read_u8()?;
         Ok(match code {
             0x00 => visitor.visit_unreachable(),
             0x01 => visitor.visit_nop(),

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -699,12 +699,10 @@ impl<'a> BinaryReader<'a> {
         let idx = self.read_var_s33()?;
         match u32::try_from(idx) {
             Ok(idx) => Ok(BlockType::FuncType(idx)),
-            Err(_) => {
-                Err(BinaryReaderError::new(
-                    "invalid function type",
-                    self.original_position(),
-                ))
-            }
+            Err(_) => Err(BinaryReaderError::new(
+                "invalid function type",
+                self.original_position(),
+            )),
         }
     }
 

--- a/crates/wasmparser/src/readers/core/coredumps.rs
+++ b/crates/wasmparser/src/readers/core/coredumps.rs
@@ -157,10 +157,7 @@ impl<'a> FromReader<'a> for CoreDumpStackSection<'a> {
         for _ in 0..reader.read_var_u32()? {
             frames.push(CoreDumpStackFrame::from_reader(reader)?);
         }
-        Ok(CoreDumpStackSection {
-            name,
-            frames,
-        })
+        Ok(CoreDumpStackSection { name, frames })
     }
 }
 

--- a/crates/wasmparser/src/readers/core/coredumps.rs
+++ b/crates/wasmparser/src/readers/core/coredumps.rs
@@ -158,8 +158,8 @@ impl<'a> FromReader<'a> for CoreDumpStackSection<'a> {
             frames.push(CoreDumpStackFrame::from_reader(reader)?);
         }
         Ok(CoreDumpStackSection {
-            name: name,
-            frames: frames,
+            name,
+            frames,
         })
     }
 }

--- a/crates/wasmparser/src/readers/core/tables.rs
+++ b/crates/wasmparser/src/readers/core/tables.rs
@@ -47,10 +47,8 @@ impl<'a> FromReader<'a> for Table<'a> {
             false
         };
 
-        if has_init_expr {
-            if reader.read_u8()? != 0x00 {
-                bail!(reader.original_position() - 1, "invalid table encoding");
-            }
+        if has_init_expr && reader.read_u8()? != 0x00 {
+            bail!(reader.original_position() - 1, "invalid table encoding");
         }
 
         let ty = reader.read::<TableType>()?;

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -731,21 +731,21 @@ impl FuncType {
 
     pub(crate) fn desc(&self) -> String {
         let mut s = String::new();
-        s.push_str("[");
+        s.push('[');
         for (i, param) in self.params().iter().enumerate() {
             if i > 0 {
-                s.push_str(" ");
+                s.push(' ');
             }
             write!(s, "{param}").unwrap();
         }
         s.push_str("] -> [");
         for (i, result) in self.results().iter().enumerate() {
             if i > 0 {
-                s.push_str(" ");
+                s.push(' ');
             }
             write!(s, "{result}").unwrap();
         }
-        s.push_str("]");
+        s.push(']');
         s
     }
 }

--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -391,7 +391,7 @@ impl ComponentState {
                 if let Some(dtor) = dtor {
                     let ty = component.core_function_at(dtor, offset)?;
                     let ty = types[ty].as_func_type().unwrap();
-                    if ty.params() != [rep] || ty.results() != [] {
+                    if ty.params() != [rep] || !ty.results().is_empty() {
                         bail!(
                             offset,
                             "core function {dtor} has wrong signature for a destructor"
@@ -1099,7 +1099,7 @@ impl ComponentState {
         }
     }
 
-    fn resource_at<'a>(&self, idx: u32, types: &'a TypeList, offset: usize) -> Result<TypeId> {
+    fn resource_at(&self, idx: u32, types: &TypeList, offset: usize) -> Result<TypeId> {
         let id = self.type_at(idx, false, offset)?;
         match &types[id] {
             Type::Resource(_) => Ok(id),

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -21,8 +21,7 @@ use std::{collections::HashSet, sync::Arc};
 //
 // Component sections are unordered and allow for duplicates,
 // so this isn't used for components.
-#[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Debug)]
-#[derive(Default)]
+#[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Debug, Default)]
 pub enum Order {
     #[default]
     Initial,
@@ -40,8 +39,6 @@ pub enum Order {
     Code,
     Data,
 }
-
-
 
 #[derive(Default)]
 pub(crate) struct ModuleState {
@@ -901,15 +898,11 @@ impl Module {
                         _ => false,
                     }
                 }
-                (HeapType::Indexed(n1), HeapType::Func) => {
-                    self.func_type_at(n1, types, 0).is_ok()
-                }
-                (HeapType::Indexed(n1), HeapType::Array) => {
-                    match self.type_at(types, n1, 0) {
-                        Ok(Type::Array(_)) => true,
-                        _ => false,
-                    }
-                }
+                (HeapType::Indexed(n1), HeapType::Func) => self.func_type_at(n1, types, 0).is_ok(),
+                (HeapType::Indexed(n1), HeapType::Array) => match self.type_at(types, n1, 0) {
+                    Ok(Type::Array(_)) => true,
+                    _ => false,
+                },
                 (_, _) => ty1 == ty2,
             }
         };

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -22,7 +22,9 @@ use std::{collections::HashSet, sync::Arc};
 // Component sections are unordered and allow for duplicates,
 // so this isn't used for components.
 #[derive(Copy, Clone, PartialOrd, Ord, PartialEq, Eq, Debug)]
+#[derive(Default)]
 pub enum Order {
+    #[default]
     Initial,
     Type,
     Import,
@@ -39,11 +41,7 @@ pub enum Order {
     Data,
 }
 
-impl Default for Order {
-    fn default() -> Order {
-        Order::Initial
-    }
-}
+
 
 #[derive(Default)]
 pub(crate) struct ModuleState {
@@ -845,8 +843,8 @@ impl Module {
     }
 
     fn eq_indexed_types(&self, n1: u32, n2: u32, types: &TypeList) -> bool {
-        let n1 = self.type_at(types, n1.into(), 0).unwrap();
-        let n2 = self.type_at(types, n2.into(), 0).unwrap();
+        let n1 = self.type_at(types, n1, 0).unwrap();
+        let n2 = self.type_at(types, n2, 0).unwrap();
         match (n1, n2) {
             (Type::Func(f1), Type::Func(f2)) => self.eq_fns(f1, f2, types),
             (Type::Array(a1), Type::Array(a2)) => {
@@ -887,8 +885,8 @@ impl Module {
             match (ty1, ty2) {
                 (HeapType::Indexed(n1), HeapType::Indexed(n2)) => {
                     // Check whether the defined types are (structurally) equivalent.
-                    let n1 = self.type_at(types, n1.into(), 0);
-                    let n2 = self.type_at(types, n2.into(), 0);
+                    let n1 = self.type_at(types, n1, 0);
+                    let n2 = self.type_at(types, n2, 0);
                     match (n1, n2) {
                         (Ok(Type::Func(n1)), Ok(Type::Func(n2))) => self.eq_fns(n1, n2, types),
                         (Ok(Type::Array(n1)), Ok(Type::Array(n2))) => {
@@ -904,10 +902,10 @@ impl Module {
                     }
                 }
                 (HeapType::Indexed(n1), HeapType::Func) => {
-                    self.func_type_at(n1.into(), types, 0).is_ok()
+                    self.func_type_at(n1, types, 0).is_ok()
                 }
                 (HeapType::Indexed(n1), HeapType::Array) => {
-                    match self.type_at(types, n1.into(), 0) {
+                    match self.type_at(types, n1, 0) {
                         Ok(Type::Array(_)) => true,
                         _ => false,
                     }

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -471,19 +471,17 @@ impl<'resources, R: WasmModuleResources> OperatorValidatorTemp<'_, 'resources, R
         };
         let actual = if self.operands.len() == control.height && control.unreachable {
             MaybeType::Bot
+        } else if self.operands.len() == control.height {
+            let desc = match expected {
+                Some(ty) => ty_to_str(ty),
+                None => "a type",
+            };
+            bail!(
+                self.offset,
+                "type mismatch: expected {desc} but nothing on stack"
+            )
         } else {
-            if self.operands.len() == control.height {
-                let desc = match expected {
-                    Some(ty) => ty_to_str(ty),
-                    None => "a type",
-                };
-                bail!(
-                    self.offset,
-                    "type mismatch: expected {desc} but nothing on stack"
-                )
-            } else {
-                self.operands.pop().unwrap()
-            }
+            self.operands.pop().unwrap()
         };
         if let Some(expected) = expected {
             match (actual, expected) {

--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -2483,7 +2483,7 @@ impl<'a> SubtypeCx<'a> {
                     .unwrap()
                     .imports
                     .iter()
-                    .map(|(name, (_url, ty))| (name.clone(), ty.clone()))
+                    .map(|(name, (_url, ty))| (name.clone(), *ty))
                     .collect();
                 self.swap();
                 let mut import_mapping =
@@ -2495,7 +2495,7 @@ impl<'a> SubtypeCx<'a> {
                         .unwrap()
                         .exports
                         .iter()
-                        .map(|(name, (_url, ty))| (name.clone(), ty.clone()))
+                        .map(|(name, (_url, ty))| (name.clone(), *ty))
                         .collect::<IndexMap<_, _>>();
                     for ty in a_exports.values_mut() {
                         this.a.remap_component_entity(ty, &mut import_mapping);
@@ -2646,7 +2646,7 @@ impl<'a> SubtypeCx<'a> {
         let mut to_typecheck = Vec::new();
         for (name, (_, expected)) in entities.iter() {
             match a.get(name) {
-                Some(arg) => to_typecheck.push((arg.clone(), expected.clone())),
+                Some(arg) => to_typecheck.push((*arg, *expected)),
                 None => bail!(offset, "missing {} named `{name}`", kind.desc()),
             }
         }

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -733,7 +733,7 @@ impl Printer {
         }
         self.print_storage_type(ty.element_type)?;
         if ty.mutable {
-            self.result.push_str(")");
+            self.result.push(')');
         }
         Ok(0)
     }
@@ -775,13 +775,13 @@ impl Printer {
                 _ => {
                     self.result.push_str("(ref null ");
                     self.print_heaptype(ty.heap_type())?;
-                    self.result.push_str(")");
+                    self.result.push(')');
                 }
             }
         } else {
             self.result.push_str("(ref ");
             self.print_heaptype(ty.heap_type())?;
-            self.result.push_str(")");
+            self.result.push(')');
         }
         Ok(())
     }
@@ -798,7 +798,7 @@ impl Printer {
             HeapType::Struct => self.result.push_str("struct"),
             HeapType::Array => self.result.push_str("array"),
             HeapType::I31 => self.result.push_str("i31"),
-            HeapType::Indexed(i) => self.result.push_str(&format!("{}", u32::from(i))),
+            HeapType::Indexed(i) => self.result.push_str(&format!("{}", i)),
         }
         Ok(())
     }
@@ -921,7 +921,7 @@ impl Printer {
             match &table.init {
                 TableInit::RefNull => {}
                 TableInit::Expr(expr) => {
-                    self.result.push_str(" ");
+                    self.result.push(' ');
                     self.print_const_expr(state, expr)?;
                 }
             }
@@ -1569,10 +1569,10 @@ impl Printer {
         Ok(())
     }
 
-    fn print_component_type<'a>(
+    fn print_component_type(
         &mut self,
         states: &mut Vec<State>,
-        decls: Vec<ComponentTypeDeclaration<'a>>,
+        decls: Vec<ComponentTypeDeclaration<'_>>,
     ) -> Result<()> {
         states.push(State::new(Encoding::Component));
         self.newline_unknown_pos();
@@ -1607,10 +1607,10 @@ impl Printer {
         Ok(())
     }
 
-    fn print_instance_type<'a>(
+    fn print_instance_type(
         &mut self,
         states: &mut Vec<State>,
-        decls: Vec<InstanceTypeDeclaration<'a>>,
+        decls: Vec<InstanceTypeDeclaration<'_>>,
     ) -> Result<()> {
         states.push(State::new(Encoding::Component));
         self.newline_unknown_pos();
@@ -1713,10 +1713,10 @@ impl Printer {
         Ok(())
     }
 
-    fn print_component_type_def<'a>(
+    fn print_component_type_def(
         &mut self,
         states: &mut Vec<State>,
-        ty: ComponentType<'a>,
+        ty: ComponentType<'_>,
     ) -> Result<()> {
         self.start_group("type ");
         {
@@ -1739,11 +1739,11 @@ impl Printer {
                 self.print_instance_type(states, decls.into_vec())?;
             }
             ComponentType::Resource { rep, dtor } => {
-                self.result.push_str(" ");
+                self.result.push(' ');
                 self.start_group("resource");
                 self.result.push_str(" (rep ");
                 self.print_valtype(rep)?;
-                self.result.push_str(")");
+                self.result.push(')');
                 if let Some(dtor) = dtor {
                     self.result.push_str("(dtor (func ");
                     self.print_idx(&states.last().unwrap().core.func_names, dtor)?;
@@ -1759,10 +1759,10 @@ impl Printer {
         Ok(())
     }
 
-    fn print_component_types<'a>(
+    fn print_component_types(
         &mut self,
         states: &mut Vec<State>,
-        parser: ComponentTypeSectionReader<'a>,
+        parser: ComponentTypeSectionReader<'_>,
     ) -> Result<()> {
         for ty in parser.into_iter_with_offsets() {
             let (offset, ty) = ty?;
@@ -1815,7 +1815,7 @@ impl Printer {
             ComponentTypeRef::Module(idx) => {
                 self.start_group("core module ");
                 if index {
-                    self.print_name(&state.core.module_names, state.core.modules as u32)?;
+                    self.print_name(&state.core.module_names, state.core.modules)?;
                     self.result.push(' ');
                     state.core.modules += 1;
                 }
@@ -1922,7 +1922,7 @@ impl Printer {
         self.print_component_external_kind(state, export.kind, export.index)?;
         if let Some(ty) = &export.ty {
             self.result.push(' ');
-            self.print_component_import_ty(state, &ty, false)?;
+            self.print_component_import_ty(state, ty, false)?;
         }
         self.end_group();
         Ok(())

--- a/crates/wasmprinter/tests/all.rs
+++ b/crates/wasmprinter/tests/all.rs
@@ -8,7 +8,7 @@ fn no_panic() {
         "#,
     )
     .unwrap();
-    wasmprinter::print_bytes(&bytes).unwrap();
+    wasmprinter::print_bytes(bytes).unwrap();
 
     let bytes = wat::parse_str(
         r#"
@@ -18,7 +18,7 @@ fn no_panic() {
         "#,
     )
     .unwrap();
-    wasmprinter::print_bytes(&bytes).unwrap();
+    wasmprinter::print_bytes(bytes).unwrap();
 }
 
 #[test]
@@ -33,7 +33,7 @@ fn code_section_overflow() {
         "#,
     )
     .unwrap();
-    let err = wasmprinter::print_bytes(&bytes).unwrap_err();
+    let err = wasmprinter::print_bytes(bytes).unwrap_err();
     assert!(
         err.to_string().contains("unexpected end-of-file"),
         "{:?}",
@@ -69,7 +69,7 @@ fn locals_overflow() {
         "#,
     )
     .unwrap();
-    let err = wasmprinter::print_bytes(&bytes).unwrap_err();
+    let err = wasmprinter::print_bytes(bytes).unwrap_err();
     assert!(
         err.to_string().contains("maximum number of locals"),
         "{:?}",
@@ -97,7 +97,7 @@ fn memarg_too_big() {
         "#,
     )
     .unwrap();
-    let err = wasmprinter::print_bytes(&bytes).unwrap_err();
+    let err = wasmprinter::print_bytes(bytes).unwrap_err();
     assert!(
         err.to_string().contains("alignment in memarg too large"),
         "{:?}",
@@ -115,7 +115,7 @@ fn no_panic_dangling_else() {
         "#,
     )
     .unwrap();
-    wasmprinter::print_bytes(&bytes).unwrap();
+    wasmprinter::print_bytes(bytes).unwrap();
 }
 
 #[test]
@@ -128,8 +128,8 @@ fn dangling_if() {
         "#,
     )
     .unwrap();
-    let wat = wasmprinter::print_bytes(&bytes).unwrap();
-    wat::parse_str(&wat).unwrap();
+    let wat = wasmprinter::print_bytes(bytes).unwrap();
+    wat::parse_str(wat).unwrap();
 }
 
 #[test]
@@ -143,7 +143,7 @@ fn no_oom() {
     }
     s.push(')');
     let bytes = wat::parse_str(&s).unwrap();
-    let wat = wasmprinter::print_bytes(&bytes).unwrap();
+    let wat = wasmprinter::print_bytes(bytes).unwrap();
     assert!(wat.len() < 500_000_000);
 }
 
@@ -161,7 +161,7 @@ fn dont_reserve_the_world() {
         "#,
     )
     .unwrap();
-    let err = wasmprinter::print_bytes(&bytes).unwrap_err();
+    let err = wasmprinter::print_bytes(bytes).unwrap_err();
     assert!(
         err.to_string()
             .contains("functions which exceeds the limit"),
@@ -186,10 +186,10 @@ fn label_shadowing_block() {
       )
     "#;
     let bytes = wat::parse_str(MODULE).unwrap();
-    let result = wasmprinter::print_bytes(&bytes).unwrap();
+    let result = wasmprinter::print_bytes(bytes).unwrap();
     assert_eq!(
-        result.replace(" ", "").trim(),
-        MODULE.replace(" ", "").trim()
+        result.replace(' ', "").trim(),
+        MODULE.replace(' ', "").trim()
     );
 }
 
@@ -209,10 +209,10 @@ fn label_shadowing_block_confusion() {
       )
     "#;
     let bytes = wat::parse_str(MODULE).unwrap();
-    let result = wasmprinter::print_bytes(&bytes).unwrap();
+    let result = wasmprinter::print_bytes(bytes).unwrap();
     assert_eq!(
-        result.replace(" ", "").trim(),
-        MODULE.replace(" ", "").trim()
+        result.replace(' ', "").trim(),
+        MODULE.replace(' ', "").trim()
     );
 }
 
@@ -228,10 +228,10 @@ fn label_shadowing_locals() {
       )
     "#;
     let bytes = wat::parse_str(MODULE).unwrap();
-    let result = wasmprinter::print_bytes(&bytes).unwrap();
+    let result = wasmprinter::print_bytes(bytes).unwrap();
     assert_eq!(
-        result.replace(" ", "").trim(),
-        MODULE.replace(" ", "").trim()
+        result.replace(' ', "").trim(),
+        MODULE.replace(' ', "").trim()
     );
 }
 

--- a/crates/wast/tests/annotations.rs
+++ b/crates/wast/tests/annotations.rs
@@ -97,7 +97,7 @@ fn assert_local_name(name: &str, wat: &str) -> anyhow::Result<()> {
 }
 
 fn get_name_section(wasm: &[u8]) -> anyhow::Result<NameSectionReader<'_>> {
-    for payload in Parser::new(0).parse_all(&wasm) {
+    for payload in Parser::new(0).parse_all(wasm) {
         if let Payload::CustomSection(c) = payload? {
             if c.name() == "name" {
                 return Ok(NameSectionReader::new(c.data(), c.data_offset()));

--- a/crates/wast/tests/parse-fail.rs
+++ b/crates/wast/tests/parse-fail.rs
@@ -53,7 +53,7 @@ fn run_test(test: &Path, bless: bool) -> anyhow::Result<()> {
     };
     let assert = test.with_extension("wat.err");
     if bless {
-        std::fs::write(assert, err.to_string())?;
+        std::fs::write(assert, &err)?;
         return Ok(());
     }
 
@@ -74,11 +74,11 @@ fn run_test(test: &Path, bless: bool) -> anyhow::Result<()> {
     );
 
     fn normalize(s: &str) -> String {
-        s.replace("\\", "/")
+        s.replace('\\', "/")
     }
 
     fn tab(s: &str) -> String {
-        s.replace("\n", "\n\t")
+        s.replace('\n', "\n\t")
     }
 }
 

--- a/crates/wast/tests/recursive.rs
+++ b/crates/wast/tests/recursive.rs
@@ -1,6 +1,6 @@
 #[test]
 fn no_stack_overflow() {
-    let mut s = format!("(module (func \n");
+    let mut s = "(module (func \n".to_string();
     for _ in 0..10_000 {
         s.push_str("(i32.add\n");
     }

--- a/crates/wit-component/src/dummy.rs
+++ b/crates/wit-component/src/dummy.rs
@@ -74,7 +74,7 @@ pub fn dummy_module(resolve: &Resolve, world: WorldId) -> Vec<u8> {
         dst.push_str(" (");
         dst.push_str(desc);
         for ty in params {
-            dst.push_str(" ");
+            dst.push(' ');
             match ty {
                 WasmType::I32 => dst.push_str("i32"),
                 WasmType::I64 => dst.push_str("i64"),
@@ -82,6 +82,6 @@ pub fn dummy_module(resolve: &Resolve, world: WorldId) -> Vec<u8> {
                 WasmType::F64 => dst.push_str("f64"),
             }
         }
-        dst.push_str(")");
+        dst.push(')');
     }
 }

--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -533,7 +533,7 @@ impl<'a> EncodingState<'a> {
         for core_wasm_name in info.required_imports.keys() {
             let index = self.import_instance_to_lowered_core_instance(
                 CustomModule::Main,
-                *core_wasm_name,
+                core_wasm_name,
                 &shims,
                 info.metadata,
             );
@@ -851,7 +851,7 @@ impl<'a> EncodingState<'a> {
                     )
                 } else {
                     let base = format!("import-type-{name}");
-                    let mut name = base.clone();
+                    let mut name = base;
                     let mut n = 0;
                     while self.imports.contains_key(&name) {
                         name = format!("{name}{n}");

--- a/crates/wit-component/src/encoding/wit.rs
+++ b/crates/wit-component/src/encoding/wit.rs
@@ -185,7 +185,7 @@ impl Encoder<'_> {
             let url = format!("pkg:/{}/{name}", doc.name);
             encoder
                 .outer
-                .export(&name, &url, ComponentTypeRef::Component(idx));
+                .export(name, &url, ComponentTypeRef::Component(idx));
         }
 
         Ok(self.component.component_type(&encoder.outer))

--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -499,7 +499,7 @@ impl<'a> Module<'a> {
             | HeapType::Struct
             | HeapType::Array
             | HeapType::I31 => {}
-            HeapType::Indexed(i) => self.ty(i.into()),
+            HeapType::Indexed(i) => self.ty(i),
         }
     }
 
@@ -1142,7 +1142,7 @@ impl Encoder {
             HeapType::Array => wasm_encoder::HeapType::Array,
             HeapType::I31 => wasm_encoder::HeapType::I31,
             HeapType::Indexed(idx) => {
-                wasm_encoder::HeapType::Indexed(self.types.remap(idx.into()).try_into().unwrap())
+                wasm_encoder::HeapType::Indexed(self.types.remap(idx).try_into().unwrap())
             }
         }
     }

--- a/crates/wit-component/src/lib.rs
+++ b/crates/wit-component/src/lib.rs
@@ -26,8 +26,7 @@ pub use dummy::dummy_module;
 mod dummy;
 
 /// Supported string encoding formats.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-#[derive(Default)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default)]
 pub enum StringEncoding {
     /// Strings are encoded with UTF-8.
     #[default]
@@ -37,8 +36,6 @@ pub enum StringEncoding {
     /// Strings are encoded with compact UTF-16 (i.e. Latin1+UTF-16).
     CompactUTF16,
 }
-
-
 
 impl Display for StringEncoding {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/wit-component/src/lib.rs
+++ b/crates/wit-component/src/lib.rs
@@ -27,8 +27,10 @@ mod dummy;
 
 /// Supported string encoding formats.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Default)]
 pub enum StringEncoding {
     /// Strings are encoded with UTF-8.
+    #[default]
     UTF8,
     /// Strings are encoded with UTF-16.
     UTF16,
@@ -36,11 +38,7 @@ pub enum StringEncoding {
     CompactUTF16,
 }
 
-impl Default for StringEncoding {
-    fn default() -> Self {
-        StringEncoding::UTF8
-    }
-}
+
 
 impl Display for StringEncoding {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -132,7 +132,7 @@ impl DocumentPrinter {
             writeln!(&mut self.output, "}}")?;
         }
 
-        if amt_to_import > 0 && types_to_declare.len() > 0 {
+        if amt_to_import > 0 && !types_to_declare.is_empty() {
             self.output.push_str("\n");
         }
 

--- a/crates/wit-component/src/validation.rs
+++ b/crates/wit-component/src/validation.rs
@@ -369,7 +369,7 @@ pub fn validate_adapter_module<'a>(
         // An empty module name is indicative of the top-level import namespace,
         // so look for top-level functions here.
         if name == BARE_FUNC_MODULE_NAME {
-            validate_imports_top_level(&resolve, world, &funcs, &types)?;
+            validate_imports_top_level(resolve, world, &funcs, &types)?;
             let funcs = resolve.worlds[world]
                 .imports
                 .iter()
@@ -430,10 +430,10 @@ pub fn validate_adapter_module<'a>(
     Ok(ret)
 }
 
-fn validate_imports_top_level<'a>(
+fn validate_imports_top_level(
     resolve: &Resolve,
     world: WorldId,
-    funcs: &IndexMap<&'a str, u32>,
+    funcs: &IndexMap<&str, u32>,
     types: &Types,
 ) -> Result<()> {
     for (name, ty) in funcs {

--- a/crates/wit-component/tests/components.rs
+++ b/crates/wit-component/tests/components.rs
@@ -119,7 +119,7 @@ fn add_adapters(
         let wasm = read_core_module(&adapter, resolve, pkg)?;
         let stem = adapter.file_stem().unwrap().to_str().unwrap();
         let name = stem.trim_start_matches("adapt-");
-        encoder = encoder.adapter(&name, &wasm)?;
+        encoder = encoder.adapter(name, &wasm)?;
     }
     Ok(encoder)
 }
@@ -146,7 +146,7 @@ fn read_core_module(path: &Path, resolve: &Resolve, pkg: PackageId) -> Result<Ve
     producers.add("processed-by", "my-fake-bindgen", "123.45");
 
     let encoded =
-        wit_component::metadata::encode(&resolve, world, StringEncoding::UTF8, Some(&producers))?;
+        wit_component::metadata::encode(resolve, world, StringEncoding::UTF8, Some(&producers))?;
 
     let section = wasm_encoder::CustomSection {
         name: "component-type".into(),

--- a/crates/wit-component/tests/interfaces.rs
+++ b/crates/wit-component/tests/interfaces.rs
@@ -76,7 +76,7 @@ fn run_test(path: &Path, is_dir: bool) -> Result<()> {
             } else {
                 root.with_extension("wit.print")
             };
-            let output = DocumentPrinter::default().print(&resolve, *doc)?;
+            let output = DocumentPrinter::default().print(resolve, *doc)?;
             assert_output(&expected, &output)?;
         }
     }
@@ -94,10 +94,10 @@ fn run_test(path: &Path, is_dir: bool) -> Result<()> {
 
 fn assert_output(expected: &Path, actual: &str) -> Result<()> {
     if std::env::var_os("BLESS").is_some() {
-        fs::write(&expected, actual).with_context(|| format!("failed to write {expected:?}"))?;
+        fs::write(expected, actual).with_context(|| format!("failed to write {expected:?}"))?;
     } else {
         assert_eq!(
-            fs::read_to_string(&expected)
+            fs::read_to_string(expected)
                 .with_context(|| format!("failed to read {expected:?}"))?
                 .replace("\r\n", "\n"),
             actual,

--- a/crates/wit-component/tests/merge.rs
+++ b/crates/wit-component/tests/merge.rs
@@ -67,10 +67,10 @@ fn merging() -> Result<()> {
 fn assert_output(expected: &Path, actual: &str) -> Result<()> {
     if std::env::var_os("BLESS").is_some() {
         fs::create_dir_all(expected.parent().unwrap())?;
-        fs::write(&expected, actual).with_context(|| format!("failed to write {expected:?}"))?;
+        fs::write(expected, actual).with_context(|| format!("failed to write {expected:?}"))?;
     } else {
         assert_eq!(
-            fs::read_to_string(&expected)
+            fs::read_to_string(expected)
                 .with_context(|| format!("failed to read {expected:?}"))?
                 .replace("\r\n", "\n"),
             actual,

--- a/crates/wit-parser/fuzz/fuzz_targets/parse.rs
+++ b/crates/wit-parser/fuzz/fuzz_targets/parse.rs
@@ -10,5 +10,5 @@ fuzz_target!(|data: &[u8]| {
         Err(_) => return,
     };
 
-    drop(wit_parser::UnresolvedPackage::parse("foo".as_ref(), &data));
+    drop(wit_parser::UnresolvedPackage::parse("foo".as_ref(), data));
 });

--- a/crates/wit-parser/src/abi.rs
+++ b/crates/wit-parser/src/abi.rs
@@ -1058,7 +1058,7 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                         // `self.return_pointer`) so we use that to read
                         // the result of the function from memory.
                         AbiVariant::GuestImport => {
-                            assert!(sig.results.len() == 0);
+                            assert!(sig.results.is_empty());
                             self.return_pointer.take().unwrap()
                         }
 
@@ -1886,7 +1886,7 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                 }
 
                 TypeDefKind::Enum(e) => {
-                    self.stack.push(addr.clone());
+                    self.stack.push(addr);
                     self.load_intrepr(offset, e.tag());
                     self.lift(ty);
                 }

--- a/crates/wit-parser/src/ast.rs
+++ b/crates/wit-parser/src/ast.rs
@@ -353,7 +353,7 @@ impl<'a> UsePath<'a> {
                 };
                 Ok(UsePath::Dependency { dep, doc, iface })
             }
-            other => return Err(err_expected(tokens, "`self`, `pkg`, or identifier", other).into()),
+            other => Err(err_expected(tokens, "`self`, `pkg`, or identifier", other).into()),
         }
     }
 }
@@ -367,7 +367,7 @@ pub struct Id<'a> {
 impl<'a> From<&'a str> for Id<'a> {
     fn from(s: &'a str) -> Id<'a> {
         Id {
-            name: s.into(),
+            name: s,
             span: Span { start: 0, end: 0 },
         }
     }
@@ -810,12 +810,12 @@ impl<'a> Type<'a> {
 
             // `foo`
             Some((span, Token::Id)) => Ok(Type::Name(Id {
-                name: tokens.parse_id(span)?.into(),
+                name: tokens.parse_id(span)?,
                 span,
             })),
             // `%foo`
             Some((span, Token::ExplicitId)) => Ok(Type::Name(Id {
-                name: tokens.parse_explicit_id(span)?.into(),
+                name: tokens.parse_explicit_id(span)?,
                 span,
             })),
 

--- a/crates/wit-parser/src/ast/lex.rs
+++ b/crates/wit-parser/src/ast/lex.rs
@@ -134,7 +134,7 @@ impl<'a> Tokenizer<'a> {
 
     pub fn parse_id(&self, span: Span) -> Result<&'a str> {
         let ret = self.get_span(span);
-        validate_id(span.start, &ret)?;
+        validate_id(span.start, ret)?;
         Ok(ret)
     }
 

--- a/crates/wit-parser/src/ast/resolve.rs
+++ b/crates/wit-parser/src/ast/resolve.rs
@@ -293,7 +293,7 @@ impl<'a> Resolver<'a> {
                         None => {
                             let name = default_interface_name.ok_or_else(|| Error {
                                 span: doc.span,
-                                msg: format!("no `default` interface in document to use from"),
+                                msg: "no `default` interface in document to use from".to_string(),
                             })?;
                             ast::Id {
                                 span: doc.span,
@@ -347,7 +347,7 @@ impl<'a> Resolver<'a> {
                 if prev.is_some() {
                     return Err(Error {
                         span: interface.name.span,
-                        msg: format!("cannot specify more than one `default` interface"),
+                        msg: "cannot specify more than one `default` interface".to_string(),
                     }
                     .into());
                 }
@@ -368,7 +368,7 @@ impl<'a> Resolver<'a> {
                 if prev.is_some() {
                     return Err(Error {
                         span: world.name.span,
-                        msg: format!("cannot specify more than one `default` world"),
+                        msg: "cannot specify more than one `default` world".to_string(),
                     }
                     .into());
                 }
@@ -712,7 +712,7 @@ impl<'a> Resolver<'a> {
                     }),
                     None => bail!(Error {
                         span: iface.span,
-                        msg: format!("interface does not exist"),
+                        msg: "interface does not exist".to_string(),
                     }),
                 }
             }
@@ -732,14 +732,14 @@ impl<'a> Resolver<'a> {
                             .into()),
                             None => bail!(Error {
                                 span: id.span,
-                                msg: format!("interface does not exist"),
+                                msg: "interface does not exist".to_string(),
                             }),
                         }
                     }
                     None => self.documents[doc_id].default_interface.ok_or_else(|| {
                         Error {
                             span: doc.span,
-                            msg: format!("document does not specify a default interface"),
+                            msg: "document does not specify a default interface".to_string(),
                         }
                         .into()
                     }),

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -176,17 +176,15 @@ impl UnresolvedPackage {
             .and_then(|s| s.to_str())
             .ok_or_else(|| anyhow!("path doesn't end in a valid package name {path:?}"))?;
         let cx = || format!("failed to read directory {path:?}");
-        for entry in path.read_dir().with_context(&cx)? {
-            let entry = entry.with_context(&cx)?;
+        for entry in path.read_dir().with_context(cx)? {
+            let entry = entry.with_context(cx)?;
             let path = entry.path();
-            let ty = entry.file_type().with_context(&cx)?;
+            let ty = entry.file_type().with_context(cx)?;
             if ty.is_dir() {
                 continue;
             }
-            if ty.is_symlink() {
-                if path.is_dir() {
-                    continue;
-                }
+            if ty.is_symlink() && path.is_dir() {
+                continue;
             }
             let filename = match path.file_name().and_then(|s| s.to_str()) {
                 Some(name) => name,

--- a/crates/wit-parser/src/resolve.rs
+++ b/crates/wit-parser/src/resolve.rs
@@ -164,7 +164,7 @@ impl Resolve {
                     if !visiting.insert(dep) {
                         bail!(Error {
                             span: *span,
-                            msg: format!("package depends on itself"),
+                            msg: "package depends on itself".to_string(),
                         });
                     }
                     visit(dep, deps, pkgs, order, visiting)?;
@@ -249,7 +249,7 @@ impl Resolve {
             self.packages.len()
         );
 
-        let mut map = MergeMap::new(&resolve, &self)?;
+        let mut map = MergeMap::new(&resolve, self)?;
         map.build()?;
         let MergeMap {
             package_map,
@@ -773,11 +773,11 @@ impl Remap {
             let iface_id = match &unresolved_iface.name {
                 Some(name) => *document.interfaces.get(name).ok_or_else(|| Error {
                     span,
-                    msg: format!("interface not defined in document"),
+                    msg: "interface not defined in document".to_string(),
                 })?,
                 None => document.default_interface.ok_or_else(|| Error {
                     span,
-                    msg: format!("default interface not specified in document"),
+                    msg: "default interface not specified in document".to_string(),
                 })?,
             };
             assert_eq!(self.interfaces.len(), unresolved_iface_id.index());
@@ -812,7 +812,7 @@ impl Remap {
                 .get(name)
                 .ok_or_else(|| Error {
                     span,
-                    msg: format!("type not defined in interface"),
+                    msg: "type not defined in interface".to_string(),
                 })?;
             assert_eq!(self.types.len(), unresolved_type_id.index());
             self.types.push(type_id);
@@ -1146,9 +1146,9 @@ impl<'a> WorldElaborator<'a, '_> {
 
         let mut msg = format!("{} of `{}`", desc(import), self.name_of(id, import));
         if self.resolving_stack.is_empty() {
-            msg.push_str(" ");
+            msg.push(' ');
         } else {
-            msg.push_str("\n");
+            msg.push('\n');
         }
         for (i, import) in self.resolving_stack.iter().rev() {
             writeln!(
@@ -1449,7 +1449,7 @@ impl<'a> MergeMap<'a> {
                     // if either is unnamed it won't be present in
                     // `interface_map` so this'll return an error.
                     _ => {
-                        if self.interface_map.get(&from) != Some(&into) {
+                        if self.interface_map.get(from) != Some(into) {
                             bail!("interfaces are not the same");
                         }
                     }

--- a/crates/wit-smith/src/generate.rs
+++ b/crates/wit-smith/src/generate.rs
@@ -47,7 +47,7 @@ impl Generator {
         while packages.len() < self.config.max_packages && (packages.is_empty() || u.arbitrary()?) {
             let name = gen_unique_name(u, &mut names)?;
             let (sources, documents) = self.gen_package(u)?;
-            if documents.len() > 0 {
+            if !documents.is_empty() {
                 self.packages.push((name.clone(), documents));
             }
             packages.push(Package { name, sources });
@@ -65,7 +65,7 @@ impl Generator {
             let (doc, interfaces) = self.gen_document(u)?;
             map.push(format!("{name}.wit").as_ref(), &name, doc);
             count += 1;
-            if interfaces.len() > 0 {
+            if !interfaces.is_empty() {
                 self.documents.push((name, interfaces));
             }
         }
@@ -94,7 +94,7 @@ impl Generator {
                     self.next_interface_id += 1;
                     let (src, types) =
                         self.gen_interface(u, Some(&name), &mut has_default_interface)?;
-                    if types.len() > 0 {
+                    if !types.is_empty() {
                         self.interfaces
                             .push((name, id, src.starts_with("default"), types));
                     }
@@ -159,35 +159,35 @@ impl Generator {
             Choice::Interfaces => {
                 dst.push_str("self.");
                 let (name, id, _default, types) = u.choose(&self.interfaces)?;
-                dst.push_str("%");
+                dst.push('%');
                 dst.push_str(name);
                 Some((*id, types))
             }
             Choice::Documents => {
                 dst.push_str("pkg.");
                 let (name, ifaces) = u.choose(&self.documents)?;
-                dst.push_str("%");
+                dst.push('%');
                 dst.push_str(name);
                 let (name, id, default, types) = u.choose(ifaces)?;
                 if !*default || !u.arbitrary()? {
-                    dst.push_str(".");
-                    dst.push_str("%");
+                    dst.push('.');
+                    dst.push('%');
                     dst.push_str(name);
                 }
                 Some((*id, types))
             }
             Choice::Packages => {
                 let (name, docs) = u.choose(&self.packages)?;
-                dst.push_str("%");
+                dst.push('%');
                 dst.push_str(name);
-                dst.push_str(".");
+                dst.push('.');
                 let (name, ifaces) = u.choose(docs)?;
-                dst.push_str("%");
+                dst.push('%');
                 dst.push_str(name);
                 let (name, id, default, types) = u.choose(ifaces)?;
                 if !*default || !u.arbitrary()? {
-                    dst.push_str(".");
-                    dst.push_str("%");
+                    dst.push('.');
+                    dst.push('%');
                     dst.push_str(name);
                 }
                 Some((*id, types))
@@ -223,9 +223,9 @@ impl<'a> InterfaceGenerator<'a> {
         }
         ret.push_str("interface ");
         if let Some(name) = name {
-            ret.push_str("%");
+            ret.push('%');
             ret.push_str(name);
-            ret.push_str(" ");
+            ret.push(' ');
         }
         ret.push_str("{\n");
 
@@ -263,7 +263,7 @@ impl<'a> InterfaceGenerator<'a> {
             ret.push_str("\n\n");
         }
 
-        ret.push_str("}");
+        ret.push('}');
         Ok(ret)
     }
 
@@ -377,10 +377,10 @@ impl<'a> InterfaceGenerator<'a> {
 
         for part in parts {
             ret.push_str(&part);
-            ret.push_str("\n");
+            ret.push('\n');
         }
 
-        ret.push_str("}");
+        ret.push('}');
 
         Ok(ret)
     }
@@ -395,7 +395,7 @@ impl<'a> InterfaceGenerator<'a> {
         part.push_str(&path);
         part.push_str(".{");
         let (name, size) = u.choose(types)?;
-        part.push_str("%");
+        part.push('%');
         part.push_str(name);
         let name = if self.unique_names.contains(name) || u.arbitrary()? {
             part.push_str(" as %");
@@ -407,7 +407,7 @@ impl<'a> InterfaceGenerator<'a> {
             name.clone()
         };
         self.types_in_interface.push((name, *size));
-        part.push_str("}");
+        part.push('}');
         Ok(true)
     }
 
@@ -436,7 +436,7 @@ impl<'a> InterfaceGenerator<'a> {
                     self.gen_type(u, &mut fuel, &mut ret)?;
                     ret.push_str(",\n");
                 }
-                ret.push_str("}");
+                ret.push('}');
             }
             Kind::Variant => {
                 ret.push_str("variant %");
@@ -446,13 +446,13 @@ impl<'a> InterfaceGenerator<'a> {
                     ret.push_str("  %");
                     ret.push_str(&self.gen_unique_name(u)?);
                     if u.arbitrary()? {
-                        ret.push_str("(");
+                        ret.push('(');
                         self.gen_type(u, &mut fuel, &mut ret)?;
-                        ret.push_str(")");
+                        ret.push(')');
                     }
                     ret.push_str(",\n");
                 }
-                ret.push_str("}");
+                ret.push('}');
             }
             Kind::Union => {
                 ret.push_str("union %");
@@ -463,7 +463,7 @@ impl<'a> InterfaceGenerator<'a> {
                     self.gen_type(u, &mut fuel, &mut ret)?;
                     ret.push_str(",\n");
                 }
-                ret.push_str("}");
+                ret.push('}');
             }
             Kind::Enum => {
                 ret.push_str("enum %");
@@ -474,7 +474,7 @@ impl<'a> InterfaceGenerator<'a> {
                     ret.push_str(&self.gen_unique_name(u)?);
                     ret.push_str(",\n");
                 }
-                ret.push_str("}");
+                ret.push('}');
             }
             Kind::Flags => {
                 ret.push_str("flags %");
@@ -485,7 +485,7 @@ impl<'a> InterfaceGenerator<'a> {
                     ret.push_str(&self.gen_unique_name(u)?);
                     ret.push_str(",\n");
                 }
-                ret.push_str("}");
+                ret.push('}');
             }
             Kind::Anonymous => {
                 ret.push_str("type %");
@@ -557,7 +557,7 @@ impl<'a> InterfaceGenerator<'a> {
                         Some(fuel) => fuel,
                         None => continue,
                     };
-                    dst.push_str("%");
+                    dst.push('%');
                     dst.push_str(name);
                 }
                 Kind::Tuple => {
@@ -573,7 +573,7 @@ impl<'a> InterfaceGenerator<'a> {
                         }
                         self.gen_type(u, fuel, dst)?;
                     }
-                    dst.push_str(">");
+                    dst.push('>');
                 }
                 Kind::Option => {
                     *fuel = match fuel.checked_sub(1) {
@@ -582,7 +582,7 @@ impl<'a> InterfaceGenerator<'a> {
                     };
                     dst.push_str("option<");
                     self.gen_type(u, fuel, dst)?;
-                    dst.push_str(">");
+                    dst.push('>');
                 }
                 Kind::List => {
                     *fuel = match fuel.checked_sub(1) {
@@ -591,7 +591,7 @@ impl<'a> InterfaceGenerator<'a> {
                     };
                     dst.push_str("list<");
                     self.gen_type(u, fuel, dst)?;
-                    dst.push_str(">");
+                    dst.push('>');
                 }
                 Kind::Result => {
                     *fuel = match fuel.checked_sub(2) {
@@ -603,21 +603,21 @@ impl<'a> InterfaceGenerator<'a> {
                     let err = u.arbitrary()?;
                     match (ok, err) {
                         (true, true) => {
-                            dst.push_str("<");
+                            dst.push('<');
                             self.gen_type(u, fuel, dst)?;
                             dst.push_str(", ");
                             self.gen_type(u, fuel, dst)?;
-                            dst.push_str(">");
+                            dst.push('>');
                         }
                         (true, false) => {
-                            dst.push_str("<");
+                            dst.push('<');
                             self.gen_type(u, fuel, dst)?;
-                            dst.push_str(">");
+                            dst.push('>');
                         }
                         (false, true) => {
                             dst.push_str("<_, ");
                             self.gen_type(u, fuel, dst)?;
-                            dst.push_str(">");
+                            dst.push('>');
                         }
                         (false, false) => {}
                     }
@@ -651,18 +651,18 @@ impl<'a> InterfaceGenerator<'a> {
     }
 
     fn gen_params(&mut self, u: &mut Unstructured<'_>, dst: &mut String) -> Result<()> {
-        dst.push_str("(");
+        dst.push('(');
         let mut fuel = self.config.max_type_size;
         for i in 0..u.int_in_range(0..=self.config.max_type_parts)? {
             if i > 0 {
                 dst.push_str(", ");
             }
-            dst.push_str("%");
+            dst.push('%');
             dst.push_str(&self.gen_unique_name(u)?);
             dst.push_str(": ");
             self.gen_type(u, &mut fuel, dst)?;
         }
-        dst.push_str(")");
+        dst.push(')');
         Ok(())
     }
 
@@ -706,7 +706,7 @@ fn gen_name(u: &mut Unstructured<'_>) -> Result<String> {
 }
 
 fn shuffle<T>(u: &mut Unstructured<'_>, mut slice: &mut [T]) -> Result<()> {
-    while slice.len() > 0 {
+    while !slice.is_empty() {
         let pos = u.int_in_range(0..=slice.len() - 1)?;
         slice.swap(0, pos);
         slice = &mut slice[1..];

--- a/fuzz/fuzz_targets/incremental-parse.rs
+++ b/fuzz/fuzz_targets/incremental-parse.rs
@@ -14,7 +14,7 @@ fuzz_target!(|data: Vec<Vec<u8>>| {
 
     // Concatenate everything together, create our expected iterator of
     // payloads, and then write out `input.wasm` if debugging is enabled.
-    let everything = data.iter().flat_map(|a| a).copied().collect::<Vec<_>>();
+    let everything = data.iter().flatten().copied().collect::<Vec<_>>();
     let mut expected = Parser::new(0).parse_all(&everything);
     if log::log_enabled!(log::Level::Debug) {
         std::fs::write("input.wasm", &everything).unwrap();
@@ -53,8 +53,7 @@ fuzz_target!(|data: Vec<Vec<u8>>| {
                 let expected = expected
                     .next()
                     .expect("full parse stopped early")
-                    .err()
-                    .expect("full parse didn't return an error");
+                    .expect_err("full parse didn't return an error");
                 assert_eq!(expected.offset(), actual.offset());
                 assert_eq!(expected.message(), actual.message());
                 break;

--- a/fuzz/fuzz_targets/no-traps.rs
+++ b/fuzz/fuzz_targets/no-traps.rs
@@ -30,7 +30,6 @@ fuzz_target!(|data: &[u8]| {
     // Tail calls aren't implemented in wasmtime, so don't try to run them
     // there.
     if config.tail_call_enabled {
-        return;
     }
 
     #[cfg(feature = "wasmtime")]

--- a/fuzz/fuzz_targets/no-traps.rs
+++ b/fuzz/fuzz_targets/no-traps.rs
@@ -29,8 +29,7 @@ fuzz_target!(|data: &[u8]| {
 
     // Tail calls aren't implemented in wasmtime, so don't try to run them
     // there.
-    if config.tail_call_enabled {
-    }
+    if config.tail_call_enabled {}
 
     #[cfg(feature = "wasmtime")]
     {

--- a/fuzz/fuzz_targets/roundtrip-wit.rs
+++ b/fuzz/fuzz_targets/roundtrip-wit.rs
@@ -81,7 +81,7 @@ fn roundtrip_through_printing(file: &str, resolve: &Resolve, wasm: &[u8]) {
         for (name, doc) in pkg.documents.iter() {
             let doc = DocumentPrinter::default().print(resolve, *doc).unwrap();
             write_file(&format!("{file}-{pkg_name}-{name}.wit"), &doc);
-            map.push(format!("{name}.wit").as_ref(), &name, doc);
+            map.push(format!("{name}.wit").as_ref(), name, doc);
         }
         let unresolved = map.parse(&pkg.name, pkg.url.as_deref()).unwrap();
         let id = new_resolve.push(unresolved, &new_deps).unwrap();
@@ -109,6 +109,6 @@ fn write_file(path: &str, contents: impl AsRef<[u8]>) {
     if path.extension().and_then(|s| s.to_str()) == Some("wasm") {
         let path = path.with_extension("wat");
         log::debug!("writing file {}", path.display());
-        std::fs::write(path, wasmprinter::print_bytes(&contents).unwrap()).unwrap();
+        std::fs::write(path, wasmprinter::print_bytes(contents).unwrap()).unwrap();
     }
 }

--- a/fuzz/fuzz_targets/roundtrip.rs
+++ b/fuzz/fuzz_targets/roundtrip.rs
@@ -9,7 +9,7 @@ fuzz_target!(|data: &[u8]| {
         Err(_) => return,
     };
     drop(env_logger::try_init());
-    write_file("wasm1.wat", &string);
+    write_file("wasm1.wat", string);
     // Weed out `(module binary ...)` because when we print the bytes and
     // convert it back to binary it's not guaranteed to be exactly the same.
     // (think of something like an over-long LEB encoding)

--- a/fuzz/fuzz_targets/validate-valid-module.rs
+++ b/fuzz/fuzz_targets/validate-valid-module.rs
@@ -13,8 +13,7 @@ fuzz_target!(|data: &[u8]| {
     //
     // TODO: remove this `false && ...` once this fuzzer works again for
     // components.
-    let generate_component = false
-        && u.ratio::<u8>(1, 10).unwrap_or(false);
+    let generate_component = false && u.ratio::<u8>(1, 10).unwrap_or(false);
     let (wasm_bytes, config) = if generate_component {
         match wasm_tools_fuzz::generate_valid_component(&mut u, |c, u| {
             c.max_components = u.int_in_range(0..=1_000)?;

--- a/fuzz/fuzz_targets/validate-valid-module.rs
+++ b/fuzz/fuzz_targets/validate-valid-module.rs
@@ -14,10 +14,7 @@ fuzz_target!(|data: &[u8]| {
     // TODO: remove this `false && ...` once this fuzzer works again for
     // components.
     let generate_component = false
-        && match u.ratio::<u8>(1, 10) {
-            Ok(b) => b,
-            Err(_) => false,
-        };
+        && u.ratio::<u8>(1, 10).unwrap_or(false);
     let (wasm_bytes, config) = if generate_component {
         match wasm_tools_fuzz::generate_valid_component(&mut u, |c, u| {
             c.max_components = u.int_in_range(0..=1_000)?;
@@ -72,7 +69,7 @@ fuzz_target!(|data: &[u8]| {
             e
         )
     });
-    let wat_string2 = wasmprinter::print_bytes(&wasm_bytes).unwrap_or_else(|e| {
+    let wat_string2 = wasmprinter::print_bytes(wasm_bytes).unwrap_or_else(|e| {
         panic!(
             "failed second disassembly of Wasm into wat with `wasmprinter::print_bytes`: {}",
             e

--- a/fuzz/fuzz_targets/validate.rs
+++ b/fuzz/fuzz_targets/validate.rs
@@ -7,7 +7,7 @@ use wasmparser::{Validator, WasmFeatures};
 
 fuzz_target!(|data: &[u8]| {
     drop(env_logger::try_init());
-    let byte1 = match data.get(0) {
+    let byte1 = match data.first() {
         Some(byte) => byte,
         None => return,
     };

--- a/src/bin/wasm-tools/addr2line.rs
+++ b/src/bin/wasm-tools/addr2line.rs
@@ -62,7 +62,7 @@ impl Opts {
         let mut output = self.io.output_writer()?;
 
         for addr in self.addresses.iter() {
-            self.addr2line(&addr, code_start, &cx, &mut output)
+            self.addr2line(addr, code_start, &cx, &mut output)
                 .with_context(|| format!("failed to find frames for `{addr}`"))?;
         }
 
@@ -98,7 +98,7 @@ impl Opts {
     ) -> Result<()> {
         // Support either `0x` or `@` prefixes for hex addresses since 0x is
         // standard and @ is used by wasmprinter (and web browsers I think?)
-        let addr = if let Some(hex) = addr.strip_prefix("0x").or_else(|| addr.strip_prefix("@")) {
+        let addr = if let Some(hex) = addr.strip_prefix("0x").or_else(|| addr.strip_prefix('@')) {
             u64::from_str_radix(hex, 16)?
         } else {
             addr.parse()?
@@ -150,7 +150,7 @@ impl Opts {
                     write!(out, ":{column}")?;
                 }
             }
-            writeln!(out, "")?;
+            writeln!(out)?;
         }
         if first {
             writeln!(out, "{addr:#x}: no dwarf frames found for this address")?;

--- a/src/bin/wasm-tools/main.rs
+++ b/src/bin/wasm-tools/main.rs
@@ -120,10 +120,10 @@ fn print_error(color: ColorChoice, err: anyhow::Error) -> Result<()> {
         writeln!(
             stderr,
             "{i:>5}: {}",
-            err.to_string().replace("\n", "\n       ")
+            err.to_string().replace('\n', "\n       ")
         )?;
     }
-    return Ok(());
+    Ok(())
 }
 
 /// If CARGO_VERSION_INFO is set, use it, otherwise use CARGO_PKG_VERSION.

--- a/src/bin/wasm-tools/objdump.rs
+++ b/src/bin/wasm-tools/objdump.rs
@@ -196,6 +196,6 @@ impl Printer {
         for _ in 0..depth {
             s.push_str("  ");
         }
-        return s;
+        s
     }
 }

--- a/src/bin/wasm-tools/shrink.rs
+++ b/src/bin/wasm-tools/shrink.rs
@@ -176,9 +176,9 @@ impl IsInteresting for OutputIsInteresting {
     }
 }
 
-fn make_predicate<'a>(
-    predicate_script: &'a Path,
-) -> impl FnMut(&[u8]) -> Result<OutputIsInteresting> + 'a {
+fn make_predicate(
+    predicate_script: &Path,
+) -> impl FnMut(&[u8]) -> Result<OutputIsInteresting> + '_ {
     move |wasm| {
         let tmp = NamedTempFile::new().context("Failed to create a temporary file.")?;
         std::fs::write(tmp.path(), wasm).with_context(|| {
@@ -188,7 +188,7 @@ fn make_predicate<'a>(
             )
         })?;
 
-        let output = std::process::Command::new(&predicate_script)
+        let output = std::process::Command::new(predicate_script)
             .arg(tmp.path())
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())

--- a/src/bin/wasm-tools/smith.rs
+++ b/src/bin/wasm-tools/smith.rs
@@ -224,7 +224,7 @@ impl Opts {
         } else {
             let json = match &self.config {
                 Some(path) => {
-                    let json = std::fs::read_to_string(&path).with_context(|| {
+                    let json = std::fs::read_to_string(path).with_context(|| {
                         format!("failed to read json config: {}", path.display())
                     })?;
                     serde_json::from_str(&json).with_context(|| {

--- a/src/bin/wasm-tools/validate.rs
+++ b/src/bin/wasm-tools/validate.rs
@@ -114,7 +114,7 @@ fn parse_features(arg: &str) -> Result<WasmFeatures> {
     ];
 
     for part in arg.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()) {
-        let (enable, part) = if let Some(part) = part.strip_prefix("-") {
+        let (enable, part) = if let Some(part) = part.strip_prefix('-') {
             (false, part)
         } else {
             (true, part)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,9 +113,7 @@ impl OutputArg {
     pub fn output(&self, output: Output<'_>) -> Result<()> {
         match output {
             Output::Wat(s) => self.output_str(s),
-            Output::Wasm { bytes, wat: true } => {
-                self.output_str(&wasmprinter::print_bytes(bytes)?)
-            }
+            Output::Wasm { bytes, wat: true } => self.output_str(&wasmprinter::print_bytes(bytes)?),
             Output::Wasm { bytes, wat: false } => {
                 match &self.output {
                     Some(path) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@ impl OutputArg {
         match output {
             Output::Wat(s) => self.output_str(s),
             Output::Wasm { bytes, wat: true } => {
-                self.output_str(&wasmprinter::print_bytes(&bytes)?)
+                self.output_str(&wasmprinter::print_bytes(bytes)?)
             }
             Output::Wasm { bytes, wat: false } => {
                 match &self.output {
@@ -156,7 +156,7 @@ impl OutputArg {
     pub fn output_writer(&self, color: ColorChoice) -> Result<Box<dyn WriteColor>> {
         match &self.output {
             Some(output) => {
-                let writer = BufWriter::new(File::create(&output)?);
+                let writer = BufWriter::new(File::create(output)?);
                 if color == ColorChoice::AlwaysAnsi {
                     Ok(Box::new(Ansi::new(writer)))
                 } else {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -106,13 +106,13 @@ fn run_test(test: &Path, bless: bool) -> Result<()> {
     assert_output(
         bless,
         &output.stdout,
-        &test.with_extension(&format!("{extension}.stdout")),
+        &test.with_extension(format!("{extension}.stdout")),
     )
     .context("failed to check stdout expectation (auto-update with BLESS=1)")?;
     assert_output(
         bless,
         &output.stderr,
-        &test.with_extension(&format!("{extension}.stderr")),
+        &test.with_extension(format!("{extension}.stderr")),
     )
     .context("failed to check stderr expectation (auto-update with BLESS=1)")?;
     Ok(())

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -53,7 +53,7 @@ fn main() {
                 }
             }
             let contents = std::fs::read(test).unwrap();
-            if skip_test(&test, &contents) {
+            if skip_test(test, &contents) {
                 None
             } else {
                 Some((test, contents))
@@ -153,7 +153,7 @@ fn skip_test(test: &Path, contents: &[u8]) -> bool {
         "gc/let.wat",
         "/proposals/gc/",
     ];
-    let test_path = test.to_str().unwrap().replace("\\", "/"); // for windows paths
+    let test_path = test.to_str().unwrap().replace('\\', "/"); // for windows paths
     if broken.iter().any(|x| test_path.contains(x)) {
         return true;
     }
@@ -235,7 +235,7 @@ impl TestState {
                 wast::lexer::Token::Whitespace(ws) => ws,
                 _ => continue,
             };
-            if ws.starts_with("\n") || ws == " " {
+            if ws.starts_with('\n') || ws == " " {
                 continue;
             }
             let offset = ws.as_ptr() as usize - string.as_ptr() as usize;
@@ -294,7 +294,7 @@ impl TestState {
                 err.set_text(contents);
             }
             s.push_str("\n\n\t--------------------------------\n\n\t");
-            s.push_str(&format!("{:?}", error).replace("\n", "\n\t"));
+            s.push_str(&format!("{:?}", error).replace('\n', "\n\t"));
         }
         bail!("{}", s)
     }
@@ -449,19 +449,19 @@ impl TestState {
                 for diff in diff::lines(&snapshot, &contents) {
                     match diff {
                         diff::Result::Left(s) => {
-                            result.push_str("-");
+                            result.push('-');
                             result.push_str(s);
                         }
                         diff::Result::Right(s) => {
-                            result.push_str("+");
+                            result.push('+');
                             result.push_str(s);
                         }
                         diff::Result::Both(s, _) => {
-                            result.push_str(" ");
+                            result.push(' ');
                             result.push_str(s);
                         }
                     }
-                    result.push_str("\n");
+                    result.push('\n');
                 }
                 anyhow::bail!(
                     "snapshot does not match the expected result, try `env BLESS=1`\n{}",
@@ -489,7 +489,7 @@ impl TestState {
             .find(|((_, actual), expected)| actual != expected);
         let pos = match difference {
             Some(((pos, _), _)) => format!("at byte {} ({0:#x})", pos),
-            None => format!("by being too small"),
+            None => "by being too small".to_string(),
         };
         let mut msg = format!("error: actual wasm differs {} from expected wasm\n", pos);
 
@@ -500,8 +500,8 @@ impl TestState {
             msg.push_str(&format!("       | + {:#04x}\n", actual[pos]));
         }
 
-        if let Ok(actual) = self.dump(&actual) {
-            if let Ok(expected) = self.dump(&expected) {
+        if let Ok(actual) = self.dump(actual) {
+            if let Ok(expected) = self.dump(expected) {
                 let mut actual = actual.lines();
                 let mut expected = expected.lines();
                 let mut differences = 0;
@@ -518,7 +518,7 @@ impl TestState {
 
                     if actual_state == expected_state {
                         if differences > 0 && !last_dots {
-                            msg.push_str(&format!(" ...\n"));
+                            msg.push_str(&" ...\n".to_string());
                             last_dots = true;
                         }
                         continue;
@@ -772,5 +772,5 @@ fn error_matches(error: &str, message: &str) -> bool {
         return error.contains("global is immutable");
     }
 
-    return false;
+    false
 }


### PR DESCRIPTION
This PR adds a Clippy job to CI. This can wait until #956 and #1027 merged in to main. 

The rest of the changes are auto-generated by `cargo clippy --all --fix` and then followed by `cargo fmt --all`