### PR TITLE
Adjust whitespace during WIT printing

### DIFF
--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -1,11 +1,16 @@
 use anyhow::{anyhow, bail, Result};
 use std::fmt::{self, Write};
+use std::mem;
 use wit_parser::*;
 
 /// A utility for printing WebAssembly interface definitions to a string.
 #[derive(Default)]
 pub struct WitPrinter {
     output: Output,
+
+    // Count of how many items in this current block have been printed to print
+    // a blank line between each item, but not the first item.
+    items: usize,
 }
 
 impl WitPrinter {
@@ -39,8 +44,16 @@ impl WitPrinter {
         Ok(std::mem::take(&mut self.output).into())
     }
 
+    fn new_item(&mut self) {
+        if self.items > 0 {
+            self.output.push_str("\n");
+        }
+        self.items += 1;
+    }
+
     /// Print the given WebAssembly interface to a string.
     fn print_interface(&mut self, resolve: &Resolve, id: InterfaceId) -> Result<()> {
+        let prev_items = mem::replace(&mut self.items, 0);
         let interface = &resolve.interfaces[id];
 
         self.print_types(
@@ -52,15 +65,15 @@ impl WitPrinter {
                 .map(|(name, id)| (name.as_str(), *id)),
         )?;
 
-        for (i, (name, func)) in interface.functions.iter().enumerate() {
-            if i > 0 {
-                self.output.push_str("\n");
-            }
+        for (name, func) in interface.functions.iter() {
+            self.new_item();
             self.print_name(name);
             self.output.push_str(": ");
             self.print_function(resolve, func)?;
             self.output.push_str("\n");
         }
+
+        self.items = prev_items;
 
         Ok(())
     }
@@ -108,8 +121,8 @@ impl WitPrinter {
             TypeOwner::World(id) => resolve.worlds[id].package.unwrap(),
             TypeOwner::None => unreachable!(),
         };
-        let amt_to_import = types_to_import.len();
         for (owner, tys) in types_to_import {
+            self.items += 1;
             write!(&mut self.output, "use ")?;
             let id = match owner {
                 TypeOwner::Interface(id) => id,
@@ -134,11 +147,8 @@ impl WitPrinter {
             writeln!(&mut self.output, "}}")?;
         }
 
-        if amt_to_import > 0 && types_to_declare.len() > 0 {
-            self.output.push_str("\n");
-        }
-
         for id in types_to_declare {
+            self.new_item();
             self.declare_type(resolve, &Type::Id(id))?;
         }
 
@@ -182,6 +192,7 @@ impl WitPrinter {
     }
 
     fn print_world(&mut self, resolve: &Resolve, id: WorldId) -> Result<()> {
+        let prev_items = mem::replace(&mut self.items, 0);
         let world = &resolve.worlds[id];
         let pkgid = world.package.unwrap();
         let mut types = Vec::new();
@@ -193,13 +204,21 @@ impl WitPrinter {
                 },
                 _ => {
                     self.print_world_item(resolve, name, import, pkgid, "import")?;
+                    // Don't put a blank line between imports, but count
+                    // imports as having printed something so if anything comes
+                    // after them then a blank line is printed after imports.
+                    self.items += 1;
                 }
             }
         }
         self.print_types(resolve, TypeOwner::World(id), types.into_iter())?;
+        if !world.exports.is_empty() {
+            self.new_item();
+        }
         for (name, export) in world.exports.iter() {
             self.print_world_item(resolve, name, export, pkgid, "export")?;
         }
+        self.items = prev_items;
         Ok(())
     }
 
@@ -466,7 +485,7 @@ impl WitPrinter {
                             self.print_name(name);
                             self.output.push_str(" = ");
                             self.print_type_name(resolve, inner)?;
-                            self.output.push_str("\n\n");
+                            self.output.push_str("\n");
                         }
                         None => bail!("unnamed type in document"),
                     },
@@ -490,7 +509,7 @@ impl WitPrinter {
                 self.print_name(name);
                 self.output.push_str(" = ");
                 self.print_handle_type(resolve, handle)?;
-                self.output.push_str("\n\n");
+                self.output.push_str("\n");
 
                 Ok(())
             }
@@ -597,7 +616,7 @@ impl WitPrinter {
                     self.print_type_name(resolve, &field.ty)?;
                     self.output.push_str(",\n");
                 }
-                self.output.push_str("}\n\n");
+                self.output.push_str("}\n");
                 Ok(())
             }
             None => bail!("document has unnamed record type"),
@@ -615,7 +634,7 @@ impl WitPrinter {
             self.print_name(name);
             self.output.push_str(" = ");
             self.print_tuple_type(resolve, tuple)?;
-            self.output.push_str("\n\n");
+            self.output.push_str("\n");
         }
         Ok(())
     }
