### PR TITLE
GC: wasmparser: Fix `gc/gc-ref.wat` roundtrip test

### DIFF
--- a/tests/local/gc/gc-ref.wat
+++ b/tests/local/gc/gc-ref.wat
@@ -7,32 +7,35 @@
   (type $f1 (func (param (ref $a))))
   (type $f2 (func (result (ref $b))))
 
-  (global (ref $a))
-  (global (ref $b))
+  (global (ref null $a) (ref.null $a))
+  (global (ref null $b) (ref.null $b))
 
   (func (param (ref $a)))
   (func (param (ref 0)))
   (func (type $f1) (param (ref 0)))
-  (func (type 2) (param (ref 0)))
-  (func (result (ref $a)))
+  (func (type $f1) (param (ref $a)))
+  (func (result (ref $a)) unreachable)
   (func (local (ref $a)))
 
   (func
-    select (result (ref $a))
+    (select (result (ref $a)) unreachable unreachable (i32.const 0))
 
-    (block (param (ref $a)))
-    (block (result (ref $b)))
-    (block $f1 (param (ref $a)))
-    (block $f2 (result (ref $b)))
+    (block (param (ref $a)) unreachable)
+    (block (result (ref $b)) unreachable)
+    (block $f1 (param (ref $a)) unreachable)
+    (block $f2 (result (ref $b)) unreachable)
 
-    (loop (param (ref $a)))
-    (loop (result (ref $b)))
-    (loop $f1 (param (ref $a)))
-    (loop $f2 (result (ref $b)))
+    (loop (param (ref $a)) unreachable)
+    (loop (result (ref $b)) unreachable)
+    (loop $f1 (param (ref $a)) unreachable)
+    (loop $f2 (result (ref $b)) unreachable)
+    drop
 
-    (if (param (ref $a)) (then) (else))
-    (if (result (ref $b)) (then) (else))
-    (if $f1 (param (ref $a)) (then) (else))
-    (if $f2 (result (ref $b)) (then) (else))
+    (if (param (ref $a)) (then unreachable) (else unreachable))
+    (if (result (ref $b)) (then unreachable) (else unreachable))
+    drop
+    (if $f1 (param (ref $a)) (then unreachable) (else unreachable))
+    (if $f2 (result (ref $b)) (then unreachable) (else unreachable))
+    drop
   )
 )

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -147,7 +147,6 @@ fn skip_test(test: &Path, contents: &[u8]) -> bool {
         // the GC proposal isn't implemented yet
         "gc/gc-array.wat",
         "gc/gc-rec-sub.wat",
-        "gc/gc-ref.wat",
         "gc/gc-ref-global-import.wat",
         "gc/gc-struct.wat",
         "gc/let.wat",

--- a/tests/snapshots/local/gc/gc-ref.wat.print
+++ b/tests/snapshots/local/gc/gc-ref.wat.print
@@ -1,0 +1,74 @@
+(module
+  (type $a (;0;) (struct))
+  (type $b (;1;) (struct))
+  (type $f1 (;2;) (func (param (ref 0))))
+  (type $f2 (;3;) (func (result (ref 1))))
+  (type (;4;) (func (param (ref 0))))
+  (type (;5;) (func (result (ref 0))))
+  (type (;6;) (func))
+  (func (;0;) (type $f1) (param (ref 0)))
+  (func (;1;) (type 4) (param (ref 0)))
+  (func (;2;) (type $f1) (param (ref 0)))
+  (func (;3;) (type $f1) (param (ref 0)))
+  (func (;4;) (type 5) (result (ref 0))
+    unreachable
+  )
+  (func (;5;) (type 6)
+    (local (ref 0))
+  )
+  (func (;6;) (type 6)
+    unreachable
+    unreachable
+    i32.const 0
+    select (result (ref 0))
+    block (type $f1) (param (ref 0)) ;; label = @1
+      unreachable
+    end
+    block (result (ref 1)) ;; label = @1
+      unreachable
+    end
+    block $f1 (type $f1) (param (ref 0)) ;; label = @1
+      unreachable
+    end
+    block $f2 (result (ref 1)) ;; label = @1
+      unreachable
+    end
+    loop (type $f1) (param (ref 0)) ;; label = @1
+      unreachable
+    end
+    loop (result (ref 1)) ;; label = @1
+      unreachable
+    end
+    loop $f1 (type $f1) (param (ref 0)) ;; label = @1
+      unreachable
+    end
+    loop $f2 (result (ref 1)) ;; label = @1
+      unreachable
+    end
+    drop
+    if (type $f1) (param (ref 0)) ;; label = @1
+      unreachable
+    else
+      unreachable
+    end
+    if (result (ref 1)) ;; label = @1
+      unreachable
+    else
+      unreachable
+    end
+    drop
+    if $f1 (type $f1) (param (ref 0)) ;; label = @1
+      unreachable
+    else
+      unreachable
+    end
+    if $f2 (result (ref 1)) ;; label = @1
+      unreachable
+    else
+      unreachable
+    end
+    drop
+  )
+  (global (;0;) (ref null 0) ref.null 0)
+  (global (;1;) (ref null 1) ref.null 1)
+)


### PR DESCRIPTION
Fix `gc/gc-ref.wat` roundtrip test.

Requires #1059.