### PR TITLE
gc: Gate value types on enabled features

### DIFF
--- a/tests/local/missing-features/reference-types/function-references.wast
+++ b/tests/local/missing-features/reference-types/function-references.wast
@@ -1,0 +1,12 @@
+(assert_invalid
+  (module (type (func (param (ref func)))))
+  "function references required")
+(assert_invalid
+  (module (type (func (param (ref extern)))))
+  "function references required")
+(assert_invalid
+  (module
+    (type $f (func))
+    (type (func (param (ref $f))))
+  )
+  "function references required")

--- a/tests/local/missing-features/reference-types/gc.wast
+++ b/tests/local/missing-features/reference-types/gc.wast
@@ -1,0 +1,30 @@
+(assert_invalid
+  (module (type (func (param i31ref))))
+  "gc proposal is not enabled")
+(assert_invalid
+  (module (type (func (param anyref))))
+  "gc proposal is not enabled")
+(assert_invalid
+  (module (type (func (param (ref none)))))
+  "gc proposal is not enabled")
+(assert_invalid
+  (module (type (func (param (ref array)))))
+  "gc proposal is not enabled")
+(assert_invalid
+  (module (type (func (param (ref struct)))))
+  "gc proposal is not enabled")
+(assert_invalid
+  (module (type (func (param (ref eq)))))
+  "gc proposal is not enabled")
+(assert_invalid
+  (module (type (func (param (ref noextern)))))
+  "gc proposal is not enabled")
+(assert_invalid
+  (module (type (func (param (ref nofunc)))))
+  "gc proposal is not enabled")
+(assert_invalid
+  (module (func (local i31ref)))
+  "gc proposal is not enabled")
+(assert_invalid
+  (module (func (block (result i31ref) unreachable)))
+  "gc proposal is not enabled")


### PR DESCRIPTION
This commit adds gates for types in the GC proposal when present in value types which gates presence in locations like function parameters, block types, instruction payloads, etc.