@@ -630,7 +649,7 @@ impl WitPrinter {
                     self.print_name(&flag.name);
                     self.output.push_str(",\n");
                 }
-                self.output.push_str("}\n\n");
+                self.output.push_str("}\n");
             }
             None => bail!("document has unnamed flags type"),
         }
@@ -659,7 +678,7 @@ impl WitPrinter {
             }
             self.output.push_str(",\n");
         }
-        self.output.push_str("}\n\n");
+        self.output.push_str("}\n");
         Ok(())
     }
 
@@ -681,7 +700,7 @@ impl WitPrinter {
             self.print_type_name(resolve, &case.ty)?;
             self.output.push_str(",\n");
         }
-        self.output.push_str("}\n\n");
+        self.output.push_str("}\n");
         Ok(())
     }
 
@@ -696,7 +715,7 @@ impl WitPrinter {
             self.print_name(name);
             self.output.push_str(" = ");
             self.print_option_type(resolve, payload)?;
-            self.output.push_str("\n\n");
+            self.output.push_str("\n");
         }
         Ok(())
     }
@@ -712,7 +731,7 @@ impl WitPrinter {
             self.print_name(name);
             self.output.push_str(" = ");
             self.print_result_type(resolve, result)?;
-            self.output.push_str("\n\n");
+            self.output.push_str("\n");
         }
         Ok(())
     }
@@ -729,7 +748,7 @@ impl WitPrinter {
             self.print_name(&case.name);
             self.output.push_str(",\n");
         }
-        self.output.push_str("}\n\n");
+        self.output.push_str("}\n");
         Ok(())
     }
 
@@ -739,7 +758,7 @@ impl WitPrinter {
             self.print_name(name);
             self.output.push_str(" = list<");
             self.print_type_name(resolve, ty)?;
-            self.output.push_str(">\n\n");
+            self.output.push_str(">\n");
             return Ok(());
         }
 

--- a/crates/wit-component/tests/components/adapt-export-reallocs/component.wit.print
+++ b/crates/wit-component/tests/components/adapt-export-reallocs/component.wit.print
@@ -4,5 +4,6 @@ world root {
   import new: interface {
     read: func(amt: u32) -> list<u8>
   }
+
   export entrypoint: func(args: list<string>)
 }

--- a/crates/wit-component/tests/components/adapt-import-only-used-in-adapter/component.wit.print
+++ b/crates/wit-component/tests/components/adapt-import-only-used-in-adapter/component.wit.print
@@ -3,6 +3,7 @@ package root:component
 world root {
   import foo:foo/adapter-imports
   import foo: func(x: string)
+
   export bar: func()
   export adapter-bar: func(x: string)
 }

--- a/crates/wit-component/tests/components/bare-funcs/component.wit.print
+++ b/crates/wit-component/tests/components/bare-funcs/component.wit.print
@@ -3,6 +3,7 @@ package root:component
 world root {
   import foo: func()
   import bar: func() -> string
+
   export baz: func()
   export foo2: func(x: string) -> option<list<u8>>
 }

--- a/crates/wit-component/tests/components/ensure-default-type-exports/component.wit.print
+++ b/crates/wit-component/tests/components/ensure-default-type-exports/component.wit.print
@@ -2,5 +2,6 @@ package root:component
 
 world root {
   import foo:foo/foo
+
   export a: func(b: u8)
 }

