### PR TITLE
Clean up parsing `(if ...)`

### DIFF
--- a/crates/wit-component/tests/components/adapt-inject-stack-with-adapt-realloc/adapt-old.wat
+++ b/crates/wit-component/tests/components/adapt-inject-stack-with-adapt-realloc/adapt-old.wat
@@ -25,7 +25,7 @@
 
     ;; `wit-component` should have injected a call to a function that allocates
     ;; the stack and sets $allocation_state to 2
-    (if (i32.ne (global.get $allocation_state) (i32.const 2)) (unreachable))
+    (if (i32.ne (global.get $allocation_state) (i32.const 2)) (then (unreachable)))
 
     ;; First, allocate a page using $cabi_realloc and write to it.  This tests
     ;; that we can use the main module's allocator if present (or else a

--- a/crates/wit-component/tests/components/adapt-inject-stack-with-realloc/adapt-old.wat
+++ b/crates/wit-component/tests/components/adapt-inject-stack-with-realloc/adapt-old.wat
@@ -25,7 +25,7 @@
 
     ;; `wit-component` should have injected a call to a function that allocates
     ;; the stack and sets $allocation_state to 2
-    (if (i32.ne (global.get $allocation_state) (i32.const 2)) (unreachable))
+    (if (i32.ne (global.get $allocation_state) (i32.const 2)) (then (unreachable)))
 
     ;; First, allocate a page using $cabi_realloc and write to it.  This tests
     ;; that we can use the main module's allocator if present (or else a

--- a/crates/wit-component/tests/components/adapt-inject-stack-with-reallocing-adapter/adapt-old.wat
+++ b/crates/wit-component/tests/components/adapt-inject-stack-with-reallocing-adapter/adapt-old.wat
@@ -24,7 +24,7 @@
 
     ;; `wit-component` should have injected a call to a function that allocates
     ;; the stack and sets $allocation_state to 2
-    (if (i32.ne (global.get $allocation_state) (i32.const 2)) (unreachable))
+    (if (i32.ne (global.get $allocation_state) (i32.const 2)) (then (unreachable)))
 
     ;; Allocate 8 bytes of stack space for the two u32 return values. The
     ;; original stack pointer is saved in local 0 and the stack frame for this

--- a/tests/local/fuzz1.wat
+++ b/tests/local/fuzz1.wat
@@ -260,9 +260,9 @@
     (i32.eqz
      (global.get $hangLimit)
     )
-    (return
+    (then (return
      (i64.const 4293531749)
-    )
+    ))
    )
    (global.set $hangLimit
     (i32.sub
@@ -279,8 +279,8 @@
       (local.tee $0
        (if (result i32)
         (i32.const -2147483647)
-        (local.get $0)
-        (block $label$4 (result i32)
+        (then (local.get $0))
+        (else (block $label$4 (result i32)
          (br_if $label$4
           (if (result i32)
            (block $label$5 (result i32)
@@ -293,9 +293,9 @@
                   (i32.eqz
                    (global.get $hangLimit)
                   )
-                  (return
+                  (then (return
                    (i64.const -32766)
-                  )
+                  ))
                  )
                  (global.set $hangLimit
                   (i32.sub
@@ -315,22 +315,22 @@
                 )
                )
               )
-              (block $label$7 (result f32)
+              (then (block $label$7 (result f32)
                (f32.const -nan:0x7fffda)
-              )
-              (f32.const 4294967296)
+              ))
+              (else (f32.const 4294967296))
              )
             )
             (i32.const -2147483648)
            )
-           (i32.const -1073741824)
-           (local.get $0)
+           (then (i32.const -1073741824))
+           (else (local.get $0))
           )
           (i32.eqz
            (global.get $global$0)
           )
          )
-        )
+        ))
        )
       )
      )

--- a/tests/local/if-else-parsing.wast
+++ b/tests/local/if-else-parsing.wast
@@ -1,0 +1,42 @@
+(module
+  (func $a1
+    i32.const 0
+    (if (then) (else))
+  )
+  (func $a2
+    (if (i32.const 1) (i32.eqz) (then) (else))
+  )
+  (func $a3
+    (if (i32.const 1) (i32.eqz) (then))
+  )
+  (func $a4
+    (if (i32.const 1) (i32.eqz) (then nop))
+  )
+)
+(assert_invalid
+  (module quote
+    "(func (if))"
+  )
+  "no `then`")
+
+(assert_invalid
+  (module quote
+    "(func (if (else)))"
+  )
+  "no `then`")
+
+(assert_invalid
+  (module quote
+    "(func (if nop (else)))"
+  )
+  "expected `(`")
+(assert_invalid
+  (module quote
+    "(func (if (nop) (else)))"
+  )
+  "no `then`")
+(assert_invalid
+  (module quote
+    "(func (if (nop) nop (then)))"
+  )
+  "expected `(`")

--- a/tests/snapshots/local/if-else-parsing.wast/0.print
+++ b/tests/snapshots/local/if-else-parsing.wast/0.print
@@ -1,0 +1,29 @@
+(module
+  (type (;0;) (func))
+  (func $a1 (;0;) (type 0)
+    i32.const 0
+    if ;; label = @1
+    else
+    end
+  )
+  (func $a2 (;1;) (type 0)
+    i32.const 1
+    i32.eqz
+    if ;; label = @1
+    else
+    end
+  )
+  (func $a3 (;2;) (type 0)
+    i32.const 1
+    i32.eqz
+    if ;; label = @1
+    end
+  )
+  (func $a4 (;3;) (type 0)
+    i32.const 1
+    i32.eqz
+    if ;; label = @1
+      nop
+    end
+  )
+)

--- a/tests/snapshots/testsuite/if.wast/0.print
+++ b/tests/snapshots/testsuite/if.wast/0.print
@@ -22,12 +22,14 @@
     end
     local.get 0
     if ;; label = @1
+    else
     end
     local.get 0
     if $l ;; label = @1
     end
     local.get 0
     if $l ;; label = @1
+    else
     end
   )
   (func (;2;) (type 5) (param i32) (result i32)

--- a/tests/snapshots/testsuite/proposals/function-references/if.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/function-references/if.wast/0.print
@@ -22,12 +22,14 @@
     end
     local.get 0
     if ;; label = @1
+    else
     end
     local.get 0
     if $l ;; label = @1
     end
     local.get 0
     if $l ;; label = @1
+    else
     end
   )
   (func (;2;) (type 5) (param i32) (result i32)

--- a/tests/snapshots/testsuite/proposals/gc/if.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/gc/if.wast/0.print
@@ -22,12 +22,14 @@
     end
     local.get 0
     if ;; label = @1
+    else
     end
     local.get 0
     if $l ;; label = @1
     end
     local.get 0
     if $l ;; label = @1
+    else
     end
   )
   (func (;2;) (type 5) (param i32) (result i32)


### PR DESCRIPTION
Much of this code dates back to when this crate was trying to parse all of WABT's tests as well as the upstream test suite. WABT at the time had syntactical forms that weren't technically supposed to be valid given the upstream test suite, so at the time more was accepted than should be.

This commit fixes how `(if ...)` is parsed to require `(then ..)` and `(else ..)` wrappers. Previously these were mistakenly only optional. Additionally this fixes #1213 by allowing multiple condition-related folded expressions before `(then ..)`.

This updates a few of the golden outputs for the spec test suites, notably those that use `(if (foo) (then) (else))` where previously `wast` would erroneously not emit an `else` instruction but now it does.

Closes #1213