### PR TITLE
Switch GC binary enconding

### DIFF
--- a/crates/wasm-encoder/src/core/code.rs
+++ b/crates/wasm-encoder/src/core/code.rs
@@ -1323,15 +1323,15 @@ impl Encode for Instruction<'_> {
             // GC instructions.
             Instruction::RefI31 => {
                 sink.push(0xfb);
-                sink.push(0x20)
+                sink.push(0x1c)
             }
             Instruction::I31GetS => {
                 sink.push(0xfb);
-                sink.push(0x21)
+                sink.push(0x1d)
             }
             Instruction::I31GetU => {
                 sink.push(0xfb);
-                sink.push(0x22)
+                sink.push(0x1e)
             }
 
             // Bulk memory instructions.

--- a/crates/wasm-encoder/src/core/code.rs
+++ b/crates/wasm-encoder/src/core/code.rs
@@ -917,7 +917,7 @@ impl Encode for Instruction<'_> {
                 l.encode(sink);
             }
             Instruction::BrOnNull(l) => {
-                sink.push(0xD4);
+                sink.push(0xD5);
                 l.encode(sink);
             }
             Instruction::BrOnNonNull(l) => {
@@ -1318,7 +1318,7 @@ impl Encode for Instruction<'_> {
                 sink.push(0xd2);
                 f.encode(sink);
             }
