### PR TITLE
Disallow `(borrow $t)` in function result types

### DIFF
--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -1,7 +1,7 @@
 //! State relating to validating a WebAssembly component.
 
 use super::{
-    check_max, combine_type_sizes,
+    check_max,
     core::Module,
     types::{
         ComponentFuncType, ComponentInstanceType, ComponentType, ComponentValType, EntityType,
@@ -14,7 +14,7 @@ use crate::{
     limits::*,
     types::{
         ComponentDefinedType, ComponentEntityType, Context, InstanceTypeKind, LoweringInfo, Remap,
-        SubtypeCx, TupleType, UnionType, VariantType,
+        SubtypeCx, TupleType, TypeInfo, UnionType, VariantType,
     },
     BinaryReaderError, CanonicalOption, ComponentExternName, ComponentExternalKind,
     ComponentOuterAliasKind, ComponentTypeRef, ExternalKind, FuncType, GlobalType,
@@ -65,7 +65,7 @@ pub(crate) struct ComponentState {
     pub kebab_named_externs: IndexSet<KebabName>,
 
     has_start: bool,
-    type_size: u32,
+    type_info: TypeInfo,
 
     /// A mapping of imported resources in this component.
     ///
@@ -226,7 +226,7 @@ impl ComponentState {
             exports: Default::default(),
             kebab_named_externs: Default::default(),
             has_start: Default::default(),
-            type_size: 1,
+            type_info: TypeInfo::new(),
             imported_resources: Default::default(),
             defined_resources: Default::default(),
             explicit_resources: Default::default(),
@@ -296,7 +296,7 @@ impl ComponentState {
         // because we cannot take the data out of the `MaybeOwned`
         // as it might be shared with a function validator.
         let ty = Type::Module(Box::new(ModuleType {
-            type_size: module.type_size,
+            info: TypeInfo::core(module.type_size),
             imports,
             exports: module.exports.clone(),
         }));
@@ -430,7 +430,7 @@ impl ComponentState {
             offset,
             &mut self.kebab_named_externs,
             &mut self.imports,
-            &mut self.type_size,
+            &mut self.type_info,
         )?;
         Ok(())
     }
@@ -754,7 +754,7 @@ impl ComponentState {
 
         let mut new_ty = ComponentInstanceType {
             // Copied from the input verbatim
-            type_size: ty.type_size,
+            info: ty.info,
 
             // Copied over as temporary storage for now, and both of these are
             // filled out and expanded below.
@@ -895,7 +895,7 @@ impl ComponentState {
             offset,
             &mut self.kebab_named_externs,
             &mut self.exports,
-            &mut self.type_size,
+            &mut self.type_info,
         )?;
         Ok(())
     }
@@ -1467,7 +1467,7 @@ impl ComponentState {
         let imports = state.imports_for_module_type(offset)?;
 
         Ok(ModuleType {
-            type_size: state.type_size,
+            info: TypeInfo::core(state.type_size),
             imports,
             exports: state.exports,
         })
@@ -1543,7 +1543,7 @@ impl ComponentState {
         assert!(state.imported_resources.is_empty());
 
         Ok(ComponentInstanceType {
-            type_size: state.type_size,
+            info: state.type_info,
 
             // The defined resources for this instance type are those listed on
             // the component state. The path to each defined resource is
@@ -1576,7 +1576,7 @@ impl ComponentState {
         types: &TypeList,
         offset: usize,
     ) -> Result<ComponentFuncType> {
-        let mut type_size = 1;
+        let mut info = TypeInfo::new();
 
         let mut set =
             HashSet::with_capacity(std::cmp::max(ty.params.len(), ty.results.type_count()));
@@ -1595,7 +1595,7 @@ impl ComponentState {
                 }
 
                 let ty = self.create_component_val_type(*ty, types, offset)?;
-                type_size = combine_type_sizes(type_size, ty.type_size(), offset)?;
+                info.combine(ty.info(),offset)?;
                 Ok((name.to_owned(), ty))
             })
             .collect::<Result<_>>()?;
@@ -1622,13 +1622,17 @@ impl ComponentState {
                     .transpose()?;
 
                 let ty = self.create_component_val_type(*ty, types, offset)?;
-                type_size = combine_type_sizes(type_size, ty.type_size(), offset)?;
+                let ty_info = ty.info();
+                if ty_info.contains_borrow() {
+                    bail!(offset, "function result cannot contain a `borrow` type");
+                }
+                info.combine(ty.info(), offset)?;
                 Ok((name, ty))
             })
             .collect::<Result<_>>()?;
 
         Ok(ComponentFuncType {
-            type_size,
+            info,
             params,
             results,
         })
@@ -1701,11 +1705,13 @@ impl ComponentState {
             })?;
         }
 
+        let mut info = TypeInfo::new();
+        for (_, ty) in module_type.exports.iter() {
+            info.combine(ty.info(), offset)?;
+        }
+
         let ty = Type::Instance(Box::new(InstanceType {
-            type_size: module_type
-                .exports
-                .iter()
-                .fold(1, |acc, (_, ty)| acc + ty.type_size()),
+            info,
             kind: InstanceTypeKind::Instantiated(module_type_id),
         }));
 
@@ -1846,10 +1852,10 @@ impl ComponentState {
 
         let component_type = types[component_type_id].unwrap_component();
         let mut exports = component_type.exports.clone();
-        let type_size = component_type
-            .exports
-            .iter()
-            .fold(1, |acc, (_, ty)| acc + ty.type_size());
+        let mut info = TypeInfo::new();
+        for (_, ty) in component_type.exports.iter() {
+            info.combine(ty.info(), offset)?;
+        }
 
         // Perform the subtype check that `args` matches the imports of
         // `component_type_id`. The result of this subtype check is the
@@ -1974,7 +1980,7 @@ impl ComponentState {
         }
 
         let ty = Type::ComponentInstance(Box::new(ComponentInstanceType {
-            type_size,
+            info,
             defined_resources: Default::default(),
             explicit_resources,
             exports,
@@ -1989,7 +1995,7 @@ impl ComponentState {
         types: &mut TypeAlloc,
         offset: usize,
     ) -> Result<TypeId> {
-        let mut type_size = 1;
+        let mut info = TypeInfo::new();
         let mut inst_exports = IndexMap::new();
         let mut explicit_resources = IndexMap::new();
         let mut kebab_names = IndexSet::new();
@@ -2064,12 +2070,12 @@ impl ComponentState {
                 offset,
                 &mut kebab_names,
                 &mut inst_exports,
-                &mut type_size,
+                &mut info,
             )?;
         }
 
         let ty = Type::ComponentInstance(Box::new(ComponentInstanceType {
-            type_size,
+            info,
             explicit_resources,
             exports: inst_exports,
 
@@ -2117,10 +2123,10 @@ impl ComponentState {
             name: &str,
             export: EntityType,
             exports: &mut IndexMap<String, EntityType>,
-            type_size: &mut u32,
+            info: &mut TypeInfo,
             offset: usize,
         ) -> Result<()> {
-            *type_size = combine_type_sizes(*type_size, export.type_size(), offset)?;
+            info.combine(export.info(), offset)?;
 
             if exports.insert(name.to_string(), export).is_some() {
                 bail!(
@@ -2132,7 +2138,7 @@ impl ComponentState {
             Ok(())
         }
 
-        let mut type_size = 1;
+        let mut info = TypeInfo::new();
         let mut inst_exports = IndexMap::new();
         for export in exports {
             match export.kind {
@@ -2141,7 +2147,7 @@ impl ComponentState {
                         export.name,
                         EntityType::Func(self.core_function_at(export.index, offset)?),
                         &mut inst_exports,
-                        &mut type_size,
+                        &mut info,
                         offset,
                     )?;
                 }
@@ -2149,14 +2155,14 @@ impl ComponentState {
                     export.name,
                     EntityType::Table(*self.table_at(export.index, offset)?),
                     &mut inst_exports,
-                    &mut type_size,
+                    &mut info,
                     offset,
                 )?,
                 ExternalKind::Memory => insert_export(
                     export.name,
                     EntityType::Memory(*self.memory_at(export.index, offset)?),
                     &mut inst_exports,
-                    &mut type_size,
+                    &mut info,
                     offset,
                 )?,
                 ExternalKind::Global => {
@@ -2164,7 +2170,7 @@ impl ComponentState {
                         export.name,
                         EntityType::Global(*self.global_at(export.index, offset)?),
                         &mut inst_exports,
-                        &mut type_size,
+                        &mut info,
                         offset,
                     )?;
                 }
@@ -2172,14 +2178,14 @@ impl ComponentState {
                     export.name,
                     EntityType::Tag(self.core_function_at(export.index, offset)?),
                     &mut inst_exports,
-                    &mut type_size,
+                    &mut info,
                     offset,
                 )?,
             }
         }
 
         let ty = Type::Instance(Box::new(InstanceType {
-            type_size,
+            info,
             kind: InstanceTypeKind::Exports(inst_exports),
         }));
 
@@ -2479,7 +2485,7 @@ impl ComponentState {
         types: &TypeList,
         offset: usize,
     ) -> Result<ComponentDefinedType> {
-        let mut type_size = 1;
+        let mut info = TypeInfo::new();
         let mut field_map = IndexMap::with_capacity(fields.len());
 
         if fields.is_empty() {
@@ -2497,14 +2503,14 @@ impl ComponentState {
                     prev = e.key()
                 ),
                 Entry::Vacant(e) => {
-                    type_size = combine_type_sizes(type_size, ty.type_size(), offset)?;
+                    info.combine(ty.info(), offset)?;
                     e.insert(ty);
                 }
             }
         }
 
         Ok(ComponentDefinedType::Record(RecordType {
-            type_size,
+            info,
             fields: field_map,
         }))
     }
@@ -2515,7 +2521,7 @@ impl ComponentState {
         types: &TypeList,
         offset: usize,
     ) -> Result<ComponentDefinedType> {
-        let mut type_size = 1;
+        let mut info = TypeInfo::new();
         let mut case_map: IndexMap<KebabString, VariantCase> = IndexMap::with_capacity(cases.len());
 
         if cases.is_empty() {
@@ -2554,11 +2560,9 @@ impl ComponentState {
                     prev = e.key()
                 ),
                 Entry::Vacant(e) => {
-                    type_size = combine_type_sizes(
-                        type_size,
-                        ty.map(|ty| ty.type_size()).unwrap_or(1),
-                        offset,
-                    )?;
+                    if let Some(ty) = ty {
+                        info.combine(ty.info(), offset)?;
+                    }
 
                     // Safety: the use of `KebabStr::new_unchecked` here is safe because the string
                     // was already verified to be kebab case.
@@ -2573,7 +2577,7 @@ impl ComponentState {
         }
 
         Ok(ComponentDefinedType::Variant(VariantType {
-            type_size,
+            info,
             cases: case_map,
         }))
     }
@@ -2584,7 +2588,7 @@ impl ComponentState {
         types: &TypeList,
         offset: usize,
     ) -> Result<ComponentDefinedType> {
-        let mut type_size = 1;
+        let mut info = TypeInfo::new();
         if tys.is_empty() {
             bail!(offset, "tuple type must have at least one type");
         }
@@ -2592,12 +2596,12 @@ impl ComponentState {
             .iter()
             .map(|ty| {
                 let ty = self.create_component_val_type(*ty, types, offset)?;
-                type_size = combine_type_sizes(type_size, ty.type_size(), offset)?;
+                info.combine(ty.info(), offset)?;
                 Ok(ty)
             })
             .collect::<Result<_>>()?;
 
-        Ok(ComponentDefinedType::Tuple(TupleType { type_size, types }))
+        Ok(ComponentDefinedType::Tuple(TupleType { info, types }))
     }
 
     fn create_flags_type(&self, names: &[&str], offset: usize) -> Result<ComponentDefinedType> {
@@ -2655,7 +2659,7 @@ impl ComponentState {
         types: &TypeList,
         offset: usize,
     ) -> Result<ComponentDefinedType> {
-        let mut type_size = 1;
+        let mut info = TypeInfo::new();
         if tys.is_empty() {
             bail!(offset, "union type must have at least one case");
         }
@@ -2663,12 +2667,12 @@ impl ComponentState {
             .iter()
             .map(|ty| {
                 let ty = self.create_component_val_type(*ty, types, offset)?;
-                type_size = combine_type_sizes(type_size, ty.type_size(), offset)?;
+                info.combine(ty.info(), offset)?;
                 Ok(ty)
             })
             .collect::<Result<_>>()?;
 
-        Ok(ComponentDefinedType::Union(UnionType { type_size, types }))
+        Ok(ComponentDefinedType::Union(UnionType { info, types }))
     }
 
     fn create_component_val_type(
@@ -2829,7 +2833,7 @@ impl ComponentState {
     pub fn finish(&mut self, types: &TypeAlloc, offset: usize) -> Result<ComponentType> {
         let mut ty = ComponentType {
             // Inherit some fields based on translation of the component.
-            type_size: self.type_size,
+            info: self.type_info,
             imports: self.imports.clone(),
             exports: self.exports.clone(),
 
@@ -2948,7 +2952,7 @@ impl KebabNameContext {
         offset: usize,
         kebab_names: &mut IndexSet<KebabName>,
         items: &mut IndexMap<String, ComponentEntityType>,
-        type_size: &mut u32,
+        info: &mut TypeInfo,
     ) -> Result<()> {
         // First validate that `name` is even a valid kebab name, meaning it's
         // in kebab-case, is an ID, etc.
@@ -2987,7 +2991,7 @@ impl KebabNameContext {
             }
             Entry::Vacant(e) => {
                 e.insert(*ty);
-                *type_size = combine_type_sizes(*type_size, ty.type_size(), offset)?;
+                info.combine(ty.info(), offset)?;
             }
         }
         Ok(())

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -649,7 +649,7 @@ impl Module {
 
         check_max(len, 0, max, desc, offset)?;
 
-        self.type_size = combine_type_sizes(self.type_size, entity.type_size(), offset)?;
+        self.type_size = combine_type_sizes(self.type_size, entity.info().size(), offset)?;
 
         self.imports
             .entry((import.module.to_string(), import.name.to_string()))
@@ -682,7 +682,7 @@ impl Module {
             check_max(self.exports.len(), 1, MAX_WASM_EXPORTS, "exports", offset)?;
         }
 
-        self.type_size = combine_type_sizes(self.type_size, ty.type_size(), offset)?;
+        self.type_size = combine_type_sizes(self.type_size, ty.info().size(), offset)?;
 
         match self.exports.insert(name.to_string(), ty) {
             Some(_) => Err(format_err!(

--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -146,11 +146,8 @@ fn push_primitive_wasm_types(ty: &PrimitiveValType, lowered_types: &mut LoweredT
 pub struct TypeId {
     /// The index into the global list of types.
     pub(crate) index: usize,
-    /// The effective type size for the type.
-    ///
-    /// This is stored as part of the ID to avoid having to recurse through
-    /// the global type list when calculating type sizes.
-    pub(crate) type_size: u32,
+    /// Metadata about this type and its recursive structure.
+    pub(crate) info: TypeInfo,
     /// A unique integer assigned to this type.
     ///
     /// The purpose of this field is to ensure that two different `TypeId`
@@ -165,6 +162,82 @@ pub struct TypeId {
 const _: () = {
     assert!(std::mem::size_of::<TypeId>() <= 16);
 };
+
+/// Metadata about a type and its transitive structure.
+///
+/// Currently contains two properties:
+///
+/// * The "size" of a type - a proxy to the recursive size of a type if
+///   everything in the type were unique (e.g. no shared references). Not an
+///   approximation of runtime size, but instead of type-complexity size if
+///   someone were to visit each element of the type individually. For example
+///   `u32` has size 1 and `(list u32)` has size 2 (roughly). Used to prevent
+///   massive trees of types.
+///
+/// * Whether or not a type contains a "borrow" transitively inside of it. For
+///   example `(borrow $t)` and `(list (borrow $t))` both contain borrows, but
+///   `(list u32)` does not. Used to validate that component function results do
+///   not contain borrows.
+///
+/// Currently this is represented as a compact 32-bit integer to ensure that
+/// `TypeId`, which this is stored in, remains relatively small. The maximum
+/// type size allowed in wasmparser is 1M at this time which is 20 bits of
+/// information, and then one more bit is used for whether or not a borrow is
+/// used. Currently this uses the low 24 bits for the type size and the MSB for
+/// the borrow bit.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct TypeInfo(u32);
+
+impl TypeInfo {
+    /// Creates a new blank set of type information.
+    ///
+    /// Defaults to size 1 to ensure that this consumes space in the final type
+    /// structure.
+    pub(crate) fn new() -> TypeInfo {
+        TypeInfo::_new(1, false)
+    }
+
+    /// Creates a new blank set of information about a leaf "borrow" type which
+    /// has size 1.
+    pub(crate) fn borrow() -> TypeInfo {
+        TypeInfo::_new(1, true)
+    }
+
+    /// Creates type information corresponding to a core type of the `size`
+    /// specified, meaning no borrows are contained within.
+    pub(crate) fn core(size: u32) -> TypeInfo {
+        TypeInfo::_new(size, false)
+    }
+
+    fn _new(size: u32, contains_borrow: bool) -> TypeInfo {
+        assert!(size < (1 << 24));
+        TypeInfo(size | ((contains_borrow as u32) << 31))
+    }
+
+    /// Combines another set of type information into this one, for example if
+    /// this is a record which has `other` as a field.
+    ///
+    /// Updates the size of `self` and whether or not this type contains a
+    /// borrow based on whether `other` contains a borrow.
+    ///
+    /// Returns an error if the type size would exceed this crate's static limit
+    /// of a type size.
+    pub(crate) fn combine(&mut self, other: TypeInfo, offset: usize) -> Result<()> {
+        *self = TypeInfo::_new(
+            super::combine_type_sizes(self.size(), other.size(), offset)?,
+            self.contains_borrow() || other.contains_borrow(),
+        );
+        Ok(())
+    }
+
+    pub(crate) fn size(&self) -> u32 {
+        self.0 & 0xffffff
+    }
+
+    pub(crate) fn contains_borrow(&self) -> bool {
+        (self.0 >> 31) != 0
+    }
+}
 
 /// A unified type definition for validating WebAssembly modules and components.
 #[derive(Debug)]
@@ -291,23 +364,24 @@ impl Type {
         }
     }
 
-    pub(crate) fn type_size(&self) -> u32 {
+    pub(crate) fn info(&self) -> TypeInfo {
         // TODO(#1036): calculate actual size for func, array, struct
         match self {
             Self::Sub(ty) => {
-                1 + match ty.clone().structural_type {
+                let size = 1 + match ty.clone().structural_type {
                     StructuralType::Func(ty) => 1 + (ty.params().len() + ty.results().len()) as u32,
                     StructuralType::Array(_) => 2,
                     StructuralType::Struct(ty) => 1 + 2 * ty.fields.len() as u32,
-                }
+                };
+                TypeInfo::core(size)
             }
-            Self::Module(ty) => ty.type_size,
-            Self::Instance(ty) => ty.type_size,
-            Self::Component(ty) => ty.type_size,
-            Self::ComponentInstance(ty) => ty.type_size,
-            Self::ComponentFunc(ty) => ty.type_size,
-            Self::Defined(ty) => ty.type_size(),
-            Self::Resource(_) => 1,
+            Self::Module(ty) => ty.info,
+            Self::Instance(ty) => ty.info,
+            Self::Component(ty) => ty.info,
+            Self::ComponentInstance(ty) => ty.info,
+            Self::ComponentFunc(ty) => ty.info,
+            Self::Defined(ty) => ty.info(),
+            Self::Resource(_) => TypeInfo::new(),
         }
     }
 }
@@ -338,10 +412,10 @@ impl ComponentValType {
         }
     }
 
-    pub(crate) fn type_size(&self) -> u32 {
+    pub(crate) fn info(&self) -> TypeInfo {
         match self {
-            Self::Primitive(_) => 1,
-            Self::Type(id) => id.type_size,
+            Self::Primitive(_) => TypeInfo::new(),
+            Self::Type(id) => id.info,
         }
     }
 }
@@ -372,10 +446,10 @@ impl EntityType {
         }
     }
 
-    pub(crate) fn type_size(&self) -> u32 {
+    pub(crate) fn info(&self) -> TypeInfo {
         match self {
-            Self::Func(id) | Self::Tag(id) => id.type_size,
-            Self::Table(_) | Self::Memory(_) | Self::Global(_) => 1,
+            Self::Func(id) | Self::Tag(id) => id.info,
+            Self::Table(_) | Self::Memory(_) | Self::Global(_) => TypeInfo::new(),
         }
     }
 }
@@ -429,8 +503,8 @@ impl ModuleImportKey for (&str, &str) {
 /// Represents a core module type.
 #[derive(Debug, Clone)]
 pub struct ModuleType {
-    /// The effective type size for the module type.
-    pub(crate) type_size: u32,
+    /// Metadata about this module type
+    pub(crate) info: TypeInfo,
     /// The imports of the module type.
     pub imports: IndexMap<(String, String), EntityType>,
     /// The exports of the module type.
@@ -458,8 +532,8 @@ pub enum InstanceTypeKind {
 /// Represents a module instance type.
 #[derive(Debug, Clone)]
 pub struct InstanceType {
-    /// The effective type size for the module instance type.
-    pub(crate) type_size: u32,
+    /// Metadata about this instance type
+    pub(crate) info: TypeInfo,
     /// The kind of module instance type.
     pub kind: InstanceTypeKind,
 }
@@ -528,14 +602,14 @@ impl ComponentEntityType {
         }
     }
 
-    pub(crate) fn type_size(&self) -> u32 {
+    pub(crate) fn info(&self) -> TypeInfo {
         match self {
             Self::Module(ty)
             | Self::Func(ty)
             | Self::Type { referenced: ty, .. }
             | Self::Instance(ty)
-            | Self::Component(ty) => ty.type_size,
-            Self::Value(ty) => ty.type_size(),
+            | Self::Component(ty) => ty.info,
+            Self::Value(ty) => ty.info(),
         }
     }
 }
@@ -543,8 +617,8 @@ impl ComponentEntityType {
 /// Represents a type of a component.
 #[derive(Debug, Clone)]
 pub struct ComponentType {
-    /// The effective type size for the component type.
-    pub(crate) type_size: u32,
+    /// Metadata about this component type
+    pub(crate) info: TypeInfo,
 
     /// The imports of the component type.
     ///
@@ -599,8 +673,8 @@ pub struct ComponentType {
 /// Represents a type of a component instance.
 #[derive(Debug, Clone)]
 pub struct ComponentInstanceType {
-    /// The effective type size for the instance type.
-    pub(crate) type_size: u32,
+    /// Metadata about this instance type
+    pub(crate) info: TypeInfo,
 
     /// The list of exports, keyed by name, that this instance has.
     ///
@@ -649,8 +723,8 @@ pub struct ComponentInstanceType {
 /// Represents a type of a component function.
 #[derive(Debug, Clone)]
 pub struct ComponentFuncType {
-    /// The effective type size for the component function type.
-    pub(crate) type_size: u32,
+    /// Metadata about this function type.
+    pub(crate) info: TypeInfo,
     /// The function parameters.
     pub params: Box<[(KebabString, ComponentValType)]>,
     /// The function's results.
@@ -739,8 +813,8 @@ pub struct VariantCase {
 /// Represents a record type.
 #[derive(Debug, Clone)]
 pub struct RecordType {
-    /// The effective type size for the record type.
-    pub(crate) type_size: u32,
+    /// Metadata about this record type.
+    pub(crate) info: TypeInfo,
     /// The map of record fields.
     pub fields: IndexMap<KebabString, ComponentValType>,
 }
@@ -748,8 +822,8 @@ pub struct RecordType {
 /// Represents a variant type.
 #[derive(Debug, Clone)]
 pub struct VariantType {
-    /// The effective type size for the variant type.
-    pub(crate) type_size: u32,
+    /// Metadata about this variant type.
+    pub(crate) info: TypeInfo,
     /// The map of variant cases.
     pub cases: IndexMap<KebabString, VariantCase>,
 }
@@ -757,8 +831,8 @@ pub struct VariantType {
 /// Represents a tuple type.
 #[derive(Debug, Clone)]
 pub struct TupleType {
-    /// The effective type size for the tuple type.
-    pub(crate) type_size: u32,
+    /// Metadata about this tuple type.
+    pub(crate) info: TypeInfo,
     /// The types of the tuple.
     pub types: Box<[ComponentValType]>,
 }
@@ -766,8 +840,8 @@ pub struct TupleType {
 /// Represents a union type.
 #[derive(Debug, Clone)]
 pub struct UnionType {
-    /// The inclusive type count for the union type.
-    pub(crate) type_size: u32,
+    /// Metadata about this union type.
+    pub(crate) info: TypeInfo,
     /// The types of the union.
     pub types: Box<[ComponentValType]>,
 }
@@ -827,20 +901,21 @@ impl ComponentDefinedType {
         }
     }
 
-    pub(crate) fn type_size(&self) -> u32 {
+    pub(crate) fn info(&self) -> TypeInfo {
         match self {
-            Self::Primitive(_)
-            | Self::Flags(_)
-            | Self::Enum(_)
-            | Self::Own(_)
-            | Self::Borrow(_) => 1,
-            Self::Record(r) => r.type_size,
-            Self::Variant(v) => v.type_size,
-            Self::Tuple(t) => t.type_size,
-            Self::Union(u) => u.type_size,
-            Self::List(ty) | Self::Option(ty) => ty.type_size(),
+            Self::Primitive(_) | Self::Flags(_) | Self::Enum(_) | Self::Own(_) => TypeInfo::new(),
+            Self::Borrow(_) => TypeInfo::borrow(),
+            Self::Record(r) => r.info,
+            Self::Variant(v) => v.info,
+            Self::Tuple(t) => t.info,
+            Self::Union(u) => u.info,
+            Self::List(ty) | Self::Option(ty) => ty.info(),
             Self::Result { ok, err } => {
-                ok.map(|ty| ty.type_size()).unwrap_or(1) + err.map(|ty| ty.type_size()).unwrap_or(1)
+                let default = TypeInfo::new();
+                let mut info = ok.map(|ty| ty.info()).unwrap_or(default);
+                info.combine(err.map(|ty| ty.info()).unwrap_or(default), 0)
+                    .unwrap();
+                info
             }
         }
     }
@@ -1898,11 +1973,11 @@ impl TypeAlloc {
     /// hash-equivalent to anything else.
     pub fn push_ty(&mut self, ty: Type) -> TypeId {
         let index = self.list.len();
-        let type_size = ty.type_size();
+        let info = ty.info();
         self.list.push(ty);
         TypeId {
             index,
-            type_size,
+            info,
             unique_id: 0,
         }
     }
@@ -3167,11 +3242,11 @@ impl Index<TypeId> for SubtypeArena<'_> {
 impl Remap for SubtypeArena<'_> {
     fn push_ty(&mut self, ty: Type) -> TypeId {
         let index = self.list.len() + self.types.len();
-        let type_size = ty.type_size();
+        let info = ty.info();
         self.list.push(ty);
         TypeId {
             index,
-            type_size,
+            info,
             unique_id: 0,
         }
     }

--- a/tests/local/component-model/resources.wast
+++ b/tests/local/component-model/resources.wast
@@ -1125,3 +1125,29 @@
     (export "x" (instance (type 0)))
   ))
 )
+
+(assert_invalid
+  (component
+    (type $r (resource (rep i32)))
+    (type (func (result (borrow $r))))
+  )
+  "function result cannot contain a `borrow` type")
+(assert_invalid
+  (component
+    (type $r (resource (rep i32)))
+    (type (func (result (list (borrow $r)))))
+  )
+  "function result cannot contain a `borrow` type")
+(assert_invalid
+  (component
+    (type $r (resource (rep i32)))
+    (type (func (result (option (borrow $r)))))
+  )
+  "function result cannot contain a `borrow` type")
+(assert_invalid
+  (component
+    (type $r (resource (rep i32)))
+    (type $t (record (field "f" (borrow $r))))
+    (type (func (result (option (list $t)))))
+  )
+  "function result cannot contain a `borrow` type")


### PR DESCRIPTION
This is something I forgot to implement in the intial implementation of resources. Validation in the component model dictates that `(borrow $t)` cannot be returned at this time, however, so this implements the necessary validation for this predicate.

This commit modifies the calculation of a type's size to instead calculate a `TypeInfo` where that embeds both the size and borrow-related information. A check when translating function types is then added to ensure that all function result types do not contain borrows.