### PR TITLE
Test a wasm target in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,29 @@ jobs:
     - run: cmake -S ${{github.workspace}}/examples -B ${{github.workspace}}/examples/build -DCMAKE_BUILD_TYPE=Release
     - run: cmake --build ${{github.workspace}}/examples/build --config Release
 
+  wasm:
+    name: Test on WebAssembly
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: Install Rust
+      run: rustup update stable --no-self-update && rustup default stable
+    - run: rustup target add wasm32-wasi
+    - run: |
+        tag=v10.0.1
+        curl -LO https://github.com/bytecodealliance/wasmtime/releases/download/${tag}/wasmtime-${tag}-x86_64-linux.tar.xz
+        tar xf wasmtime-${tag}-x86_64-linux.tar.xz
+        echo `pwd`/wasmtime-${tag}-x86_64-linux >> $GITHUB_PATH
+        echo CARGO_TARGET_WASM32_WASI_RUNNER='wasmtime run --dir . --' >> $GITHUB_ENV
+        echo CARGO_BUILD_TARGET='wasm32-wasi' >> $GITHUB_ENV
+    - run: |
+        cargo test --workspace \
+          --exclude fuzz-stats \
+          --exclude wasm-tools-fuzz \
+          --exclude wasm-mutate-stats
+
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,6 @@ wasm-smith = { workspace = true, features = ["_internal_cli"], optional = true }
 
 # Dependencies of `shrink`
 wasm-shrink = { workspace = true, features = ["clap"], optional = true }
-is_executable = { version = "1.0.1", optional = true }
 
 # Dependencies of `mutate`
 wasm-mutate = { workspace = true, features = ["clap"], optional = true }
