### PR TITLE
added initial parsing for resources and shared handles

### DIFF
--- a/crates/wit-component/src/decoding.rs
+++ b/crates/wit-component/src/decoding.rs
@@ -904,9 +904,11 @@ impl WitPackageDecoder<'_> {
             | TypeDefKind::List(_)
             | TypeDefKind::Tuple(_)
             | TypeDefKind::Option(_)
-            | TypeDefKind::Result(_) => {}
+            | TypeDefKind::Result(_)
+            | TypeDefKind::Handle(_) => {}
 
-            TypeDefKind::Record(_)
+            TypeDefKind::Resource(_)
+            | TypeDefKind::Record(_)
             | TypeDefKind::Enum(_)
             | TypeDefKind::Variant(_)
             | TypeDefKind::Union(_)

--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -286,6 +286,12 @@ impl TypeContents {
     fn for_type(resolve: &Resolve, ty: &Type) -> Self {
         match ty {
             Type::Id(id) => match &resolve.types[*id].kind {
+                TypeDefKind::Handle(h) => match h {
+                    wit_parser::Handle::Shared(ty) => Self::for_type(resolve, ty),
+                },
+                TypeDefKind::Resource(..) => {
+                    todo!();
+                }
                 TypeDefKind::Record(r) => Self::for_types(resolve, r.fields.iter().map(|f| &f.ty)),
                 TypeDefKind::Tuple(t) => Self::for_types(resolve, t.types.iter()),
                 TypeDefKind::Flags(_) => Self::empty(),

--- a/crates/wit-component/src/encoding/types.rs
+++ b/crates/wit-component/src/encoding/types.rs
@@ -153,6 +153,8 @@ pub trait ValtypeEncoder<'a> {
                     TypeDefKind::Future(_) => todo!("encoding for future type"),
                     TypeDefKind::Stream(_) => todo!("encoding for stream type"),
                     TypeDefKind::Unknown => unreachable!(),
+                    TypeDefKind::Resource(_) => todo!(),
+                    TypeDefKind::Handle(_) => todo!(),
                 };
 
                 if let Some(name) = &ty.name {

--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -291,6 +291,12 @@ impl WitPrinter {
                 }
 
                 match &ty.kind {
+                    TypeDefKind::Handle(h) => {
+                        self.print_handle_type(resolve, h)?;
+                    }
+                    TypeDefKind::Resource(_) => {
+                        bail!("resolve has an unnamed resource type");
+                    }
                     TypeDefKind::Tuple(t) => {
                         self.print_tuple_type(resolve, t)?;
                     }
@@ -329,6 +335,18 @@ impl WitPrinter {
                     }
                     TypeDefKind::Unknown => unreachable!(),
                 }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn print_handle_type(&mut self, resolve: &Resolve, handle: &Handle) -> Result<()> {
+        match handle {
+            Handle::Shared(ty) => {
+                self.output.push_str("shared<");
+                self.print_type_name(resolve, ty)?;
+                self.output.push_str(">");
             }
         }
 
@@ -412,6 +430,12 @@ impl WitPrinter {
             Type::Id(id) => {
                 let ty = &resolve.types[*id];
                 match &ty.kind {
+                    TypeDefKind::Handle(h) => {
+                        self.declare_handle(resolve, ty.name.as_deref(), h)?
+                    }
+                    TypeDefKind::Resource(r) => {
+                        self.declare_resource(resolve, ty.name.as_deref(), r)?
+                    }
                     TypeDefKind::Record(r) => {
                         self.declare_record(resolve, ty.name.as_deref(), r)?
                     }
@@ -447,6 +471,115 @@ impl WitPrinter {
                 }
             }
         }
+        Ok(())
+    }
+
+    fn declare_handle(
+        &mut self,
+        resolve: &Resolve,
+        name: Option<&str>,
+        handle: &Handle,
+    ) -> Result<()> {
+        match name {
+            Some(name) => {
+                self.print_name(name);
+                self.output.push_str(" = ");
+
+                match handle {
+                    Handle::Shared(ty) => {
+                        self.output.push_str("shared<");
+                        self.print_type_name(resolve, ty)?;
+                        self.output.push_str(">");
+                    }
+                }
+
+                self.output.push_str("\n\n");
+
+                Ok(())
+            }
+            None => bail!("document has unnamed handle type"),
+        }
+    }
+
+    fn declare_resource(
+        &mut self,
+        resolve: &Resolve,
+        name: Option<&str>,
+        resource: &Resource,
+    ) -> Result<()> {
+        match name {
+            Some(name) => {
+                self.output.push_str("resource ");
+                self.print_name(name);
+                self.output.push_str(" {\n");
+                for function in &resource.methods {
+                    self.declare_function(resolve, Some(name), function)?;
+                }
+                self.output.push_str(" }\n\n");
+                Ok(())
+            }
+            None => bail!("document has unnamed resource type"),
+        }
+    }
+
+    fn declare_function(
+        &mut self,
+        resolve: &Resolve,
+        name: Option<&str>,
+        function: &Function,
+    ) -> Result<()> {
+        match function.kind {
+            FunctionKind::Static => {
+                self.output.push_str("static ");
+            }
+            _ => {}
+        }
+
+        self.print_name(&function.name);
+        self.output.push_str(": func(");
+
+        match function.kind {
+            FunctionKind::Method => match name {
+                Some(name) => {
+                    self.output.push_str(&format!("self: shared<{name}>"));
+                }
+                None => bail!("document has unnamed resource type"),
+            },
+            _ => {}
+        }
+
+        for (name, ty) in &function.params {
+            self.print_name(&name);
+            self.output.push_str(": ");
+            self.print_type_name(resolve, &ty)?;
+            self.output.push_str(", ");
+        }
+
+        self.output.push_str(") ");
+
+        self.output.push_str("-> ");
+
+        match &function.results {
+            Results::Named(results) => {
+                self.output.push_str("(");
+
+                if results.len() > 0 {
+                    for (name, ty) in results {
+                        self.print_name(&name);
+                        self.output.push_str(": ");
+                        self.print_type_name(resolve, &ty)?;
+                        self.output.push_str(", ");
+                    }
+                }
+                self.output.push_str(")");
+            }
+            Results::Anon(ty) => {
+                self.print_type_name(resolve, &ty)?;
+            }
+        }
+
+        self.output.push_str(";\n");
+
         Ok(())
     }
 
@@ -630,7 +763,7 @@ fn is_keyword(name: &str) -> bool {
         | "float32" | "float64" | "char" | "record" | "flags" | "variant" | "enum" | "union"
         | "bool" | "string" | "option" | "result" | "future" | "stream" | "list" | "_" | "as"
         | "from" | "static" | "interface" | "tuple" | "implements" | "world" | "import"
-        | "export" | "default" | "pkg" | "self" | "package" => true,
+        | "export" | "shared" | "default" | "pkg" | "self" | "package" => true,
         _ => false,
     }
 }

--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -762,8 +762,8 @@ fn is_keyword(name: &str) -> bool {
         "use" | "type" | "func" | "u8" | "u16" | "u32" | "u64" | "s8" | "s16" | "s32" | "s64"
         | "float32" | "float64" | "char" | "resource" | "record" | "flags" | "variant" | "enum"
         | "union" | "bool" | "string" | "option" | "result" | "future" | "stream" | "list"
-        | "_" | "as" | "from" | "static" | "interface" | "tuple" | "implements" | "world"
-        | "import" | "export" | "shared" | "default" | "pkg" | "self" | "package" => true,
+        | "shared" | "_" | "as" | "from" | "static" | "interface" | "tuple" | "implements"
+        | "world" | "import" | "export" | "default" | "pkg" | "self" | "package" => true,
         _ => false,
     }
 }

--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -760,10 +760,10 @@ impl WitPrinter {
 fn is_keyword(name: &str) -> bool {
     match name {
         "use" | "type" | "func" | "u8" | "u16" | "u32" | "u64" | "s8" | "s16" | "s32" | "s64"
-        | "float32" | "float64" | "char" | "record" | "flags" | "variant" | "enum" | "union"
-        | "bool" | "string" | "option" | "result" | "future" | "stream" | "list" | "_" | "as"
-        | "from" | "static" | "interface" | "tuple" | "implements" | "world" | "import"
-        | "export" | "shared" | "default" | "pkg" | "self" | "package" => true,
+        | "float32" | "float64" | "char" | "resource" | "record" | "flags" | "variant" | "enum"
+        | "union" | "bool" | "string" | "option" | "result" | "future" | "stream" | "list"
+        | "_" | "as" | "from" | "static" | "interface" | "tuple" | "implements" | "world"
+        | "import" | "export" | "shared" | "default" | "pkg" | "self" | "package" => true,
         _ => false,
     }
 }

--- a/crates/wit-component/tests/interfaces/diamond.wat
+++ b/crates/wit-component/tests/interfaces/diamond.wat
@@ -7,7 +7,7 @@
           (export (;1;) "the-enum" (type (eq 0)))
         )
       )
-      (export (;0;) (interface "foo:foo/shared") (instance (type 0)))
+      (export (;0;) (interface "foo:foo/shared-items") (instance (type 0)))
       (type (;1;)
         (component
           (type (;0;)
@@ -16,7 +16,7 @@
               (export (;1;) "the-enum" (type (eq 0)))
             )
           )
-          (import (interface "foo:foo/shared") (instance (;0;) (type 0)))
+          (import (interface "foo:foo/shared-items") (instance (;0;) (type 0)))
           (alias export 0 "the-enum" (type (;1;)))
           (type (;2;)
             (instance
@@ -43,7 +43,7 @@
               (export (;1;) "the-enum" (type (eq 0)))
             )
           )
-          (import (interface "foo:foo/shared") (instance (;0;) (type 0)))
+          (import (interface "foo:foo/shared-items") (instance (;0;) (type 0)))
           (alias export 0 "the-enum" (type (;1;)))
           (type (;2;)
             (instance
@@ -70,7 +70,7 @@
               (export (;1;) "the-enum" (type (eq 0)))
             )
           )
-          (import (interface "foo:foo/shared") (instance (;0;) (type 0)))
+          (import (interface "foo:foo/shared-items") (instance (;0;) (type 0)))
           (alias export 0 "the-enum" (type (;1;)))
           (type (;2;)
             (instance

--- a/crates/wit-component/tests/interfaces/diamond.wit
+++ b/crates/wit-component/tests/interfaces/diamond.wit
@@ -1,6 +1,6 @@
 package foo:foo
 
-interface shared {
+interface shared-items {
   enum the-enum {
     a
   }
@@ -8,24 +8,24 @@ interface shared {
 
 world w1 {
   import foo: interface {
-    use shared.{the-enum}
+    use shared-items.{the-enum}
   }
   import bar: interface {
-    use shared.{the-enum}
+    use shared-items.{the-enum}
   }
 }
 
 world w2 {
   import foo: interface {
-    use shared.{the-enum}
+    use shared-items.{the-enum}
   }
   export bar: interface {
-    use shared.{the-enum}
+    use shared-items.{the-enum}
   }
 }
 
 world w3 {
   export bar: interface {
-    use shared.{the-enum}
+    use shared-items.{the-enum}
   }
 }

--- a/crates/wit-component/tests/interfaces/diamond.wit.print
+++ b/crates/wit-component/tests/interfaces/diamond.wit.print
@@ -1,6 +1,6 @@
 package foo:foo
 
-interface shared {
+interface shared-items {
   enum the-enum {
     a,
   }
@@ -8,26 +8,26 @@ interface shared {
 }
 
 world w1 {
-  import shared
+  import shared-items
   import foo: interface {
-    use shared.{the-enum}
+    use shared-items.{the-enum}
   }
   import bar: interface {
-    use shared.{the-enum}
+    use shared-items.{the-enum}
   }
 }
 world w2 {
-  import shared
+  import shared-items
   import foo: interface {
-    use shared.{the-enum}
+    use shared-items.{the-enum}
   }
   export bar: interface {
-    use shared.{the-enum}
+    use shared-items.{the-enum}
   }
 }
 world w3 {
-  import shared
+  import shared-items
   export bar: interface {
-    use shared.{the-enum}
+    use shared-items.{the-enum}
   }
 }

--- a/crates/wit-component/tests/merge/success/from/deps/foo/shared.wit
+++ b/crates/wit-component/tests/merge/success/from/deps/foo/shared.wit
@@ -10,14 +10,14 @@ interface shared-only-from {
   use foo:only-from-dep/a.{a}
 }
 
-interface shared {
+interface shared-items {
   type a = u32
 }
 
 world shared-world {
-  import shared
+  import shared-items
 
-  export shared
+  export shared-items
 
   type c = u32
 

--- a/crates/wit-component/tests/merge/success/into/deps/foo/shared.wit
+++ b/crates/wit-component/tests/merge/success/into/deps/foo/shared.wit
@@ -8,14 +8,14 @@ interface shared-only-into {
   bar: func(x: v)
 }
 
-interface shared {
+interface shared-items {
   type a = u32
 }
 
 world shared-world {
-  import shared
+  import shared-items
 
-  export shared
+  export shared-items
 
   type c = u32
 

--- a/crates/wit-component/tests/merge/success/merge/foo.wit
+++ b/crates/wit-component/tests/merge/success/merge/foo.wit
@@ -8,7 +8,7 @@ interface shared-only-into {
   bar: func(x: v)
 }
 
-interface shared {
+interface shared-items {
   type a = u32
 
 }
@@ -38,10 +38,10 @@ interface only-from {
 }
 
 world shared-world {
-  import shared
+  import shared-items
   import d: interface {
   }
   type c = u32
 
-  export shared
+  export shared-items
 }

--- a/crates/wit-parser/src/abi.rs
+++ b/crates/wit-parser/src/abi.rs
@@ -772,6 +772,10 @@ impl Resolve {
             Type::Id(id) => match &self.types[*id].kind {
                 TypeDefKind::Type(t) => self.push_wasm(variant, t, result),
 
+                TypeDefKind::Handle(_) => todo!(),
+
+                TypeDefKind::Resource(_) => todo!(),
+
                 TypeDefKind::Record(r) => {
                     for field in r.fields.iter() {
                         self.push_wasm(variant, &field.ty, result);
@@ -899,6 +903,8 @@ impl Resolve {
             Type::Id(id) => match &self.types[*id].kind {
                 TypeDefKind::List(_) => true,
                 TypeDefKind::Type(t) => self.needs_post_return(t),
+                TypeDefKind::Handle(_) => true,
+                TypeDefKind::Resource(_) => true,
                 TypeDefKind::Record(r) => r.fields.iter().any(|f| self.needs_post_return(&f.ty)),
                 TypeDefKind::Tuple(t) => t.types.iter().any(|t| self.needs_post_return(t)),
                 TypeDefKind::Union(t) => t.cases.iter().any(|t| self.needs_post_return(&t.ty)),
@@ -1285,6 +1291,10 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                         self.emit(&ListLower { element, realloc });
                     }
                 }
+                TypeDefKind::Handle(_) => todo!(),
+                TypeDefKind::Resource(_) => {
+                    todo!();
+                }
                 TypeDefKind::Record(record) => {
                     self.emit(&RecordLower {
                         record,
@@ -1468,6 +1478,12 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                         self.emit(&ListLift { element, ty: id });
                     }
                 }
+                TypeDefKind::Handle(_) => {
+                    todo!();
+                }
+                TypeDefKind::Resource(_) => {
+                    todo!();
+                }
                 TypeDefKind::Record(record) => {
                     let mut temp = Vec::new();
                     self.resolve.push_wasm(self.variant, ty, &mut temp);
@@ -1615,6 +1631,8 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                 TypeDefKind::Type(t) => self.write_to_memory(t, addr, offset),
                 TypeDefKind::List(_) => self.write_list_to_memory(ty, addr, offset),
 
+                TypeDefKind::Handle(_) => todo!(),
+
                 // Decompose the record into its components and then write all
                 // the components into memory one-by-one.
                 TypeDefKind::Record(record) => {
@@ -1624,6 +1642,9 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                         name: self.resolve.types[id].name.as_deref().unwrap(),
                     });
                     self.write_fields_to_memory(record.fields.iter().map(|f| &f.ty), addr, offset);
+                }
+                TypeDefKind::Resource(resource) => {
+                    todo!()
                 }
                 TypeDefKind::Tuple(tuple) => {
                     self.emit(&TupleLower { tuple, ty: id });
@@ -1814,6 +1835,14 @@ impl<'a, B: Bindgen> Generator<'a, B> {
 
                 TypeDefKind::List(_) => self.read_list_from_memory(ty, addr, offset),
 
+                TypeDefKind::Handle(_) => {
+                    todo!();
+                }
+
+                TypeDefKind::Resource(_) => {
+                    todo!();
+                }
+
                 // Read and lift each field individually, adjusting the offset
                 // as we go along, then aggregate all the fields into the
                 // record.
@@ -1825,6 +1854,7 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                         name: self.resolve.types[id].name.as_deref().unwrap(),
                     });
                 }
+
                 TypeDefKind::Tuple(tuple) => {
                     self.read_fields_from_memory(&tuple.types, addr, offset);
                     self.emit(&TupleLift { tuple, ty: id });
@@ -2029,6 +2059,14 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                     self.emit(&Instruction::GuestDeallocateList { element });
                 }
 
+                TypeDefKind::Handle(_) => {
+                    todo!()
+                }
+
+                TypeDefKind::Resource(_) => {
+                    todo!()
+                }
+
                 TypeDefKind::Record(record) => {
                     self.deallocate_fields(
                         &record.fields.iter().map(|f| f.ty).collect::<Vec<_>>(),
@@ -2036,6 +2074,7 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                         offset,
                     );
                 }
+
                 TypeDefKind::Tuple(tuple) => {
                     self.deallocate_fields(&tuple.types, addr, offset);
                 }

--- a/crates/wit-parser/src/abi.rs
+++ b/crates/wit-parser/src/abi.rs
@@ -1643,7 +1643,7 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                     });
                     self.write_fields_to_memory(record.fields.iter().map(|f| &f.ty), addr, offset);
                 }
-                TypeDefKind::Resource(resource) => {
+                TypeDefKind::Resource(_) => {
                     todo!()
                 }
                 TypeDefKind::Tuple(tuple) => {

--- a/crates/wit-parser/src/ast/lex.rs
+++ b/crates/wit-parser/src/ast/lex.rs
@@ -66,6 +66,8 @@ pub enum Token {
     Float64,
     Char,
     Record,
+    Resource,
+    Shared,
     Flags,
     Variant,
     Enum,
@@ -259,6 +261,8 @@ impl<'a> Tokenizer<'a> {
                     "float32" => Float32,
                     "float64" => Float64,
                     "char" => Char,
+                    "resource" => Resource,
+                    "shared" => Shared,
                     "record" => Record,
                     "flags" => Flags,
                     "variant" => Variant,
@@ -502,6 +506,8 @@ impl Token {
             Float32 => "keyword `float32`",
             Float64 => "keyword `float64`",
             Char => "keyword `char`",
+            Shared => "keyword `shared`",
+            Resource => "keyword `resource`",
             Record => "keyword `record`",
             Flags => "keyword `flags`",
             Variant => "keyword `variant`",
@@ -663,6 +669,19 @@ fn test_tokenizer() {
             Token::Func,
             Token::LeftParen,
             Token::RightParen
+        ]
+    );
+
+    assert_eq!(collect("resource").unwrap(), vec![Token::Resource]);
+
+    assert_eq!(collect("shared").unwrap(), vec![Token::Shared]);
+    assert_eq!(
+        collect("shared<some-id>").unwrap(),
+        vec![
+            Token::Shared,
+            Token::LessThan,
+            Token::Id,
+            Token::GreaterThan
         ]
     );
 

--- a/crates/wit-parser/src/ast/resolve.rs
+++ b/crates/wit-parser/src/ast/resolve.rs
@@ -652,7 +652,7 @@ impl<'a> Resolver<'a> {
                         assert!(prev.is_none());
                     }
                     ValueKind::Static(_) => {
-                        unreachable!("static functions are only supported in resources")
+                        bail!("static functions are only supported in resources")
                     }
                 },
                 ast::InterfaceItem::Use(_) | ast::InterfaceItem::TypeDef(_) => {}

--- a/crates/wit-parser/src/ast/resolve.rs
+++ b/crates/wit-parser/src/ast/resolve.rs
@@ -84,7 +84,6 @@ enum Key {
     Variant(Vec<(String, Option<Type>)>),
     Handle(Handle),
     Record(Vec<(String, Type)>),
-    Resource(Vec<(String, Type)>),
     Flags(Vec<String>),
     Tuple(Vec<Type>),
     Enum(Vec<String>),

--- a/crates/wit-parser/src/ast/resolve.rs
+++ b/crates/wit-parser/src/ast/resolve.rs
@@ -82,7 +82,9 @@ enum AstItem {
 #[derive(PartialEq, Eq, Hash)]
 enum Key {
     Variant(Vec<(String, Option<Type>)>),
+    Handle(Handle),
     Record(Vec<(String, Type)>),
+    Resource(Vec<(String, Type)>),
     Flags(Vec<String>),
     Tuple(Vec<Type>),
     Enum(Vec<String>),
@@ -650,6 +652,9 @@ impl<'a> Resolver<'a> {
                             .insert(value.name.name.to_string(), func);
                         assert!(prev.is_none());
                     }
+                    ValueKind::Static(_) => {
+                        unreachable!("static functions are only supported in resources")
+                    }
                 },
                 ast::InterfaceItem::Use(_) | ast::InterfaceItem::TypeDef(_) => {}
             }
@@ -854,6 +859,52 @@ impl<'a> Resolver<'a> {
                 let ty = self.resolve_type(list)?;
                 TypeDefKind::List(ty)
             }
+            ast::Type::Handle(handle) => match handle {
+                ast::Handle::Shared { ty } => {
+                    let ty = self.resolve_type(ty)?;
+                    TypeDefKind::Handle(Handle::Shared(ty))
+                }
+            },
+            ast::Type::Resource(resource) => {
+                let methods = resource
+                    .methods
+                    .iter()
+                    .map(|value| {
+                        let (func, kind) = match &value.kind {
+                            ValueKind::Func(func) => (func, FunctionKind::Method),
+                            ValueKind::Static(func) => (func, FunctionKind::Static),
+                        };
+
+                        let params = func
+                            .params
+                            .iter()
+                            .map(|(id, ty)| (id.name.to_owned(), self.resolve_type(ty).unwrap()))
+                            .collect();
+
+                        let results = match &func.results {
+                            ResultList::Named(results) => {
+                                let results = results
+                                    .into_iter()
+                                    .map(|(id, ty)| {
+                                        (id.name.to_owned(), self.resolve_type(&ty).unwrap())
+                                    })
+                                    .collect();
+                                Results::Named(results)
+                            }
+                            ResultList::Anon(ty) => Results::Anon(self.resolve_type(&ty).unwrap()),
+                        };
+
+                        Ok(Function {
+                            docs: self.docs(&value.docs),
+                            name: value.name.name.to_string(),
+                            kind: kind,
+                            params: params,
+                            results: results,
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                TypeDefKind::Resource(Resource { methods })
+            }
             ast::Type::Record(record) => {
                 let fields = record
                     .fields
@@ -986,6 +1037,8 @@ impl<'a> Resolver<'a> {
                     .map(|case| (case.name.clone(), case.ty))
                     .collect::<Vec<_>>(),
             ),
+            TypeDefKind::Handle(h) => Key::Handle(*h),
+            TypeDefKind::Resource(_) => unreachable!("anonymous resources aren't supported"),
             TypeDefKind::Record(r) => Key::Record(
                 r.fields
                     .iter()
@@ -1074,6 +1127,30 @@ fn collect_deps<'a>(ty: &ast::Type<'a>, deps: &mut Vec<ast::Id<'a>>) {
         | ast::Type::Enum(_) => {}
         ast::Type::Name(name) => deps.push(name.clone()),
         ast::Type::List(list) => collect_deps(list, deps),
+        ast::Type::Handle(handle) => match handle {
+            ast::Handle::Shared { ty } => collect_deps(ty, deps),
+        },
+        ast::Type::Resource(resource) => {
+            for method in resource.methods.iter() {
+                let func = match &method.kind {
+                    ValueKind::Func(func) => func,
+                    ValueKind::Static(func) => func,
+                };
+
+                for (_, ty) in func.params.iter() {
+                    collect_deps(ty, deps);
+                }
+
+                match &func.results {
+                    ResultList::Named(results) => {
+                        for (_, ty) in results.iter() {
+                            collect_deps(ty, deps);
+                        }
+                    }
+                    ResultList::Anon(ty) => collect_deps(&ty, deps),
+                }
+            }
+        }
         ast::Type::Record(record) => {
             for field in record.fields.iter() {
                 collect_deps(&field.ty, deps);

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -307,6 +307,8 @@ pub struct TypeDef {
 #[derive(Debug, Clone, PartialEq)]
 pub enum TypeDefKind {
     Record(Record),
+    Resource(Resource),
+    Handle(Handle),
     Flags(Flags),
     Tuple(Tuple),
     Variant(Variant),
@@ -331,6 +333,10 @@ impl TypeDefKind {
     pub fn as_str(&self) -> &'static str {
         match self {
             TypeDefKind::Record(_) => "record",
+            TypeDefKind::Resource(_) => "resource",
+            TypeDefKind::Handle(handle) => match handle {
+                Handle::Shared(_) => "shared",
+            },
             TypeDefKind::Flags(_) => "flags",
             TypeDefKind::Tuple(_) => "tuple",
             TypeDefKind::Variant(_) => "variant",
@@ -356,6 +362,11 @@ pub enum TypeOwner {
     /// This type wasn't inherently defined anywhere, such as a `list<T>`, which
     /// doesn't need an owner.
     None,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
+pub enum Handle {
+    Shared(Type),
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
@@ -387,6 +398,11 @@ pub enum Int {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Record {
     pub fields: Vec<Field>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Resource {
+    pub methods: Vec<Function>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -519,7 +535,7 @@ pub struct Stream {
     pub end: Option<Type>,
 }
 
-#[derive(Clone, Default, Debug, PartialEq)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub struct Docs {
     pub contents: Option<String>,
 }
@@ -591,7 +607,7 @@ impl Results {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Function {
     pub docs: Docs,
     pub name: String,
@@ -600,15 +616,19 @@ pub struct Function {
     pub results: Results,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FunctionKind {
     Freestanding,
+    Method,
+    Static,
 }
 
 impl Function {
     pub fn item_name(&self) -> &str {
         match &self.kind {
             FunctionKind::Freestanding => &self.name,
+            FunctionKind::Method => &self.name,
+            FunctionKind::Static => &self.name,
         }
     }
 

--- a/crates/wit-parser/src/live.rs
+++ b/crates/wit-parser/src/live.rs
@@ -58,6 +58,24 @@ impl LiveTypes {
             | TypeDefKind::List(t)
             | TypeDefKind::Option(t)
             | TypeDefKind::Future(Some(t)) => self.add_type(resolve, t),
+            TypeDefKind::Handle(handle) => match handle {
+                crate::Handle::Shared(ty) => self.add_type(resolve, ty),
+            },
+            TypeDefKind::Resource(r) => {
+                for function in r.methods.iter() {
+                    for (_, ty) in &function.params {
+                        self.add_type(resolve, ty);
+                    }
+                    match &function.results {
+                        crate::Results::Named(results) => {
+                            for (_, ty) in results {
+                                self.add_type(resolve, ty);
+                            }
+                        }
+                        crate::Results::Anon(ty) => self.add_type(resolve, ty),
+                    }
+                }
+            }
             TypeDefKind::Record(r) => {
                 for field in r.fields.iter() {
                     self.add_type(resolve, &field.ty);

--- a/crates/wit-parser/src/sizealign.rs
+++ b/crates/wit-parser/src/sizealign.rs
@@ -30,10 +30,13 @@ impl SizeAlign {
             TypeDefKind::Option(t) => self.variant(Int::U8, [Some(t)]),
             TypeDefKind::Result(r) => self.variant(Int::U8, [r.ok.as_ref(), r.err.as_ref()]),
             TypeDefKind::Union(u) => self.variant(u.tag(), u.cases.iter().map(|c| Some(&c.ty))),
+            // A resource is represented as an index.
+            TypeDefKind::Handle(_) => (4, 4),
             // A future is represented as an index.
             TypeDefKind::Future(_) => (4, 4),
             // A stream is represented as an index.
             TypeDefKind::Stream(_) => (4, 4),
+            TypeDefKind::Resource(_) => unreachable!(),
             TypeDefKind::Unknown => unreachable!(),
         }
     }

--- a/crates/wit-parser/tests/ui/resources-empty.wit
+++ b/crates/wit-parser/tests/ui/resources-empty.wit
@@ -1,0 +1,9 @@
+package foo:resources-empty
+
+interface resources-empty {
+  t1: func(a: shared<r1>) -> ()
+
+  resource r1 {
+  }
+}
+

--- a/crates/wit-parser/tests/ui/resources-multiple-returns-shared.wit
+++ b/crates/wit-parser/tests/ui/resources-multiple-returns-shared.wit
@@ -1,0 +1,11 @@
+package foo:resources1
+
+interface resources1 {
+  t1: func(a: shared<r1>) -> ()
+
+  resource r1 {
+    //TODO: Fix so it will allow references to itself if it's inside a handle
+    //f1: func() -> (a: s32, handle: shared<r1>)
+  }
+}
+

--- a/crates/wit-parser/tests/ui/resources-multiple.wit
+++ b/crates/wit-parser/tests/ui/resources-multiple.wit
@@ -1,0 +1,19 @@
+package foo:resources-multiple
+
+interface resources-multiple {
+  t1: func(a: shared<r1>) -> ()
+
+  resource r1 {
+    f1: func(), 
+    f2: func(a: u32),
+    f3: func(a: u32,),
+    f4: func() -> u32,
+    f6: func() -> tuple<u32, u32>,
+    f7: func(a: float32, b: float32) -> tuple<u32, u32>,
+    f8: func(a: option<u32>) -> result<u32, float32>,
+    f9: func() -> (u: u32, f: float32),
+    f10: func() -> (u: u32),
+    f11: func() -> ()
+  }
+}
+

--- a/crates/wit-parser/tests/ui/resources-return-shared.wit
+++ b/crates/wit-parser/tests/ui/resources-return-shared.wit
@@ -1,0 +1,11 @@
+package foo:resources1
+
+interface resources1 {
+  t1: func(a: shared<r1>) -> ()
+
+  resource r1 {
+    //TODO: Fix so it will allow references to itself if it's inside a handle
+    //f1: func() -> shared<r1>
+  }
+}
+

--- a/crates/wit-parser/tests/ui/resources1.wit
+++ b/crates/wit-parser/tests/ui/resources1.wit
@@ -1,0 +1,10 @@
+package foo:resources1
+
+interface resources1 {
+  t1: func(a: shared<r1>) -> ()
+
+  resource r1 {
+    f1: func()
+  }
+}
+

--- a/crates/wit-parser/tests/ui/shared-types.wit
+++ b/crates/wit-parser/tests/ui/shared-types.wit
@@ -1,4 +1,4 @@
-package foo:shared
+package foo:shared-items
 
 world foo {
   import foo: interface {

--- a/crates/wit-parser/tests/ui/world-diamond.wit
+++ b/crates/wit-parser/tests/ui/world-diamond.wit
@@ -1,17 +1,17 @@
 package foo:foo
 
-interface shared {
+interface shared-items {
   type foo = u32
 }
 
 interface i1 {
-  use shared.{foo}
+  use shared-items.{foo}
 
   a: func() -> foo
 }
 
 interface i2 {
-  use shared.{foo}
+  use shared-items.{foo}
 
   a: func() -> foo
 }

--- a/crates/wit-parser/tests/ui/world-same-fields4.wit
+++ b/crates/wit-parser/tests/ui/world-same-fields4.wit
@@ -1,13 +1,13 @@
 package foo:foo
 
-interface shared {
+interface shared-items {
   type a = u32
 }
 
 world foo {
-  import shared: interface {}
+  import shared-items: interface {}
   export a-name: interface {
-    use shared.{a}
+    use shared-items.{a}
   }
 }
 

--- a/crates/wit-parser/tests/ui/world-top-level-resources.wit
+++ b/crates/wit-parser/tests/ui/world-top-level-resources.wit
@@ -1,0 +1,23 @@
+package foo:foo
+
+interface types {
+  resource request { 
+    foo: func(),  
+    bar: func(arg: list<u32>) 
+  }
+
+  resource response { 
+    foo: func(),
+    bar: func(arg: list<u32>) 
+  }
+}
+
+interface handler {
+  use types.{request, response}
+  handle: func(some: shared<request>) -> shared<response>
+}
+
+world proxy {
+  import handler
+  export handler
+}


### PR DESCRIPTION
Adds the initial pass for the parsing of resources and shared handles.

Do we want to store resources as a `TypeDefKind`? I assume we might want to move this to an indexmap of resources and just store a resource id in handles?

@sunfishcode 