### PR TITLE
Serialize TypeOwner::None to JSON null

### DIFF
--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -19,7 +19,8 @@ mod live;
 pub use live::LiveTypes;
 mod serde_;
 use serde_::{
-    serialize_anon_result, serialize_id, serialize_id_map, serialize_none, serialize_optional_id, serialize_params,
+    serialize_anon_result, serialize_id, serialize_id_map, serialize_none, serialize_optional_id,
+    serialize_params,
 };
 
 /// Checks if the given string is a legal identifier in wit.

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -19,7 +19,7 @@ mod live;
 pub use live::LiveTypes;
 mod serde_;
 use serde_::{
-    serialize_anon_result, serialize_id, serialize_id_map, serialize_optional_id, serialize_params,
+    serialize_anon_result, serialize_id, serialize_id_map, serialize_none, serialize_optional_id, serialize_params,
 };
 
 /// Checks if the given string is a legal identifier in wit.
@@ -427,6 +427,7 @@ pub enum TypeOwner {
     Interface(InterfaceId),
     /// This type wasn't inherently defined anywhere, such as a `list<T>`, which
     /// doesn't need an owner.
+    #[serde(untagged, serialize_with = "serialize_none")]
     None,
 }
 

--- a/crates/wit-parser/src/serde_.rs
+++ b/crates/wit-parser/src/serde_.rs
@@ -4,6 +4,13 @@ use indexmap::IndexMap;
 use serde::ser::{SerializeMap, SerializeSeq, Serializer};
 use serde::Serialize;
 
+pub fn serialize_none<S>(serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_none()
+}
+
 pub fn serialize_arena<T, S>(arena: &Arena<T>, serializer: S) -> Result<S::Ok, S::Error>
 where
     T: Serialize,

--- a/crates/wit-parser/tests/ui/functions.wit.json
+++ b/crates/wit-parser/tests/ui/functions.wit.json
@@ -134,14 +134,14 @@
           ]
         }
       },
-      "owner": "none"
+      "owner": null
     },
     {
       "name": null,
       "kind": {
         "option": "u32"
       },
-      "owner": "none"
+      "owner": null
     },
     {
       "name": null,
@@ -151,7 +151,7 @@
           "err": "float32"
         }
       },
-      "owner": "none"
+      "owner": null
     }
   ],
   "packages": [

--- a/crates/wit-parser/tests/ui/random.wit.json
+++ b/crates/wit-parser/tests/ui/random.wit.json
@@ -49,7 +49,7 @@
       "kind": {
         "list": "u8"
       },
-      "owner": "none"
+      "owner": null
     }
   ],
   "packages": [

--- a/crates/wit-parser/tests/ui/resources-empty.wit.json
+++ b/crates/wit-parser/tests/ui/resources-empty.wit.json
@@ -48,7 +48,7 @@
           "borrow": 0
         }
       },
-      "owner": "none"
+      "owner": null
     },
     {
       "name": null,
@@ -57,7 +57,7 @@
           "own": 0
         }
       },
-      "owner": "none"
+      "owner": null
     }
   ],
   "packages": [

--- a/crates/wit-parser/tests/ui/resources-multiple-returns-borrow.wit.json
+++ b/crates/wit-parser/tests/ui/resources-multiple-returns-borrow.wit.json
@@ -59,7 +59,7 @@
           "borrow": 0
         }
       },
-      "owner": "none"
+      "owner": null
     }
   ],
   "packages": [

--- a/crates/wit-parser/tests/ui/resources-multiple-returns-own.wit.json
+++ b/crates/wit-parser/tests/ui/resources-multiple-returns-own.wit.json
@@ -59,7 +59,7 @@
           "borrow": 0
         }
       },
-      "owner": "none"
+      "owner": null
     },
     {
       "name": null,
@@ -68,7 +68,7 @@
           "own": 0
         }
       },
-      "owner": "none"
+      "owner": null
     }
   ],
   "packages": [

--- a/crates/wit-parser/tests/ui/resources-multiple.wit.json
+++ b/crates/wit-parser/tests/ui/resources-multiple.wit.json
@@ -228,7 +228,7 @@
           "borrow": 0
         }
       },
-      "owner": "none"
+      "owner": null
     },
     {
       "name": null,
@@ -240,14 +240,14 @@
           ]
         }
       },
-      "owner": "none"
+      "owner": null
     },
     {
       "name": null,
       "kind": {
         "option": "u32"
       },
-      "owner": "none"
+      "owner": null
     },
     {
       "name": null,
@@ -257,7 +257,7 @@
           "err": "float32"
         }
       },
-      "owner": "none"
+      "owner": null
     },
     {
       "name": null,
@@ -266,7 +266,7 @@
           "own": 0
         }
       },
-      "owner": "none"
+      "owner": null
     }
   ],
   "packages": [

--- a/crates/wit-parser/tests/ui/resources-return-borrow.wit.json
+++ b/crates/wit-parser/tests/ui/resources-return-borrow.wit.json
@@ -54,7 +54,7 @@
           "borrow": 0
         }
       },
-      "owner": "none"
+      "owner": null
     }
   ],
   "packages": [

--- a/crates/wit-parser/tests/ui/resources-return-own.wit.json
+++ b/crates/wit-parser/tests/ui/resources-return-own.wit.json
@@ -54,7 +54,7 @@
           "borrow": 0
         }
       },
