### PR TITLE
Fix "duplicate identifier for field" for subtype fields

### DIFF
--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -4,10 +4,7 @@ use once_cell::unsync::Lazy;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
-use wasmparser::{
-    DataKind, ElementKind, HeapType, Parser, Payload, ValType, Validator, VisitOperator,
-    WasmFeatures,
-};
+use wasmparser::{DataKind, ElementKind, Parser, Payload, Validator, VisitOperator, WasmFeatures};
 
 /// A benchmark input.
 pub struct BenchmarkInput {

--- a/crates/wast/src/core/resolve/names.rs
+++ b/crates/wast/src/core/resolve/names.rs
@@ -57,27 +57,6 @@ impl<'a> Resolver<'a> {
             TypeDef::Struct(r#struct) => {
                 for (i, field) in r#struct.fields.iter().enumerate() {
                     if let Some(id) = field.id {
-                        if let Some(parent_type_index) = ty
-                            .parent
-                            .map(|index| self.types.get_index(&index))
-                            .flatten()
-                        {
-                            if let Some(parent_field_ns) = self.fields.get(&parent_type_index) {
-                                let field_idx =
-                                    parent_field_ns.resolve(&mut Index::Id(id), "field")?;
-                                if field_idx != i as u32 {
-                                    return Err(Error::new(
-                                        id.span(),
-                                        format!(
-                                            "field index mismatch for `{}`: expected {}, got {}",
-                                            id.name(),
-                                            field_idx,
-                                            i
-                                        ),
-                                    ));
-                                }
-                            }
-                        }
                         self.fields
                             .entry(type_index)
                             .or_insert(Namespace::default())

--- a/crates/wast/src/core/resolve/names.rs
+++ b/crates/wast/src/core/resolve/names.rs
@@ -615,11 +615,11 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
 
             StructSet(s) | StructGet(s) | StructGetS(s) | StructGetU(s) => {
                 let type_index = self.resolver.resolve(&mut s.r#struct, Ns::Type)?;
-                if let Index::Id(id) = s.r#struct {
+                if let Index::Id(field_id) = s.field {
                     self.resolver
                         .fields
                         .get(&type_index)
-                        .ok_or(Error::new(id.span(), format!("accessing a named field `{}` in a struct without named fields, type index {}", id.name(), type_index)))?
+                        .ok_or(Error::new(field_id.span(), format!("accessing a named field `{}` in a struct without named fields, type index {}", field_id.name(), type_index)))?
                         .resolve(&mut s.field, "field")?;
                 }
             }

--- a/crates/wast/src/core/resolve/names.rs
+++ b/crates/wast/src/core/resolve/names.rs
@@ -636,11 +636,13 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
 
             StructSet(s) | StructGet(s) | StructGetS(s) | StructGetU(s) => {
                 let type_index = self.resolver.resolve(&mut s.r#struct, Ns::Type)?;
-                self.resolver
-                    .fields
-                    .get(&type_index)
-                    .unwrap()
-                    .resolve(&mut s.field, "field")?;
+                if let Index::Id(id) = s.r#struct {
+                    self.resolver
+                        .fields
+                        .get(&type_index)
+                        .ok_or(Error::new(id.span(), format!("accessing a named field `{}` in a struct without named fields, type index {}", id.name(), type_index)))?
+                        .resolve(&mut s.field, "field")?;
+                }
             }
 
             ArrayNewFixed(a) => {

--- a/crates/wast/src/names.rs
+++ b/crates/wast/src/names.rs
@@ -51,13 +51,11 @@ impl<'a> Namespace<'a> {
     }
 
     pub fn register_specific(&mut self, name: Id<'a>, index: u32, desc: &str) -> Result<(), Error> {
-        if let Some(prev) = self.names.insert(name, index) {
-            if prev != index {
-                return Err(Error::new(
-                    name.span(),
-                    format!("duplicate identifier `{}` for {}", name.name(), desc),
-                ));
-            }
+        if let Some(_prev) = self.names.insert(name, index) {
+            return Err(Error::new(
+                name.span(),
+                format!("duplicate identifier `{}` for {}", name.name(), desc),
+            ));
         }
         Ok(())
     }
@@ -72,14 +70,6 @@ impl<'a> Namespace<'a> {
             return Ok(n);
         }
         Err(resolve_error(*id, desc))
-    }
-
-    pub fn get_index(&self, idx: &Index<'a>) -> Option<u32> {
-        let id = match idx {
-            Index::Num(n, _) => return Some(*n),
-            Index::Id(id) => id,
-        };
-        self.names.get(id).copied()
     }
 }
 

--- a/crates/wast/src/names.rs
+++ b/crates/wast/src/names.rs
@@ -51,11 +51,13 @@ impl<'a> Namespace<'a> {
     }
 
     pub fn register_specific(&mut self, name: Id<'a>, index: u32, desc: &str) -> Result<(), Error> {
-        if let Some(_prev) = self.names.insert(name, index) {
-            return Err(Error::new(
-                name.span(),
-                format!("duplicate identifier for {}", desc),
-            ));
+        if let Some(prev) = self.names.insert(name, index) {
+            if prev != index {
+                return Err(Error::new(
+                    name.span(),
+                    format!("duplicate identifier for {}", desc),
+                ));
+            }
         }
         Ok(())
     }
@@ -70,6 +72,14 @@ impl<'a> Namespace<'a> {
             return Ok(n);
         }
         Err(resolve_error(*id, desc))
+    }
+
+    pub fn get_index(&self, idx: &Index<'a>) -> Option<u32> {
+        let id = match idx {
+            Index::Num(n, _) => return Some(*n),
+            Index::Id(id) => id,
+        };
+        self.names.get(id).copied()
     }
 }
 

--- a/crates/wast/src/names.rs
+++ b/crates/wast/src/names.rs
@@ -55,7 +55,7 @@ impl<'a> Namespace<'a> {
             if prev != index {
                 return Err(Error::new(
                     name.span(),
-                    format!("duplicate identifier for {}", desc),
+                    format!("duplicate identifier `{}` for {}", name.name(), desc),
                 ));
             }
         }

--- a/tests/local/gc/gc-subtypes-invalid.wast
+++ b/tests/local/gc/gc-subtypes-invalid.wast
@@ -131,20 +131,6 @@
 )
 (assert_invalid
   (module
-    (type $A (struct (field $vt (mut i32))))
-    (type $C (sub $A (struct (field $tv (mut i32)))))
-  )
-  "unknown field"
-)
-(assert_invalid
-  (module
-    (type $A (struct (field $vt (mut i32))))
-    (type $C (sub $A (struct (field (mut i32)) (field $vt (mut i32)))))
-  )
-  "field index mismatch"
-)
-(assert_invalid
-  (module
     (type (struct (field $vt (mut i32)) (field $vt (mut i64))))
   )
   "duplicate identifier"

--- a/tests/local/gc/gc-subtypes-invalid.wast
+++ b/tests/local/gc/gc-subtypes-invalid.wast
@@ -143,3 +143,9 @@
   )
   "field index mismatch"
 )
+(assert_invalid
+  (module
+    (type (struct (field $vt (mut i32)) (field $vt (mut i64))))
+  )
+  "duplicate identifier"
+)

--- a/tests/local/gc/gc-subtypes-invalid.wast
+++ b/tests/local/gc/gc-subtypes-invalid.wast
@@ -129,3 +129,17 @@
   )
   "type index out of bounds"
 )
