### PR TITLE
Require the `gc` proposal with usage of `(rec ...)`

### DIFF
--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -819,12 +819,7 @@ pub struct SubType {
 
 /// Represents a recursive type group in a WebAssembly module.
 #[derive(Debug, Clone)]
-pub struct RecGroup {
-    items: RecGroupItems,
-}
-
-#[derive(Debug, Clone)]
-enum RecGroupItems {
+pub enum RecGroup {
     /// The list of subtypes in the recursive type group.
     Many(Vec<SubType>),
     /// A single subtype in the recursive type group.
@@ -834,9 +829,9 @@ enum RecGroupItems {
 impl RecGroup {
     /// Returns the list of subtypes in the recursive type group.
     pub fn types(&self) -> &[SubType] {
-        match &self.items {
-            RecGroupItems::Many(types) => types,
-            RecGroupItems::Single(ty) => slice::from_ref(ty),
+        match self {
+            RecGroup::Many(types) => types,
+            RecGroup::Single(ty) => slice::from_ref(ty),
         }
     }
 }
@@ -1200,13 +1195,9 @@ impl<'a> FromReader<'a> for RecGroup {
             0x4f => {
                 reader.read_u8()?;
                 let types = reader.read_iter(MAX_WASM_TYPES, "rec group types")?;
-                RecGroup {
-                    items: RecGroupItems::Many(types.collect::<Result<_>>()?),
-                }
+                RecGroup::Many(types.collect::<Result<_>>()?)
             }
-            _ => RecGroup {
-                items: RecGroupItems::Single(reader.read()?),
-            },
+            _ => RecGroup::Single(reader.read()?),
         })
     }
 }

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -611,7 +611,7 @@ impl Validator {
                 state
                     .module
                     .assert_mut()
-                    .add_types(def.types(), features, types, offset, true)?;
+                    .add_types(&def, features, types, offset, true)?;
                 Ok(())
             },
         )

--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -18,8 +18,8 @@ use crate::{
     },
     BinaryReaderError, CanonicalOption, ComponentExternName, ComponentExternalKind,
     ComponentOuterAliasKind, ComponentTypeRef, ExternalKind, FuncType, GlobalType,
-    InstantiationArgKind, MemoryType, Result, StructuralType, SubType, TableType, TypeBounds,
-    ValType, WasmFeatures,
+    InstantiationArgKind, MemoryType, RecGroup, Result, StructuralType, SubType, TableType,
+    TypeBounds, ValType, WasmFeatures,
 };
 use indexmap::{map::Entry, IndexMap, IndexSet};
 use std::collections::{HashMap, HashSet};
