### PR TITLE
Bump crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1757,7 +1757,7 @@ checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-compose"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "glob",
@@ -1770,8 +1770,8 @@ dependencies = [
  "serde_yaml",
  "smallvec",
  "wasm-encoder 0.31.1",
- "wasmparser 0.110.0",
- "wasmprinter 0.2.62",
+ "wasmparser 0.111.0",
+ "wasmprinter 0.2.63",
  "wat",
  "wit-component",
 ]
@@ -1792,12 +1792,12 @@ dependencies = [
  "anyhow",
  "leb128",
  "tempfile",
- "wasmparser 0.110.0",
+ "wasmparser 0.111.0",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "clap 4.3.22",
@@ -1806,13 +1806,13 @@ dependencies = [
  "serde_json",
  "spdx",
  "wasm-encoder 0.31.1",
- "wasmparser 0.110.0",
+ "wasmparser 0.111.0",
  "wat",
 ]
 
 [[package]]
 name = "wasm-mutate"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "anyhow",
  "clap 4.3.22",
@@ -1822,8 +1822,8 @@ dependencies = [
  "rand",
  "thiserror",
  "wasm-encoder 0.31.1",
- "wasmparser 0.110.0",
- "wasmprinter 0.2.62",
+ "wasmparser 0.111.0",
+ "wasmprinter 0.2.63",
  "wat",
 ]
 
@@ -1840,14 +1840,14 @@ dependencies = [
  "num_cpus",
  "rand",
  "wasm-mutate",
- "wasmparser 0.110.0",
- "wasmprinter 0.2.62",
+ "wasmparser 0.111.0",
+ "wasmprinter 0.2.63",
  "wasmtime",
 ]
 
 [[package]]
 name = "wasm-shrink"
-version = "0.1.31"
+version = "0.1.32"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1856,14 +1856,14 @@ dependencies = [
  "log",
  "rand",
  "wasm-mutate",
- "wasmparser 0.110.0",
- "wasmprinter 0.2.62",
+ "wasmparser 0.111.0",
+ "wasmprinter 0.2.63",
  "wat",
 ]
 
 [[package]]
 name = "wasm-smith"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "arbitrary",
  "criterion",
@@ -1874,14 +1874,14 @@ dependencies = [
  "rand",
  "serde",
  "wasm-encoder 0.31.1",
- "wasmparser 0.110.0",
- "wasmprinter 0.2.62",
+ "wasmparser 0.111.0",
+ "wasmprinter 0.2.63",
  "wat",
 ]
 
 [[package]]
 name = "wasm-tools"
-version = "1.0.38"
+version = "1.0.39"
 dependencies = [
  "addr2line 0.20.0",
  "anyhow",
@@ -1907,12 +1907,12 @@ dependencies = [
  "wasm-mutate",
  "wasm-shrink",
  "wasm-smith",
- "wasmparser 0.110.0",
- "wasmprinter 0.2.62",
+ "wasmparser 0.111.0",
+ "wasmprinter 0.2.63",
  "wast",
  "wat",
  "wit-component",
- "wit-parser 0.9.2",
+ "wit-parser 0.10.0",
  "wit-smith",
 ]
 
@@ -1924,8 +1924,8 @@ dependencies = [
  "wasm-mutate",
  "wasm-shrink",
  "wasm-smith",
- "wasmparser 0.110.0",
- "wasmprinter 0.2.62",
+ "wasmparser 0.111.0",
+ "wasmprinter 0.2.63",
  "wast",
  "wat",
 ]
@@ -1943,13 +1943,13 @@ dependencies = [
  "wasm-encoder 0.31.1",
  "wasm-mutate",
  "wasm-smith",
- "wasmparser 0.110.0",
- "wasmprinter 0.2.62",
+ "wasmparser 0.111.0",
+ "wasmprinter 0.2.63",
  "wasmtime",
  "wast",
  "wat",
  "wit-component",
- "wit-parser 0.9.2",
+ "wit-parser 0.10.0",
  "wit-smith",
 ]
 
@@ -1966,6 +1966,16 @@ dependencies = [
 [[package]]
 name = "wasmparser"
 version = "0.110.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dfcdb72d96f01e6c85b6bf20102e7423bdbaad5c337301bab2bbf253d26413c"
+dependencies = [
+ "indexmap 2.0.0",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.111.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1979,36 +1989,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.110.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dfcdb72d96f01e6c85b6bf20102e7423bdbaad5c337301bab2bbf253d26413c"
-dependencies = [
- "indexmap 2.0.0",
- "semver",
-]
-
-[[package]]
-name = "wasmprinter"
-version = "0.2.62"
-dependencies = [
- "anyhow",
- "diff",
- "rayon",
- "tempfile",
- "wasmparser 0.110.0",
- "wast",
- "wat",
-]
-
-[[package]]
 name = "wasmprinter"
 version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42cd12ed4d96a984e4b598a17457f1126d01640cc7461afbb319642111ff9e7f"
 dependencies = [
  "anyhow",
- "wasmparser 0.110.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmparser 0.110.0",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.2.63"
+dependencies = [
+ "anyhow",
+ "diff",
+ "rayon",
+ "tempfile",
+ "wasmparser 0.111.0",
+ "wast",
+ "wat",
 ]
 
 [[package]]
@@ -2130,7 +2130,7 @@ dependencies = [
  "thiserror",
  "wasm-encoder 0.29.0",
  "wasmparser 0.107.0",
- "wasmprinter 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasmprinter 0.2.62",
  "wasmtime-component-util",
  "wasmtime-types",
 ]
@@ -2247,7 +2247,7 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "62.0.1"
+version = "63.0.0"
 dependencies = [
  "anyhow",
  "leb128",
@@ -2255,13 +2255,13 @@ dependencies = [
  "rayon",
  "unicode-width",
  "wasm-encoder 0.31.1",
- "wasmparser 0.110.0",
+ "wasmparser 0.111.0",
  "wat",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.69"
+version = "1.0.70"
 dependencies = [
  "wast",
 ]
@@ -2391,7 +2391,7 @@ checksum = "bd1df36d9fd0bbe4849461de9b969f765170f4e0f90497d580a235d515722b10"
 
 [[package]]
 name = "wit-component"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "anyhow",
  "bitflags 2.4.0",
@@ -2402,11 +2402,11 @@ dependencies = [
  "pretty_assertions",
  "wasm-encoder 0.31.1",
  "wasm-metadata",
- "wasmparser 0.110.0",
- "wasmprinter 0.2.62",
+ "wasmparser 0.111.0",
+ "wasmprinter 0.2.63",
  "wasmtime",
  "wat",
- "wit-parser 0.9.2",
+ "wit-parser 0.10.0",
 ]
 
 [[package]]
@@ -2427,7 +2427,7 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -2450,13 +2450,13 @@ dependencies = [
  "env_logger",
  "libfuzzer-sys",
  "log",
- "wasmprinter 0.2.62",
- "wit-parser 0.9.2",
+ "wasmprinter 0.2.63",
+ "wit-parser 0.10.0",
 ]
 
 [[package]]
 name = "wit-smith"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "arbitrary",
  "clap 4.3.22",
@@ -2464,7 +2464,7 @@ dependencies = [
  "log",
  "semver",
  "wit-component",
- "wit-parser 0.9.2",
+ "wit-parser 0.10.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-tools"
-version = "1.0.38"
+version = "1.0.39"
 authors = ["The Wasmtime Project Developers"]
 edition.workspace = true
 description = "CLI tools for interoperating with WebAssembly files"
@@ -44,18 +44,18 @@ pretty_assertions = "1.3.0"
 semver = "1.0.0"
 
 wasm-encoder = { version = "0.31.1", path = "crates/wasm-encoder" }
-wasm-compose = { version = "0.4.0", path = "crates/wasm-compose" }
-wasm-metadata = { version = "0.10.1", path = "crates/wasm-metadata" }
-wasm-mutate = { version = "0.2.30", path = "crates/wasm-mutate" }
-wasm-shrink = { version = "0.1.31", path = "crates/wasm-shrink" }
-wasm-smith = { version = "0.12.13", path = "crates/wasm-smith" }
-wasmparser = { version = "0.110.0", path = "crates/wasmparser" }
-wasmprinter = { version = "0.2.62", path = "crates/wasmprinter" }
-wast = { version = "62.0.1", path = "crates/wast" }
-wat = { version = "1.0.69", path = "crates/wat" }
-wit-component = { version = "0.13.1", path = "crates/wit-component" }
-wit-parser = { version = "0.9.2", path = "crates/wit-parser" }
-wit-smith = { version = "0.1.8", path = "crates/wit-smith" }
+wasm-compose = { version = "0.4.1", path = "crates/wasm-compose" }
+wasm-metadata = { version = "0.10.2", path = "crates/wasm-metadata" }
+wasm-mutate = { version = "0.2.31", path = "crates/wasm-mutate" }
+wasm-shrink = { version = "0.1.32", path = "crates/wasm-shrink" }
+wasm-smith = { version = "0.12.14", path = "crates/wasm-smith" }
+wasmparser = { version = "0.111.0", path = "crates/wasmparser" }
+wasmprinter = { version = "0.2.63", path = "crates/wasmprinter" }
+wast = { version = "63.0.0", path = "crates/wast" }
+wat = { version = "1.0.70", path = "crates/wat" }
+wit-component = { version = "0.13.2", path = "crates/wit-component" }
+wit-parser = { version = "0.10.0", path = "crates/wit-parser" }
+wit-smith = { version = "0.1.9", path = "crates/wit-smith" }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/wasm-compose/Cargo.toml
+++ b/crates/wasm-compose/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-compose"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 authors = ["Peter Huene <peter@huene.dev>"]
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasm-metadata/Cargo.toml
+++ b/crates/wasm-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-metadata"
-version = "0.10.1"
+version = "0.10.2"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-metadata"

--- a/crates/wasm-mutate/Cargo.toml
+++ b/crates/wasm-mutate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-mutate"
-version = "0.2.30"
+version = "0.2.31"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-mutate"

--- a/crates/wasm-shrink/Cargo.toml
+++ b/crates/wasm-shrink/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-shrink"
 name = "wasm-shrink"
-version = "0.1.31"
+version = "0.1.32"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "wasm-smith"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-smith"
-version = "0.12.13"
+version = "0.12.14"
 exclude = ["/benches/corpus"]
 
 [[bench]]

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.110.0"
+version = "0.111.0"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser"

--- a/crates/wasmprinter/Cargo.toml
+++ b/crates/wasmprinter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmprinter"
-version = "0.2.62"
+version = "0.2.63"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wast"
-version = "62.0.1"
+version = "63.0.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wat/Cargo.toml
+++ b/crates/wat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wat"
-version = "1.0.69"
+version = "1.0.70"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wit-component/Cargo.toml
+++ b/crates/wit-component/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-component"
 authors = ["Peter Huene <peter@huene.dev>"]
-version = "0.13.1"
+version = "0.13.2"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"

--- a/crates/wit-parser/Cargo.toml
+++ b/crates/wit-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-parser"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.9.2"
+version = "0.10.0"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"

--- a/crates/wit-smith/Cargo.toml
+++ b/crates/wit-smith/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 name = "wit-smith"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-smith"
-version = "0.1.8"
+version = "0.1.9"
 
 [dependencies]
 arbitrary = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
Release latest changes such as:

* `wasm-tools compose` now supports `-t` (#1148)
* The `abi` module is removed from the `wit-parser` crate (#1149, #1159)
* Fix validation of lowered functions in the component model (#1150)
* Fix a panic decoding WIT from a component (#1157)
* Add text format and printing support for `dylink.0` (#1135)
* Support shared-everything linking in `wasm-tools component new` (#1133)
* Printing a WIT document now prints comments as well (#1167)
* Disallow `(borrow $t)` in component function results (#1162)