### PR TITLE
wit-parser: reorder fields for readability

### DIFF
--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -62,9 +62,6 @@ pub struct UnresolvedPackage {
     /// The namespace, name, and version information for this package.
     pub name: PackageName,
 
-    /// Doc comments for this package.
-    pub docs: Docs,
-
     /// All worlds from all documents within this package.
     ///
     /// Each world lists the document that it is from.
@@ -95,6 +92,9 @@ pub struct UnresolvedPackage {
     /// fields of `self.interfaces` describes the required types that are from
     /// each foreign interface.
     pub foreign_deps: IndexMap<PackageName, IndexMap<String, AstItem>>,
+
+    /// Doc comments for this package.
+    pub docs: Docs,
 
     unknown_type_spans: Vec<Span>,
     world_item_spans: Vec<(Vec<Span>, Vec<Span>)>,
@@ -251,10 +251,6 @@ pub struct World {
     /// The WIT identifier name of this world.
     pub name: String,
 
-    /// Documentation associated with this world declaration.
-    #[serde(skip_serializing_if = "Docs::is_empty")]
-    pub docs: Docs,
-
     /// All imported items into this interface, both worlds and functions.
     pub imports: IndexMap<WorldKey, WorldItem>,
 
@@ -264,6 +260,10 @@ pub struct World {
     /// The package that owns this world.
     #[serde(serialize_with = "serialize_optional_id")]
     pub package: Option<PackageId>,
+
+    /// Documentation associated with this world declaration.
+    #[serde(skip_serializing_if = "Docs::is_empty")]
+    pub docs: Docs,
 
     /// All the included worlds from this world. Empty if this is fully resolved
     #[serde(skip)]
@@ -339,10 +339,6 @@ pub struct Interface {
     /// This is `None` for inline interfaces in worlds.
     pub name: Option<String>,
 
-    /// Documentation associated with this interface.
-    #[serde(skip_serializing_if = "Docs::is_empty")]
-    pub docs: Docs,
-
     /// Exported types from this interface.
     ///
     /// Export names are listed within the types themselves. Note that the
@@ -353,6 +349,10 @@ pub struct Interface {
     /// Exported functions from this interface.
     pub functions: IndexMap<String, Function>,
 
+    /// Documentation associated with this interface.
+    #[serde(skip_serializing_if = "Docs::is_empty")]
+    pub docs: Docs,
+
     /// The package that owns this interface.
     #[serde(serialize_with = "serialize_optional_id")]
     pub package: Option<PackageId>,
@@ -360,11 +360,11 @@ pub struct Interface {
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct TypeDef {
+    pub name: Option<String>,
+    pub kind: TypeDefKind,
+    pub owner: TypeOwner,
     #[serde(skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
-    pub kind: TypeDefKind,
-    pub name: Option<String>,
-    pub owner: TypeOwner,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -472,11 +472,11 @@ pub struct Record {
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Field {
-    #[serde(skip_serializing_if = "Docs::is_empty")]
-    pub docs: Docs,
     pub name: String,
     #[serde(rename = "type")]
     pub ty: Type,
+    #[serde(skip_serializing_if = "Docs::is_empty")]
+    pub docs: Docs,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -486,9 +486,9 @@ pub struct Flags {
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Flag {
+    pub name: String,
     #[serde(skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
-    pub name: String,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -531,11 +531,11 @@ pub struct Variant {
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Case {
-    #[serde(skip_serializing_if = "Docs::is_empty")]
-    pub docs: Docs,
     pub name: String,
     #[serde(rename = "type")]
     pub ty: Option<Type>,
+    #[serde(skip_serializing_if = "Docs::is_empty")]
+    pub docs: Docs,
 }
 
 impl Variant {
@@ -556,9 +556,9 @@ pub struct Enum {
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct EnumCase {
+    pub name: String,
     #[serde(skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
-    pub name: String,
 }
 
 impl Enum {
@@ -667,13 +667,13 @@ impl Results {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct Function {
-    #[serde(skip_serializing_if = "Docs::is_empty")]
-    pub docs: Docs,
     pub name: String,
     pub kind: FunctionKind,
     #[serde(serialize_with = "serialize_params")]
     pub params: Params,
     pub results: Results,
+    #[serde(skip_serializing_if = "Docs::is_empty")]
+    pub docs: Docs,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]

--- a/crates/wit-parser/tests/all.rs
+++ b/crates/wit-parser/tests/all.rs
@@ -161,7 +161,7 @@ impl Runner<'_> {
                 "failed to read test expectation file {:?}\nthis can be fixed with BLESS=1",
                 result_file
             ))?;
-            let expected = normalize(&expected, extension);
+            let result = normalize(&result, extension);
             if expected != result {
                 bail!(
                     "failed test: result is not as expected:{}",

--- a/crates/wit-parser/tests/all.rs
+++ b/crates/wit-parser/tests/all.rs
@@ -161,6 +161,7 @@ impl Runner<'_> {
                 "failed to read test expectation file {:?}\nthis can be fixed with BLESS=1",
                 result_file
             ))?;
+            let expected = normalize(&expected, extension);
             let result = normalize(&result, extension);
             if expected != result {
                 bail!(

--- a/crates/wit-parser/tests/all.rs
+++ b/crates/wit-parser/tests/all.rs
@@ -160,7 +160,6 @@ impl Runner<'_> {
                 "failed to read test expectation file {:?}\nthis can be fixed with BLESS=1",
                 result_file
             ))?;
-            let expected = normalize(&expected);
             if expected != result {
                 bail!(
                     "failed test: result is not as expected:{}",

--- a/crates/wit-parser/tests/all.rs
+++ b/crates/wit-parser/tests/all.rs
@@ -154,12 +154,14 @@ impl Runner<'_> {
             test.with_extension(format!("wit.{extension}"))
         };
         if env::var_os("BLESS").is_some() {
-            fs::write(&result_file, result)?;
+            let normalized = normalize(&result);
+            fs::write(&result_file, normalized)?;
         } else {
             let expected = fs::read_to_string(&result_file).context(format!(
                 "failed to read test expectation file {:?}\nthis can be fixed with BLESS=1",
                 result_file
             ))?;
+            let expected = normalize(&expected);
             if expected != result {
                 bail!(
                     "failed test: result is not as expected:{}",
@@ -177,5 +179,5 @@ impl Runner<'_> {
 }
 
 fn normalize(s: &str) -> String {
-    s.replace('\\', "/").replace("\r\n", "\n")
+    s.replace("\r\n", "\n")
 }

--- a/crates/wit-parser/tests/ui/comments.wit.json
+++ b/crates/wit-parser/tests/ui/comments.wit.json
@@ -13,22 +13,22 @@
   ],
   "types": [
     {
+      "name": "x",
       "kind": {
         "type": "u32"
       },
-      "name": "x",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "bar",
       "kind": {
         "stream": {
           "element": 0,
           "end": null
         }
       },
-      "name": "bar",
       "owner": {
         "interface": 0
       }

--- a/crates/wit-parser/tests/ui/cross-package-resource.wit.json
+++ b/crates/wit-parser/tests/ui/cross-package-resource.wit.json
@@ -21,28 +21,28 @@
   ],
   "types": [
     {
-      "kind": "resource",
       "name": "r",
+      "kind": "resource",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "r",
       "kind": {
         "type": 0
       },
-      "name": "r",
       "owner": {
         "interface": 1
       }
     },
     {
+      "name": "t",
       "kind": {
         "handle": {
           "own": 1
         }
       },
-      "name": "t",
       "owner": {
         "interface": 1
       }

--- a/crates/wit-parser/tests/ui/disambiguate-diamond.wit.json
+++ b/crates/wit-parser/tests/ui/disambiguate-diamond.wit.json
@@ -56,37 +56,37 @@
   ],
   "types": [
     {
+      "name": "the-type",
       "kind": {
         "type": "u32"
       },
-      "name": "the-type",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "the-type",
       "kind": {
         "type": "u32"
       },
-      "name": "the-type",
       "owner": {
         "interface": 1
       }
     },
     {
+      "name": "the-type",
       "kind": {
         "type": 0
       },
-      "name": "the-type",
       "owner": {
         "interface": 2
       }
     },
     {
+      "name": "the-type",
       "kind": {
         "type": 1
       },
-      "name": "the-type",
       "owner": {
         "interface": 3
       }

--- a/crates/wit-parser/tests/ui/foreign-deps-union.wit.json
+++ b/crates/wit-parser/tests/ui/foreign-deps-union.wit.json
@@ -189,51 +189,52 @@
   ],
   "types": [
     {
+      "name": "some-type",
       "kind": {
         "type": "u32"
       },
-      "name": "some-type",
       "owner": {
         "interface": 3
       }
     },
     {
+      "name": "from-default",
       "kind": {
         "type": "string"
       },
-      "name": "from-default",
       "owner": {
         "interface": 4
       }
     },
     {
+      "name": "another-type",
       "kind": {
         "type": "u32"
       },
-      "name": "another-type",
       "owner": {
         "interface": 5
       }
     },
     {
+      "name": "yet-another-type",
       "kind": {
         "type": "u8"
       },
-      "name": "yet-another-type",
       "owner": {
         "interface": 6
       }
     },
     {
+      "name": "timestamp",
       "kind": {
         "type": "u64"
       },
-      "name": "timestamp",
       "owner": {
         "interface": 7
       }
     },
     {
+      "name": "stat",
       "kind": {
         "record": {
           "fields": [
@@ -244,70 +245,69 @@
           ]
         }
       },
-      "name": "stat",
       "owner": {
         "interface": 8
       }
     },
     {
+      "name": "timestamp",
       "kind": {
         "type": 4
       },
-      "name": "timestamp",
       "owner": {
         "interface": 9
       }
     },
     {
+      "name": "stat",
       "kind": {
         "type": 5
       },
-      "name": "stat",
       "owner": {
         "interface": 9
       }
     },
     {
+      "name": "from-default",
       "kind": {
         "type": 1
       },
-      "name": "from-default",
       "owner": {
         "interface": 10
       }
     },
     {
+      "name": "another-type",
       "kind": {
         "type": 2
       },
-      "name": "another-type",
       "owner": {
         "interface": 10
       }
     },
     {
+      "name": "yet-another-type",
       "kind": {
         "type": 3
       },
-      "name": "yet-another-type",
       "owner": {
         "interface": 10
       }
     },
     {
+      "name": "some-type",
       "kind": {
         "type": 0
       },
-      "name": "some-type",
       "owner": {
         "interface": 11
       }
     },
     {
+      "name": "some-type",
       "kind": {
         "type": 0
       },
-      "name": "some-type",
       "owner": {
         "interface": 12
       }

--- a/crates/wit-parser/tests/ui/foreign-deps.wit.json
+++ b/crates/wit-parser/tests/ui/foreign-deps.wit.json
@@ -156,51 +156,52 @@
   ],
   "types": [
     {
+      "name": "some-type",
       "kind": {
         "type": "u32"
       },
-      "name": "some-type",
       "owner": {
         "interface": 3
       }
     },
     {
+      "name": "from-default",
       "kind": {
         "type": "string"
       },
-      "name": "from-default",
       "owner": {
         "interface": 4
       }
     },
     {
+      "name": "another-type",
       "kind": {
         "type": "u32"
       },
-      "name": "another-type",
       "owner": {
         "interface": 5
       }
     },
     {
+      "name": "yet-another-type",
       "kind": {
         "type": "u8"
       },
-      "name": "yet-another-type",
       "owner": {
         "interface": 6
       }
     },
     {
+      "name": "timestamp",
       "kind": {
         "type": "u64"
       },
-      "name": "timestamp",
       "owner": {
         "interface": 7
       }
     },
     {
+      "name": "stat",
       "kind": {
         "record": {
           "fields": [
@@ -211,70 +212,69 @@
           ]
         }
       },
-      "name": "stat",
       "owner": {
         "interface": 8
       }
     },
     {
+      "name": "timestamp",
       "kind": {
         "type": 4
       },
-      "name": "timestamp",
       "owner": {
         "interface": 9
       }
     },
     {
+      "name": "stat",
       "kind": {
         "type": 5
       },
-      "name": "stat",
       "owner": {
         "interface": 9
       }
     },
     {
+      "name": "from-default",
       "kind": {
         "type": 1
       },
-      "name": "from-default",
       "owner": {
         "interface": 10
       }
     },
     {
+      "name": "another-type",
       "kind": {
         "type": 2
       },
-      "name": "another-type",
       "owner": {
         "interface": 10
       }
     },
     {
+      "name": "yet-another-type",
       "kind": {
         "type": 3
       },
-      "name": "yet-another-type",
       "owner": {
         "interface": 10
       }
     },
     {
+      "name": "some-type",
       "kind": {
         "type": 0
       },
-      "name": "some-type",
       "owner": {
         "interface": 11
       }
     },
     {
+      "name": "some-type",
       "kind": {
         "type": 0
       },
-      "name": "some-type",
       "owner": {
         "interface": 12
       }

--- a/crates/wit-parser/tests/ui/functions.wit.json
+++ b/crates/wit-parser/tests/ui/functions.wit.json
@@ -125,6 +125,7 @@
   ],
   "types": [
     {
+      "name": null,
       "kind": {
         "tuple": {
           "types": [
@@ -133,24 +134,23 @@
           ]
         }
       },
-      "name": null,
       "owner": "none"
     },
     {
+      "name": null,
       "kind": {
         "option": "u32"
       },
-      "name": null,
       "owner": "none"
     },
     {
+      "name": null,
       "kind": {
         "result": {
           "ok": "u32",
           "err": "float32"
         }
       },
-      "name": null,
       "owner": "none"
     }
   ],

--- a/crates/wit-parser/tests/ui/multi-file.wit.json
+++ b/crates/wit-parser/tests/ui/multi-file.wit.json
@@ -128,147 +128,147 @@
   ],
   "types": [
     {
+      "name": "a-name",
       "kind": {
         "record": {
           "fields": []
         }
       },
-      "name": "a-name",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "x",
       "kind": {
         "type": "u32"
       },
-      "name": "x",
       "owner": {
         "interface": 1
       }
     },
     {
+      "name": "x",
       "kind": {
         "type": 1
       },
-      "name": "x",
       "owner": {
         "interface": 2
       }
     },
     {
+      "name": "t",
       "kind": {
         "type": "u32"
       },
-      "name": "t",
       "owner": {
         "interface": 4
       }
     },
     {
+      "name": "t",
       "kind": {
         "type": 3
       },
-      "name": "t",
       "owner": {
         "interface": 5
       }
     },
     {
+      "name": "t",
       "kind": {
         "type": 4
       },
-      "name": "t",
       "owner": {
         "interface": 6
       }
     },
     {
+      "name": "x",
       "kind": {
         "type": "u32"
       },
-      "name": "x",
       "owner": {
         "interface": 7
       }
     },
     {
+      "name": "y",
       "kind": {
         "type": "u64"
       },
-      "name": "y",
       "owner": {
         "interface": 8
       }
     },
     {
-      "kind": {
-        "type": 6
-      },
       "name": "x",
+      "kind": {
+        "type": 6
+      },
       "owner": {
         "interface": 9
       }
     },
     {
-      "kind": {
-        "type": 6
-      },
       "name": "x2",
-      "owner": {
-        "interface": 9
-      }
-    },
-    {
       "kind": {
         "type": 6
       },
-      "name": "x3",
       "owner": {
         "interface": 9
       }
     },
     {
+      "name": "x3",
+      "kind": {
+        "type": 6
+      },
+      "owner": {
+        "interface": 9
+      }
+    },
+    {
+      "name": "x4",
       "kind": {
         "type": 1
       },
-      "name": "x4",
       "owner": {
         "interface": 9
       }
     },
     {
-      "kind": {
-        "type": 7
-      },
       "name": "y",
-      "owner": {
-        "interface": 9
-      }
-    },
-    {
       "kind": {
         "type": 7
       },
-      "name": "y2",
       "owner": {
         "interface": 9
       }
     },
     {
+      "name": "y2",
+      "kind": {
+        "type": 7
+      },
+      "owner": {
+        "interface": 9
+      }
+    },
+    {
+      "name": "a-name",
       "kind": {
         "type": 0
       },
-      "name": "a-name",
       "owner": {
         "interface": 9
       }
     },
     {
+      "name": "x",
       "kind": {
         "type": 1
       },
-      "name": "x",
       "owner": {
         "world": 1
       }

--- a/crates/wit-parser/tests/ui/name-both-resource-and-type.wit.json
+++ b/crates/wit-parser/tests/ui/name-both-resource-and-type.wit.json
@@ -23,48 +23,48 @@
   ],
   "types": [
     {
-      "kind": "resource",
       "name": "a",
+      "kind": "resource",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "a",
       "kind": {
         "type": 0
       },
-      "name": "a",
       "owner": {
         "interface": 1
       }
     },
     {
+      "name": "t1",
       "kind": {
         "type": 1
       },
-      "name": "t1",
       "owner": {
         "interface": 1
       }
     },
     {
+      "name": "t2",
       "kind": {
         "handle": {
           "borrow": 1
         }
       },
-      "name": "t2",
       "owner": {
         "interface": 1
       }
     },
     {
+      "name": "t3",
       "kind": {
         "handle": {
           "borrow": 2
         }
       },
-      "name": "t3",
       "owner": {
         "interface": 1
       }

--- a/crates/wit-parser/tests/ui/random.wit
+++ b/crates/wit-parser/tests/ui/random.wit
@@ -1,0 +1,27 @@
+package wasi:random
+
+/// WASI Random is a random data API.
+///
+/// It is intended to be portable at least between Unix-family platforms and
+/// Windows.
+interface random {
+    /// Return `len` cryptographically-secure random or pseudo-random bytes.
+    ///
+    /// This function must produce data at least as cryptographically secure and
+    /// fast as an adequately seeded cryptographically-secure pseudo-random
+    /// number generator (CSPRNG). It must not block, from the perspective of
+    /// the calling program, under any circumstances, including on the first
+    /// request and on requests for numbers of bytes. The returned data must
+    /// always be unpredictable.
+    ///
+    /// This function must always return fresh data. Deterministic environments
+    /// must omit this function, rather than implementing it with deterministic
+    /// data.
+    get-random-bytes: func(len: u64) -> list<u8>
+
+    /// Return a cryptographically-secure random or pseudo-random `u64` value.
+    ///
+    /// This function returns the same type of data as `get-random-bytes`,
+    /// represented as a `u64`.
+    get-random-u64: func() -> u64
+}

--- a/crates/wit-parser/tests/ui/random.wit.json
+++ b/crates/wit-parser/tests/ui/random.wit.json
@@ -1,0 +1,64 @@
+{
+  "worlds": [],
+  "interfaces": [
+    {
+      "name": "random",
+      "types": {},
+      "functions": {
+        "get-random-bytes": {
+          "name": "get-random-bytes",
+          "kind": "freestanding",
+          "params": [
+            {
+              "name": "len",
+              "type": "u64"
+            }
+          ],
+          "results": [
+            {
+              "type": 0
+            }
+          ],
+          "docs": {
+            "contents": "Return `len` cryptographically-secure random or pseudo-random bytes.\n\nThis function must produce data at least as cryptographically secure and\nfast as an adequately seeded cryptographically-secure pseudo-random\nnumber generator (CSPRNG). It must not block, from the perspective of\nthe calling program, under any circumstances, including on the first\nrequest and on requests for numbers of bytes. The returned data must\nalways be unpredictable.\n\nThis function must always return fresh data. Deterministic environments\nmust omit this function, rather than implementing it with deterministic\ndata."
+          }
+        },
+        "get-random-u64": {
+          "name": "get-random-u64",
+          "kind": "freestanding",
+          "params": [],
+          "results": [
+            {
+              "type": "u64"
+            }
+          ],
+          "docs": {
+            "contents": "Return a cryptographically-secure random or pseudo-random `u64` value.\n\nThis function returns the same type of data as `get-random-bytes`,\nrepresented as a `u64`."
+          }
+        }
+      },
+      "docs": {
+        "contents": "WASI Random is a random data API.\n\nIt is intended to be portable at least between Unix-family platforms and\nWindows."
+      },
+      "package": 0
+    }
+  ],
+  "types": [
+    {
+      "name": null,
+      "kind": {
+        "list": "u8"
+      },
+      "owner": "none"
+    }
+  ],
+  "packages": [
+    {
+      "name": "wasi:random",
+      "interfaces": {
+        "random": 0
+      },
+      "worlds": {}
+    }
+  ]
+}

--- a/crates/wit-parser/tests/ui/resources-empty.wit.json
+++ b/crates/wit-parser/tests/ui/resources-empty.wit.json
@@ -35,28 +35,28 @@
   ],
   "types": [
     {
-      "kind": "resource",
       "name": "r1",
+      "kind": "resource",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": null,
       "kind": {
         "handle": {
           "borrow": 0
         }
       },
-      "name": null,
       "owner": "none"
     },
     {
+      "name": null,
       "kind": {
         "handle": {
           "own": 0
         }
       },
-      "name": null,
       "owner": "none"
     }
   ],

--- a/crates/wit-parser/tests/ui/resources-multiple-returns-borrow.wit.json
+++ b/crates/wit-parser/tests/ui/resources-multiple-returns-borrow.wit.json
@@ -46,19 +46,19 @@
   ],
   "types": [
     {
-      "kind": "resource",
       "name": "r1",
+      "kind": "resource",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": null,
       "kind": {
         "handle": {
           "borrow": 0
         }
       },
-      "name": null,
       "owner": "none"
     }
   ],

--- a/crates/wit-parser/tests/ui/resources-multiple-returns-own.wit.json
+++ b/crates/wit-parser/tests/ui/resources-multiple-returns-own.wit.json
@@ -46,28 +46,28 @@
   ],
   "types": [
     {
-      "kind": "resource",
       "name": "r1",
+      "kind": "resource",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": null,
       "kind": {
         "handle": {
           "borrow": 0
         }
       },
-      "name": null,
       "owner": "none"
     },
     {
+      "name": null,
       "kind": {
         "handle": {
           "own": 0
         }
       },
-      "name": null,
       "owner": "none"
     }
   ],

--- a/crates/wit-parser/tests/ui/resources-multiple.wit.json
+++ b/crates/wit-parser/tests/ui/resources-multiple.wit.json
@@ -215,22 +215,23 @@
   ],
   "types": [
     {
-      "kind": "resource",
       "name": "r1",
+      "kind": "resource",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": null,
       "kind": {
         "handle": {
           "borrow": 0
         }
       },
-      "name": null,
       "owner": "none"
     },
     {
+      "name": null,
       "kind": {
         "tuple": {
           "types": [
@@ -239,33 +240,32 @@
           ]
         }
       },
-      "name": null,
       "owner": "none"
     },
     {
+      "name": null,
       "kind": {
         "option": "u32"
       },
-      "name": null,
       "owner": "none"
     },
     {
+      "name": null,
       "kind": {
         "result": {
           "ok": "u32",
           "err": "float32"
         }
       },
-      "name": null,
       "owner": "none"
     },
     {
+      "name": null,
       "kind": {
         "handle": {
           "own": 0
         }
       },
-      "name": null,
       "owner": "none"
     }
   ],

--- a/crates/wit-parser/tests/ui/resources-return-borrow.wit.json
+++ b/crates/wit-parser/tests/ui/resources-return-borrow.wit.json
@@ -41,19 +41,19 @@
   ],
   "types": [
     {
-      "kind": "resource",
       "name": "r1",
+      "kind": "resource",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": null,
       "kind": {
         "handle": {
           "borrow": 0
         }
       },
-      "name": null,
       "owner": "none"
     }
   ],

--- a/crates/wit-parser/tests/ui/resources-return-own.wit.json
+++ b/crates/wit-parser/tests/ui/resources-return-own.wit.json
@@ -41,28 +41,28 @@
   ],
   "types": [
     {
-      "kind": "resource",
       "name": "r1",
+      "kind": "resource",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": null,
       "kind": {
         "handle": {
           "borrow": 0
         }
       },
-      "name": null,
       "owner": "none"
     },
     {
+      "name": null,
       "kind": {
         "handle": {
           "own": 0
         }
       },
-      "name": null,
       "owner": "none"
     }
   ],

--- a/crates/wit-parser/tests/ui/resources.wit.json
+++ b/crates/wit-parser/tests/ui/resources.wit.json
@@ -168,160 +168,160 @@
   ],
   "types": [
     {
-      "kind": "resource",
       "name": "a",
+      "kind": "resource",
       "owner": {
         "interface": 0
       }
     },
     {
-      "kind": "resource",
       "name": "b",
+      "kind": "resource",
       "owner": {
         "interface": 0
       }
     },
     {
-      "kind": "resource",
       "name": "c",
+      "kind": "resource",
       "owner": {
         "interface": 0
       }
     },
     {
-      "kind": "resource",
       "name": "d",
-      "owner": {
-        "interface": 0
-      }
-    },
-    {
       "kind": "resource",
-      "name": "e",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "e",
+      "kind": "resource",
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
+      "name": null,
       "kind": {
         "handle": {
           "borrow": 3
         }
       },
-      "name": null,
       "owner": "none"
     },
     {
+      "name": null,
       "kind": {
         "handle": {
           "borrow": 4
         }
       },
-      "name": null,
       "owner": "none"
     },
     {
-      "kind": "resource",
       "name": "a",
+      "kind": "resource",
       "owner": {
         "interface": 1
       }
     },
     {
+      "name": "t1",
       "kind": {
         "type": 7
       },
-      "name": "t1",
       "owner": {
         "interface": 1
       }
     },
     {
+      "name": "t2",
       "kind": {
         "handle": {
           "borrow": 7
         }
       },
-      "name": "t2",
       "owner": {
         "interface": 1
       }
     },
     {
+      "name": "t3",
       "kind": {
         "handle": {
           "borrow": 8
         }
       },
-      "name": "t3",
       "owner": {
         "interface": 1
       }
     },
     {
-      "kind": "resource",
       "name": "a",
+      "kind": "resource",
       "owner": {
         "world": 0
       }
     },
     {
-      "kind": "resource",
       "name": "b",
-      "owner": {
-        "world": 0
-      }
-    },
-    {
       "kind": "resource",
-      "name": "c",
       "owner": {
         "world": 0
       }
     },
     {
+      "name": "c",
+      "kind": "resource",
+      "owner": {
+        "world": 0
+      }
+    },
+    {
+      "name": null,
       "kind": {
         "handle": {
           "own": 1
         }
       },
-      "name": null,
       "owner": "none"
     },
     {
+      "name": null,
       "kind": {
         "handle": {
           "own": 2
         }
       },
-      "name": null,
       "owner": "none"
     },
     {
+      "name": null,
       "kind": {
         "handle": {
           "own": 3
         }
       },
-      "name": null,
       "owner": "none"
     },
     {
+      "name": null,
       "kind": {
         "handle": {
           "own": 4
         }
       },
-      "name": null,
       "owner": "none"
     },
     {
+      "name": null,
       "kind": {
         "handle": {
           "own": 13
         }
       },
-      "name": null,
       "owner": "none"
     }
   ],

--- a/crates/wit-parser/tests/ui/resources1.wit.json
+++ b/crates/wit-parser/tests/ui/resources1.wit.json
@@ -59,28 +59,28 @@
   ],
   "types": [
     {
-      "kind": "resource",
       "name": "r1",
+      "kind": "resource",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": null,
       "kind": {
         "handle": {
           "borrow": 0
         }
       },
-      "name": null,
       "owner": "none"
     },
     {
+      "name": null,
       "kind": {
         "handle": {
           "own": 0
         }
       },
-      "name": null,
       "owner": "none"
     }
   ],

--- a/crates/wit-parser/tests/ui/shared-types.wit.json
+++ b/crates/wit-parser/tests/ui/shared-types.wit.json
@@ -53,13 +53,14 @@
   ],
   "types": [
     {
+      "name": null,
       "kind": {
         "list": "u8"
       },
-      "name": null,
       "owner": "none"
     },
     {
+      "name": null,
       "kind": {
         "tuple": {
           "types": [
@@ -67,7 +68,6 @@
           ]
         }
       },
-      "name": null,
       "owner": "none"
     }
   ],

--- a/crates/wit-parser/tests/ui/stress-export-elaborate.wit.json
+++ b/crates/wit-parser/tests/ui/stress-export-elaborate.wit.json
@@ -213,901 +213,901 @@
   ],
   "types": [
     {
-      "kind": {
-        "type": "u32"
-      },
       "name": "t1",
+      "kind": {
+        "type": "u32"
+      },
       "owner": {
         "interface": 0
       }
     },
     {
-      "kind": {
-        "type": "u32"
-      },
       "name": "t2",
+      "kind": {
+        "type": "u32"
+      },
       "owner": {
         "interface": 0
       }
     },
     {
-      "kind": {
-        "type": "u32"
-      },
       "name": "t3",
+      "kind": {
+        "type": "u32"
+      },
       "owner": {
         "interface": 0
       }
     },
     {
-      "kind": {
-        "type": "u32"
-      },
       "name": "t4",
+      "kind": {
+        "type": "u32"
+      },
       "owner": {
         "interface": 0
       }
     },
     {
-      "kind": {
-        "type": "u32"
-      },
       "name": "t5",
+      "kind": {
+        "type": "u32"
+      },
       "owner": {
         "interface": 0
       }
     },
     {
-      "kind": {
-        "type": "u32"
-      },
       "name": "t6",
+      "kind": {
+        "type": "u32"
+      },
       "owner": {
         "interface": 0
       }
     },
     {
-      "kind": {
-        "type": "u32"
-      },
       "name": "t7",
+      "kind": {
+        "type": "u32"
+      },
       "owner": {
         "interface": 0
       }
     },
     {
-      "kind": {
-        "type": "u32"
-      },
       "name": "t8",
+      "kind": {
+        "type": "u32"
+      },
       "owner": {
         "interface": 0
       }
     },
     {
-      "kind": {
-        "type": "u32"
-      },
       "name": "t9",
-      "owner": {
-        "interface": 0
-      }
-    },
-    {
       "kind": {
         "type": "u32"
       },
-      "name": "t10",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t10",
+      "kind": {
+        "type": "u32"
+      },
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
+      "name": "t1",
       "kind": {
         "type": 0
       },
-      "name": "t1",
       "owner": {
         "interface": 1
       }
     },
     {
+      "name": "t2",
       "kind": {
         "type": 1
       },
-      "name": "t2",
       "owner": {
         "interface": 1
       }
     },
     {
+      "name": "t3",
       "kind": {
         "type": 2
       },
-      "name": "t3",
       "owner": {
         "interface": 1
       }
     },
     {
+      "name": "t4",
       "kind": {
         "type": 3
       },
-      "name": "t4",
       "owner": {
         "interface": 1
       }
     },
     {
+      "name": "t5",
       "kind": {
         "type": 4
       },
-      "name": "t5",
       "owner": {
         "interface": 1
       }
     },
     {
+      "name": "t6",
       "kind": {
         "type": 5
       },
-      "name": "t6",
       "owner": {
         "interface": 1
       }
     },
     {
+      "name": "t7",
       "kind": {
         "type": 6
       },
-      "name": "t7",
       "owner": {
         "interface": 1
       }
     },
     {
+      "name": "t8",
       "kind": {
         "type": 7
       },
-      "name": "t8",
       "owner": {
         "interface": 1
       }
     },
     {
+      "name": "t9",
       "kind": {
         "type": 8
       },
-      "name": "t9",
       "owner": {
         "interface": 1
       }
     },
     {
+      "name": "t10",
       "kind": {
         "type": 9
       },
-      "name": "t10",
       "owner": {
         "interface": 1
       }
     },
     {
+      "name": "t1",
       "kind": {
         "type": 10
       },
-      "name": "t1",
       "owner": {
         "interface": 2
       }
     },
     {
+      "name": "t2",
       "kind": {
         "type": 11
       },
-      "name": "t2",
       "owner": {
         "interface": 2
       }
     },
     {
+      "name": "t3",
       "kind": {
         "type": 12
       },
-      "name": "t3",
       "owner": {
         "interface": 2
       }
     },
     {
+      "name": "t4",
       "kind": {
         "type": 13
       },
-      "name": "t4",
       "owner": {
         "interface": 2
       }
     },
     {
+      "name": "t5",
       "kind": {
         "type": 14
       },
-      "name": "t5",
       "owner": {
         "interface": 2
       }
     },
     {
+      "name": "t6",
       "kind": {
         "type": 15
       },
-      "name": "t6",
       "owner": {
         "interface": 2
       }
     },
     {
+      "name": "t7",
       "kind": {
         "type": 16
       },
-      "name": "t7",
       "owner": {
         "interface": 2
       }
     },
     {
+      "name": "t8",
       "kind": {
         "type": 17
       },
-      "name": "t8",
       "owner": {
         "interface": 2
       }
     },
     {
+      "name": "t9",
       "kind": {
         "type": 18
       },
-      "name": "t9",
       "owner": {
         "interface": 2
       }
     },
     {
+      "name": "t10",
       "kind": {
         "type": 19
       },
-      "name": "t10",
       "owner": {
         "interface": 2
       }
     },
     {
+      "name": "t1",
       "kind": {
         "type": 20
       },
-      "name": "t1",
       "owner": {
         "interface": 3
       }
     },
     {
+      "name": "t2",
       "kind": {
         "type": 21
       },
-      "name": "t2",
       "owner": {
         "interface": 3
       }
     },
     {
+      "name": "t3",
       "kind": {
         "type": 22
       },
-      "name": "t3",
       "owner": {
         "interface": 3
       }
     },
     {
+      "name": "t4",
       "kind": {
         "type": 23
       },
-      "name": "t4",
       "owner": {
         "interface": 3
       }
     },
     {
+      "name": "t5",
       "kind": {
         "type": 24
       },
-      "name": "t5",
       "owner": {
         "interface": 3
       }
     },
     {
+      "name": "t6",
       "kind": {
         "type": 25
       },
-      "name": "t6",
       "owner": {
         "interface": 3
       }
     },
     {
+      "name": "t7",
       "kind": {
         "type": 26
       },
-      "name": "t7",
       "owner": {
         "interface": 3
       }
     },
     {
+      "name": "t8",
       "kind": {
         "type": 27
       },
-      "name": "t8",
       "owner": {
         "interface": 3
       }
     },
     {
+      "name": "t9",
       "kind": {
         "type": 28
       },
-      "name": "t9",
       "owner": {
         "interface": 3
       }
     },
     {
+      "name": "t10",
       "kind": {
         "type": 29
       },
-      "name": "t10",
       "owner": {
         "interface": 3
       }
     },
     {
+      "name": "t1",
       "kind": {
         "type": 30
       },
-      "name": "t1",
       "owner": {
         "interface": 4
       }
     },
     {
+      "name": "t2",
       "kind": {
         "type": 31
       },
-      "name": "t2",
       "owner": {
         "interface": 4
       }
     },
     {
+      "name": "t3",
       "kind": {
         "type": 32
       },
-      "name": "t3",
       "owner": {
         "interface": 4
       }
     },
     {
+      "name": "t4",
       "kind": {
         "type": 33
       },
-      "name": "t4",
       "owner": {
         "interface": 4
       }
     },
     {
+      "name": "t5",
       "kind": {
         "type": 34
       },
-      "name": "t5",
       "owner": {
         "interface": 4
       }
     },
     {
+      "name": "t6",
       "kind": {
         "type": 35
       },
-      "name": "t6",
       "owner": {
         "interface": 4
       }
     },
     {
+      "name": "t7",
       "kind": {
         "type": 36
       },
-      "name": "t7",
       "owner": {
         "interface": 4
       }
     },
     {
+      "name": "t8",
       "kind": {
         "type": 37
       },
-      "name": "t8",
       "owner": {
         "interface": 4
       }
     },
     {
+      "name": "t9",
       "kind": {
         "type": 38
       },
-      "name": "t9",
       "owner": {
         "interface": 4
       }
     },
     {
+      "name": "t10",
       "kind": {
         "type": 39
       },
-      "name": "t10",
       "owner": {
         "interface": 4
       }
     },
     {
+      "name": "t1",
       "kind": {
         "type": 40
       },
-      "name": "t1",
       "owner": {
         "interface": 5
       }
     },
     {
+      "name": "t2",
       "kind": {
         "type": 41
       },
-      "name": "t2",
       "owner": {
         "interface": 5
       }
     },
     {
+      "name": "t3",
       "kind": {
         "type": 42
       },
-      "name": "t3",
       "owner": {
         "interface": 5
       }
     },
     {
+      "name": "t4",
       "kind": {
         "type": 43
       },
-      "name": "t4",
       "owner": {
         "interface": 5
       }
     },
     {
+      "name": "t5",
       "kind": {
         "type": 44
       },
-      "name": "t5",
       "owner": {
         "interface": 5
       }
     },
     {
+      "name": "t6",
       "kind": {
         "type": 45
       },
-      "name": "t6",
       "owner": {
         "interface": 5
       }
     },
     {
+      "name": "t7",
       "kind": {
         "type": 46
       },
-      "name": "t7",
       "owner": {
         "interface": 5
       }
     },
     {
+      "name": "t8",
       "kind": {
         "type": 47
       },
-      "name": "t8",
       "owner": {
         "interface": 5
       }
     },
     {
+      "name": "t9",
       "kind": {
         "type": 48
       },
-      "name": "t9",
       "owner": {
         "interface": 5
       }
     },
     {
+      "name": "t10",
       "kind": {
         "type": 49
       },
-      "name": "t10",
       "owner": {
         "interface": 5
       }
     },
     {
+      "name": "t1",
       "kind": {
         "type": 50
       },
-      "name": "t1",
       "owner": {
         "interface": 6
       }
     },
     {
+      "name": "t2",
       "kind": {
         "type": 51
       },
-      "name": "t2",
       "owner": {
         "interface": 6
       }
     },
     {
+      "name": "t3",
       "kind": {
         "type": 52
       },
-      "name": "t3",
       "owner": {
         "interface": 6
       }
     },
     {
+      "name": "t4",
       "kind": {
         "type": 53
       },
-      "name": "t4",
       "owner": {
         "interface": 6
       }
     },
     {
+      "name": "t5",
       "kind": {
         "type": 54
       },
-      "name": "t5",
       "owner": {
         "interface": 6
       }
     },
     {
+      "name": "t6",
       "kind": {
         "type": 55
       },
-      "name": "t6",
       "owner": {
         "interface": 6
       }
     },
     {
+      "name": "t7",
       "kind": {
         "type": 56
       },
-      "name": "t7",
       "owner": {
         "interface": 6
       }
     },
     {
+      "name": "t8",
       "kind": {
         "type": 57
       },
-      "name": "t8",
       "owner": {
         "interface": 6
       }
     },
     {
+      "name": "t9",
       "kind": {
         "type": 58
       },
-      "name": "t9",
       "owner": {
         "interface": 6
       }
     },
     {
+      "name": "t10",
       "kind": {
         "type": 59
       },
-      "name": "t10",
       "owner": {
         "interface": 6
       }
     },
     {
+      "name": "t1",
       "kind": {
         "type": 60
       },
-      "name": "t1",
       "owner": {
         "interface": 7
       }
     },
     {
+      "name": "t2",
       "kind": {
         "type": 61
       },
-      "name": "t2",
       "owner": {
         "interface": 7
       }
     },
     {
+      "name": "t3",
       "kind": {
         "type": 62
       },
-      "name": "t3",
       "owner": {
         "interface": 7
       }
     },
     {
+      "name": "t4",
       "kind": {
         "type": 63
       },
-      "name": "t4",
       "owner": {
         "interface": 7
       }
     },
     {
+      "name": "t5",
       "kind": {
         "type": 64
       },
-      "name": "t5",
       "owner": {
         "interface": 7
       }
     },
     {
+      "name": "t6",
       "kind": {
         "type": 65
       },
-      "name": "t6",
       "owner": {
         "interface": 7
       }
     },
     {
+      "name": "t7",
       "kind": {
         "type": 66
       },
-      "name": "t7",
       "owner": {
         "interface": 7
       }
     },
     {
+      "name": "t8",
       "kind": {
         "type": 67
       },
-      "name": "t8",
       "owner": {
         "interface": 7
       }
     },
     {
+      "name": "t9",
       "kind": {
         "type": 68
       },
-      "name": "t9",
       "owner": {
         "interface": 7
       }
     },
     {
+      "name": "t10",
       "kind": {
         "type": 69
       },
-      "name": "t10",
       "owner": {
         "interface": 7
       }
     },
     {
+      "name": "t1",
       "kind": {
         "type": 70
       },
-      "name": "t1",
       "owner": {
         "interface": 8
       }
     },
     {
+      "name": "t2",
       "kind": {
         "type": 71
       },
-      "name": "t2",
       "owner": {
         "interface": 8
       }
     },
     {
+      "name": "t3",
       "kind": {
         "type": 72
       },
-      "name": "t3",
       "owner": {
         "interface": 8
       }
     },
     {
+      "name": "t4",
       "kind": {
         "type": 73
       },
-      "name": "t4",
       "owner": {
         "interface": 8
       }
     },
     {
+      "name": "t5",
       "kind": {
         "type": 74
       },
-      "name": "t5",
       "owner": {
         "interface": 8
       }
     },
     {
+      "name": "t6",
       "kind": {
         "type": 75
       },
-      "name": "t6",
       "owner": {
         "interface": 8
       }
     },
     {
+      "name": "t7",
       "kind": {
         "type": 76
       },
-      "name": "t7",
       "owner": {
         "interface": 8
       }
     },
     {
+      "name": "t8",
       "kind": {
         "type": 77
       },
-      "name": "t8",
       "owner": {
         "interface": 8
       }
     },
     {
+      "name": "t9",
       "kind": {
         "type": 78
       },
-      "name": "t9",
       "owner": {
         "interface": 8
       }
     },
     {
+      "name": "t10",
       "kind": {
         "type": 79
       },
-      "name": "t10",
       "owner": {
         "interface": 8
       }
     },
     {
+      "name": "t1",
       "kind": {
         "type": 80
       },
-      "name": "t1",
       "owner": {
         "interface": 9
       }
     },
     {
+      "name": "t2",
       "kind": {
         "type": 81
       },
-      "name": "t2",
       "owner": {
         "interface": 9
       }
     },
     {
+      "name": "t3",
       "kind": {
         "type": 82
       },
-      "name": "t3",
       "owner": {
         "interface": 9
       }
     },
     {
+      "name": "t4",
       "kind": {
         "type": 83
       },
-      "name": "t4",
       "owner": {
         "interface": 9
       }
     },
     {
+      "name": "t5",
       "kind": {
         "type": 84
       },
-      "name": "t5",
       "owner": {
         "interface": 9
       }
     },
     {
+      "name": "t6",
       "kind": {
         "type": 85
       },
-      "name": "t6",
       "owner": {
         "interface": 9
       }
     },
     {
+      "name": "t7",
       "kind": {
         "type": 86
       },
-      "name": "t7",
       "owner": {
         "interface": 9
       }
     },
     {
+      "name": "t8",
       "kind": {
         "type": 87
       },
-      "name": "t8",
       "owner": {
         "interface": 9
       }
     },
     {
+      "name": "t9",
       "kind": {
         "type": 88
       },
-      "name": "t9",
       "owner": {
         "interface": 9
       }
     },
     {
+      "name": "t10",
       "kind": {
         "type": 89
       },
-      "name": "t10",
       "owner": {
         "interface": 9
       }

--- a/crates/wit-parser/tests/ui/types.wit.json
+++ b/crates/wit-parser/tests/ui/types.wit.json
@@ -63,207 +63,192 @@
   ],
   "types": [
     {
+      "name": "t1",
       "kind": {
         "type": "u8"
       },
-      "name": "t1",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t2",
       "kind": {
         "type": "u16"
       },
-      "name": "t2",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t3",
       "kind": {
         "type": "u32"
       },
-      "name": "t3",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t4",
       "kind": {
         "type": "u64"
       },
-      "name": "t4",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t5",
       "kind": {
         "type": "s8"
       },
-      "name": "t5",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t6",
       "kind": {
         "type": "s16"
       },
-      "name": "t6",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t7",
       "kind": {
         "type": "s32"
       },
-      "name": "t7",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t8",
       "kind": {
         "type": "s64"
       },
-      "name": "t8",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t9",
       "kind": {
         "type": "float32"
       },
-      "name": "t9",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t10",
       "kind": {
         "type": "float64"
       },
-      "name": "t10",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t11",
       "kind": {
         "type": "char"
       },
-      "name": "t11",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t12",
       "kind": {
         "list": "char"
       },
-      "name": "t12",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t13",
       "kind": {
         "type": "string"
       },
-      "name": "t13",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t14",
       "kind": {
         "option": "u32"
       },
-      "name": "t14",
       "owner": {
         "interface": 0
       }
     },
     {
-      "kind": {
-        "result": {
-          "ok": "u32",
-          "err": "u32"
-        }
-      },
       "name": "t15",
+      "kind": {
+        "result": {
+          "ok": "u32",
+          "err": "u32"
+        }
+      },
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t16",
       "kind": {
         "result": {
           "ok": null,
           "err": "u32"
         }
       },
-      "name": "t16",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t17",
       "kind": {
         "result": {
           "ok": "u32",
           "err": null
         }
       },
-      "name": "t17",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t18",
       "kind": {
         "result": {
           "ok": null,
           "err": null
         }
       },
-      "name": "t18",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t20",
       "kind": {
         "record": {
           "fields": []
         }
       },
-      "name": "t20",
       "owner": {
         "interface": 0
       }
     },
     {
-      "kind": {
-        "record": {
-          "fields": [
-            {
-              "name": "a",
-              "type": "u32"
-            }
-          ]
-        }
-      },
       "name": "t21",
-      "owner": {
-        "interface": 0
-      }
-    },
-    {
       "kind": {
         "record": {
           "fields": [
@@ -274,32 +259,28 @@
           ]
         }
       },
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
       "name": "t22",
-      "owner": {
-        "interface": 0
-      }
-    },
-    {
       "kind": {
         "record": {
           "fields": [
             {
               "name": "a",
               "type": "u32"
-            },
-            {
-              "name": "b",
-              "type": "u64"
             }
           ]
         }
       },
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
       "name": "t23",
-      "owner": {
-        "interface": 0
-      }
-    },
-    {
       "kind": {
         "record": {
           "fields": [
@@ -314,12 +295,32 @@
           ]
         }
       },
-      "name": "t24",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t24",
+      "kind": {
+        "record": {
+          "fields": [
+            {
+              "name": "a",
+              "type": "u32"
+            },
+            {
+              "name": "b",
+              "type": "u64"
+            }
+          ]
+        }
+      },
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
+      "name": "t25",
       "kind": {
         "record": {
           "fields": [
@@ -330,47 +331,34 @@
           ]
         }
       },
-      "name": "t25",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "record",
       "kind": {
         "record": {
           "fields": []
         }
       },
-      "name": "record",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t26",
       "kind": {
         "tuple": {
           "types": []
         }
       },
-      "name": "t26",
       "owner": {
         "interface": 0
       }
     },
     {
-      "kind": {
-        "tuple": {
-          "types": [
-            "u32"
-          ]
-        }
-      },
       "name": "t27",
-      "owner": {
-        "interface": 0
-      }
-    },
-    {
       "kind": {
         "tuple": {
           "types": [
@@ -378,12 +366,25 @@
           ]
         }
       },
-      "name": "t28",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t28",
+      "kind": {
+        "tuple": {
+          "types": [
+            "u32"
+          ]
+        }
+      },
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
+      "name": "t29",
       "kind": {
         "tuple": {
           "types": [
@@ -392,44 +393,23 @@
           ]
         }
       },
-      "name": "t29",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t30",
       "kind": {
         "flags": {
           "flags": []
         }
       },
-      "name": "t30",
       "owner": {
         "interface": 0
       }
     },
     {
-      "kind": {
-        "flags": {
-          "flags": [
-            {
-              "name": "a"
-            },
-            {
-              "name": "b"
-            },
-            {
-              "name": "c"
-            }
-          ]
-        }
-      },
       "name": "t31",
-      "owner": {
-        "interface": 0
-      }
-    },
-    {
       "kind": {
         "flags": {
           "flags": [
@@ -445,48 +425,49 @@
           ]
         }
       },
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
       "name": "t32",
+      "kind": {
+        "flags": {
+          "flags": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            },
+            {
+              "name": "c"
+            }
+          ]
+        }
+      },
       "owner": {
         "interface": 0
       }
     },
     {
-      "kind": {
-        "variant": {
-          "cases": [
-            {
-              "name": "a",
-              "type": null
-            }
-          ]
-        }
-      },
       "name": "t33",
-      "owner": {
-        "interface": 0
-      }
-    },
-    {
       "kind": {
         "variant": {
           "cases": [
             {
               "name": "a",
               "type": null
-            },
-            {
-              "name": "b",
-              "type": null
             }
           ]
         }
       },
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
       "name": "t34",
-      "owner": {
-        "interface": 0
-      }
-    },
-    {
       "kind": {
         "variant": {
           "cases": [
@@ -501,12 +482,32 @@
           ]
         }
       },
-      "name": "t35",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t35",
+      "kind": {
+        "variant": {
+          "cases": [
+            {
+              "name": "a",
+              "type": null
+            },
+            {
+              "name": "b",
+              "type": null
+            }
+          ]
+        }
+      },
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
+      "name": "t36",
       "kind": {
         "variant": {
           "cases": [
@@ -521,19 +522,19 @@
           ]
         }
       },
-      "name": "t36",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": null,
       "kind": {
         "option": "u32"
       },
-      "name": null,
       "owner": "none"
     },
     {
+      "name": "t37",
       "kind": {
         "variant": {
           "cases": [
@@ -548,33 +549,12 @@
           ]
         }
       },
-      "name": "t37",
       "owner": {
         "interface": 0
       }
     },
     {
-      "kind": {
-        "enum": {
-          "cases": [
-            {
-              "name": "a"
-            },
-            {
-              "name": "b"
-            },
-            {
-              "name": "c"
-            }
-          ]
-        }
-      },
       "name": "t41",
-      "owner": {
-        "interface": 0
-      }
-    },
-    {
       "kind": {
         "enum": {
           "cases": [
@@ -590,150 +570,170 @@
           ]
         }
       },
-      "name": "t42",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t42",
+      "kind": {
+        "enum": {
+          "cases": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            },
+            {
+              "name": "c"
+            }
+          ]
+        }
+      },
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
+      "name": "t43",
       "kind": {
         "type": "bool"
       },
-      "name": "t43",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t44",
       "kind": {
         "type": "string"
       },
-      "name": "t44",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": null,
       "kind": {
         "list": 31
       },
-      "name": null,
       "owner": "none"
     },
     {
+      "name": null,
       "kind": {
         "list": 42
       },
-      "name": null,
       "owner": "none"
     },
     {
+      "name": "t45",
       "kind": {
         "list": 43
       },
-      "name": "t45",
       "owner": {
         "interface": 0
       }
     },
     {
-      "kind": {
-        "type": 41
-      },
       "name": "t46",
-      "owner": {
-        "interface": 0
-      }
-    },
-    {
       "kind": {
         "type": 41
       },
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
       "name": "t47",
+      "kind": {
+        "type": 41
+      },
       "owner": {
         "interface": 0
       }
     },
     {
-      "kind": {
-        "stream": {
-          "element": "u32",
-          "end": "u32"
-        }
-      },
       "name": "t48",
+      "kind": {
+        "stream": {
+          "element": "u32",
+          "end": "u32"
+        }
+      },
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t49",
       "kind": {
         "stream": {
           "element": null,
           "end": "u32"
         }
       },
-      "name": "t49",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t50",
       "kind": {
         "stream": {
           "element": "u32",
           "end": null
         }
       },
-      "name": "t50",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t51",
       "kind": {
         "stream": {
           "element": null,
           "end": null
         }
       },
-      "name": "t51",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t52",
       "kind": {
         "future": "u32"
       },
-      "name": "t52",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t53",
       "kind": {
         "future": null
       },
-      "name": "t53",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "bar",
       "kind": {
         "type": "u32"
       },
-      "name": "bar",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "foo",
       "kind": {
         "type": 53
       },
-      "name": "foo",
       "owner": {
         "interface": 0
       }

--- a/crates/wit-parser/tests/ui/use-chain.wit.json
+++ b/crates/wit-parser/tests/ui/use-chain.wit.json
@@ -20,21 +20,21 @@
   ],
   "types": [
     {
+      "name": "foo",
       "kind": {
         "record": {
           "fields": []
         }
       },
-      "name": "foo",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "foo",
       "kind": {
         "type": 0
       },
-      "name": "foo",
       "owner": {
         "interface": 1
       }

--- a/crates/wit-parser/tests/ui/use.wit.json
+++ b/crates/wit-parser/tests/ui/use.wit.json
@@ -75,69 +75,70 @@
   ],
   "types": [
     {
+      "name": "the-type",
       "kind": {
         "type": "u32"
       },
-      "name": "the-type",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "the-type",
       "kind": {
         "type": 0
       },
-      "name": "the-type",
       "owner": {
         "interface": 1
       }
     },
     {
+      "name": "the-type",
       "kind": {
         "type": 1
       },
-      "name": "the-type",
       "owner": {
         "interface": 2
       }
     },
     {
+      "name": "test",
       "kind": {
         "type": 0
       },
-      "name": "test",
       "owner": {
         "interface": 2
       }
     },
     {
+      "name": "the-type",
       "kind": {
         "type": 2
       },
-      "name": "the-type",
       "owner": {
         "interface": 5
       }
     },
     {
+      "name": "test",
       "kind": {
         "type": 3
       },
-      "name": "test",
       "owner": {
         "interface": 5
       }
     },
     {
+      "name": "the-type",
       "kind": {
         "type": 1
       },
-      "name": "the-type",
       "owner": {
         "interface": 6
       }
     },
     {
+      "name": "the-foo",
       "kind": {
         "record": {
           "fields": [
@@ -148,7 +149,6 @@
           ]
         }
       },
-      "name": "the-foo",
       "owner": {
         "interface": 6
       }

--- a/crates/wit-parser/tests/ui/versions.wit.json
+++ b/crates/wit-parser/tests/ui/versions.wit.json
@@ -29,37 +29,37 @@
   ],
   "types": [
     {
+      "name": "t",
       "kind": {
         "type": "u32"
       },
-      "name": "t",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t",
       "kind": {
         "type": "u32"
       },
-      "name": "t",
       "owner": {
         "interface": 1
       }
     },
     {
+      "name": "t",
       "kind": {
         "type": 0
       },
-      "name": "t",
       "owner": {
         "interface": 2
       }
     },
     {
+      "name": "t2",
       "kind": {
         "type": 1
       },
-      "name": "t2",
       "owner": {
         "interface": 2
       }

--- a/crates/wit-parser/tests/ui/wasi.wit.json
+++ b/crates/wit-parser/tests/ui/wasi.wit.json
@@ -14,6 +14,7 @@
   ],
   "types": [
     {
+      "name": "clockid",
       "kind": {
         "enum": {
           "cases": [
@@ -26,21 +27,21 @@
           ]
         }
       },
-      "name": "clockid",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "timestamp",
       "kind": {
         "type": "u64"
       },
-      "name": "timestamp",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "errno",
       "kind": {
         "enum": {
           "cases": [
@@ -278,7 +279,6 @@
           ]
         }
       },
-      "name": "errno",
       "owner": {
         "interface": 0
       }

--- a/crates/wit-parser/tests/ui/world-diamond.wit.json
+++ b/crates/wit-parser/tests/ui/world-diamond.wit.json
@@ -75,28 +75,28 @@
   ],
   "types": [
     {
+      "name": "foo",
       "kind": {
         "type": "u32"
       },
-      "name": "foo",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "foo",
       "kind": {
         "type": 0
       },
-      "name": "foo",
       "owner": {
         "interface": 1
       }
     },
     {
+      "name": "foo",
       "kind": {
         "type": 0
       },
-      "name": "foo",
       "owner": {
         "interface": 2
       }

--- a/crates/wit-parser/tests/ui/world-iface-no-collide.wit.json
+++ b/crates/wit-parser/tests/ui/world-iface-no-collide.wit.json
@@ -34,19 +34,19 @@
   ],
   "types": [
     {
+      "name": "t",
       "kind": {
         "type": "u32"
       },
-      "name": "t",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "t",
       "kind": {
         "type": 0
       },
-      "name": "t",
       "owner": {
         "world": 0
       }

--- a/crates/wit-parser/tests/ui/world-implicit-import1.wit.json
+++ b/crates/wit-parser/tests/ui/world-implicit-import1.wit.json
@@ -43,19 +43,19 @@
   ],
   "types": [
     {
+      "name": "a",
       "kind": {
         "type": "u32"
       },
-      "name": "a",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "a",
       "kind": {
         "type": 0
       },
-      "name": "a",
       "owner": {
         "interface": 1
       }

--- a/crates/wit-parser/tests/ui/world-implicit-import2.wit.json
+++ b/crates/wit-parser/tests/ui/world-implicit-import2.wit.json
@@ -38,19 +38,19 @@
   ],
   "types": [
     {
+      "name": "g",
       "kind": {
         "type": "char"
       },
-      "name": "g",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "g",
       "kind": {
         "type": 0
       },
-      "name": "g",
       "owner": {
         "world": 0
       }

--- a/crates/wit-parser/tests/ui/world-implicit-import3.wit.json
+++ b/crates/wit-parser/tests/ui/world-implicit-import3.wit.json
@@ -39,19 +39,19 @@
   ],
   "types": [
     {
+      "name": "g",
       "kind": {
         "type": "char"
       },
-      "name": "g",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "g",
       "kind": {
         "type": 0
       },
-      "name": "g",
       "owner": {
         "world": 0
       }

--- a/crates/wit-parser/tests/ui/world-same-fields4.wit.json
+++ b/crates/wit-parser/tests/ui/world-same-fields4.wit.json
@@ -44,19 +44,19 @@
   ],
   "types": [
     {
+      "name": "a",
       "kind": {
         "type": "u32"
       },
-      "name": "a",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "a",
       "kind": {
         "type": 0
       },
-      "name": "a",
       "owner": {
         "interface": 2
       }

--- a/crates/wit-parser/tests/ui/world-top-level-funcs.wit.json
+++ b/crates/wit-parser/tests/ui/world-top-level-funcs.wit.json
@@ -53,24 +53,24 @@
   "interfaces": [],
   "types": [
     {
+      "name": null,
       "kind": {
         "list": "u32"
       },
-      "name": null,
       "owner": "none"
     },
     {
+      "name": null,
       "kind": {
         "option": "u32"
       },
-      "name": null,
       "owner": "none"
     },
     {
+      "name": null,
       "kind": {
         "list": 1
       },
-      "name": null,
       "owner": "none"
     }
   ],

--- a/crates/wit-parser/tests/ui/world-top-level-resources.wit.json
+++ b/crates/wit-parser/tests/ui/world-top-level-resources.wit.json
@@ -132,96 +132,96 @@
   ],
   "types": [
     {
-      "kind": "resource",
       "name": "request",
-      "owner": {
-        "interface": 0
-      }
-    },
-    {
       "kind": "resource",
-      "name": "response",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "response",
+      "kind": "resource",
+      "owner": {
+        "interface": 0
+      }
+    },
+    {
+      "name": null,
       "kind": {
         "handle": {
           "borrow": 0
         }
       },
-      "name": null,
       "owner": "none"
     },
     {
+      "name": null,
       "kind": {
         "list": "u32"
       },
-      "name": null,
       "owner": "none"
     },
     {
+      "name": null,
       "kind": {
         "handle": {
           "borrow": 1
         }
       },
-      "name": null,
       "owner": "none"
     },
     {
+      "name": "request",
       "kind": {
         "type": 0
       },
-      "name": "request",
       "owner": {
         "interface": 1
       }
     },
     {
+      "name": "response",
       "kind": {
         "type": 1
       },
-      "name": "response",
       "owner": {
         "interface": 1
       }
     },
     {
+      "name": null,
       "kind": {
         "handle": {
           "borrow": 5
         }
       },
-      "name": null,
       "owner": "none"
     },
     {
+      "name": null,
       "kind": {
         "handle": {
           "borrow": 6
         }
       },
-      "name": null,
       "owner": "none"
     },
     {
+      "name": null,
       "kind": {
         "handle": {
           "own": 5
         }
       },
-      "name": null,
       "owner": "none"
     },
     {
+      "name": null,
       "kind": {
         "handle": {
           "own": 6
         }
       },
-      "name": null,
       "owner": "none"
     }
   ],

--- a/crates/wit-parser/tests/ui/worlds-with-types.wit.json
+++ b/crates/wit-parser/tests/ui/worlds-with-types.wit.json
@@ -118,42 +118,43 @@
   ],
   "types": [
     {
+      "name": "t",
       "kind": {
         "type": "u32"
       },
-      "name": "t",
       "owner": {
         "interface": 0
       }
     },
     {
+      "name": "a",
       "kind": {
         "type": "u32"
       },
-      "name": "a",
       "owner": {
         "world": 0
       }
     },
     {
+      "name": "b",
       "kind": {
         "type": 1
       },
-      "name": "b",
       "owner": {
         "world": 0
       }
     },
     {
+      "name": "t",
       "kind": {
         "type": 0
       },
-      "name": "t",
       "owner": {
         "world": 1
       }
     },
     {
+      "name": "a",
       "kind": {
         "record": {
           "fields": [
@@ -164,12 +165,12 @@
           ]
         }
       },
-      "name": "a",
       "owner": {
         "world": 2
       }
     },
     {
+      "name": "b",
       "kind": {
         "variant": {
           "cases": [
@@ -180,7 +181,6 @@
           ]
         }
       },
-      "name": "b",
       "owner": {
         "world": 2
       }


### PR DESCRIPTION
This modifies the field order of WIT structures in the wit-parser crate:

1. The `name` field is moved to the first position in the handful of structs it wasn’t already the first field.
2. The `docs` field is moved to the last (public, serialized) position, since it is A) often empty/omitted, or B) when present, contains paragraphs of plaintext.

These two changes make the JSON serialized output of `Resolve` more consistent and readable. For example, see [random.wit](https://github.com/bytecodealliance/wasm-tools/pull/1208/files#diff-c51a45dab8b06f3fd18a76a24b5f641108d26fb8204f49e63ed15e147c515e83) and random.wit.json in this PR.

Question: does changing the order of fields in a Rust struct break any compatibility guarantee(s) to dependents?