### PR TITLE
Fix validation of resource methods in instance types

### DIFF
--- a/tests/local/component-model/resources.wast
+++ b/tests/local/component-model/resources.wast
@@ -1127,3 +1127,13 @@
     (export "t2" (instance (type $t2')))
   ))
 )
+
+(component
+  (type (component
+    (type (instance
+      (export "bar" (type (sub resource)))
+      (export "[static]bar.a" (func))
+    ))
+    (export "x" (instance (type 0)))
+  ))
+)

--- a/tests/snapshots/local/component-model/resources.wast/110.print
+++ b/tests/snapshots/local/component-model/resources.wast/110.print
@@ -1,0 +1,14 @@
+(component
+  (type (;0;)
+    (component
+      (type (;0;)
+        (instance
+          (export (;0;) "bar" (type (sub resource)))
+          (type (;1;) (func))
+          (export (;0;) "[static]bar.a" (func (type 1)))
+        )
+      )
+      (export (;0;) "x" (instance (type 0)))
+    )
+  )
+)


### PR DESCRIPTION
This commit fixes an issue in `wasmparser`'s validation of component instance types where `[method]foo.bar`-style name mangling was erroneously considered invalid. This happened because registration of which names were valid to use only happened for components and component types, not for instance types. This is because the location that registered names of resources also did other validation which isn't required for instance types as that validation is deferred to later.

This commit addresses the issue by moving the logic to register the names of resources above the short-circuit that skips the rest of the validation logic in the function.