### PR TITLE
 Add support for semicolon delimiters to wit-parser 

### DIFF
--- a/crates/wit-component/tests/components/adapt-empty-interface/adapt-old.wit
+++ b/crates/wit-component/tests/components/adapt-empty-interface/adapt-old.wit
@@ -1,5 +1,5 @@
 world adapt-old {
   import new: interface {
-    thunk-that-is-not-called: func()
+    thunk-that-is-not-called: func();
   }
 }

--- a/crates/wit-component/tests/components/adapt-export-default/adapt-old.wit
+++ b/crates/wit-component/tests/components/adapt-export-default/adapt-old.wit
@@ -1,3 +1,3 @@
 world adapt-old {
-  export entrypoint: func()
+  export entrypoint: func();
 }

--- a/crates/wit-component/tests/components/adapt-export-namespaced/adapt-old.wit
+++ b/crates/wit-component/tests/components/adapt-export-namespaced/adapt-old.wit
@@ -1,7 +1,7 @@
 interface new {
-  entrypoint: func()
+  entrypoint: func();
 }
 
 world adapt-old {
-  export new
+  export new;
 }

--- a/crates/wit-component/tests/components/adapt-export-reallocs/adapt-old.wit
+++ b/crates/wit-component/tests/components/adapt-export-reallocs/adapt-old.wit
@@ -1,6 +1,6 @@
 world adapt-old {
   import new: interface {
-    read: func(amt: u32) -> list<u8>
+    read: func(amt: u32) -> list<u8>;
   }
-  export entrypoint: func(args: list<string>)
+  export entrypoint: func(args: list<string>);
 }

--- a/crates/wit-component/tests/components/adapt-export-save-args/adapt-old.wit
+++ b/crates/wit-component/tests/components/adapt-export-save-args/adapt-old.wit
@@ -1,3 +1,3 @@
 world adapt-old {
-  export entrypoint: func(nargs: u32)
+  export entrypoint: func(nargs: u32);
 }

--- a/crates/wit-component/tests/components/adapt-export-with-post-return/adapt-old.wit
+++ b/crates/wit-component/tests/components/adapt-export-with-post-return/adapt-old.wit
@@ -1,7 +1,7 @@
 interface new {
-  foo: func() -> string
+  foo: func() -> string;
 }
 
 world adapt-old {
-  export new
+  export new;
 }

--- a/crates/wit-component/tests/components/adapt-import-only-used-in-adapter/adapt-unused.wit
+++ b/crates/wit-component/tests/components/adapt-import-only-used-in-adapter/adapt-unused.wit
@@ -1,9 +1,9 @@
 interface adapter-imports {
-  foo: func(x: string)
+  foo: func(x: string);
 }
 
 world adapt-unused {
-  import adapter-imports
+  import adapter-imports;
 
-  export adapter-bar: func(x: string)
+  export adapter-bar: func(x: string);
 }

--- a/crates/wit-component/tests/components/adapt-import-only-used-in-adapter/module.wit
+++ b/crates/wit-component/tests/components/adapt-import-only-used-in-adapter/module.wit
@@ -1,6 +1,6 @@
 package foo:foo
 
 world module {
-  import foo: func(x: string)
-  export bar: func()
+  import foo: func(x: string);
+  export bar: func();
 }

--- a/crates/wit-component/tests/components/adapt-inject-stack-with-adapt-realloc/adapt-old.wit
+++ b/crates/wit-component/tests/components/adapt-inject-stack-with-adapt-realloc/adapt-old.wit
@@ -1,5 +1,5 @@
 world adapt-old {
   import new: interface {
-    get-two: func() -> (a: u32, b: u32)
+    get-two: func() -> (a: u32, b: u32);
   }
 }

--- a/crates/wit-component/tests/components/adapt-inject-stack-with-realloc-no-state/adapt-old.wit
+++ b/crates/wit-component/tests/components/adapt-inject-stack-with-realloc-no-state/adapt-old.wit
@@ -1,5 +1,5 @@
 world adapt-old {
   import new: interface {
-    get-two: func() -> (a: u32, b: u32)
+    get-two: func() -> (a: u32, b: u32);
   }
 }

--- a/crates/wit-component/tests/components/adapt-inject-stack-with-realloc/adapt-old.wit
+++ b/crates/wit-component/tests/components/adapt-inject-stack-with-realloc/adapt-old.wit
@@ -1,5 +1,5 @@
 world adapt-old {
   import new: interface {
-    get-two: func() -> (a: u32, b: u32)
+    get-two: func() -> (a: u32, b: u32);
   }
 }

--- a/crates/wit-component/tests/components/adapt-inject-stack-with-reallocing-adapter/adapt-old.wit
+++ b/crates/wit-component/tests/components/adapt-inject-stack-with-reallocing-adapter/adapt-old.wit
@@ -1,5 +1,5 @@
 world adapt-old {
   import new: interface {
-    get-two: func() -> (a: u32, b: u32)
+    get-two: func() -> (a: u32, b: u32);
   }
 }

--- a/crates/wit-component/tests/components/adapt-inject-stack/adapt-old.wit
+++ b/crates/wit-component/tests/components/adapt-inject-stack/adapt-old.wit
@@ -1,5 +1,5 @@
 world adapt-old {
   import new: interface {
-    get-two: func() -> (a: u32, b: u32)
+    get-two: func() -> (a: u32, b: u32);
   }
 }

--- a/crates/wit-component/tests/components/adapt-list-return/adapt-old.wit
+++ b/crates/wit-component/tests/components/adapt-list-return/adapt-old.wit
@@ -1,5 +1,5 @@
 world adapt-old {
   import new: interface {
-    read: func() -> list<u8>
+    read: func() -> list<u8>;
   }
 }

--- a/crates/wit-component/tests/components/adapt-memory-simple/adapt-old.wit
+++ b/crates/wit-component/tests/components/adapt-memory-simple/adapt-old.wit
@@ -1,5 +1,5 @@
 world adapt-old {
   import new: interface {
-    log: func(s: string)
+    log: func(s: string);
   }
 }

--- a/crates/wit-component/tests/components/adapt-multiple/adapt-foo.wit
+++ b/crates/wit-component/tests/components/adapt-multiple/adapt-foo.wit
@@ -1,8 +1,8 @@
 world adapt-foo {
   import other1: interface {
-    foo: func()
+    foo: func();
   }
   import other2: interface {
-    bar: func()
+    bar: func();
   }
 }

--- a/crates/wit-component/tests/components/adapt-preview1/adapt-wasi-snapshot-preview1.wit
+++ b/crates/wit-component/tests/components/adapt-preview1/adapt-wasi-snapshot-preview1.wit
@@ -2,11 +2,11 @@
 // to implement the `wasi_snapshot_preview1` interface.
 
 interface my-wasi {
-  random-get: func(size: u32) -> list<u8>
-  proc-exit: func(code: u32)
-  something-not-used: func()
+  random-get: func(size: u32) -> list<u8>;
+  proc-exit: func(code: u32);
+  something-not-used: func();
 }
 
 world adapt-wasi-snapshot-preview1 {
-  import my-wasi
+  import my-wasi;
 }

--- a/crates/wit-component/tests/components/adapt-preview1/module.wit
+++ b/crates/wit-component/tests/components/adapt-preview1/module.wit
@@ -2,6 +2,6 @@ package foo:foo
 
 world module {
   import foo: interface {
-    foo: func()
+    foo: func();
   }
 }

--- a/crates/wit-component/tests/components/adapt-unused/adapt-old.wit
+++ b/crates/wit-component/tests/components/adapt-unused/adapt-old.wit
@@ -1,5 +1,5 @@
 world adapt-old {
   import new: interface {
-    log: func(s: string)
+    log: func(s: string);
   }
 }

--- a/crates/wit-component/tests/components/bare-funcs/module.wit
+++ b/crates/wit-component/tests/components/bare-funcs/module.wit
@@ -1,7 +1,7 @@
 package foo:foo
 world module {
-  import foo: func()
-  import bar: func() -> string
-  export baz: func()
-  export foo2: func(x: string) -> option<list<u8>>
+  import foo: func();
+  import bar: func() -> string;
+  export baz: func();
+  export foo2: func(x: string) -> option<list<u8>>;
 }

--- a/crates/wit-component/tests/components/ensure-default-type-exports/module.wit
+++ b/crates/wit-component/tests/components/ensure-default-type-exports/module.wit
@@ -1,17 +1,17 @@
 package foo:foo
 
 interface foo {
-  type foo = u8
+  type foo = u8;
 
   record bar {
       x: foo
   }
 
-  a: func(b: bar)
+  a: func(b: bar);
 }
 
 world module {
-  import foo
+  import foo;
 
-  export a: func(b: u8)
+  export a: func(b: u8);
 }

--- a/crates/wit-component/tests/components/error-adapt-missing-memory/adapt-old.wit
+++ b/crates/wit-component/tests/components/error-adapt-missing-memory/adapt-old.wit
@@ -1,5 +1,5 @@
 world adapt-old {
   import new: interface {
-    log: func(s: string)
+    log: func(s: string);
   }
 }

--- a/crates/wit-component/tests/components/error-default-export-sig-mismatch/module.wit
+++ b/crates/wit-component/tests/components/error-default-export-sig-mismatch/module.wit
@@ -1,5 +1,5 @@
 package foo:foo
 
 world module {
-  export a: func(x: string) -> string
+  export a: func(x: string) -> string;
 }

--- a/crates/wit-component/tests/components/error-export-sig-mismatch/module.wit
+++ b/crates/wit-component/tests/components/error-export-sig-mismatch/module.wit
@@ -2,6 +2,6 @@ package foo:foo
 
 world module {
   export foo: interface {
-    a: func(x: string) -> string
+    a: func(x: string) -> string;
   }
 }

--- a/crates/wit-component/tests/components/error-import-resource-rep/module.wit
+++ b/crates/wit-component/tests/components/error-import-resource-rep/module.wit
@@ -1,5 +1,5 @@
 package foo:bar
 
 world module {
-  resource a
+  resource a;
 }

--- a/crates/wit-component/tests/components/error-import-resource-wrong-signature/module.wit
+++ b/crates/wit-component/tests/components/error-import-resource-wrong-signature/module.wit
@@ -1,5 +1,5 @@
 package foo:bar
 
 world module {
-  resource a
+  resource a;
 }

--- a/crates/wit-component/tests/components/error-import-sig-mismatch/module.wit
+++ b/crates/wit-component/tests/components/error-import-sig-mismatch/module.wit
@@ -2,6 +2,6 @@ package foo:foo
 
 world module {
   import foo: interface {
-    bar: func(s: string)
+    bar: func(s: string);
   }
 }

--- a/crates/wit-component/tests/components/error-link-duplicate-symbols/lib-foo.wit
+++ b/crates/wit-component/tests/components/error-link-duplicate-symbols/lib-foo.wit
@@ -1,10 +1,10 @@
 package test:test
 
 interface test {
-   foo: func(v: s32) -> s32
+   foo: func(v: s32) -> s32;
 }
 
 world lib-foo {
-    import test
-    export test
+    import test;
+    export test;
 }

--- a/crates/wit-component/tests/components/error-link-missing-needed/lib-foo.wit
+++ b/crates/wit-component/tests/components/error-link-missing-needed/lib-foo.wit
@@ -1,10 +1,10 @@
 package test:test
 
 interface test {
-   foo: func(v: s32) -> s32
+   foo: func(v: s32) -> s32;
 }
 
 world lib-foo {
-    import test
-    export test
+    import test;
+    export test;
 }

--- a/crates/wit-component/tests/components/error-link-missing-symbols/lib-foo.wit
+++ b/crates/wit-component/tests/components/error-link-missing-symbols/lib-foo.wit
@@ -1,10 +1,10 @@
 package test:test
 
 interface test {
-   foo: func(v: s32) -> s32
+   foo: func(v: s32) -> s32;
 }
 
 world lib-foo {
-    import test
-    export test
+    import test;
+    export test;
 }

--- a/crates/wit-component/tests/components/error-missing-default-export/module.wit
+++ b/crates/wit-component/tests/components/error-missing-default-export/module.wit
@@ -1,4 +1,4 @@
 package foo:foo
 world module {
-  export a: func()
+  export a: func();
 }

--- a/crates/wit-component/tests/components/error-missing-export/module.wit
+++ b/crates/wit-component/tests/components/error-missing-export/module.wit
@@ -2,6 +2,6 @@ package foo:foo
 
 world module {
   export foo: interface {
-    a: func()
+    a: func();
   }
 }

--- a/crates/wit-component/tests/components/error-missing-import-func/module.wit
+++ b/crates/wit-component/tests/components/error-missing-import-func/module.wit
@@ -1,9 +1,9 @@
 package foo:foo
 
 interface foo {
-  a: func()
+  a: func();
 }
 
 world module {
-  import foo
+  import foo;
 }

--- a/crates/wit-component/tests/components/export-interface-using-import/module.wit
+++ b/crates/wit-component/tests/components/export-interface-using-import/module.wit
@@ -12,6 +12,6 @@ interface foo {
 
 world module {
   export x: interface {
-    use foo.{r}
+    use foo.{r};
   }
 }

--- a/crates/wit-component/tests/components/export-name-shuffling/module.wit
+++ b/crates/wit-component/tests/components/export-name-shuffling/module.wit
@@ -7,11 +7,11 @@ interface name {
 }
 
 world module {
-  export name
+  export name;
 
   export name: interface {
-    use name.{foo}
+    use name.{foo};
 
-    a: func(f: foo)
+    a: func(f: foo);
   }
 }

--- a/crates/wit-component/tests/components/export-resource/module.wit
+++ b/crates/wit-component/tests/components/export-resource/module.wit
@@ -3,9 +3,9 @@ package foo:bar
 world module {
   export foo: interface {
     resource a {
-      constructor()
+      constructor();
 
-      other-new: static func() -> a
+      other-new: static func() -> a;
     }
   }
 }

--- a/crates/wit-component/tests/components/export-type-name-conflict/module.wit
+++ b/crates/wit-component/tests/components/export-type-name-conflict/module.wit
@@ -8,8 +8,8 @@ interface foo {
 
 world module {
   export bar: interface {
-    use foo.{foo as bar}
+    use foo.{foo as bar};
 
-    foo: func() -> bar
+    foo: func() -> bar;
   }
 }

--- a/crates/wit-component/tests/components/export-with-type-alias/module.wit
+++ b/crates/wit-component/tests/components/export-with-type-alias/module.wit
@@ -1,11 +1,11 @@
 package foo:foo
 
 interface foo {
-  type a = u8
-  type b = a
-  c: func(a: a) -> b
+  type a = u8;
+  type b = a;
+  c: func(a: a) -> b;
 }
 
 world module {
-  export foo
+  export foo;
 }

--- a/crates/wit-component/tests/components/exports/module.wit
+++ b/crates/wit-component/tests/components/exports/module.wit
@@ -1,9 +1,9 @@
 package foo:foo
 
 world module {
-  export a: func()
-  export b: func(a: s8, b: s16, c: s32, d: s64) -> string
-  export c: func() -> tuple<s8, s16, s32, s64>
+  export a: func();
+  export b: func(a: s8, b: s16, c: s32, d: s64) -> string;
+  export c: func() -> tuple<s8, s16, s32, s64>;
 
   export bar: interface {
     flags x {
@@ -12,7 +12,7 @@ world module {
         c
     }
 
-    a: func(x: x)
+    a: func(x: x);
   }
 
   export foo: interface {
@@ -22,8 +22,8 @@ world module {
         c(s64)
     }
 
-    a: func()
-    b: func(x: string) -> x
-    c: func(x: x) -> string
+    a: func();
+    b: func(x: string) -> x;
+    c: func(x: x) -> string;
   }
 }

--- a/crates/wit-component/tests/components/import-and-export-resource/module.wit
+++ b/crates/wit-component/tests/components/import-and-export-resource/module.wit
@@ -1,12 +1,12 @@
 package foo:bar
 
 interface foo {
-  resource a
+  resource a;
 }
 
 world module {
-  import foo
-  use foo.{a}
+  import foo;
+  use foo.{a};
 
-  export foo
+  export foo;
 }

--- a/crates/wit-component/tests/components/import-conflict/module.wit
+++ b/crates/wit-component/tests/components/import-conflict/module.wit
@@ -1,19 +1,19 @@
 package foo:foo
 
 interface foo {
-  a: func()
+  a: func();
 }
 
 interface bar {
-  a: func(x: u64, y: string)
+  a: func(x: u64, y: string);
 }
 
 interface baz {
-  baz: func(x: list<u8>) -> list<u8>
+  baz: func(x: list<u8>) -> list<u8>;
 }
 
 world module {
-  import bar
-  import baz
-  import foo
+  import bar;
+  import baz;
+  import foo;
 }

--- a/crates/wit-component/tests/components/import-export-same-iface-name/deps/dep/foo.wit
+++ b/crates/wit-component/tests/components/import-export-same-iface-name/deps/dep/foo.wit
@@ -1,5 +1,5 @@
 package foo:dep
 
 interface the-name {
-  a: func()
+  a: func();
 }

--- a/crates/wit-component/tests/components/import-export-same-iface-name/module.wit
+++ b/crates/wit-component/tests/components/import-export-same-iface-name/module.wit
@@ -1,11 +1,11 @@
 package foo:foo
 
 interface the-name {
-  a: func()
+  a: func();
 }
 
 world module {
-  import foo:dep/the-name
-  import the-name
-  export the-name
+  import foo:dep/the-name;
+  import the-name;
+  export the-name;
 }

--- a/crates/wit-component/tests/components/import-export/module.wit
+++ b/crates/wit-component/tests/components/import-export/module.wit
@@ -2,13 +2,13 @@ package foo:foo
 
 world module {
   import foo: interface {
-    a: func() -> string
+    a: func() -> string;
   }
 
   export bar: interface {
-    a: func()
-    b: func() -> string
+    a: func();
+    b: func() -> string;
   }
 
-  export a: func(x: string) -> tuple<string, u32, string>
+  export a: func(x: string) -> tuple<string, u32, string>;
 }

--- a/crates/wit-component/tests/components/import-in-adapter-and-main-module/adapt-old.wit
+++ b/crates/wit-component/tests/components/import-in-adapter-and-main-module/adapt-old.wit
@@ -1,9 +1,9 @@
 world adapt-old {
-  import foo:shared-dependency/doc
+  import foo:shared-dependency/doc;
 
   import adapter-dep: interface {
-    use foo:shared-dependency/types.{a-typedef}
+    use foo:shared-dependency/types.{a-typedef};
 
-    foo: func() -> a-typedef
+    foo: func() -> a-typedef;
   }
 }

--- a/crates/wit-component/tests/components/import-in-adapter-and-main-module/deps/shared-dependency/doc.wit
+++ b/crates/wit-component/tests/components/import-in-adapter-and-main-module/deps/shared-dependency/doc.wit
@@ -1,13 +1,13 @@
 package foo:shared-dependency
 
 interface doc {
-  f1: func()
-  f2: func()
-  f3: func()
+  f1: func();
+  f2: func();
+  f3: func();
 
-  g1: func() -> string
-  g2: func() -> string
-  g3: func() -> string
+  g1: func() -> string;
+  g2: func() -> string;
+  g3: func() -> string;
 
-  unused-in-adapter: func()
+  unused-in-adapter: func();
 }

--- a/crates/wit-component/tests/components/import-in-adapter-and-main-module/deps/shared-dependency/types.wit
+++ b/crates/wit-component/tests/components/import-in-adapter-and-main-module/deps/shared-dependency/types.wit
@@ -1,3 +1,3 @@
 interface types {
-  type a-typedef = u32
+  type a-typedef = u32;
 }

--- a/crates/wit-component/tests/components/import-in-adapter-and-main-module/module.wit
+++ b/crates/wit-component/tests/components/import-in-adapter-and-main-module/module.wit
@@ -1,11 +1,11 @@
 package foo:foo
 
 world module {
-  import foo:shared-dependency/doc
+  import foo:shared-dependency/doc;
 
   import main-dep: interface {
-    use foo:shared-dependency/types.{a-typedef}
+    use foo:shared-dependency/types.{a-typedef};
 
-    foo: func() -> a-typedef
+    foo: func() -> a-typedef;
   }
 }

--- a/crates/wit-component/tests/components/import-partial-export-full/module.wit
+++ b/crates/wit-component/tests/components/import-partial-export-full/module.wit
@@ -12,8 +12,8 @@ interface name {
 }
 
 world module {
-  import name
-  use name.{name}
+  import name;
+  use name.{name};
 
-  export name
+  export name;
 }

--- a/crates/wit-component/tests/components/import-resource-in-interface/module.wit
+++ b/crates/wit-component/tests/components/import-resource-in-interface/module.wit
@@ -3,9 +3,9 @@ package foo:bar
 world module {
   import foo: interface {
     resource a {
-      constructor()
+      constructor();
 
-      other-new: static func() -> a
+      other-new: static func() -> a;
     }
   }
 }

--- a/crates/wit-component/tests/components/import-resource-simple/module.wit
+++ b/crates/wit-component/tests/components/import-resource-simple/module.wit
@@ -2,8 +2,8 @@ package foo:bar
 
 world module {
   resource a {
-    constructor()
+    constructor();
 
-    other-new: static func() -> a
+    other-new: static func() -> a;
   }
 }

--- a/crates/wit-component/tests/components/imports/module.wit
+++ b/crates/wit-component/tests/components/imports/module.wit
@@ -6,23 +6,23 @@ world module {
         a: u8
     }
 
-    bar1: func(x: string)
-    bar2: func(x: x)
+    bar1: func(x: string);
+    bar2: func(x: x);
   }
 
   import baz: interface {
-    type x = s8
+    type x = s8;
 
-    baz1: func(x: list<string>)
-    baz2: func()
-    baz3: func(x: x)
+    baz1: func(x: list<string>);
+    baz2: func();
+    baz3: func(x: x);
   }
 
   import foo: interface {
-    foo1: func()
-    foo2: func(x: u8)
-    foo3: func(x: float32)
-    unused: func()
+    foo1: func();
+    foo2: func(x: u8);
+    foo3: func(x: float32);
+    unused: func();
 
     // doesn't show up in the wit output despite being exported here since it's
     // not actually used by anything

--- a/crates/wit-component/tests/components/lift-options/module.wit
+++ b/crates/wit-component/tests/components/lift-options/module.wit
@@ -17,24 +17,24 @@ interface my-default {
       s(u32)
   }
 
-  a: func()
-  b: func(x: list<string>)
-  c: func(x: r)
-  d: func(x: v)
-  e: func(x: r-no-string)
-  f: func(x: v-no-string)
-  g: func(x: list<r>)
-  h: func(x: list<v>)
-  i: func(x: list<u32>)
-  j: func(x: u32)
-  k: func() -> tuple<u32, u32>
-  l: func() -> string
-  m: func() -> list<u32>
-  n: func() -> u32
-  o: func() -> v
-  p: func() -> list<v-no-string>
+  a: func();
+  b: func(x: list<string>);
+  c: func(x: r);
+  d: func(x: v);
+  e: func(x: r-no-string);
+  f: func(x: v-no-string);
+  g: func(x: list<r>);
+  h: func(x: list<v>);
+  i: func(x: list<u32>);
+  j: func(x: u32);
+  k: func() -> tuple<u32, u32>;
+  l: func() -> string;
+  m: func() -> list<u32>;
+  n: func() -> u32;
+  o: func() -> v;
+  p: func() -> list<v-no-string>;
 }
 
 world module {
-  export my-default
+  export my-default;
 }

--- a/crates/wit-component/tests/components/link-bare-funcs/lib-foo.wit
+++ b/crates/wit-component/tests/components/link-bare-funcs/lib-foo.wit
@@ -1,7 +1,7 @@
 package test:test
 world lib-foo {
-  import foo1: func()
-  import bar: func() -> string
-  export baz: func()
-  export foo2: func(x: string) -> option<list<u8>>
+  import foo1: func();
+  import bar: func() -> string;
+  export baz: func();
+  export foo2: func(x: string) -> option<list<u8>>;
 }

--- a/crates/wit-component/tests/components/link-circular/lib-foo.wit
+++ b/crates/wit-component/tests/components/link-circular/lib-foo.wit
@@ -1,10 +1,10 @@
 package test:test
 
 interface test {
-   foo: func(v: s32) -> s32
+   foo: func(v: s32) -> s32;
 }
 
 world lib-foo {
-    import test
-    export test
+    import test;
+    export test;
 }

--- a/crates/wit-component/tests/components/link-dl-openable/dlopen-lib-foo.wit
+++ b/crates/wit-component/tests/components/link-dl-openable/dlopen-lib-foo.wit
@@ -1,10 +1,10 @@
 package test:test
 
 interface test {
-   foo: func(v: s32) -> s32
+   foo: func(v: s32) -> s32;
 }
 
 world dlopen-lib-foo {
-    import test
-    export test
+    import test;
+    export test;
 }

--- a/crates/wit-component/tests/components/link-got-func/lib-foo.wit
+++ b/crates/wit-component/tests/components/link-got-func/lib-foo.wit
@@ -1,10 +1,10 @@
 package test:test
 
 interface test {
-   foo: func(v: s32) -> s32
+   foo: func(v: s32) -> s32;
 }
 
 world lib-foo {
-    import test
-    export test
+    import test;
+    export test;
 }

--- a/crates/wit-component/tests/components/link-stubs/lib-foo.wit
+++ b/crates/wit-component/tests/components/link-stubs/lib-foo.wit
@@ -1,10 +1,10 @@
 package test:test
 
 interface test {
-   foo: func(v: s32) -> s32
+   foo: func(v: s32) -> s32;
 }
 
 world lib-foo {
-    import test
-    export test
+    import test;
+    export test;
 }

--- a/crates/wit-component/tests/components/link-weak-import/lib-foo.wit
+++ b/crates/wit-component/tests/components/link-weak-import/lib-foo.wit
@@ -1,10 +1,10 @@
 package test:test
 
 interface test {
-   foo: func(v: s32) -> s32
+   foo: func(v: s32) -> s32;
 }
 
 world lib-foo {
-    import test
-    export test
+    import test;
+    export test;
 }

--- a/crates/wit-component/tests/components/link/lib-bar.wit
+++ b/crates/wit-component/tests/components/link/lib-bar.wit
@@ -1,10 +1,10 @@
 package test:test
 
 interface test {
-   bar: func(v: s32) -> s32
+   bar: func(v: s32) -> s32;
 }
 
 world lib-bar {
-    import test
-    export test
+    import test;
+    export test;
 }

--- a/crates/wit-component/tests/components/live-exports-dead-imports/module.wit
+++ b/crates/wit-component/tests/components/live-exports-dead-imports/module.wit
@@ -2,11 +2,11 @@ package foo:foo
 
 interface a {
   resource r {
-    constructor()
+    constructor();
   }
 }
 
 world module {
-  import a
-  export a
+  import a;
+  export a;
 }

--- a/crates/wit-component/tests/components/lower-options/module.wit
+++ b/crates/wit-component/tests/components/lower-options/module.wit
@@ -17,24 +17,24 @@ interface foo {
       s(u32)
   }
 
-  a: func()
-  b: func(x: list<string>)
-  c: func(x: r)
-  d: func(x: v)
-  e: func(x: r-no-string)
-  f: func(x: v-no-string)
-  g: func(x: list<r>)
-  h: func(x: list<v>)
-  i: func(x: list<u32>)
-  j: func(x: u32)
-  k: func() -> tuple<u32, u32>
-  l: func() -> string
-  m: func() -> list<u32>
-  n: func() -> u32
-  o: func() -> v
-  p: func() -> list<v-no-string>
+  a: func();
+  b: func(x: list<string>);
+  c: func(x: r);
+  d: func(x: v);
+  e: func(x: r-no-string);
+  f: func(x: v-no-string);
+  g: func(x: list<r>);
+  h: func(x: list<v>);
+  i: func(x: list<u32>);
+  j: func(x: u32);
+  k: func() -> tuple<u32, u32>;
+  l: func() -> string;
+  m: func() -> list<u32>;
+  n: func() -> u32;
+  o: func() -> v;
+  p: func() -> list<v-no-string>;
 }
 
 world module {
-  import foo
+  import foo;
 }

--- a/crates/wit-component/tests/components/many-same-names/module.wit
+++ b/crates/wit-component/tests/components/many-same-names/module.wit
@@ -11,11 +11,11 @@ interface name {
 }
 
 world module {
-  import name
-  export name
+  import name;
+  export name;
 
   export name: interface {
-    use name.{r2}
-    a: func()
+    use name.{r2};
+    a: func();
   }
 }

--- a/crates/wit-component/tests/components/no-realloc-required/module.wit
+++ b/crates/wit-component/tests/components/no-realloc-required/module.wit
@@ -2,6 +2,6 @@ package foo:foo
 
 world module {
   import foo: interface {
-    log: func(s: string)
+    log: func(s: string);
   }
 }

--- a/crates/wit-component/tests/components/post-return/module.wit
+++ b/crates/wit-component/tests/components/post-return/module.wit
@@ -1,5 +1,5 @@
 package foo:foo
 
 world module {
-  export a: func() -> string
+  export a: func() -> string;
 }

--- a/crates/wit-component/tests/components/rename-import-interface/module.wit
+++ b/crates/wit-component/tests/components/rename-import-interface/module.wit
@@ -1,9 +1,9 @@
 package foo:foo
 
 interface foo {
-  the-func: func()
+  the-func: func();
 }
 
 world module {
-  import foo
+  import foo;
 }

--- a/crates/wit-component/tests/components/rename-interface/module.wit
+++ b/crates/wit-component/tests/components/rename-interface/module.wit
@@ -5,14 +5,14 @@ interface foo {
     f: u8,
   }
 
-  a: func() -> bar
+  a: func() -> bar;
 }
 
 world module {
-  import foo
+  import foo;
   import other-name: interface {
-    use foo.{bar}
+    use foo.{bar};
 
-    a: func() -> bar
+    a: func() -> bar;
   }
 }

