### PR TITLE
Fix formatting for Rust 1.72.0

### DIFF
--- a/crates/wit-component/src/linking.rs
+++ b/crates/wit-component/src/linking.rs
@@ -1066,7 +1066,15 @@ fn make_stubs_module(missing: &[(&str, Export)]) -> Vec<u8> {
     for (offset, (_, export)) in missing.iter().enumerate() {
         let offset = u32::try_from(offset).unwrap();
 
-        let Export { key: ExportKey { name, ty: Type::Function(ty) }, .. } = export else {
+        let Export {
+            key:
+                ExportKey {
+                    name,
+                    ty: Type::Function(ty),
+                },
+            ..
+        } = export
+        else {
             unreachable!();
         };
 


### PR DESCRIPTION
CI for https://github.com/bytecodealliance/wasm-tools/pull/1169 was green but on merge it used Rust 1.72.0 instead (just released) which had a formatting difference, so this gets this repository's CI green again.