### PR TITLE
Shrink the size of wast text tokens

### DIFF
--- a/crates/wast/src/lexer.rs
+++ b/crates/wast/src/lexer.rs
@@ -43,55 +43,100 @@ pub struct Lexer<'a> {
     allow_confusing_unicode: bool,
 }
 
-/// A fragment of source lex'd from an input string.
+/// A single token parsed from a `Lexer`.
+#[derive(Debug, PartialEq)]
+pub struct Token {
+    /// The kind of token this represents, such as whether it's whitespace, a
+    /// keyword, etc.
+    pub kind: TokenKind,
+    /// The byte offset within the original source for where this token came
+    /// from.
+    pub offset: usize,
+    /// The byte length of this token as it resides in the original source.
+    //
+    // NB: this is `u32` to enable packing `Token` into two pointers of size.
+    // This does limit a single token to being at most 4G large, but that seems
+    // probably ok.
+    pub len: u32,
+}
+
+const _: () = {
+    assert!(std::mem::size_of::<Token>() <= std::mem::size_of::<usize>() * 2);
+};
+
+/// Classification of what was parsed from the input stream.
 ///
 /// This enumeration contains all kinds of fragments, including comments and
-/// whitespace. For most cases you'll probably ignore these and simply look at
-/// tokens.
-#[derive(Debug, PartialEq)]
-pub enum Token<'a> {
+/// whitespace.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum TokenKind {
     /// A line comment, preceded with `;;`
