### PR TITLE
Fix a panic validating resources

### DIFF
--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -841,9 +841,8 @@ impl ComponentState {
                 types.remap_component_entity(ty, &mut mapping);
             }
             for (id, path) in mem::take(&mut new_ty.explicit_resources) {
-                new_ty
-                    .explicit_resources
-                    .insert(mapping.resources[&id], path);
+                let id = mapping.resources.get(&id).copied().unwrap_or(id);
+                new_ty.explicit_resources.insert(id, path);
             }
             *id = types.push_ty(Type::ComponentInstance(Box::new(new_ty)));
         }

--- a/tests/local/component-model/resources.wast
+++ b/tests/local/component-model/resources.wast
@@ -1112,3 +1112,18 @@
     ))
   )
   "resource types are not the same")
+
+(component
+  (type (export "x") (component
+    (type $t' (instance
+      (export "r" (type (sub resource)))
+    ))
+    (export $t "t" (instance (type $t')))
+    (alias export $t "r" (type $r))
+    (type $t2' (instance
+      (export "r2" (type (eq $r)))
+      (export "r" (type (sub resource)))
+    ))
+    (export "t2" (instance (type $t2')))
+  ))
+)

--- a/tests/snapshots/local/component-model/resources.wast/109.print
+++ b/tests/snapshots/local/component-model/resources.wast/109.print
@@ -1,0 +1,22 @@
+(component
+  (type (;0;)
+    (component
+      (type (;0;)
+        (instance
+          (export (;0;) "r" (type (sub resource)))
+        )
+      )
+      (export (;0;) "t" (instance (type 0)))
+      (alias export 0 "r" (type (;1;)))
+      (type (;2;)
+        (instance
+          (alias outer 1 1 (type (;0;)))
+          (export (;1;) "r2" (type (eq 0)))
+          (export (;2;) "r" (type (sub resource)))
+        )
+      )
+      (export (;1;) "t2" (instance (type 2)))
+    )
+  )
+  (export (;1;) "x" (type 0))
+)


### PR DESCRIPTION
A remapping lookup was too eagerly assuming that an ID was listed in the remapping when it didn't need to be. This fixes the panic by handling the case where it's not remapped. Additionally a test is added showcasing the problem before.