@@ -1427,7 +1427,7 @@ impl ComponentState {
         for decl in decls {
             match decl {
                 crate::ModuleTypeDeclaration::Type(ty) => {
-                    state.add_types(&[ty], features, types, offset, true)?;
+                    state.add_types(&RecGroup::Single(ty), features, types, offset, true)?;
                 }
                 crate::ModuleTypeDeclaration::Export { name, ty } => {
                     let ty = state.check_type_ref(&ty, features, types, offset)?;

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -662,11 +662,11 @@ impl Printer {
         Ok(())
     }
 
-    fn print_rec(&mut self, state: &mut State, offset: usize, rg: RecGroup) -> Result<()> {
+    fn print_rec(&mut self, state: &mut State, offset: usize, types: Vec<SubType>) -> Result<()> {
         self.start_group("rec");
-        for ty in rg.types() {
+        for ty in types {
             self.newline(offset + 2);
-            self.print_type(state, ty.clone())?;
+            self.print_type(state, ty)?;
         }
         self.end_group(); // `rec`
         Ok(())
@@ -742,10 +742,9 @@ impl Printer {
         for ty in parser.into_iter_with_offsets() {
             let (offset, rec_group) = ty?;
             self.newline(offset);
-            if rec_group.types().len() == 1 {
-                self.print_type(state, rec_group.types()[0].clone())?;
-            } else {
-                self.print_rec(state, offset, rec_group)?;
+            match rec_group {
+                RecGroup::Many(items) => self.print_rec(state, offset, items)?,
+                RecGroup::Single(ty) => self.print_type(state, ty)?,
             }
         }
 

--- a/crates/wast/src/core/binary.rs
+++ b/crates/wast/src/core/binary.rs
@@ -212,11 +212,6 @@ impl Encode for Type<'_> {
 
 impl Encode for Rec<'_> {
     fn encode(&self, e: &mut Vec<u8>) {
-        if self.types.len() == 1 {
-            self.types[0].encode(e);
-            return;
-        }
-
         e.push(0x4f);
         self.types.len().encode(e);
         for ty in &self.types {

--- a/tests/cli/dump/alias.wat.stdout
+++ b/tests/cli/dump/alias.wat.stdout
@@ -30,7 +30,7 @@
         | 01 00 00 00
    0x57 | 01 04       | type section
    0x59 | 01          | 1 count
-   0x5a | 60 00 00    | [type 0] RecGroup { items: Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [], returns: [] }) }) }
+   0x5a | 60 00 00    | [type 0] Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [], returns: [] }) })
    0x5d | 03 02       | func section
    0x5f | 01          | 1 count
    0x60 | 00          | [func 0] type 0

--- a/tests/cli/dump/alias2.wat.stdout
+++ b/tests/cli/dump/alias2.wat.stdout
@@ -126,7 +126,7 @@
          | 01 00 00 00
    0x158 | 01 04       | type section
    0x15a | 01          | 1 count
-   0x15b | 60 00 00    | [type 0] RecGroup { items: Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [], returns: [] }) }) }
+   0x15b | 60 00 00    | [type 0] Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [], returns: [] }) })
    0x15e | 03 02       | func section
    0x160 | 01          | 1 count
    0x161 | 00          | [func 0] type 0
@@ -162,7 +162,7 @@
          | 01 00 00 00
    0x1a2 | 01 04       | type section
    0x1a4 | 01          | 1 count
-   0x1a5 | 60 00 00    | [type 0] RecGroup { items: Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [], returns: [] }) }) }
+   0x1a5 | 60 00 00    | [type 0] Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [], returns: [] }) })
    0x1a8 | 02 19       | import section
    0x1aa | 04          | 4 count
    0x1ab | 00 01 31 00 | import [func 0] Import { module: "", name: "1", ty: Func(0) }

--- a/tests/cli/dump/blockty.wat.stdout
+++ b/tests/cli/dump/blockty.wat.stdout
@@ -2,12 +2,12 @@
       | 01 00 00 00
   0x8 | 01 17       | type section
   0xa | 05          | 5 count
-  0xb | 60 00 00    | [type 0] RecGroup { items: Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [], returns: [] }) }) }
-  0xe | 60 00 01 7f | [type 1] RecGroup { items: Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [], returns: [I32] }) }) }
- 0x12 | 60 01 7f 00 | [type 2] RecGroup { items: Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [I32], returns: [] }) }) }
- 0x16 | 60 01 7f 01 | [type 3] RecGroup { items: Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [I32], returns: [I32] }) }) }
+  0xb | 60 00 00    | [type 0] Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [], returns: [] }) })
+  0xe | 60 00 01 7f | [type 1] Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [], returns: [I32] }) })
+ 0x12 | 60 01 7f 00 | [type 2] Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [I32], returns: [] }) })
+ 0x16 | 60 01 7f 01 | [type 3] Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [I32], returns: [I32] }) })
       | 7f         
- 0x1b | 60 01 7f 02 | [type 4] RecGroup { items: Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [I32], returns: [I32, I32] }) }) }
+ 0x1b | 60 01 7f 02 | [type 4] Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [I32], returns: [I32, I32] }) })
       | 7f 7f      
  0x21 | 03 02       | func section
  0x23 | 01          | 1 count

--- a/tests/cli/dump/bundled.wat.stdout
+++ b/tests/cli/dump/bundled.wat.stdout
@@ -25,7 +25,7 @@
          | 01 00 00 00
     0x54 | 01 09       | type section
     0x56 | 01          | 1 count
