### PR TITLE
Remove public deps from `wasm-metadata`'s API

### DIFF
--- a/crates/wasm-encoder/src/component.rs
+++ b/crates/wasm-encoder/src/component.rs
@@ -20,7 +20,7 @@ pub use self::names::*;
 pub use self::start::*;
 pub use self::types::*;
 
-use crate::{CustomSection, Encode, ProducersSection};
+use crate::{CustomSection, Encode, ProducersSection, RawCustomSection};
 
 // Core sorts extended by the component model
 const CORE_TYPE_SORT: u8 = 0x10;
@@ -148,6 +148,12 @@ impl Default for Component {
 }
 
 impl ComponentSection for CustomSection<'_> {
+    fn id(&self) -> u8 {
+        ComponentSectionId::CoreCustom.into()
+    }
+}
+
+impl ComponentSection for RawCustomSection<'_> {
     fn id(&self) -> u8 {
         ComponentSectionId::CoreCustom.into()
     }

--- a/crates/wasm-encoder/src/core/custom.rs
+++ b/crates/wasm-encoder/src/core/custom.rs
@@ -26,6 +26,24 @@ impl Section for CustomSection<'_> {
     }
 }
 
+/// A raw custom section where the bytes specified contain the leb-encoded
+/// length of the custom section, the custom section's name, and the custom
+/// section's data.
+#[derive(Clone, Debug)]
+pub struct RawCustomSection<'a>(pub &'a [u8]);
+
+impl Encode for RawCustomSection<'_> {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        sink.extend(self.0);
+    }
+}
+
+impl Section for RawCustomSection<'_> {
+    fn id(&self) -> u8 {
+        SectionId::Custom.into()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/wit-component/src/builder.rs
+++ b/crates/wit-component/src/builder.rs
@@ -41,7 +41,8 @@ impl ComponentBuilder {
         let mut base = crate::base_producers();
         base.merge(&self.producers);
         // Write producers section as last section:
-        self.component.section(&base.section());
+        self.component
+            .section(&RawCustomSection(&base.raw_custom_section()));
         self.flush();
         self.component.finish()
     }

--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -1277,14 +1277,19 @@ impl<'a> EncodingState<'a> {
         shim.section(&tables);
         shim.section(&exports);
         shim.section(&code);
-        shim.section(&crate::base_producers().section());
+        shim.section(&RawCustomSection(
+            &crate::base_producers().raw_custom_section(),
+        ));
         shim.section(&names);
 
         let mut fixups = Module::default();
         fixups.section(&types);
         fixups.section(&imports_section);
         fixups.section(&elements);
-        fixups.section(&crate::base_producers().section());
+        fixups.section(&RawCustomSection(
+            &crate::base_producers().raw_custom_section(),
+        ));
+
         let mut names = NameSection::new();
         names.module("wit-component:fixups");
         fixups.section(&names);

--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -7,7 +7,7 @@ use std::{
     mem,
     ops::Deref,
 };
-use wasm_encoder::{Encode, EntityType, Instruction};
+use wasm_encoder::{Encode, EntityType, Instruction, RawCustomSection};
 use wasmparser::*;
 
 const PAGE_SIZE: i32 = 64 * 1024;
@@ -392,8 +392,8 @@ impl<'a> Module<'a> {
     }
 
     fn parse_producers_section(&mut self, section: &CustomSectionReader<'a>) -> Result<()> {
-        let section = ProducersSectionReader::new(section.data(), section.data_offset())?;
-        let producers = wasm_metadata::Producers::from_reader(section)?;
+        let producers =
+            wasm_metadata::Producers::from_bytes(section.data(), section.data_offset())?;
         self.producers = Some(producers);
         Ok(())
     }
@@ -963,7 +963,7 @@ impl<'a> Module<'a> {
             });
         }
         if let Some(producers) = &self.producers {
-            ret.section(&producers.section());
+            ret.section(&RawCustomSection(&producers.raw_custom_section()));
         }
 
         Ok(ret.finish())


### PR DESCRIPTION
Currently whenever `wasmparser` or `wasm-encoder` have a major version bump this requires a major revision of `wasm-metadata` to be released due to their appearance in the API of `wasm-metadata`. This in turn forces a major version bump of `wit-component` due to `wit-component`'s usage of `wasm-metadata` in its public API.

The `wasmparser` and `wasm-encoder` crates, however, are relatively "unstable" crates in that the amount of features they support for wasm are shifting quite a lot over time meaning that they have a lot of major version bumps. Coupling this rate of change to `wit-component` which is expected to be embedded in many WIT-related bindings generators I'm predicting won't be the best development story.

To decouple these crates this commit removes the `wasmparser` and `wasm-encoder` types from the API of `wasm-metadata` by making them internal implementation details. After this it's possible to have a major revision of `wasmparser` without updating the major revision of `wasm-metadata` or `wit-component` for example.