### PR TITLE
wast: Don't use lookahead1 on parsing `Index`

### DIFF
--- a/crates/wast/src/token.rs
+++ b/crates/wast/src/token.rs
@@ -167,14 +167,15 @@ impl Index<'_> {
 
 impl<'a> Parse<'a> for Index<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
-        let mut l = parser.lookahead1();
-        if l.peek::<Id>() {
+        if parser.peek::<Id>() {
             Ok(Index::Id(parser.parse()?))
-        } else if l.peek::<u32>() {
+        } else if parser.peek::<u32>() {
             let (val, span) = parser.parse()?;
             Ok(Index::Num(val, span))
         } else {
-            Err(l.error())
+            Err(parser.error(format!(
+                "unexpected token, expected an index or an identifier"
+            )))
         }
     }
 }


### PR DESCRIPTION
Otherwise parsing an `Index` requires heap allocations due to the error message tracking in `lookahead1` which typically gets thrown away as other branches succeed in parsing.

I found this via DHAT while looking into #1095 and while it wasn't much of a perf improvement it drastically reduced the number of temporary allocations performed at this location which seems like a nice little micro-optimization to have nonetheless.