### PR TITLE
Don't panic in wasmprinter with non-function types

### DIFF
--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -751,8 +751,7 @@ impl Printer {
                 structural_type: StructuralType::Func(ty),
                 ..
             })) => self.print_func_type(state, ty, names_for).map(Some),
-            Some(Some(_)) => unreachable!("the core type must be a func"),
-            Some(None) | None => Ok(None),
+            Some(Some(_)) | Some(None) | None => Ok(None),
         }
     }
 

--- a/crates/wasmprinter/tests/all.rs
+++ b/crates/wasmprinter/tests/all.rs
@@ -264,3 +264,15 @@ fn offsets_and_lines_smoke_test() {
 
     assert_eq!(actual, expected);
 }
+
+#[test]
+fn no_panic_non_func_type() {
+    let bytes = wat::parse_str(
+        "(module
+            (type (struct))
+            (func (type 0))
+        )",
+    )
+    .unwrap();
+    wasmprinter::print_bytes(&bytes).unwrap();
+}


### PR DESCRIPTION
This fixes an accidental regression from #1059 where an invalid wasm file was causing a panic in wasmprinter, and wasmprinter shouldn't be panicking on invalid wasm files.