### PR TITLE
Really check rustfmt on all files in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install Rust
       run: rustup update stable && rustup default stable && rustup component add rustfmt
-    - run: cargo fmt -- --check
+    # Note that this doesn't use `cargo fmt` because that doesn't format
+    # modules-defined-in-macros which is in use in `wast` for example. This is
+    # the best alternative I can come up with at this time
+    - run: find . -name '*.rs' | xargs rustfmt --check --edition 2021
 
   fuzz:
     name: Fuzz


### PR DESCRIPTION
I noticed that currently in #1146 the CI there is green but some files are unformatted which got me wondering why that was the case. Turns out that `cargo fmt` won't find files that are referenced through macro-expanded macros, meaning that most of `wast` isn't actually checked for formatting on CI. This commit fixes that.