### PR TITLE
GC array.init_data requires the data count section

### DIFF
--- a/crates/wast/src/core/expr.rs
+++ b/crates/wast/src/core/expr.rs
@@ -1164,7 +1164,8 @@ impl<'a> Instruction<'a> {
         match self {
             Instruction::MemoryInit(_)
             | Instruction::DataDrop(_)
-            | Instruction::ArrayNewData(_) => true,
+            | Instruction::ArrayNewData(_)
+            | Instruction::ArrayInitData(_) => true,
             _ => false,
         }
     }


### PR DESCRIPTION
The `array.init_data` instruction from the GC proposal requires the data count section in the binary, just like `array.new_data`.

I have to say, this `needs_data_count` stuff seems fragile and expensive for very little gain. Is a [scan of all instructions in the module](https://github.com/bytecodealliance/wasm-tools/blob/03d21b8d9f0dd29441c5de4d6a2fc1505a9fd0d5/crates/wast/src/core/binary.rs#L83-L92) really worth it to save, like, three bytes?