-    LineComment(&'a str),
+    LineComment,
 
     /// A block comment, surrounded by `(;` and `;)`. Note that these can be
     /// nested.
-    BlockComment(&'a str),
+    BlockComment,
 
     /// A fragment of source that represents whitespace.
-    Whitespace(&'a str),
+    Whitespace,
 
     /// A left-parenthesis, including the source text for where it comes from.
-    LParen(&'a str),
+    LParen,
     /// A right-parenthesis, including the source text for where it comes from.
-    RParen(&'a str),
+    RParen,
 
     /// A string literal, which is actually a list of bytes.
-    String(WasmString<'a>),
+    String,
 
     /// An identifier (like `$foo`).
     ///
     /// All identifiers start with `$` and the payload here is the original
     /// source text.
-    Id(&'a str),
+    Id,
 
     /// A keyword, or something that starts with an alphabetic character.
     ///
     /// The payload here is the original source text.
-    Keyword(&'a str),
+    Keyword,
 
     /// A reserved series of `idchar` symbols. Unknown what this is meant to be
     /// used for, you'll probably generate an error about an unexpected token.
-    Reserved(&'a str),
+    Reserved,
 
     /// An integer.
-    Integer(Integer<'a>),
+    Integer(IntegerKind),
 
     /// A float.
-    Float(Float<'a>),
+    Float(FloatKind),
 }
 
-enum ReservedKind<'a> {
-    String(Cow<'a, [u8]>),
+/// Description of the parsed integer from the source.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct IntegerKind {
+    sign: Option<SignToken>,
+    has_underscores: bool,
+    hex: bool,
+}
+
+/// Description of a parsed float from the source.
+#[allow(missing_docs)]
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum FloatKind {
+    #[doc(hidden)]
+    Inf { negative: bool },
+    #[doc(hidden)]
+    Nan { negative: bool },
+    #[doc(hidden)]
+    NanVal {
+        negative: bool,
+        has_underscores: bool,
+    },
+    #[doc(hidden)]
+    Normal { has_underscores: bool, hex: bool },
+}
+
+enum ReservedKind {
+    String,
     Idchars,
     Reserved,
 }
@@ -165,45 +210,18 @@ pub enum SignToken {
     Minus,
 }
 
-/// A parsed integer, signed or unsigned.
-///
-/// Methods can be use to access the value of the integer.
+/// A fully parsed integer from a source string with a payload ready to parse
+/// into an integral type.
 #[derive(Debug, PartialEq)]
-pub struct Integer<'a>(Box<IntegerInner<'a>>);
-
-#[derive(Debug, PartialEq)]
-struct IntegerInner<'a> {
+pub struct Integer<'a> {
     sign: Option<SignToken>,
-    src: &'a str,
     val: Cow<'a, str>,
     hex: bool,
 }
 
-/// A parsed float.
-///
-/// Methods can be use to access the value of the float.
-#[derive(Debug, PartialEq)]
-pub struct Float<'a>(Box<FloatInner<'a>>);
-
-#[derive(Debug, PartialEq)]
-struct FloatInner<'a> {
-    src: &'a str,
-    val: FloatVal<'a>,
-}
-
-/// A parsed string.
-#[derive(Debug, PartialEq)]
-pub struct WasmString<'a>(Box<WasmStringInner<'a>>);
-
-#[derive(Debug, PartialEq)]
-struct WasmStringInner<'a> {
-    src: &'a str,
-    val: Cow<'a, [u8]>,
-}
-
 /// Possible parsed float values
 #[derive(Debug, PartialEq, Eq)]
-pub enum FloatVal<'a> {
+pub enum Float<'a> {
     /// A float `NaN` representation
     Nan {
         /// The specific bits to encode for this float, optionally
@@ -301,7 +319,19 @@ impl<'a> Lexer<'a> {
     /// # Errors
     ///
     /// Returns an error if the input is malformed.
-    pub fn parse(&mut self) -> Result<Option<Token<'a>>, Error> {
+    pub fn parse(&mut self) -> Result<Option<Token>, Error> {
+        let offset = self.cur();
+        Ok(match self.parse_kind()? {
+            Some(kind) => Some(Token {
+                kind,
+                offset,
+                len: (self.cur() - offset).try_into().unwrap(),
+            }),
+            None => None,
+        })
+    }
+
+    fn parse_kind(&mut self) -> Result<Option<TokenKind>, Error> {
         let pos = self.cur();
         // This `match` generally parses the grammar specified at
         //
@@ -346,7 +376,7 @@ impl<'a> Lexer<'a> {
                                         let (comment, remaining) = self.remaining.split_at(len);
                                         self.remaining = remaining;
                                         self.check_confusing_comment(comment)?;
-                                        return Ok(Some(Token::BlockComment(comment)));
+                                        return Ok(Some(TokenKind::BlockComment));
                                     }
                                 }
                             }
@@ -355,38 +385,42 @@ impl<'a> Lexer<'a> {
                     }
                     Err(self.error(pos, LexError::DanglingBlockComment))
                 }
-                _ => Ok(Some(Token::LParen(self.split_first_byte()))),
+                _ => {
+                    self.remaining = &self.remaining[1..];
+                    Ok(Some(TokenKind::LParen))
+                }
             },
 
-            b')' => Ok(Some(Token::RParen(self.split_first_byte()))),
+            b')' => {
+                self.remaining = &self.remaining[1..];
+                Ok(Some(TokenKind::RParen))
+            }
 
             // https://webassembly.github.io/spec/core/text/lexical.html#white-space
-            b' ' | b'\n' | b'\r' | b'\t' => Ok(Some(Token::Whitespace(self.split_ws()))),
+            b' ' | b'\n' | b'\r' | b'\t' => {
+                self.skip_ws();
+                Ok(Some(TokenKind::Whitespace))
+            }
 
             c @ (idchars!() | b'"') => {
-                let (kind, src) = self.split_reserved()?;
+                let (kind, src) = self.parse_reserved()?;
                 match kind {
                     // If the reserved token was simply a single string then
                     // that is converted to a standalone string token
-                    ReservedKind::String(val) => {
-                        return Ok(Some(Token::String(WasmString(Box::new(WasmStringInner {
-                            val,
-                            src,
-                        })))));
-                    }
+                    ReservedKind::String => return Ok(Some(TokenKind::String)),
 
                     // If only idchars were consumed then this could be a
                     // specific kind of standalone token we're interested in.
                     ReservedKind::Idchars => {
                         // https://webassembly.github.io/spec/core/text/values.html#integers
-                        if let Some(number) = self.number(src) {
-                            return Ok(Some(number));
+                        if let Some(ret) = self.classify_number(src) {
+                            return Ok(Some(ret));
                         // https://webassembly.github.io/spec/core/text/values.html#text-id
                         } else if *c == b'$' && src.len() > 1 {
-                            return Ok(Some(Token::Id(src)));
+                            return Ok(Some(TokenKind::Id));
                         // https://webassembly.github.io/spec/core/text/lexical.html#text-keyword
                         } else if b'a' <= *c && *c <= b'z' {
-                            return Ok(Some(Token::Keyword(src)));
+                            return Ok(Some(TokenKind::Keyword));
                         }
                     }
 
@@ -397,7 +431,7 @@ impl<'a> Lexer<'a> {
                     ReservedKind::Reserved => {}
                 }
 
-                Ok(Some(Token::Reserved(src)))
+                Ok(Some(TokenKind::Reserved))
             }
 
             // This could be a line comment, otherwise `;` is a reserved token.
@@ -409,28 +443,28 @@ impl<'a> Lexer<'a> {
                 Some(b';') => {
                     let comment = self.split_until(b'\n');
                     self.check_confusing_comment(comment)?;
-                    Ok(Some(Token::LineComment(comment)))
+                    Ok(Some(TokenKind::LineComment))
                 }
-                _ => Ok(Some(Token::Reserved(self.split_first_byte()))),
+                _ => {
+                    self.remaining = &self.remaining[1..];
+                    Ok(Some(TokenKind::Reserved))
+                }
             },
 
             // Other known reserved tokens other than `;`
             //
             // Note that these characters being considered as part of a
             // `reserved` token is part of the annotations proposal.
-            b',' | b'[' | b']' | b'{' | b'}' => Ok(Some(Token::Reserved(self.split_first_byte()))),
+            b',' | b'[' | b']' | b'{' | b'}' => {
+                self.remaining = &self.remaining[1..];
+                Ok(Some(TokenKind::Reserved))
+            }
 
             _ => {
                 let ch = self.remaining.chars().next().unwrap();
                 Err(self.error(pos, LexError::Unexpected(ch)))
             }
         }
-    }
-
-    fn split_first_byte(&mut self) -> &'a str {
-        let (token, remaining) = self.remaining.split_at(1);
-        self.remaining = remaining;
-        token
     }
 
     fn split_until(&mut self, byte: u8) -> &'a str {
@@ -440,7 +474,7 @@ impl<'a> Lexer<'a> {
         ret
     }
 
-    fn split_ws(&mut self) -> &'a str {
+    fn skip_ws(&mut self) {
         // This table is a byte lookup table to determine whether a byte is a
         // whitespace byte. There are only 4 whitespace bytes for the `*.wat`
         // format right now which are ' ', '\t', '\r', and '\n'. These 4 bytes
@@ -484,9 +518,7 @@ impl<'a> Lexer<'a> {
             .iter()
             .position(|b| WS[*b as usize] != 1)
             .unwrap_or(self.remaining.len());
-        let (ret, remaining) = self.remaining.split_at(pos);
-        self.remaining = remaining;
-        ret
+        self.remaining = &self.remaining[pos..];
     }
 
     /// Splits off a "reserved" token which is then further processed later on
@@ -504,10 +536,9 @@ impl<'a> Lexer<'a> {
     /// tokens (e.g. `a"b"c`) and returning the classification of what was
     /// eaten. The classification assists in determining what the actual token
     /// here eaten looks like.
-    fn split_reserved(&mut self) -> Result<(ReservedKind<'a>, &'a str), Error> {
+    fn parse_reserved(&mut self) -> Result<(ReservedKind, &'a str), Error> {
         let mut idchars = false;
         let mut strings = 0u32;
-        let mut last_string_val = None;
         let mut pos = 0;
         while let Some(byte) = self.remaining.as_bytes().get(pos) {
             match byte {
@@ -526,7 +557,7 @@ impl<'a> Lexer<'a> {
                     let result = Lexer::parse_str(&mut it, self.allow_confusing_unicode);
                     pos = self.remaining.len() - it.as_str().len();
                     match result {
-                        Ok(s) => last_string_val = Some(s),
+                        Ok(_) => {}
                         Err(e) => {
                             let start = self.input.len() - self.remaining.len();
                             self.remaining = &self.remaining[pos..];
@@ -553,13 +584,13 @@ impl<'a> Lexer<'a> {
         self.remaining = remaining;
         Ok(match (idchars, strings) {
             (false, 0) => unreachable!(),
-            (false, 1) => (ReservedKind::String(last_string_val.unwrap()), ret),
+            (false, 1) => (ReservedKind::String, ret),
             (true, 0) => (ReservedKind::Idchars, ret),
             _ => (ReservedKind::Reserved, ret),
         })
     }
 
-    fn number(&self, src: &'a str) -> Option<Token<'a>> {
+    fn classify_number(&self, src: &str) -> Option<TokenKind> {
         let (sign, num) = if let Some(stripped) = src.strip_prefix('+') {
             (Some(SignToken::Plus), stripped)
         } else if let Some(stripped) = src.strip_prefix('-') {
@@ -572,32 +603,19 @@ impl<'a> Lexer<'a> {
 
         // Handle `inf` and `nan` which are special numbers here
         if num == "inf" {
-            return Some(Token::Float(Float(Box::new(FloatInner {
-                src,
-                val: FloatVal::Inf { negative },
-            }))));
+            return Some(TokenKind::Float(FloatKind::Inf { negative }));
         } else if num == "nan" {
-            return Some(Token::Float(Float(Box::new(FloatInner {
-                src,
-                val: FloatVal::Nan {
-                    val: None,
-                    negative,
-                },
-            }))));
+            return Some(TokenKind::Float(FloatKind::Nan { negative }));
         } else if let Some(stripped) = num.strip_prefix("nan:0x") {
             let mut it = stripped.chars();
-            let to_parse = skip_undescores(&mut it, false, char::is_ascii_hexdigit)?;
+            let has_underscores = skip_underscores(&mut it, char::is_ascii_hexdigit)?;
             if it.next().is_some() {
                 return None;
             }
-            let n = u64::from_str_radix(&to_parse, 16).ok()?;
-            return Some(Token::Float(Float(Box::new(FloatInner {
-                src,
-                val: FloatVal::Nan {
-                    val: Some(n),
-                    negative,
-                },
-            }))));
+            return Some(TokenKind::Float(FloatKind::NanVal {
+                negative,
+                has_underscores,
+            }));
         }
 
         // Figure out if we're a hex number or not
@@ -616,7 +634,7 @@ impl<'a> Lexer<'a> {
         };
 
         // Evaluate the first part, moving out all underscores
-        let val = skip_undescores(&mut it, negative, test_valid)?;
+        let mut has_underscores = skip_underscores(&mut it, test_valid)?;
 
         match it.clone().next() {
             // If we're followed by something this may be a float so keep going.
@@ -624,47 +642,48 @@ impl<'a> Lexer<'a> {
 
             // Otherwise this is a valid integer literal!
             None => {
-                return Some(Token::Integer(Integer(Box::new(IntegerInner {
+                return Some(TokenKind::Integer(IntegerKind {
+                    has_underscores,
                     sign,
-                    src,
-                    val,
                     hex,
-                }))))
+                }))
             }
         }
 
         // A number can optionally be after the decimal so only actually try to
         // parse one if it's there.
-        let decimal = if it.clone().next() == Some('.') {
+        if it.clone().next() == Some('.') {
             it.next();
             match it.clone().next() {
-                Some(c) if test_valid(&c) => Some(skip_undescores(&mut it, false, test_valid)?),
-                Some(_) | None => None,
+                Some(c) if test_valid(&c) => {
+                    if skip_underscores(&mut it, test_valid)? {
+                        has_underscores = true;
+                    }
+                }
+                Some(_) | None => {}
             }
-        } else {
-            None
         };
 
         // Figure out if there's an exponential part here to make a float, and
         // if so parse it but defer its actual calculation until later.
-        let exponent = match (hex, it.next()) {
+        match (hex, it.next()) {
             (true, Some('p')) | (true, Some('P')) | (false, Some('e')) | (false, Some('E')) => {
-                let negative = match it.clone().next() {
+                match it.clone().next() {
                     Some('-') => {
                         it.next();
-                        true
                     }
                     Some('+') => {
                         it.next();
-                        false
                     }
-                    _ => false,
-                };
-                Some(skip_undescores(&mut it, negative, char::is_ascii_digit)?)
+                    _ => {}
+                }
+                if skip_underscores(&mut it, char::is_ascii_digit)? {
+                    has_underscores = true;
+                }
             }
-            (_, None) => None,
+            (_, None) => {}
             _ => return None,
-        };
+        }
 
         // We should have eaten everything by now, if not then this is surely
         // not a float or integer literal.
@@ -672,45 +691,21 @@ impl<'a> Lexer<'a> {
             return None;
         }
 
-        return Some(Token::Float(Float(Box::new(FloatInner {
-            src,
-            val: FloatVal::Val {
-                hex,
-                integral: val,
-                exponent,
-                decimal,
-            },
-        }))));
+        return Some(TokenKind::Float(FloatKind::Normal {
+            has_underscores,
+            hex,
+        }));
 
-        fn skip_undescores<'a>(
-            it: &mut str::Chars<'a>,
-            negative: bool,
-            good: fn(&char) -> bool,
-        ) -> Option<Cow<'a, str>> {
-            enum State {
-                Raw,
-                Collecting(String),
-            }
+        fn skip_underscores<'a>(it: &mut str::Chars<'a>, good: fn(&char) -> bool) -> Option<bool> {
             let mut last_underscore = false;
-            let mut state = if negative {
-                State::Collecting("-".to_string())
-            } else {
-                State::Raw
-            };
-            let input = it.as_str();
+            let mut has_underscores = false;
             let first = it.next()?;
             if !good(&first) {
                 return None;
             }
-            if let State::Collecting(s) = &mut state {
-                s.push(first);
-            }
-            let mut last = 1;
             while let Some(c) = it.clone().next() {
                 if c == '_' && !last_underscore {
-                    if let State::Raw = state {
-                        state = State::Collecting(input[..last].to_string());
-                    }
+                    has_underscores = true;
                     it.next();
                     last_underscore = true;
                     continue;
@@ -718,20 +713,13 @@ impl<'a> Lexer<'a> {
                 if !good(&c) {
                     break;
                 }
-                if let State::Collecting(s) = &mut state {
-                    s.push(c);
-                }
                 last_underscore = false;
                 it.next();
-                last += 1;
             }
             if last_underscore {
                 return None;
             }
-            Some(match state {
-                State::Raw => input[..last].into(),
-                State::Collecting(s) => s.into(),
-            })
+            Some(has_underscores)
         }
     }
 
@@ -901,28 +889,171 @@ impl<'a> Lexer<'a> {
 }
 
 impl<'a> Iterator for Lexer<'a> {
-    type Item = Result<Token<'a>, Error>;
+    type Item = Result<Token, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.parse().transpose()
     }
 }
 
-impl<'a> Token<'a> {
+impl Token {
     /// Returns the original source text for this token.
-    pub fn src(&self) -> &'a str {
-        match self {
-            Token::Whitespace(s) => s,
-            Token::BlockComment(s) => s,
-            Token::LineComment(s) => s,
-            Token::LParen(s) => s,
-            Token::RParen(s) => s,
-            Token::String(s) => s.src(),
-            Token::Id(s) => s,
-            Token::Keyword(s) => s,
-            Token::Reserved(s) => s,
-            Token::Integer(i) => i.src(),
-            Token::Float(f) => f.src(),
+    pub fn src<'a>(&self, s: &'a str) -> &'a str {
+        &s[self.offset..][..self.len.try_into().unwrap()]
+    }
+
+    /// Returns the identifier, without the leading `$` symbol, that this token
+    /// represents.
+    ///
+    /// Should only be used with `TokenKind::Id`.
+    pub fn id<'a>(&self, s: &'a str) -> &'a str {
+        &self.src(s)[1..]
+    }
+
+    /// Returns the keyword this token represents.
+    ///
+    /// Should only be used with `TokenKind::Keyword`.
+    pub fn keyword<'a>(&self, s: &'a str) -> &'a str {
+        self.src(s)
+    }
+
+    /// Returns the reserved string this token represents.
+    ///
+    /// Should only be used with `TokenKind::Reserved`.
+    pub fn reserved<'a>(&self, s: &'a str) -> &'a str {
+        self.src(s)
+    }
+
+    /// Returns the parsed string that this token represents.
+    ///
+    /// This returns either a raw byte slice into the source if that's possible
+    /// or an owned representation to handle escaped characters and such.
+    ///
+    /// Should only be used with `TokenKind::String`.
+    pub fn string<'a>(&self, s: &'a str) -> Cow<'a, [u8]> {
+        let mut ch = self.src(s).chars();
+        ch.next().unwrap();
+        Lexer::parse_str(&mut ch, true).unwrap()
+    }
+
+    /// Returns the decomposed float token that this represents.
+    ///
+    /// This will slice up the float token into its component parts and return a
+    /// description of the float token in the source.
+    ///
+    /// Should only be used with `TokenKind::Float`.
+    pub fn float<'a>(&self, s: &'a str, kind: FloatKind) -> Float<'a> {
+        match kind {
+            FloatKind::Inf { negative } => Float::Inf { negative },
+            FloatKind::Nan { negative } => Float::Nan {
+                val: None,
+                negative,
+            },
+            FloatKind::NanVal {
+                negative,
+                has_underscores,
+            } => {
+                let src = self.src(s);
+                let src = if src.starts_with("n") { src } else { &src[1..] };
+                let mut src = src.strip_prefix("nan:0x").unwrap();
+                let owned;
+                if has_underscores {
+                    owned = src.replace("_", "");
+                    src = &owned;
+                }
+                let val = u64::from_str_radix(src, 16).unwrap();
+                Float::Nan {
+                    val: Some(val),
+                    negative,
+                }
+            }
+            FloatKind::Normal {
+                has_underscores,
+                hex,
+            } => {
+                let src = self.src(s);
+                let (integral, decimal, exponent) = match src.find('.') {
+                    Some(i) => {
+                        let integral = &src[..i];
+                        let rest = &src[i + 1..];
+                        let exponent = if hex {
+                            rest.find('p').or_else(|| rest.find('P'))
+                        } else {
+                            rest.find('e').or_else(|| rest.find('E'))
+                        };
+                        match exponent {
+                            Some(i) => (integral, Some(&rest[..i]), Some(&rest[i + 1..])),
+                            None => (integral, Some(rest), None),
+                        }
+                    }
+                    None => {
+                        let exponent = if hex {
+                            src.find('p').or_else(|| src.find('P'))
+                        } else {
+                            src.find('e').or_else(|| src.find('E'))
+                        };
+                        match exponent {
+                            Some(i) => (&src[..i], None, Some(&src[i + 1..])),
+                            None => (src, None, None),
+                        }
+                    }
+                };
+                let mut integral = Cow::Borrowed(integral.strip_prefix('+').unwrap_or(integral));
+                let mut decimal = decimal.and_then(|s| {
+                    if s.is_empty() {
+                        None
+                    } else {
+                        Some(Cow::Borrowed(s))
+                    }
+                });
+                let mut exponent =
+                    exponent.map(|s| Cow::Borrowed(s.strip_prefix('+').unwrap_or(s)));
+                if has_underscores {
+                    *integral.to_mut() = integral.replace("_", "");
+                    if let Some(decimal) = &mut decimal {
+                        *decimal.to_mut() = decimal.replace("_", "");
+                    }
+                    if let Some(exponent) = &mut exponent {
+                        *exponent.to_mut() = exponent.replace("_", "");
+                    }
+                }
+                if hex {
+                    *integral.to_mut() = integral.replace("0x", "");
+                }
+                Float::Val {
+                    hex,
+                    integral,
+                    decimal,
+                    exponent,
+                }
+            }
+        }
+    }
+
+    /// Returns the decomposed integer token that this represents.
+    ///
+    /// This will slice up the integer token into its component parts and
+    /// return a description of the integer token in the source.
+    ///
+    /// Should only be used with `TokenKind::Integer`.
+    pub fn integer<'a>(&self, s: &'a str, kind: IntegerKind) -> Integer<'a> {
+        let src = self.src(s);
+        let val = match kind.sign {
+            Some(SignToken::Plus) => src.strip_prefix('+').unwrap(),
+            Some(SignToken::Minus) => src,
+            None => src,
+        };
+        let mut val = Cow::Borrowed(val);
+        if kind.has_underscores {
+            *val.to_mut() = val.replace("_", "");
+        }
+        if kind.hex {
+            *val.to_mut() = val.replace("0x", "");
+        }
+        Integer {
+            sign: kind.sign,
+            hex: kind.hex,
+            val,
         }
     }
 }
@@ -930,43 +1061,13 @@ impl<'a> Token<'a> {
 impl<'a> Integer<'a> {
     /// Returns the sign token for this integer.
     pub fn sign(&self) -> Option<SignToken> {
-        self.0.sign
+        self.sign
     }
 
-    /// Returns the original source text for this integer.
-    pub fn src(&self) -> &'a str {
-        self.0.src
-    }
-
-    /// Returns the value string that can be parsed for this integer, as well as
-    /// the base that it should be parsed in
+    /// Returns the value string that can be parsed for this integer, as well
+    /// as the base that it should be parsed in
     pub fn val(&self) -> (&str, u32) {
-        (&self.0.val, if self.0.hex { 16 } else { 10 })
-    }
-}
-
-impl<'a> Float<'a> {
-    /// Returns the original source text for this integer.
-    pub fn src(&self) -> &'a str {
-        self.0.src
-    }
-
-    /// Returns a parsed value of this float with all of the components still
-    /// listed as strings.
-    pub fn val(&self) -> &FloatVal<'a> {
-        &self.0.val
-    }
-}
-
-impl<'a> WasmString<'a> {
-    /// Returns the original source text for this string.
-    pub fn src(&self) -> &'a str {
-        self.0.src
-    }
-
-    /// Returns a parsed value, as a list of bytes, for this string.
-    pub fn val(&self) -> &[u8] {
-        &self.0.val
+        (&self.val, if self.hex { 16 } else { 10 })
     }
 }
 
@@ -1049,8 +1150,9 @@ mod tests {
     #[test]
     fn ws_smoke() {
         fn get_whitespace(input: &str) -> &str {
-            match Lexer::new(input).parse().expect("no first token") {
-                Some(Token::Whitespace(s)) => s,
+            let token = get_token(input);
+            match token.kind {
+                TokenKind::Whitespace => token.src(input),
                 other => panic!("unexpected {:?}", other),
             }
         }
@@ -1064,8 +1166,9 @@ mod tests {
     #[test]
     fn line_comment_smoke() {
         fn get_line_comment(input: &str) -> &str {
-            match Lexer::new(input).parse().expect("no first token") {
-                Some(Token::LineComment(s)) => s,
+            let token = get_token(input);
+            match token.kind {
+                TokenKind::LineComment => token.src(input),
                 other => panic!("unexpected {:?}", other),
             }
         }
@@ -1079,8 +1182,9 @@ mod tests {
     #[test]
     fn block_comment_smoke() {
         fn get_block_comment(input: &str) -> &str {
-            match Lexer::new(input).parse().expect("no first token") {
-                Some(Token::BlockComment(s)) => s,
+            let token = get_token(input);
+            match token.kind {
+                TokenKind::BlockComment => token.src(input),
                 other => panic!("unexpected {:?}", other),
             }
         }
@@ -1089,7 +1193,7 @@ mod tests {
         assert_eq!(get_block_comment("(; (;;) ;)"), "(; (;;) ;)");
     }
 
-    fn get_token(input: &str) -> Token<'_> {
+    fn get_token(input: &str) -> Token {
         Lexer::new(input)
             .parse()
             .expect("no first token")
@@ -1098,23 +1202,21 @@ mod tests {
 
     #[test]
     fn lparen() {
-        assert_eq!(get_token("(("), Token::LParen("("));
+        assert_eq!(get_token("((").kind, TokenKind::LParen);
     }
 
     #[test]
     fn rparen() {
-        assert_eq!(get_token(")("), Token::RParen(")"));
+        assert_eq!(get_token(")(").kind, TokenKind::RParen);
     }
 
     #[test]
     fn strings() {
         fn get_string(input: &str) -> Vec<u8> {
-            match get_token(input) {
-                Token::String(s) => {
-                    assert_eq!(input, s.src());
-                    s.val().to_vec()
-                }
-                other => panic!("not string {:?}", other),
+            let token = get_token(input);
+            match token.kind {
+                TokenKind::String => token.string(input).to_vec(),
+                other => panic!("not keyword {:?}", other),
             }
         }
         assert_eq!(&*get_string("\"\""), b"");
@@ -1146,25 +1248,27 @@ mod tests {
     #[test]
     fn id() {
         fn get_id(input: &str) -> &str {
-            match get_token(input) {
-                Token::Id(s) => s,
+            let token = get_token(input);
+            match token.kind {
+                TokenKind::Id => token.id(input),
                 other => panic!("not id {:?}", other),
             }
         }
-        assert_eq!(get_id("$x"), "$x");
-        assert_eq!(get_id("$xyz"), "$xyz");
-        assert_eq!(get_id("$x_z"), "$x_z");
-        assert_eq!(get_id("$0^"), "$0^");
-        assert_eq!(get_id("$0^;;"), "$0^");
-        assert_eq!(get_id("$0^ ;;"), "$0^");
+        assert_eq!(get_id("$x"), "x");
+        assert_eq!(get_id("$xyz"), "xyz");
+        assert_eq!(get_id("$x_z"), "x_z");
+        assert_eq!(get_id("$0^"), "0^");
+        assert_eq!(get_id("$0^;;"), "0^");
+        assert_eq!(get_id("$0^ ;;"), "0^");
     }
 
     #[test]
     fn keyword() {
         fn get_keyword(input: &str) -> &str {
-            match get_token(input) {
-                Token::Keyword(s) => s,
-                other => panic!("not id {:?}", other),
+            let token = get_token(input);
+            match token.kind {
+                TokenKind::Keyword => token.keyword(input),
+                other => panic!("not keyword {:?}", other),
             }
         }
         assert_eq!(get_keyword("x"), "x");
@@ -1177,8 +1281,9 @@ mod tests {
     #[test]
     fn reserved() {
         fn get_reserved(input: &str) -> &str {
-            match get_token(input) {
-                Token::Reserved(s) => s,
+            let token = get_token(input);
+            match token.kind {
+                TokenKind::Reserved => token.reserved(input),
                 other => panic!("not reserved {:?}", other),
             }
         }
@@ -1189,11 +1294,9 @@ mod tests {
     #[test]
     fn integer() {
         fn get_integer(input: &str) -> String {
-            match get_token(input) {
-                Token::Integer(i) => {
-                    assert_eq!(input, i.src());
-                    i.val().0.to_string()
-                }
+            let token = get_token(input);
+            match token.kind {
+                TokenKind::Integer(i) => token.integer(input, i).val.to_string(),
                 other => panic!("not integer {:?}", other),
             }
         }
@@ -1210,57 +1313,55 @@ mod tests {
 
     #[test]
     fn float() {
-        fn get_float(input: &str) -> FloatVal<'_> {
-            match get_token(input) {
-                Token::Float(i) => {
-                    assert_eq!(input, i.src());
-                    i.0.val
-                }
-                other => panic!("not reserved {:?}", other),
+        fn get_float(input: &str) -> Float<'_> {
+            let token = get_token(input);
+            match token.kind {
+                TokenKind::Float(f) => token.float(input, f),
+                other => panic!("not float {:?}", other),
             }
         }
         assert_eq!(
             get_float("nan"),
-            FloatVal::Nan {
+            Float::Nan {
                 val: None,
                 negative: false
             },
         );
         assert_eq!(
             get_float("-nan"),
-            FloatVal::Nan {
+            Float::Nan {
                 val: None,
                 negative: true,
             },
         );
         assert_eq!(
             get_float("+nan"),
-            FloatVal::Nan {
+            Float::Nan {
                 val: None,
                 negative: false,
             },
         );
         assert_eq!(
             get_float("+nan:0x1"),
-            FloatVal::Nan {
+            Float::Nan {
                 val: Some(1),
                 negative: false,
             },
         );
         assert_eq!(
             get_float("nan:0x7f_ffff"),
-            FloatVal::Nan {
+            Float::Nan {
                 val: Some(0x7fffff),
                 negative: false,
             },
         );
-        assert_eq!(get_float("inf"), FloatVal::Inf { negative: false });
-        assert_eq!(get_float("-inf"), FloatVal::Inf { negative: true });
-        assert_eq!(get_float("+inf"), FloatVal::Inf { negative: false });
+        assert_eq!(get_float("inf"), Float::Inf { negative: false });
+        assert_eq!(get_float("-inf"), Float::Inf { negative: true });
+        assert_eq!(get_float("+inf"), Float::Inf { negative: false });
 
         assert_eq!(
             get_float("1.2"),
-            FloatVal::Val {
+            Float::Val {
                 integral: "1".into(),
                 decimal: Some("2".into()),
                 exponent: None,
@@ -1269,7 +1370,7 @@ mod tests {
         );
         assert_eq!(
             get_float("1.2e3"),
-            FloatVal::Val {
+            Float::Val {
                 integral: "1".into(),
                 decimal: Some("2".into()),
                 exponent: Some("3".into()),
@@ -1278,7 +1379,7 @@ mod tests {
         );
         assert_eq!(
             get_float("-1_2.1_1E+0_1"),
-            FloatVal::Val {
+            Float::Val {
                 integral: "-12".into(),
                 decimal: Some("11".into()),
                 exponent: Some("01".into()),
@@ -1287,7 +1388,7 @@ mod tests {
         );
         assert_eq!(
             get_float("+1_2.1_1E-0_1"),
-            FloatVal::Val {
+            Float::Val {
                 integral: "12".into(),
                 decimal: Some("11".into()),
                 exponent: Some("-01".into()),
@@ -1296,7 +1397,7 @@ mod tests {
         );
         assert_eq!(
             get_float("0x1_2.3_4p5_6"),
-            FloatVal::Val {
+            Float::Val {
                 integral: "12".into(),
                 decimal: Some("34".into()),
                 exponent: Some("56".into()),
@@ -1305,7 +1406,7 @@ mod tests {
         );
         assert_eq!(
             get_float("+0x1_2.3_4P-5_6"),
-            FloatVal::Val {
+            Float::Val {
                 integral: "12".into(),
                 decimal: Some("34".into()),
                 exponent: Some("-56".into()),
@@ -1314,7 +1415,7 @@ mod tests {
         );
         assert_eq!(
             get_float("1."),
-            FloatVal::Val {
+            Float::Val {
                 integral: "1".into(),
                 decimal: None,
                 exponent: None,
@@ -1323,7 +1424,7 @@ mod tests {
         );
         assert_eq!(
             get_float("0x1p-24"),
-            FloatVal::Val {
+            Float::Val {
                 integral: "1".into(),
                 decimal: None,
                 exponent: Some("-24".into()),

--- a/crates/wast/src/parser.rs
+++ b/crates/wast/src/parser.rs
@@ -64,9 +64,10 @@
 //! This module is heavily inspired by [`syn`](https://docs.rs/syn) so you can
 //! likely also draw inspiration from the excellent examples in the `syn` crate.
 
-use crate::lexer::{Float, Integer, Lexer, Token};
+use crate::lexer::{Float, Integer, Lexer, Token, TokenKind};
 use crate::token::Span;
 use crate::Error;
+use std::borrow::Cow;
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::fmt;
@@ -303,11 +304,12 @@ pub struct ParseBuffer<'a> {
     // list of tokens from the tokenized source (including whitespace and
     // comments), and the second element is how to skip this token, if it can be
     // skipped.
-    tokens: Box<[(Token<'a>, Cell<NextTokenAt>)]>,
+    tokens: Box<[(Token, Cell<NextTokenAt>)]>,
     input: &'a str,
     cur: Cell<usize>,
     known_annotations: RefCell<HashMap<String, usize>>,
     depth: Cell<usize>,
+    strings: RefCell<Vec<Box<[u8]>>>,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -380,6 +382,7 @@ impl ParseBuffer<'_> {
             depth: Cell::new(0),
             input,
             known_annotations: Default::default(),
+            strings: Default::default(),
         };
         ret.validate_annotations()?;
         Ok(ret)
@@ -393,7 +396,7 @@ impl ParseBuffer<'_> {
     // delimiters. This is required since while parsing we generally skip
     // annotations and there's no real opportunity to return a parse error.
     fn validate_annotations(&self) -> Result<()> {
-        use crate::lexer::Token::*;
+        use crate::lexer::TokenKind::*;
         enum State {
             None,
             LParen,
@@ -401,33 +404,40 @@ impl ParseBuffer<'_> {
         }
         let mut state = State::None;
         for token in self.tokens.iter() {
-            state = match (&token.0, state) {
+            state = match (token.0.kind, state) {
                 // From nothing, a `(` starts the search for an annotation
-                (LParen(_), State::None) => State::LParen,
+                (LParen, State::None) => State::LParen,
                 // ... otherwise in nothing we always preserve that state.
                 (_, State::None) => State::None,
 
-                // If the previous state was an `LParen`, we may have an
-                // annotation if the next keyword is reserved
-                (Reserved(s), State::LParen) if s.starts_with('@') && !s.is_empty() => {
-                    let offset = self.input_pos(s);
-                    State::Annotation {
-                        span: Span { offset },
-                        depth: 1,
-                    }
-                }
                 // ... otherwise anything after an `LParen` kills the lparen
                 // state.
-                (_, State::LParen) => State::None,
+                (kind, State::LParen) => {
+                    // If the previous state was an `LParen`, we may have an
+                    // annotation if the next keyword is reserved
+                    if let Reserved = kind {
+                        let reserved = token.0.reserved(self.input);
+                        if reserved.starts_with('@') && reserved.len() > 1 {
+                            state = State::Annotation {
+                                span: Span {
+                                    offset: token.0.offset,
+                                },
+                                depth: 1,
+                            };
+                            continue;
+                        }
+                    }
+                    State::None
+                }
 
                 // Once we're in an annotation we need to balance parentheses,
                 // so handle the depth changes.
-                (LParen(_), State::Annotation { span, depth }) => State::Annotation {
+                (LParen, State::Annotation { span, depth }) => State::Annotation {
                     span,
                     depth: depth + 1,
                 },
-                (RParen(_), State::Annotation { depth: 1, .. }) => State::None,
-                (RParen(_), State::Annotation { span, depth }) => State::Annotation {
+                (RParen, State::Annotation { depth: 1, .. }) => State::None,
+                (RParen, State::Annotation { span, depth }) => State::Annotation {
                     span,
                     depth: depth - 1,
                 },
@@ -441,8 +451,20 @@ impl ParseBuffer<'_> {
         Ok(())
     }
 
-    fn input_pos(&self, src: &str) -> usize {
-        src.as_ptr() as usize - self.input.as_ptr() as usize
+    /// Stores an owned allocation in this `Parser` to attach the lifetime of
+    /// the vector to `self`.
+    ///
+    /// This will return a reference to `s`, but one that's safely rooted in the
+    /// `Parser`.
+    fn push_str(&self, s: Vec<u8>) -> &[u8] {
+        let s = Box::from(s);
+        let ret = &*s as *const [u8];
+        self.strings.borrow_mut().push(s);
+        // This should be safe in that the address of `ret` isn't changing as
+        // it's on the heap itself. Additionally the lifetime of this return
+        // value is tied to the lifetime of `self` (nothing is deallocated
+        // early), so it should be safe to say the two have the same lifetime.
+        unsafe { &*ret }
     }
 }
 
@@ -458,16 +480,16 @@ impl<'a> Parser<'a> {
     /// and whitespace are not considered for whether this parser is empty.
     pub fn is_empty(self) -> bool {
         match self.cursor().advance_token() {
-            Some(Token::RParen(_)) | None => true,
-            Some(_) => false, // more tokens to parse!
+            Some(token) => matches!(token.kind, TokenKind::RParen),
+            None => true,
         }
     }
 
     pub(crate) fn has_meaningful_tokens(self) -> bool {
         self.buf.tokens[self.cursor().cur..].iter().any(|(t, _)| {
             !matches!(
-                t,
-                Token::Whitespace(_) | Token::LineComment(_) | Token::BlockComment(_)
+                t.kind,
+                TokenKind::Whitespace | TokenKind::LineComment | TokenKind::BlockComment
             )
         })
     }
@@ -953,7 +975,7 @@ impl<'a> Cursor<'a> {
     /// Does not take into account whitespace or comments.
     pub fn cur_span(&self) -> Span {
         let offset = match self.clone().advance_token() {
-            Some(t) => self.parser.buf.input_pos(t.src()),
+            Some(t) => t.offset,
             None => self.parser.buf.input.len(),
         };
         Span { offset }
@@ -965,7 +987,7 @@ impl<'a> Cursor<'a> {
     pub(crate) fn prev_span(&self) -> Option<Span> {
         let (token, _) = self.parser.buf.tokens.get(self.cur.checked_sub(1)?)?;
         Some(Span {
-            offset: self.parser.buf.input_pos(token.src()),
+            offset: token.offset,
         })
     }
 
@@ -983,8 +1005,8 @@ impl<'a> Cursor<'a> {
     /// This function will automatically skip over any comments, whitespace, or
     /// unknown annotations.
     pub fn lparen(mut self) -> Option<Self> {
-        match self.advance_token()? {
-            Token::LParen(_) => Some(self),
+        match self.advance_token()?.kind {
+            TokenKind::LParen => Some(self),
             _ => None,
         }
     }
@@ -997,8 +1019,8 @@ impl<'a> Cursor<'a> {
     /// This function will automatically skip over any comments, whitespace, or
     /// unknown annotations.
     pub fn rparen(mut self) -> Option<Self> {
-        match self.advance_token()? {
-            Token::RParen(_) => Some(self),
+        match self.advance_token()?.kind {
+            TokenKind::RParen => Some(self),
             _ => None,
         }
     }
@@ -1013,8 +1035,9 @@ impl<'a> Cursor<'a> {
     /// This function will automatically skip over any comments, whitespace, or
     /// unknown annotations.
     pub fn id(mut self) -> Option<(&'a str, Self)> {
-        match self.advance_token()? {
-            Token::Id(id) => Some((&id[1..], self)),
+        let token = self.advance_token()?;
+        match token.kind {
+            TokenKind::Id => Some((token.id(self.parser.buf.input), self)),
             _ => None,
         }
     }
@@ -1029,8 +1052,9 @@ impl<'a> Cursor<'a> {
     /// This function will automatically skip over any comments, whitespace, or
     /// unknown annotations.
     pub fn keyword(mut self) -> Option<(&'a str, Self)> {
-        match self.advance_token()? {
-            Token::Keyword(id) => Some((id, self)),
+        let token = self.advance_token()?;
+        match token.kind {
+            TokenKind::Keyword => Some((token.keyword(self.parser.buf.input), self)),
             _ => None,
         }
     }
@@ -1045,8 +1069,9 @@ impl<'a> Cursor<'a> {
     /// This function will automatically skip over any comments, whitespace, or
     /// unknown annotations.
     pub fn reserved(mut self) -> Option<(&'a str, Self)> {
-        match self.advance_token()? {
-            Token::Reserved(id) => Some((id, self)),
+        let token = self.advance_token()?;
+        match token.kind {
+            TokenKind::Reserved => Some((token.reserved(self.parser.buf.input), self)),
             _ => None,
         }
     }
@@ -1060,9 +1085,10 @@ impl<'a> Cursor<'a> {
     ///
     /// This function will automatically skip over any comments, whitespace, or
     /// unknown annotations.
-    pub fn integer(mut self) -> Option<(&'a Integer<'a>, Self)> {
-        match self.advance_token()? {
-            Token::Integer(i) => Some((i, self)),
+    pub fn integer(mut self) -> Option<(Integer<'a>, Self)> {
+        let token = self.advance_token()?;
+        match token.kind {
+            TokenKind::Integer(i) => Some((token.integer(self.parser.buf.input, i), self)),
             _ => None,
         }
     }
@@ -1076,9 +1102,10 @@ impl<'a> Cursor<'a> {
     ///
     /// This function will automatically skip over any comments, whitespace, or
     /// unknown annotations.
-    pub fn float(mut self) -> Option<(&'a Float<'a>, Self)> {
-        match self.advance_token()? {
-            Token::Float(f) => Some((f, self)),
+    pub fn float(mut self) -> Option<(Float<'a>, Self)> {
+        let token = self.advance_token()?;
+        match token.kind {
+            TokenKind::Float(f) => Some((token.float(self.parser.buf.input, f), self)),
             _ => None,
         }
     }
@@ -1093,10 +1120,16 @@ impl<'a> Cursor<'a> {
     /// This function will automatically skip over any comments, whitespace, or
     /// unknown annotations.
     pub fn string(mut self) -> Option<(&'a [u8], Self)> {
-        match self.advance_token()? {
-            Token::String(s) => Some((s.val(), self)),
-            _ => None,
+        let token = self.advance_token()?;
+        match token.kind {
+            TokenKind::String => {}
+            _ => return None,
         }
+        let string = match token.string(self.parser.buf.input) {
+            Cow::Borrowed(s) => s,
+            Cow::Owned(s) => self.parser.buf.push_str(s),
+        };
+        Some((string, self))
     }
 
     /// Attempts to advance this cursor if the current token is a
@@ -1124,8 +1157,8 @@ impl<'a> Cursor<'a> {
         if !token.starts_with('@') || token.len() <= 1 {
             return None;
         }
-        match &self.parser.buf.tokens.get(self.cur.wrapping_sub(1))?.0 {
-            Token::LParen(_) => Some((&token[1..], cursor)),
+        match self.parser.buf.tokens.get(self.cur.wrapping_sub(1))?.0.kind {
+            TokenKind::LParen => Some((&token[1..], cursor)),
             _ => None,
         }
     }
@@ -1137,12 +1170,13 @@ impl<'a> Cursor<'a> {
     /// This function will only skip whitespace, no other tokens.
     pub fn comment(mut self) -> Option<(&'a str, Self)> {
         let comment = loop {
-            match &self.parser.buf.tokens.get(self.cur)?.0 {
-                Token::LineComment(c) | Token::BlockComment(c) => {
+            let token = &self.parser.buf.tokens.get(self.cur)?.0;
+            match token.kind {
+                TokenKind::LineComment | TokenKind::BlockComment => {
                     self.cur += 1;
-                    break c;
+                    break token.src(self.parser.buf.input);
                 }
-                Token::Whitespace(_) => {
+                TokenKind::Whitespace => {
                     self.cur += 1;
                 }
                 _ => return None,
@@ -1151,7 +1185,7 @@ impl<'a> Cursor<'a> {
         Some((comment, self))
     }
 
-    fn advance_token(&mut self) -> Option<&'a Token<'a>> {
+    fn advance_token(&mut self) -> Option<&'a Token> {
         let known_annotations = self.parser.buf.known_annotations.borrow();
         let is_known_annotation = |name: &str| match known_annotations.get(name) {
             Some(0) | None => false,
@@ -1164,8 +1198,8 @@ impl<'a> Cursor<'a> {
             // If we're currently pointing at a token, and it's not the start
             // of an annotation, then we return that token and advance
             // ourselves to just after that token.
-            match token {
-                Token::Whitespace(_) | Token::LineComment(_) | Token::BlockComment(_) => {}
+            match token.kind {
+                TokenKind::Whitespace | TokenKind::LineComment | TokenKind::BlockComment => {}
                 _ => match self.annotation_start() {
                     Some(n) if !is_known_annotation(n) => {}
                     _ => {
@@ -1209,14 +1243,16 @@ impl<'a> Cursor<'a> {
     }
 
     fn annotation_start(&self) -> Option<&'a str> {
-        match self.parser.buf.tokens.get(self.cur).map(|p| &p.0) {
-            Some(Token::LParen(_)) => {}
+        match self.parser.buf.tokens.get(self.cur)?.0.kind {
+            TokenKind::LParen => {}
             _ => return None,
         }
-        let reserved = match self.parser.buf.tokens.get(self.cur + 1).map(|p| &p.0) {
-            Some(Token::Reserved(n)) => n,
+        let reserved = &self.parser.buf.tokens.get(self.cur + 1)?.0;
+        match reserved.kind {
+            TokenKind::Reserved => {}
             _ => return None,
-        };
+        }
+        let reserved = reserved.src(self.parser.buf.input);
         if reserved.starts_with('@') && reserved.len() > 1 {
             Some(&reserved[1..])
         } else {
@@ -1239,9 +1275,9 @@ impl<'a> Cursor<'a> {
             let mut depth = 1;
             self.cur += 1;
             while depth > 0 {
-                match &self.parser.buf.tokens.get(self.cur)?.0 {
-                    Token::LParen(_) => depth += 1,
-                    Token::RParen(_) => depth -= 1,
+                match self.parser.buf.tokens.get(self.cur)?.0.kind {
+                    TokenKind::LParen => depth += 1,
+                    TokenKind::RParen => depth -= 1,
                     _ => {}
                 }
                 self.cur += 1;
@@ -1255,8 +1291,8 @@ impl<'a> Cursor<'a> {
             let (token, _) = self.parser.buf.tokens.get(self.cur)?;
             // and otherwise we skip all comments/whitespace and only
             // get interested once a normal `Token` pops up.
-            match token {
-                Token::Whitespace(_) | Token::LineComment(_) | Token::BlockComment(_) => {
+            match token.kind {
+                TokenKind::Whitespace | TokenKind::LineComment | TokenKind::BlockComment => {
                     self.cur += 1
                 }
                 _ => return Some(self.cur),

--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -444,7 +444,7 @@ fn parse_wit(path: &Path) -> Result<(Resolve, PackageId)> {
 /// This briefly lexes past whitespace and comments as a `*.wat` file to see if
 /// we can find a left-paren. If that fails then it's probably `*.wit` instead.
 fn is_wasm(bytes: &[u8]) -> bool {
-    use wast::lexer::{Lexer, Token};
+    use wast::lexer::{Lexer, TokenKind};
 
     if bytes.starts_with(b"\0asm") {
         return true;
@@ -457,9 +457,11 @@ fn is_wasm(bytes: &[u8]) -> bool {
     let mut lexer = Lexer::new(text);
 
     while let Some(next) = lexer.next() {
-        match next {
-            Ok(Token::Whitespace(_)) | Ok(Token::BlockComment(_)) | Ok(Token::LineComment(_)) => {}
-            Ok(Token::LParen(_)) => return true,
+        match next.map(|t| t.kind) {
+            Ok(TokenKind::Whitespace)
+            | Ok(TokenKind::BlockComment)
+            | Ok(TokenKind::LineComment) => {}
+            Ok(TokenKind::LParen) => return true,
             _ => break,
         }
     }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -231,8 +231,9 @@ impl TestState {
         // which while they don't actually affect the meaning they do "affect"
         // humans reading the output.
         for token in wast::lexer::Lexer::new(&string).allow_confusing_unicode(true) {
-            let ws = match token? {
-                wast::lexer::Token::Whitespace(ws) => ws,
+            let token = token?;
+            let ws = match token.kind {
+                wast::lexer::TokenKind::Whitespace => token.src(&string),
                 _ => continue,
             };
             if ws.starts_with("\n") || ws == " " {


### PR DESCRIPTION
This commit is another improvement towards addressing #1095 where the goal here is to shrink the size of `Token` and reduce the allocated memory that it retains. Currently the entire input string is tokenized and stored as a list of tokens for `Parser` to process. This means that the size of a token has a large affect on the size of this vector for large inputs.

Even before this commit tokens had been slightly optimized for size where some variants were heap-allocated with a `Box`. In profiling with DHAT, however, it appears that a large portion of peak memory was these boxes, namely for integer/float tokens which appear quite a lot in many inputs.

The changes in this commit were to:

* Shrink the size of `Token` to two words. This is done by removing all pointers from `Token` and instead only storing a `TokenKind` which is packed to 32-bits or less. Span information is still stored in a `Token`, however.

* With no more payload tokens which previously had a payload such as integers, strings, and floats are now re-parsed. They're sort of parsed once while lexing, then again when the token is interpreted later on. Some of this is fundamental where the parsing currently happens in a type-specific context but the context isn't known during lexing (e.g. if something is parsed as `u8` then that shouldn't accept `256` as input).

The hypothesis behind this is that tokens are far more often keywords, whitespace, and comments rather than integers, strings, and floats. This means that if these tokens require some extra work then that should hopefully "come out in the wash" after and this representation would otherwise allow for other speedups.

Locally the example in #1095 has a peak memory usage reduced from 5G to 4G from this commit and additionally the parsing time drops from 8.9s to 7.6s.