### PR TITLE
wast: Shrink the size of `Instruction`

### DIFF
--- a/crates/wast/src/core/binary.rs
+++ b/crates/wast/src/core/binary.rs
@@ -641,10 +641,10 @@ impl Encode for Func<'_> {
     }
 }
 
-impl Encode for Vec<Local<'_>> {
+impl Encode for Box<[Local<'_>]> {
     fn encode(&self, e: &mut Vec<u8>) {
         let mut locals_compressed = Vec::<(u32, ValType)>::new();
-        for local in self {
+        for local in self.iter() {
             if let Some((cnt, prev)) = locals_compressed.last_mut() {
                 if *prev == local.ty {
                     *cnt += 1;
@@ -919,7 +919,7 @@ fn find_names<'a>(
                 locals, expression, ..
             } = &f.kind
             {
-                for local in locals {
+                for local in locals.iter() {
                     if let Some(name) = get_name(&local.id, &local.name) {
                         local_names.push((local_idx, name));
                     }

--- a/crates/wast/src/core/expr.rs
+++ b/crates/wast/src/core/expr.rs
@@ -502,10 +502,10 @@ macro_rules! instructions {
 
 instructions! {
     pub enum Instruction<'a> {
-        Block(BlockType<'a>) : [0x02] : "block",
-        If(BlockType<'a>) : [0x04] : "if",
+        Block(Box<BlockType<'a>>) : [0x02] : "block",
+        If(Box<BlockType<'a>>) : [0x04] : "if",
         Else(Option<Id<'a>>) : [0x05] : "else",
-        Loop(BlockType<'a>) : [0x03] : "loop",
+        Loop(Box<BlockType<'a>>) : [0x03] : "loop",
         End(Option<Id<'a>>) : [0x0b] : "end",
 
         Unreachable : [0x00] : "unreachable",
@@ -515,11 +515,11 @@ instructions! {
         BrTable(BrTableIndices<'a>) : [0x0e] : "br_table",
         Return : [0x0f] : "return",
         Call(Index<'a>) : [0x10] : "call",
-        CallIndirect(CallIndirect<'a>) : [0x11] : "call_indirect",
+        CallIndirect(Box<CallIndirect<'a>>) : [0x11] : "call_indirect",
 
         // tail-call proposal
         ReturnCall(Index<'a>) : [0x12] : "return_call",
-        ReturnCallIndirect(CallIndirect<'a>) : [0x13] : "return_call_indirect",
+        ReturnCallIndirect(Box<CallIndirect<'a>>) : [0x13] : "return_call_indirect",
 
         // function-references proposal
         CallRef(Index<'a>) : [0x14] : "call_ref",
@@ -621,8 +621,8 @@ instructions! {
         // gc proposal, concrete casting
         RefTest(RefTest<'a>) : [] : "ref.test",
         RefCast(RefCast<'a>) : [] : "ref.cast",
-        BrOnCast(BrOnCast<'a>) : [] : "br_on_cast",
-        BrOnCastFail(BrOnCastFail<'a>) : [] : "br_on_cast_fail",
+        BrOnCast(Box<BrOnCast<'a>>) : [] : "br_on_cast",
+        BrOnCastFail(Box<BrOnCastFail<'a>>) : [] : "br_on_cast_fail",
 
         // gc proposal extern/any coercion operations
         ExternInternalize : [0xfb, 0x70] : "extern.internalize",
@@ -1118,7 +1118,7 @@ instructions! {
         F64x2PromoteLowF32x4 : [0xfd, 95] : "f64x2.promote_low_f32x4",
 
         // Exception handling proposal
-        Try(BlockType<'a>) : [0x06] : "try",
+        Try(Box<BlockType<'a>>) : [0x06] : "try",
         Catch(Index<'a>) : [0x07] : "catch",
         Throw(Index<'a>) : [0x08] : "throw",
         Rethrow(Index<'a>) : [0x09] : "rethrow",
@@ -1148,6 +1148,16 @@ instructions! {
         I32x4RelaxedDotI8x16I7x16AddS: [0xfd, 0x113]: "i32x4.relaxed_dot_i8x16_i7x16_add_s",
     }
 }
+
+// As shown in #1095 the size of this variant is somewhat performance-sensitive
+// since big `*.wat` files will have a lot of these. This is a small ratchet to
+// make sure that this enum doesn't become larger than it already is, although
+// ideally it also wouldn't be as large as it is now.
+const _: () = {
+    let size = std::mem::size_of::<Instruction<'_>>();
+    let pointer = std::mem::size_of::<usize>();
+    assert!(size <= pointer * 10);
+};
 
 impl<'a> Instruction<'a> {
     pub(crate) fn needs_data_count(&self) -> bool {
@@ -1205,15 +1215,15 @@ impl<'a> Parse<'a> for FuncBindType<'a> {
 #[derive(Debug)]
 #[allow(missing_docs)]
 pub struct LetType<'a> {
-    pub block: BlockType<'a>,
-    pub locals: Vec<Local<'a>>,
+    pub block: Box<BlockType<'a>>,
+    pub locals: Box<[Local<'a>]>,
 }
 
 impl<'a> Parse<'a> for LetType<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
         Ok(LetType {
             block: parser.parse()?,
-            locals: Local::parse_remainder(parser)?,
+            locals: Local::parse_remainder(parser)?.into(),
         })
     }
 }

--- a/crates/wast/src/core/func.rs
+++ b/crates/wast/src/core/func.rs
@@ -38,7 +38,7 @@ pub enum FuncKind<'a> {
     /// Almost all functions, those defined inline in a wasm module.
     Inline {
         /// The list of locals, if any, for this function.
-        locals: Vec<Local<'a>>,
+        locals: Box<[Local<'a>]>,
 
         /// The instructions of the function.
         expression: Expression<'a>,
@@ -56,7 +56,7 @@ impl<'a> Parse<'a> for Func<'a> {
             (parser.parse()?, FuncKind::Import(import))
         } else {
             let ty = parser.parse()?;
-            let locals = Local::parse_remainder(parser)?;
+            let locals = Local::parse_remainder(parser)?.into();
             (
                 ty,
                 FuncKind::Inline {

--- a/crates/wast/src/core/resolve/names.rs
+++ b/crates/wast/src/core/resolve/names.rs
@@ -176,7 +176,7 @@ impl<'a> Resolver<'a> {
                     }
 
                     // .. followed by locals themselves
-                    for local in locals {
+                    for local in locals.iter() {
                         scope.register(local.id, "local")?;
                     }
 
@@ -492,13 +492,13 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
 
             Let(t) => {
                 // Resolve (ref T) in locals
-                for local in &mut t.locals {
+                for local in t.locals.iter_mut() {
                     self.resolver.resolve_valtype(&mut local.ty)?;
                 }
 
                 // Register all locals defined in this let
                 let mut scope = Namespace::default();
-                for local in &t.locals {
+                for local in t.locals.iter() {
                     scope.register(local.id, "local")?;
                 }
                 self.scopes.push(scope);
@@ -604,8 +604,8 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
                 self.resolver.resolve_reftype(&mut i.from_type)?;
             }
 
-            StructNew(i) | StructNewDefault(i) | ArrayNew(i)
-            | ArrayNewDefault(i) | ArrayGet(i) | ArrayGetS(i) | ArrayGetU(i) | ArraySet(i) => {
+            StructNew(i) | StructNewDefault(i) | ArrayNew(i) | ArrayNewDefault(i) | ArrayGet(i)
+            | ArrayGetS(i) | ArrayGetU(i) | ArraySet(i) => {
                 self.resolver.resolve(i, Ns::Type)?;
             }
 

--- a/crates/wast/src/encode.rs
+++ b/crates/wast/src/encode.rs
@@ -8,6 +8,12 @@ impl<T: Encode + ?Sized> Encode for &'_ T {
     }
 }
 
+impl<T: Encode + ?Sized> Encode for Box<T> {
+    fn encode(&self, e: &mut Vec<u8>) {
+        T::encode(self, e)
+    }
+}
+
 impl<T: Encode> Encode for [T] {
     fn encode(&self, e: &mut Vec<u8>) {
         self.len().encode(e);

--- a/crates/wast/src/parser.rs
+++ b/crates/wast/src/parser.rs
@@ -243,6 +243,15 @@ pub trait Parse<'a>: Sized {
     fn parse(parser: Parser<'a>) -> Result<Self>;
 }
 
+impl<'a, T> Parse<'a> for Box<T>
+where
+    T: Parse<'a>,
+{
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        Ok(Box::new(parser.parse()?))
+    }
+}
+
 /// A trait for types which be used to "peek" to see if they're the next token
 /// in an input stream of [`Parser`].
 ///


### PR DESCRIPTION
This commit shrinks the size of the `Instruction` enum on x86_64 from 152 bytes to 80 bytes. This is in an effort to reduce the resource consumption reported in #1095 since it's definitely excessively large at this point. This reduces the peak memory usage from 6G to 5G when parsing that input `*.wat` file.

Shrinking this enum has been done by running a build with `RUSTFLAGS=-Zprint-type-sizes` and then adding a `Box` to variants with excessively large payloads. The current size of 80 bytes is still a bit large, but I didn't want to go too crazy with inserting boxes just yet.