### PR TITLE
Fix referring to resources in dependencies

### DIFF
--- a/crates/wit-parser/src/ast/resolve.rs
+++ b/crates/wit-parser/src/ast/resolve.rs
@@ -1214,7 +1214,7 @@ impl<'a> Resolver<'a> {
                 }
                 _ => bail!(Error {
                     span: name.span,
-                    msg: format!("type `{}` is not a resource", name.name),
+                    msg: format!("type `{}` used in a handle must be a resource", name.name),
                 }),
             }
         }

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -95,6 +95,7 @@ pub struct UnresolvedPackage {
     foreign_dep_spans: Vec<Span>,
     source_map: SourceMap,
     foreign_world_spans: Vec<Span>,
+    required_resource_types: Vec<(TypeId, Span)>,
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/crates/wit-parser/src/resolve.rs
+++ b/crates/wit-parser/src/resolve.rs
@@ -752,7 +752,7 @@ impl Remap {
                     TypeDefKind::Resource => break,
                     _ => bail!(Error {
                         span: *span,
-                        msg: format!("type is not a resource"),
+                        msg: format!("type used in a handle must be a resource"),
                     }),
                 }
             }

--- a/crates/wit-parser/src/resolve.rs
+++ b/crates/wit-parser/src/resolve.rs
@@ -744,6 +744,20 @@ impl Remap {
         // what they map to.
         self.process_foreign_types(unresolved, resolve)?;
 
+        for (id, span) in unresolved.required_resource_types.iter() {
+            let mut id = self.types[id.index()];
+            loop {
+                match resolve.types[id].kind {
+                    TypeDefKind::Type(Type::Id(i)) => id = i,
+                    TypeDefKind::Resource => break,
+                    _ => bail!(Error {
+                        span: *span,
+                        msg: format!("type is not a resource"),
+                    }),
+                }
+            }
+        }
+
         Ok(())
     }
 

--- a/crates/wit-parser/tests/ui/cross-package-resource/deps/foo/foo.wit
+++ b/crates/wit-parser/tests/ui/cross-package-resource/deps/foo/foo.wit
@@ -1,0 +1,5 @@
+package some:dep
+
+interface foo {
+  resource r
+}

--- a/crates/wit-parser/tests/ui/cross-package-resource/foo.wit
+++ b/crates/wit-parser/tests/ui/cross-package-resource/foo.wit
@@ -1,0 +1,7 @@
+package foo:bar
+
+interface foo {
+  use some:dep/foo.{r}
+
+  type t = own<r>
+}

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource13.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource13.wit.result
@@ -1,4 +1,4 @@
-type `foo` is not a resource
+type `foo` used in a handle must be a resource
      --> tests/ui/parse-fail/bad-resource13.wit:5:16
       |
     5 |   type t = own<foo>

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource14.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource14.wit.result
@@ -1,4 +1,4 @@
-type `t` is not a resource
+type `t` used in a handle must be a resource
      --> tests/ui/parse-fail/bad-resource14.wit:6:16
       |
     6 |   type b = own<t>

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource15.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource15.wit.result
@@ -1,4 +1,4 @@
-type is not a resource
+type used in a handle must be a resource
      --> tests/ui/parse-fail/bad-resource15/foo.wit:6:16
       |
     6 |   type t = own<r>

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource15.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource15.wit.result
@@ -1,0 +1,5 @@
+type is not a resource
+     --> tests/ui/parse-fail/bad-resource15/foo.wit:6:16
+      |
+    6 |   type t = own<r>
+      |                ^

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource15/deps/foo/foo.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource15/deps/foo/foo.wit
@@ -1,0 +1,5 @@
+package some:dep
+
+interface foo {
+  type r = u32
+}

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource15/foo.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource15/foo.wit
@@ -1,0 +1,7 @@
+package foo:bar
+
+interface foo {
+  use some:dep/foo.{r}
+
+  type t = own<r>
+}

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource4.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource4.wit.result
@@ -1,4 +1,4 @@
-type `foo` is not a resource
+type `foo` used in a handle must be a resource
      --> tests/ui/parse-fail/bad-resource4.wit:5:19
       |
     5 |   type t = borrow<foo>

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource5.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource5.wit.result
@@ -1,4 +1,4 @@
-type `t` is not a resource
+type `t` used in a handle must be a resource
      --> tests/ui/parse-fail/bad-resource5.wit:6:19
       |
     6 |   type b = borrow<t>


### PR DESCRIPTION
This commit fixes an issue in `wit-parser` where resources may be referred to from dependency packages rather than defined locally. In these situations the requirement that these types are resources is propagated to when `UnresolvedPackage`s are pushed into a `Resolve` to get finalized at that time.