### PR TITLE
Say "component name section" instead of "component section" in `dump`

### DIFF
--- a/src/bin/wasm-tools/dump.rs
+++ b/src/bin/wasm-tools/dump.rs
@@ -476,7 +476,7 @@ impl<'a> Dump<'a> {
     }
 
     fn print_name_map(&mut self, thing: &str, n: NameMap<'_>) -> Result<()> {
-        self.section(n, thing, |me, end, naming| {
+        self.section(n, &format!("{thing} name"), |me, end, naming| {
             write!(me.state, "{:?}", naming)?;
             me.print(end)
         })

--- a/tests/cli/dump-invalid-name-section.wat.stdout
+++ b/tests/cli/dump-invalid-name-section.wat.stdout
@@ -5,9 +5,9 @@
       | 65         
   0xf | 02 07       | local section
  0x11 | 06          | 6 count
- 0x12 | 22          | function 34 local section
+ 0x12 | 22          | function 34 local name section
  0x13 | 00          | 0 count
- 0x14 | 00          | function 0 local section
+ 0x14 | 00          | function 0 local name section
  0x15 | 00          | 0 count
  0x16 | 00 40       | ???
  0x18 |-------------| ... failed to decode 2 more bytes: unexpected end-of-file (at offset 0x18)

--- a/tests/cli/dump-invalid-name-section2.wat.stdout
+++ b/tests/cli/dump-invalid-name-section2.wat.stdout
@@ -5,10 +5,10 @@
       | 65         
   0xf | 02 07       | local section
  0x11 | 06          | 6 count
- 0x12 | 22          | function 34 local section
+ 0x12 | 22          | function 34 local name section
  0x13 | 00          | 0 count
- 0x14 | 00          | function 0 local section
+ 0x14 | 00          | function 0 local name section
  0x15 | 00          | 0 count
- 0x16 | 00          | function 0 local section
+ 0x16 | 00          | function 0 local name section
  0x17 | 00          | 0 count
  0x18 |-------------| ... failed to decode 2 more bytes: unexpected end-of-file (at offset 0x18)

--- a/tests/cli/dump/alias.wat.stdout
+++ b/tests/cli/dump/alias.wat.stdout
@@ -63,12 +63,12 @@
       | 70 6f 6e 65
       | 6e 74 2d 6e
       | 61 6d 65   
- 0xa2 | 01 06 00 11 | core module section
+ 0xa2 | 01 06 00 11 | core module name section
  0xa6 | 01          | 1 count
  0xa7 | 00 01 6d    | Naming { index: 0, name: "m" }
- 0xaa | 01 06 00 12 | core instance section
+ 0xaa | 01 06 00 12 | core instance name section
  0xae | 01          | 1 count
  0xaf | 00 01 6d    | Naming { index: 0, name: "m" }
- 0xb2 | 01 05 05    | instance section
+ 0xb2 | 01 05 05    | instance name section
  0xb5 | 01          | 1 count
  0xb6 | 00 01 69    | Naming { index: 0, name: "i" }

--- a/tests/cli/dump/alias2.wat.stdout
+++ b/tests/cli/dump/alias2.wat.stdout
@@ -95,7 +95,7 @@
          | 61 6d 65   
     0xff | 00 03       | component name
    0x101 | 02 63 32    | "c2"
-   0x104 | 01 05 03    | type section
+   0x104 | 01 05 03    | type name section
    0x107 | 01          | 1 count
    0x108 | 00 01 74    | Naming { index: 0, name: "t" }
  0x10b | 06 1b       | component alias section
@@ -207,41 +207,41 @@
        | 70 6f 6e 65
        | 6e 74 2d 6e
        | 61 6d 65   
- 0x222 | 01 06 00 00 | core func section
+ 0x222 | 01 06 00 00 | core func name section
  0x226 | 01          | 1 count
  0x227 | 00 01 66    | Naming { index: 0, name: "f" }
- 0x22a | 01 06 00 01 | core table section
+ 0x22a | 01 06 00 01 | core table name section
  0x22e | 01          | 1 count
  0x22f | 00 01 74    | Naming { index: 0, name: "t" }
- 0x232 | 01 06 00 02 | core memory section
+ 0x232 | 01 06 00 02 | core memory name section
  0x236 | 01          | 1 count
  0x237 | 00 01 6d    | Naming { index: 0, name: "m" }
- 0x23a | 01 06 00 03 | core global section
+ 0x23a | 01 06 00 03 | core global name section
  0x23e | 01          | 1 count
  0x23f | 00 01 67    | Naming { index: 0, name: "g" }
- 0x242 | 01 0e 00 11 | core module section
+ 0x242 | 01 0e 00 11 | core module name section
  0x246 | 03          | 3 count
  0x247 | 01 01 6d    | Naming { index: 1, name: "m" }
  0x24a | 02 02 6d 31 | Naming { index: 2, name: "m1" }
  0x24e | 03 02 6d 32 | Naming { index: 3, name: "m2" }
- 0x252 | 01 06 00 12 | core instance section
+ 0x252 | 01 06 00 12 | core instance name section
  0x256 | 01          | 1 count
  0x257 | 00 01 69    | Naming { index: 0, name: "i" }
- 0x25a | 01 05 01    | func section
+ 0x25a | 01 05 01    | func name section
  0x25d | 01          | 1 count
  0x25e | 01 01 66    | Naming { index: 1, name: "f" }
- 0x261 | 01 05 02    | value section
+ 0x261 | 01 05 02    | value name section
  0x264 | 01          | 1 count
  0x265 | 01 01 76    | Naming { index: 1, name: "v" }
- 0x268 | 01 05 03    | type section
+ 0x268 | 01 05 03    | type name section
  0x26b | 01          | 1 count
  0x26c | 00 01 74    | Naming { index: 0, name: "t" }
- 0x26f | 01 0d 04    | component section
+ 0x26f | 01 0d 04    | component name section
  0x272 | 03          | 3 count
  0x273 | 00 01 63    | Naming { index: 0, name: "c" }
  0x276 | 02 02 63 32 | Naming { index: 2, name: "c2" }
  0x27a | 03 02 63 33 | Naming { index: 3, name: "c3" }
- 0x27e | 01 09 05    | instance section
+ 0x27e | 01 09 05    | instance name section
  0x281 | 02          | 2 count
  0x282 | 00 01 69    | Naming { index: 0, name: "i" }
  0x285 | 03 02 69 32 | Naming { index: 3, name: "i2" }

--- a/tests/cli/dump/blockty.wat.stdout
+++ b/tests/cli/dump/blockty.wat.stdout
@@ -37,7 +37,7 @@
  0x43 | 00 12       | custom section
  0x45 | 04 6e 61 6d | name: "name"
       | 65         
- 0x4a | 04 0b       | type section
+ 0x4a | 04 0b       | type name section
  0x4c | 02          | 2 count
  0x4d | 00 05 65 6d | Naming { index: 0, name: "empty" }
       | 70 74 79   

--- a/tests/cli/dump/bundled.wat.stdout
+++ b/tests/cli/dump/bundled.wat.stdout
@@ -91,7 +91,7 @@
     0xdb | 00 06       | module name
     0xdd | 05 43 48 49 | "CHILD"
          | 4c 44      
-    0xe3 | 01 12       | function section
+    0xe3 | 01 12       | function name section
     0xe5 | 02          | 2 count
     0xe6 | 00 09 77 61 | Naming { index: 0, name: "wasi-file" }
          | 73 69 2d 66
@@ -197,13 +197,13 @@
        | 70 6f 6e 65
        | 6e 74 2d 6e
        | 61 6d 65   
- 0x1fd | 01 13 00 00 | core func section
+ 0x1fd | 01 13 00 00 | core func name section
  0x201 | 01          | 1 count
  0x202 | 01 0e 72 65 | Naming { index: 1, name: "real-wasi-read" }
        | 61 6c 2d 77
        | 61 73 69 2d
        | 72 65 61 64
- 0x212 | 01 1c 00 11 | core module section
+ 0x212 | 01 1c 00 11 | core module name section
  0x216 | 03          | 3 count
  0x217 | 00 04 6c 69 | Naming { index: 0, name: "libc" }
        | 62 63      
@@ -212,7 +212,7 @@
  0x224 | 02 0a 56 49 | Naming { index: 2, name: "VIRTUALIZE" }
        | 52 54 55 41
        | 4c 49 5a 45
- 0x230 | 01 1b 00 12 | core instance section
+ 0x230 | 01 1b 00 12 | core instance name section
  0x234 | 03          | 3 count
  0x235 | 00 04 6c 69 | Naming { index: 0, name: "libc" }
        | 62 63      
@@ -221,12 +221,12 @@
        | 61 73 69   
  0x246 | 03 05 63 68 | Naming { index: 3, name: "child" }
        | 69 6c 64   
- 0x24d | 01 0c 03    | type section
+ 0x24d | 01 0c 03    | type name section
  0x250 | 01          | 1 count
  0x251 | 00 08 57 61 | Naming { index: 0, name: "WasiFile" }
        | 73 69 46 69
        | 6c 65      
- 0x25b | 01 0d 05    | instance section
+ 0x25b | 01 0d 05    | instance name section
  0x25e | 01          | 1 count
  0x25f | 00 09 72 65 | Naming { index: 0, name: "real-wasi" }
        | 61 6c 2d 77

--- a/tests/cli/dump/component-expand-bundle.wat.stdout
+++ b/tests/cli/dump/component-expand-bundle.wat.stdout
@@ -56,13 +56,13 @@
       | 70 6f 6e 65
       | 6e 74 2d 6e
       | 61 6d 65   
- 0x85 | 01 06 00 00 | core func section
+ 0x85 | 01 06 00 00 | core func name section
  0x89 | 01          | 1 count
  0x8a | 00 01 66    | Naming { index: 0, name: "f" }
- 0x8d | 01 0a 00 11 | core module section
+ 0x8d | 01 0a 00 11 | core module name section
  0x91 | 02          | 2 count
  0x92 | 00 01 6d    | Naming { index: 0, name: "m" }
  0x95 | 01 02 6d 32 | Naming { index: 1, name: "m2" }
- 0x99 | 01 06 00 12 | core instance section
+ 0x99 | 01 06 00 12 | core instance name section
  0x9d | 01          | 1 count
  0x9e | 00 01 4d    | Naming { index: 0, name: "M" }

--- a/tests/cli/dump/component-expand-bundle2.wat.stdout
+++ b/tests/cli/dump/component-expand-bundle2.wat.stdout
@@ -54,13 +54,13 @@
       | 70 6f 6e 65
       | 6e 74 2d 6e
       | 61 6d 65   
- 0xa4 | 01 06 00 11 | core module section
+ 0xa4 | 01 06 00 11 | core module name section
  0xa8 | 01          | 1 count
  0xa9 | 00 01 6d    | Naming { index: 0, name: "m" }
- 0xac | 01 09 04    | component section
+ 0xac | 01 09 04    | component name section
  0xaf | 02          | 2 count
  0xb0 | 00 01 63    | Naming { index: 0, name: "c" }
  0xb3 | 01 02 63 32 | Naming { index: 1, name: "c2" }
- 0xb7 | 01 05 05    | instance section
+ 0xb7 | 01 05 05    | instance name section
  0xba | 01          | 1 count
  0xbb | 00 01 43    | Naming { index: 0, name: "C" }

--- a/tests/cli/dump/component-instance-type.wat.stdout
+++ b/tests/cli/dump/component-instance-type.wat.stdout
@@ -17,7 +17,7 @@
       | 70 6f 6e 65
       | 6e 74 2d 6e
       | 61 6d 65   
- 0x43 | 01 09 03    | type section
+ 0x43 | 01 09 03    | type name section
  0x46 | 01          | 1 count
  0x47 | 00 05 6f 75 | Naming { index: 0, name: "outer" }
       | 74 65 72   

--- a/tests/cli/dump/component-linking.wat.stdout
+++ b/tests/cli/dump/component-linking.wat.stdout
@@ -83,9 +83,9 @@
       | 70 6f 6e 65
       | 6e 74 2d 6e
       | 61 6d 65   
- 0xe6 | 01 05 04    | component section
+ 0xe6 | 01 05 04    | component name section
  0xe9 | 01          | 1 count
  0xea | 00 01 63    | Naming { index: 0, name: "c" }
- 0xed | 01 05 05    | instance section
+ 0xed | 01 05 05    | instance name section
  0xf0 | 01          | 1 count
  0xf1 | 00 01 69    | Naming { index: 0, name: "i" }

--- a/tests/cli/dump/component-outer-alias.wat.stdout
+++ b/tests/cli/dump/component-outer-alias.wat.stdout
@@ -20,7 +20,7 @@
         | 70 6f 6e 65
         | 6e 74 2d 6e
         | 61 6d 65   
-   0x41 | 01 05 03    | type section
+   0x41 | 01 05 03    | type name section
    0x44 | 01          | 1 count
    0x45 | 00 01 74    | Naming { index: 0, name: "t" }
  0x48 | 04 32       | [component 1] inline size
@@ -38,7 +38,7 @@
         | 70 6f 6e 65
         | 6e 74 2d 6e
         | 61 6d 65   
-   0x75 | 01 05 03    | type section
+   0x75 | 01 05 03    | type name section
    0x78 | 01          | 1 count
    0x79 | 00 01 74    | Naming { index: 0, name: "t" }
  0x7c | 07 02       | component type section
@@ -59,7 +59,7 @@
         | 70 6f 6e 65
         | 6e 74 2d 6e
         | 61 6d 65   
-   0xad | 01 06 03    | type section
+   0xad | 01 06 03    | type name section
    0xb0 | 01          | 1 count
    0xb1 | 00 02 74 32 | Naming { index: 0, name: "t2" }
  0xb5 | 00 1a       | custom section
@@ -67,7 +67,7 @@
       | 70 6f 6e 65
       | 6e 74 2d 6e
       | 61 6d 65   
- 0xc6 | 01 09 03    | type section
+ 0xc6 | 01 09 03    | type name section
  0xc9 | 02          | 2 count
  0xca | 00 01 74    | Naming { index: 0, name: "t" }
  0xcd | 02 02 74 32 | Naming { index: 2, name: "t2" }

--- a/tests/cli/dump/import-modules.wat.stdout
+++ b/tests/cli/dump/import-modules.wat.stdout
@@ -42,11 +42,11 @@
       | 70 6f 6e 65
       | 6e 74 2d 6e
       | 61 6d 65   
- 0x6b | 01 0b 00 11 | core module section
+ 0x6b | 01 0b 00 11 | core module name section
  0x6f | 02          | 2 count
  0x70 | 00 02 6d 31 | Naming { index: 0, name: "m1" }
  0x74 | 01 02 6d 32 | Naming { index: 1, name: "m2" }
- 0x78 | 01 0b 00 12 | core instance section
+ 0x78 | 01 0b 00 12 | core instance name section
  0x7c | 02          | 2 count
  0x7d | 00 02 69 31 | Naming { index: 0, name: "i1" }
  0x81 | 01 02 69 32 | Naming { index: 1, name: "i2" }

--- a/tests/cli/dump/instance-expand.wat.stdout
+++ b/tests/cli/dump/instance-expand.wat.stdout
@@ -14,6 +14,6 @@
       | 70 6f 6e 65
       | 6e 74 2d 6e
       | 61 6d 65   
- 0x30 | 01 05 03    | type section
+ 0x30 | 01 05 03    | type name section
  0x33 | 01          | 1 count
  0x34 | 00 01 69    | Naming { index: 0, name: "i" }

--- a/tests/cli/dump/instance-type2.wat.stdout
+++ b/tests/cli/dump/instance-type2.wat.stdout
@@ -14,6 +14,6 @@
       | 70 6f 6e 65
       | 6e 74 2d 6e
       | 61 6d 65   
- 0x33 | 01 05 03    | type section
+ 0x33 | 01 05 03    | type name section
  0x36 | 01          | 1 count
  0x37 | 02 01 78    | Naming { index: 2, name: "x" }

--- a/tests/cli/dump/instantiate.wat.stdout
+++ b/tests/cli/dump/instantiate.wat.stdout
@@ -23,12 +23,12 @@
       | 70 6f 6e 65
       | 6e 74 2d 6e
       | 61 6d 65   
- 0x3f | 01 05 01    | func section
+ 0x3f | 01 05 01    | func name section
  0x42 | 01          | 1 count
  0x43 | 00 01 66    | Naming { index: 0, name: "f" }
- 0x46 | 01 05 04    | component section
+ 0x46 | 01 05 04    | component name section
  0x49 | 01          | 1 count
  0x4a | 00 01 63    | Naming { index: 0, name: "c" }
- 0x4d | 01 05 05    | instance section
+ 0x4d | 01 05 05    | instance name section
  0x50 | 01          | 1 count
  0x51 | 00 01 61    | Naming { index: 0, name: "a" }

--- a/tests/cli/dump/instantiate2.wat.stdout
+++ b/tests/cli/dump/instantiate2.wat.stdout
@@ -18,6 +18,6 @@
       | 70 6f 6e 65
       | 6e 74 2d 6e
       | 61 6d 65   
- 0x37 | 01 05 04    | component section
+ 0x37 | 01 05 04    | component name section
  0x3a | 01          | 1 count
  0x3b | 00 01 63    | Naming { index: 0, name: "c" }

--- a/tests/cli/dump/module-types.wat.stdout
+++ b/tests/cli/dump/module-types.wat.stdout
@@ -23,10 +23,10 @@
       | 70 6f 6e 65
       | 6e 74 2d 6e
       | 61 6d 65   
- 0x4c | 01 06 00 11 | core module section
+ 0x4c | 01 06 00 11 | core module name section
  0x50 | 01          | 1 count
  0x51 | 00 01 6d    | Naming { index: 0, name: "m" }
- 0x54 | 01 09 03    | type section
+ 0x54 | 01 09 03    | type name section
  0x57 | 01          | 1 count
  0x58 | 00 05 65 6d | Naming { index: 0, name: "empty" }
       | 70 74 79   

--- a/tests/cli/dump/names.wat.stdout
+++ b/tests/cli/dump/names.wat.stdout
@@ -18,12 +18,12 @@
       | 65         
  0x22 | 00 04       | module name
  0x24 | 03 66 6f 6f | "foo"
- 0x28 | 01 04       | function section
+ 0x28 | 01 04       | function name section
  0x2a | 01          | 1 count
  0x2b | 00 01 66    | Naming { index: 0, name: "f" }
  0x2e | 02 09       | local section
  0x30 | 01          | 1 count
- 0x31 | 00          | function 0 local section
+ 0x31 | 00          | function 0 local name section
  0x32 | 02          | 2 count
  0x33 | 00 01 78    | Naming { index: 0, name: "x" }
  0x36 | 01 01 79    | Naming { index: 1, name: "y" }

--- a/tests/cli/dump/nested-component.wat.stdout
+++ b/tests/cli/dump/nested-component.wat.stdout
@@ -64,7 +64,7 @@
         | 70 6f 6e 65
         | 6e 74 2d 6e
         | 61 6d 65   
-   0xb4 | 01 06 00 11 | core module section
+   0xb4 | 01 06 00 11 | core module name section
    0xb8 | 01          | 1 count
    0xb9 | 00 01 6d    | Naming { index: 0, name: "m" }
  0xbc | 0b 07       | component export section

--- a/tests/cli/dump/try-delegate.wat.stdout
+++ b/tests/cli/dump/try-delegate.wat.stdout
@@ -21,6 +21,6 @@
       | 65         
  0x26 | 03 06       | label section
  0x28 | 01          | 1 count
- 0x29 | 00          | function 0 label section
+ 0x29 | 00          | function 0 label name section
  0x2a | 01          | 1 count
  0x2b | 00 01 6c    | Naming { index: 0, name: "l" }


### PR DESCRIPTION
When dumping the name section, add "name" to the printed section names, so that they appear as eg. "component name section" instead of "component section", which makes it a little easier to read when you're jumping into the middle of a component to find things.