### PR TITLE
Change data representation of resource methods 

### DIFF
--- a/crates/wit-component/src/decoding.rs
+++ b/crates/wit-component/src/decoding.rs
@@ -911,7 +911,7 @@ impl WitPackageDecoder<'_> {
             | TypeDefKind::Result(_)
             | TypeDefKind::Handle(_) => {}
 
-            TypeDefKind::Resource(_)
+            TypeDefKind::Resource
             | TypeDefKind::Record(_)
             | TypeDefKind::Enum(_)
             | TypeDefKind::Variant(_)

--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -289,7 +289,7 @@ impl TypeContents {
                 TypeDefKind::Handle(h) => match h {
                     wit_parser::Handle::Shared(_) => Self::empty(),
                 },
-                TypeDefKind::Resource(..) => Self::empty(),
+                TypeDefKind::Resource => Self::empty(),
                 TypeDefKind::Record(r) => Self::for_types(resolve, r.fields.iter().map(|f| &f.ty)),
                 TypeDefKind::Tuple(t) => Self::for_types(resolve, t.types.iter()),
                 TypeDefKind::Flags(_) => Self::empty(),

--- a/crates/wit-component/src/encoding/types.rs
+++ b/crates/wit-component/src/encoding/types.rs
@@ -153,7 +153,7 @@ pub trait ValtypeEncoder<'a> {
                     TypeDefKind::Future(_) => todo!("encoding for future type"),
                     TypeDefKind::Stream(_) => todo!("encoding for stream type"),
                     TypeDefKind::Unknown => unreachable!(),
-                    TypeDefKind::Resource(_) => todo!(),
+                    TypeDefKind::Resource => todo!(),
                     TypeDefKind::Handle(_) => todo!(),
                 };
 

