### PR TITLE
Change how WIT static functions are parsed

### DIFF
--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -192,9 +192,9 @@ impl WitPrinter {
                     self.output.push_str(": ");
                 }
                 FunctionKind::Static(_) => {
-                    self.output.push_str("static ");
                     self.print_name(func.item_name());
                     self.output.push_str(": ");
+                    self.output.push_str("static ");
                 }
                 FunctionKind::Freestanding => unreachable!(),
             }

--- a/crates/wit-component/tests/components/export-resource/component.wit.print
+++ b/crates/wit-component/tests/components/export-resource/component.wit.print
@@ -4,7 +4,7 @@ world root {
   export foo: interface {
     resource a {
       constructor()
-      static other-new: func() -> a
+      other-new: static func() -> a
     }
   }
 }

--- a/crates/wit-component/tests/components/export-resource/module.wit
+++ b/crates/wit-component/tests/components/export-resource/module.wit
@@ -5,7 +5,7 @@ world module {
     resource a {
       constructor()
 
-      static other-new: func() -> a
+      other-new: static func() -> a
     }
   }
 }

--- a/crates/wit-component/tests/components/import-resource-in-interface/component.wit.print
+++ b/crates/wit-component/tests/components/import-resource-in-interface/component.wit.print
@@ -4,7 +4,7 @@ world root {
   import foo: interface {
     resource a {
       constructor()
-      static other-new: func() -> a
+      other-new: static func() -> a
     }
   }
 }

--- a/crates/wit-component/tests/components/import-resource-in-interface/module.wit
+++ b/crates/wit-component/tests/components/import-resource-in-interface/module.wit
@@ -5,7 +5,7 @@ world module {
     resource a {
       constructor()
 
-      static other-new: func() -> a
+      other-new: static func() -> a
     }
   }
 }

--- a/crates/wit-component/tests/components/import-resource-simple/component.wit.print
+++ b/crates/wit-component/tests/components/import-resource-simple/component.wit.print
@@ -3,6 +3,6 @@ package root:component
 world root {
   resource a {
     constructor()
-    static other-new: func() -> a
+    other-new: static func() -> a
   }
 }

--- a/crates/wit-component/tests/components/import-resource-simple/module.wit
+++ b/crates/wit-component/tests/components/import-resource-simple/module.wit
@@ -4,6 +4,6 @@ world module {
   resource a {
     constructor()
 
-    static other-new: func() -> a
+    other-new: static func() -> a
   }
 }

--- a/crates/wit-component/tests/interfaces/resources.wit
+++ b/crates/wit-component/tests/interfaces/resources.wit
@@ -3,7 +3,7 @@ package foo:bar
 interface foo {
   resource bar {
     constructor()
-    static a: func()
+    a: static func()
     b: func()
   }
 
@@ -34,7 +34,7 @@ world some-world {
     resource a {
       constructor()
 
-      static b: func()
+      b: static func()
 
       c: func()
     }
@@ -63,7 +63,7 @@ interface implicit-own-handles2 {
   // same as the above, the `own` argument should have the same type as the
   // return value
   resource c {
-    static a: func(a: own<c>) -> c
+    a: static func(a: own<c>) -> c
   }
 }
 

--- a/crates/wit-component/tests/interfaces/resources.wit.print
+++ b/crates/wit-component/tests/interfaces/resources.wit.print
@@ -3,7 +3,7 @@ package foo:bar
 interface foo {
   resource bar {
     constructor()
-    static a: func()
+    a: static func()
     b: func()
   }
 
@@ -40,7 +40,7 @@ interface implicit-own-handles2 {
   }
 
   resource c {
-    static a: func(a: c) -> c
+    a: static func(a: c) -> c
   }
 }
 
@@ -48,7 +48,7 @@ world some-world {
   import anon: interface {
     resource a {
       constructor()
-      static b: func()
+      b: static func()
       c: func()
     }
   }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource6.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource6.wit.result
@@ -1,4 +1,4 @@
-expected `static`, `constructor` or identifier, found `->`
+expected `constructor` or identifier, found `->`
      --> tests/ui/parse-fail/bad-resource6.wit:5:19
       |
     5 |     constructor() -> u32

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource8.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource8.wit
@@ -3,6 +3,6 @@ package foo:bar
 interface foo {
   resource a {
     a: func()
-    static a: func()
+    a: static func()
   }
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource8.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource8.wit.result
@@ -1,5 +1,5 @@
 duplicate function name `a`
-     --> tests/ui/parse-fail/bad-resource8.wit:6:12
+     --> tests/ui/parse-fail/bad-resource8.wit:6:5
       |
-    6 |     static a: func()
-      |            ^
+    6 |     a: static func()
+      |     ^

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource9.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource9.wit.result
@@ -1,4 +1,4 @@
-expected `static`, `constructor` or identifier, found keyword `interface`
+expected `constructor` or identifier, found keyword `interface`
      --> tests/ui/parse-fail/bad-resource9.wit:5:5
       |
     5 |     interface foo {}

--- a/crates/wit-parser/tests/ui/resources.wit
+++ b/crates/wit-parser/tests/ui/resources.wit
@@ -17,7 +17,7 @@ interface foo {
 
     a: func()
 
-    static b: func()
+    b: static func()
   }
 
   resource e {


### PR DESCRIPTION
This updates the parsing of static functions on resources to match the upstream explainer where `static` comes after the colon rather than before a function's name.