### PR TITLE
Add a helper method to parse types without GC types 

### DIFF
--- a/crates/wasm-mutate/src/info.rs
+++ b/crates/wasm-mutate/src/info.rs
@@ -1,6 +1,6 @@
 use crate::{
     module::{PrimitiveTypeInfo, TypeInfo},
-    Error, Result,
+    Result,
 };
 use std::collections::HashSet;
 use std::convert::TryFrom;
@@ -92,20 +92,8 @@ impl<'a> ModuleInfo<'a> {
                     info.section(SectionId::Type.into(), reader.range(), input_wasm);
 
                     // Save function types
-                    for rec_group in reader {
-                        if let Ok(rg) = rec_group {
-                            if rg.types().len() != 1 {
-                                return Err(Error::unsupported("GC types not supported yet"));
-                            }
-                            for st in rg.types() {
-                                if st.is_final || st.supertype_idx.is_some() {
-                                    return Err(Error::unsupported("GC types not supported yet"));
-                                }
-                                let typeinfo =
-                                    TypeInfo::try_from(st.clone().structural_type).unwrap();
-                                info.types_map.push(typeinfo);
-                            }
-                        }
+                    for ty in reader.into_iter_err_on_gc_types() {
+                        info.types_map.push(ty?.into());
                     }
                 }
                 Payload::ImportSection(reader) => {

--- a/crates/wasm-mutate/src/module.rs
+++ b/crates/wasm-mutate/src/module.rs
@@ -1,5 +1,4 @@
-use crate::{Error, Result};
-use std::convert::TryFrom;
+use crate::Result;
 use wasm_encoder::{BlockType, HeapType, RefType, ValType};
 
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -49,30 +48,20 @@ impl From<wasmparser::RefType> for PrimitiveTypeInfo {
     }
 }
 
-impl TryFrom<wasmparser::StructuralType> for TypeInfo {
-    type Error = Error;
-
-    fn try_from(value: wasmparser::StructuralType) -> Result<Self> {
-        match value {
-            wasmparser::StructuralType::Func(ft) => Ok(TypeInfo::Func(FuncInfo {
-                params: ft
-                    .params()
-                    .iter()
-                    .map(|&t| PrimitiveTypeInfo::from(t))
-                    .collect(),
-                returns: ft
-                    .results()
-                    .iter()
-                    .map(|&t| PrimitiveTypeInfo::from(t))
-                    .collect(),
-            })),
-            wasmparser::StructuralType::Array(_) => {
-                Err(Error::unsupported("Array types are not supported yet."))
-            }
-            wasmparser::StructuralType::Struct(_) => {
-                Err(Error::unsupported("Struct types are not supported yet."))
-            }
-        }
+impl From<wasmparser::FuncType> for TypeInfo {
+    fn from(ft: wasmparser::FuncType) -> Self {
+        TypeInfo::Func(FuncInfo {
+            params: ft
+                .params()
+                .iter()
+                .map(|&t| PrimitiveTypeInfo::from(t))
+                .collect(),
+            returns: ft
+                .results()
+                .iter()
+                .map(|&t| PrimitiveTypeInfo::from(t))
+                .collect(),
+        })
     }
 }
 

--- a/crates/wasm-mutate/src/mutators/add_type.rs
+++ b/crates/wasm-mutate/src/mutators/add_type.rs
@@ -2,7 +2,7 @@
 
 use super::Mutator;
 use crate::module::map_type;
-use crate::{Error, Result};
+use crate::Result;
 use rand::Rng;
 use std::iter;
 
@@ -55,32 +55,21 @@ impl Mutator for AddTypeMutator {
         if let Some(old_types) = config.info().get_type_section() {
             // Copy the existing types section over into the encoder.
             let reader = wasmparser::TypeSectionReader::new(old_types.data, 0)?;
-            for rec_group in reader {
-                for ty in rec_group?.types() {
-                    match ty.clone().structural_type {
-                        wasmparser::StructuralType::Func(ty) => {
-                            let params = ty
-                                .params()
-                                .iter()
-                                .copied()
-                                .map(map_type)
-                                .collect::<Result<Vec<_>, _>>()?;
-                            let results = ty
-                                .results()
-                                .iter()
-                                .copied()
-                                .map(map_type)
-                                .collect::<Result<Vec<_>, _>>()?;
-                            types.function(params, results);
-                        }
-                        wasmparser::StructuralType::Array(_) => {
-                            return Err(Error::unsupported("Array types are not supported yet."));
-                        }
-                        wasmparser::StructuralType::Struct(_) => {
-                            return Err(Error::unsupported("Struct types are not supported yet."));
-                        }
-                    }
-                }
+            for ty in reader.into_iter_err_on_gc_types() {
+                let ty = ty?;
+                let params = ty
+                    .params()
+                    .iter()
+                    .copied()
+                    .map(map_type)
+                    .collect::<Result<Vec<_>, _>>()?;
+                let results = ty
+                    .results()
+                    .iter()
+                    .copied()
+                    .map(map_type)
+                    .collect::<Result<Vec<_>, _>>()?;
+                types.function(params, results);
             }
             // And then add our new type.
             types.function(params, results);

--- a/crates/wasm-mutate/src/mutators/remove_item.rs
+++ b/crates/wasm-mutate/src/mutators/remove_item.rs
@@ -17,7 +17,7 @@ use wasm_encoder::*;
 use wasmparser::{
     BinaryReader, CodeSectionReader, DataSectionReader, ElementSectionReader, ExportSectionReader,
     ExternalKind, FromReader, FunctionSectionReader, GlobalSectionReader, ImportSectionReader,
-    MemorySectionReader, Operator, SectionLimited, TableInit, TableSectionReader, TagSectionReader,
+    MemorySectionReader, Operator, TableInit, TableSectionReader, TagSectionReader,
     TypeSectionReader,
 };
 
@@ -134,12 +134,10 @@ impl RemoveItem {
                     self.filter_out(
                         &mut module,
                         0,
-                        TypeSectionReader::new(section.data, 0)?,
+                        TypeSectionReader::new(section.data, 0)?.into_iter_err_on_gc_types(),
                         Item::Type,
-                        |me, rec_group, section| {
-                            for ty in rec_group.types() {
-                                me.translate_type_def(ty.clone().structural_type, section)?;
-                            }
+                        |me, ty, section| {
+                            me.translate_func_type(ty,section)?;
                             Ok(())
                         },
                     )?;
@@ -378,7 +376,7 @@ impl RemoveItem {
         &mut self,
         module: &mut Module,
         offset: u32,
-        section: SectionLimited<'a, S>,
+        section: impl IntoIterator<Item = wasmparser::Result<S>>,
         section_item: Item,
         encode: impl Fn(&mut Self, S, &mut T) -> Result<()>,
     ) -> Result<()>

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -547,16 +547,14 @@ impl Module {
         // index in our newly generated module. Initially the option is `None` and will become a
         // `Some` when we encounter an import that uses this signature in the next portion of this
         // function. See also the `make_func_type` closure below.
-        let mut available_types = Vec::<(wasmparser::StructuralType, Option<u32>)>::new();
+        let mut available_types = Vec::new();
         let mut available_imports = Vec::<wasmparser::Import>::new();
         for payload in wasmparser::Parser::new(0).parse_all(&example_module) {
             match payload.expect("could not parse the available import payload") {
                 wasmparser::Payload::TypeSection(type_reader) => {
-                    for ty in type_reader {
-                        let rec_group = ty.expect("could not parse type section");
-                        for ty in rec_group.types() {
-                            available_types.push((ty.clone().structural_type, None));
-                        }
+                    for ty in type_reader.into_iter_err_on_gc_types() {
+                        let ty = ty.expect("could not parse type section");
+                        available_types.push((ty, None));
                     }
                 }
                 wasmparser::Payload::ImportSection(import_reader) => {
@@ -589,7 +587,7 @@ impl Module {
             let serialized_sig_idx = match available_types.get_mut(parsed_sig_idx as usize) {
                 None => panic!("signature index refers to a type out of bounds"),
                 Some((_, Some(idx))) => *idx as usize,
-                Some((wasmparser::StructuralType::Func(func_type), index_store)) => {
+                Some((func_type, index_store)) => {
                     let multi_value_required = func_type.results().len() > 1;
                     let new_index = first_type_index + new_types.len();
                     if new_index >= max_types || (multi_value_required && !multi_value_enabled) {
@@ -610,12 +608,6 @@ impl Module {
                     index_store.replace(new_index as u32);
                     new_types.push(Type::Func(Rc::clone(&func_type)));
                     new_index
-                }
-                Some((wasmparser::StructuralType::Array(_array_type), _index_store)) => {
-                    unimplemented!("Array types are not supported yet.");
-                }
-                Some((wasmparser::StructuralType::Struct(_struct_type), _index_store)) => {
-                    unimplemented!("Struct types are not supported yet.");
                 }
             };
             match &new_types[serialized_sig_idx - first_type_index] {

--- a/crates/wasm-smith/tests/core.rs
+++ b/crates/wasm-smith/tests/core.rs
@@ -129,18 +129,8 @@ fn smoke_test_imports_config() {
                 let payload = payload.unwrap();
                 if let wasmparser::Payload::TypeSection(rdr) = payload {
                     // Gather the signature types to later check function types against.
-                    for rec_group in rdr {
-                        for ty in rec_group.unwrap().types() {
-                            match ty.clone().structural_type {
-                                wasmparser::StructuralType::Func(ft) => sig_types.push(ft),
-                                wasmparser::StructuralType::Array(_) => {
-                                    unimplemented!("Array types are not supported yet.")
-                                }
-                                wasmparser::StructuralType::Struct(_) => {
-                                    unimplemented!("Struct types are not supported yet.")
-                                }
-                            }
-                        }
+                    for ty in rdr.into_iter_err_on_gc_types() {
+                        sig_types.push(ty.unwrap());
                     }
                 } else if let wasmparser::Payload::ImportSection(rdr) = payload {
                     // Read out imports, checking that they all are within the list of expected

--- a/crates/wit-component/src/linking/metadata.rs
+++ b/crates/wit-component/src/linking/metadata.rs
@@ -9,7 +9,7 @@ use {
     },
     wasmparser::{
         BinaryReader, BinaryReaderError, ExternalKind, FuncType, Parser, Payload, RefType,
-        StructuralType, Subsection, Subsections, TableType, TypeRef, ValType,
+        Subsection, Subsections, TableType, TypeRef, ValType,
     },
 };
 
@@ -343,22 +343,7 @@ impl<'a> Metadata<'a> {
 
                 Payload::TypeSection(reader) => {
                     types = reader
-                        .into_iter()
-                        .flat_map(|r| match r {
-                            Err(e) => vec![Err(e)],
-                            Ok(rg) => rg
-                                .types()
-                                .iter()
-                                .map(|st| Ok(st.clone()))
-                                .collect::<Vec<_>>(),
-                        })
-                        .filter_map(|r| {
-                            r.map(|ty| match ty.clone().structural_type {
-                                StructuralType::Func(ty) => Some(ty),
-                                StructuralType::Array(_) | StructuralType::Struct(_) => None,
-                            })
-                            .transpose()
-                        })
+                        .into_iter_err_on_gc_types()
                         .collect::<Result<Vec<_>, _>>()?;
                 }
 


### PR DESCRIPTION
This commit updates the API of the `wasmparser` crate to make it easier
to iterate over a type section without working with GC types. A new
method `into_iter_err_on_gc_types` is added which automatically
"unwraps" any GC features and returns an error, instead returning only
the `FuncType` which is possible with non-GC wasm. This is intended to
make it easier for tools that don't support the GC proposal to continue
to use `wasmparser` and avoid API changes related to the GC proposal
support.

Many users in this repository have been updated as well. For example
those that are translating from one encoding to another can't ignore
`rec` groups as they currently do, instead the `rec` group structure
itself would have to be mirrored which isn't supported right now.