+(assert_invalid
+  (module
+    (type $A (struct (field $vt (mut i32))))
+    (type $C (sub $A (struct (field $tv (mut i32)))))
+  )
+  "unknown field"
+)
+(assert_invalid
+  (module
+    (type $A (struct (field $vt (mut i32))))
+    (type $C (sub $A (struct (field (mut i32)) (field $vt (mut i32)))))
+  )
+  "field index mismatch"
+)

--- a/tests/local/gc/gc-subtypes.wat
+++ b/tests/local/gc/gc-subtypes.wat
@@ -97,4 +97,7 @@
   (type $y0 (sub $v0 (array (ref noextern))))
   (type $y01 (sub $u0 (array (ref noextern))))
   (type $z0 (sub $u0 (array nullexternref)))
+
+  (type $A (struct (field $vt (mut i32))))
+  (type $B (sub $A (struct (field $vt (mut i32)))))
 )

--- a/tests/local/gc/gc-subtypes.wat
+++ b/tests/local/gc/gc-subtypes.wat
@@ -100,4 +100,6 @@
 
   (type $A (struct (field $vt (mut i32))))
   (type $B (sub $A (struct (field $vt (mut i32)))))
+  (type (sub $A (struct (field $tv (mut i32))))) ;; same field, different name
+  (type (sub $A (struct (field (mut i32)) (field $vt (mut i64))))) ;; different field, same name
 )

--- a/tests/snapshots/local/gc/gc-subtypes.wat.print
+++ b/tests/snapshots/local/gc/gc-subtypes.wat.print
@@ -70,4 +70,6 @@
   (type $z0 (;68;) (sub $u0 (;64;) (array nullexternref)))
   (type $A (;69;) (struct (field (mut i32))))
   (type $B (;70;) (sub $A (;69;) (struct (field (mut i32)))))
+  (type (;71;) (sub $A (;69;) (struct (field (mut i32)))))
+  (type (;72;) (sub $A (;69;) (struct (field (mut i32)) (field (mut i64)))))
 )

--- a/tests/snapshots/local/gc/gc-subtypes.wat.print
+++ b/tests/snapshots/local/gc/gc-subtypes.wat.print
@@ -68,4 +68,6 @@
   (type $y0 (;66;) (sub $v0 (;65;) (array (ref noextern))))
   (type $y01 (;67;) (sub $u0 (;64;) (array (ref noextern))))
   (type $z0 (;68;) (sub $u0 (;64;) (array nullexternref)))
+  (type $A (;69;) (struct (field (mut i32))))
+  (type $B (;70;) (sub $A (;69;) (struct (field (mut i32)))))
 )


### PR DESCRIPTION
Field namespaces are per struct now. Inherited fields' names must be exactly the same as in the super-type.

Fixes #1092.