-      "owner": "none"
+      "owner": null
     },
     {
       "name": null,
@@ -63,7 +63,7 @@
           "own": 0
         }
       },
-      "owner": "none"
+      "owner": null
     }
   ],
   "packages": [

--- a/crates/wit-parser/tests/ui/resources.wit.json
+++ b/crates/wit-parser/tests/ui/resources.wit.json
@@ -209,7 +209,7 @@
           "borrow": 3
         }
       },
-      "owner": "none"
+      "owner": null
     },
     {
       "name": null,
@@ -218,7 +218,7 @@
           "borrow": 4
         }
       },
-      "owner": "none"
+      "owner": null
     },
     {
       "name": "a",
@@ -286,7 +286,7 @@
           "own": 1
         }
       },
-      "owner": "none"
+      "owner": null
     },
     {
       "name": null,
@@ -295,7 +295,7 @@
           "own": 2
         }
       },
-      "owner": "none"
+      "owner": null
     },
     {
       "name": null,
@@ -304,7 +304,7 @@
           "own": 3
         }
       },
-      "owner": "none"
+      "owner": null
     },
     {
       "name": null,
@@ -313,7 +313,7 @@
           "own": 4
         }
       },
-      "owner": "none"
+      "owner": null
     },
     {
       "name": null,
@@ -322,7 +322,7 @@
           "own": 13
         }
       },
-      "owner": "none"
+      "owner": null
     }
   ],
   "packages": [

--- a/crates/wit-parser/tests/ui/resources1.wit.json
+++ b/crates/wit-parser/tests/ui/resources1.wit.json
@@ -72,7 +72,7 @@
           "borrow": 0
         }
       },
-      "owner": "none"
+      "owner": null
     },
     {
       "name": null,
@@ -81,7 +81,7 @@
           "own": 0
         }
       },
-      "owner": "none"
+      "owner": null
     }
   ],
   "packages": [

--- a/crates/wit-parser/tests/ui/shared-types.wit.json
+++ b/crates/wit-parser/tests/ui/shared-types.wit.json
@@ -57,7 +57,7 @@
       "kind": {
         "list": "u8"
       },
-      "owner": "none"
+      "owner": null
     },
     {
       "name": null,
@@ -68,7 +68,7 @@
           ]
         }
       },
-      "owner": "none"
+      "owner": null
     }
   ],
   "packages": [

--- a/crates/wit-parser/tests/ui/types.wit.json
+++ b/crates/wit-parser/tests/ui/types.wit.json
@@ -531,7 +531,7 @@
       "kind": {
         "option": "u32"
       },
-      "owner": "none"
+      "owner": null
     },
     {
       "name": "t37",
@@ -618,14 +618,14 @@
       "kind": {
         "list": 31
       },
-      "owner": "none"
+      "owner": null
     },
     {
       "name": null,
       "kind": {
         "list": 42
       },
-      "owner": "none"
+      "owner": null
     },
     {
       "name": "t45",

--- a/crates/wit-parser/tests/ui/world-top-level-funcs.wit.json
+++ b/crates/wit-parser/tests/ui/world-top-level-funcs.wit.json
@@ -57,21 +57,21 @@
       "kind": {
         "list": "u32"
       },
-      "owner": "none"
+      "owner": null
     },
     {
       "name": null,
       "kind": {
         "option": "u32"
       },
-      "owner": "none"
+      "owner": null
     },
     {
       "name": null,
       "kind": {
         "list": 1
       },
-      "owner": "none"
+      "owner": null
     }
   ],
   "packages": [

--- a/crates/wit-parser/tests/ui/world-top-level-resources.wit.json
+++ b/crates/wit-parser/tests/ui/world-top-level-resources.wit.json
@@ -152,14 +152,14 @@
           "borrow": 0
         }
       },
-      "owner": "none"
+      "owner": null
     },
     {
       "name": null,
       "kind": {
         "list": "u32"
       },
-      "owner": "none"
+      "owner": null
     },
     {
       "name": null,
@@ -168,7 +168,7 @@
           "borrow": 1
         }
       },
-      "owner": "none"
+      "owner": null
     },
     {
       "name": "request",
@@ -195,7 +195,7 @@
           "borrow": 5
         }
       },
-      "owner": "none"
+      "owner": null
     },
     {
       "name": null,
@@ -204,7 +204,7 @@
           "borrow": 6
         }
       },
-      "owner": "none"
+      "owner": null
     },
     {
       "name": null,
@@ -213,7 +213,7 @@
           "own": 5
         }
       },
-      "owner": "none"
+      "owner": null
     },
     {
       "name": null,
@@ -222,7 +222,7 @@
           "own": 6
         }
       },
-      "owner": "none"
+      "owner": null
     }
   ],
   "packages": [


### PR DESCRIPTION
This is a minor update to the JSON serialization introduced in #1203. It modifies the output so the `TypeOwner` value of `None` in Rust serializes to `null` in JSON.

### Before

```json
    {
      "kind": {
        "type": "u32"
      },
      "name": "example",
      "owner": "none"
    }
```

### After

```json
    {
      "kind": {
        "type": "u32"
      },
      "name": "example",
      "owner": null
    }
```