### PR TITLE
Update serde_yaml used by `wasm-compose`

### DIFF
--- a/crates/wasm-compose/Cargo.toml
+++ b/crates/wasm-compose/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = { workspace = true }
 serde = { workspace = true }
 petgraph = "0.6.2"
 log = { workspace = true }
-serde_yaml = "0.8.26"
+serde_yaml = "0.9.22"
 clap = { workspace = true, optional = true }
 smallvec = "1.10.0"
 heck = "0.4.0"


### PR DESCRIPTION
Gets on a new track of releases to let other transitive deps stay up-to-date.