--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -294,7 +294,7 @@ impl WitPrinter {
                     TypeDefKind::Handle(h) => {
                         self.print_handle_type(resolve, h)?;
                     }
-                    TypeDefKind::Resource(_) => {
+                    TypeDefKind::Resource => {
                         bail!("resolve has an unnamed resource type");
                     }
                     TypeDefKind::Tuple(t) => {
@@ -438,9 +438,7 @@ impl WitPrinter {
                     TypeDefKind::Handle(h) => {
                         self.declare_handle(resolve, ty.name.as_deref(), h)?
                     }
-                    TypeDefKind::Resource(r) => {
-                        self.declare_resource(resolve, ty.name.as_deref(), r)?
-                    }
+                    TypeDefKind::Resource => self.declare_resource(resolve, ty.name.as_deref())?,
                     TypeDefKind::Record(r) => {
                         self.declare_record(resolve, ty.name.as_deref(), r)?
                     }
@@ -498,86 +496,16 @@ impl WitPrinter {
         }
     }
 
-    fn declare_resource(
-        &mut self,
-        resolve: &Resolve,
-        name: Option<&str>,
-        resource: &Resource,
-    ) -> Result<()> {
+    fn declare_resource(&mut self, _resolve: &Resolve, name: Option<&str>) -> Result<()> {
         match name {
             Some(name) => {
                 self.output.push_str("resource ");
                 self.print_name(name);
-                self.output.push_str(" {\n");
-                for function in &resource.methods {
-                    self.declare_function(resolve, Some(name), function)?;
-                }
-                self.output.push_str(" }\n\n");
+                self.output.push_str("\n\n");
                 Ok(())
             }
             None => bail!("document has unnamed resource type"),
         }
-    }
-
-    fn declare_function(
-        &mut self,
-        resolve: &Resolve,
-        name: Option<&str>,
-        function: &Function,
-    ) -> Result<()> {
-        match function.kind {
-            FunctionKind::Static => {
-                self.output.push_str("static ");
-            }
-            _ => {}
-        }
-
-        self.print_name(&function.name);
-        self.output.push_str(": func(");
-
-        match function.kind {
-            FunctionKind::Method => match name {
-                Some(name) => {
-                    self.output.push_str(&format!("self: shared<{name}>"));
-                }
-                None => bail!("document has unnamed resource type"),
-            },
-            _ => {}
-        }
-
-        for (name, ty) in &function.params {
-            self.print_name(&name);
-            self.output.push_str(": ");
-            self.print_type_name(resolve, &ty)?;
-            self.output.push_str(", ");
-        }
-
-        self.output.push_str(") ");
-
-        self.output.push_str("-> ");
-
-        match &function.results {
-            Results::Named(results) => {
-                self.output.push_str("(");
-
-                if results.len() > 0 {
-                    for (name, ty) in results {
-                        self.print_name(&name);
-                        self.output.push_str(": ");
-                        self.print_type_name(resolve, &ty)?;
-                        self.output.push_str(", ");
-                    }
-                }
-                self.output.push_str(")");
-            }
-            Results::Anon(ty) => {
-                self.print_type_name(resolve, &ty)?;
-            }
-        }
-
-        self.output.push_str(";\n");
-
-        Ok(())
     }
 
     fn declare_record(

--- a/crates/wit-parser/src/abi.rs
+++ b/crates/wit-parser/src/abi.rs
@@ -774,7 +774,7 @@ impl Resolve {
 
                 TypeDefKind::Handle(_) => todo!(),
 
-                TypeDefKind::Resource(_) => todo!(),
+                TypeDefKind::Resource => todo!(),
 
                 TypeDefKind::Record(r) => {
                     for field in r.fields.iter() {
@@ -904,7 +904,7 @@ impl Resolve {
                 TypeDefKind::List(_) => true,
                 TypeDefKind::Type(t) => self.needs_post_return(t),
                 TypeDefKind::Handle(_) => true,
-                TypeDefKind::Resource(_) => true,
+                TypeDefKind::Resource => true,
                 TypeDefKind::Record(r) => r.fields.iter().any(|f| self.needs_post_return(&f.ty)),
                 TypeDefKind::Tuple(t) => t.types.iter().any(|t| self.needs_post_return(t)),
                 TypeDefKind::Union(t) => t.cases.iter().any(|t| self.needs_post_return(&t.ty)),
@@ -1292,7 +1292,7 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                     }
                 }
                 TypeDefKind::Handle(_) => todo!(),
-                TypeDefKind::Resource(_) => {
+                TypeDefKind::Resource => {
                     todo!();
                 }
                 TypeDefKind::Record(record) => {
@@ -1481,7 +1481,7 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                 TypeDefKind::Handle(_) => {
                     todo!();
                 }
-                TypeDefKind::Resource(_) => {
+                TypeDefKind::Resource => {
                     todo!();
                 }
                 TypeDefKind::Record(record) => {
@@ -1643,7 +1643,7 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                     });
                     self.write_fields_to_memory(record.fields.iter().map(|f| &f.ty), addr, offset);
                 }
-                TypeDefKind::Resource(_) => {
+                TypeDefKind::Resource => {
                     todo!()
                 }
                 TypeDefKind::Tuple(tuple) => {
@@ -1839,7 +1839,7 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                     todo!();
                 }
 
-                TypeDefKind::Resource(_) => {
+                TypeDefKind::Resource => {
                     todo!();
                 }
 
@@ -2063,7 +2063,7 @@ impl<'a, B: Bindgen> Generator<'a, B> {
                     todo!()
                 }
 
-                TypeDefKind::Resource(_) => {
+                TypeDefKind::Resource => {
                     todo!()
                 }
 

--- a/crates/wit-parser/src/ast/lex.rs
+++ b/crates/wit-parser/src/ast/lex.rs
@@ -89,6 +89,7 @@ pub enum Token {
     Export,
     World,
     Package,
+    Constructor,
 
     Id,
     ExplicitId,
@@ -288,6 +289,7 @@ impl<'a> Tokenizer<'a> {
                     "import" => Import,
                     "export" => Export,
                     "package" => Package,
+                    "constructor" => Constructor,
                     "include" => Include,
                     "with" => With,
                     _ => Id,
@@ -543,6 +545,7 @@ impl Token {
             Export => "keyword `export`",
             World => "keyword `world`",
             Package => "keyword `package`",
+            Constructor => "keyword `constructor`",
             Integer => "an integer",
             Include => "keyword `include`",
             With => "keyword `with`",

--- a/crates/wit-parser/src/ast/resolve.rs
+++ b/crates/wit-parser/src/ast/resolve.rs
@@ -619,6 +619,7 @@ impl<'a> Resolver<'a> {
                     ..
                 }) => {
                     for func in r.funcs.iter() {
+                        import_spans.push(func.named_func().name.span);
                         let func = self.resolve_resource_func(func, name)?;
                         let prev = self.worlds[world_id]
                             .imports

--- a/crates/wit-parser/src/ast/resolve.rs
+++ b/crates/wit-parser/src/ast/resolve.rs
@@ -1,4 +1,4 @@
-use super::{Error, ParamList, ResultList, ValueKind, WorldOrInterface};
+use super::{Error, ParamList, ResultList, WorldOrInterface};
 use crate::ast::toposort::toposort;
 use crate::*;
 use anyhow::{bail, Result};
@@ -598,11 +598,6 @@ impl<'a> Resolver<'a> {
         let mut exported_interfaces = HashSet::new();
         for item in world.items.iter() {
             let (docs, kind, desc, spans, interfaces) = match item {
-                // handled in `resolve_types`
-                ast::WorldItem::Use(_) | ast::WorldItem::Type(_) | ast::WorldItem::Include(_) => {
-                    continue
-                }
-
                 ast::WorldItem::Import(import) => (
                     &import.docs,
                     &import.kind,
@@ -617,6 +612,29 @@ impl<'a> Resolver<'a> {
                     &mut export_spans,
                     &mut exported_interfaces,
                 ),
+
+                ast::WorldItem::Type(ast::TypeDef {
+                    name,
+                    ty: ast::Type::Resource(r),
+                    ..
+                }) => {
+                    for func in r.funcs.iter() {
+                        let func = self.resolve_resource_func(func, name)?;
+                        let prev = self.worlds[world_id]
+                            .imports
+                            .insert(WorldKey::Name(func.name.clone()), WorldItem::Function(func));
+                        // Resource names themselves are unique, and methods are
+                        // uniquely named, so this should be possible to assert
+                        // at this point and never trip.
+                        assert!(prev.is_none());
+                    }
+                    continue;
+                }
+
+                // handled in `resolve_types`
+                ast::WorldItem::Use(_) | ast::WorldItem::Type(_) | ast::WorldItem::Include(_) => {
+                    continue
+                }
             };
             let key = match kind {
                 ast::ExternKind::Interface(name, _) | ast::ExternKind::Func(name, _) => {
@@ -682,7 +700,8 @@ impl<'a> Resolver<'a> {
                 Ok(WorldItem::Interface(id))
             }
             ast::ExternKind::Func(name, func) => {
-                let func = self.resolve_function(docs, name.name, func)?;
+                let func =
+                    self.resolve_function(docs, name.name, func, FunctionKind::Freestanding)?;
                 Ok(WorldItem::Function(func))
             }
         }
@@ -702,7 +721,7 @@ impl<'a> Resolver<'a> {
             fields.iter().filter_map(|i| match i {
                 ast::InterfaceItem::Use(u) => Some(TypeItem::Use(u)),
                 ast::InterfaceItem::TypeDef(t) => Some(TypeItem::Def(t)),
-                ast::InterfaceItem::Value(_) => None,
+                ast::InterfaceItem::Func(_) => None,
             }),
         )?;
 
@@ -719,23 +738,36 @@ impl<'a> Resolver<'a> {
 
         // Finally process all function definitions now that all types are
         // defined.
+        let mut funcs = Vec::new();
         for field in fields {
             match field {
-                ast::InterfaceItem::Value(value) => match &value.kind {
-                    ValueKind::Func(func) => {
-                        self.define_interface_name(&value.name, TypeOrItem::Item("function"))?;
-                        let func = self.resolve_function(&value.docs, value.name.name, func)?;
-                        let prev = self.interfaces[interface_id]
-                            .functions
-                            .insert(value.name.name.to_string(), func);
-                        assert!(prev.is_none());
+                ast::InterfaceItem::Func(f) => {
+                    self.define_interface_name(&f.name, TypeOrItem::Item("function"))?;
+                    funcs.push(self.resolve_function(
+                        &f.docs,
+                        &f.name.name,
+                        &f.func,
+                        FunctionKind::Freestanding,
+                    )?);
+                }
+                ast::InterfaceItem::Use(_) => {}
+                ast::InterfaceItem::TypeDef(ast::TypeDef {
+                    name,
+                    ty: ast::Type::Resource(r),
+                    ..
+                }) => {
+                    for func in r.funcs.iter() {
+                        funcs.push(self.resolve_resource_func(func, name)?);
                     }
-                    ValueKind::Static(_) => {
-                        bail!("static functions are only supported in resources")
-                    }
-                },
-                ast::InterfaceItem::Use(_) | ast::InterfaceItem::TypeDef(_) => {}
+                }
+                ast::InterfaceItem::TypeDef(_) => {}
             }
+        }
+        for func in funcs {
+            let prev = self.interfaces[interface_id]
+                .functions
+                .insert(func.name.clone(), func);
+            assert!(prev.is_none());
         }
 
         let lookup = mem::take(&mut self.type_lookup);
@@ -866,19 +898,48 @@ impl<'a> Resolver<'a> {
         Ok(())
     }
 
+    fn resolve_resource_func(
+        &mut self,
+        func: &ast::ResourceFunc<'_>,
+        resource: &ast::Id<'_>,
+    ) -> Result<Function> {
+        let resource_id = match self.type_lookup.get(resource.name) {
+            Some((TypeOrItem::Type(id), _)) => *id,
+            _ => panic!("type lookup for resource failed"),
+        };
+        let (name, kind);
+        match func {
+            ast::ResourceFunc::Method(f) => {
+                name = format!("[method]{}.{}", resource.name, f.name.name);
+                kind = FunctionKind::Method(resource_id);
+            }
+            ast::ResourceFunc::Static(f) => {
+                name = format!("[static]{}.{}", resource.name, f.name.name);
+                kind = FunctionKind::Static(resource_id);
+            }
+            ast::ResourceFunc::Constructor(_) => {
+                name = format!("[constructor]{}", resource.name);
+                kind = FunctionKind::Constructor(resource_id);
+            }
+        }
+        let named_func = func.named_func();
+        self.resolve_function(&named_func.docs, &name, &named_func.func, kind)
+    }
+
     fn resolve_function(
         &mut self,
         docs: &ast::Docs<'_>,
         name: &str,
         func: &ast::Func,
+        kind: FunctionKind,
     ) -> Result<Function> {
         let docs = self.docs(docs);
-        let params = self.resolve_params(&func.params)?;
-        let results = self.resolve_results(&func.results)?;
+        let params = self.resolve_params(&func.params, &kind)?;
+        let results = self.resolve_results(&func.results, &kind)?;
         Ok(Function {
             docs,
             name: name.to_string(),
-            kind: FunctionKind::Freestanding,
+            kind,
             params,
             results,
         })
@@ -979,44 +1040,33 @@ impl<'a> Resolver<'a> {
                 }
             }),
             ast::Type::Resource(resource) => {
-                let methods = resource
-                    .methods
-                    .iter()
-                    .map(|value| {
-                        let (func, kind) = match &value.kind {
-                            ValueKind::Func(func) => (func, FunctionKind::Method),
-                            ValueKind::Static(func) => (func, FunctionKind::Static),
-                        };
-
-                        let params = func
-                            .params
-                            .iter()
-                            .map(|(id, ty)| (id.name.to_owned(), self.resolve_type(ty).unwrap()))
-                            .collect();
-
-                        let results = match &func.results {
-                            ResultList::Named(results) => {
-                                let results = results
-                                    .into_iter()
-                                    .map(|(id, ty)| {
-                                        (id.name.to_owned(), self.resolve_type(&ty).unwrap())
-                                    })
-                                    .collect();
-                                Results::Named(results)
+                // Validate here that the resource doesn't have any duplicate-ly
+                // named methods and that there's at most one constructor.
+                let mut ctors = 0;
+                let mut names = HashSet::new();
+                for func in resource.funcs.iter() {
+                    match func {
+                        ast::ResourceFunc::Method(f) | ast::ResourceFunc::Static(f) => {
+                            if !names.insert(&f.name.name) {
+                                bail!(Error {
+                                    span: f.name.span,
+                                    msg: format!("duplicate function name `{}`", f.name.name),
+                                })
                             }
-                            ResultList::Anon(ty) => Results::Anon(self.resolve_type(&ty).unwrap()),
-                        };
+                        }
+                        ast::ResourceFunc::Constructor(f) => {
+                            ctors += 1;
+                            if ctors > 1 {
+                                bail!(Error {
+                                    span: f.name.span,
+                                    msg: format!("duplicate constructors"),
+                                })
+                            }
+                        }
+                    }
+                }
 
-                        Ok(Function {
-                            docs: self.docs(&value.docs),
-                            name: value.name.name.to_string(),
-                            kind: kind,
-                            params: params,
-                            results: results,
-                        })
-                    })
-                    .collect::<Result<Vec<_>>>()?;
-                TypeDefKind::Resource(Resource { methods })
+                TypeDefKind::Resource
             }
             ast::Type::Record(record) => {
                 let fields = record
@@ -1143,7 +1193,7 @@ impl<'a> Resolver<'a> {
         let mut cur = id;
         loop {
             match self.types[cur].kind {
-                TypeDefKind::Resource(_) => break Ok(id),
+                TypeDefKind::Resource => break Ok(id),
                 TypeDefKind::Type(Type::Id(ty)) => cur = ty,
                 _ => bail!(Error {
                     span: name.span,
@@ -1154,6 +1204,13 @@ impl<'a> Resolver<'a> {
     }
 
     fn resolve_type(&mut self, ty: &super::Type<'_>) -> Result<Type> {
+        // Resources must be declared at the top level to have their methods
+        // processed appropriately, but resources also shouldn't show up
+        // recursively so assert that's not happening here.
+        match ty {
+            ast::Type::Resource(_) => unreachable!(),
+            _ => {}
+        }
         let kind = self.resolve_type_def(ty)?;
         Ok(self.anon_type_def(TypeDef {
             kind,
@@ -1180,7 +1237,7 @@ impl<'a> Resolver<'a> {
                     .collect::<Vec<_>>(),
             ),
             TypeDefKind::Handle(h) => Key::Handle(*h),
-            TypeDefKind::Resource(_) => unreachable!("anonymous resources aren't supported"),
+            TypeDefKind::Resource => unreachable!("anonymous resources aren't supported"),
             TypeDefKind::Record(r) => Key::Record(
                 r.fields
                     .iter()
@@ -1235,17 +1292,65 @@ impl<'a> Resolver<'a> {
         Docs { contents: docs }
     }
 
-    fn resolve_params(&mut self, params: &ParamList<'_>) -> Result<Params> {
-        params
-            .iter()
-            .map(|(name, ty)| Ok((name.name.to_string(), self.resolve_type(ty)?)))
-            .collect::<Result<_>>()
+    fn resolve_params(&mut self, params: &ParamList<'_>, kind: &FunctionKind) -> Result<Params> {
+        let mut ret = Vec::new();
+        match *kind {
+            // These kinds of methods don't have any adjustments to the
+            // parameters, so do nothing here.
+            FunctionKind::Freestanding | FunctionKind::Constructor(_) | FunctionKind::Static(_) => {
+            }
+
+            // Methods automatically get a `self` initial argument so insert
+            // that here before processing the normal parameters.
+            FunctionKind::Method(id) => {
+                let shared = self.anon_type_def(TypeDef {
+                    docs: Docs::default(),
+                    kind: TypeDefKind::Handle(Handle::Shared(id)),
+                    name: None,
+                    owner: TypeOwner::None,
+                });
+                ret.push(("self".to_string(), shared));
+            }
+        }
+        for (name, ty) in params {
+            ret.push((name.name.to_string(), self.resolve_type(ty)?));
+        }
+        Ok(ret)
     }
 
-    fn resolve_results(&mut self, results: &ResultList<'_>) -> Result<Results> {
-        match results {
-            ResultList::Named(rs) => Ok(Results::Named(self.resolve_params(rs)?)),
-            ResultList::Anon(ty) => Ok(Results::Anon(self.resolve_type(ty)?)),
+    fn resolve_results(
+        &mut self,
+        results: &ResultList<'_>,
+        kind: &FunctionKind,
+    ) -> Result<Results> {
+        match *kind {
+            // These kinds of methods don't have any adjustments to the return
+            // values, so plumb them through as-is.
+            FunctionKind::Freestanding | FunctionKind::Method(_) | FunctionKind::Static(_) => {
+                match results {
+                    ResultList::Named(rs) => Ok(Results::Named(
+                        self.resolve_params(rs, &FunctionKind::Freestanding)?,
+                    )),
+                    ResultList::Anon(ty) => Ok(Results::Anon(self.resolve_type(ty)?)),
+                }
+            }
+
+            // Constructors are alwys parsed as 0 returned types but they're
+            // automatically translated as a single return type of the type that
+            // it's a constructor for.
+            FunctionKind::Constructor(id) => {
+                match results {
+                    ResultList::Named(rs) => assert!(rs.is_empty()),
+                    ResultList::Anon(_) => unreachable!(),
+                }
+                let shared = self.anon_type_def(TypeDef {
+                    docs: Docs::default(),
+                    kind: TypeDefKind::Handle(Handle::Shared(id)),
+                    name: None,
+                    owner: TypeOwner::None,
+                });
+                Ok(Results::Anon(shared))
+            }
         }
     }
 }
@@ -1272,27 +1377,7 @@ fn collect_deps<'a>(ty: &ast::Type<'a>, deps: &mut Vec<ast::Id<'a>>) {
         ast::Type::Handle(handle) => match handle {
             ast::Handle::Shared { resource } => deps.push(resource.clone()),
         },
-        ast::Type::Resource(resource) => {
-            for method in resource.methods.iter() {
-                let func = match &method.kind {
-                    ValueKind::Func(func) => func,
-                    ValueKind::Static(func) => func,
-                };
-
-                for (_, ty) in func.params.iter() {
-                    collect_deps(ty, deps);
-                }
-
-                match &func.results {
-                    ResultList::Named(results) => {
-                        for (_, ty) in results.iter() {
-                            collect_deps(ty, deps);
-                        }
-                    }
-                    ResultList::Anon(ty) => collect_deps(&ty, deps),
-                }
-            }
-        }
+        ast::Type::Resource(_) => {}
         ast::Type::Record(record) => {
             for field in record.fields.iter() {
                 collect_deps(&field.ty, deps);

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -330,7 +330,7 @@ pub struct TypeDef {
 #[derive(Debug, Clone, PartialEq)]
 pub enum TypeDefKind {
     Record(Record),
-    Resource(Resource),
+    Resource,
     Handle(Handle),
     Flags(Flags),
     Tuple(Tuple),
@@ -356,7 +356,7 @@ impl TypeDefKind {
     pub fn as_str(&self) -> &'static str {
         match self {
             TypeDefKind::Record(_) => "record",
-            TypeDefKind::Resource(_) => "resource",
+            TypeDefKind::Resource => "resource",
             TypeDefKind::Handle(handle) => match handle {
                 Handle::Shared(_) => "shared",
             },
@@ -421,11 +421,6 @@ pub enum Int {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Record {
     pub fields: Vec<Field>,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct Resource {
-    pub methods: Vec<Function>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -642,16 +637,19 @@ pub struct Function {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FunctionKind {
     Freestanding,
-    Method,
-    Static,
+    Method(TypeId),
+    Static(TypeId),
+    Constructor(TypeId),
 }
 
 impl Function {
     pub fn item_name(&self) -> &str {
         match &self.kind {
             FunctionKind::Freestanding => &self.name,
-            FunctionKind::Method => &self.name,
-            FunctionKind::Static => &self.name,
+            FunctionKind::Method(_) | FunctionKind::Static(_) => {
+                &self.name[self.name.find('.').unwrap() + 1..]
+            }
+            FunctionKind::Constructor(_) => "constructor",
         }
     }
 

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -376,7 +376,7 @@ impl TypeDefKind {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum TypeOwner {
     /// This type was defined within a `world` block.
     World(WorldId),

--- a/crates/wit-parser/src/live.rs
+++ b/crates/wit-parser/src/live.rs
@@ -61,21 +61,7 @@ impl LiveTypes {
             TypeDefKind::Handle(handle) => match handle {
                 crate::Handle::Shared(ty) => self.add_type_id(resolve, *ty),
             },
-            TypeDefKind::Resource(r) => {
-                for function in r.methods.iter() {
-                    for (_, ty) in &function.params {
-                        self.add_type(resolve, ty);
-                    }
-                    match &function.results {
-                        crate::Results::Named(results) => {
-                            for (_, ty) in results {
-                                self.add_type(resolve, ty);
-                            }
-                        }
-                        crate::Results::Anon(ty) => self.add_type(resolve, ty),
-                    }
-                }
-            }
+            TypeDefKind::Resource => {}
             TypeDefKind::Record(r) => {
                 for field in r.fields.iter() {
                     self.add_type(resolve, &field.ty);

--- a/crates/wit-parser/src/resolve.rs
+++ b/crates/wit-parser/src/resolve.rs
@@ -205,7 +205,7 @@ impl Resolve {
                     crate::Handle::Shared(_) => true,
                 },
 
-                TypeDefKind::Resource(_) => false,
+                TypeDefKind::Resource => false,
                 TypeDefKind::Record(r) => r.fields.iter().all(|f| self.all_bits_valid(&f.ty)),
                 TypeDefKind::Tuple(t) => t.types.iter().all(|t| self.all_bits_valid(t)),
 
@@ -880,23 +880,7 @@ impl Remap {
             Handle(handle) => match handle {
                 crate::Handle::Shared(ty) => *ty = self.types[ty.index()],
             },
-            Resource(r) => {
-                for function in r.methods.iter_mut() {
-                    for (_, ty) in function.params.iter_mut() {
-                        self.update_ty(ty);
-                    }
-                    match &mut function.results {
-                        Results::Named(results) => {
-                            for (_, ty) in results {
-                                self.update_ty(ty);
-                            }
-                        }
-                        Results::Anon(ty) => {
-                            self.update_ty(ty);
-                        }
-                    }
-                }
-            }
+            Resource => {}
             Record(r) => {
                 for field in r.fields.iter_mut() {
                     self.update_ty(&mut field.ty);

--- a/crates/wit-parser/src/resolve.rs
+++ b/crates/wit-parser/src/resolve.rs
@@ -1,9 +1,9 @@
 use crate::ast::lex::Span;
 use crate::ast::{parse_use_path, AstUsePath};
 use crate::{
-    AstItem, Error, Function, IncludeName, Interface, InterfaceId, PackageName, Results, Type,
-    TypeDef, TypeDefKind, TypeId, TypeOwner, UnresolvedPackage, World, WorldId, WorldItem,
-    WorldKey,
+    AstItem, Error, Function, FunctionKind, IncludeName, Interface, InterfaceId, PackageName,
+    Results, Type, TypeDef, TypeDefKind, TypeId, TypeOwner, UnresolvedPackage, World, WorldId,
+    WorldItem, WorldKey,
 };
 use anyhow::{anyhow, bail, Context, Result};
 use id_arena::{Arena, Id};
@@ -949,6 +949,12 @@ impl Remap {
     }
 
     fn update_function(&self, func: &mut Function) {
+        match &mut func.kind {
+            FunctionKind::Freestanding => {}
+            FunctionKind::Method(id) | FunctionKind::Constructor(id) | FunctionKind::Static(id) => {
+                *id = self.types[id.index()];
+            }
+        }
         for (_, ty) in func.params.iter_mut() {
             self.update_ty(ty);
         }

--- a/crates/wit-parser/src/sizealign.rs
+++ b/crates/wit-parser/src/sizealign.rs
@@ -36,7 +36,7 @@ impl SizeAlign {
             TypeDefKind::Future(_) => (4, 4),
             // A stream is represented as an index.
             TypeDefKind::Stream(_) => (4, 4),
-            TypeDefKind::Resource(_) => unreachable!(),
+            TypeDefKind::Resource => unreachable!(),
             TypeDefKind::Unknown => unreachable!(),
         }
     }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource6.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource6.wit
@@ -1,0 +1,7 @@
+package foo:bar
+
+interface foo {
+  resource a {
+    constructor() -> u32
+  }
+}

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource6.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource6.wit.result
@@ -1,0 +1,5 @@
+expected `static`, `constructor` or identifier, found `->`
+     --> tests/ui/parse-fail/bad-resource6.wit:5:19
+      |
+    5 |     constructor() -> u32
+      |                   ^-

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource7.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource7.wit
@@ -1,0 +1,8 @@
+package foo:bar
+
+interface foo {
+  resource a {
+    constructor()
+    constructor()
+  }
+}

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource7.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource7.wit.result
@@ -1,0 +1,5 @@
+duplicate constructors
+     --> tests/ui/parse-fail/bad-resource7.wit:6:5
+      |
+    6 |     constructor()
+      |     ^----------

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource8.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource8.wit
@@ -1,0 +1,8 @@
+package foo:bar
+
+interface foo {
+  resource a {
+    a: func()
+    static a: func()
+  }
+}

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource8.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource8.wit.result
@@ -1,0 +1,5 @@
+duplicate function name `a`
+     --> tests/ui/parse-fail/bad-resource8.wit:6:12
+      |
+    6 |     static a: func()
+      |            ^

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource9.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource9.wit
@@ -1,0 +1,7 @@
+package foo:bar
+
+interface foo {
+  resource a {
+    interface foo {}
+  }
+}

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource9.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource9.wit.result
@@ -1,0 +1,5 @@
+expected `static`, `constructor` or identifier, found keyword `interface`
+     --> tests/ui/parse-fail/bad-resource9.wit:5:5
+      |
+    5 |     interface foo {}
+      |     ^--------

--- a/crates/wit-parser/tests/ui/resources-multiple.wit
+++ b/crates/wit-parser/tests/ui/resources-multiple.wit
@@ -4,15 +4,15 @@ interface resources-multiple {
   t1: func(a: shared<r1>) -> ()
 
   resource r1 {
-    f1: func(), 
-    f2: func(a: u32),
-    f3: func(a: u32,),
-    f4: func() -> u32,
-    f6: func() -> tuple<u32, u32>,
-    f7: func(a: float32, b: float32) -> tuple<u32, u32>,
-    f8: func(a: option<u32>) -> result<u32, float32>,
-    f9: func() -> (u: u32, f: float32),
-    f10: func() -> (u: u32),
+    f1: func()
+    f2: func(a: u32)
+    f3: func(a: u32,)
+    f4: func() -> u32
+    f6: func() -> tuple<u32, u32>
+    f7: func(a: float32, b: float32) -> tuple<u32, u32>
+    f8: func(a: option<u32>) -> result<u32, float32>
+    f9: func() -> (u: u32, f: float32)
+    f10: func() -> (u: u32)
     f11: func() -> ()
   }
 }

--- a/crates/wit-parser/tests/ui/resources.wit
+++ b/crates/wit-parser/tests/ui/resources.wit
@@ -1,0 +1,28 @@
+package foo:bar
+
+interface foo {
+  resource a {
+  }
+
+  resource b {
+    constructor()
+  }
+
+  resource c {
+    constructor(x: u32)
+  }
+
+  resource d {
+    constructor(x: u32)
+
+    a: func()
+
+    static b: func()
+  }
+
+  resource e {
+    constructor(other: shared<e>)
+
+    method: func(thing: shared<e>)
+  }
+}

--- a/crates/wit-parser/tests/ui/resources.wit
+++ b/crates/wit-parser/tests/ui/resources.wit
@@ -26,3 +26,14 @@ interface foo {
     method: func(thing: shared<e>)
   }
 }
+
+world w {
+  resource a
+
+  resource b {
+  }
+
+  resource c {
+    constructor()
+  }
+}

--- a/crates/wit-parser/tests/ui/world-top-level-resources.wit
+++ b/crates/wit-parser/tests/ui/world-top-level-resources.wit
@@ -1,14 +1,14 @@
 package foo:foo
 
 interface types {
-  resource request { 
-    foo: func(),  
-    bar: func(arg: list<u32>) 
+  resource request {
+    foo: func()
+    bar: func(arg: list<u32>)
   }
 
-  resource response { 
-    foo: func(),
-    bar: func(arg: list<u32>) 
+  resource response {
+    foo: func()
+    bar: func(arg: list<u32>)
   }
 }
 


### PR DESCRIPTION
> Note: this builds on https://github.com/bytecodealliance/wasm-tools/pull/1068

This commit changes the representation of resources and their methods in
the `wit-parser` crate as implemented originally in https://github.com/bytecodealliance/wasm-tools/pull/1053. Previously
methods related to a resource were strung as a separate list of methods
from each `Resource` type which provided a nested view of functions for
bindings generators to interpret. This representation, however, does not
allow for methods or constructors to actually refer to the resource type
itself because the resource type can't be created until the method list
is created, a cyclic dependency.

To handle this problem this commit removes the nested list of functions
and instead places all resource methods and functions and such within
the normal single list of functions within an interface. This represents
a "flattened" version of all functions available within an interface or
world and aligns with the WebAssembly representation of how these will
work. The names of these functions are not valid identifiers and have
the component-model mangling along the lines of `[method]foo.bar` for
example.

My hope is that in the future as bindings generators are worked on
various helper methods can be added to automatically group functions
based on their kind to avoid any issues. Otherwise though this will
likely "break" all existing code generators when resources are
introduced because the names aren't valid identifiers in any language.
I think this is a good thing, however, as that way it can't be forgotten
to handle the resources case and failures will be "loud" in theory.

This commit changes a number of other miscellaneous details such as:

* Type resolution no longer needs to consider types referenced by
  methods of resources as dependencies which reflects how this will all
  look in a wasm binary format where resources are declared before their
  member functions are declared.

* Parsing has been updated to address some minor issues here and there
  and additionally has some new names to remove the old "value" concept
  which is no longer a thing.