--- a/crates/wit-component/tests/components/resource-intrinsics-with-just-import/module.wit
+++ b/crates/wit-component/tests/components/resource-intrinsics-with-just-import/module.wit
@@ -2,6 +2,6 @@ package foo:bar
 
 world module {
   import foo: interface {
-    resource a
+    resource a;
   }
 }

--- a/crates/wit-component/tests/components/resource-used-through-import/module.wit
+++ b/crates/wit-component/tests/components/resource-used-through-import/module.wit
@@ -1,13 +1,13 @@
 package foo:bar
 
 interface a {
-  resource r
+  resource r;
 }
 
 world module {
   export b: interface {
-    use a.{r}
+    use a.{r};
 
-    foo: func() -> r
+    foo: func() -> r;
   }
 }

--- a/crates/wit-component/tests/components/resource-using-export/module.wit
+++ b/crates/wit-component/tests/components/resource-using-export/module.wit
@@ -1,16 +1,16 @@
 package foo:bar
 
 interface foo {
-  resource r
+  resource r;
 
-  type handle = own<r>
+  type handle = own<r>;
 }
 
 world module {
-  export foo
+  export foo;
   export anon: interface {
-    use foo.{handle}
-    f: func() -> handle
+    use foo.{handle};
+    f: func() -> handle;
   }
 }
 

--- a/crates/wit-component/tests/components/simple/module.wit
+++ b/crates/wit-component/tests/components/simple/module.wit
@@ -1,7 +1,7 @@
 package foo:foo
 
 world module {
-  export a: func()
-  export b: func() -> string
-  export c: func(x: string) -> string
+  export a: func();
+  export b: func() -> string;
+  export c: func(x: string) -> string;
 }

--- a/crates/wit-component/tests/components/tricky-order/module.wit
+++ b/crates/wit-component/tests/components/tricky-order/module.wit
@@ -7,14 +7,14 @@ interface name1 {
 }
 
 interface name2 {
-  use name1.{name}
+  use name1.{name};
 }
 
 world module {
-  import name1
-  import name2
+  import name1;
+  import name2;
   export name: interface {
-    use name1.{name}
-    use name2.{name as name1}
+    use name1.{name};
+    use name2.{name as name1};
   }
 }

--- a/crates/wit-component/tests/components/tricky-resources/module.wit
+++ b/crates/wit-component/tests/components/tricky-resources/module.wit
@@ -1,19 +1,19 @@
 package foo:bar
 
 interface a {
-  resource r
+  resource r;
 }
 
 interface b {
-  use a.{r}
+  use a.{r};
 }
 
 world module {
-  export b
+  export b;
   export some-name: interface {
-    use b.{r}
+    use b.{r};
 
-    f: func() -> r
+    f: func() -> r;
   }
-  export a
+  export a;
 }

--- a/crates/wit-component/tests/components/tricky-resources2/module.wit
+++ b/crates/wit-component/tests/components/tricky-resources2/module.wit
@@ -1,14 +1,14 @@
 package foo:bar
 
 interface a {
-  resource r
+  resource r;
 }
 
 world module {
   export anon: interface {
-    use a.{r}
+    use a.{r};
 
-    foo: func() -> r
+    foo: func() -> r;
   }
-  export a
+  export a;
 }

--- a/crates/wit-component/tests/components/tricky-resources3/module.wit
+++ b/crates/wit-component/tests/components/tricky-resources3/module.wit
@@ -1,17 +1,17 @@
 package foo:bar
 
 interface foo {
-  resource name
+  resource name;
 }
 
 interface name {
-  use foo.{name}
+  use foo.{name};
 }
 
 world module {
-  export foo
-  export name
+  export foo;
+  export name;
   export name: interface {
-    use name.{name}
+    use name.{name};
   }
 }

--- a/crates/wit-component/tests/components/tricky-resources4/module.wit
+++ b/crates/wit-component/tests/components/tricky-resources4/module.wit
@@ -1,16 +1,16 @@
 package foo:bar
 
 interface name {
-  resource name
+  resource name;
 
-  type handle = name
+  type handle = name;
 
-  foo: func() -> handle
+  foo: func() -> handle;
 }
 
 world module {
-  export name
+  export name;
   export name: interface {
-    use name.{handle}
+    use name.{handle};
   }
 }

--- a/crates/wit-component/tests/components/unused-import/module.wit
+++ b/crates/wit-component/tests/components/unused-import/module.wit
@@ -3,10 +3,10 @@ package foo:foo
 interface bar {}
 
 interface foo {
-  name: func(x: bool)
+  name: func(x: bool);
 }
 
 world module {
-  import bar // unused
-  import foo
+  import bar; // unused
+  import foo;
 }

--- a/crates/wit-component/tests/components/worlds-with-type-renamings/module.wit
+++ b/crates/wit-component/tests/components/worlds-with-type-renamings/module.wit
@@ -5,13 +5,13 @@ interface i {
     f: u8,
   }
 
-  the-func: func() -> some-type
+  the-func: func() -> some-type;
 }
 
 
 world module {
-  use i.{some-type as other-name}
+  use i.{some-type as other-name};
 
-  import i
-  export i
+  import i;
+  export i;
 }

--- a/crates/wit-component/tests/components/worlds-with-types/module.wit
+++ b/crates/wit-component/tests/components/worlds-with-types/module.wit
@@ -1,10 +1,10 @@
 package foo:foo
 
 world module {
-  type t = u32
+  type t = u32;
   record r {
     x: t
   }
 
-  export a: func(r: r) -> t
+  export a: func(r: r) -> t;
 }

--- a/crates/wit-component/tests/interfaces/console.wit
+++ b/crates/wit-component/tests/interfaces/console.wit
@@ -1,5 +1,5 @@
 package foo:console
 
 interface console {
-  log: func(arg: string)
+  log: func(arg: string);
 }

--- a/crates/wit-component/tests/interfaces/diamond-disambiguate/join.wit
+++ b/crates/wit-component/tests/interfaces/diamond-disambiguate/join.wit
@@ -2,9 +2,9 @@ package foo:foo
 
 world w1 {
   import foo: interface {
-    use shared1.{t1}
+    use shared1.{t1};
   }
   import bar: interface {
-    use shared2.{t2}
+    use shared2.{t2};
   }
 }

--- a/crates/wit-component/tests/interfaces/diamond-disambiguate/shared1.wit
+++ b/crates/wit-component/tests/interfaces/diamond-disambiguate/shared1.wit
@@ -1,3 +1,3 @@
 interface shared1 {
-  type t1 = u8
+  type t1 = u8;
 }

--- a/crates/wit-component/tests/interfaces/diamond-disambiguate/shared2.wit
+++ b/crates/wit-component/tests/interfaces/diamond-disambiguate/shared2.wit
@@ -1,3 +1,3 @@
 interface shared2 {
-  type t2 = u8
+  type t2 = u8;
 }

--- a/crates/wit-component/tests/interfaces/diamond.wit
+++ b/crates/wit-component/tests/interfaces/diamond.wit
@@ -8,24 +8,24 @@ interface shared-items {
 
 world w1 {
   import foo: interface {
-    use shared-items.{the-enum}
+    use shared-items.{the-enum};
   }
   import bar: interface {
-    use shared-items.{the-enum}
+    use shared-items.{the-enum};
   }
 }
 
 world w2 {
   import foo: interface {
-    use shared-items.{the-enum}
+    use shared-items.{the-enum};
   }
   export bar: interface {
-    use shared-items.{the-enum}
+    use shared-items.{the-enum};
   }
 }
 
 world w3 {
   export bar: interface {
-    use shared-items.{the-enum}
+    use shared-items.{the-enum};
   }
 }

--- a/crates/wit-component/tests/interfaces/doc-comments/foo.wit
+++ b/crates/wit-component/tests/interfaces/doc-comments/foo.wit
@@ -4,7 +4,7 @@ package foo:foo
 /// interface docs
 interface coverage-iface {
   /// basic typedef docs
-  type t = u32
+  type t = u32;
 
   /// record typedef docs
   record r {
@@ -33,35 +33,35 @@ interface coverage-iface {
 
   resource res {
     /// constructor docs
-    constructor()
+    constructor();
     /// method docs
-    m: func()
+    m: func();
     /// static func docs
-    s: static func()
+    s: static func();
   }
 
   /// interface func docs
-  f: func()
+  f: func();
 }
 
 /// world docs
 world coverage-world {
   /// world func import docs
-  import imp: func()
+  import imp: func();
 
   /// world typedef docs
-  type t = u32
+  type t = u32;
 
   /// world inline interface docs
   export i: interface {
     /// inline interface typedef docs
-    type t = u32
+    type t = u32;
 
     /// inline interface func docs
-    f: func()
+    f: func();
   }
   /// world func export docs
-  export exp: func()
+  export exp: func();
 }
 
 /** other comment forms
@@ -70,10 +70,10 @@ interface other-comment-forms {
   /// one doc line
   // non-doc in the middle
   /// another doc line
-  multiple-lines-split: func()
+  multiple-lines-split: func();
 
   /// mixed forms; line doc
   /** plus block doc
       multi-line */
-  mixed-forms: func()
+  mixed-forms: func();
 }

--- a/crates/wit-component/tests/interfaces/empty.wit
+++ b/crates/wit-component/tests/interfaces/empty.wit
@@ -3,9 +3,9 @@ package foo:empty
 interface empty {}
 
 world empty-world {
-  import empty
+  import empty;
   import empty: interface {}
-  export empty
+  export empty;
   export empty2: interface {}
 }
 

--- a/crates/wit-component/tests/interfaces/export-other-packages-interface/deps/the-dep/the-doc.wit
+++ b/crates/wit-component/tests/interfaces/export-other-packages-interface/deps/the-dep/the-doc.wit
@@ -1,9 +1,9 @@
 package foo:the-dep
 
 interface the-interface {
-  type t = u8
+  type t = u8;
 }
 
 interface unused-interface {
-  type u = u32
+  type u = u32;
 }

--- a/crates/wit-component/tests/interfaces/export-other-packages-interface/foo.wit
+++ b/crates/wit-component/tests/interfaces/export-other-packages-interface/foo.wit
@@ -1,5 +1,5 @@
 package foo:foo
 
 world foo {
-  export foo:the-dep/the-interface
+  export foo:the-dep/the-interface;
 }

--- a/crates/wit-component/tests/interfaces/exports.wit
+++ b/crates/wit-component/tests/interfaces/exports.wit
@@ -5,9 +5,9 @@ interface foo {
     a: u32,
   }
 
-  my-function: func(a: my-struct) -> string
+  my-function: func(a: my-struct) -> string;
 }
 
 world export-foo {
-  export foo
+  export foo;
 }

--- a/crates/wit-component/tests/interfaces/flags.wit
+++ b/crates/wit-component/tests/interfaces/flags.wit
@@ -149,21 +149,21 @@ interface imports {
     b63,
   }
 
-  roundtrip-flag1: func(x: flag1) -> flag1
+  roundtrip-flag1: func(x: flag1) -> flag1;
 
-  roundtrip-flag2: func(x: flag2) -> flag2
+  roundtrip-flag2: func(x: flag2) -> flag2;
 
-  roundtrip-flag4: func(x: flag4) -> flag4
+  roundtrip-flag4: func(x: flag4) -> flag4;
 
-  roundtrip-flag8: func(x: flag8) -> flag8
+  roundtrip-flag8: func(x: flag8) -> flag8;
 
-  roundtrip-flag16: func(x: flag16) -> flag16
+  roundtrip-flag16: func(x: flag16) -> flag16;
 
-  roundtrip-flag32: func(x: flag32) -> flag32
+  roundtrip-flag32: func(x: flag32) -> flag32;
 
-  roundtrip-flag64: func(x: flag64) -> flag64
+  roundtrip-flag64: func(x: flag64) -> flag64;
 }
 
 world flags-world {
-  import imports
+  import imports;
 }

--- a/crates/wit-component/tests/interfaces/floats.wit
+++ b/crates/wit-component/tests/interfaces/floats.wit
@@ -1,12 +1,12 @@
 package foo:floats
 
 interface floats {
-  float32-param: func(x: float32)
-  float64-param: func(x: float64)
-  float32-result: func() -> float32
-  float64-result: func() -> float64
+  float32-param: func(x: float32);
+  float64-param: func(x: float64);
+  float32-result: func() -> float32;
+  float64-result: func() -> float64;
 }
 
 world floats-world {
-  import floats
+  import floats;
 }

--- a/crates/wit-component/tests/interfaces/foreign-use-chain/deps/bar/bar.wit
+++ b/crates/wit-component/tests/interfaces/foreign-use-chain/deps/bar/bar.wit
@@ -1,9 +1,9 @@
 package foo:bar
 
 interface bar {
-  use the-interface.{the-type as bar}
+  use the-interface.{the-type as bar};
 }
 
 interface the-interface {
-  type the-type = u8
+  type the-type = u8;
 }

--- a/crates/wit-component/tests/interfaces/foreign-use-chain/foo.wit
+++ b/crates/wit-component/tests/interfaces/foreign-use-chain/foo.wit
@@ -1,5 +1,5 @@
 package foo:foo
 
 world foo {
-  import foo:bar/bar
+  import foo:bar/bar;
 }

--- a/crates/wit-component/tests/interfaces/import-and-export.wit
+++ b/crates/wit-component/tests/interfaces/import-and-export.wit
@@ -1,14 +1,14 @@
 package foo:foo
 
 interface foo {
-  foo: func()
+  foo: func();
 }
 
 interface bar {
-  bar: func()
+  bar: func();
 }
 
 world import-and-export {
-  import foo
-  export bar
+  import foo;
+  export bar;
 }

--- a/crates/wit-component/tests/interfaces/integers.wit
+++ b/crates/wit-component/tests/interfaces/integers.wit
@@ -1,27 +1,27 @@
 package foo:foo
 
 interface integers {
-  a1: func(x: u8)
-  a2: func(x: s8)
-  a3: func(x: u16)
-  a4: func(x: s16)
-  a5: func(x: u32)
-  a6: func(x: s32)
-  a7: func(x: u64)
-  a8: func(x: s64)
-  a9: func(p1: u8, p2: s8, p3: u16, p4: s16, p5: u32, p6: s32, p7: u64, p8: s64)
-  r1: func() -> u8
-  r2: func() -> s8
-  r3: func() -> u16
-  r4: func() -> s16
-  r5: func() -> u32
-  r6: func() -> s32
-  r7: func() -> u64
-  r8: func() -> s64
-  pair-ret: func() -> tuple<s64, u8>
-  multi-ret: func() -> (a: s64, b: u8)
+  a1: func(x: u8);
+  a2: func(x: s8);
+  a3: func(x: u16);
+  a4: func(x: s16);
+  a5: func(x: u32);
+  a6: func(x: s32);
+  a7: func(x: u64);
+  a8: func(x: s64);
+  a9: func(p1: u8, p2: s8, p3: u16, p4: s16, p5: u32, p6: s32, p7: u64, p8: s64);
+  r1: func() -> u8;
+  r2: func() -> s8;
+  r3: func() -> u16;
+  r4: func() -> s16;
+  r5: func() -> u32;
+  r6: func() -> s32;
+  r7: func() -> u64;
+  r8: func() -> s64;
+  pair-ret: func() -> tuple<s64, u8>;
+  multi-ret: func() -> (a: s64, b: u8);
 }
 
 world integers-world {
-  import integers
+  import integers;
 }

--- a/crates/wit-component/tests/interfaces/lists.wit
+++ b/crates/wit-component/tests/interfaces/lists.wit
@@ -32,65 +32,65 @@ interface lists {
     d(list<other-variant>),
   }
 
-  type load-store-all-sizes = list<tuple<string, u8, s8, u16, s16, u32, s32, u64, s64, float32, float64, char>>
+  type load-store-all-sizes = list<tuple<string, u8, s8, u16, s16, u32, s32, u64, s64, float32, float64, char>>;
 
-  list-u8-param: func(x: list<u8>)
+  list-u8-param: func(x: list<u8>);
 
-  list-u16-param: func(x: list<u16>)
+  list-u16-param: func(x: list<u16>);
 
-  list-u32-param: func(x: list<u32>)
+  list-u32-param: func(x: list<u32>);
 
-  list-u64-param: func(x: list<u64>)
+  list-u64-param: func(x: list<u64>);
 
-  list-s8-param: func(x: list<s8>)
+  list-s8-param: func(x: list<s8>);
 
-  list-s16-param: func(x: list<s16>)
+  list-s16-param: func(x: list<s16>);
 
-  list-s32-param: func(x: list<s32>)
+  list-s32-param: func(x: list<s32>);
 
-  list-s64-param: func(x: list<s64>)
+  list-s64-param: func(x: list<s64>);
 
-  list-float32-param: func(x: list<float32>)
+  list-float32-param: func(x: list<float32>);
 
-  list-float64-param: func(x: list<float64>)
+  list-float64-param: func(x: list<float64>);
 
-  list-u8-ret: func() -> list<u8>
+  list-u8-ret: func() -> list<u8>;
 
-  list-u16-ret: func() -> list<u16>
+  list-u16-ret: func() -> list<u16>;
 
-  list-u32-ret: func() -> list<u32>
+  list-u32-ret: func() -> list<u32>;
 
-  list-u64-ret: func() -> list<u64>
+  list-u64-ret: func() -> list<u64>;
 
-  list-s8-ret: func() -> list<s8>
+  list-s8-ret: func() -> list<s8>;
 
-  list-s16-ret: func() -> list<s16>
+  list-s16-ret: func() -> list<s16>;
 
