### PR TITLE
fix: add `include` to the world parsing error message

### DIFF
--- a/crates/wit-parser/src/ast.rs
+++ b/crates/wit-parser/src/ast.rs
@@ -246,7 +246,7 @@ impl<'a> WorldItem<'a> {
             Some((_span, Token::Include)) => Include::parse(tokens).map(WorldItem::Include),
             other => Err(err_expected(
                 tokens,
-                "`import`, `export`, `include`, `use`, or type definition",
+                "`import`, `export`, `include`, `use`, `include` or type definition",
                 other,
             )
             .into()),


### PR DESCRIPTION
tiny change - adding the missing `include` to an error message