--- a/crates/wit-component/tests/components/export-interface-using-import/component.wit.print
+++ b/crates/wit-component/tests/components/export-interface-using-import/component.wit.print
@@ -2,6 +2,7 @@ package root:component
 
 world root {
   import foo:foo/foo
+
   export x: interface {
     use foo:foo/foo.{r}
   }

--- a/crates/wit-component/tests/components/export-name-shuffling/component.wit.print
+++ b/crates/wit-component/tests/components/export-name-shuffling/component.wit.print
@@ -4,6 +4,7 @@ world root {
   export foo:foo/name
   export name: interface {
     use foo:foo/name.{foo}
+
     a: func(f: foo)
   }
 }

--- a/crates/wit-component/tests/components/export-type-name-conflict/component.wit.print
+++ b/crates/wit-component/tests/components/export-type-name-conflict/component.wit.print
@@ -2,8 +2,10 @@ package root:component
 
 world root {
   import foo:foo/foo
+
   export bar: interface {
     use foo:foo/foo.{foo as bar}
+
     foo: func() -> bar
   }
 }

--- a/crates/wit-component/tests/components/import-export-same-iface-name/component.wit.print
+++ b/crates/wit-component/tests/components/import-export-same-iface-name/component.wit.print
@@ -3,5 +3,6 @@ package root:component
 world root {
   import foo:dep/the-name
   import foo:foo/the-name
+
   export foo:foo/the-name
 }

--- a/crates/wit-component/tests/components/import-export/component.wit.print
+++ b/crates/wit-component/tests/components/import-export/component.wit.print
@@ -4,6 +4,7 @@ world root {
   import foo: interface {
     a: func() -> string
   }
+
   export bar: interface {
     a: func()
 

--- a/crates/wit-component/tests/components/import-in-adapter-and-main-module/component.wit.print
+++ b/crates/wit-component/tests/components/import-in-adapter-and-main-module/component.wit.print
@@ -5,10 +5,12 @@ world root {
   import foo:shared-dependency/types
   import main-dep: interface {
     use foo:shared-dependency/types.{a-typedef}
+
     foo: func() -> a-typedef
   }
   import adapter-dep: interface {
     use foo:shared-dependency/types.{a-typedef}
+
     foo: func() -> a-typedef
   }
 }

--- a/crates/wit-component/tests/components/many-same-names/component.wit.print
+++ b/crates/wit-component/tests/components/many-same-names/component.wit.print
@@ -2,9 +2,11 @@ package root:component
 
 world root {
   import foo:foo/name
+
   export foo:foo/name
   export name: interface {
     use foo:foo/name.{r2}
+
     a: func()
   }
 }

--- a/crates/wit-component/tests/components/rename-interface/component.wit.print
+++ b/crates/wit-component/tests/components/rename-interface/component.wit.print
@@ -4,6 +4,7 @@ world root {
   import foo:foo/foo
   import other-name: interface {
     use foo:foo/foo.{bar}
+
     a: func() -> bar
   }
 }

--- a/crates/wit-component/tests/components/tricky-order/component.wit.print
+++ b/crates/wit-component/tests/components/tricky-order/component.wit.print
@@ -3,6 +3,7 @@ package root:component
 world root {
   import foo:foo/name1
   import foo:foo/name2
+
   export name: interface {
     use foo:foo/name1.{name}
     use foo:foo/name2.{name as name1}

--- a/crates/wit-component/tests/components/worlds-with-type-renamings/component.wit.print
+++ b/crates/wit-component/tests/components/worlds-with-type-renamings/component.wit.print
@@ -3,5 +3,6 @@ package root:component
 world root {
   import foo:foo/i
   use foo:foo/i.{some-type as other-name}
+
   export foo:foo/i
 }

--- a/crates/wit-component/tests/interfaces/diamond-disambiguate/foo.wit.print
+++ b/crates/wit-component/tests/interfaces/diamond-disambiguate/foo.wit.print
@@ -2,12 +2,10 @@ package foo:foo
 
 interface shared2 {
   type t2 = u8
-
 }
 
 interface shared1 {
   type t1 = u8
-
 }
 
 world w1 {

--- a/crates/wit-component/tests/interfaces/diamond.wit.print
+++ b/crates/wit-component/tests/interfaces/diamond.wit.print
@@ -4,11 +4,11 @@ interface shared-items {
   enum the-enum {
     a,
   }
-
 }
 
 world w3 {
   import shared-items
+
   export bar: interface {
     use shared-items.{the-enum}
   }
@@ -18,6 +18,7 @@ world w2 {
   import foo: interface {
     use shared-items.{the-enum}
   }
+
   export bar: interface {
     use shared-items.{the-enum}
   }

--- a/crates/wit-component/tests/interfaces/empty.wit.print
+++ b/crates/wit-component/tests/interfaces/empty.wit.print
@@ -7,6 +7,7 @@ world empty-world {
   import empty
   import empty: interface {
   }
+
   export empty
   export empty2: interface {
   }

--- a/crates/wit-component/tests/interfaces/import-and-export.wit.print
+++ b/crates/wit-component/tests/interfaces/import-and-export.wit.print
@@ -10,5 +10,6 @@ interface bar {
 
 world import-and-export {
   import foo
+
   export bar
 }

--- a/crates/wit-component/tests/interfaces/multi-doc/foo.wit.print
+++ b/crates/wit-component/tests/interfaces/multi-doc/foo.wit.print
@@ -3,7 +3,6 @@ package foo:foo
 interface b {
   record the-type {
   }
-
 }
 
 interface b2 {

--- a/crates/wit-component/tests/interfaces/multiple-use.wit.print
+++ b/crates/wit-component/tests/interfaces/multiple-use.wit.print
@@ -4,12 +4,10 @@ interface foo {
   type t2 = u8
 
   type t1 = u8
-
 }
 
 interface bar {
   type u = u8
-
 }
 
 interface baz {

--- a/crates/wit-component/tests/interfaces/pkg-use-chain/chain.wit.print
+++ b/crates/wit-component/tests/interfaces/pkg-use-chain/chain.wit.print
@@ -2,7 +2,6 @@ package foo:chain
 
 interface a {
   type a = u8
-
 }
 
 interface def {
@@ -11,7 +10,6 @@ interface def {
   enum name {
     other,
   }
-
 }
 
 interface foo {

--- a/crates/wit-component/tests/interfaces/pkg-use-chain2/foo.wit.print
+++ b/crates/wit-component/tests/interfaces/pkg-use-chain2/foo.wit.print
@@ -3,7 +3,6 @@ package foo:foo
 interface other {
   record name {
   }
-
 }
 
 interface bar {
@@ -12,7 +11,6 @@ interface bar {
   enum name {
     a,
   }
-
 }
 
 interface foo {

--- a/crates/wit-component/tests/interfaces/print-keyword.wit.print
+++ b/crates/wit-component/tests/interfaces/print-keyword.wit.print
@@ -8,6 +8,5 @@ interface %interface {
   record %record {
     %variant: %world,
   }
-
 }
 

--- a/crates/wit-component/tests/interfaces/records.wit.print
+++ b/crates/wit-component/tests/interfaces/records.wit.print
@@ -58,5 +58,6 @@ interface records {
 
 world records-world {
   import records
+
   export records
 }

--- a/crates/wit-component/tests/interfaces/simple-use.wit.print
+++ b/crates/wit-component/tests/interfaces/simple-use.wit.print
@@ -5,11 +5,11 @@ interface types {
     info,
     debug,
   }
-
 }
 
 interface console {
   use types.{level}
+
   log: func(level: level, msg: string)
 }
 

--- a/crates/wit-component/tests/interfaces/type-alias.wit.print
+++ b/crates/wit-component/tests/interfaces/type-alias.wit.print
@@ -10,5 +10,6 @@ interface foo {
 
 world my-world {
   import foo
+
   export foo
 }

--- a/crates/wit-component/tests/interfaces/use-chain.wit.print
+++ b/crates/wit-component/tests/interfaces/use-chain.wit.print
@@ -6,7 +6,6 @@ interface foo {
   type b = a
 
   type c = b
-
 }
 
 interface bar {

--- a/crates/wit-component/tests/interfaces/use-for-type.wit.print
+++ b/crates/wit-component/tests/interfaces/use-for-type.wit.print
@@ -5,7 +5,6 @@ interface foo {
 
 interface bar {
   type t = u8
-
 }
 
 interface baz {
@@ -14,6 +13,5 @@ interface baz {
   record bar {
     a: t,
   }
-
 }
 

--- a/crates/wit-component/tests/interfaces/wasi-http/http.wit.print
+++ b/crates/wit-component/tests/interfaces/wasi-http/http.wit.print
@@ -129,11 +129,13 @@ interface types {
 
 interface outgoing-handler {
   use types.{outgoing-request, request-options, future-incoming-response}
+
   handle: func(request: outgoing-request, options: option<request-options>) -> future-incoming-response
 }
 
 interface incoming-handler {
   use types.{incoming-request, response-outparam}
+
   handle: func(request: incoming-request, response-out: response-outparam)
 }
 
@@ -144,5 +146,6 @@ world proxy {
   import wasi:io/streams
   import types
   import outgoing-handler
+
   export incoming-handler
 }

--- a/crates/wit-component/tests/interfaces/world-inline-interface.wit.print
+++ b/crates/wit-component/tests/interfaces/world-inline-interface.wit.print
@@ -3,6 +3,7 @@ package foo:foo
 world has-inline {
   import foo: interface {
   }
+
   export bar: interface {
   }
 }

--- a/crates/wit-component/tests/interfaces/world-pkg-conflict/foo.wit.print
+++ b/crates/wit-component/tests/interfaces/world-pkg-conflict/foo.wit.print
@@ -2,7 +2,6 @@ package foo:foo
 
 interface a {
   type t = u32
-
 }
 
 interface foo {

--- a/crates/wit-component/tests/interfaces/world-top-level.wit.print
+++ b/crates/wit-component/tests/interfaces/world-top-level.wit.print
@@ -11,6 +11,7 @@ world foo {
   }
   import foo: func()
   import bar: func(arg: u32)
+
   export another-interface: interface {
   }
   export foo2: func()

--- a/crates/wit-component/tests/interfaces/worlds-with-types.wit.print
+++ b/crates/wit-component/tests/interfaces/worlds-with-types.wit.print
@@ -2,17 +2,18 @@ package foo:foo
 
 interface import-me {
   type foo = u32
-
 }
 
 world with-imports {
   import import-me
   import a: func(a: foo)
   use import-me.{foo}
+
   export b: func(a: foo)
 }
 world simple {
   import a: func(a: foo) -> bar
+
   record foo {
   }
 

--- a/crates/wit-component/tests/merge/success/merge/foo.wit
+++ b/crates/wit-component/tests/merge/success/merge/foo.wit
@@ -10,7 +10,6 @@ interface shared-only-into {
 
 interface shared-items {
   type a = u32
-
 }
 
 interface only-into {
@@ -41,6 +40,7 @@ world shared-world {
   import shared-items
   import d: interface {
   }
+
   type c = u32
 
   export shared-items

--- a/crates/wit-component/tests/merge/success/merge/from.wit
+++ b/crates/wit-component/tests/merge/success/merge/from.wit
@@ -2,6 +2,7 @@ package foo:%from
 
 interface a {
   use foo:foo/only-from.{r}
+
   foo: func()
 }
 

--- a/crates/wit-component/tests/merge/success/merge/into.wit
+++ b/crates/wit-component/tests/merge/success/merge/into.wit
@@ -2,6 +2,7 @@ package foo:into
 
 interface b {
   use foo:foo/only-into.{r}
+
   foo: func()
 }
 

--- a/crates/wit-component/tests/merge/success/merge/only-from-dep.wit
+++ b/crates/wit-component/tests/merge/success/merge/only-from-dep.wit
@@ -2,6 +2,5 @@ package foo:only-from-dep
 
 interface a {
   type a = u32
-
 }
 


### PR DESCRIPTION
The goal is to put a blank line between functions and types but this was manually done previously which involved meticulously keeping track of when items were printed and how many were remaining. Instead this replaces this logic with a simpler "I'm about to start a new line" request which bumps a counter for how many items have been printed. This will help simplify whitespace management a bit with the upcoming resources implementation.