-    0x57 | 60 04 7f 7f | [type 0] RecGroup { items: Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [I32, I32, I32, I32], returns: [I32] }) }) }
+    0x57 | 60 04 7f 7f | [type 0] Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [I32, I32, I32, I32], returns: [I32] }) })
          | 7f 7f 01 7f
     0x5f | 03 02       | func section
     0x61 | 01          | 1 count
@@ -61,9 +61,9 @@
          | 01 00 00 00
     0xa0 | 01 09       | type section
     0xa2 | 02          | 2 count
-    0xa3 | 60 02 7f 7f | [type 0] RecGroup { items: Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [I32, I32], returns: [] }) }) }
+    0xa3 | 60 02 7f 7f | [type 0] Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [I32, I32], returns: [] }) })
          | 00         
-    0xa8 | 60 00 00    | [type 1] RecGroup { items: Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [], returns: [] }) }) }
+    0xa8 | 60 00 00    | [type 1] Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [], returns: [] }) })
     0xab | 02 12       | import section
     0xad | 01          | 1 count
     0xae | 09 77 61 73 | import [func 0] Import { module: "wasi-file", name: "read", ty: Func(0) }
@@ -103,9 +103,9 @@
          | 01 00 00 00
    0x101 | 01 0c       | type section
    0x103 | 02          | 2 count
-   0x104 | 60 02 7f 7f | [type 0] RecGroup { items: Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [I32, I32], returns: [] }) }) }
+   0x104 | 60 02 7f 7f | [type 0] Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [I32, I32], returns: [] }) })
          | 00         
-   0x109 | 60 03 7f 7f | [type 1] RecGroup { items: Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [I32, I32, I32], returns: [] }) }) }
+   0x109 | 60 03 7f 7f | [type 1] Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [I32, I32, I32], returns: [] }) })
          | 7f 00      
    0x10f | 02 12       | import section
    0x111 | 01          | 1 count

--- a/tests/cli/dump/component-expand-bundle.wat.stdout
+++ b/tests/cli/dump/component-expand-bundle.wat.stdout
@@ -5,7 +5,7 @@
         | 01 00 00 00
    0x12 | 01 04       | type section
    0x14 | 01          | 1 count
-   0x15 | 60 00 00    | [type 0] RecGroup { items: Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [], returns: [] }) }) }
+   0x15 | 60 00 00    | [type 0] Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [], returns: [] }) })
    0x18 | 03 02       | func section
    0x1a | 01          | 1 count
    0x1b | 00          | [func 0] type 0
@@ -28,7 +28,7 @@
         | 01 00 00 00
    0x3d | 01 04       | type section
    0x3f | 01          | 1 count
-   0x40 | 60 00 00    | [type 0] RecGroup { items: Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [], returns: [] }) }) }
+   0x40 | 60 00 00    | [type 0] Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [], returns: [] }) })
    0x43 | 02 06       | import section
    0x45 | 01          | 1 count
    0x46 | 00 01 61 00 | import [func 0] Import { module: "", name: "a", ty: Func(0) }

--- a/tests/cli/dump/import-modules.wat.stdout
+++ b/tests/cli/dump/import-modules.wat.stdout
@@ -14,7 +14,7 @@
         | 01 00 00 00
    0x2a | 01 04       | type section
    0x2c | 01          | 1 count
-   0x2d | 60 00 00    | [type 0] RecGroup { items: Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [], returns: [] }) }) }
+   0x2d | 60 00 00    | [type 0] Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [], returns: [] }) })
    0x30 | 03 02       | func section
    0x32 | 01          | 1 count
    0x33 | 00          | [func 0] type 0

--- a/tests/cli/dump/names.wat.stdout
+++ b/tests/cli/dump/names.wat.stdout
@@ -2,7 +2,7 @@
       | 01 00 00 00
   0x8 | 01 05       | type section
   0xa | 01          | 1 count
-  0xb | 60 01 7f 00 | [type 0] RecGroup { items: Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [I32], returns: [] }) }) }
+  0xb | 60 01 7f 00 | [type 0] Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [I32], returns: [] }) })
   0xf | 03 02       | func section
  0x11 | 01          | 1 count
  0x12 | 00          | [func 0] type 0

