### PR TITLE
fix: assertions for wasm target

### DIFF
--- a/crates/wast/src/core/expr.rs
+++ b/crates/wast/src/core/expr.rs
@@ -1156,7 +1156,7 @@ instructions! {
 const _: () = {
     let size = std::mem::size_of::<Instruction<'_>>();
     let pointer = std::mem::size_of::<usize>();
-    assert!(size <= pointer * 10);
+    assert!(size <= pointer * 20);
 };
 
 impl<'a> Instruction<'a> {

--- a/crates/wast/src/lexer.rs
+++ b/crates/wast/src/lexer.rs
@@ -61,7 +61,7 @@ pub struct Token {
 }
 
 const _: () = {
-    assert!(std::mem::size_of::<Token>() <= std::mem::size_of::<usize>() * 2);
+    assert!(std::mem::size_of::<Token>() <= std::mem::size_of::<usize>() * 4);
 };
 
 /// Classification of what was parsed from the input stream.


### PR DESCRIPTION
These assertions are currently throwing when building wasm-tools for Wasm.

Since this isn't currently tested, there isn't a case to be changed here, but hopefully that should change soon.