### PR TITLE
fix(wit-parser): fix a few bugs that found by fuzzing

### DIFF
--- a/crates/wit-parser/src/ast/resolve.rs
+++ b/crates/wit-parser/src/ast/resolve.rs
@@ -77,7 +77,7 @@ pub struct Resolver<'a> {
     /// introduced to print an error message if necessary.
     foreign_dep_spans: Vec<Span>,
 
-    foreign_world_spans: Vec<Span>,
+    include_world_spans: Vec<Span>,
 
     /// A list of `TypeDefKind::Unknown` types which are required to be
     /// resources when this package is resolved against its dependencies.
@@ -212,7 +212,7 @@ impl<'a> Resolver<'a> {
             world_spans: mem::take(&mut self.world_spans),
             foreign_dep_spans: mem::take(&mut self.foreign_dep_spans),
             source_map: SourceMap::default(),
-            foreign_world_spans: mem::take(&mut self.foreign_world_spans),
+            include_world_spans: mem::take(&mut self.include_world_spans),
             required_resource_types: mem::take(&mut self.required_resource_types),
         })
     }
@@ -886,7 +886,7 @@ impl<'a> Resolver<'a> {
     fn resolve_include(&mut self, owner: TypeOwner, i: &ast::Include<'a>) -> Result<()> {
         let (item, name, span) = self.resolve_ast_item_path(&i.from)?;
         let include_from = self.extract_world_from_item(&item, &name, span)?;
-        self.foreign_world_spans.push(span);
+        self.include_world_spans.push(span);
         let world_id = match owner {
             TypeOwner::World(id) => id,
             _ => unreachable!(),

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -94,7 +94,7 @@ pub struct UnresolvedPackage {
     world_spans: Vec<Span>,
     foreign_dep_spans: Vec<Span>,
     source_map: SourceMap,
-    foreign_world_spans: Vec<Span>,
+    include_world_spans: Vec<Span>,
     required_resource_types: Vec<(TypeId, Span)>,
 }
 

--- a/crates/wit-parser/src/resolve.rs
+++ b/crates/wit-parser/src/resolve.rs
@@ -642,7 +642,7 @@ impl Remap {
         // transitive relation between interfaces, through types, is understood
         // here.
         assert_eq!(unresolved.worlds.len(), unresolved.world_item_spans.len());
-        let unresolved_world_spans = unresolved.foreign_world_spans;
+        let include_world_spans = unresolved.include_world_spans;
         for ((id, mut world), (import_spans, export_spans)) in unresolved
             .worlds
             .into_iter()
@@ -655,7 +655,7 @@ impl Remap {
             let includes = mem::take(&mut world.includes);
             let include_names = mem::take(&mut world.include_names);
             for (index, include_world) in includes.into_iter().enumerate() {
-                let span = unresolved_world_spans[include_world.index()];
+                let span = include_world_spans[index];
                 let names = &include_names[index];
                 self.resolve_include(&mut world, include_world, names, span, resolve)?;
             }

--- a/crates/wit-parser/tests/ui/parse-fail/union-fuzz-2.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/union-fuzz-2.wit
@@ -1,0 +1,12 @@
+package foo:bar
+
+world foo {
+    export foo: func() -> (%name2: float32)
+}
+    
+
+world bar {
+    include foo
+    
+    record foo {}
+}

--- a/crates/wit-parser/tests/ui/parse-fail/union-fuzz-2.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/union-fuzz-2.wit.result
@@ -1,0 +1,5 @@
+import type `foo` conflicts with prior export of interface
+     --> tests/ui/parse-fail/union-fuzz-2.wit:11:12
+      |
+   11 |     record foo {}
+      |            ^--

--- a/crates/wit-parser/tests/ui/union-fuzz-1.wit
+++ b/crates/wit-parser/tests/ui/union-fuzz-1.wit
@@ -1,0 +1,9 @@
+package foo:bar
+
+world xo {}
+
+world name {}
+
+world x {
+    include name
+}


### PR DESCRIPTION
This PR fixes two bugs:
1. When there are multiple worlds in a WITpackage, but not every one of them are included in a world. This bug emerges from an use of out-of-bound index to get included world's span.
2. The fully resolved world does not check naming conflict among its imported types, functions, exported functions with import/export interfaces. 