### PR TITLE
Update accessors on `TypesRef`

### DIFF
--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -1484,7 +1484,8 @@ mod tests {
             })
         );
 
-        match types.function_at(0) {
+        let id = types.function_at(0).unwrap();
+        match types.type_from_id(id).unwrap().as_func_type() {
             Some(ty) => {
                 assert_eq!(ty.params(), [ValType::I32, ValType::I64]);
                 assert_eq!(ty.results(), [ValType::I32]);

--- a/crates/wit-component/src/validation.rs
+++ b/crates/wit-component/src/validation.rs
@@ -419,7 +419,8 @@ pub fn validate_adapter_module<'a>(
             Some(idx) => *idx,
             None => bail!("adapter module did not export `{name}`"),
         };
-        let actual = types.function_at(idx).unwrap();
+        let id = types.function_at(idx).unwrap();
+        let actual = types.type_from_id(id).unwrap().as_func_type().unwrap();
         if ty == actual {
             continue;
         }
@@ -548,7 +549,8 @@ fn validate_exported_item(
         let expected_export_name = func.core_export_name(name);
         match exports.get(expected_export_name.as_ref()) {
             Some(func_index) => {
-                let ty = types.function_at(*func_index).unwrap();
+                let id = types.function_at(*func_index).unwrap();
+                let ty = types.type_from_id(id).unwrap().as_func_type().unwrap();
                 validate_func(resolve, ty, func, AbiVariant::GuestExport)
             }
             None => bail!(


### PR DESCRIPTION
Previously accessors of type information would return the actual information itself, and this commit updates them to instead return the `TypeId`. A `TypeId` can be turned into the concrete type information and otherwise upcoming resources support in Wasmtime needs more aggressive use of `TypeId` so I found it easier to have those returned from these methods since it's not possible to go from `&FuncType` to `TypeId`.

Additionally this commit adds accessors for the size of all the index spaces in the component model and core wasm binary format. This enables witnessing intermediate state while validating a component for example which is also used in the upcoming support for resources in Wasmtime.