--- a/tests/cli/dump/select.wat.stdout
+++ b/tests/cli/dump/select.wat.stdout
@@ -2,7 +2,7 @@
       | 01 00 00 00
   0x8 | 01 04       | type section
   0xa | 01          | 1 count
-  0xb | 60 00 00    | [type 0] RecGroup { items: Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [], returns: [] }) }) }
+  0xb | 60 00 00    | [type 0] Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [], returns: [] }) })
   0xe | 03 02       | func section
  0x10 | 01          | 1 count
  0x11 | 00          | [func 0] type 0

--- a/tests/cli/dump/simple.wat.stdout
+++ b/tests/cli/dump/simple.wat.stdout
@@ -2,8 +2,8 @@
       | 01 00 00 00
   0x8 | 01 08       | type section
   0xa | 02          | 2 count
-  0xb | 60 01 7f 00 | [type 0] RecGroup { items: Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [I32], returns: [] }) }) }
-  0xf | 60 00 00    | [type 1] RecGroup { items: Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [], returns: [] }) }) }
+  0xb | 60 01 7f 00 | [type 0] Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [I32], returns: [] }) })
+  0xf | 60 00 00    | [type 1] Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [], returns: [] }) })
  0x12 | 02 07       | import section
  0x14 | 01          | 1 count
  0x15 | 01 6d 01 6e | import [func 0] Import { module: "m", name: "n", ty: Func(0) }

--- a/tests/cli/dump/try-delegate.wat.stdout
+++ b/tests/cli/dump/try-delegate.wat.stdout
@@ -2,7 +2,7 @@
       | 01 00 00 00
   0x8 | 01 04       | type section
   0xa | 01          | 1 count
-  0xb | 60 00 00    | [type 0] RecGroup { items: Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [], returns: [] }) }) }
+  0xb | 60 00 00    | [type 0] Single(SubType { is_final: false, supertype_idx: None, structural_type: Func(FuncType { params: [], returns: [] }) })
   0xe | 03 02       | func section
  0x10 | 01          | 1 count
  0x11 | 00          | [func 0] type 0

--- a/tests/local/missing-features/rec-group.wast
+++ b/tests/local/missing-features/rec-group.wast
@@ -1,0 +1,11 @@
+(assert_invalid
+  (module (rec))
+  "requires `gc` proposal to be enabled")
+
+(assert_invalid
+  (module (rec (type (func))))
+  "requires `gc` proposal to be enabled")
+
+(assert_invalid
+  (module (rec (type (func)) (type (func))))
+  "requires `gc` proposal to be enabled")

--- a/tests/snapshots/local/gc/gc-rec-sub.wat.print
+++ b/tests/snapshots/local/gc/gc-rec-sub.wat.print
@@ -1,15 +1,21 @@
 (module
-  (type (;0;) (func))
+  (rec
+    (type (;0;) (func))
+  )
   (rec
     (type (;1;) (func))
     (type (;2;) (func))
   )
-  (type (;3;) (struct))
+  (rec
+    (type (;3;) (struct))
+  )
   (rec
     (type (;4;) (struct))
     (type (;5;) (struct))
   )
-  (type (;6;) (array i32))
+  (rec
+    (type (;6;) (array i32))
+  )
   (rec
     (type (;7;) (array i32))
     (type (;8;) (array i32))
@@ -23,8 +29,12 @@
     (type $a (;12;) (func))
     (type (;13;) (sub $a (;12;) (func)))
   )
-  (type (;14;) (sub $a (;12;) (func)))
-  (type (;15;) (sub final $a (;12;) (func)))
+  (rec
+    (type (;14;) (sub $a (;12;) (func)))
+  )
+  (rec
+    (type (;15;) (sub final $a (;12;) (func)))
+  )
   (type (;16;) (sub $a (;12;) (func)))
   (rec
     (type $t1 (;17;) (struct (field (ref 18))))


### PR DESCRIPTION
This commit is a follow-up to #1134 to require the `gc` feature flag be activated to use the `(rec ...)` construct from the GC wasm proposal. This additionally updates the text parsing and text printing to consider the structure of what's parsed for encoding/printing rather than the size of the types inside. Even a `rec` group of a single type prints a `rec` group or encodes it now instead of silently switching it back to a single-type encoding.