### PR TITLE
Update wit-component's `bitflags` dependency

### DIFF
--- a/crates/wit-component/Cargo.toml
+++ b/crates/wit-component/Cargo.toml
@@ -19,7 +19,7 @@ wasm-metadata = { workspace = true }
 wit-parser = { workspace = true }
 anyhow = { workspace = true }
 log = "0.4.17"
-bitflags = "1.3.2"
+bitflags = "2.3.3"
 indexmap = { workspace = true }
 wat = { workspace = true, optional = true }
 

--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -109,6 +109,7 @@ fn to_val_type(ty: &WasmType) -> ValType {
 bitflags::bitflags! {
     /// Options in the `canon lower` or `canon lift` required for a particular
     /// function.
+    #[derive(Copy, Clone, Debug)]
     pub struct RequiredOptions: u8 {
         /// A memory must be specified, typically the "main module"'s memory
         /// export.


### PR DESCRIPTION
Move to the 2.x.x track from the 1.x.x track.