### PR TITLE
Disable wasmtime execution in the `mutate` fuzzer

### DIFF
--- a/fuzz/fuzz_targets/mutate.rs
+++ b/fuzz/fuzz_targets/mutate.rs
@@ -130,6 +130,13 @@ mod eval {
     /// We should get identical results because we told `wasm-mutate` to preserve
     /// semantics.
     pub fn assert_same_evaluation(wasm: &[u8], mutated_wasm: &[u8]) {
+        // FIXME: should re-enable this when the fuzzer works again, needs
+        // someone to invest energy into running this locally for a long time
+        // and then be on the hook for incoming oss-fuzz bugs.
+        if true {
+            return;
+        }
+
         let mut config = wasmtime::Config::default();
         config.cranelift_nan_canonicalization(true);
         config.consume_fuel(true);


### PR DESCRIPTION
This fuzzer has had active bugs on OSS-Fuzz for quite some time but doesn't have the manpower to address them, so it seems that time is likely better spent fuzzing other portions of the code until someone has time to come back around and fix these fuzz bugs.

Four reproduction test cases as of 620b4ab26820b67f93e70022e6cf656c5d7fb108 are: [bugs.tar.gz](https://github.com/bytecodealliance/wasm-tools/files/12014780/bugs.tar.gz)