-  list-s32-ret: func() -> list<s32>
+  list-s32-ret: func() -> list<s32>;
 
-  list-s64-ret: func() -> list<s64>
+  list-s64-ret: func() -> list<s64>;
 
-  list-float32-ret: func() -> list<float32>
+  list-float32-ret: func() -> list<float32>;
 
-  list-float64-ret: func() -> list<float64>
+  list-float64-ret: func() -> list<float64>;
 
-  tuple-list: func(x: list<tuple<u8, s8>>) -> list<tuple<s64, u32>>
+  tuple-list: func(x: list<tuple<u8, s8>>) -> list<tuple<s64, u32>>;
 
-  string-list-arg: func(a: list<string>)
+  string-list-arg: func(a: list<string>);
 
-  string-list-ret: func() -> list<string>
+  string-list-ret: func() -> list<string>;
 
-  tuple-string-list: func(x: list<tuple<u8, string>>) -> list<tuple<string, u8>>
+  tuple-string-list: func(x: list<tuple<u8, string>>) -> list<tuple<string, u8>>;
 
-  string-list: func(x: list<string>) -> list<string>
+  string-list: func(x: list<string>) -> list<string>;
 
-  record-list: func(x: list<some-record>) -> list<other-record>
+  record-list: func(x: list<some-record>) -> list<other-record>;
 
-  variant-list: func(x: list<some-variant>) -> list<other-variant>
+  variant-list: func(x: list<some-variant>) -> list<other-variant>;
 
-  load-store-everything: func(a: load-store-all-sizes) -> load-store-all-sizes
+  load-store-everything: func(a: load-store-all-sizes) -> load-store-all-sizes;
 }
 
 world lists-world {
-  import lists
+  import lists;
 }

--- a/crates/wit-component/tests/interfaces/multi-doc/a.wit
+++ b/crates/wit-component/tests/interfaces/multi-doc/a.wit
@@ -1,9 +1,9 @@
 package foo:foo
 
 interface a {
-  use b.{the-type}
+  use b.{the-type};
 }
 
 interface b2 {
-  use b.{the-type}
+  use b.{the-type};
 }

--- a/crates/wit-component/tests/interfaces/multi-doc/b.wit
+++ b/crates/wit-component/tests/interfaces/multi-doc/b.wit
@@ -1,5 +1,5 @@
 interface a2 {
-  use b.{the-type}
+  use b.{the-type};
 }
 
 interface b {

--- a/crates/wit-component/tests/interfaces/multiple-use.wit
+++ b/crates/wit-component/tests/interfaces/multiple-use.wit
@@ -1,16 +1,16 @@
 package foo:multiuse
 
 interface foo {
-  type t1 = u8
-  type t2 = u8
+  type t1 = u8;
+  type t2 = u8;
 }
 
 interface bar {
-  type u = u8
+  type u = u8;
 }
 
 interface baz {
-  use foo.{t1}
-  use bar.{u}
-  use foo.{t2}
+  use foo.{t1};
+  use bar.{u};
+  use foo.{t2};
 }

--- a/crates/wit-component/tests/interfaces/pkg-use-chain/def.wit
+++ b/crates/wit-component/tests/interfaces/pkg-use-chain/def.wit
@@ -1,7 +1,7 @@
 package foo:chain
 
 interface def {
-  use a.{a}
+  use a.{a};
 
   enum name {
     other,
@@ -9,5 +9,5 @@ interface def {
 }
 
 interface a {
-  type a = u8
+  type a = u8;
 }

--- a/crates/wit-component/tests/interfaces/pkg-use-chain/the-use.wit
+++ b/crates/wit-component/tests/interfaces/pkg-use-chain/the-use.wit
@@ -1,5 +1,5 @@
 package foo:chain
 
 interface foo {
-  use def.{name}
+  use def.{name};
 }

--- a/crates/wit-component/tests/interfaces/pkg-use-chain2/bar.wit
+++ b/crates/wit-component/tests/interfaces/pkg-use-chain2/bar.wit
@@ -1,5 +1,5 @@
 interface bar {
-  use other.{name as the-name}
+  use other.{name as the-name};
 
   enum name {
     a

--- a/crates/wit-component/tests/interfaces/pkg-use-chain2/foo.wit
+++ b/crates/wit-component/tests/interfaces/pkg-use-chain2/foo.wit
@@ -1,5 +1,5 @@
 package foo:foo
 
 interface foo {
-  use bar.{the-name}
+  use bar.{the-name};
 }

--- a/crates/wit-component/tests/interfaces/preserve-dep-type-order/foo.wit
+++ b/crates/wit-component/tests/interfaces/preserve-dep-type-order/foo.wit
@@ -1,9 +1,9 @@
 package foo:foo
 
 interface foo {
-  use foo:dep/foo.{ty}
+  use foo:dep/foo.{ty};
 }
 
 world bar {
-  import foo:dep/foo
+  import foo:dep/foo;
 }

--- a/crates/wit-component/tests/interfaces/preserve-foreign-reexport/deps/my-dep/my-doc.wit
+++ b/crates/wit-component/tests/interfaces/preserve-foreign-reexport/deps/my-dep/my-doc.wit
@@ -4,5 +4,5 @@ interface my-interface {
   record foo {
     f: u8,
   }
-  type bar = foo
+  type bar = foo;
 }

--- a/crates/wit-component/tests/interfaces/preserve-foreign-reexport/foo.wit
+++ b/crates/wit-component/tests/interfaces/preserve-foreign-reexport/foo.wit
@@ -1,5 +1,5 @@
 package foo:foo
 
 world foo {
-  export foo:my-dep/my-interface
+  export foo:my-dep/my-interface;
 }

--- a/crates/wit-component/tests/interfaces/print-keyword.wit
+++ b/crates/wit-component/tests/interfaces/print-keyword.wit
@@ -1,10 +1,10 @@
 package foo:foo
 
 interface %interface {
-  type %type = u32
-  type %world = %type
+  type %type = u32;
+  type %world = %type;
 
   record %record {
-    %variant: %world
+    %variant: %world,
   }
 }

--- a/crates/wit-component/tests/interfaces/records.wit
+++ b/crates/wit-component/tests/interfaces/records.wit
@@ -30,34 +30,34 @@ interface records {
     e: really-flags,
   }
 
-  type int-typedef = s32
+  type int-typedef = s32;
 
-  type tuple-typedef2 = tuple<int-typedef>
+  type tuple-typedef2 = tuple<int-typedef>;
 
-  tuple-arg: func(x: tuple<char, u32>)
+  tuple-arg: func(x: tuple<char, u32>);
 
-  tuple-result: func() -> tuple<char, u32>
+  tuple-result: func() -> tuple<char, u32>;
 
-  single-arg: func(x: single)
+  single-arg: func(x: single);
 
-  single-result: func() -> single
+  single-result: func() -> single;
 
-  scalar-arg: func(x: scalars)
+  scalar-arg: func(x: scalars);
 
-  scalar-result: func() -> scalars
+  scalar-result: func() -> scalars;
 
-  flags-arg: func(x: really-flags)
+  flags-arg: func(x: really-flags);
 
-  flags-result: func() -> really-flags
+  flags-result: func() -> really-flags;
 
-  aggregate-arg: func(x: aggregates)
+  aggregate-arg: func(x: aggregates);
 
-  aggregate-result: func() -> aggregates
+  aggregate-result: func() -> aggregates;
 
-  typedef-inout: func(e: tuple-typedef2) -> s32
+  typedef-inout: func(e: tuple-typedef2) -> s32;
 }
 
 world records-world {
-  import records
-  export records
+  import records;
+  export records;
 }

--- a/crates/wit-component/tests/interfaces/reference-out-of-order.wit
+++ b/crates/wit-component/tests/interfaces/reference-out-of-order.wit
@@ -1,10 +1,10 @@
 package foo:foo
 
 interface foo {
-  a: func(x: r)
-  b: func(x: v)
-  c: func(x: r-no-string)
-  d: func(x: v-no-string)
+  a: func(x: r);
+  b: func(x: v);
+  c: func(x: r-no-string);
+  d: func(x: v-no-string);
 
   record r {
     s: string,
@@ -24,5 +24,5 @@ interface foo {
 }
 
 world foo-world {
-  import foo
+  import foo;
 }

--- a/crates/wit-component/tests/interfaces/resources.wit
+++ b/crates/wit-component/tests/interfaces/resources.wit
@@ -2,68 +2,68 @@ package foo:bar
 
 interface foo {
   resource bar {
-    constructor()
-    a: static func()
-    b: func()
+    constructor();
+    a: static func();
+    b: func();
   }
 
-  a: func(x: bar) -> bar
-  type t = bar
-  type t2 = own<bar>
+  a: func(x: bar) -> bar;
+  type t = bar;
+  type t2 = own<bar>;
 }
 
 interface baz {
-  use foo.{bar,t}
-  a: func(x: bar) -> bar
+  use foo.{bar,t};
+  a: func(x: bar) -> bar;
 
-  b: func() -> t
+  b: func() -> t;
 }
 
 
 world some-world {
-  use baz.{bar}
+  use baz.{bar};
 
   resource a {
-    constructor()
+    constructor();
   }
 
-  export x: func() -> a
-  export y: func() -> bar
+  export x: func() -> a;
+  export y: func() -> bar;
 
   import anon: interface {
     resource a {
-      constructor()
+      constructor();
 
-      b: static func()
+      b: static func();
 
-      c: func()
+      c: func();
     }
   }
 }
 
 interface implicit-own-handles {
-  resource a
+  resource a;
 
-  b: func(a1: a, a2: a) -> own<a>
-  c: func() -> list<own<a>>
+  b: func(a1: a, a2: a) -> own<a>;
+  c: func() -> list<own<a>>;
 }
 
 interface implicit-own-handles2 {
   // the `own` return and list param should be the same `own`
   resource a {
-    constructor(a: list<a>)
+    constructor(a: list<a>);
   }
 
   // same as above, even when the `list<b>` implicitly-defined `own` comes
   // before an explicitly defined `own`
   resource b {
-    constructor(a: list<b>, b: own<b>)
+    constructor(a: list<b>, b: own<b>);
   }
 
   // same as the above, the `own` argument should have the same type as the
   // return value
   resource c {
-    a: static func(a: own<c>) -> c
+    a: static func(a: own<c>) -> c;
   }
 }
 
@@ -71,6 +71,6 @@ world implicit-own-handles3 {
   // there should only be one `list` type despite there looking like two
   // list types here
   resource a {
-    constructor(a: list<a>, b: list<own<a>>)
+    constructor(a: list<a>, b: list<own<a>>);
   }
 }

--- a/crates/wit-component/tests/interfaces/simple-deps/deps/some-dep/types.wit
+++ b/crates/wit-component/tests/interfaces/simple-deps/deps/some-dep/types.wit
@@ -1,5 +1,5 @@
 package foo:some-dep
 
 interface types {
-  type some-type = u8
+  type some-type = u8;
 }

--- a/crates/wit-component/tests/interfaces/simple-deps/foo.wit
+++ b/crates/wit-component/tests/interfaces/simple-deps/foo.wit
@@ -1,4 +1,4 @@
 package foo:foo
 interface foo {
-  use foo:some-dep/types.{some-type}
+  use foo:some-dep/types.{some-type};
 }

--- a/crates/wit-component/tests/interfaces/simple-use.wit
+++ b/crates/wit-component/tests/interfaces/simple-use.wit
@@ -8,6 +8,6 @@ interface types {
 }
 
 interface console {
-  use types.{level}
-  log: func(level: level, msg: string)
+  use types.{level};
+  log: func(level: level, msg: string);
 }

--- a/crates/wit-component/tests/interfaces/simple-world.wit
+++ b/crates/wit-component/tests/interfaces/simple-world.wit
@@ -1,9 +1,9 @@
 package foo:foo
 
 world the-world {
-  import console
+  import console;
 }
 
 interface console {
-  log: func(arg: string)
+  log: func(arg: string);
 }

--- a/crates/wit-component/tests/interfaces/single-named-result.wit
+++ b/crates/wit-component/tests/interfaces/single-named-result.wit
@@ -1,5 +1,5 @@
 package foo:foo
 
 interface foo {
-  a: func() -> (a: u32)
+  a: func() -> (a: u32);
 }

--- a/crates/wit-component/tests/interfaces/type-alias.wit
+++ b/crates/wit-component/tests/interfaces/type-alias.wit
@@ -1,13 +1,13 @@
 package foo:foo
 
 interface foo {
-  type a = u8
-  type b = a
+  type a = u8;
+  type b = a;
 
-  f: func(a: a) -> b
+  f: func(a: a) -> b;
 }
 
 world my-world {
-  import foo
-  export foo
+  import foo;
+  export foo;
 }

--- a/crates/wit-component/tests/interfaces/type-alias2.wit
+++ b/crates/wit-component/tests/interfaces/type-alias2.wit
@@ -5,11 +5,11 @@ interface foo {
     b,
   }
 
-  type b = a
+  type b = a;
 
-  f: func() -> b
+  f: func() -> b;
 }
 
 world my-world {
-  export foo
+  export foo;
 }

--- a/crates/wit-component/tests/interfaces/upstream-deps-same-name/deps/a/the-name.wit
+++ b/crates/wit-component/tests/interfaces/upstream-deps-same-name/deps/a/the-name.wit
@@ -1,4 +1,4 @@
 package foo:a
 interface the-name {
-  type ty = u8
+  type ty = u8;
 }

--- a/crates/wit-component/tests/interfaces/upstream-deps-same-name/deps/b/the-name.wit
+++ b/crates/wit-component/tests/interfaces/upstream-deps-same-name/deps/b/the-name.wit
@@ -1,4 +1,4 @@
 package foo:b
 interface the-name {
-  type ty = u8
+  type ty = u8;
 }

--- a/crates/wit-component/tests/interfaces/upstream-deps-same-name/foo.wit
+++ b/crates/wit-component/tests/interfaces/upstream-deps-same-name/foo.wit
@@ -1,6 +1,6 @@
 package foo:foo
 
 interface a {
-  use foo:a/the-name.{ty}
-  use foo:b/the-name.{ty as ty2}
+  use foo:a/the-name.{ty};
+  use foo:b/the-name.{ty as ty2};
 }

--- a/crates/wit-component/tests/interfaces/use-chain.wit
+++ b/crates/wit-component/tests/interfaces/use-chain.wit
@@ -1,15 +1,15 @@
 package foo:foo
 
 interface foo {
-  type a = u32
-  type b = a
-  type c = b
+  type a = u32;
+  type b = a;
+  type c = b;
 }
 
 interface bar {
-  use foo.{c}
+  use foo.{c};
 }
 
 interface baz {
-  use bar.{c}
+  use bar.{c};
 }

--- a/crates/wit-component/tests/interfaces/use-for-type.wit
+++ b/crates/wit-component/tests/interfaces/use-for-type.wit
@@ -4,11 +4,11 @@ interface foo {
 }
 
 interface bar {
-  type t = u8
+  type t = u8;
 }
 
 interface baz {
-  use bar.{t}
+  use bar.{t};
 
   record bar {
     a: t,

--- a/crates/wit-component/tests/interfaces/variants.wit
+++ b/crates/wit-component/tests/interfaces/variants.wit
@@ -53,26 +53,26 @@ interface variants {
     bad2,
   }
 
-  e1-arg: func(x: e1)
-  e1-result: func() -> e1
-  v1-arg: func(x: v1)
-  v1-result: func() -> v1
-  bool-arg: func(x: bool)
-  bool-result: func() -> bool
-  option-arg: func(a: option<bool>, b: option<tuple<u32>>, c: option<u32>, d: option<e1>, e: option<float32>, g: option<option<bool>>)
-  option-result: func() -> tuple<option<bool>, option<tuple<u32>>, option<u32>, option<e1>, option<float32>, option<option<bool>>>
-  casts: func(a: casts1, b: casts2, c: casts3, d: casts4, e: casts5, f: casts6) -> tuple<casts1, casts2, casts3, casts4, casts5, casts6>
-  expected-arg: func(a: result, b: result<_, e1>, c: result<e1>, d: result<tuple<u32>, tuple<u32>>, e: result<u32, v1>, f: result<string, list<u8>>)
-  expected-result: func() -> tuple<result, result<_, e1>, result<e1>, result<tuple<u32>, tuple<u32>>, result<u32, v1>, result<string, list<u8>>>
-  return-expected-sugar: func() -> result<s32, my-errno>
-  return-expected-sugar2: func() -> result<_, my-errno>
-  return-expected-sugar3: func() -> result<my-errno, my-errno>
-  return-expected-sugar4: func() -> result<tuple<s32, u32>, my-errno>
-  return-option-sugar: func() -> option<s32>
-  return-option-sugar2: func() -> option<my-errno>
-  expected-simple: func() -> result<u32, s32>
+  e1-arg: func(x: e1);
+  e1-result: func() -> e1;
+  v1-arg: func(x: v1);
+  v1-result: func() -> v1;
+  bool-arg: func(x: bool);
+  bool-result: func() -> bool;
+  option-arg: func(a: option<bool>, b: option<tuple<u32>>, c: option<u32>, d: option<e1>, e: option<float32>, g: option<option<bool>>);
+  option-result: func() -> tuple<option<bool>, option<tuple<u32>>, option<u32>, option<e1>, option<float32>, option<option<bool>>>;
+  casts: func(a: casts1, b: casts2, c: casts3, d: casts4, e: casts5, f: casts6) -> tuple<casts1, casts2, casts3, casts4, casts5, casts6>;
+  expected-arg: func(a: result, b: result<_, e1>, c: result<e1>, d: result<tuple<u32>, tuple<u32>>, e: result<u32, v1>, f: result<string, list<u8>>);
+  expected-result: func() -> tuple<result, result<_, e1>, result<e1>, result<tuple<u32>, tuple<u32>>, result<u32, v1>, result<string, list<u8>>>;
+  return-expected-sugar: func() -> result<s32, my-errno>;
+  return-expected-sugar2: func() -> result<_, my-errno>;
+  return-expected-sugar3: func() -> result<my-errno, my-errno>;
+  return-expected-sugar4: func() -> result<tuple<s32, u32>, my-errno>;
+  return-option-sugar: func() -> option<s32>;
+  return-option-sugar2: func() -> option<my-errno>;
+  expected-simple: func() -> result<u32, s32>;
 }
 
 world variants-world {
-  import variants
+  import variants;
 }

--- a/crates/wit-component/tests/interfaces/wasi-http/deps/io/streams.wit
+++ b/crates/wit-component/tests/interfaces/wasi-http/deps/io/streams.wit
@@ -6,7 +6,7 @@ package wasi:io
 /// In the future, the component model is expected to add built-in stream types;
 /// when it does, they are expected to subsume this API.
 interface streams {
-    use wasi:poll/poll.{pollable}
+    use wasi:poll/poll.{pollable};
 
     /// An error type returned from a stream operation. Currently this
     /// doesn't provide any additional information.
@@ -31,7 +31,7 @@ interface streams {
     /// the wit-bindgen implementation of handles and resources is ready.
     ///
     /// This [represents a resource](https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources).
-    type input-stream = u32
+    type input-stream = u32;
 
     /// Read bytes from a stream.
     ///
@@ -55,7 +55,7 @@ interface streams {
         this: input-stream,
         /// The maximum number of bytes to read
         len: u64
-    ) -> result<tuple<list<u8>, bool>, stream-error>
+    ) -> result<tuple<list<u8>, bool>, stream-error>;
 
     /// Read bytes from a stream, with blocking.
     ///
@@ -65,7 +65,7 @@ interface streams {
         this: input-stream,
         /// The maximum number of bytes to read
         len: u64
-    ) -> result<tuple<list<u8>, bool>, stream-error>
+    ) -> result<tuple<list<u8>, bool>, stream-error>;
 
     /// Skip bytes from a stream.
     ///
@@ -83,7 +83,7 @@ interface streams {
         this: input-stream,
         /// The maximum number of bytes to skip.
         len: u64,
-    ) -> result<tuple<u64, bool>, stream-error>
+    ) -> result<tuple<u64, bool>, stream-error>;
 
     /// Skip bytes from a stream, with blocking.
     ///
@@ -93,16 +93,16 @@ interface streams {
         this: input-stream,
         /// The maximum number of bytes to skip.
         len: u64,
-    ) -> result<tuple<u64, bool>, stream-error>
+    ) -> result<tuple<u64, bool>, stream-error>;
 
     /// Create a `pollable` which will resolve once either the specified stream
     /// has bytes available to read or the other end of the stream has been
     /// closed.
-    subscribe-to-input-stream: func(this: input-stream) -> pollable
+    subscribe-to-input-stream: func(this: input-stream) -> pollable;
 
     /// Dispose of the specified `input-stream`, after which it may no longer
     /// be used.
-    drop-input-stream: func(this: input-stream)
+    drop-input-stream: func(this: input-stream);
 
     /// An output bytestream. In the future, this will be replaced by handle
     /// types.
@@ -121,7 +121,7 @@ interface streams {
     /// the wit-bindgen implementation of handles and resources is ready.
     ///
     /// This [represents a resource](https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources).
-    type output-stream = u32
+    type output-stream = u32;
 
     /// Write bytes to a stream.
     ///
@@ -131,7 +131,7 @@ interface streams {
         this: output-stream,
         /// Data to write
         buf: list<u8>
-    ) -> result<u64, stream-error>
+    ) -> result<u64, stream-error>;
 
     /// Write bytes to a stream, with blocking.
     ///
@@ -141,7 +141,7 @@ interface streams {
         this: output-stream,
         /// Data to write
         buf: list<u8>
-    ) -> result<u64, stream-error>
+    ) -> result<u64, stream-error>;
 
     /// Write multiple zero bytes to a stream.
     ///
@@ -151,7 +151,7 @@ interface streams {
         this: output-stream,
         /// The number of zero bytes to write
         len: u64
-    ) -> result<u64, stream-error>
+    ) -> result<u64, stream-error>;
 
     /// Write multiple zero bytes to a stream, with blocking.
     ///
@@ -161,7 +161,7 @@ interface streams {
         this: output-stream,
         /// The number of zero bytes to write
         len: u64
-    ) -> result<u64, stream-error>
+    ) -> result<u64, stream-error>;
 
     /// Read from one stream and write to another.
     ///
@@ -176,7 +176,7 @@ interface streams {
         src: input-stream,
         /// The number of bytes to splice
         len: u64,
-    ) -> result<tuple<u64, bool>, stream-error>
+    ) -> result<tuple<u64, bool>, stream-error>;
 
     /// Read from one stream and write to another, with blocking.
     ///
@@ -188,7 +188,7 @@ interface streams {
         src: input-stream,
         /// The number of bytes to splice
         len: u64,
-    ) -> result<tuple<u64, bool>, stream-error>
+    ) -> result<tuple<u64, bool>, stream-error>;
 
     /// Forward the entire contents of an input stream to an output stream.
     ///
@@ -205,13 +205,13 @@ interface streams {
         this: output-stream,
         /// The stream to read from
         src: input-stream
-    ) -> result<u64, stream-error>
+    ) -> result<u64, stream-error>;
 
     /// Create a `pollable` which will resolve once either the specified stream
     /// is ready to accept bytes or the other end of the stream has been closed.
-    subscribe-to-output-stream: func(this: output-stream) -> pollable
+    subscribe-to-output-stream: func(this: output-stream) -> pollable;
 
     /// Dispose of the specified `output-stream`, after which it may no longer
     /// be used.
-    drop-output-stream: func(this: output-stream)
+    drop-output-stream: func(this: output-stream);
 }

