### PR TITLE
Fix the `Parser::parse` example to work with nested components

### DIFF
--- a/crates/wasmparser/src/lib.rs
+++ b/crates/wasmparser/src/lib.rs
@@ -22,6 +22,9 @@
 //! If you need random access to the entire WebAssembly data-structure,
 //! this is not the right library for you. You could however, build such
 //! a data-structure using this library.
+//!
+//! To get started, create a [`Parser`] using [`Parser::new`] and then follow
+//! the examples documented for [`Parser::parse`] or [`Parser::parse_all`].
 
 #![deny(missing_docs)]
 


### PR DESCRIPTION
Fix the `Parser::parse` example to properly push and pop parsers for parsing nested components and modules.

While here, also add an example for `Parser::parse_all`, and a top-level wasmparser comment pointing at `Parser::parse` and `Parser::parse_all` as the place to get started with the library.