### PR TITLE
Fix exponential behavior elaborating WIT world exports

### DIFF
--- a/crates/wit-parser/src/resolve.rs
+++ b/crates/wit-parser/src/resolve.rs
@@ -1342,6 +1342,11 @@ impl Remap {
                     return false;
                 }
             }
+            // If this is an import and it's already in the `required_imports`
+            // set then we can skip it as we've already visited this interface.
+            if !add_export && required_imports.contains(&id) {
+                return true;
+            }
             let ok = foreach_interface_dep(resolve, id, |dep| {
                 let key = WorldKey::Interface(dep);
                 let add_export = add_export && export_interfaces.contains_key(&dep);

--- a/crates/wit-parser/tests/ui/stress-export-elaborate.wit
+++ b/crates/wit-parser/tests/ui/stress-export-elaborate.wit
@@ -1,0 +1,54 @@
+package foo:bar
+
+interface i1 {
+  type t1 = u32
+  type t2 = u32
+  type t3 = u32
+  type t4 = u32
+  type t5 = u32
+  type t6 = u32
+  type t7 = u32
+  type t8 = u32
+  type t9 = u32
+  type t10 = u32
+}
+
+interface i2 {
+  use i1.{t1, t2, t3, t4, t5, t6, t7, t8, t9, t10}
+}
+
+interface i3 {
+  use i2.{t1, t2, t3, t4, t5, t6, t7, t8, t9, t10}
+}
+
+interface i4 {
+  use i3.{t1, t2, t3, t4, t5, t6, t7, t8, t9, t10}
+}
+
+interface i5 {
+  use i4.{t1, t2, t3, t4, t5, t6, t7, t8, t9, t10}
+}
+
+interface i6 {
+  use i5.{t1, t2, t3, t4, t5, t6, t7, t8, t9, t10}
+}
+
+interface i7 {
+  use i6.{t1, t2, t3, t4, t5, t6, t7, t8, t9, t10}
+}
+
+interface i8 {
+  use i7.{t1, t2, t3, t4, t5, t6, t7, t8, t9, t10}
+}
+
+interface i9 {
+  use i8.{t1, t2, t3, t4, t5, t6, t7, t8, t9, t10}
+}
+
+interface i10 {
+  use i9.{t1, t2, t3, t4, t5, t6, t7, t8, t9, t10}
+}
+
+world foo {
+  export i10
+}


### PR DESCRIPTION
While a short-circuit existed for exports one didn't exist for imports, so this commit adds one. This fixes a fuzz-found timeout on OSS-Fuzz last night.