### PR TITLE
Convert more things to links in the rustdoc documentation.

### DIFF
--- a/crates/wasm-metadata/src/lib.rs
+++ b/crates/wasm-metadata/src/lib.rs
@@ -14,7 +14,7 @@ use wasmparser::{
 
 /// A representation of a WebAssembly producers section.
 ///
-/// Spec: https://github.com/WebAssembly/tool-conventions/blob/main/ProducersSection.md
+/// Spec: <https://github.com/WebAssembly/tool-conventions/blob/main/ProducersSection.md>
 #[derive(Debug, Serialize)]
 pub struct Producers(
     #[serde(serialize_with = "indexmap::map::serde_seq::serialize")]
@@ -775,13 +775,13 @@ pub struct RegistryMetadata {
     description: Option<String>,
 
     /// SPDX License Expression
-    /// https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/
-    /// SPDX License List: https://spdx.org/licenses/
+    /// <https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/>
+    /// SPDX License List: <https://spdx.org/licenses/>
     #[serde(skip_serializing_if = "Option::is_none")]
     license: Option<String>,
 
     /// A list of custom licenses that should be referenced to from the license expression.
-    /// https://spdx.github.io/spdx-spec/v2.3/other-licensing-information-detected/
+    /// <https://spdx.github.io/spdx-spec/v2.3/other-licensing-information-detected/>
     #[serde(skip_serializing_if = "Option::is_none")]
     custom_licenses: Option<Vec<CustomLicense>>,
 
@@ -1054,22 +1054,22 @@ impl Display for LinkType {
 pub struct CustomLicense {
     /// License Identifier
     /// Provides a locally unique identifier to refer to licenses that are not found on the SPDX License List.
-    /// https://spdx.github.io/spdx-spec/v2.3/other-licensing-information-detected/#101-license-identifier-field
+    /// <https://spdx.github.io/spdx-spec/v2.3/other-licensing-information-detected/#101-license-identifier-field>
     pub id: String,
 
     /// License Name
     /// Provide a common name of the license that is not on the SPDX list.
-    /// https://spdx.github.io/spdx-spec/v2.3/other-licensing-information-detected/#103-license-name-field
+    /// <https://spdx.github.io/spdx-spec/v2.3/other-licensing-information-detected/#103-license-name-field>
     pub name: String,
 
     /// Extracted Text
     /// Provides a copy of the actual text of the license reference extracted from the package or file that is associated with the License Identifier to aid in future analysis.
-    /// https://spdx.github.io/spdx-spec/v2.3/other-licensing-information-detected/#102-extracted-text-field
+    /// <https://spdx.github.io/spdx-spec/v2.3/other-licensing-information-detected/#102-extracted-text-field>
     pub text: String,
 
     /// License Cross Reference
     /// Provides a pointer to the official source of a license that is not included in the SPDX License List, that is referenced by the License Identifier.
-    /// https://spdx.github.io/spdx-spec/v2.3/other-licensing-information-detected/#104-license-cross-reference-field
+    /// <https://spdx.github.io/spdx-spec/v2.3/other-licensing-information-detected/#104-license-cross-reference-field>
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reference: Option<String>,
 }

--- a/crates/wasm-mutate/src/mutators.rs
+++ b/crates/wasm-mutate/src/mutators.rs
@@ -12,13 +12,15 @@
 //! specifycally at the code section level of the binary. The code motion mutator
 //! parses the code and provides an AST which is transformed in a semantically
 //! equivalent way. We provide two concrete implementations using this type of
-//! mutator: [LoopUnrollMutator][codemotion::mutators::loop_unrolling::LoopUnrollMutator] and [IfComplementMutator][codemotion::mutators::if_complement::IfComplementMutator].
+//! mutator: [`LoopUnrollMutator`] and [`IfComplementMutator`].
 //!
 //! The last group of mutators are the [**peephole
 //! mutators**][super::PeepholeMutator]. When it comes to the input Wasm binary code section, it
 //! iterates through the defined functions, and then each instruction of the
 //! functions is processed in order to construct an equivalent piece of code.
 //!
+//! [`LoopUnrollMutator`]: crate::mutators::codemotion::loop_unrolling::LoopUnrollMutator
+//! [`IfComplementMutator`]: crate::mutators::codemotion::if_complement::IfComplementMutator
 
 pub mod add_function;
 pub mod add_type;

--- a/crates/wast/src/lexer.rs
+++ b/crates/wast/src/lexer.rs
@@ -529,7 +529,7 @@ impl<'a> Lexer<'a> {
     /// to figure out which kind of token it is `depending on `ReservedKind`.
     ///
     /// For more information on this method see the clarification at
-    /// https://github.com/WebAssembly/spec/pull/1499 but the general gist is
+    /// <https://github.com/WebAssembly/spec/pull/1499> but the general gist is
     /// that this is parsing the grammar:
     ///
     /// ```text
@@ -923,14 +923,14 @@ impl Token {
 
     /// Returns the keyword this token represents.
     ///
-    /// Should only be used with `TokenKind::Keyword`.
+    /// Should only be used with [`TokenKind::Keyword`].
     pub fn keyword<'a>(&self, s: &'a str) -> &'a str {
         self.src(s)
     }
 
     /// Returns the reserved string this token represents.
     ///
-    /// Should only be used with `TokenKind::Reserved`.
+    /// Should only be used with [`TokenKind::Reserved`].
     pub fn reserved<'a>(&self, s: &'a str) -> &'a str {
         self.src(s)
     }
@@ -940,7 +940,7 @@ impl Token {
     /// This returns either a raw byte slice into the source if that's possible
     /// or an owned representation to handle escaped characters and such.
     ///
-    /// Should only be used with `TokenKind::String`.
+    /// Should only be used with [`TokenKind::String`].
     pub fn string<'a>(&self, s: &'a str) -> Cow<'a, [u8]> {
         let mut ch = self.src(s).chars();
         ch.next().unwrap();
@@ -952,7 +952,7 @@ impl Token {
     /// This will slice up the float token into its component parts and return a
     /// description of the float token in the source.
     ///
-    /// Should only be used with `TokenKind::Float`.
+    /// Should only be used with [`TokenKind::Float`].
     pub fn float<'a>(&self, s: &'a str, kind: FloatKind) -> Float<'a> {
         match kind {
             FloatKind::Inf { negative } => Float::Inf { negative },
@@ -1043,7 +1043,7 @@ impl Token {
     /// This will slice up the integer token into its component parts and
     /// return a description of the integer token in the source.
     ///
-    /// Should only be used with `TokenKind::Integer`.
+    /// Should only be used with [`TokenKind::Integer`].
     pub fn integer<'a>(&self, s: &'a str, kind: IntegerKind) -> Integer<'a> {
         let src = self.src(s);
         let val = match kind.sign {


### PR DESCRIPTION
Enclose URLs in `<`/`>` and some code identifiers in `[`/`]` so that they're clickable in the generated documentation.