### PR TITLE
Fix generation of versions in wit-smith

### DIFF
--- a/crates/wit-smith/Cargo.toml
+++ b/crates/wit-smith/Cargo.toml
@@ -14,3 +14,4 @@ wit-parser = { workspace = true }
 clap = { workspace = true, optional = true }
 indexmap = { workspace = true }
 log = { workspace = true }
+semver = { workspace = true }


### PR DESCRIPTION
A full semver is now generated instead of just major/minor.