### PR TITLE
Require resources use `shared<..>` syntax

### DIFF
--- a/crates/wit-parser/src/ast/resolve.rs
+++ b/crates/wit-parser/src/ast/resolve.rs
@@ -1029,6 +1029,12 @@ impl<'a> Resolver<'a> {
             ast::Type::String => TypeDefKind::Type(Type::String),
             ast::Type::Name(name) => {
                 let id = self.resolve_type_name(name)?;
+                if let TypeDefKind::Resource = &self.types[id].kind {
+                    bail!(Error {
+                        span: name.span,
+                        msg: format!("muse use `shared<..>` to refer to a resource"),
+                    })
+                }
                 TypeDefKind::Type(Type::Id(id))
             }
             ast::Type::List(list) => {

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource10.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource10.wit
@@ -1,0 +1,8 @@
+package foo:bar
+
+interface foo {
+  resource a
+
+  // NB: this will start working when `a` is sugar for `own<a>`
+  b: func() -> a
+}

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource10.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource10.wit.result
@@ -1,0 +1,5 @@
+muse use `shared<..>` to refer to a resource
+     --> tests/ui/parse-fail/bad-resource10.wit:7:16
+      |
+    7 |   b: func() -> a
+      |                ^


### PR DESCRIPTION
This is likely to change in the near future since the bare name of a resource will be synonymous with `own<T>`, but for the time being while `shared<T>` is implemented this explicitly disallows using `foo: resource-name`, for example.