### PR TITLE
Fix WIT sugar for resource names being `own<T>`

### DIFF
--- a/crates/wit-parser/tests/ui/name-both-resource-and-type/deps/dep/foo.wit
+++ b/crates/wit-parser/tests/ui/name-both-resource-and-type/deps/dep/foo.wit
@@ -1,0 +1,5 @@
+package some:dep
+
+interface foo {
+  resource a
+}

--- a/crates/wit-parser/tests/ui/name-both-resource-and-type/foo.wit
+++ b/crates/wit-parser/tests/ui/name-both-resource-and-type/foo.wit
@@ -1,0 +1,8 @@
+package foo:bar
+
+interface foo {
+  use some:dep/foo.{a}
+
+  type t1 = a
+  type t2 = borrow<a>
+}

--- a/crates/wit-parser/tests/ui/parse-fail/type-and-resource-same-name.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/type-and-resource-same-name.wit.result
@@ -1,0 +1,5 @@
+type is not a resource
+     --> tests/ui/parse-fail/type-and-resource-same-name/foo.wit:7:20
+      |
+    7 |   type t2 = borrow<a>
+      |                    ^

--- a/crates/wit-parser/tests/ui/parse-fail/type-and-resource-same-name.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/type-and-resource-same-name.wit.result
@@ -1,4 +1,4 @@
-type is not a resource
+type used in a handle must be a resource
      --> tests/ui/parse-fail/type-and-resource-same-name/foo.wit:7:20
       |
     7 |   type t2 = borrow<a>

--- a/crates/wit-parser/tests/ui/parse-fail/type-and-resource-same-name/deps/dep/foo.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/type-and-resource-same-name/deps/dep/foo.wit
@@ -1,0 +1,5 @@
+package some:dep
+
+interface foo {
+  type a = u32
+}

--- a/crates/wit-parser/tests/ui/parse-fail/type-and-resource-same-name/foo.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/type-and-resource-same-name/foo.wit
@@ -1,0 +1,8 @@
+package foo:bar
+
+interface foo {
+  use some:dep/foo.{a}
+
+  type t1 = a
+  type t2 = borrow<a>
+}


### PR DESCRIPTION
This commit fixes an issue where WIT resources should not have to be
wrapped in `own<T>` but instead are allowed to be defined as just `T`.
This is a bit tricky when `T` is defined in a foreign package since the
"inject the `own` wrapper" isn't apparent during parsing but only later
once packages are merged together. This phase has been updated
accordingly to inject `own` wrappers as necessary.

> Note: this builds on https://github.com/bytecodealliance/wasm-tools/pull/1079 as the first commit