### PR TITLE
Update `shared<T>` require `T` is an identifer

### DIFF
--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -287,11 +287,9 @@ impl TypeContents {
         match ty {
             Type::Id(id) => match &resolve.types[*id].kind {
                 TypeDefKind::Handle(h) => match h {
-                    wit_parser::Handle::Shared(ty) => Self::for_type(resolve, ty),
+                    wit_parser::Handle::Shared(_) => Self::empty(),
                 },
-                TypeDefKind::Resource(..) => {
-                    todo!();
-                }
+                TypeDefKind::Resource(..) => Self::empty(),
                 TypeDefKind::Record(r) => Self::for_types(resolve, r.fields.iter().map(|f| &f.ty)),
                 TypeDefKind::Tuple(t) => Self::for_types(resolve, t.types.iter()),
                 TypeDefKind::Flags(_) => Self::empty(),

--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -345,7 +345,12 @@ impl WitPrinter {
         match handle {
             Handle::Shared(ty) => {
                 self.output.push_str("shared<");
-                self.print_type_name(resolve, ty)?;
+                let ty = &resolve.types[*ty];
+                self.print_name(
+                    ty.name
+                        .as_ref()
+                        .ok_or_else(|| anyhow!("unnamed resource type"))?,
+                );
                 self.output.push_str(">");
             }
         }
@@ -484,15 +489,7 @@ impl WitPrinter {
             Some(name) => {
                 self.print_name(name);
                 self.output.push_str(" = ");
-
-                match handle {
-                    Handle::Shared(ty) => {
-                        self.output.push_str("shared<");
-                        self.print_type_name(resolve, ty)?;
-                        self.output.push_str(">");
-                    }
-                }
-
+                self.print_handle_type(resolve, handle)?;
                 self.output.push_str("\n\n");
 
                 Ok(())

--- a/crates/wit-parser/src/ast.rs
+++ b/crates/wit-parser/src/ast.rs
@@ -539,7 +539,7 @@ enum Type<'a> {
 }
 
 enum Handle<'a> {
-    Shared { ty: Box<Type<'a>> },
+    Shared { resource: Id<'a> },
 }
 
 struct Resource<'a> {
@@ -1039,9 +1039,9 @@ impl<'a> Type<'a> {
             // shared<T>
             Some((_span, Token::Shared)) => {
                 tokens.expect(Token::LessThan)?;
-                let ty = Box::new(Type::parse(tokens)?);
+                let resource = parse_id(tokens)?;
                 tokens.expect(Token::GreaterThan)?;
-                Ok(Type::Handle(Handle::Shared { ty }))
+                Ok(Type::Handle(Handle::Shared { resource }))
             }
 
             // `foo`

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -389,7 +389,7 @@ pub enum TypeOwner {
 
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]
 pub enum Handle {
-    Shared(Type),
+    Shared(TypeId),
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Copy, Clone)]

--- a/crates/wit-parser/src/live.rs
+++ b/crates/wit-parser/src/live.rs
@@ -59,7 +59,7 @@ impl LiveTypes {
             | TypeDefKind::Option(t)
             | TypeDefKind::Future(Some(t)) => self.add_type(resolve, t),
             TypeDefKind::Handle(handle) => match handle {
-                crate::Handle::Shared(ty) => self.add_type(resolve, ty),
+                crate::Handle::Shared(ty) => self.add_type_id(resolve, *ty),
             },
             TypeDefKind::Resource(r) => {
                 for function in r.methods.iter() {

--- a/crates/wit-parser/src/resolve.rs
+++ b/crates/wit-parser/src/resolve.rs
@@ -878,7 +878,7 @@ impl Remap {
         use crate::TypeDefKind::*;
         match &mut ty.kind {
             Handle(handle) => match handle {
-                crate::Handle::Shared(ty) => self.update_ty(ty),
+                crate::Handle::Shared(ty) => *ty = self.types[ty.index()],
             },
             Resource(r) => {
                 for function in r.methods.iter_mut() {

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource1.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource1.wit
@@ -1,0 +1,5 @@
+package foo:bar
+
+interface foo {
+  type t = shared<u32>
+}

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource1.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource1.wit.result
@@ -1,0 +1,5 @@
+expected an identifier or string, found keyword `u32`
+     --> tests/ui/parse-fail/bad-resource1.wit:4:19
+      |
+    4 |   type t = shared<u32>
+      |                   ^--

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource2.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource2.wit
@@ -1,0 +1,5 @@
+package foo:bar
+
+interface foo {
+  type t = shared<foo>
+}

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource2.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource2.wit.result
@@ -1,0 +1,5 @@
+type `foo` does not exist
+     --> tests/ui/parse-fail/bad-resource2.wit:4:19
+      |
+    4 |   type t = shared<foo>
+      |                   ^--

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource3.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource3.wit
@@ -1,0 +1,6 @@
+package foo:bar
+
+interface foo {
+  foo: func()
+  type t = shared<foo>
+}

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource3.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource3.wit.result
@@ -1,0 +1,5 @@
+type `foo` does not exist
+     --> tests/ui/parse-fail/bad-resource3.wit:5:19
+      |
+    5 |   type t = shared<foo>
+      |                   ^--

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource4.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource4.wit
@@ -1,0 +1,6 @@
+package foo:bar
+
+interface foo {
+  type foo = u32
+  type t = shared<foo>
+}

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource4.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource4.wit.result
@@ -1,0 +1,5 @@
+type `foo` is not a resource
+     --> tests/ui/parse-fail/bad-resource4.wit:5:19
+      |
+    5 |   type t = shared<foo>
+      |                   ^--

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource5.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource5.wit
@@ -1,0 +1,7 @@
+package foo:bar
+
+interface foo {
+  resource a {}
+  type t = shared<a>
+  type b = shared<t>
+}

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource5.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource5.wit.result
@@ -1,0 +1,5 @@
+type `t` is not a resource
+     --> tests/ui/parse-fail/bad-resource5.wit:6:19
+      |
+    6 |   type b = shared<t>
+      |                   ^


### PR DESCRIPTION
Previously `T` could be any arbitrary type which would allow parsing `shared<shared<T>>` for example but these are intended to only be used with one layer of resource handles so the contents of the brackets are now required to be a single identifier. Additionally during resolution/validation the identifier is required to not only be a type but additionally be a resource type.