### PR TITLE
Don't consume arbitrary bytes if we aren't trapping

### DIFF
--- a/crates/wasm-smith/src/core/code_builder.rs
+++ b/crates/wasm-smith/src/core/code_builder.rs
@@ -1069,7 +1069,7 @@ impl CodeBuilder<'_> {
         // Generating an unreachable instruction is always a valid way to
         // generate any types for a label, but it's not too interesting, so
         // don't favor it.
-        if u.arbitrary::<u16>().unwrap_or(0) == 1 && !disallow_traps {
+        if !disallow_traps && u.ratio(1, u16::MAX).unwrap_or(false) {
             instructions.push(Instruction::Unreachable);
             return;
         }


### PR DESCRIPTION
No need to consume arbitrary bytes to determine whether we should trap when we are configured not to trap anyways. By checking the configuration first, we early branch away before consuming arbitrary bytes.

Also rewrite the one-in-u16::MAX logic to use `u.ratio` since it is more clear and easier to follow.