### PR TITLE
Added the ability to add features when decoding Wasm with wit-component

### DIFF
--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -252,6 +252,32 @@ pub struct WasmFeatures {
 }
 
 impl WasmFeatures {
+    /// Returns [`WasmFeatures`] with all features enabled.
+    pub fn all() -> Self {
+        WasmFeatures {
+            mutable_global: true,
+            saturating_float_to_int: true,
+            sign_extension: true,
+            reference_types: true,
+            multi_value: true,
+            bulk_memory: true,
+            simd: true,
+            relaxed_simd: true,
+            threads: true,
+            tail_call: true,
+            floats: true,
+            multi_memory: true,
+            exceptions: true,
+            memory64: true,
+            extended_const: true,
+            component_model: true,
+            function_references: true,
+            memory_control: true,
+            gc: true,
+            component_model_values: true,
+        }
+    }
+
     /// NOTE: This only checks that the value type corresponds to the feature set!!
     ///
     /// To check that reference types are valid, we need access to the module

--- a/crates/wit-component/src/decoding.rs
+++ b/crates/wit-component/src/decoding.rs
@@ -30,14 +30,7 @@ enum Extern<'a> {
 impl<'a> ComponentInfo<'a> {
     /// Creates a new component info by parsing the given WebAssembly component bytes.
     fn new(bytes: &'a [u8]) -> Result<Self> {
-        Self::new_with_features(bytes, WasmFeatures::default())
-    }
-
-    fn new_with_features(bytes: &'a [u8], features: WasmFeatures) -> Result<Self> {
-        let mut validator = Validator::new_with_features(WasmFeatures {
-            component_model: true,
-            ..features
-        });
+        let mut validator = Validator::new_with_features(WasmFeatures::all());
         let mut externs = Vec::new();
         let mut depth = 1;
         let mut types = None;
@@ -239,11 +232,7 @@ impl DecodedWasm {
 /// WIT-package-encoded-as-binary or an actual component itself. A [`Resolve`]
 /// is always created and the return value indicates which was detected.
 pub fn decode(bytes: &[u8]) -> Result<DecodedWasm> {
-    decode_with_features(bytes, WasmFeatures::default())
-}
-
-pub fn decode_with_features(bytes: &[u8], features: WasmFeatures) -> Result<DecodedWasm> {
-    let info = ComponentInfo::new_with_features(bytes, features)?;
+    let info = ComponentInfo::new(bytes)?;
 
     if info.is_wit_package() {
         log::debug!("decoding a WIT package encoded as wasm");

--- a/crates/wit-component/src/decoding.rs
+++ b/crates/wit-component/src/decoding.rs
@@ -30,9 +30,13 @@ enum Extern<'a> {
 impl<'a> ComponentInfo<'a> {
     /// Creates a new component info by parsing the given WebAssembly component bytes.
     fn new(bytes: &'a [u8]) -> Result<Self> {
+        Self::new_with_features(bytes, WasmFeatures::default())
+    }
+
+    fn new_with_features(bytes: &'a [u8], features: WasmFeatures) -> Result<Self> {
         let mut validator = Validator::new_with_features(WasmFeatures {
             component_model: true,
-            ..Default::default()
+            ..features
         });
         let mut externs = Vec::new();
         let mut depth = 1;
@@ -235,7 +239,11 @@ impl DecodedWasm {
 /// WIT-package-encoded-as-binary or an actual component itself. A [`Resolve`]
 /// is always created and the return value indicates which was detected.
 pub fn decode(bytes: &[u8]) -> Result<DecodedWasm> {
-    let info = ComponentInfo::new(bytes)?;
+    decode_with_features(bytes, WasmFeatures::default())
+}
+
+pub fn decode_with_features(bytes: &[u8], features: WasmFeatures) -> Result<DecodedWasm> {
+    let info = ComponentInfo::new_with_features(bytes, features)?;
 
     if info.is_wit_package() {
         log::debug!("decoding a WIT package encoded as wasm");

--- a/crates/wit-component/src/lib.rs
+++ b/crates/wit-component/src/lib.rs
@@ -15,7 +15,7 @@ mod printing;
 mod targets;
 mod validation;
 
-pub use decoding::{decode, DecodedWasm};
+pub use decoding::{decode, decode_with_features, DecodedWasm};
 pub use encoding::{encode, ComponentEncoder};
 pub use linking::Linker;
 pub use printing::*;

--- a/crates/wit-component/src/lib.rs
+++ b/crates/wit-component/src/lib.rs
@@ -15,7 +15,7 @@ mod printing;
 mod targets;
 mod validation;
 
-pub use decoding::{decode, decode_with_features, DecodedWasm};
+pub use decoding::{decode, DecodedWasm};
 pub use encoding::{encode, ComponentEncoder};
 pub use linking::Linker;
 pub use printing::*;


### PR DESCRIPTION
Added the ability to add features when decoding Wasm with wit-component
This is something I needed to get the WASM Analyzer working with arbitrary Wasm files as some Wasm files had features enabled that wasn't supported with the default features used in wit-component.