--- a/crates/wit-component/tests/interfaces/wasi-http/deps/logging/handler.wit
+++ b/crates/wit-component/tests/interfaces/wasi-http/deps/logging/handler.wit
@@ -30,5 +30,5 @@ interface handler {
     /// sent, a context, which is an uninterpreted string meant to help
     /// consumers group similar messages, and a string containing the message
     /// text.
-    log: func(level: level, context: string, message: string)
+    log: func(level: level, context: string, message: string);
 }

--- a/crates/wit-component/tests/interfaces/wasi-http/deps/poll/poll.wit
+++ b/crates/wit-component/tests/interfaces/wasi-http/deps/poll/poll.wit
@@ -17,11 +17,11 @@ interface poll {
     /// that they do not outlive the resource they reference.
     ///
     /// This [represents a resource](https://github.com/WebAssembly/WASI/blob/main/docs/WitInWasi.md#Resources).
-    type pollable = u32
+    type pollable = u32;
 
     /// Dispose of the specified `pollable`, after which it may no longer
     /// be used.
-    drop-pollable: func(this: pollable)
+    drop-pollable: func(this: pollable);
 
     /// Poll for completion on a set of pollables.
     ///
@@ -37,5 +37,5 @@ interface poll {
     /// See <https://github.com/bytecodealliance/preview2-prototyping/pull/11#issuecomment-1329873061>
     /// for details.  For now, we use zero to mean "not ready" and non-zero to
     /// mean "ready".
-    poll-oneoff: func(in: list<pollable>) -> list<u8>
+    poll-oneoff: func(in: list<pollable>) -> list<u8>;
 }

--- a/crates/wit-component/tests/interfaces/wasi-http/deps/random/random.wit
+++ b/crates/wit-component/tests/interfaces/wasi-http/deps/random/random.wit
@@ -15,13 +15,13 @@ interface random {
     /// This function must always return fresh pseudo-random data. Deterministic
     /// environments must omit this function, rather than implementing it with
     /// deterministic data.
-    get-random-bytes: func(len: u64) -> list<u8>
+    get-random-bytes: func(len: u64) -> list<u8>;
 
     /// Return a cryptographically-secure pseudo-random `u64` value.
     ///
     /// This function returns the same type of pseudo-random data as
     /// `get-random-bytes`, represented as a `u64`.
-    get-random-u64: func() -> u64
+    get-random-u64: func() -> u64;
 
     /// Return a 128-bit value that may contain a pseudo-random value.
     ///
@@ -40,5 +40,5 @@ interface random {
     /// This will likely be changed to a value import, to prevent it from being
     /// called multiple times and potentially used for purposes other than DoS
     /// protection.
-    insecure-random: func() -> tuple<u64, u64>
+    insecure-random: func() -> tuple<u64, u64>;
 }

--- a/crates/wit-component/tests/interfaces/wasi-http/incoming-handler.wit
+++ b/crates/wit-component/tests/interfaces/wasi-http/incoming-handler.wit
@@ -7,7 +7,7 @@
 //   that takes a `request` parameter and returns a `response` result.
 //
 interface incoming-handler {
-  use types.{incoming-request, response-outparam}
+  use types.{incoming-request, response-outparam};
 
   // The `handle` function takes an outparam instead of returning its response
   // so that the component may stream its response while streaming any other
@@ -22,5 +22,5 @@ interface incoming-handler {
   handle: func(
     request: incoming-request,
     response-out: response-outparam
-  )
+  );
 }

--- a/crates/wit-component/tests/interfaces/wasi-http/outgoing-handler.wit
+++ b/crates/wit-component/tests/interfaces/wasi-http/outgoing-handler.wit
@@ -6,7 +6,7 @@
 //   that takes a `request` parameter and returns a `response` result.
 //
 interface outgoing-handler {
-  use types.{outgoing-request, request-options, future-incoming-response}
+  use types.{outgoing-request, request-options, future-incoming-response};
 
   // The parameter and result types of the `handle` function allow the caller
   // to concurrently stream the bodies of the outgoing request and the incoming
@@ -14,5 +14,5 @@ interface outgoing-handler {
   handle: func(
     request: outgoing-request,
     options: option<request-options>
-  ) -> future-incoming-response
+  ) -> future-incoming-response;
 }

--- a/crates/wit-component/tests/interfaces/wasi-http/proxy.wit
+++ b/crates/wit-component/tests/interfaces/wasi-http/proxy.wit
@@ -4,21 +4,21 @@
 // outgoing HTTP requests.
 world proxy {
   // HTTP proxies have access to time and randomness.
-  import wasi:random/random
+  import wasi:random/random;
   // TODO: add `import wall-clock: clocks.wall-clock`
   // TODO: add `import monotonic-clock: clocks.monotonic-clock`
 
   // This is the default logging handler to use when user code simply wants to
   // log to a developer-facing console (e.g., via `console.log()`).
-  import wasi:logging/handler
+  import wasi:logging/handler;
 
   // This is the default handler to use when user code simply wants to make an
   // HTTP request (e.g., via `fetch()`).
-  import outgoing-handler
+  import outgoing-handler;
 
   // The host delivers incoming HTTP requests to a component by calling the
   // `handle` function of this exported interface. A host may arbitrarily reuse
   // or not reuse component instance when delivering incoming HTTP requests and
   // thus a component must be able to handle 0..N calls to `handle`.
-  export incoming-handler
+  export incoming-handler;
 }

--- a/crates/wit-component/tests/interfaces/wasi-http/types.wit
+++ b/crates/wit-component/tests/interfaces/wasi-http/types.wit
@@ -4,8 +4,8 @@ package wasi:http
 // define the HTTP resource types and operations used by the component's
 // imported and exported interfaces.
 interface types {
-  use wasi:io/streams.{input-stream, output-stream}
-  use wasi:poll/poll.{pollable}
+  use wasi:io/streams.{input-stream, output-stream};
+  use wasi:poll/poll.{pollable};
 
   // This type corresponds to HTTP standard Methods.
   variant method {
@@ -42,18 +42,18 @@ interface types {
   // HTTP standard Fields. Soon, when resource types are added, the `type
   // fields = u32` type alias can be replaced by a proper `resource fields`
   // definition containing all the functions using the method syntactic sugar.
-  type fields = u32
-  drop-fields: func(fields: fields)
-  new-fields: func(entries: list<tuple<string,string>>) -> fields
-  fields-get: func(fields: fields, name: string) -> list<string>
-  fields-set: func(fields: fields, name: string, value: list<string>)
-  fields-delete: func(fields: fields, name: string)
-  fields-append: func(fields: fields, name: string, value: string)
-  fields-entries: func(fields: fields) -> list<tuple<string,string>>
-  fields-clone: func(fields: fields) -> fields
+  type fields = u32;
+  drop-fields: func(fields: fields);
+  new-fields: func(entries: list<tuple<string,string>>) -> fields;
+  fields-get: func(fields: fields, name: string) -> list<string>;
+  fields-set: func(fields: fields, name: string, value: list<string>);
+  fields-delete: func(fields: fields, name: string);
+  fields-append: func(fields: fields, name: string, value: string);
+  fields-entries: func(fields: fields) -> list<tuple<string,string>>;
+  fields-clone: func(fields: fields) -> fields;
 
-  type headers = fields
-  type trailers = fields
+  type headers = fields;
+  type trailers = fields;
 
   // The following block defines stream types which corresponds to the HTTP
   // standard Contents and Trailers. With Preview3, all of these fields can be
@@ -62,10 +62,10 @@ interface types {
   // `finish-` functions emulate the stream's result value and MUST be called
   // exactly once after the final read/write from/to the stream before dropping
   // the stream.
-  type incoming-stream = input-stream
-  type outgoing-stream = output-stream
-  finish-incoming-stream: func(s: incoming-stream) -> option<trailers>
-  finish-outgoing-stream: func(s: outgoing-stream, trailers: option<trailers>)
+  type incoming-stream = input-stream;
+  type outgoing-stream = output-stream;
+  finish-incoming-stream: func(s: incoming-stream) -> option<trailers>;
+  finish-outgoing-stream: func(s: outgoing-stream, trailers: option<trailers>);
 
   // The following block defines the `incoming-request` and `outgoing-request`
   // resource types that correspond to HTTP standard Requests. Soon, when
@@ -75,17 +75,17 @@ interface types {
   // a single `request` type (that uses the single `stream` type mentioned
   // above). The `consume` and `write` methods may only be called once (and
   // return failure thereafter).
-  type incoming-request = u32
-  type outgoing-request = u32
-  drop-incoming-request: func(request: incoming-request)
-  drop-outgoing-request: func(request: outgoing-request)
-  incoming-request-method: func(request: incoming-request) -> method
-  incoming-request-path: func(request: incoming-request) -> string
-  incoming-request-query: func(request: incoming-request) -> string
-  incoming-request-scheme: func(request: incoming-request) -> option<scheme>
-  incoming-request-authority: func(request: incoming-request) -> string
-  incoming-request-headers: func(request: incoming-request) -> headers
-  incoming-request-consume: func(request: incoming-request) -> result<incoming-stream>
+  type incoming-request = u32;
+  type outgoing-request = u32;
+  drop-incoming-request: func(request: incoming-request);
+  drop-outgoing-request: func(request: outgoing-request);
+  incoming-request-method: func(request: incoming-request) -> method;
+  incoming-request-path: func(request: incoming-request) -> string;
+  incoming-request-query: func(request: incoming-request) -> string;
+  incoming-request-scheme: func(request: incoming-request) -> option<scheme>;
+  incoming-request-authority: func(request: incoming-request) -> string;
+  incoming-request-headers: func(request: incoming-request) -> headers;
+  incoming-request-consume: func(request: incoming-request) -> result<incoming-stream>;
   new-outgoing-request: func(
     method: method,
     path: string,
@@ -93,8 +93,8 @@ interface types {
     scheme: option<scheme>,
     authority: string,
     headers: headers
-  ) -> outgoing-request
-  outgoing-request-write: func(request: outgoing-request) -> result<outgoing-stream>
+  ) -> outgoing-request;
+  outgoing-request-write: func(request: outgoing-request) -> result<outgoing-stream>;
 
   // Additional optional parameters that can be set when making a request.
   record request-options {
@@ -118,12 +118,12 @@ interface types {
   // definition. Later, with Preview3, the need for an outparam goes away entirely
   // (the `wasi:http/handler` interface used for both incoming and outgoing can
   // simply return a `stream`).
-  type response-outparam = u32
-  drop-response-outparam: func(response: response-outparam)
-  set-response-outparam: func(param: response-outparam, response: result<outgoing-response, error>) -> result
+  type response-outparam = u32;
+  drop-response-outparam: func(response: response-outparam);
+  set-response-outparam: func(param: response-outparam, response: result<outgoing-response, error>) -> result;
 
   // This type corresponds to the HTTP standard Status Code.
-  type status-code = u16
+  type status-code = u16;
 
   // The following block defines the `incoming-response` and `outgoing-response`
   // resource types that correspond to HTTP standard Responses. Soon, when
@@ -132,18 +132,18 @@ interface types {
   // Preview2 will allow both types to be merged together into a single `response`
   // type (that uses the single `stream` type mentioned above). The `consume` and
   // `write` methods may only be called once (and return failure thereafter).
-  type incoming-response = u32
-  type outgoing-response = u32
-  drop-incoming-response: func(response: incoming-response)
-  drop-outgoing-response: func(response: outgoing-response)
-  incoming-response-status: func(response: incoming-response) -> status-code
-  incoming-response-headers: func(response: incoming-response) -> headers
-  incoming-response-consume: func(response: incoming-response) -> result<incoming-stream>
+  type incoming-response = u32;
+  type outgoing-response = u32;
+  drop-incoming-response: func(response: incoming-response);
+  drop-outgoing-response: func(response: outgoing-response);
+  incoming-response-status: func(response: incoming-response) -> status-code;
+  incoming-response-headers: func(response: incoming-response) -> headers;
+  incoming-response-consume: func(response: incoming-response) -> result<incoming-stream>;
   new-outgoing-response: func(
     status-code: status-code,
     headers: headers
-  ) -> outgoing-response
-  outgoing-response-write: func(response: outgoing-response) -> result<outgoing-stream>
+  ) -> outgoing-response;
+  outgoing-response-write: func(response: outgoing-response) -> result<outgoing-stream>;
 
   // The following block defines a special resource type used by the
   // `wasi:http/outgoing-handler` interface to emulate
@@ -152,8 +152,8 @@ interface types {
   // method to get the result if it is available. If the result is not available,
   // the client can call `listen` to get a `pollable` that can be passed to
   // `io.poll.poll-oneoff`.
-  type future-incoming-response = u32
-  drop-future-incoming-response: func(f: future-incoming-response)
-  future-incoming-response-get: func(f: future-incoming-response) -> option<result<incoming-response, error>>
-  listen-to-future-incoming-response: func(f: future-incoming-response) -> pollable
+  type future-incoming-response = u32;
+  drop-future-incoming-response: func(f: future-incoming-response);
+  future-incoming-response-get: func(f: future-incoming-response) -> option<result<incoming-response, error>>;
+  listen-to-future-incoming-response: func(f: future-incoming-response) -> pollable;
 }

--- a/crates/wit-component/tests/interfaces/world-pkg-conflict/bar.wit
+++ b/crates/wit-component/tests/interfaces/world-pkg-conflict/bar.wit
@@ -1,3 +1,3 @@
 interface a {
-  type t = u32
+  type t = u32;
 }

--- a/crates/wit-component/tests/interfaces/world-pkg-conflict/foo.wit
+++ b/crates/wit-component/tests/interfaces/world-pkg-conflict/foo.wit
@@ -5,5 +5,5 @@ world c {
 }
 
 interface foo {
-  use a.{t}
+  use a.{t};
 }

--- a/crates/wit-component/tests/interfaces/world-top-level.wit
+++ b/crates/wit-component/tests/interfaces/world-top-level.wit
@@ -1,20 +1,20 @@
 package foo:foo
 
 world foo {
-  import foo: func()
-  export foo2: func()
+  import foo: func();
+  export foo2: func();
 
-  import bar: func(arg: u32)
-  export bar2: func() -> u32
+  import bar: func(arg: u32);
+  export bar2: func() -> u32;
 
   import some-interface: interface {}
   export another-interface: interface {}
 }
 
 world just-import {
-  import foo: func()
+  import foo: func();
 }
 
 world just-export {
-  export foo: func()
+  export foo: func();
 }

--- a/crates/wit-component/tests/interfaces/worlds-with-types.wit
+++ b/crates/wit-component/tests/interfaces/worlds-with-types.wit
@@ -5,19 +5,19 @@ world simple {
     f: u8,
   }
 
-  type bar = foo
+  type bar = foo;
 
-  import a: func(a: foo) -> bar
-  export b: func(a: foo) -> bar
+  import a: func(a: foo) -> bar;
+  export b: func(a: foo) -> bar;
 }
 
 interface import-me {
-  type foo = u32
+  type foo = u32;
 }
 
 world with-imports {
-  use import-me.{foo}
+  use import-me.{foo};
 
-  import a: func(a: foo)
-  export b: func(a: foo)
+  import a: func(a: foo);
+  export b: func(a: foo);
 }

--- a/crates/wit-component/tests/linking.rs
+++ b/crates/wit-component/tests/linking.rs
@@ -128,12 +128,12 @@ const WIT: &str = r#"
 package test:test
 
 interface test {
-   bar: func(v: s32) -> s32
+   bar: func(v: s32) -> s32;
 }
 
 world bar {
-    import test
-    export test
+    import test;
+    export test;
 }
 "#;
 

--- a/crates/wit-component/tests/merge/bad-interface1/from/a.wit
+++ b/crates/wit-component/tests/merge/bad-interface1/from/a.wit
@@ -1,5 +1,5 @@
 package foo:%from
 
 interface a {
-  use foo:foo/a.{a}
+  use foo:foo/a.{a};
 }

--- a/crates/wit-component/tests/merge/bad-interface1/from/deps/foo/a.wit
+++ b/crates/wit-component/tests/merge/bad-interface1/from/deps/foo/a.wit
@@ -1,5 +1,5 @@
 package foo:foo
 
 interface a {
-  type a = u32
+  type a = u32;
 }

--- a/crates/wit-component/tests/merge/bad-interface1/into/a.wit
+++ b/crates/wit-component/tests/merge/bad-interface1/into/a.wit
@@ -1,5 +1,5 @@
 package foo:into
 
 interface a {
-  use foo:foo/a.{b}
+  use foo:foo/a.{b};
 }

--- a/crates/wit-component/tests/merge/bad-interface1/into/deps/foo/a.wit
+++ b/crates/wit-component/tests/merge/bad-interface1/into/deps/foo/a.wit
@@ -1,6 +1,5 @@
 package foo:foo
 
 interface a {
-  type b = s32
+  type b = s32;
 }
-

--- a/crates/wit-component/tests/merge/bad-interface2/from/a.wit
+++ b/crates/wit-component/tests/merge/bad-interface2/from/a.wit
@@ -1,5 +1,5 @@
 package foo:%from
 
 interface a {
-  use foo:foo/a.{t}
+  use foo:foo/a.{t};
 }

--- a/crates/wit-component/tests/merge/bad-interface2/from/deps/foo/a.wit
+++ b/crates/wit-component/tests/merge/bad-interface2/from/deps/foo/a.wit
@@ -1,8 +1,7 @@
 package foo:foo
 
 interface a {
-  type t = u32
+  type t = u32;
 
-  a: func()
+  a: func();
 }
-

--- a/crates/wit-component/tests/merge/bad-interface2/into/a.wit
+++ b/crates/wit-component/tests/merge/bad-interface2/into/a.wit
@@ -1,5 +1,5 @@
 package foo:into
 
 interface a {
-  use foo:foo/a.{t}
+  use foo:foo/a.{t};
 }

--- a/crates/wit-component/tests/merge/bad-interface2/into/deps/foo/a.wit
+++ b/crates/wit-component/tests/merge/bad-interface2/into/deps/foo/a.wit
@@ -1,8 +1,7 @@
 package foo:foo
 
 interface a {
-  type t = u32
+  type t = u32;
 
-  b: func()
+  b: func();
 }
-

--- a/crates/wit-component/tests/merge/bad-world1/from/a.wit
+++ b/crates/wit-component/tests/merge/bad-world1/from/a.wit
@@ -1,4 +1,4 @@
 package foo:%from
 interface a {
-  use foo:foo/a.{a}
+  use foo:foo/a.{a};
 }

--- a/crates/wit-component/tests/merge/bad-world1/from/deps/foo/a.wit
+++ b/crates/wit-component/tests/merge/bad-world1/from/deps/foo/a.wit
@@ -1,11 +1,11 @@
 package foo:foo
 
 interface a {
-  type a = u32
+  type a = u32;
 }
 
 world foo {
   import b: interface {
-    type a = u32
+    type a = u32;
   }
 }

--- a/crates/wit-component/tests/merge/bad-world1/into/a.wit
+++ b/crates/wit-component/tests/merge/bad-world1/into/a.wit
@@ -1,4 +1,4 @@
 package foo:into
 interface a {
-  use foo:foo/a.{a}
+  use foo:foo/a.{a};
 }

--- a/crates/wit-component/tests/merge/bad-world1/into/deps/foo/a.wit
+++ b/crates/wit-component/tests/merge/bad-world1/into/deps/foo/a.wit
@@ -1,9 +1,9 @@
 package foo:foo
 
 interface a {
-  type a = u32
+  type a = u32;
 }
 
 world foo {
-  import a
+  import a;
 }

--- a/crates/wit-component/tests/merge/bad-world2/from/a.wit
+++ b/crates/wit-component/tests/merge/bad-world2/from/a.wit
@@ -1,5 +1,5 @@
 package foo:%from
 
 interface a {
-  use foo:foo/a.{a}
+  use foo:foo/a.{a};
 }

--- a/crates/wit-component/tests/merge/bad-world2/from/deps/foo/a.wit
+++ b/crates/wit-component/tests/merge/bad-world2/from/deps/foo/a.wit
@@ -1,7 +1,7 @@
 package foo:foo
 
 interface a {
-  type a = u32
+  type a = u32;
 }
 
 world foo {

--- a/crates/wit-component/tests/merge/bad-world2/into/a.wit
+++ b/crates/wit-component/tests/merge/bad-world2/into/a.wit
@@ -1,5 +1,5 @@
 package foo:into
 
 interface a {
-  use foo:foo/a.{a}
+  use foo:foo/a.{a};
 }

--- a/crates/wit-component/tests/merge/bad-world2/into/deps/foo/a.wit
+++ b/crates/wit-component/tests/merge/bad-world2/into/deps/foo/a.wit
@@ -1,9 +1,9 @@
 package foo:foo
 
 interface a {
-  type a = u32
+  type a = u32;
 }
 
 world foo {
-  import a
+  import a;
 }

--- a/crates/wit-component/tests/merge/bad-world3/from/a.wit
+++ b/crates/wit-component/tests/merge/bad-world3/from/a.wit
@@ -1,5 +1,5 @@
 package foo:%from
 
 interface a {
-  use foo:foo/a.{a}
+  use foo:foo/a.{a};
 }

--- a/crates/wit-component/tests/merge/bad-world3/from/deps/foo/a.wit
+++ b/crates/wit-component/tests/merge/bad-world3/from/deps/foo/a.wit
@@ -1,7 +1,7 @@
 package foo:foo
 
 interface a {
-  type a = u32
+  type a = u32;
 }
 
 world foo {

--- a/crates/wit-component/tests/merge/bad-world3/into/a.wit
+++ b/crates/wit-component/tests/merge/bad-world3/into/a.wit
@@ -1,5 +1,5 @@
 package foo:into
 
 interface a {
-  use foo:foo/a.{a}
+  use foo:foo/a.{a};
 }

--- a/crates/wit-component/tests/merge/bad-world3/into/deps/foo/a.wit
+++ b/crates/wit-component/tests/merge/bad-world3/into/deps/foo/a.wit
@@ -1,9 +1,9 @@
 package foo:foo
 
 interface a {
-  type a = u32
+  type a = u32;
 }
 
 world foo {
-  export a
+  export a;
 }

--- a/crates/wit-component/tests/merge/bad-world4/from/a.wit
+++ b/crates/wit-component/tests/merge/bad-world4/from/a.wit
@@ -1,5 +1,5 @@
 package foo:%from
 
 interface a {
-  use foo:foo/a.{a}
+  use foo:foo/a.{a};
 }

--- a/crates/wit-component/tests/merge/bad-world4/from/deps/foo/a.wit
+++ b/crates/wit-component/tests/merge/bad-world4/from/deps/foo/a.wit
@@ -1,11 +1,11 @@
 package foo:foo
 
 interface a {
-  type a = u32
+  type a = u32;
 }
 
 world foo {
   export b: interface {
-    type a = u32
+    type a = u32;
   }
 }

--- a/crates/wit-component/tests/merge/bad-world4/into/a.wit
+++ b/crates/wit-component/tests/merge/bad-world4/into/a.wit
@@ -1,5 +1,5 @@
 package foo:into
 
 interface a {
-  use foo:foo/a.{a}
+  use foo:foo/a.{a};
 }

--- a/crates/wit-component/tests/merge/bad-world4/into/deps/foo/a.wit
+++ b/crates/wit-component/tests/merge/bad-world4/into/deps/foo/a.wit
@@ -1,9 +1,9 @@
 package foo:foo
 
 interface a {
-  type a = u32
+  type a = u32;
 }
 
 world foo {
-  export a
+  export a;
 }

--- a/crates/wit-component/tests/merge/bad-world5/from/a.wit
+++ b/crates/wit-component/tests/merge/bad-world5/from/a.wit
@@ -1,5 +1,5 @@
 package foo:%from
 
 interface a {
-  use foo:foo/a.{a}
+  use foo:foo/a.{a};
 }

--- a/crates/wit-component/tests/merge/bad-world5/from/deps/foo/a.wit
+++ b/crates/wit-component/tests/merge/bad-world5/from/deps/foo/a.wit
@@ -1,11 +1,11 @@
 package foo:foo
 
 interface a {
-  type a = u32
+  type a = u32;
 }
 
 world foo {
   import a: interface {
-    type a = u32
+    type a = u32;
   }
 }

--- a/crates/wit-component/tests/merge/bad-world5/into/a.wit
+++ b/crates/wit-component/tests/merge/bad-world5/into/a.wit
@@ -1,5 +1,5 @@
 package foo:into
 
 interface a {
-  use foo:foo/a.{a}
+  use foo:foo/a.{a};
 }

--- a/crates/wit-component/tests/merge/bad-world5/into/deps/foo/a.wit
+++ b/crates/wit-component/tests/merge/bad-world5/into/deps/foo/a.wit
@@ -1,9 +1,9 @@
 package foo:foo
 
 interface a {
-  type a = u32
+  type a = u32;
 }
 
 world foo {
-  import a
+  import a;
 }

--- a/crates/wit-component/tests/merge/success/from/a.wit
+++ b/crates/wit-component/tests/merge/success/from/a.wit
@@ -1,7 +1,7 @@
 package foo:%from
 
 interface a {
-  use foo:foo/only-from.{r}
+  use foo:foo/only-from.{r};
 
-  foo: func()
+  foo: func();
 }

--- a/crates/wit-component/tests/merge/success/from/deps/foo/only-from.wit
+++ b/crates/wit-component/tests/merge/success/from/deps/foo/only-from.wit
@@ -1,5 +1,5 @@
 interface only-from {
   record r {}
 
-  foo: func() -> r
+  foo: func() -> r;
 }

--- a/crates/wit-component/tests/merge/success/from/deps/foo/shared.wit
+++ b/crates/wit-component/tests/merge/success/from/deps/foo/shared.wit
@@ -5,21 +5,21 @@ interface shared-only-from {
     c1,
   }
 
-  bar: func(x: v)
+  bar: func(x: v);
 
-  use foo:only-from-dep/a.{a}
+  use foo:only-from-dep/a.{a};
 }
 
 interface shared-items {
-  type a = u32
+  type a = u32;
 }
 
 world shared-world {
-  import shared-items
+  import shared-items;
 
-  export shared-items
+  export shared-items;
 
-  type c = u32
+  type c = u32;
 
   import d: interface {}
 }

--- a/crates/wit-component/tests/merge/success/from/deps/only-from-dep/a.wit
+++ b/crates/wit-component/tests/merge/success/from/deps/only-from-dep/a.wit
@@ -1,5 +1,5 @@
 package foo:only-from-dep
 
 interface a {
-  type a = u32
+  type a = u32;
 }

--- a/crates/wit-component/tests/merge/success/into/b.wit
+++ b/crates/wit-component/tests/merge/success/into/b.wit
@@ -1,7 +1,7 @@
 package foo:into
 
 interface b {
-  use foo:foo/only-into.{r}
+  use foo:foo/only-into.{r};
 
-  foo: func()
+  foo: func();
 }

--- a/crates/wit-component/tests/merge/success/into/deps/foo/only-into.wit
+++ b/crates/wit-component/tests/merge/success/into/deps/foo/only-into.wit
@@ -1,5 +1,5 @@
 interface only-into {
   record r {}
 
-  foo: func() -> r
+  foo: func() -> r;
 }

--- a/crates/wit-component/tests/merge/success/into/deps/foo/shared.wit
+++ b/crates/wit-component/tests/merge/success/into/deps/foo/shared.wit
@@ -5,19 +5,19 @@ interface shared-only-into {
     c1,
   }
 
-  bar: func(x: v)
+  bar: func(x: v);
 }
 
 interface shared-items {
-  type a = u32
+  type a = u32;
 }
 
 world shared-world {
-  import shared-items
+  import shared-items;
 
-  export shared-items
+  export shared-items;
 
-  type c = u32
+  type c = u32;
 
   import d: interface {}
 }

--- a/crates/wit-component/tests/targets/error-missing-export/test.wit
+++ b/crates/wit-component/tests/targets/error-missing-export/test.wit
@@ -1,18 +1,18 @@
 package test:foo
 
 interface bar {
-    f: func()
+    f: func();
 }
 
 interface foo {
-    f: func()
+    f: func();
 }
 
 world foobar {
-    export bar
-    export foo
+    export bar;
+    export foo;
 }
 
 world foo-only {
-    export foo
+    export foo;
 }

--- a/crates/wit-component/tests/targets/error-missing-import/test.wit
+++ b/crates/wit-component/tests/targets/error-missing-import/test.wit
@@ -1,13 +1,13 @@
 package test:foo
 
 interface foo {
-    f: func()
+    f: func();
 }
 
 world foobar {
-    export foo
+    export foo;
 }
 
 world imports {
-    import foo
+    import foo;
 }

--- a/crates/wit-component/tests/targets/success-empty/test.wit
+++ b/crates/wit-component/tests/targets/success-empty/test.wit
@@ -1,9 +1,9 @@
 package test:foo
 
 interface foo {
-    f: func()
+    f: func();
 }
 
 world foobar {
-    import foo
+    import foo;
 }

--- a/crates/wit-component/tests/targets/success/test.wit
+++ b/crates/wit-component/tests/targets/success/test.wit
@@ -1,14 +1,14 @@
 package test:foo
 
 interface bar {
-    f: func()
+    f: func();
 }
 
 interface foo {
-    f: func()
+    f: func();
 }
 
 world foobar {
-    export bar
-    export foo
+    export bar;
+    export foo;
 }

--- a/crates/wit-parser/src/ast/lex.rs
+++ b/crates/wit-parser/src/ast/lex.rs
@@ -12,6 +12,7 @@ pub struct Tokenizer<'a> {
     input: &'a str,
     span_offset: u32,
     chars: CrlfFold<'a>,
+    require_semicolons: bool,
 }
 
 #[derive(Clone)]
@@ -115,8 +116,14 @@ pub enum Error {
     },
 }
 
+const REQUIRE_SEMICOLONS_BY_DEFAULT: bool = false;
+
 impl<'a> Tokenizer<'a> {
-    pub fn new(input: &'a str, span_offset: u32) -> Result<Tokenizer<'a>> {
+    pub fn new(
+        input: &'a str,
+        span_offset: u32,
+        require_semicolons: Option<bool>,
+    ) -> Result<Tokenizer<'a>> {
         detect_invalid_input(input)?;
 
         let mut t = Tokenizer {
@@ -125,10 +132,25 @@ impl<'a> Tokenizer<'a> {
             chars: CrlfFold {
                 chars: input.char_indices(),
             },
+            require_semicolons: require_semicolons.unwrap_or_else(|| {
+                match std::env::var("WIT_REQUIRE_SEMICOLONS") {
+                    Ok(s) => s == "1",
+                    Err(_) => REQUIRE_SEMICOLONS_BY_DEFAULT,
+                }
+            }),
         };
         // Eat utf-8 BOM
         t.eatc('\u{feff}');
         Ok(t)
+    }
+
+    pub fn expect_semicolon(&mut self) -> Result<()> {
+        if self.require_semicolons {
+            self.expect(Token::Semicolon)?;
+        } else {
+            self.eat(Token::Semicolon)?;
+        }
+        Ok(())
     }
 
     pub fn input(&self) -> &'a str {
@@ -631,7 +653,7 @@ fn test_validate_id() {
 #[test]
 fn test_tokenizer() {
     fn collect(s: &str) -> Result<Vec<Token>> {
-        let mut t = Tokenizer::new(s, 0)?;
+        let mut t = Tokenizer::new(s, 0, Some(true))?;
         let mut tokens = Vec::new();
         while let Some(token) = t.next()? {
             tokens.push(token.1);

--- a/crates/wit-parser/src/ast/lex.rs
+++ b/crates/wit-parser/src/ast/lex.rs
@@ -116,6 +116,7 @@ pub enum Error {
     },
 }
 
+// NB: keep in sync with `crates/wit-component/src/printing.rs`.
 const REQUIRE_SEMICOLONS_BY_DEFAULT: bool = false;
 
 impl<'a> Tokenizer<'a> {

--- a/crates/wit-parser/tests/all.rs
+++ b/crates/wit-parser/tests/all.rs
@@ -106,7 +106,11 @@ impl Runner<'_> {
         let result = if test.is_dir() {
             resolve.push_dir(test).map(|(id, _)| id)
         } else {
-            UnresolvedPackage::parse_file(test).and_then(|p| resolve.push(p))
+            let mut map = SourceMap::new();
+            map.set_require_semicolons(true);
+            map.push_file(test)
+                .and_then(|()| map.parse())
+                .and_then(|p| resolve.push(p))
         };
 
         let result = if test.iter().any(|s| s == "parse-fail") {
@@ -180,6 +184,7 @@ impl Runner<'_> {
 }
 
 fn normalize(s: &str, extension: &str) -> String {
+    let s = s.trim();
     match extension {
         // .result files have error messages with paths, so normalize Windows \ separators to /
         "result" => s.replace("\\", "/").replace("\r\n", "\n"),

--- a/crates/wit-parser/tests/ui/comments.wit
+++ b/crates/wit-parser/tests/ui/comments.wit
@@ -8,7 +8,7 @@ package foo:comments
 /* this /* is /* a */ nested */ comment */
 
 interface foo {
-  type x = u32
+  type x = u32;
 
   type /* foo */ bar /* baz */ = //
   stream < //
@@ -20,6 +20,6 @@ interface foo {
 
   x
 
-  >
+  >;
 
 }

--- a/crates/wit-parser/tests/ui/complex-include/deps/bar/root.wit
+++ b/crates/wit-parser/tests/ui/complex-include/deps/bar/root.wit
@@ -4,6 +4,6 @@ interface a {}
 interface b {}
 
 world bar-a {
-    import a
-    import b
+    import a;
+    import b;
 }

--- a/crates/wit-parser/tests/ui/complex-include/deps/baz/root.wit
+++ b/crates/wit-parser/tests/ui/complex-include/deps/baz/root.wit
@@ -4,6 +4,6 @@ interface a {}
 interface b {}
 
 world baz-a {
-    import a
-    import b
+    import a;
+    import b;
 }

--- a/crates/wit-parser/tests/ui/complex-include/root.wit
+++ b/crates/wit-parser/tests/ui/complex-include/root.wit
@@ -4,23 +4,23 @@ interface ai {}
 interface bi {}
 
 world a {
-    import ai
-    import bi
+    import ai;
+    import bi;
 }
 
 world b {
-    include foo:bar/bar-a
+    include foo:bar/bar-a;
 }
 
 world c {
-    include b
-    include foo:bar/bar-a
+    include b;
+    include foo:bar/bar-a;
 }
 
 world union-world {
-    include a
-    include b
-    include c
-    include foo:bar/bar-a
-    include foo:baz/baz-a
+    include a;
+    include b;
+    include c;
+    include foo:bar/bar-a;
+    include foo:baz/baz-a;
 }

--- a/crates/wit-parser/tests/ui/cross-package-resource/deps/foo/foo.wit
+++ b/crates/wit-parser/tests/ui/cross-package-resource/deps/foo/foo.wit
@@ -1,5 +1,5 @@
 package some:dep
 
 interface foo {
-  resource r
+  resource r;
 }

--- a/crates/wit-parser/tests/ui/cross-package-resource/foo.wit
+++ b/crates/wit-parser/tests/ui/cross-package-resource/foo.wit
@@ -1,7 +1,7 @@
 package foo:bar
 
 interface foo {
-  use some:dep/foo.{r}
+  use some:dep/foo.{r};
 
-  type t = own<r>
+  type t = own<r>;
 }

--- a/crates/wit-parser/tests/ui/diamond1/join.wit
+++ b/crates/wit-parser/tests/ui/diamond1/join.wit
@@ -1,6 +1,6 @@
 package foo:foo
 
 world foo {
-  import foo:dep1/types
-  import foo:dep2/types
+  import foo:dep1/types;
+  import foo:dep2/types;
 }

--- a/crates/wit-parser/tests/ui/disambiguate-diamond/shared1.wit
+++ b/crates/wit-parser/tests/ui/disambiguate-diamond/shared1.wit
@@ -1,3 +1,3 @@
 interface shared1 {
-  type the-type = u32
+  type the-type = u32;
 }

--- a/crates/wit-parser/tests/ui/disambiguate-diamond/shared2.wit
+++ b/crates/wit-parser/tests/ui/disambiguate-diamond/shared2.wit
@@ -1,3 +1,3 @@
 interface shared2 {
-  type the-type = u32
+  type the-type = u32;
 }

--- a/crates/wit-parser/tests/ui/disambiguate-diamond/world.wit
+++ b/crates/wit-parser/tests/ui/disambiguate-diamond/world.wit
@@ -2,12 +2,12 @@ package foo:diamond
 
 world foo {
   import foo: interface {
-    use shared1.{the-type}
+    use shared1.{the-type};
   }
   import bar: interface {
-    use shared2.{the-type}
+    use shared2.{the-type};
   }
 
-  import shared1
-  import shared2
+  import shared1;
+  import shared2;
 }

--- a/crates/wit-parser/tests/ui/embedded.wit.md
+++ b/crates/wit-parser/tests/ui/embedded.wit.md
@@ -9,7 +9,7 @@ interface foo {
 ```
 
 ```wit
-x: func()
+x: func();
 ```
 
 Intervening content, including a non-wit codeblock:
@@ -18,7 +18,7 @@ function func() {}
 ```
 
 ```wit
-y: func()
+y: func();
 ```
 
 ## A new section
@@ -26,7 +26,7 @@ y: func()
 In which, another wit code block!
 
 ```wit
-z: func()
+z: func();
 ```
 
 ```wit

--- a/crates/wit-parser/tests/ui/foreign-deps-union/deps/foreign-pkg/the-doc.wit
+++ b/crates/wit-parser/tests/ui/foreign-deps-union/deps/foreign-pkg/the-doc.wit
@@ -1,5 +1,5 @@
 package foo:foreign-pkg
 
 interface the-default {
-  type some-type = u32
+  type some-type = u32;
 }

--- a/crates/wit-parser/tests/ui/foreign-deps-union/deps/some-pkg/some-doc.wit
+++ b/crates/wit-parser/tests/ui/foreign-deps-union/deps/some-pkg/some-doc.wit
@@ -1,13 +1,13 @@
 package foo:some-pkg
 
 interface the-default {
-  type from-default = string
+  type from-default = string;
 }
 
 interface some-interface {
-  type another-type = u32
+  type another-type = u32;
 }
 
 interface another-interface {
-  type yet-another-type = u8
+  type yet-another-type = u8;
 }

--- a/crates/wit-parser/tests/ui/foreign-deps-union/deps/wasi/clocks.wit
+++ b/crates/wit-parser/tests/ui/foreign-deps-union/deps/wasi/clocks.wit
@@ -1,5 +1,5 @@
 package foo:wasi
 
 interface clocks {
-  type timestamp = u64
+  type timestamp = u64;
 }

--- a/crates/wit-parser/tests/ui/foreign-deps-union/deps/wasi/wasi.wit
+++ b/crates/wit-parser/tests/ui/foreign-deps-union/deps/wasi/wasi.wit
@@ -1,6 +1,6 @@
 package foo:wasi
 
 world wasi {
-    import filesystem
-    import clocks
+    import filesystem;
+    import clocks;
 }

--- a/crates/wit-parser/tests/ui/foreign-deps-union/root.wit
+++ b/crates/wit-parser/tests/ui/foreign-deps-union/root.wit
@@ -1,50 +1,50 @@
 package foo:root
 
 interface foo {
-  use foo:wasi/clocks.{timestamp}
-  use foo:wasi/filesystem.{stat}
+  use foo:wasi/clocks.{timestamp};
+  use foo:wasi/filesystem.{stat};
 }
 
 world my-world {
-  import foo:wasi/filesystem
-  import foo:wasi/clocks
+  import foo:wasi/filesystem;
+  import foo:wasi/clocks;
 
-  export foo:corp/saas
+  export foo:corp/saas;
 }
 
-use foo:wasi/filesystem as filesystem
-use foo:wasi/clocks as clocks
+use foo:wasi/filesystem as filesystem;
+use foo:wasi/clocks as clocks;
 
 world my-world2 {
-  import filesystem
-  import clocks
-  export foo
-  export foo:corp/saas
+  import filesystem;
+  import clocks;
+  export foo;
+  export foo:corp/saas;
 }
 
 interface bar {
-  use filesystem.{}
-  use foo:some-pkg/the-default.{from-default}
-  use foo:some-pkg/some-interface.{another-type}
-  use foo:some-pkg/some-interface.{}
-  use foo:some-pkg/another-interface.{yet-another-type}
-  use foo:different-pkg/i.{}
+  use filesystem.{};
+  use foo:some-pkg/the-default.{from-default};
+  use foo:some-pkg/some-interface.{another-type};
+  use foo:some-pkg/some-interface.{};
+  use foo:some-pkg/another-interface.{yet-another-type};
+  use foo:different-pkg/i.{};
 }
 
 world bars-world {
-  import foo:some-pkg/the-default
-  import foo:another-pkg/other-interface
+  import foo:some-pkg/the-default;
+  import foo:another-pkg/other-interface;
 }
 
 interface use1 {
-  use foo:foreign-pkg/the-default.{some-type}
+  use foo:foreign-pkg/the-default.{some-type};
 }
 interface use2 {
-  use foo:foreign-pkg/the-default.{some-type}
+  use foo:foreign-pkg/the-default.{some-type};
 }
 
 world unionw-world {
-  include my-world
-  include my-world2
-  include foo:wasi/wasi
+  include my-world;
+  include my-world2;
+  include foo:wasi/wasi;
 }

--- a/crates/wit-parser/tests/ui/foreign-deps/deps/foreign-pkg/the-doc.wit
+++ b/crates/wit-parser/tests/ui/foreign-deps/deps/foreign-pkg/the-doc.wit
@@ -1,5 +1,5 @@
 package foo:foreign-pkg
 
 interface the-default {
-  type some-type = u32
+  type some-type = u32;
 }

--- a/crates/wit-parser/tests/ui/foreign-deps/deps/some-pkg/some-doc.wit
+++ b/crates/wit-parser/tests/ui/foreign-deps/deps/some-pkg/some-doc.wit
@@ -1,13 +1,13 @@
 package foo:some-pkg
 
 interface the-default {
-  type from-default = string
+  type from-default = string;
 }
 
 interface some-interface {
-  type another-type = u32
+  type another-type = u32;
 }
 
 interface another-interface {
-  type yet-another-type = u8
+  type yet-another-type = u8;
 }

--- a/crates/wit-parser/tests/ui/foreign-deps/deps/wasi/clocks.wit
+++ b/crates/wit-parser/tests/ui/foreign-deps/deps/wasi/clocks.wit
@@ -1,5 +1,5 @@
 package foo:wasi
 
 interface clocks {
-  type timestamp = u64
+  type timestamp = u64;
 }

--- a/crates/wit-parser/tests/ui/foreign-deps/root.wit
+++ b/crates/wit-parser/tests/ui/foreign-deps/root.wit
@@ -1,44 +1,44 @@
 package foo:root
 
 interface foo {
-  use foo:wasi/clocks.{timestamp}
-  use foo:wasi/filesystem.{stat}
+  use foo:wasi/clocks.{timestamp};
+  use foo:wasi/filesystem.{stat};
 }
 
 world my-world {
-  import foo:wasi/filesystem
-  import foo:wasi/clocks
+  import foo:wasi/filesystem;
+  import foo:wasi/clocks;
 
-  export foo:corp/saas
+  export foo:corp/saas;
 }
 
-use foo:wasi/filesystem as filesystem
-use foo:wasi/clocks as clocks
+use foo:wasi/filesystem as filesystem;
+use foo:wasi/clocks as clocks;
 
 world my-world2 {
-  import filesystem
-  import clocks
-  export foo
-  export foo:corp/saas
+  import filesystem;
+  import clocks;
+  export foo;
+  export foo:corp/saas;
 }
 
 interface bar {
-  use filesystem.{}
-  use foo:some-pkg/the-default.{from-default}
-  use foo:some-pkg/some-interface.{another-type}
-  use foo:some-pkg/some-interface.{}
-  use foo:some-pkg/another-interface.{yet-another-type}
-  use foo:different-pkg/i.{}
+  use filesystem.{};
+  use foo:some-pkg/the-default.{from-default};
+  use foo:some-pkg/some-interface.{another-type};
+  use foo:some-pkg/some-interface.{};
+  use foo:some-pkg/another-interface.{yet-another-type};
+  use foo:different-pkg/i.{};
 }
 
 world bars-world {
-  import foo:some-pkg/the-default
-  import foo:another-pkg/other-interface
+  import foo:some-pkg/the-default;
+  import foo:another-pkg/other-interface;
 }
 
 interface use1 {
-  use foo:foreign-pkg/the-default.{some-type}
+  use foo:foreign-pkg/the-default.{some-type};
 }
 interface use2 {
-  use foo:foreign-pkg/the-default.{some-type}
+  use foo:foreign-pkg/the-default.{some-type};
 }

--- a/crates/wit-parser/tests/ui/functions.wit
+++ b/crates/wit-parser/tests/ui/functions.wit
@@ -1,14 +1,14 @@
 package foo:functions
 
 interface functions {
-  f1: func()
-  f2: func(a: u32)
-  f3: func(a: u32,)
-  f4: func() -> u32
-  f6: func() -> tuple<u32, u32>
-  f7: func(a: float32, b: float32) -> tuple<u32, u32>
-  f8: func(a: option<u32>) -> result<u32, float32>
-  f9: func() -> (u: u32, f: float32)
-  f10: func() -> (u: u32)
-  f11: func() -> ()
+  f1: func();
+  f2: func(a: u32);
+  f3: func(a: u32,);
+  f4: func() -> u32;
+  f6: func() -> tuple<u32, u32>;
+  f7: func(a: float32, b: float32) -> tuple<u32, u32>;
+  f8: func(a: option<u32>) -> result<u32, float32>;
+  f9: func() -> (u: u32, f: float32);
+  f10: func() -> (u: u32);
+  f11: func() -> ();
 }

--- a/crates/wit-parser/tests/ui/ignore-files-deps/world.wit
+++ b/crates/wit-parser/tests/ui/ignore-files-deps/world.wit
@@ -1,5 +1,5 @@
 package foo:foo
 
 world foo {
-  import foo:bar/types
+  import foo:bar/types;
 }

--- a/crates/wit-parser/tests/ui/include-reps.wit
+++ b/crates/wit-parser/tests/ui/include-reps.wit
@@ -4,12 +4,12 @@ interface a {}
 interface b {}
 
 world bar {
-    import a
-    export b
+    import a;
+    export b;
 }
 
 world foo {
-  include bar
-  include bar
-  include bar
+  include bar;
+  include bar;
+  include bar;
 }

--- a/crates/wit-parser/tests/ui/kebab-name-include-with.wit
+++ b/crates/wit-parser/tests/ui/kebab-name-include-with.wit
@@ -1,8 +1,8 @@
 package foo:foo
 
-world foo { import a: func() }
-world bar { import a: func() }
-world baz { 
+world foo { import a: func(); }
+world bar { import a: func(); }
+world baz {
     include foo with { a as b }
-    include bar
+    include bar;
 }

--- a/crates/wit-parser/tests/ui/many-names/a.wit
+++ b/crates/wit-parser/tests/ui/many-names/a.wit
@@ -1,2 +1,2 @@
 interface x {}
-use x as name
+use x as name;

--- a/crates/wit-parser/tests/ui/multi-file/bar.wit
+++ b/crates/wit-parser/tests/ui/multi-file/bar.wit
@@ -5,16 +5,16 @@ interface irrelevant-name {
 }
 
 interface depends-on-later-item {
-  use depend-on-me.{x}
+  use depend-on-me.{x};
 }
 
 interface depend-on-me {
-  type x = u32
+  type x = u32;
 }
 
 world more-depends-on-later-things {
-  import later-interface
-  export later-interface
+  import later-interface;
+  export later-interface;
 }
 
 interface later-interface {

--- a/crates/wit-parser/tests/ui/multi-file/cycle-a.wit
+++ b/crates/wit-parser/tests/ui/multi-file/cycle-a.wit
@@ -1,7 +1,7 @@
 interface cycle1 {
-  type t = u32
+  type t = u32;
 }
 
 interface cycle3 {
-  use cycle2.{t}
+  use cycle2.{t};
 }

--- a/crates/wit-parser/tests/ui/multi-file/cycle-b.wit
+++ b/crates/wit-parser/tests/ui/multi-file/cycle-b.wit
@@ -1,3 +1,3 @@
 interface cycle2 {
-  use cycle1.{t}
+  use cycle1.{t};
 }

--- a/crates/wit-parser/tests/ui/multi-file/foo.wit
+++ b/crates/wit-parser/tests/ui/multi-file/foo.wit
@@ -1,31 +1,31 @@
 package foo:multi-file
 
 interface foo {
-  type x = u32
+  type x = u32;
 }
 
-use foo as foo2
+use foo as foo2;
 
 interface something-else {
-  type y = u64
+  type y = u64;
 }
 
-use depend-on-me as a-different-name
+use depend-on-me as a-different-name;
 
 interface bar {
-  use foo.{x}
-  use foo.{x as x2}
-  use foo2.{x as x3}
-  use a-different-name.{x as x4}
-  use something-else.{y}
-  use something-else.{y as y2}
-  use irrelevant-name.{a-name}
+  use foo.{x};
+  use foo.{x as x2};
+  use foo2.{x as x3};
+  use a-different-name.{x as x4};
+  use something-else.{y};
+  use something-else.{y as y2};
+  use irrelevant-name.{a-name};
 }
 
 world the-world {
-  import a-different-name
+  import a-different-name;
 
-  use a-different-name.{x}
+  use a-different-name.{x};
 
-  import foo: func() -> x
+  import foo: func() -> x;
 }

--- a/crates/wit-parser/tests/ui/name-both-resource-and-type/deps/dep/foo.wit
+++ b/crates/wit-parser/tests/ui/name-both-resource-and-type/deps/dep/foo.wit
@@ -1,5 +1,5 @@
 package some:dep
 
 interface foo {
-  resource a
+  resource a;
 }

--- a/crates/wit-parser/tests/ui/name-both-resource-and-type/foo.wit
+++ b/crates/wit-parser/tests/ui/name-both-resource-and-type/foo.wit
@@ -1,9 +1,9 @@
 package foo:bar
 
 interface foo {
-  use some:dep/foo.{a}
+  use some:dep/foo.{a};
 
-  type t1 = a
-  type t2 = borrow<a>
-  type t3 = borrow<t1>
+  type t1 = a;
+  type t2 = borrow<a>;
+  type t3 = borrow<t1>;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/alias-no-type.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/alias-no-type.wit
@@ -1,4 +1,6 @@
 // parse-fail
+package foo:bar
+
 interface foo {
-  type foo = bar
+  type foo = bar;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/alias-no-type.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/alias-no-type.wit.result
@@ -1,1 +1,5 @@
-no `package` header was found in any WIT file for this package
+type `bar` does not exist
+     --> tests/ui/parse-fail/alias-no-type.wit:5:14
+      |
+    5 |   type foo = bar;
+      |              ^--

--- a/crates/wit-parser/tests/ui/parse-fail/bad-function.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-function.wit
@@ -3,5 +3,5 @@
 package foo:foo
 
 interface foo {
-  x: func(param: nonexistent)
+  x: func(param: nonexistent);
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-function.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-function.wit.result
@@ -1,5 +1,5 @@
 name `nonexistent` is not defined
      --> tests/ui/parse-fail/bad-function.wit:6:18
       |
-    6 |   x: func(param: nonexistent)
+    6 |   x: func(param: nonexistent);
       |                  ^----------

--- a/crates/wit-parser/tests/ui/parse-fail/bad-function2.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-function2.wit
@@ -3,5 +3,5 @@
 package foo:foo
 
 interface foo {
-  x: func() -> nonexistent
+  x: func() -> nonexistent;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-function2.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-function2.wit.result
@@ -1,5 +1,5 @@
 name `nonexistent` is not defined
      --> tests/ui/parse-fail/bad-function2.wit:6:16
       |
-    6 |   x: func() -> nonexistent
+    6 |   x: func() -> nonexistent;
       |                ^----------

--- a/crates/wit-parser/tests/ui/parse-fail/bad-include1.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-include1.wit
@@ -1,5 +1,5 @@
 package foo:foo
 
 world foo {
-  include non-existance
+  include non-existance;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-include1.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-include1.wit.result
@@ -1,5 +1,5 @@
 interface or world `non-existance` not found in package
      --> tests/ui/parse-fail/bad-include1.wit:4:11
       |
-    4 |   include non-existance
+    4 |   include non-existance;
       |           ^------------

--- a/crates/wit-parser/tests/ui/parse-fail/bad-include2.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-include2.wit
@@ -1,9 +1,9 @@
 package foo:foo
 
 world bar {
-    include foo
+    include foo;
 }
 
 world foo {
-    include bar
+    include bar;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-include3.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-include3.wit
@@ -1,5 +1,5 @@
 package foo:foo
 
 world foo {
-  include foo
+  include foo;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-pkg1.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-pkg1.wit.result
@@ -4,5 +4,5 @@ Caused by:
     interface or world `nonexistent` not found in package
          --> tests/ui/parse-fail/bad-pkg1/root.wit:4:7
           |
-        4 |   use nonexistent.{}
+        4 |   use nonexistent.{};
           |       ^----------

--- a/crates/wit-parser/tests/ui/parse-fail/bad-pkg1/root.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-pkg1/root.wit
@@ -1,5 +1,5 @@
 package foo:foo
 
 interface foo {
-  use nonexistent.{}
+  use nonexistent.{};
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-pkg2.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-pkg2.wit.result
@@ -1,5 +1,5 @@
 interface not found in package
      --> tests/ui/parse-fail/bad-pkg2/root.wit:4:15
       |
-    4 |   use foo:bar/nonexistent.{}
+    4 |   use foo:bar/nonexistent.{};
       |               ^----------

--- a/crates/wit-parser/tests/ui/parse-fail/bad-pkg2/root.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-pkg2/root.wit
@@ -1,5 +1,5 @@
 package foo:foo
 
 interface foo {
-  use foo:bar/nonexistent.{}
+  use foo:bar/nonexistent.{};
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-pkg3.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-pkg3.wit.result
@@ -1,5 +1,5 @@
 interface not found in package
      --> tests/ui/parse-fail/bad-pkg3/root.wit:4:15
       |
-    4 |   use foo:bar/baz.{}
+    4 |   use foo:bar/baz.{};
       |               ^--

--- a/crates/wit-parser/tests/ui/parse-fail/bad-pkg3/root.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-pkg3/root.wit
@@ -1,5 +1,5 @@
 package foo:foo
 
 interface foo {
-  use foo:bar/baz.{}
+  use foo:bar/baz.{};
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-pkg4.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-pkg4.wit.result
@@ -1,5 +1,5 @@
 type `a-name` not defined in interface
      --> tests/ui/parse-fail/bad-pkg4/root.wit:3:20
       |
-    3 |   use foo:bar/baz.{a-name}
+    3 |   use foo:bar/baz.{a-name};
       |                    ^-----

--- a/crates/wit-parser/tests/ui/parse-fail/bad-pkg4/deps/bar/baz.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-pkg4/deps/bar/baz.wit
@@ -1,4 +1,4 @@
 package foo:bar
 interface baz {
-  a-name: func()
+  a-name: func();
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-pkg4/root.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-pkg4/root.wit
@@ -1,4 +1,4 @@
 package foo:foo
 interface foo {
-  use foo:bar/baz.{a-name}
+  use foo:bar/baz.{a-name};
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-pkg5.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-pkg5.wit.result
@@ -1,5 +1,5 @@
 type `nonexistent` not defined in interface
      --> tests/ui/parse-fail/bad-pkg5/root.wit:3:20
       |
-    3 |   use foo:bar/baz.{nonexistent}
+    3 |   use foo:bar/baz.{nonexistent};
       |                    ^----------

--- a/crates/wit-parser/tests/ui/parse-fail/bad-pkg5/root.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-pkg5/root.wit
@@ -1,4 +1,4 @@
 package foo:foo
 interface foo {
-  use foo:bar/baz.{nonexistent}
+  use foo:bar/baz.{nonexistent};
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-pkg6.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-pkg6.wit.result
@@ -1,5 +1,5 @@
 failed to find package `foo:bar` in `deps` directory
      --> tests/ui/parse-fail/bad-pkg6/root.wit:3:7
       |
-    3 |   use foo:bar/baz.{}
+    3 |   use foo:bar/baz.{};
       |       ^------

--- a/crates/wit-parser/tests/ui/parse-fail/bad-pkg6/root.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-pkg6/root.wit
@@ -1,4 +1,4 @@
 package foo:foo
 interface foo {
-  use foo:bar/baz.{}
+  use foo:bar/baz.{};
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource1.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource1.wit
@@ -1,5 +1,5 @@
 package foo:bar
 
 interface foo {
-  type t = borrow<u32>
+  type t = borrow<u32>;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource1.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource1.wit.result
@@ -1,5 +1,5 @@
 expected an identifier or string, found keyword `u32`
      --> tests/ui/parse-fail/bad-resource1.wit:4:19
       |
-    4 |   type t = borrow<u32>
+    4 |   type t = borrow<u32>;
       |                   ^--

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource10.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource10.wit
@@ -1,5 +1,5 @@
 package foo:bar
 
 interface foo {
-  type t = own<u32>
+  type t = own<u32>;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource10.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource10.wit.result
@@ -1,5 +1,5 @@
 expected an identifier or string, found keyword `u32`
      --> tests/ui/parse-fail/bad-resource10.wit:4:16
       |
-    4 |   type t = own<u32>
+    4 |   type t = own<u32>;
       |                ^--

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource11.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource11.wit
@@ -1,5 +1,5 @@
 package foo:bar
 
 interface foo {
-  type t = own<foo>
+  type t = own<foo>;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource11.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource11.wit.result
@@ -1,5 +1,5 @@
 type `foo` does not exist
      --> tests/ui/parse-fail/bad-resource11.wit:4:16
       |
-    4 |   type t = own<foo>
+    4 |   type t = own<foo>;
       |                ^--

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource12.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource12.wit
@@ -1,6 +1,6 @@
 package foo:bar
 
 interface foo {
-  foo: func()
-  type t = own<foo>
+  foo: func();
+  type t = own<foo>;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource12.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource12.wit.result
@@ -1,5 +1,5 @@
 type `foo` does not exist
      --> tests/ui/parse-fail/bad-resource12.wit:5:16
       |
-    5 |   type t = own<foo>
+    5 |   type t = own<foo>;
       |                ^--

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource13.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource13.wit
@@ -1,6 +1,6 @@
 package foo:bar
 
 interface foo {
-  type foo = u32
-  type t = own<foo>
+  type foo = u32;
+  type t = own<foo>;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource13.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource13.wit.result
@@ -1,5 +1,5 @@
 type `foo` used in a handle must be a resource
      --> tests/ui/parse-fail/bad-resource13.wit:5:16
       |
-    5 |   type t = own<foo>
+    5 |   type t = own<foo>;
       |                ^--

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource14.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource14.wit
@@ -2,6 +2,6 @@ package foo:bar
 
 interface foo {
   resource a {}
-  type t = own<a>
-  type b = own<t>
+  type t = own<a>;
+  type b = own<t>;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource14.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource14.wit.result
@@ -1,5 +1,5 @@
 type `t` used in a handle must be a resource
      --> tests/ui/parse-fail/bad-resource14.wit:6:16
       |
-    6 |   type b = own<t>
+    6 |   type b = own<t>;
       |                ^

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource15.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource15.wit.result
@@ -1,5 +1,5 @@
 type used in a handle must be a resource
      --> tests/ui/parse-fail/bad-resource15/foo.wit:6:16
       |
-    6 |   type t = own<r>
+    6 |   type t = own<r>;
       |                ^

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource15/deps/foo/foo.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource15/deps/foo/foo.wit
@@ -1,5 +1,5 @@
 package some:dep
 
 interface foo {
-  type r = u32
+  type r = u32;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource15/foo.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource15/foo.wit
@@ -1,7 +1,7 @@
 package foo:bar
 
 interface foo {
-  use some:dep/foo.{r}
+  use some:dep/foo.{r};
 
-  type t = own<r>
+  type t = own<r>;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource2.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource2.wit
@@ -1,5 +1,5 @@
 package foo:bar
 
 interface foo {
-  type t = borrow<foo>
+  type t = borrow<foo>;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource2.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource2.wit.result
@@ -1,5 +1,5 @@
 type `foo` does not exist
      --> tests/ui/parse-fail/bad-resource2.wit:4:19
       |
-    4 |   type t = borrow<foo>
+    4 |   type t = borrow<foo>;
       |                   ^--

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource3.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource3.wit
@@ -1,6 +1,6 @@
 package foo:bar
 
 interface foo {
-  foo: func()
-  type t = borrow<foo>
+  foo: func();
+  type t = borrow<foo>;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource3.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource3.wit.result
@@ -1,5 +1,5 @@
 type `foo` does not exist
      --> tests/ui/parse-fail/bad-resource3.wit:5:19
       |
-    5 |   type t = borrow<foo>
+    5 |   type t = borrow<foo>;
       |                   ^--

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource4.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource4.wit
@@ -1,6 +1,6 @@
 package foo:bar
 
 interface foo {
-  type foo = u32
-  type t = borrow<foo>
+  type foo = u32;
+  type t = borrow<foo>;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource4.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource4.wit.result
@@ -1,5 +1,5 @@
 type `foo` used in a handle must be a resource
      --> tests/ui/parse-fail/bad-resource4.wit:5:19
       |
-    5 |   type t = borrow<foo>
+    5 |   type t = borrow<foo>;
       |                   ^--

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource5.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource5.wit
@@ -2,6 +2,6 @@ package foo:bar
 
 interface foo {
   resource a {}
-  type t = borrow<a>
-  type b = borrow<t>
+  type t = borrow<a>;
+  type b = borrow<t>;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource5.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource5.wit.result
@@ -1,5 +1,5 @@
 type `t` used in a handle must be a resource
      --> tests/ui/parse-fail/bad-resource5.wit:6:19
       |
-    6 |   type b = borrow<t>
+    6 |   type b = borrow<t>;
       |                   ^

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource6.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource6.wit
@@ -2,6 +2,6 @@ package foo:bar
 
 interface foo {
   resource a {
-    constructor() -> u32
+    constructor() -> u32;
   }
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource6.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource6.wit.result
@@ -1,5 +1,5 @@
-expected `constructor` or identifier, found `->`
+expected ';', found `->`
      --> tests/ui/parse-fail/bad-resource6.wit:5:19
       |
-    5 |     constructor() -> u32
-      |                   ^-
+    5 |     constructor() -> u32;
+      |                   ^

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource7.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource7.wit
@@ -2,7 +2,7 @@ package foo:bar
 
 interface foo {
   resource a {
-    constructor()
-    constructor()
+    constructor();
+    constructor();
   }
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource7.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource7.wit.result
@@ -1,5 +1,5 @@
 duplicate constructors
      --> tests/ui/parse-fail/bad-resource7.wit:6:5
       |
-    6 |     constructor()
+    6 |     constructor();
       |     ^----------

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource8.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource8.wit
@@ -2,7 +2,7 @@ package foo:bar
 
 interface foo {
   resource a {
-    a: func()
-    a: static func()
+    a: func();
+    a: static func();
   }
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource8.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource8.wit.result
@@ -1,5 +1,5 @@
 duplicate function name `a`
      --> tests/ui/parse-fail/bad-resource8.wit:6:5
       |
-    6 |     a: static func()
+    6 |     a: static func();
       |     ^

--- a/crates/wit-parser/tests/ui/parse-fail/bad-world-type1.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-world-type1.wit
@@ -1,5 +1,5 @@
 package foo:foo
 world a {
-  type a = u32
-  import a: func()
+  type a = u32;
+  import a: func();
 }

--- a/crates/wit-parser/tests/ui/parse-fail/bad-world-type1.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-world-type1.wit.result
@@ -1,5 +1,5 @@
 import `a` conflicts with prior import of same name
      --> tests/ui/parse-fail/bad-world-type1.wit:4:10
       |
-    4 |   import a: func()
+    4 |   import a: func();
       |          ^

--- a/crates/wit-parser/tests/ui/parse-fail/cycle.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/cycle.wit
@@ -2,5 +2,5 @@
 package foo:foo
 
 interface foo {
-  type foo = foo
+  type foo = foo;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/cycle.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/cycle.wit.result
@@ -1,5 +1,5 @@
 type `foo` depends on itself
      --> tests/ui/parse-fail/cycle.wit:5:14
       |
-    5 |   type foo = foo
+    5 |   type foo = foo;
       |              ^--

--- a/crates/wit-parser/tests/ui/parse-fail/cycle2.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/cycle2.wit
@@ -2,6 +2,6 @@
 package foo:foo
 
 interface foo {
-  type foo = bar
-  type bar = foo
+  type foo = bar;
+  type bar = foo;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/cycle2.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/cycle2.wit.result
@@ -1,5 +1,5 @@
 type `bar` depends on itself
      --> tests/ui/parse-fail/cycle2.wit:5:14
       |
-    5 |   type foo = bar
+    5 |   type foo = bar;
       |              ^--

--- a/crates/wit-parser/tests/ui/parse-fail/cycle3.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/cycle3.wit
@@ -2,6 +2,6 @@
 package foo:foo
 
 interface foo {
-  type foo = bar
-  type bar = option<foo>
+  type foo = bar;
+  type bar = option<foo>;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/cycle3.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/cycle3.wit.result
@@ -1,5 +1,5 @@
 type `bar` depends on itself
      --> tests/ui/parse-fail/cycle3.wit:5:14
       |
-    5 |   type foo = bar
+    5 |   type foo = bar;
       |              ^--

--- a/crates/wit-parser/tests/ui/parse-fail/cycle4.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/cycle4.wit
@@ -2,6 +2,6 @@
 package foo:foo
 
 interface foo {
-  type foo = bar
+  type foo = bar;
   record bar { x: foo }
 }

--- a/crates/wit-parser/tests/ui/parse-fail/cycle4.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/cycle4.wit.result
@@ -1,5 +1,5 @@
 type `bar` depends on itself
      --> tests/ui/parse-fail/cycle4.wit:5:14
       |
-    5 |   type foo = bar
+    5 |   type foo = bar;
       |              ^--

--- a/crates/wit-parser/tests/ui/parse-fail/cycle5.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/cycle5.wit
@@ -2,6 +2,6 @@
 package foo:foo
 
 interface foo {
-  type foo = bar
-  type bar = list<foo>
+  type foo = bar;
+  type bar = list<foo>;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/cycle5.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/cycle5.wit.result
@@ -1,5 +1,5 @@
 type `bar` depends on itself
      --> tests/ui/parse-fail/cycle5.wit:5:14
       |
-    5 |   type foo = bar
+    5 |   type foo = bar;
       |              ^--

--- a/crates/wit-parser/tests/ui/parse-fail/duplicate-functions.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/duplicate-functions.wit
@@ -3,6 +3,6 @@
 package foo:foo
 
 interface foo {
-  foo: func()
-  foo: func()
+  foo: func();
+  foo: func();
 }

--- a/crates/wit-parser/tests/ui/parse-fail/duplicate-functions.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/duplicate-functions.wit.result
@@ -1,5 +1,5 @@
 name `foo` is defined more than once
      --> tests/ui/parse-fail/duplicate-functions.wit:7:3
       |
-    7 |   foo: func()
+    7 |   foo: func();
       |   ^--

--- a/crates/wit-parser/tests/ui/parse-fail/duplicate-type.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/duplicate-type.wit
@@ -2,6 +2,6 @@
 package foo:foo
 
 interface foo {
-  type foo = s32
-  type foo = s32
+  type foo = s32;
+  type foo = s32;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/duplicate-type.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/duplicate-type.wit.result
@@ -1,5 +1,5 @@
 name `foo` is defined more than once
      --> tests/ui/parse-fail/duplicate-type.wit:6:8
       |
-    6 |   type foo = s32
+    6 |   type foo = s32;
       |        ^--

--- a/crates/wit-parser/tests/ui/parse-fail/export-twice.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/export-twice.wit
@@ -3,6 +3,6 @@ package foo:foo
 interface foo {}
 
 world bar {
-  export foo
-  export foo
+  export foo;
+  export foo;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/export-twice.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/export-twice.wit.result
@@ -1,5 +1,5 @@
 interface cannot be exported more than once
      --> tests/ui/parse-fail/export-twice.wit:7:10
       |
-    7 |   export foo
+    7 |   export foo;
       |          ^--

--- a/crates/wit-parser/tests/ui/parse-fail/import-and-export1.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/import-and-export1.wit
@@ -1,17 +1,17 @@
 package foo:foo
 interface i1 {
-  type t = u32
+  type t = u32;
 }
 interface i2 {
-  use i1.{t}
+  use i1.{t};
 }
 interface i3 {
-  use i2.{t}
+  use i2.{t};
 }
 
 world test {
   import i1: interface {}
 
-  export i1
-  export i3
+  export i1;
+  export i3;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/import-and-export1.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/import-and-export1.wit.result
@@ -1,5 +1,5 @@
 interface transitively depends on an interface in incompatible ways
      --> tests/ui/parse-fail/import-and-export1.wit:16:10
       |
-   16 |   export i3
+   16 |   export i3;
       |          ^-

--- a/crates/wit-parser/tests/ui/parse-fail/import-and-export2.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/import-and-export2.wit
@@ -1,18 +1,18 @@
 package foo:foo
 
 interface foo {
-  type t = u32
+  type t = u32;
 }
 
 interface bar {
-  use foo.{t}
+  use foo.{t};
 }
 
 world baz {
-  export foo
-  import bar
+  export foo;
+  import bar;
   export anon: interface {
-    use foo.{t}
-    use bar.{t as t2}
+    use foo.{t};
+    use bar.{t as t2};
   }
 }

--- a/crates/wit-parser/tests/ui/parse-fail/import-and-export3.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/import-and-export3.wit
@@ -4,34 +4,34 @@ interface foo {}
 interface bar {}
 
 world the-world {
-  import foo
-  import bar
+  import foo;
+  import bar;
   import baz: interface {
-    foo: func()
+    foo: func();
   }
-  export foo
-  export bar
+  export foo;
+  export bar;
   export baz2: interface {
-    foo: func()
+    foo: func();
   }
 }
 
 world a-different-world {
-  import foo
+  import foo;
 }
 
 interface i1 {
-  type t = u32
+  type t = u32;
 }
 interface i2 {
-  use i1.{t}
+  use i1.{t};
 }
 interface i3 {
-  use i2.{t}
+  use i2.{t};
 }
 
 world test {
-  import i3
-  export i1
-  export i3
+  import i3;
+  export i1;
+  export i3;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/import-and-export3.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/import-and-export3.wit.result
@@ -1,5 +1,5 @@
 interface transitively depends on an interface in incompatible ways
      --> tests/ui/parse-fail/import-and-export3.wit:36:10
       |
-   36 |   export i3
+   36 |   export i3;
       |          ^-

--- a/crates/wit-parser/tests/ui/parse-fail/import-and-export4.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/import-and-export4.wit
@@ -2,43 +2,43 @@ package foo:foo
 
 
 world union-world {
-  include test
-  include a-different-world
-  include the-world
+  include test;
+  include a-different-world;
+  include the-world;
 }
 
 interface foo {}
 interface bar {}
 
 world the-world {
-  import foo
-  import bar
+  import foo;
+  import bar;
   import baz: interface {
-    foo: func()
+    foo: func();
   }
-  export foo
-  export bar
+  export foo;
+  export bar;
   export baz2: interface {
-    foo: func()
+    foo: func();
   }
 }
 
 world a-different-world {
-  import foo
+  import foo;
 }
 
 interface i1 {
-  type t = u32
+  type t = u32;
 }
 interface i2 {
-  use i1.{t}
+  use i1.{t};
 }
 interface i3 {
-  use i2.{t}
+  use i2.{t};
 }
 
 world test {
-  import i3
-  export i1
-  export i3
+  import i3;
+  export i1;
+  export i3;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/import-and-export4.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/import-and-export4.wit.result
@@ -1,5 +1,5 @@
 interface transitively depends on an interface in incompatible ways
      --> tests/ui/parse-fail/import-and-export4.wit:43:10
       |
-   43 |   export i3
+   43 |   export i3;
       |          ^-

--- a/crates/wit-parser/tests/ui/parse-fail/import-and-export5.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/import-and-export5.wit
@@ -6,13 +6,13 @@ interface a {
 }
 
 interface b {
-  use a.{x}
+  use a.{x};
 }
 
 world w {
   export anon: interface {
-    use b.{x as x2}
-    use a.{x}
+    use b.{x as x2};
+    use a.{x};
   }
-  export a
+  export a;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/import-export-overlap1.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/import-export-overlap1.wit
@@ -1,5 +1,5 @@
 package foo:foo
 world foo {
-  import a: func()
-  export a: func()
+  import a: func();
+  export a: func();
 }

--- a/crates/wit-parser/tests/ui/parse-fail/import-export-overlap1.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/import-export-overlap1.wit.result
@@ -1,5 +1,5 @@
 export `a` conflicts with prior import of same name
      --> tests/ui/parse-fail/import-export-overlap1.wit:4:10
       |
-    4 |   export a: func()
+    4 |   export a: func();
       |          ^

--- a/crates/wit-parser/tests/ui/parse-fail/import-export-overlap2.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/import-export-overlap2.wit
@@ -1,5 +1,5 @@
 package foo:foo
 world foo {
-  import a: func()
+  import a: func();
   export a: interface {}
 }

--- a/crates/wit-parser/tests/ui/parse-fail/import-twice.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/import-twice.wit
@@ -3,6 +3,6 @@ package foo:foo
 interface foo {}
 
 world bar {
-  import foo
-  import foo
+  import foo;
+  import foo;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/import-twice.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/import-twice.wit.result
@@ -1,5 +1,5 @@
 interface cannot be imported more than once
      --> tests/ui/parse-fail/import-twice.wit:7:10
       |
-    7 |   import foo
+    7 |   import foo;
       |          ^--

--- a/crates/wit-parser/tests/ui/parse-fail/include-cycle.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/include-cycle.wit
@@ -1,9 +1,9 @@
 package foo:foo
 
 world a {
-    include b
+    include b;
 }
 
 world b {
-    include a
+    include a;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/include-foreign.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/include-foreign.wit.result
@@ -1,5 +1,5 @@
 world not found in package
      --> tests/ui/parse-fail/include-foreign/root.wit:4:19
       |
-    4 |   include foo:bar/bar
+    4 |   include foo:bar/bar;
       |                   ^--

--- a/crates/wit-parser/tests/ui/parse-fail/include-foreign/root.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/include-foreign/root.wit
@@ -1,5 +1,5 @@
 package foo:foo
 
 world foo {
-  include foo:bar/bar
+  include foo:bar/bar;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/include-with-id.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/include-with-id.wit
@@ -3,7 +3,7 @@ package foo:foo
 interface foo {}
 
 world a {
-    import foo
+    import foo;
 }
 
 world b {

--- a/crates/wit-parser/tests/ui/parse-fail/include-with-on-id.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/include-with-on-id.wit
@@ -3,7 +3,7 @@ package foo:foo
 interface foo {}
 
 world a {
-    import foo
+    import foo;
 }
 
 world b {

--- a/crates/wit-parser/tests/ui/parse-fail/invalid-type-reference.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/invalid-type-reference.wit
@@ -1,7 +1,7 @@
 package foo:foo
 
 interface foo {
-  x: func()
+  x: func();
 
   record foo {
     // TODO: this should have a better error message referring to `x: func()`

--- a/crates/wit-parser/tests/ui/parse-fail/invalid-type-reference2.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/invalid-type-reference2.wit
@@ -1,6 +1,6 @@
 package foo:foo
 
 interface foo {
-  x: func()
-  y: func() -> x
+  x: func();
+  y: func() -> x;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/invalid-type-reference2.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/invalid-type-reference2.wit.result
@@ -1,5 +1,5 @@
 cannot use function `x` as a type
      --> tests/ui/parse-fail/invalid-type-reference2.wit:5:16
       |
-    5 |   y: func() -> x
+    5 |   y: func() -> x;
       |                ^

--- a/crates/wit-parser/tests/ui/parse-fail/kebab-name-include-not-found.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/kebab-name-include-not-found.wit
@@ -1,8 +1,8 @@
 package foo:foo
 
-world foo { import a: func() }
-world bar { import a: func() }
-world baz { 
+world foo { import a: func(); }
+world bar { import a: func(); }
+world baz {
     include foo with { b1 as b2 }
     include bar with { a as b }
 }

--- a/crates/wit-parser/tests/ui/parse-fail/kebab-name-include.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/kebab-name-include.wit
@@ -1,8 +1,8 @@
 package foo:foo
 
-world foo { import a: func() }
-world bar { import a: func() }
-world baz { 
-    include foo 
-    include bar 
+world foo { import a: func(); }
+world bar { import a: func(); }
+world baz {
+    include foo;
+    include bar;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/kebab-name-include.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/kebab-name-include.wit.result
@@ -1,5 +1,5 @@
 import of `a` shadows previously imported items
      --> tests/ui/parse-fail/kebab-name-include.wit:7:13
       |
-    7 |     include bar 
+    7 |     include bar;
       |             ^--

--- a/crates/wit-parser/tests/ui/parse-fail/no-access-to-sibling-use.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/no-access-to-sibling-use.wit.result
@@ -4,5 +4,5 @@ Caused by:
     interface or world `bar-renamed` does not exist
          --> tests/ui/parse-fail/no-access-to-sibling-use/foo.wit:3:5
           |
-        3 | use bar-renamed
+        3 | use bar-renamed;
           |     ^----------

--- a/crates/wit-parser/tests/ui/parse-fail/no-access-to-sibling-use/bar.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/no-access-to-sibling-use/bar.wit
@@ -1,1 +1,1 @@
-use bar as bar-renamed
+use bar as bar-renamed;

--- a/crates/wit-parser/tests/ui/parse-fail/no-access-to-sibling-use/foo.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/no-access-to-sibling-use/foo.wit
@@ -1,5 +1,5 @@
 package foo:foo
 
-use bar-renamed
+use bar-renamed;
 
 interface bar {}

--- a/crates/wit-parser/tests/ui/parse-fail/non-existance-world-include.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/non-existance-world-include.wit.result
@@ -1,5 +1,5 @@
 world not found in package
      --> tests/ui/parse-fail/non-existance-world-include/root.wit:4:19
       |
-    4 |   include foo:baz/non-existance
+    4 |   include foo:baz/non-existance;
       |                   ^------------

--- a/crates/wit-parser/tests/ui/parse-fail/non-existance-world-include/root.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/non-existance-world-include/root.wit
@@ -1,5 +1,5 @@
 package foo:foo
 
 world foo {
-  include foo:baz/non-existance
+  include foo:baz/non-existance;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/pkg-cycle.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/pkg-cycle.wit.result
@@ -1,5 +1,5 @@
 package depends on itself
      --> tests/ui/parse-fail/pkg-cycle/deps/a1/root.wit:3:7
       |
-    3 |   use foo:a1/foo.{}
+    3 |   use foo:a1/foo.{};
       |       ^-----

--- a/crates/wit-parser/tests/ui/parse-fail/pkg-cycle/deps/a1/root.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/pkg-cycle/deps/a1/root.wit
@@ -1,4 +1,4 @@
 package foo:a1
 interface foo {
-  use foo:a1/foo.{}
+  use foo:a1/foo.{};
 }

--- a/crates/wit-parser/tests/ui/parse-fail/pkg-cycle/root.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/pkg-cycle/root.wit
@@ -1,4 +1,4 @@
 package foo:foo
 interface foo {
-  use foo:a1/foo.{}
+  use foo:a1/foo.{};
 }

--- a/crates/wit-parser/tests/ui/parse-fail/pkg-cycle2.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/pkg-cycle2.wit.result
@@ -1,5 +1,5 @@
 package depends on itself
      --> tests/ui/parse-fail/pkg-cycle2/deps/a1/root.wit:3:7
       |
-    3 |   use foo:a2/foo.{}
+    3 |   use foo:a2/foo.{};
       |       ^-----

--- a/crates/wit-parser/tests/ui/parse-fail/pkg-cycle2/deps/a1/root.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/pkg-cycle2/deps/a1/root.wit
@@ -1,4 +1,4 @@
 package foo:a1
 interface foo {
-  use foo:a2/foo.{}
+  use foo:a2/foo.{};
 }

--- a/crates/wit-parser/tests/ui/parse-fail/pkg-cycle2/deps/a2/root.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/pkg-cycle2/deps/a2/root.wit
@@ -1,4 +1,4 @@
 package foo:a2
 interface foo {
-  use foo:a1/foo.{}
+  use foo:a1/foo.{};
 }

--- a/crates/wit-parser/tests/ui/parse-fail/pkg-cycle2/root.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/pkg-cycle2/root.wit
@@ -1,4 +1,4 @@
 package foo:root
 interface foo {
-  use foo:a1/foo.{}
+  use foo:a1/foo.{};
 }

--- a/crates/wit-parser/tests/ui/parse-fail/type-and-resource-same-name.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/type-and-resource-same-name.wit.result
@@ -1,5 +1,5 @@
 type used in a handle must be a resource
      --> tests/ui/parse-fail/type-and-resource-same-name/foo.wit:7:20
       |
-    7 |   type t2 = borrow<a>
+    7 |   type t2 = borrow<a>;
       |                    ^

--- a/crates/wit-parser/tests/ui/parse-fail/type-and-resource-same-name/deps/dep/foo.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/type-and-resource-same-name/deps/dep/foo.wit
@@ -1,5 +1,5 @@
 package some:dep
 
 interface foo {
-  type a = u32
+  type a = u32;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/type-and-resource-same-name/foo.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/type-and-resource-same-name/foo.wit
@@ -1,8 +1,8 @@
 package foo:bar
 
 interface foo {
-  use some:dep/foo.{a}
+  use some:dep/foo.{a};
 
-  type t1 = a
-  type t2 = borrow<a>
+  type t1 = a;
+  type t2 = borrow<a>;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/undefined-typed.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/undefined-typed.wit
@@ -2,5 +2,5 @@
 package foo:foo
 
 interface foo {
-  type foo = bar
+  type foo = bar;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/undefined-typed.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/undefined-typed.wit.result
@@ -1,5 +1,5 @@
 type `bar` does not exist
      --> tests/ui/parse-fail/undefined-typed.wit:5:14
       |
-    5 |   type foo = bar
+    5 |   type foo = bar;
       |              ^--

--- a/crates/wit-parser/tests/ui/parse-fail/union-fuzz-2.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/union-fuzz-2.wit
@@ -1,12 +1,12 @@
 package foo:bar
 
 world foo {
-    export foo: func() -> (%name2: float32)
+    export foo: func() -> (%name2: float32);
 }
-    
+
 
 world bar {
-    include foo
-    
+    include foo;
+
     record foo {}
 }

--- a/crates/wit-parser/tests/ui/parse-fail/unknown-interface.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/unknown-interface.wit
@@ -3,5 +3,5 @@
 package foo:foo
 
 world foo {
-  import bar
+  import bar;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/unknown-interface.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/unknown-interface.wit.result
@@ -1,5 +1,5 @@
 interface or world `bar` does not exist
      --> tests/ui/parse-fail/unknown-interface.wit:6:10
       |
-    6 |   import bar
+    6 |   import bar;
       |          ^--

--- a/crates/wit-parser/tests/ui/parse-fail/unresolved-interface1.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/unresolved-interface1.wit
@@ -3,5 +3,5 @@
 package foo:foo
 
 world foo {
-  import foo
+  import foo;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/unresolved-interface1.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/unresolved-interface1.wit.result
@@ -1,5 +1,5 @@
 name `foo` is defined as a world, not an interface
      --> tests/ui/parse-fail/unresolved-interface1.wit:6:10
       |
-    6 |   import foo
+    6 |   import foo;
       |          ^--

--- a/crates/wit-parser/tests/ui/parse-fail/unresolved-interface2.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/unresolved-interface2.wit
@@ -3,6 +3,6 @@
 package foo:foo
 
 world foo {
-  import bar
+  import bar;
 }
 

--- a/crates/wit-parser/tests/ui/parse-fail/unresolved-interface2.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/unresolved-interface2.wit.result
@@ -1,5 +1,5 @@
 interface or world `bar` does not exist
      --> tests/ui/parse-fail/unresolved-interface2.wit:6:10
       |
-    6 |   import bar
+    6 |   import bar;
       |          ^--

--- a/crates/wit-parser/tests/ui/parse-fail/unresolved-interface3.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/unresolved-interface3.wit
@@ -2,4 +2,4 @@
 
 package foo:foo
 
-use bar as foo
+use bar as foo;

--- a/crates/wit-parser/tests/ui/parse-fail/unresolved-interface3.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/unresolved-interface3.wit.result
@@ -1,5 +1,5 @@
 interface or world `bar` does not exist
      --> tests/ui/parse-fail/unresolved-interface3.wit:5:5
       |
-    5 | use bar as foo
+    5 | use bar as foo;
       |     ^--

--- a/crates/wit-parser/tests/ui/parse-fail/unresolved-interface4.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/unresolved-interface4.wit
@@ -3,5 +3,5 @@
 package foo:foo
 
 world foo {
-  import some:dependency/iface
+  import some:dependency/iface;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/unresolved-interface4.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/unresolved-interface4.wit.result
@@ -1,5 +1,5 @@
 package not found
      --> tests/ui/parse-fail/unresolved-interface4.wit:6:10
       |
-    6 |   import some:dependency/iface
+    6 |   import some:dependency/iface;
       |          ^--------------

--- a/crates/wit-parser/tests/ui/parse-fail/unresolved-use1.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/unresolved-use1.wit
@@ -3,5 +3,5 @@
 package foo:foo
 
 interface foo {
-  use bar.{x}
+  use bar.{x};
 }

--- a/crates/wit-parser/tests/ui/parse-fail/unresolved-use1.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/unresolved-use1.wit.result
@@ -1,5 +1,5 @@
 interface or world `bar` not found in package
      --> tests/ui/parse-fail/unresolved-use1.wit:6:7
       |
-    6 |   use bar.{x}
+    6 |   use bar.{x};
       |       ^--

--- a/crates/wit-parser/tests/ui/parse-fail/unresolved-use10.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/unresolved-use10.wit.result
@@ -4,5 +4,5 @@ Caused by:
     name `thing` is not defined
          --> tests/ui/parse-fail/unresolved-use10/bar.wit:4:12
           |
-        4 |   use foo.{thing}
+        4 |   use foo.{thing};
           |            ^----

--- a/crates/wit-parser/tests/ui/parse-fail/unresolved-use10/bar.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/unresolved-use10/bar.wit
@@ -1,5 +1,5 @@
 package foo:foo
 
 interface bar {
-  use foo.{thing}
+  use foo.{thing};
 }

--- a/crates/wit-parser/tests/ui/parse-fail/unresolved-use2.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/unresolved-use2.wit
@@ -3,7 +3,7 @@
 package foo:foo
 
 interface foo {
-  use bar.{x}
+  use bar.{x};
 }
 
 interface bar {

--- a/crates/wit-parser/tests/ui/parse-fail/unresolved-use2.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/unresolved-use2.wit.result
@@ -1,5 +1,5 @@
 name `x` is not defined
      --> tests/ui/parse-fail/unresolved-use2.wit:6:12
       |
-    6 |   use bar.{x}
+    6 |   use bar.{x};
       |            ^

--- a/crates/wit-parser/tests/ui/parse-fail/unresolved-use3.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/unresolved-use3.wit
@@ -3,9 +3,9 @@
 package foo:foo
 
 interface foo {
-  use bar.{x}
+  use bar.{x};
 }
 
 interface bar {
-  x: func()
+  x: func();
 }

--- a/crates/wit-parser/tests/ui/parse-fail/unresolved-use3.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/unresolved-use3.wit.result
@@ -1,5 +1,5 @@
 cannot import function `x`
      --> tests/ui/parse-fail/unresolved-use3.wit:6:12
       |
-    6 |   use bar.{x}
+    6 |   use bar.{x};
       |            ^

--- a/crates/wit-parser/tests/ui/parse-fail/unresolved-use7.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/unresolved-use7.wit
@@ -3,7 +3,7 @@
 package foo:foo
 
 interface foo {
-  use bar.{x}
+  use bar.{x};
 }
 
 interface bar {

--- a/crates/wit-parser/tests/ui/parse-fail/unresolved-use7.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/unresolved-use7.wit.result
@@ -1,5 +1,5 @@
 name `x` is not defined
      --> tests/ui/parse-fail/unresolved-use7.wit:6:12
       |
-    6 |   use bar.{x}
+    6 |   use bar.{x};
       |            ^

--- a/crates/wit-parser/tests/ui/parse-fail/unresolved-use8.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/unresolved-use8.wit
@@ -4,6 +4,6 @@ package foo:foo
 
 world foo {
   import foo: interface {
-    use foo.{i32}
+    use foo.{i32};
   }
 }

--- a/crates/wit-parser/tests/ui/parse-fail/unresolved-use8.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/unresolved-use8.wit.result
@@ -1,5 +1,5 @@
 name `foo` is defined as a world, not an interface
      --> tests/ui/parse-fail/unresolved-use8.wit:7:9
       |
-    7 |     use foo.{i32}
+    7 |     use foo.{i32};
       |         ^--

--- a/crates/wit-parser/tests/ui/parse-fail/unresolved-use9.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/unresolved-use9.wit
@@ -4,6 +4,6 @@ package foo:foo
 
 world foo {
   import foo: interface {
-    use bar.{i32}
+    use bar.{i32};
   }
 }

--- a/crates/wit-parser/tests/ui/parse-fail/unresolved-use9.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/unresolved-use9.wit.result
@@ -1,5 +1,5 @@
 interface or world `bar` does not exist
      --> tests/ui/parse-fail/unresolved-use9.wit:7:9
       |
-    7 |     use bar.{i32}
+    7 |     use bar.{i32};
       |         ^--

--- a/crates/wit-parser/tests/ui/parse-fail/use-and-include-world.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/use-and-include-world.wit.result
@@ -4,5 +4,5 @@ Caused by:
     name `bar` is defined as an interface, not a world
          --> tests/ui/parse-fail/use-and-include-world/root.wit:6:21
           |
-        6 |     include foo:baz/bar
+        6 |     include foo:baz/bar;
           |                     ^--

--- a/crates/wit-parser/tests/ui/parse-fail/use-and-include-world/root.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/use-and-include-world/root.wit
@@ -1,7 +1,7 @@
 package foo:foo
 
-use foo:baz/bar
+use foo:baz/bar;
 
 world foo {
-    include foo:baz/bar
+    include foo:baz/bar;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/use-conflict.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/use-conflict.wit
@@ -3,9 +3,9 @@
 package foo:foo
 
 interface foo {
-  type x = u32
+  type x = u32;
 }
 
 interface bar {
-  use foo.{x, x}
+  use foo.{x, x};
 }

--- a/crates/wit-parser/tests/ui/parse-fail/use-conflict.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/use-conflict.wit.result
@@ -1,5 +1,5 @@
 name `x` is defined more than once
      --> tests/ui/parse-fail/use-conflict.wit:10:15
       |
-   10 |   use foo.{x, x}
+   10 |   use foo.{x, x};
       |               ^

--- a/crates/wit-parser/tests/ui/parse-fail/use-conflict2.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/use-conflict2.wit
@@ -3,11 +3,11 @@
 package foo:foo
 
 interface foo {
-  type x = u32
+  type x = u32;
 }
 
 interface bar {
-  use foo.{x}
+  use foo.{x};
 
-  type x = s64
+  type x = s64;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/use-conflict2.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/use-conflict2.wit.result
@@ -1,5 +1,5 @@
 name `x` is defined more than once
      --> tests/ui/parse-fail/use-conflict2.wit:12:8
       |
-   12 |   type x = s64
+   12 |   type x = s64;
       |        ^

--- a/crates/wit-parser/tests/ui/parse-fail/use-conflict3.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/use-conflict3.wit
@@ -3,11 +3,11 @@
 package foo:foo
 
 interface foo {
-  type x = u32
+  type x = u32;
 }
 
 interface bar {
-  use foo.{x}
+  use foo.{x};
 
-  x: func()
+  x: func();
 }

--- a/crates/wit-parser/tests/ui/parse-fail/use-conflict3.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/use-conflict3.wit.result
@@ -1,5 +1,5 @@
 name `x` is defined more than once
      --> tests/ui/parse-fail/use-conflict3.wit:12:3
       |
-   12 |   x: func()
+   12 |   x: func();
       |   ^

--- a/crates/wit-parser/tests/ui/parse-fail/use-cycle1.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/use-cycle1.wit
@@ -3,5 +3,5 @@
 package foo:foo
 
 interface foo {
-  use foo.{bar}
+  use foo.{bar};
 }

--- a/crates/wit-parser/tests/ui/parse-fail/use-cycle4.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/use-cycle4.wit
@@ -2,13 +2,13 @@
 package foo:foo
 
 interface foo {
-  use bar.{y}
+  use bar.{y};
 
-  type x = u32
+  type x = u32;
 }
 
 interface bar {
-  use foo.{x}
+  use foo.{x};
 
-  type y = u32
+  type y = u32;
 }

--- a/crates/wit-parser/tests/ui/parse-fail/use-shadow1.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/use-shadow1.wit
@@ -1,6 +1,6 @@
 package foo:foo
 
-use foo as bar
+use foo as bar;
 
 interface foo {}
 

--- a/crates/wit-parser/tests/ui/parse-fail/use-world.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/use-world.wit.result
@@ -1,5 +1,5 @@
 interface not found in package
      --> tests/ui/parse-fail/use-world/root.wit:3:13
       |
-    3 | use foo:baz/bar
+    3 | use foo:baz/bar;
       |             ^--

--- a/crates/wit-parser/tests/ui/parse-fail/use-world/root.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/use-world/root.wit
@@ -1,7 +1,7 @@
 package foo:foo
 
-use foo:baz/bar
+use foo:baz/bar;
 
 world foo {
-  
+
 }

--- a/crates/wit-parser/tests/ui/parse-fail/world-top-level-func.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/world-top-level-func.wit
@@ -1,5 +1,5 @@
 package foo:foo
 world foo {
-  import foo: func()
-  import foo: func()
+  import foo: func();
+  import foo: func();
 }

--- a/crates/wit-parser/tests/ui/parse-fail/world-top-level-func.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/world-top-level-func.wit.result
@@ -1,5 +1,5 @@
 import `foo` conflicts with prior import of same name
      --> tests/ui/parse-fail/world-top-level-func.wit:4:10
       |
-    4 |   import foo: func()
+    4 |   import foo: func();
       |          ^--

--- a/crates/wit-parser/tests/ui/parse-fail/world-top-level-func2.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/world-top-level-func2.wit
@@ -1,4 +1,4 @@
 package foo:foo
 world foo {
-  import foo: func(a: b)
+  import foo: func(a: b);
 }

--- a/crates/wit-parser/tests/ui/parse-fail/world-top-level-func2.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/world-top-level-func2.wit.result
@@ -1,5 +1,5 @@
 name `b` is not defined
      --> tests/ui/parse-fail/world-top-level-func2.wit:3:23
       |
-    3 |   import foo: func(a: b)
+    3 |   import foo: func(a: b);
       |                       ^

--- a/crates/wit-parser/tests/ui/random.wit
+++ b/crates/wit-parser/tests/ui/random.wit
@@ -17,11 +17,11 @@ interface random {
     /// This function must always return fresh data. Deterministic environments
     /// must omit this function, rather than implementing it with deterministic
     /// data.
-    get-random-bytes: func(len: u64) -> list<u8>
+    get-random-bytes: func(len: u64) -> list<u8>;
 
     /// Return a cryptographically-secure random or pseudo-random `u64` value.
     ///
     /// This function returns the same type of data as `get-random-bytes`,
     /// represented as a `u64`.
-    get-random-u64: func() -> u64
+    get-random-u64: func() -> u64;
 }

--- a/crates/wit-parser/tests/ui/resources-empty.wit
+++ b/crates/wit-parser/tests/ui/resources-empty.wit
@@ -1,8 +1,8 @@
 package foo:resources-empty
 
 interface resources-empty {
-  t1: func(a: own<r1>) -> ()
-  t2: func(a: borrow<r1>) -> ()
+  t1: func(a: own<r1>) -> ();
+  t2: func(a: borrow<r1>) -> ();
 
   resource r1 {
   }

--- a/crates/wit-parser/tests/ui/resources-multiple-returns-borrow.wit
+++ b/crates/wit-parser/tests/ui/resources-multiple-returns-borrow.wit
@@ -1,10 +1,10 @@
 package foo:resources1
 
 interface resources1 {
-  t1: func(a: borrow<r1>) -> ()
+  t1: func(a: borrow<r1>) -> ();
 
   resource r1 {
-    f1: func() -> (a: s32, handle: borrow<r1>)
+    f1: func() -> (a: s32, handle: borrow<r1>);
   }
 }
 

--- a/crates/wit-parser/tests/ui/resources-multiple-returns-own.wit
+++ b/crates/wit-parser/tests/ui/resources-multiple-returns-own.wit
@@ -1,10 +1,10 @@
 package foo:resources1
 
 interface resources1 {
-  t1: func(a: own<r1>) -> ()
+  t1: func(a: own<r1>) -> ();
 
   resource r1 {
-    f1: func() -> (a: s32, handle: own<r1>)
+    f1: func() -> (a: s32, handle: own<r1>);
   }
 }
 

--- a/crates/wit-parser/tests/ui/resources-multiple.wit
+++ b/crates/wit-parser/tests/ui/resources-multiple.wit
@@ -1,20 +1,20 @@
 package foo:resources-multiple
 
 interface resources-multiple {
-  t1: func(a: borrow<r1>) -> ()
-  t2: func(a: own<r1>) -> ()
+  t1: func(a: borrow<r1>) -> ();
+  t2: func(a: own<r1>) -> ();
 
   resource r1 {
-    f1: func()
-    f2: func(a: u32)
-    f3: func(a: u32,)
-    f4: func() -> u32
-    f6: func() -> tuple<u32, u32>
-    f7: func(a: float32, b: float32) -> tuple<u32, u32>
-    f8: func(a: option<u32>) -> result<u32, float32>
-    f9: func() -> (u: u32, f: float32)
-    f10: func() -> (u: u32)
-    f11: func() -> ()
+    f1: func();
+    f2: func(a: u32);
+    f3: func(a: u32,);
+    f4: func() -> u32;
+    f6: func() -> tuple<u32, u32>;
+    f7: func(a: float32, b: float32) -> tuple<u32, u32>;
+    f8: func(a: option<u32>) -> result<u32, float32>;
+    f9: func() -> (u: u32, f: float32);
+    f10: func() -> (u: u32);
+    f11: func() -> ();
   }
 }
 

--- a/crates/wit-parser/tests/ui/resources-return-borrow.wit
+++ b/crates/wit-parser/tests/ui/resources-return-borrow.wit
@@ -1,10 +1,10 @@
 package foo:resources1
 
 interface resources1 {
-  t1: func(a: borrow<r1>) -> ()
+  t1: func(a: borrow<r1>) -> ();
 
   resource r1 {
-    f1: func() -> borrow<r1>
+    f1: func() -> borrow<r1>;
   }
 }
 

--- a/crates/wit-parser/tests/ui/resources-return-own.wit
+++ b/crates/wit-parser/tests/ui/resources-return-own.wit
@@ -1,10 +1,10 @@
 package foo:resources1
 
 interface resources1 {
-  t1: func(a: own<r1>) -> ()
+  t1: func(a: own<r1>) -> ();
 
   resource r1 {
-    f1: func() -> own<r1>
+    f1: func() -> own<r1>;
   }
 }
 

--- a/crates/wit-parser/tests/ui/resources.wit
+++ b/crates/wit-parser/tests/ui/resources.wit
@@ -5,43 +5,43 @@ interface foo {
   }
 
   resource b {
-    constructor()
+    constructor();
   }
 
   resource c {
-    constructor(x: u32)
+    constructor(x: u32);
   }
 
   resource d {
-    constructor(x: u32)
+    constructor(x: u32);
 
-    a: func()
+    a: func();
 
-    b: static func()
+    b: static func();
   }
 
   resource e {
-    constructor(other: own<e>, other2: borrow<e>)
+    constructor(other: own<e>, other2: borrow<e>);
 
-    method: func(thing: own<e>, thing2: borrow<e>)
+    method: func(thing: own<e>, thing2: borrow<e>);
   }
 }
 
 world w {
-  resource a
+  resource a;
 
   resource b {
   }
 
   resource c {
-    constructor()
+    constructor();
   }
 }
 
 interface i {
-  resource a
+  resource a;
 
-  type t1 = a
-  type t2 = borrow<a>
-  type t3 = borrow<t1>
+  type t1 = a;
+  type t2 = borrow<a>;
+  type t3 = borrow<t1>;
 }

--- a/crates/wit-parser/tests/ui/resources1.wit
+++ b/crates/wit-parser/tests/ui/resources1.wit
@@ -1,12 +1,12 @@
 package foo:resources1
 
 interface resources1 {
-  t1: func(a: borrow<r1>) -> ()
-  t2: func(a: own<r1>) -> ()
-  t3: func(a: r1) -> ()
+  t1: func(a: borrow<r1>) -> ();
+  t2: func(a: own<r1>) -> ();
+  t3: func(a: r1) -> ();
 
   resource r1 {
-    f1: func()
+    f1: func();
   }
 }
 

--- a/crates/wit-parser/tests/ui/shared-types.wit
+++ b/crates/wit-parser/tests/ui/shared-types.wit
@@ -2,9 +2,9 @@ package foo:shared-items
 
 world foo {
   import foo: interface {
-    a: func() -> list<u8>
+    a: func() -> list<u8>;
   }
   export bar: interface {
-    a: func() -> tuple<list<u8>>
+    a: func() -> tuple<list<u8>>;
   }
 }

--- a/crates/wit-parser/tests/ui/stress-export-elaborate.wit
+++ b/crates/wit-parser/tests/ui/stress-export-elaborate.wit
@@ -1,54 +1,54 @@
 package foo:bar
 
 interface i1 {
-  type t1 = u32
-  type t2 = u32
-  type t3 = u32
-  type t4 = u32
-  type t5 = u32
-  type t6 = u32
-  type t7 = u32
-  type t8 = u32
-  type t9 = u32
-  type t10 = u32
+  type t1 = u32;
+  type t2 = u32;
+  type t3 = u32;
+  type t4 = u32;
+  type t5 = u32;
+  type t6 = u32;
+  type t7 = u32;
+  type t8 = u32;
+  type t9 = u32;
+  type t10 = u32;
 }
 
 interface i2 {
-  use i1.{t1, t2, t3, t4, t5, t6, t7, t8, t9, t10}
+  use i1.{t1, t2, t3, t4, t5, t6, t7, t8, t9, t10};
 }
 
 interface i3 {
-  use i2.{t1, t2, t3, t4, t5, t6, t7, t8, t9, t10}
+  use i2.{t1, t2, t3, t4, t5, t6, t7, t8, t9, t10};
 }
 
 interface i4 {
-  use i3.{t1, t2, t3, t4, t5, t6, t7, t8, t9, t10}
+  use i3.{t1, t2, t3, t4, t5, t6, t7, t8, t9, t10};
 }
 
 interface i5 {
-  use i4.{t1, t2, t3, t4, t5, t6, t7, t8, t9, t10}
+  use i4.{t1, t2, t3, t4, t5, t6, t7, t8, t9, t10};
 }
 
 interface i6 {
-  use i5.{t1, t2, t3, t4, t5, t6, t7, t8, t9, t10}
+  use i5.{t1, t2, t3, t4, t5, t6, t7, t8, t9, t10};
 }
 
 interface i7 {
-  use i6.{t1, t2, t3, t4, t5, t6, t7, t8, t9, t10}
+  use i6.{t1, t2, t3, t4, t5, t6, t7, t8, t9, t10};
 }
 
 interface i8 {
-  use i7.{t1, t2, t3, t4, t5, t6, t7, t8, t9, t10}
+  use i7.{t1, t2, t3, t4, t5, t6, t7, t8, t9, t10};
 }
 
 interface i9 {
-  use i8.{t1, t2, t3, t4, t5, t6, t7, t8, t9, t10}
+  use i8.{t1, t2, t3, t4, t5, t6, t7, t8, t9, t10};
 }
 
 interface i10 {
-  use i9.{t1, t2, t3, t4, t5, t6, t7, t8, t9, t10}
+  use i9.{t1, t2, t3, t4, t5, t6, t7, t8, t9, t10};
 }
 
 world foo {
-  export i10
+  export i10;
 }

--- a/crates/wit-parser/tests/ui/type-then-eof.wit
+++ b/crates/wit-parser/tests/ui/type-then-eof.wit
@@ -1,5 +1,5 @@
 package foo:foo
 
 interface foo {
-  foo: func() -> string
+  foo: func() -> string;
 }

--- a/crates/wit-parser/tests/ui/types.wit
+++ b/crates/wit-parser/tests/ui/types.wit
@@ -1,24 +1,24 @@
 package foo:types
 
 interface types {
-  type t1 = u8
-  type t2 = u16
-  type t3 = u32
-  type t4 = u64
-  type t5 = s8
-  type t6 = s16
-  type t7 = s32
-  type t8 = s64
-  type t9 = float32
-  type t10 = float64
-  type t11 = char
-  type t12 = list<char>
-  type t13 = string
-  type t14 = option<u32>
-  type t15 = result<u32, u32>
-  type t16 = result<_, u32>
-  type t17 = result<u32>
-  type t18 = result
+  type t1 = u8;
+  type t2 = u16;
+  type t3 = u32;
+  type t4 = u64;
+  type t5 = s8;
+  type t6 = s16;
+  type t7 = s32;
+  type t8 = s64;
+  type t9 = float32;
+  type t10 = float64;
+  type t11 = char;
+  type t12 = list<char>;
+  type t13 = string;
+  type t14 = option<u32>;
+  type t15 = result<u32, u32>;
+  type t16 = result<_, u32>;
+  type t17 = result<u32>;
+  type t18 = result;
   record t20 {}
   record t21 { a: u32 }
   record t22 { a: u32, }
@@ -26,10 +26,10 @@ interface types {
   record t24 { a: u32, b: u64, }
   record t25 { x: u32 }
   record %record {}
-  type t26 = tuple<>
-  type t27 = tuple<u32>
-  type t28 = tuple<u32,>
-  type t29 = tuple<u32, u64>
+  type t26 = tuple<>;
+  type t27 = tuple<u32>;
+  type t28 = tuple<u32,>;
+  type t29 = tuple<u32, u64>;
   flags t30 {}
   flags t31 { a, b, c }
   flags t32 { a, b, c, }
@@ -40,19 +40,19 @@ interface types {
   variant t37 { a, b(option<u32>), }
   enum t41 { a, b, c }
   enum t42 { a, b, c, }
-  type t43 = bool
-  type t44 = string
-  type t45 = list<list<list<t32>>>
-  type t46 = t44
-  type t47 = %t44
-  type t48 = stream<u32, u32>
-  type t49 = stream<_, u32>
-  type t50 = stream<u32>
-  type t51 = stream
-  type t52 = future<u32>
-  type t53 = future
+  type t43 = bool;
+  type t44 = string;
+  type t45 = list<list<list<t32>>>;
+  type t46 = t44;
+  type t47 = %t44;
+  type t48 = stream<u32, u32>;
+  type t49 = stream<_, u32>;
+  type t50 = stream<u32>;
+  type t51 = stream;
+  type t52 = future<u32>;
+  type t53 = future;
 
   // type order doesn't matter
-  type foo = bar
-  type bar = u32
+  type foo = bar;
+  type bar = u32;
 }

--- a/crates/wit-parser/tests/ui/union-fuzz-1.wit
+++ b/crates/wit-parser/tests/ui/union-fuzz-1.wit
@@ -5,5 +5,5 @@ world xo {}
 world name {}
 
 world x {
-    include name
+    include name;
 }

--- a/crates/wit-parser/tests/ui/use-chain.wit
+++ b/crates/wit-parser/tests/ui/use-chain.wit
@@ -4,8 +4,8 @@ interface foo {
   record foo {}
 }
 
-use foo as bar
+use foo as bar;
 
 interface name {
-  use bar.{foo}
+  use bar.{foo};
 }

--- a/crates/wit-parser/tests/ui/use.wit
+++ b/crates/wit-parser/tests/ui/use.wit
@@ -1,34 +1,34 @@
 package foo:foo
 
 interface foo {
-  use bar.{the-type}
+  use bar.{the-type};
 }
 
 interface bar {
-  type the-type = u32
+  type the-type = u32;
 }
 
 interface baz {
-  use foo.{the-type}
-  use bar.{the-type as test}
+  use foo.{the-type};
+  use bar.{the-type as test};
 }
 
 interface empty {
 }
 
 interface use-from-empty {
-  use empty.{}
-  use empty.{}
+  use empty.{};
+  use empty.{};
 }
 
 interface use-multiple {
-  use baz.{the-type, test}
+  use baz.{the-type, test};
 
-  some-function: func(x: the-type) -> test
+  some-function: func(x: the-type) -> test;
 }
 
 interface trailing-comma {
-  use foo.{the-type,}
+  use foo.{the-type,};
 
   record the-foo { a: the-type }
 }

--- a/crates/wit-parser/tests/ui/versions/deps/a1/foo.wit
+++ b/crates/wit-parser/tests/ui/versions/deps/a1/foo.wit
@@ -1,5 +1,5 @@
 package a:a@1.0.0
 
 interface foo {
-  type t = u32
+  type t = u32;
 }

--- a/crates/wit-parser/tests/ui/versions/deps/a2/foo.wit
+++ b/crates/wit-parser/tests/ui/versions/deps/a2/foo.wit
@@ -1,5 +1,5 @@
 package a:a@2.0.0
 
 interface foo {
-  type t = u32
+  type t = u32;
 }

--- a/crates/wit-parser/tests/ui/versions/foo.wit
+++ b/crates/wit-parser/tests/ui/versions/foo.wit
@@ -1,7 +1,7 @@
 package foo:versions
 
 interface foo {
-  use a:a/foo@1.0.0.{t}
-  use a:a/foo@2.0.0.{t as t2}
+  use a:a/foo@1.0.0.{t};
+  use a:a/foo@2.0.0.{t as t2};
 }
 

--- a/crates/wit-parser/tests/ui/wasi.wit
+++ b/crates/wit-parser/tests/ui/wasi.wit
@@ -13,7 +13,7 @@ interface wasi {
   }
 
   // Timestamp in nanoseconds.
-  type timestamp = u64
+  type timestamp = u64;
 
   // Error codes returned by functions.
   // Not all of these error codes are returned by the functions provided by this

--- a/crates/wit-parser/tests/ui/world-diamond.wit
+++ b/crates/wit-parser/tests/ui/world-diamond.wit
@@ -1,23 +1,23 @@
 package foo:foo
 
 interface shared-items {
-  type foo = u32
+  type foo = u32;
 }
 
 interface i1 {
-  use shared-items.{foo}
+  use shared-items.{foo};
 
-  a: func() -> foo
+  a: func() -> foo;
 }
 
 interface i2 {
-  use shared-items.{foo}
+  use shared-items.{foo};
 
-  a: func() -> foo
+  a: func() -> foo;
 }
 
 world the-world {
-  import i1
-  import i2
-  import a: func()
+  import i1;
+  import i2;
+  import a: func();
 }

--- a/crates/wit-parser/tests/ui/world-iface-no-collide.wit
+++ b/crates/wit-parser/tests/ui/world-iface-no-collide.wit
@@ -1,11 +1,11 @@
 package foo:foo
 
 interface foo {
-  type t = u32
+  type t = u32;
 }
 
 world bar {
-  use foo.{t}
+  use foo.{t};
 
-  import foo: func()
+  import foo: func();
 }

--- a/crates/wit-parser/tests/ui/world-implicit-import1.wit
+++ b/crates/wit-parser/tests/ui/world-implicit-import1.wit
@@ -1,12 +1,12 @@
 package foo:foo
 
 interface foo {
-  type a = u32
+  type a = u32;
 }
 
 world the-world {
   import bar: interface {
-    use foo.{a}
+    use foo.{a};
   }
   import foo: interface {}
 }

--- a/crates/wit-parser/tests/ui/world-implicit-import2.wit
+++ b/crates/wit-parser/tests/ui/world-implicit-import2.wit
@@ -1,11 +1,11 @@
 package foo:foo
 
 interface foo {
-  type g = char
+  type g = char;
 }
 
 world w {
-  use foo.{g}
+  use foo.{g};
 
-  import foo: func() -> g
+  import foo: func() -> g;
 }

--- a/crates/wit-parser/tests/ui/world-implicit-import3.wit
+++ b/crates/wit-parser/tests/ui/world-implicit-import3.wit
@@ -1,11 +1,11 @@
 package foo:foo
 
 interface foo {
-  type g = char
+  type g = char;
 }
 
 world w {
-  use foo.{g}
+  use foo.{g};
 
-  export foo: func() -> g
+  export foo: func() -> g;
 }

--- a/crates/wit-parser/tests/ui/world-same-fields4.wit
+++ b/crates/wit-parser/tests/ui/world-same-fields4.wit
@@ -1,13 +1,13 @@
 package foo:foo
 
 interface shared-items {
-  type a = u32
+  type a = u32;
 }
 
 world foo {
   import shared-items: interface {}
   export a-name: interface {
-    use shared-items.{a}
+    use shared-items.{a};
   }
 }
 

--- a/crates/wit-parser/tests/ui/world-top-level-funcs.wit
+++ b/crates/wit-parser/tests/ui/world-top-level-funcs.wit
@@ -1,9 +1,9 @@
 package foo:foo
 
 world foo {
-  import foo: func()
-  export foo2: func()
+  import foo: func();
+  export foo2: func();
 
-  import bar: func(arg: list<u32>)
-  export some-name: func() -> list<option<u32>>
+  import bar: func(arg: list<u32>);
+  export some-name: func() -> list<option<u32>>;
 }

--- a/crates/wit-parser/tests/ui/world-top-level-resources.wit
+++ b/crates/wit-parser/tests/ui/world-top-level-resources.wit
@@ -2,23 +2,23 @@ package foo:foo
 
 interface types {
   resource request {
-    foo: func()
-    bar: func(arg: list<u32>)
+    foo: func();
+    bar: func(arg: list<u32>);
   }
 
   resource response {
-    foo: func()
-    bar: func(arg: list<u32>)
+    foo: func();
+    bar: func(arg: list<u32>);
   }
 }
 
 interface handler {
-  use types.{request, response}
-  handle: func(some: borrow<request>) -> borrow<response>
-  handle-owned: func(some: own<request>) -> own<response>
+  use types.{request, response};
+  handle: func(some: borrow<request>) -> borrow<response>;
+  handle-owned: func(some: own<request>) -> own<response>;
 }
 
 world proxy {
-  import handler
-  export handler
+  import handler;
+  export handler;
 }

--- a/crates/wit-parser/tests/ui/worlds-union-dedup.wit
+++ b/crates/wit-parser/tests/ui/worlds-union-dedup.wit
@@ -8,16 +8,16 @@ interface c { }
 interface d { }
 
 world my-world-a {
-    import a1
-    import b1
+    import a1;
+    import b1;
 }
 
 world my-world-b {
-    import a1
-    import b1
+    import a1;
+    import b1;
 }
 
 world union-my-world {
-    include my-world-a
-    include my-world-b
+    include my-world-a;
+    include my-world-b;
 }

--- a/crates/wit-parser/tests/ui/worlds-with-types.wit
+++ b/crates/wit-parser/tests/ui/worlds-with-types.wit
@@ -1,23 +1,23 @@
 package foo:foo
 
 world foo {
-  type a = u32
-  type b = a
+  type a = u32;
+  type b = a;
 
-  export c: func(a: a) -> b
+  export c: func(a: a) -> b;
 }
 
 
 interface disambiguate {
-  type t = u32
+  type t = u32;
 }
 
 world bar {
-  import disambiguate
+  import disambiguate;
 
-  use disambiguate.{t}
+  use disambiguate.{t};
 
-  export foo: func() -> t
+  export foo: func() -> t;
 }
 
 world the-test {
@@ -29,6 +29,6 @@ world the-test {
     c(a),
   }
 
-  import foo: func(a: a) -> b
-  export bar: func(a: a) -> b
+  import foo: func(a: a) -> b;
+  export bar: func(a: a) -> b;
 }

--- a/tests/cli/print-core-wasm-wit.wit
+++ b/tests/cli/print-core-wasm-wit.wit
@@ -3,9 +3,9 @@
 package foo:foo
 
 interface my-interface {
-  foo: func()
+  foo: func();
 }
 
 world my-world {
-  import my-interface
+  import my-interface;
 }


### PR DESCRIPTION
This commit is an implementation of https://github.com/WebAssembly/component-model/issues/142 to
add semicolon delimiters to the WIT text format. The intention of this
change is to be rolled out gradually to minimize ecosystem disruption
(although some is inevitable). The strategy implemented in this commit
is to add support to parse semicolons but optionally do so. Requiring
semicolons is configured via:

* A new `WIT_REQUIRE_SEMICOLONS` environment variable is now read. If
  set to `1` then semicolons are required during parsing.
* A new `SourceMap::set_require_semicolons` is provided to
  programmatically indicate what to do.

When semicolons are not required they are still parsed, but a failure is
not generated if they're not present. This should allow semicolon-using
WIT to coexist with non-semicolon-using WIT for a transitionary period.
After a release or two the default for requiring semicolons will
switch to `true` from the current `false`. That means that
`WIT_REQUIRE_SEMICOLONS=0` can be used to keep old WITs compiling. The
after a few releases of that support for optionally parsing semicolons
will be removed and they'll be unconditionally required.