### PR TITLE
Rename i31.new to ref.i31

### DIFF
--- a/crates/wasm-encoder/src/core/code.rs
+++ b/crates/wasm-encoder/src/core/code.rs
@@ -523,7 +523,7 @@ pub enum Instruction<'a> {
     RefAsNonNull,
 
     // GC types instructions.
-    I31New,
+    RefI31,
     I31GetS,
     I31GetU,
 
@@ -1321,7 +1321,7 @@ impl Encode for Instruction<'_> {
             Instruction::RefAsNonNull => sink.push(0xD3),
 
             // GC instructions.
-            Instruction::I31New => {
+            Instruction::RefI31 => {
                 sink.push(0xfb);
                 sink.push(0x20)
             }

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -1001,7 +1001,7 @@ impl<'a> BinaryReader<'a> {
     {
         let code = self.read_var_u32()?;
         Ok(match code {
-            0x20 => visitor.visit_i31_new(),
+            0x20 => visitor.visit_ref_i31(),
             0x21 => visitor.visit_i31_get_s(),
             0x22 => visitor.visit_i31_get_u(),
 

--- a/crates/wasmparser/src/lib.rs
+++ b/crates/wasmparser/src/lib.rs
@@ -316,7 +316,7 @@ macro_rules! for_each_operator {
             // 0xFB prefixed operators
             // Garbage Collection
             // http://github.com/WebAssembly/gc
-            @gc I31New => visit_i31_new
+            @gc RefI31 => visit_ref_i31
             @gc I31GetS => visit_i31_get_s
             @gc I31GetU => visit_i31_get_u
 

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -3338,7 +3338,7 @@ where
         self.pop_operand(Some(ValType::I32))?;
         Ok(())
     }
-    fn visit_i31_new(&mut self) -> Self::Output {
+    fn visit_ref_i31(&mut self) -> Self::Output {
         self.pop_operand(Some(ValType::I32))?;
         self.push_operand(ValType::Ref(RefType::I31))
     }

--- a/crates/wasmprinter/src/operator.rs
+++ b/crates/wasmprinter/src/operator.rs
@@ -861,7 +861,7 @@ macro_rules! define_visit {
     (name I16x8RelaxedQ15mulrS) => ("i16x8.relaxed_q15mulr_s");
     (name I16x8RelaxedDotI8x16I7x16S) => ("i16x8.relaxed_dot_i8x16_i7x16_s");
     (name I32x4RelaxedDotI8x16I7x16AddS) => ("i32x4.relaxed_dot_i8x16_i7x16_add_s");
-    (name I31New) => ("i31.new");
+    (name RefI31) => ("ref.i31");
     (name I31GetS) => ("i31.get_s");
     (name I31GetU) => ("i31.get_u");
 }

--- a/crates/wast/src/core/expr.rs
+++ b/crates/wast/src/core/expr.rs
@@ -614,7 +614,7 @@ instructions! {
         ArrayInitElem(ArrayInit<'a>) : [0xfb, 0x55] : "array.init_elem",
 
         // gc proposal, i31
-        I31New : [0xfb, 0x20] : "i31.new",
+        RefI31 : [0xfb, 0x20] : "ref.i31",
         I31GetS : [0xfb, 0x21] : "i31.get_s",
         I31GetU : [0xfb, 0x22] : "i31.get_u",
 

--- a/tests/local/gc/gc-i31.wat
+++ b/tests/local/gc/gc-i31.wat
@@ -6,8 +6,8 @@
     (local $b (ref null i31))
     (local $c i31ref)
 
-    (local.set $a (i31.new (i32.const 42)))
-    (local.set $b (i31.new (i32.const 0)))
+    (local.set $a (ref.i31 (i32.const 42)))
+    (local.set $b (ref.i31 (i32.const 0)))
     (i31.get_u (local.get $a))
     (i31.get_s (local.get $b))
   )

--- a/tests/snapshots/local/gc/gc-i31.wat.print
+++ b/tests/snapshots/local/gc/gc-i31.wat.print
@@ -3,10 +3,10 @@
   (func $f (;0;) (type 0) (result i32 i32)
     (local $a (ref i31)) (local $b i31ref) (local $c i31ref)
     i32.const 42
-    i31.new
+    ref.i31
     local.set $a
     i32.const 0
-    i31.new
+    ref.i31
     local.set $b
     local.get $a
     i31.get_u


### PR DESCRIPTION
The i31.new instruction has been renamed to ref.i31. ([PR](https://github.com/WebAssembly/gc/pull/422), [commit](https://github.com/WebAssembly/gc/commit/5d2313b3467ff9e11095f703164a0431bf3828fd))