### PR TITLE
Fix requiring memory for lowered functions

### DIFF
--- a/crates/wasmparser/src/readers/component/types.rs
+++ b/crates/wasmparser/src/readers/component/types.rs
@@ -186,7 +186,7 @@ impl PrimitiveValType {
         })
     }
 
-    pub(crate) fn requires_realloc(&self) -> bool {
+    pub(crate) fn contains_ptr(&self) -> bool {
         matches!(self, Self::String)
     }
 

--- a/tests/local/component-model/lower.wast
+++ b/tests/local/component-model/lower.wast
@@ -1,0 +1,15 @@
+(assert_invalid
+  (component
+    (import "f" (func $f (param "x" (list u8))))
+    (core func $f (canon lower (func $f)
+    ))
+  )
+  "canonical option `memory` is required")
+
+(assert_invalid
+  (component
+    (import "f" (func $f (result (list u8))))
+    (core func $f (canon lower (func $f)
+    ))
+  )
+  "canonical option `memory` is required")


### PR DESCRIPTION
Currently component validation erroneously allows lowering a component function with lists/strings in parameters without a `memory` canonical option, despite this being required for the function. This commit fixes the issue and additionally refactors the code by renaming `import` to `is_lower` and renaming `requires_realloc` to `contains_ptr`.