### PR TITLE
chore(example): update example of wasm-compose

### DIFF
--- a/crates/wasm-compose/example/README.md
+++ b/crates/wasm-compose/example/README.md
@@ -87,7 +87,7 @@ Follow the [installation instructions](https://github.com/bytecodealliance/cargo
 to install `cargo component` locally.
 
 > *Note*: `cargo component` is under active development. This example has been tested
-> with git sha [`012daba`](https://github.com/bytecodealliance/cargo-component/commit/012daba27c48e1ce19b27f09730d51e9018f5135)
+> with git sha [`df2eb26`](https://github.com/bytecodealliance/cargo-component/commit/df2eb2633fa6d0c234372fb0471b8e9867d135c6)
 > and may not work with other versions of `cargo component`.
 
 Additionally, it is assumed that `wasm-tools` has been installed from the

--- a/crates/wasm-compose/example/middleware/Cargo.toml
+++ b/crates/wasm-compose/example/middleware/Cargo.toml
@@ -6,12 +6,12 @@ publish = false
 
 [dependencies]
 flate2 = "1.0.24"
-wit-bindgen = { version = "0.5.0", default_features = false }
+wit-bindgen = { version = "0.6.0", default_features = false }
 
 [lib]
 crate-type = ["cdylib"]
 
 [package.metadata.component]
-target = { path = "../service.wit", world = "service.middleware" }
+target = { path = "../service.wit", world = "middleware" }
 
 [workspace]

--- a/crates/wasm-compose/example/middleware/src/lib.rs
+++ b/crates/wasm-compose/example/middleware/src/lib.rs
@@ -1,7 +1,5 @@
-use bindings::{
-    downstream,
-    handler::{Error, Handler, Request, Response},
-};
+use bindings::example::service::handler as downstream;
+use bindings::exports::example::service::handler::{Error, Handler, Request, Response};
 use flate2::{write::GzEncoder, Compression};
 use std::io::Write;
 

--- a/crates/wasm-compose/example/server/Cargo.toml
+++ b/crates/wasm-compose/example/server/Cargo.toml
@@ -9,8 +9,9 @@ async-std = { version = "1.12.0", features = ["attributes"] }
 clap = { version = "3.2.23", features = ["derive"] }
 driftwood = "0.0.6"
 tide = "0.16.0"
-wasi-cap-std-sync = { git = "https://github.com/bytecodealliance/preview2-prototyping", rev = "0d5ca073d1131002d97c9f5984d388b55539950e" }
-wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", rev = "299131ae2d6655c49138bfab2c4469650763ef3b", features = ["component-model"] }
-wasi-host = { git = "https://github.com/bytecodealliance/preview2-prototyping", package = "host", rev = "0d5ca073d1131002d97c9f5984d388b55539950e" }
+wasmtime = { git = "https://github.com/bytecodealliance/wasmtime", rev = "46826c62735dc22cc512fd5d23aa702a92e8a364", features = ["component-model"] }
+wasmtime-wasi = { git = "https://github.com/bytecodealliance/wasmtime", rev = "46826c62735dc22cc512fd5d23aa702a92e8a364" }
+wasi-cap-std-sync = { git = "https://github.com/bytecodealliance/wasmtime", rev = "46826c62735dc22cc512fd5d23aa702a92e8a364" }
+anyhow = "1.0.71"
 
 [workspace]

--- a/crates/wasm-compose/example/server/config.yml
+++ b/crates/wasm-compose/example/server/config.yml
@@ -4,4 +4,4 @@ search-paths:
 instantiations:
   $input:
     arguments:
-      downstream: svc
+      example:service/handler: svc

--- a/crates/wasm-compose/example/service.wit
+++ b/crates/wasm-compose/example/service.wit
@@ -1,3 +1,5 @@
+package example:service
+
 interface handler {
     record request {
         headers: list<tuple<list<u8>, list<u8>>>,
@@ -16,11 +18,11 @@ interface handler {
     execute: func(req: request) -> result<response, error>
 }
 
-default world service {
-    export handler: self.handler
+world service {
+    export handler
 }
 
 world middleware {
-    import downstream: self.handler
-    export handler: self.handler
+    import handler
+    export handler
 }

--- a/crates/wasm-compose/example/service/Cargo.toml
+++ b/crates/wasm-compose/example/service/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 publish = false
 
 [dependencies]
-wit-bindgen = { version = "0.5.0", default_features = false }
+wit-bindgen = { version = "0.6.0", default_features = false }
 
 [lib]
 crate-type = ["cdylib"]
 
 [package.metadata.component]
-target = { path = "../service.wit" }
+target = { path = "../service.wit",  world = "service" }
 
 [workspace]

--- a/crates/wasm-compose/example/service/src/lib.rs
+++ b/crates/wasm-compose/example/service/src/lib.rs
@@ -1,4 +1,4 @@
-use bindings::handler::{Error, Handler, Request, Response};
+use bindings::exports::example::service::handler::{Error, Handler, Request, Response};
 use std::str;
 
 struct Component;


### PR DESCRIPTION
The wit syntax and the generated code for cargo-compose have changed quite a bit

And https://github.com/bytecodealliance/preview2-prototyping is being deprecated, we will use `wasmtime-wasi` and `wasi-cap-std-sync`