### PR TITLE
Update adapter name inference from its filename

### DIFF
--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -43,10 +43,14 @@ fn parse_optionally_name_file(s: &str) -> (&str, &str) {
         Some(path) => (name_or_path, path),
         None => {
             let name = Path::new(name_or_path)
-                .file_stem()
+                .file_name()
                 .unwrap()
                 .to_str()
                 .unwrap();
+            let name = match name.find('.') {
+                Some(i) => &name[..i],
+                None => name,
+            };
             (name, name_or_path)
         }
     }


### PR DESCRIPTION
Previously the "file stem" was used which only chops off the extension of the file (e.g. `foo` in `foo.wasm`) but this updates it to chop off everything after the first `.` so the name of `foo.bar.wasm` is now inferred as `foo` instead of `foo.bar`. This'll help with how Wasmtime is distributing `wasi_snapshot_preview1.reactor.wasm` when it's used to adapt `wasi_snapshot_preview1`.