### PR TITLE
Fix merge conflict

### DIFF
--- a/crates/wit-parser/tests/ui/parse-fail/duplicate-function-params.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/duplicate-function-params.wit
@@ -3,5 +3,5 @@
 package foo:foo
 
 interface foo {
-  foo: func(foo: u32, foo: u64)
+  foo: func(foo: u32, foo: u64);
 }

--- a/crates/wit-parser/tests/ui/parse-fail/duplicate-function-params.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/duplicate-function-params.wit.result
@@ -1,5 +1,5 @@
 param `foo` is defined more than once
      --> tests/ui/parse-fail/duplicate-function-params.wit:6:23
       |
-    6 |   foo: func(foo: u32, foo: u64)
+    6 |   foo: func(foo: u32, foo: u64);
       |                       ^--


### PR DESCRIPTION
More semicolons, restores green status to `main`