### PR TITLE
Support WIT package doc comments

### DIFF
--- a/crates/wit-component/src/decoding.rs
+++ b/crates/wit-component/src/decoding.rs
@@ -160,6 +160,7 @@ impl<'a> ComponentInfo<'a> {
                 version: None,
                 name: "component".to_string(),
             },
+            docs: Default::default(),
             worlds: [(world_name.to_string(), world)].into_iter().collect(),
             interfaces: Default::default(),
         };
@@ -284,6 +285,7 @@ impl WitPackageDecoder<'_> {
                 },
                 _ => bail!("package name is not a valid id: {name}"),
             },
+            docs: Default::default(),
             interfaces: Default::default(),
             worlds: Default::default(),
         };
@@ -561,6 +563,7 @@ impl WitPackageDecoder<'_> {
             .entry(package_name.to_string())
             .or_insert_with(|| Package {
                 name: package_name.clone(),
+                docs: Default::default(),
                 interfaces: Default::default(),
                 worlds: Default::default(),
             });

--- a/crates/wit-component/src/metadata.rs
+++ b/crates/wit-component/src/metadata.rs
@@ -67,6 +67,7 @@ impl Default for Bindgen {
                 name: "root".to_string(),
                 version: None,
             },
+            docs: Default::default(),
             interfaces: Default::default(),
             worlds: Default::default(),
         });

--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -38,6 +38,7 @@ impl WitPrinter {
     /// Print the given WIT package to a string.
     pub fn print(&mut self, resolve: &Resolve, pkgid: PackageId) -> Result<String> {
         let pkg = &resolve.packages[pkgid];
+        self.print_docs(&pkg.docs);
         self.output.push_str("package ");
         self.print_name(&pkg.name.namespace);
         self.output.push_str(":");

--- a/crates/wit-parser/src/ast.rs
+++ b/crates/wit-parser/src/ast.rs
@@ -961,12 +961,16 @@ fn parse_docs<'a>(tokens: &mut Tokenizer<'a>) -> Result<Docs<'a>> {
             Token::Comment => {
                 let comment = tokens.get_span(span);
                 if comment.starts_with("///") || (comment.starts_with("/**") && comment != "/**/") {
-                    if started {
-                        docs.span.end = span.end;
-                    } else {
-                        docs.span = span;
+                    if !started {
+                        docs.span.start = span.start;
                         started = true;
                     }
+                    let trailing_ws = comment
+                        .bytes()
+                        .rev()
+                        .take_while(|ch| ch.is_ascii_whitespace())
+                        .count();
+                    docs.span.end = span.end - (trailing_ws as u32);
                     docs.docs.push(comment.into());
                 }
             }

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -57,6 +57,9 @@ pub struct UnresolvedPackage {
     /// The namespace, name, and version information for this package.
     pub name: PackageName,
 
+    /// Doc comments for this package.
+    pub docs: Docs,
+
     /// All worlds from all documents within this package.
     ///
     /// Each world lists the document that it is from.

--- a/crates/wit-parser/src/resolve.rs
+++ b/crates/wit-parser/src/resolve.rs
@@ -1,7 +1,7 @@
 use crate::ast::lex::Span;
 use crate::ast::{parse_use_path, AstUsePath};
 use crate::{
-    AstItem, Error, Function, FunctionKind, Handle, IncludeName, Interface, InterfaceId,
+    AstItem, Docs, Error, Function, FunctionKind, Handle, IncludeName, Interface, InterfaceId,
     PackageName, Results, Type, TypeDef, TypeDefKind, TypeId, TypeOwner, UnresolvedPackage, World,
     WorldId, WorldItem, WorldKey,
 };
@@ -43,6 +43,9 @@ pub struct Resolve {
 pub struct Package {
     /// A unique name corresponding to this package.
     pub name: PackageName,
+
+    /// Documentation associated with this package.
+    pub docs: Docs,
 
     /// All interfaces contained in this packaged, keyed by the interface's
     /// name.
@@ -733,6 +736,7 @@ impl Remap {
         // Fixup "parent" ids now that everything has been identified
         let pkgid = resolve.packages.alloc(Package {
             name: unresolved.name.clone(),
+            docs: unresolved.docs.clone(),
             interfaces: Default::default(),
             worlds: Default::default(),
         });

--- a/crates/wit-parser/tests/ui/parse-fail/multiple-package-docs.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/multiple-package-docs.wit.result
@@ -1,0 +1,8 @@
+failed to parse package: tests/ui/parse-fail/multiple-package-docs
+
+Caused by:
+    found doc comments on multiple 'package' items
+         --> tests/ui/parse-fail/multiple-package-docs/b.wit:1:1
+          |
+        1 | /// Multiple package docs, B
+          | ^----------------------------

--- a/crates/wit-parser/tests/ui/parse-fail/multiple-package-docs.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/multiple-package-docs.wit.result
@@ -5,4 +5,4 @@ Caused by:
          --> tests/ui/parse-fail/multiple-package-docs/b.wit:1:1
           |
         1 | /// Multiple package docs, B
-          | ^----------------------------
+          | ^---------------------------

--- a/crates/wit-parser/tests/ui/parse-fail/multiple-package-docs/a.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/multiple-package-docs/a.wit
@@ -1,0 +1,2 @@
+/// Multiple package docs, A
+package foo:foo

--- a/crates/wit-parser/tests/ui/parse-fail/multiple-package-docs/b.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/multiple-package-docs/b.wit
@@ -1,0 +1,2 @@
+/// Multiple package docs, B
+package foo:foo


### PR DESCRIPTION
```wit
/// Documentation for an entire package
package wasi:documented
```

At most one file can have a package doc comment.

Fixes #836