@@ -116,6 +115,9 @@ wit-smith = { workspace = true, features = ["clap"], optional = true }
 # Dependencies of `addr2line`
 addr2line = { version = "0.20.0", optional = true }
 gimli = { version = "0.27.2", optional = true }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+is_executable = { version = "1.0.1", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/crates/wasm-compose/tests/compositions/component-missing/error.txt
+++ b/crates/wasm-compose/tests/compositions/component-missing/error.txt
@@ -2,4 +2,4 @@ failed to parse component `tests/compositions/component-missing/a.wat`
 
 Caused by:
     0: failed to read from `tests/compositions/component-missing/a.wat`
-    1: No such file or directory (os error 2)
+    1: platform-specific error

--- a/crates/wasm-compose/tests/compositions/component-not-wat/error.txt
+++ b/crates/wasm-compose/tests/compositions/component-not-wat/error.txt
@@ -2,7 +2,7 @@ failed to parse component `tests/compositions/component-not-wat/root.wat`
 
 Caused by:
     expected `(`
-         --> tests/compositions/component-not-wat/root.wat:1:1
-          |
-        1 | not valid
-          | ^
+     --> tests/compositions/component-not-wat/root.wat:1:1
+      |
+    1 | not valid
+      | ^

--- a/crates/wasm-compose/tests/compositions/missing-explicit-dep/error.txt
+++ b/crates/wasm-compose/tests/compositions/missing-explicit-dep/error.txt
@@ -2,4 +2,4 @@ failed to parse component `tests/compositions/missing-explicit-dep/a.wat`
 
 Caused by:
     0: failed to read from `tests/compositions/missing-explicit-dep/a.wat`
-    1: No such file or directory (os error 2)
+    1: platform-specific error

--- a/crates/wasm-compose/tests/compositions/missing-root/error.txt
+++ b/crates/wasm-compose/tests/compositions/missing-root/error.txt
@@ -2,4 +2,4 @@ failed to parse component `tests/compositions/missing-root/root.wat`
 
 Caused by:
     0: failed to read from `tests/compositions/missing-root/root.wat`
-    1: No such file or directory (os error 2)
+    1: platform-specific error

--- a/crates/wasm-mutate/src/mutators.rs
+++ b/crates/wasm-mutate/src/mutators.rs
@@ -136,7 +136,7 @@ impl WasmMutate<'_> {
 
         assert!(can_mutate);
 
-        let attempts = 100;
+        let attempts = 2000;
         let mut last_mutation = None;
 
         for _ in 0..attempts {

--- a/crates/wasm-mutate/src/mutators/peephole.rs
+++ b/crates/wasm-mutate/src/mutators/peephole.rs
@@ -569,6 +569,7 @@ mod tests {
 
     /// Condition to apply the unfold operator
     /// check that the var is a constant
+    #[allow(dead_code)]
     fn is_const(vari: &'static str) -> impl Fn(&mut EG, Id, &Subst) -> bool {
         move |egraph: &mut EG, _, subst| {
             let var = vari.parse();
@@ -608,7 +609,11 @@ mod tests {
         }
     }
 
+    // Random numbers vary by pointer-width presumably due to `usize` at some
+    // point factoring in, and this test is only known to pass within a
+    // reasonable amount of time on 64-bit platforms.
     #[test]
+    #[cfg(target_pointer_width = "64")]
     fn test_peep_unfold2() {
         let rules: &[Rewrite<super::Lang, PeepholeMutationAnalysis>] = &[
             rewrite!("unfold-2";  "?x" => "(i32.unfold ?x)" if is_const("?x") if is_type("?x", PrimitiveTypeInfo::I32)),
@@ -1588,7 +1593,7 @@ mod tests {
         seed: u64,
     ) {
         let mut config = WasmMutate::default();
-        config.fuel(300);
+        config.fuel(10000);
         config.seed(seed);
 
         let mutator = PeepholeMutator::new_with_rules(3, rules.to_vec());

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -26,10 +26,12 @@ wasmparser = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
-libfuzzer-sys = { workspace = true }
 rand = { workspace = true }
 wasmprinter = { path = "../wasmprinter" }
 wat = { path = "../wat" }
+
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
+libfuzzer-sys = { workspace = true }
 
 [features]
 _internal_cli = ["serde", "flagset/serde"]

--- a/crates/wast/src/core/expr.rs
+++ b/crates/wast/src/core/expr.rs
@@ -1155,8 +1155,8 @@ instructions! {
 // ideally it also wouldn't be as large as it is now.
 const _: () = {
     let size = std::mem::size_of::<Instruction<'_>>();
-    let pointer = std::mem::size_of::<usize>();
-    assert!(size <= pointer * 20);
+    let pointer = std::mem::size_of::<u64>();
+    assert!(size <= pointer * 10);
 };
 
 impl<'a> Instruction<'a> {

--- a/crates/wast/src/lexer.rs
+++ b/crates/wast/src/lexer.rs
@@ -61,7 +61,7 @@ pub struct Token {
 }
 
 const _: () = {
-    assert!(std::mem::size_of::<Token>() <= std::mem::size_of::<usize>() * 4);
+    assert!(std::mem::size_of::<Token>() <= std::mem::size_of::<u64>() * 2);
 };
 
 /// Classification of what was parsed from the input stream.

--- a/src/bin/wasm-tools/main.rs
+++ b/src/bin/wasm-tools/main.rs
@@ -7,10 +7,11 @@ use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 macro_rules! subcommands {
     ($(
         $(#[$attr:meta])*
-        ($name:ident, $string:tt)
+        ($name:ident, $string:tt $($cfg:tt)*)
     )*) => {
         $(
             #[cfg(feature = $string)]
+            $($cfg)*
             mod $name;
         )*
 
@@ -20,6 +21,7 @@ macro_rules! subcommands {
         enum WasmTools {
             $(
                 #[cfg(feature = $string)]
+                $($cfg)*
                 $(#[$attr])*
                 $name($name::Opts),
             )*
@@ -30,6 +32,7 @@ macro_rules! subcommands {
                 match self {
                     $(
                         #[cfg(feature = $string)]
+                        $($cfg)*
                         Self::$name(opts) => opts.run(),
                     )*
                 }
@@ -39,6 +42,7 @@ macro_rules! subcommands {
                 match *self {
                     $(
                         #[cfg(feature = $string)]
+                        $($cfg)*
                         Self::$name(ref opts) => opts.general_opts(),
                     )*
                 }
@@ -52,7 +56,10 @@ subcommands! {
     (validate, "validate")
     (print, "print")
     (smith, "smith")
-    (shrink, "shrink")
+    // The shrink subcommand relies on executing new processes to test a
+    // predicate which isn't supported on wasm, so always omit this command on
+    // wasm.
+    (shrink, "shrink" #[cfg(not(target_family = "wasm"))])
     (mutate, "mutate")
     (dump, "dump")
     (objdump, "objdump")

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -34,6 +34,12 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 
 fn main() {
+    // This test suite can't run on wasm since it involves spawning
+    // subprocesses.
+    if cfg!(target_family = "wasm") {
+        return;
+    }
+
     let mut tests = Vec::new();
     find_tests("tests/cli".as_ref(), &mut tests);
     let filter = std::env::args().nth(1);


### PR DESCRIPTION
This PR is intended to help address a "root cause" of https://github.com/bytecodealliance/wasm-tools/pull/1109 where this project is being used in the context of being compiled to wasm itself but we didn't actually test that on CI. This PR addresses the issue by adding a CI target that runs all the tests in CI. Some gotchas here were:

* Any tests that spawns a subprocess can't run in CI
* The `shrink` command is disabled unconditionally in the CLI since it requires spawning a process
* Some `wasm-mutate` tests had limits tweaked since the RNG behavior is different on 32-bit than on 64-bit (presumably because of `usize`)
* Some platform-specific error messags in `wasm-compose` are scrubbed more aggressively.
* Fuzzing-related pieces are all disabled for wasm since libfuzzer doesn't compile for wasm at this time.