### PR TITLE
Fix subtype encoding in wasm-encoder

### DIFF
--- a/crates/wasm-encoder/src/core/types.rs
+++ b/crates/wasm-encoder/src/core/types.rs
@@ -336,7 +336,7 @@ impl TypeSection {
             None => vec![],
         };
         if ty.is_final {
-            self.bytes.push(0x4e);
+            self.bytes.push(0x4f);
             st.encode(&mut self.bytes);
         } else if !st.is_empty() {
             self.bytes.push(0x50);


### PR DESCRIPTION
Missing piece in #1204
<img width="776" alt="Screenshot 2023-09-19 at 3 29 25 PM" src="https://github.com/bytecodealliance/wasm-tools/assets/1523410/0ece7d7d-7340-4eb3-8ca6-4d68b2f95191">
