### PR TITLE
Use `std::io::IsTerminal` instead of `atty`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,6 @@ wit-smith = { version = "0.1.6", path = "crates/wit-smith" }
 [dependencies]
 anyhow = { workspace = true }
 env_logger = { workspace = true }
-atty = "0.2"
 log = { workspace = true }
 clap = { workspace = true }
 tempfile = "3.2.0"

--- a/src/bin/wasm-tools/main.rs
+++ b/src/bin/wasm-tools/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use clap::Parser;
-use std::io::{self, Write};
+use std::io::{self, IsTerminal, Write};
 use std::process::ExitCode;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
@@ -100,7 +100,7 @@ fn main() -> ExitCode {
 }
 
 fn print_error(color: ColorChoice, err: anyhow::Error) -> Result<()> {
-    let color = if color == ColorChoice::Auto && !atty::is(atty::Stream::Stderr) {
+    let color = if color == ColorChoice::Auto && !io::stderr().is_terminal() {
         ColorChoice::Never
     } else {
         color


### PR DESCRIPTION
This is a new feature of Rust 1.71.0 and enables dropping a small dependency in favor of built-in functionality.