### PR TITLE
Remove keywords from wit-component that are not in use anymore

### DIFF
--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -706,8 +706,8 @@ fn is_keyword(name: &str) -> bool {
         "use" | "type" | "func" | "u8" | "u16" | "u32" | "u64" | "s8" | "s16" | "s32" | "s64"
         | "float32" | "float64" | "char" | "resource" | "record" | "flags" | "variant" | "enum"
         | "union" | "bool" | "string" | "option" | "result" | "future" | "stream" | "list"
-        | "shared" | "_" | "as" | "from" | "static" | "interface" | "tuple" | "implements"
-        | "world" | "import" | "export" | "default" | "pkg" | "self" | "package" | "with" => true,
+        | "shared" | "_" | "as" | "from" | "static" | "interface" | "tuple" | "world"
+        | "import" | "export" | "package" | "with" => true,
         _ => false,
     }
 }


### PR DESCRIPTION
In the last few changes a few keywords has been removed from WIT and also from crates/wit-parser, but it still exists in crates/wit-component, causing a wrong print of WIT files when using these keywords. For instance, `self` will be printed as `%self`.