### PR TITLE
Add --locked to `cargo test` in ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,8 +41,8 @@ jobs:
     - name: Install Rust (rustup)
       run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
       shell: bash
-    - run: cargo test --all
-    - run: cargo test -p wasmparser --benches
+    - run: cargo test --locked --all
+    - run: cargo test --locked -p wasmparser --benches
     - run: cargo build --manifest-path crates/wast/Cargo.toml --no-default-features
     - run: cargo build --manifest-path crates/wast/Cargo.toml --no-default-features --features wasm-module
     - run: cmake -S ${{github.workspace}}/examples -B ${{github.workspace}}/examples/build -DCMAKE_BUILD_TYPE=Release
@@ -66,7 +66,7 @@ jobs:
         echo CARGO_TARGET_WASM32_WASI_RUNNER='wasmtime run --dir . --' >> $GITHUB_ENV
         echo CARGO_BUILD_TARGET='wasm32-wasi' >> $GITHUB_ENV
     - run: |
-        cargo test --workspace \
+        cargo --locked test --workspace \
           --exclude fuzz-stats \
           --exclude wasm-tools-fuzz \
           --exclude wasm-mutate-stats


### PR DESCRIPTION
Now that we have a lock file committed, we can add `--locked` in ci to ensure that we're staying up-to-date.