-            Instruction::RefAsNonNull => sink.push(0xD3),
+            Instruction::RefAsNonNull => sink.push(0xd4),
 
             // GC instructions.
             Instruction::RefI31 => {

--- a/crates/wasm-encoder/src/core/types.rs
+++ b/crates/wasm-encoder/src/core/types.rs
@@ -124,8 +124,8 @@ impl ValType {
 impl Encode for StorageType {
     fn encode(&self, sink: &mut Vec<u8>) {
         match self {
-            StorageType::I8 => sink.push(0x7A),
-            StorageType::I16 => sink.push(0x79),
+            StorageType::I8 => sink.push(0x78),
+            StorageType::I16 => sink.push(0x77),
             StorageType::Val(vt) => vt.encode(sink),
         }
     }
@@ -183,9 +183,9 @@ impl Encode for RefType {
         }
 
         if self.nullable {
-            sink.push(0x6C);
+            sink.push(0x63);
         } else {
-            sink.push(0x6B);
+            sink.push(0x64);
         }
         self.heap_type.encode(sink);
     }
@@ -231,13 +231,13 @@ impl Encode for HeapType {
             HeapType::Func => sink.push(0x70),
             HeapType::Extern => sink.push(0x6F),
             HeapType::Any => sink.push(0x6E),
-            HeapType::None => sink.push(0x65),
-            HeapType::NoExtern => sink.push(0x69),
-            HeapType::NoFunc => sink.push(0x68),
+            HeapType::None => sink.push(0x71),
+            HeapType::NoExtern => sink.push(0x72),
+            HeapType::NoFunc => sink.push(0x73),
             HeapType::Eq => sink.push(0x6D),
-            HeapType::Struct => sink.push(0x67),
-            HeapType::Array => sink.push(0x66),
-            HeapType::I31 => sink.push(0x6A),
+            HeapType::Struct => sink.push(0x6B),
+            HeapType::Array => sink.push(0x6A),
+            HeapType::I31 => sink.push(0x6C),
             // Note that this is encoded as a signed type rather than unsigned
             // as it's decoded as an s33
             HeapType::Indexed(i) => i64::from(*i).encode(sink),

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -978,8 +978,8 @@ impl<'a> BinaryReader<'a> {
             0xd0 => visitor.visit_ref_null(self.read()?),
             0xd1 => visitor.visit_ref_is_null(),
             0xd2 => visitor.visit_ref_func(self.read_var_u32()?),
-            0xd3 => visitor.visit_ref_as_non_null(),
-            0xd4 => visitor.visit_br_on_null(self.read_var_u32()?),
+            0xd4 => visitor.visit_ref_as_non_null(),
+            0xd5 => visitor.visit_br_on_null(self.read_var_u32()?),
             0xd6 => visitor.visit_br_on_non_null(self.read_var_u32()?),
 
             0xfb => self.visit_0xfb_operator(pos, visitor)?,

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -1001,9 +1001,9 @@ impl<'a> BinaryReader<'a> {
     {
         let code = self.read_var_u32()?;
         Ok(match code {
-            0x20 => visitor.visit_ref_i31(),
-            0x21 => visitor.visit_i31_get_s(),
-            0x22 => visitor.visit_i31_get_u(),
+            0x1c => visitor.visit_ref_i31(),
+            0x1d => visitor.visit_i31_get_s(),
+            0x1e => visitor.visit_i31_get_u(),
 
             _ => bail!(pos, "unknown 0xfb subopcode: 0x{code:x}"),
         })

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -99,8 +99,8 @@ impl ValType {
 
     pub(crate) fn is_valtype_byte(byte: u8) -> bool {
         match byte {
-            0x7F | 0x7E | 0x7D | 0x7C | 0x7B | 0x70 | 0x6F | 0x6B | 0x6C | 0x6E | 0x65 | 0x69
-            | 0x68 | 0x6D | 0x67 | 0x66 | 0x6A => true,
+            0x7F | 0x7E | 0x7D | 0x7C | 0x7B | 0x70 | 0x6F | 0x64 | 0x63 | 0x6E | 0x71 | 0x72
+            | 0x73 | 0x6D | 0x6B | 0x6A | 0x6C => true,
             _ => false,
         }
     }
@@ -132,11 +132,11 @@ impl Inherits for ValType {
 impl<'a> FromReader<'a> for StorageType {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
         match reader.peek()? {
-            0x7A => {
+            0x78 => {
                 reader.position += 1;
                 Ok(StorageType::I8)
             }
-            0x79 => {
+            0x77 => {
                 reader.position += 1;
                 Ok(StorageType::I16)
             }
@@ -168,7 +168,7 @@ impl<'a> FromReader<'a> for ValType {
                 reader.position += 1;
                 Ok(ValType::V128)
             }
-            0x70 | 0x6F | 0x6B | 0x6C | 0x6E | 0x65 | 0x69 | 0x68 | 0x6D | 0x67 | 0x66 | 0x6A => {
+            0x70 | 0x6F | 0x64 | 0x63 | 0x6E | 0x71 | 0x72 | 0x73 | 0x6D | 0x6B | 0x6A | 0x6C => {
                 Ok(ValType::Ref(reader.read()?))
             }
             _ => bail!(reader.original_position(), "invalid value type"),
@@ -578,15 +578,15 @@ impl<'a> FromReader<'a> for RefType {
             0x70 => Ok(RefType::FUNC.nullable()),
             0x6F => Ok(RefType::EXTERN.nullable()),
             0x6E => Ok(RefType::ANY.nullable()),
-            0x65 => Ok(RefType::NONE.nullable()),
-            0x69 => Ok(RefType::NOEXTERN.nullable()),
-            0x68 => Ok(RefType::NOFUNC.nullable()),
+            0x71 => Ok(RefType::NONE.nullable()),
+            0x72 => Ok(RefType::NOEXTERN.nullable()),
+            0x73 => Ok(RefType::NOFUNC.nullable()),
             0x6D => Ok(RefType::EQ.nullable()),
-            0x67 => Ok(RefType::STRUCT.nullable()),
-            0x66 => Ok(RefType::ARRAY.nullable()),
-            0x6A => Ok(RefType::I31.nullable()),
-            byte @ (0x6B | 0x6C) => {
-                let nullable = byte == 0x6C;
+            0x6B => Ok(RefType::STRUCT.nullable()),
+            0x6A => Ok(RefType::ARRAY.nullable()),
+            0x6C => Ok(RefType::I31.nullable()),
+            byte @ (0x63 | 0x64) => {
+                let nullable = byte == 0x63;
                 let pos = reader.original_position();
                 RefType::new(nullable, reader.read()?)
                     .ok_or_else(|| crate::BinaryReaderError::new("type index too large", pos))
@@ -754,15 +754,15 @@ impl<'a> FromReader<'a> for HeapType {
                 reader.position += 1;
                 Ok(HeapType::Any)
             }
-            0x65 => {
+            0x71 => {
                 reader.position += 1;
                 Ok(HeapType::None)
             }
-            0x69 => {
+            0x72 => {
                 reader.position += 1;
                 Ok(HeapType::NoExtern)
             }
-            0x68 => {
+            0x73 => {
                 reader.position += 1;
                 Ok(HeapType::NoFunc)
             }
@@ -770,15 +770,15 @@ impl<'a> FromReader<'a> for HeapType {
                 reader.position += 1;
                 Ok(HeapType::Eq)
             }
-            0x67 => {
+            0x6B => {
                 reader.position += 1;
                 Ok(HeapType::Struct)
             }
-            0x66 => {
+            0x6A => {
                 reader.position += 1;
                 Ok(HeapType::Array)
             }
-            0x6A => {
+            0x6C => {
                 reader.position += 1;
                 Ok(HeapType::I31)
             }

--- a/crates/wast/src/core/binary.rs
+++ b/crates/wast/src/core/binary.rs
@@ -1181,9 +1181,9 @@ impl Encode for RefTest<'_> {
     fn encode(&self, e: &mut Vec<u8>) {
         e.push(0xfb);
         if self.r#type.nullable {
-            e.push(0x48);
+            e.push(0x15);
         } else {
-            e.push(0x40);
+            e.push(0x14);
         }
         self.r#type.heap.encode(e);
     }
@@ -1193,9 +1193,9 @@ impl Encode for RefCast<'_> {
     fn encode(&self, e: &mut Vec<u8>) {
         e.push(0xfb);
         if self.r#type.nullable {
-            e.push(0x49);
+            e.push(0x17);
         } else {
-            e.push(0x41);
+            e.push(0x16);
         }
         self.r#type.heap.encode(e);
     }
@@ -1215,7 +1215,7 @@ fn br_on_cast_flags(from_nullable: bool, to_nullable: bool) -> u8 {
 impl Encode for BrOnCast<'_> {
     fn encode(&self, e: &mut Vec<u8>) {
         e.push(0xfb);
-        e.push(0x4e);
+        e.push(0x18);
         e.push(br_on_cast_flags(
             self.from_type.nullable,
             self.to_type.nullable,
@@ -1229,7 +1229,7 @@ impl Encode for BrOnCast<'_> {
 impl Encode for BrOnCastFail<'_> {
     fn encode(&self, e: &mut Vec<u8>) {
         e.push(0xfb);
-        e.push(0x4f);
+        e.push(0x19);
         e.push(br_on_cast_flags(
             self.from_type.nullable,
             self.to_type.nullable,

--- a/crates/wast/src/core/binary.rs
+++ b/crates/wast/src/core/binary.rs
@@ -248,12 +248,12 @@ impl<'a> Encode for HeapType<'a> {
             HeapType::Extern => e.push(0x6f),
             HeapType::Any => e.push(0x6e),
             HeapType::Eq => e.push(0x6d),
-            HeapType::Struct => e.push(0x67),
-            HeapType::Array => e.push(0x66),
-            HeapType::I31 => e.push(0x6a),
-            HeapType::NoFunc => e.push(0x68),
-            HeapType::NoExtern => e.push(0x69),
-            HeapType::None => e.push(0x65),
+            HeapType::Struct => e.push(0x6b),
+            HeapType::Array => e.push(0x6a),
+            HeapType::I31 => e.push(0x6c),
+            HeapType::NoFunc => e.push(0x73),
+            HeapType::NoExtern => e.push(0x72),
+            HeapType::None => e.push(0x71),
             // Note that this is encoded as a signed leb128 so be sure to cast
             // to an i64 first
             HeapType::Index(Index::Num(n, _)) => i64::from(*n).encode(e),
@@ -286,34 +286,34 @@ impl<'a> Encode for RefType<'a> {
             RefType {
                 nullable: true,
                 heap: HeapType::Struct,
-            } => e.push(0x67),
+            } => e.push(0x6b),
             // The 'i31ref' binary abbreviation
             RefType {
                 nullable: true,
                 heap: HeapType::I31,
-            } => e.push(0x6a),
+            } => e.push(0x6c),
             // The 'nullfuncref' binary abbreviation
             RefType {
                 nullable: true,
                 heap: HeapType::NoFunc,
-            } => e.push(0x68),
+            } => e.push(0x73),
             // The 'nullexternref' binary abbreviation
             RefType {
                 nullable: true,
                 heap: HeapType::NoExtern,
-            } => e.push(0x69),
+            } => e.push(0x72),
             // The 'nullref' binary abbreviation
             RefType {
                 nullable: true,
                 heap: HeapType::None,
-            } => e.push(0x65),
+            } => e.push(0x71),
 
             // Generic 'ref null <heaptype>' encoding
             RefType {
                 nullable: true,
                 heap,
             } => {
-                e.push(0x6c);
+                e.push(0x63);
                 heap.encode(e);
             }
             // Generic 'ref <heaptype>' encoding
@@ -321,7 +321,7 @@ impl<'a> Encode for RefType<'a> {
                 nullable: false,
                 heap,
             } => {
-                e.push(0x6b);
+                e.push(0x64);
                 heap.encode(e);
             }
         }
@@ -331,8 +331,8 @@ impl<'a> Encode for RefType<'a> {
 impl<'a> Encode for StorageType<'a> {
     fn encode(&self, e: &mut Vec<u8>) {
         match self {
-            StorageType::I8 => e.push(0x7a),
-            StorageType::I16 => e.push(0x79),
+            StorageType::I8 => e.push(0x78),
+            StorageType::I16 => e.push(0x77),
             StorageType::Val(ty) => {
                 ty.encode(e);
             }

--- a/crates/wast/src/core/expr.rs
+++ b/crates/wast/src/core/expr.rs
@@ -590,33 +590,33 @@ instructions! {
         RefEq : [0xd3] : "ref.eq",
 
         // gc proposal: struct
-        StructNew(Index<'a>) : [0xfb, 0x07] : "struct.new",
-        StructNewDefault(Index<'a>) : [0xfb, 0x08] : "struct.new_default",
-        StructGet(StructAccess<'a>) : [0xfb, 0x03] : "struct.get",
-        StructGetS(StructAccess<'a>) : [0xfb, 0x04] : "struct.get_s",
-        StructGetU(StructAccess<'a>) : [0xfb, 0x05] : "struct.get_u",
-        StructSet(StructAccess<'a>) : [0xfb, 0x06] : "struct.set",
+        StructNew(Index<'a>) : [0xfb, 0x00] : "struct.new",
+        StructNewDefault(Index<'a>) : [0xfb, 0x01] : "struct.new_default",
+        StructGet(StructAccess<'a>) : [0xfb, 0x02] : "struct.get",
+        StructGetS(StructAccess<'a>) : [0xfb, 0x03] : "struct.get_s",
+        StructGetU(StructAccess<'a>) : [0xfb, 0x04] : "struct.get_u",
+        StructSet(StructAccess<'a>) : [0xfb, 0x05] : "struct.set",
 
         // gc proposal: array
-        ArrayNew(Index<'a>) : [0xfb, 0x1b] : "array.new",
-        ArrayNewDefault(Index<'a>) : [0xfb, 0x1c] : "array.new_default",
-        ArrayNewFixed(ArrayNewFixed<'a>) : [0xfb, 0x1a] : "array.new_fixed",
-        ArrayNewData(ArrayNewData<'a>) : [0xfb, 0x1d] : "array.new_data",
-        ArrayNewElem(ArrayNewElem<'a>) : [0xfb, 0x1f] : "array.new_elem",
-        ArrayGet(Index<'a>) : [0xfb, 0x13] : "array.get",
-        ArrayGetS(Index<'a>) : [0xfb, 0x14] : "array.get_s",
-        ArrayGetU(Index<'a>) : [0xfb, 0x15] : "array.get_u",
-        ArraySet(Index<'a>) : [0xfb, 0x16] : "array.set",
-        ArrayLen : [0xfb, 0x19] : "array.len",
-        ArrayFill(ArrayFill<'a>) : [0xfb, 0x0f] : "array.fill",
-        ArrayCopy(ArrayCopy<'a>) : [0xfb, 0x18] : "array.copy",
-        ArrayInitData(ArrayInit<'a>) : [0xfb, 0x54] : "array.init_data",
-        ArrayInitElem(ArrayInit<'a>) : [0xfb, 0x55] : "array.init_elem",
+        ArrayNew(Index<'a>) : [0xfb, 0x06] : "array.new",
+        ArrayNewDefault(Index<'a>) : [0xfb, 0x07] : "array.new_default",
+        ArrayNewFixed(ArrayNewFixed<'a>) : [0xfb, 0x08] : "array.new_fixed",
+        ArrayNewData(ArrayNewData<'a>) : [0xfb, 0x09] : "array.new_data",
+        ArrayNewElem(ArrayNewElem<'a>) : [0xfb, 0x0a] : "array.new_elem",
+        ArrayGet(Index<'a>) : [0xfb, 0x0b] : "array.get",
+        ArrayGetS(Index<'a>) : [0xfb, 0x0c] : "array.get_s",
+        ArrayGetU(Index<'a>) : [0xfb, 0x0d] : "array.get_u",
+        ArraySet(Index<'a>) : [0xfb, 0x0e] : "array.set",
+        ArrayLen : [0xfb, 0x0f] : "array.len",
+        ArrayFill(ArrayFill<'a>) : [0xfb, 0x10] : "array.fill",
+        ArrayCopy(ArrayCopy<'a>) : [0xfb, 0x11] : "array.copy",
+        ArrayInitData(ArrayInit<'a>) : [0xfb, 0x12] : "array.init_data",
+        ArrayInitElem(ArrayInit<'a>) : [0xfb, 0x13] : "array.init_elem",
 
         // gc proposal, i31
-        RefI31 : [0xfb, 0x20] : "ref.i31",
-        I31GetS : [0xfb, 0x21] : "i31.get_s",
-        I31GetU : [0xfb, 0x22] : "i31.get_u",
+        RefI31 : [0xfb, 0x1c] : "ref.i31",
+        I31GetS : [0xfb, 0x1d] : "i31.get_s",
+        I31GetU : [0xfb, 0x1e] : "i31.get_u",
 
         // gc proposal, concrete casting
         RefTest(RefTest<'a>) : [] : "ref.test",
@@ -625,8 +625,8 @@ instructions! {
         BrOnCastFail(Box<BrOnCastFail<'a>>) : [] : "br_on_cast_fail",
 
         // gc proposal extern/any coercion operations
-        ExternInternalize : [0xfb, 0x70] : "extern.internalize",
-        ExternExternalize : [0xfb, 0x71] : "extern.externalize",
+        ExternInternalize : [0xfb, 0x1a] : "extern.internalize",
+        ExternExternalize : [0xfb, 0x1b] : "extern.externalize",
 
         I32Const(i32) : [0x41] : "i32.const",
         I64Const(i64) : [0x42] : "i64.const",

--- a/crates/wast/src/core/expr.rs
+++ b/crates/wast/src/core/expr.rs
@@ -582,12 +582,12 @@ instructions! {
         RefFunc(Index<'a>) : [0xd2] : "ref.func",
 
         // function-references proposal
-        RefAsNonNull : [0xd3] : "ref.as_non_null",
-        BrOnNull(Index<'a>) : [0xd4] : "br_on_null",
+        RefAsNonNull : [0xd4] : "ref.as_non_null",
+        BrOnNull(Index<'a>) : [0xd5] : "br_on_null",
         BrOnNonNull(Index<'a>) : [0xd6] : "br_on_non_null",
 
         // gc proposal: eqref
-        RefEq : [0xd5] : "ref.eq",
+        RefEq : [0xd3] : "ref.eq",
 
         // gc proposal: struct
         StructNew(Index<'a>) : [0xfb, 0x07] : "struct.new",

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -741,7 +741,7 @@ fn error_matches(error: &str, message: &str) -> bool {
 
     if message == "illegal opcode" {
         // The test suite includes "bad opcodes" that later became valid opcodes
-        // (0xd3, function references proposal). However, they are still not
+        // (0xd4, function references proposal). However, they are still not
         // constant expressions, so we can sidestep by checking for that error
         // instead
         return error.contains("constant expression required")


### PR DESCRIPTION
Following the https://github.com/WebAssembly/gc/pull/372 lead.

## Quick summary of changes

... that I used to created this PR

### Types

nullref: 0x65->0x71
arrayref: 0x66->0x6a
structref: 0x67->0x6b
nullfuncref: 0x68->0x73
nullexternref: 0x69->0x72
i31ref: 0x6a->0x6c
ref $t: 0x6b->0x64
ref null $t: 0x6c->0x63
i16: 0x79->0x77
i8: 0x7a->0x78

### Instructions

ref.as_non_null: 0xd3->0xd4
br_on_null: 0xd4->0xd5
ref.eq: 0xd5->0xd3

struct.get: 0xfb03->0xfb02
struct.get_s: 0xfb04->0xfb03
struct.get_u: 0xfb05->0xfb04
struct.set: 0xfb06->0xfb05
struct.new: 0xfb07->0xfb00
struct.new_default: 0xfb08->0xfb01
array.fill: 0xfb0f->0xfb10
array.get: 0xfb13->0xfb0b
array.get_s: 0xfb14->0xfb0c
array.get_u: 0xfb15->0xfb0d
array.set: 0xfb16->0xfb0e
array.copy: 0xfb18->0xfb11
array.len: 0xfb19->0xfb0f
array.new_fixed: 0xfb1a->0xfb08
array.new: 0xfb1b->0xfb06
array.new_default: 0xfb1c->0xfb07
array.new_data: 0xfb1d->0xfb09
array.new_elem: 0xfb1f->0xfb0a
i31.new: 0xfb20->0xfb1c
i31.get_s: 0xfb21->0xfb1d
i31.get_u: 0xfb22->0xfb1e
ref.test: 0xfb40->0xfb14
ref.cast: 0xfb41->0xfb16
ref.test null: 0xfb48->0xfb15
ref.cast null: 0xfb49->0xfb17
br_on_cast: 0xfb4e->0xfb18
br_on_cast_fail: 0xfb4f->0xfb19
array.init_data: 0xfb54->0xfb12
array.init_elem: 0xfb55->0xfb13
extern.internalize: 0xfb70->0xfb1a
extern.externalize: 0xfb71->0xfb1b

Rest of the encoding was not affected.

I'm working on https://bugzilla.mozilla.org/show_bug.cgi?id=1845374 to verify these changes against it.

