### PR TITLE
Move component `value` support behind a feature flag

### DIFF
--- a/crates/wasm-shrink/src/lib.rs
+++ b/crates/wasm-shrink/src/lib.rs
@@ -235,6 +235,7 @@ impl ShrinkRun {
             component_model: false,
             function_references: false,
             gc: false,
+            component_model_values: false,
 
             floats: true,
             memory_control: true,

--- a/crates/wasm-smith/tests/core.rs
+++ b/crates/wasm-smith/tests/core.rs
@@ -309,6 +309,7 @@ fn parser_features_from_config(config: &impl Config) -> WasmFeatures {
         function_references: false,
         memory_control: false,
         gc: false,
+        component_model_values: false,
     }
 }
 

--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -254,6 +254,7 @@ fn define_benchmarks(c: &mut Criterion) {
             function_references: true,
             memory_control: true,
             gc: true,
+            component_model_values: true,
         })
     }
 

--- a/fuzz/fuzz_targets/validate.rs
+++ b/fuzz/fuzz_targets/validate.rs
@@ -39,6 +39,7 @@ fuzz_target!(|data: &[u8]| {
         memory_control: (byte3 & 0b0000_0001) != 0,
         function_references: (byte3 & 0b0000_0010) != 0,
         gc: (byte3 & 0b0000_0100) != 0,
+        component_model_values: (byte3 & 0b0000_1000) != 0,
     });
     let use_maybe_invalid = byte3 & 0b0000_1000 != 0;
 

--- a/src/bin/wasm-tools/validate.rs
+++ b/src/bin/wasm-tools/validate.rs
@@ -106,6 +106,7 @@ fn parse_features(arg: &str) -> Result<WasmFeatures> {
         ("multi-value", |f| &mut f.multi_value),
         ("tail-call", |f| &mut f.tail_call),
         ("component-model", |f| &mut f.component_model),
+        ("component-model-values", |f| &mut f.component_model_values),
         ("multi-memory", |f| &mut f.multi_memory),
         ("exception-handling", |f| &mut f.exceptions),
         ("memory64", |f| &mut f.memory64),

--- a/tests/local/missing-features/component-model/value-not-enabled.wast
+++ b/tests/local/missing-features/component-model/value-not-enabled.wast
@@ -1,0 +1,41 @@
+(assert_invalid
+  (component
+    (import "f" (func $f))
+    (start $f)
+  )
+  "support for component model `value`s is not enabled")
+
+(assert_invalid
+  (component
+    (import "f" (value string))
+  )
+  "support for component model `value`s is not enabled")
+
+(assert_invalid
+  (component
+    (export "f" (value 0))
+  )
+  "support for component model `value`s is not enabled")
+
+(assert_invalid
+  (component
+    (alias export 0 "f" (value))
+  )
+  "support for component model `value`s is not enabled")
+(assert_invalid
+  (component
+    (import "f1" (func))
+    (export "f" (func 0) (value string))
+  )
+  "support for component model `value`s is not enabled")
+(assert_invalid
+  (component
+    (component)
+    (instance (instantiate 0 (with "" (value 0))))
+  )
+  "support for component model `value`s is not enabled")
+(assert_invalid
+  (component
+    (instance (export "i" (value 0)))
+  )
+  "support for component model `value`s is not enabled")

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -554,6 +554,7 @@ impl TestState {
             function_references: true,
             memory_control: true,
             gc: true,
+            component_model_values: true,
         };
         for part in test.iter().filter_map(|t| t.to_str()) {
             match part {
@@ -569,6 +570,7 @@ impl TestState {
                     features.bulk_memory = false;
                     features.function_references = false;
                     features.gc = false;
+                    features.component_model_values = false;
                 }
                 "floats-disabled.wast" => features.floats = false,
                 "threads" => {


### PR DESCRIPTION
Support for the `value` type in the component model is somewhat best-effort right now in implementations like Wasmtime's. Additionally there's open questions in the upstream specification about what to do with `value`, especially around `post-return` and ABI details. For now this adds a separate feature gate for the `value` type to have first-class errors about its usage in the binary encoding rather than possible panics in Wasmtime, for example.