### PR TITLE
Bump crate versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-tools"
-version = "1.0.35"
+version = "1.0.36"
 authors = ["The Wasmtime Project Developers"]
 edition.workspace = true
 description = "CLI tools for interoperating with WebAssembly files"
@@ -45,19 +45,19 @@ url = "2.0.0"
 pretty_assertions = "1.3.0"
 semver = "1.0.0"
 
-wasm-encoder = { version = "0.29.0", path = "crates/wasm-encoder" }
-wasm-compose = { version = "0.2.17", path = "crates/wasm-compose" }
-wasm-metadata = { version = "0.8.0", path = "crates/wasm-metadata" }
-wasm-mutate = { version = "0.2.27", path = "crates/wasm-mutate" }
-wasm-shrink = { version = "0.1.28", path = "crates/wasm-shrink" }
-wasm-smith = { version = "0.12.10", path = "crates/wasm-smith" }
-wasmparser = { version = "0.107.0", path = "crates/wasmparser" }
-wasmprinter = { version = "0.2.59", path = "crates/wasmprinter" }
-wast = { version = "60.0.0", path = "crates/wast" }
-wat = { version = "1.0.66", path = "crates/wat" }
-wit-component = { version = "0.11.0", path = "crates/wit-component" }
-wit-parser = { version = "0.8.0", path = "crates/wit-parser" }
-wit-smith = { version = "0.1.5", path = "crates/wit-smith" }
+wasm-encoder = { version = "0.30.0", path = "crates/wasm-encoder" }
+wasm-compose = { version = "0.3.0", path = "crates/wasm-compose" }
+wasm-metadata = { version = "0.9.0", path = "crates/wasm-metadata" }
+wasm-mutate = { version = "0.2.28", path = "crates/wasm-mutate" }
+wasm-shrink = { version = "0.1.29", path = "crates/wasm-shrink" }
+wasm-smith = { version = "0.12.11", path = "crates/wasm-smith" }
+wasmparser = { version = "0.108.0", path = "crates/wasmparser" }
+wasmprinter = { version = "0.2.60", path = "crates/wasmprinter" }
+wast = { version = "61.0.0", path = "crates/wast" }
+wat = { version = "1.0.67", path = "crates/wat" }
+wit-component = { version = "0.12.0", path = "crates/wit-component" }
+wit-parser = { version = "0.9.0", path = "crates/wit-parser" }
+wit-smith = { version = "0.1.6", path = "crates/wit-smith" }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/wasm-compose/Cargo.toml
+++ b/crates/wasm-compose/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-compose"
-version = "0.2.17"
+version = "0.3.0"
 edition.workspace = true
 authors = ["Peter Huene <peter@huene.dev>"]
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasm-encoder/Cargo.toml
+++ b/crates/wasm-encoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-encoder"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasm-metadata/Cargo.toml
+++ b/crates/wasm-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-metadata"
-version = "0.8.0"
+version = "0.9.0"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-metadata"

--- a/crates/wasm-mutate/Cargo.toml
+++ b/crates/wasm-mutate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-mutate"
-version = "0.2.27"
+version = "0.2.28"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-mutate"

--- a/crates/wasm-shrink/Cargo.toml
+++ b/crates/wasm-shrink/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-shrink"
 name = "wasm-shrink"
-version = "0.1.28"
+version = "0.1.29"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "wasm-smith"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-smith"
-version = "0.12.10"
+version = "0.12.11"
 exclude = ["/benches/corpus"]
 
 [[bench]]

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.107.0"
+version = "0.108.0"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser"

--- a/crates/wasmprinter/Cargo.toml
+++ b/crates/wasmprinter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmprinter"
-version = "0.2.59"
+version = "0.2.60"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wast"
-version = "60.0.0"
+version = "61.0.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wat/Cargo.toml
+++ b/crates/wat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wat"
-version = "1.0.66"
+version = "1.0.67"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wit-component/Cargo.toml
+++ b/crates/wit-component/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-component"
 authors = ["Peter Huene <peter@huene.dev>"]
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"

--- a/crates/wit-parser/Cargo.toml
+++ b/crates/wit-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-parser"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.8.0"
+version = "0.9.0"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"

--- a/crates/wit-smith/Cargo.toml
+++ b/crates/wit-smith/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 name = "wit-smith"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-smith"
-version = "0.1.5"
+version = "0.1.6"
 
 [dependencies]
 arbitrary = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
Turns out it's been a little over a month since a release was last made but quite a few changes have happened in the meantime. Primarily motivated by me working on resources in Wasmtime but these are lots of changes which I think would be good to publish nonetheless.

Releases recent changes such as:

* More support for the gc proposal. [#1045](https://github.com/bytecodealliance/wasm-tools/pull/1045) [#1059](https://github.com/bytecodealliance/wasm-tools/pull/1059)
* Support for resources throughout most tooling. [#1053](https://github.com/bytecodealliance/wasm-tools/pull/1053) [#1068](https://github.com/bytecodealliance/wasm-tools/pull/1068) [#1070](https://github.com/bytecodealliance/wasm-tools/pull/1070) [#1082](https://github.com/bytecodealliance/wasm-tools/pull/1082) [#1079](https://github.com/bytecodealliance/wasm-tools/pull/1079) [#1083](https://github.com/bytecodealliance/wasm-tools/pull/1083) [#1084](https://github.com/bytecodealliance/wasm-tools/pull/1084) [#1105](https://github.com/bytecodealliance/wasm-tools/pull/1105) [#1113](https://github.com/bytecodealliance/wasm-tools/pull/1113) [#1116](https://github.com/bytecodealliance/wasm-tools/pull/1116)
* Support for `include` in WIT files. [#1054](https://github.com/bytecodealliance/wasm-tools/pull/1054) [#1085](https://github.com/bytecodealliance/wasm-tools/pull/1085) [#1088](https://github.com/bytecodealliance/wasm-tools/pull/1088)
* WIT worlds may now be rejected if the same interface can be "reached" as both an import and an export simultaneously. [#1081](https://github.com/bytecodealliance/wasm-tools/pull/1081) [#1107](https://github.com/bytecodealliance/wasm-tools/pull/1107)
* Support for registry metadata in `wasm-tools metadata`. [#1060](https://github.com/bytecodealliance/wasm-tools/pull/1060)
* A new subcommand `wasm-tools component targets`. [#1089](https://github.com/bytecodealliance/wasm-tools/pull/1089)
* An `--out-dir` argument is supported on `wasm-tools component wit` to print the entire `Resolve` instead of just one package. [#1108](https://github.com/bytecodealliance/wasm-tools/pull/1108)
* Miscellaneous bug fixes and improvements. [#1061](https://github.com/bytecodealliance/wasm-tools/pull/1061) [#1065](https://github.com/bytecodealliance/wasm-tools/pull/1065) [#1074](https://github.com/bytecodealliance/wasm-tools/pull/1074) [#1073](https://github.com/bytecodealliance/wasm-tools/pull/1073) [#1078](https://github.com/bytecodealliance/wasm-tools/pull/1078) [#1077](https://github.com/bytecodealliance/wasm-tools/pull/1077) [#1072](https://github.com/bytecodealliance/wasm-tools/pull/1072) [#1086](https://github.com/bytecodealliance/wasm-tools/pull/1086) [#1091](https://github.com/bytecodealliance/wasm-tools/pull/1091) [#1094](https://github.com/bytecodealliance/wasm-tools/pull/1094) [#1114](https://github.com/bytecodealliance/wasm-tools/pull/1114) [#1106](https://github.com/bytecodealliance/wasm-tools/pull/1106)