### PR TITLE
wast: Add exnref, try_table, and throw_ref

### DIFF
--- a/crates/wast/src/component/binary.rs
+++ b/crates/wast/src/component/binary.rs
@@ -599,6 +599,9 @@ impl From<core::HeapType<'_>> for wasm_encoder::HeapType {
         match r {
             core::HeapType::Func => Self::Func,
             core::HeapType::Extern => Self::Extern,
+            core::HeapType::Exn => {
+                todo!("encoding of exceptions proposal types not yet implemented")
+            }
             core::HeapType::Index(Index::Num(i, _)) => Self::Indexed(i),
             core::HeapType::Index(_) => panic!("unresolved index"),
             core::HeapType::Any

--- a/crates/wast/src/component/resolve.rs
+++ b/crates/wast/src/component/resolve.rs
@@ -523,6 +523,7 @@ impl<'a> Resolver<'a> {
                     ValType::Ref(r) => match &mut r.heap {
                         core::HeapType::Func
                         | core::HeapType::Extern
+                        | core::HeapType::Exn
                         | core::HeapType::Any
                         | core::HeapType::Eq
                         | core::HeapType::Array

--- a/crates/wast/src/core/binary.rs
+++ b/crates/wast/src/core/binary.rs
@@ -1038,17 +1038,32 @@ impl<'a> Encode for TryTable<'a> {
     fn encode(&self, dst: &mut Vec<u8>) {
         self.block.encode(dst);
         self.catches.encode(dst);
+
+        let catch_all_flag_byte: u8 = match self.catch_all {
+            None => 0,
+            Some(TryTableCatchAll {
+                kind: TryTableCatchKind::Ref,
+                ..
+            }) => 1,
+            Some(TryTableCatchAll {
+                kind: TryTableCatchKind::Drop,
+                ..
+            }) => 2,
+        };
+        catch_all_flag_byte.encode(dst);
         if let Some(catch_all) = &self.catch_all {
-            (1 as u8).encode(dst);
             catch_all.encode(dst);
-        } else {
-            (0 as u8).encode(dst);
         }
     }
 }
 
 impl<'a> Encode for TryTableCatch<'a> {
     fn encode(&self, dst: &mut Vec<u8>) {
+        let catch_flag_byte: u8 = match self.kind {
+            TryTableCatchKind::Ref => 0,
+            TryTableCatchKind::Drop => 1,
+        };
+        catch_flag_byte.encode(dst);
         self.tag.encode(dst);
         self.label.encode(dst);
     }

--- a/crates/wast/src/core/binary.rs
+++ b/crates/wast/src/core/binary.rs
@@ -246,6 +246,7 @@ impl<'a> Encode for HeapType<'a> {
         match self {
             HeapType::Func => e.push(0x70),
             HeapType::Extern => e.push(0x6f),
+            HeapType::Exn => e.push(0x69),
             HeapType::Any => e.push(0x6e),
             HeapType::Eq => e.push(0x6d),
             HeapType::Struct => e.push(0x6b),
@@ -277,6 +278,11 @@ impl<'a> Encode for RefType<'a> {
                 nullable: true,
                 heap: HeapType::Extern,
             } => e.push(0x6f),
+            // The 'exnref' binary abbreviation
+            RefType {
+                nullable: true,
+                heap: HeapType::Exn,
+            } => e.push(0x69),
             // The 'eqref' binary abbreviation
             RefType {
                 nullable: true,
@@ -1025,6 +1031,32 @@ impl Encode for Id<'_> {
     fn encode(&self, dst: &mut Vec<u8>) {
         assert!(!self.is_gensym());
         self.name().encode(dst);
+    }
+}
+
+impl<'a> Encode for TryTable<'a> {
+    fn encode(&self, dst: &mut Vec<u8>) {
+        self.block.encode(dst);
+        self.catches.encode(dst);
+        if let Some(catch_all) = &self.catch_all {
+            (1 as u8).encode(dst);
+            catch_all.encode(dst);
+        } else {
+            (0 as u8).encode(dst);
+        }
+    }
+}
+
+impl<'a> Encode for TryTableCatch<'a> {
+    fn encode(&self, dst: &mut Vec<u8>) {
+        self.tag.encode(dst);
+        self.label.encode(dst);
+    }
+}
+
+impl<'a> Encode for TryTableCatchAll<'a> {
+    fn encode(&self, dst: &mut Vec<u8>) {
+        self.label.encode(dst);
     }
 }
 

--- a/crates/wast/src/core/binary.rs
+++ b/crates/wast/src/core/binary.rs
@@ -1042,11 +1042,11 @@ impl<'a> Encode for TryTable<'a> {
         let catch_all_flag_byte: u8 = match self.catch_all {
             None => 0,
             Some(TryTableCatchAll {
-                kind: TryTableCatchKind::Ref,
+                kind: TryTableCatchKind::Drop,
                 ..
             }) => 1,
             Some(TryTableCatchAll {
-                kind: TryTableCatchKind::Drop,
+                kind: TryTableCatchKind::Ref,
                 ..
             }) => 2,
         };
@@ -1060,8 +1060,8 @@ impl<'a> Encode for TryTable<'a> {
 impl<'a> Encode for TryTableCatch<'a> {
     fn encode(&self, dst: &mut Vec<u8>) {
         let catch_flag_byte: u8 = match self.kind {
-            TryTableCatchKind::Ref => 0,
-            TryTableCatchKind::Drop => 1,
+            TryTableCatchKind::Drop => 0,
+            TryTableCatchKind::Ref => 1,
         };
         catch_flag_byte.encode(dst);
         self.tag.encode(dst);

--- a/crates/wast/src/core/resolve/names.rs
+++ b/crates/wast/src/core/resolve/names.rs
@@ -521,6 +521,20 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
                 });
                 self.resolve_block_type(bt)?;
             }
+            TryTable(try_table) => {
+                self.blocks.push(ExprBlock {
+                    label: try_table.block.label,
+                    pushed_scope: false,
+                });
+                self.resolve_block_type(&mut try_table.block)?;
+                for catch in &mut try_table.catches {
+                    self.resolver.resolve(&mut catch.tag, Ns::Tag)?;
+                    self.resolve_label(&mut catch.label)?;
+                }
+                if let Some(catch_all) = &mut try_table.catch_all {
+                    self.resolve_label(&mut catch_all.label)?;
+                }
+            }
 
             // On `End` instructions we pop a label from the stack, and for both
             // `End` and `Else` instructions if they have labels listed we

--- a/crates/wast/src/core/resolve/types.rs
+++ b/crates/wast/src/core/resolve/types.rs
@@ -140,7 +140,8 @@ impl<'a> Expander<'a> {
             | Instruction::If(bt)
             | Instruction::Loop(bt)
             | Instruction::Let(LetType { block: bt, .. })
-            | Instruction::Try(bt) => {
+            | Instruction::Try(bt)
+            | Instruction::TryTable(TryTable { block: bt, .. }) => {
                 // No expansion necessary, a type reference is already here.
                 // We'll verify that it's the same as the inline type, if any,
                 // later.

--- a/crates/wast/src/core/types.rs
+++ b/crates/wast/src/core/types.rs
@@ -66,6 +66,8 @@ pub enum HeapType<'a> {
     /// A reference to any host value: externref. This is part of the reference
     /// types proposal.
     Extern,
+    /// A reference to a wasm exception. This is part of the exceptions proposal.
+    Exn,
     /// A reference to any reference value: anyref. This is part of the GC
     /// proposal.
     Any,
@@ -98,6 +100,9 @@ impl<'a> Parse<'a> for HeapType<'a> {
         } else if l.peek::<kw::r#extern>()? {
             parser.parse::<kw::r#extern>()?;
             Ok(HeapType::Extern)
+        } else if l.peek::<kw::exn>()? {
+            parser.parse::<kw::exn>()?;
+            Ok(HeapType::Exn)
         } else if l.peek::<kw::r#any>()? {
             parser.parse::<kw::r#any>()?;
             Ok(HeapType::Any)
@@ -134,6 +139,7 @@ impl<'a> Peek for HeapType<'a> {
     fn peek(cursor: Cursor<'_>) -> Result<bool> {
         Ok(kw::func::peek(cursor)?
             || kw::r#extern::peek(cursor)?
+            || kw::exn::peek(cursor)?
             || kw::any::peek(cursor)?
             || kw::eq::peek(cursor)?
             || kw::r#struct::peek(cursor)?
@@ -171,6 +177,14 @@ impl<'a> RefType<'a> {
         RefType {
             nullable: true,
             heap: HeapType::Extern,
+        }
+    }
+
+    /// An `exnrefr` as an abbreviation for `(ref null exn)`.
+    pub fn exn() -> Self {
+        RefType {
+            nullable: true,
+            heap: HeapType::Exn,
         }
     }
 
@@ -251,6 +265,9 @@ impl<'a> Parse<'a> for RefType<'a> {
         } else if l.peek::<kw::externref>()? {
             parser.parse::<kw::externref>()?;
             Ok(RefType::r#extern())
+        } else if l.peek::<kw::exnref>()? {
+            parser.parse::<kw::exnref>()?;
+            Ok(RefType::exn())
         } else if l.peek::<kw::anyref>()? {
             parser.parse::<kw::anyref>()?;
             Ok(RefType::any())
@@ -306,6 +323,7 @@ impl<'a> Peek for RefType<'a> {
         Ok(kw::funcref::peek(cursor)?
             || /* legacy */ kw::anyfunc::peek(cursor)?
             || kw::externref::peek(cursor)?
+            || kw::exnref::peek(cursor)?
             || kw::anyref::peek(cursor)?
             || kw::eqref::peek(cursor)?
             || kw::structref::peek(cursor)?

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -404,6 +404,8 @@ pub mod kw {
     custom_keyword!(elem);
     custom_keyword!(end);
     custom_keyword!(tag);
+    custom_keyword!(exn);
+    custom_keyword!(exnref);
     custom_keyword!(export);
     custom_keyword!(r#extern = "extern");
     custom_keyword!(externref);

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -393,7 +393,9 @@ pub mod kw {
     custom_keyword!(block);
     custom_keyword!(borrow);
     custom_keyword!(catch);
+    custom_keyword!(catch_ref);
     custom_keyword!(catch_all);
+    custom_keyword!(catch_all_ref);
     custom_keyword!(code);
     custom_keyword!(component);
     custom_keyword!(data);

--- a/tests/local/exnref/exnref.wast
+++ b/tests/local/exnref/exnref.wast
@@ -1,0 +1,5 @@
+(module
+  (func (param exnref))
+  (func (param (ref null exn)))
+  (func (param (ref exn)))
+)

--- a/tests/local/exnref/throw_ref.wast
+++ b/tests/local/exnref/throw_ref.wast
@@ -1,0 +1,6 @@
+(module
+  (func (param exnref)
+    local.get 0
+    throw_ref
+  )
+)

--- a/tests/local/exnref/try_table.wast
+++ b/tests/local/exnref/try_table.wast
@@ -2,14 +2,17 @@
   (tag $a (param i32))
 
   (func
+    (; empty try_table ;)
     try_table
     end
 
+    (; try_table with result  ;)
     try_table (result i32)
       i32.const 0
     end
     drop
 
+    (; try_table can catches ;)
     try_table (catch $a 0)
     end
 
@@ -25,6 +28,7 @@
     try_table (catch $a 0) (catch $a 0) (catch_all 0)
     end
 
+    (; try_table can have results and catches ;)
     try_table (result i32) (catch $a 0)
       i32.const 0
     end
@@ -49,5 +53,43 @@
       i32.const 0
     end
     drop
+
+    (; mixes of catch, catch_ref, catch_all, and catch_all_ref ;)
+
+    try_table (catch_ref $a 0)
+    end
+
+    try_table (catch_ref $a 0) (catch_ref $a 0)
+    end
+
+    try_table (catch $a 0) (catch_ref $a 0)
+    end
+
+    try_table (catch_ref $a 0) (catch_ref $a 0)
+    end
+
+    try_table (catch_ref $a 0) (catch $a 0)
+    end
+
+    try_table (catch_all 0)
+    end
+
+    try_table (catch_all_ref 0)
+    end
+
+    try_table (catch_ref $a 0) (catch_all_ref 0)
+    end
+
+    try_table (catch_ref $a 0) (catch_ref $a 0) (catch_all_ref 0)
+    end
+
+    try_table (catch $a 0) (catch_ref $a 0) (catch_all_ref 0)
+    end
+
+    try_table (catch_ref $a 0) (catch_ref $a 0) (catch_all_ref 0)
+    end
+
+    try_table (catch_ref $a 0) (catch $a 0) (catch_all_ref 0)
+    end
   )
 )

--- a/tests/local/exnref/try_table.wast
+++ b/tests/local/exnref/try_table.wast
@@ -1,0 +1,53 @@
+(module
+  (tag $a (param i32))
+
+  (func
+    try_table
+    end
+
+    try_table (result i32)
+      i32.const 0
+    end
+    drop
+
+    try_table (catch $a 0)
+    end
+
+    try_table (catch $a 0) (catch $a 0)
+    end
+
+    try_table (catch_all 0)
+    end
+
+    try_table (catch $a 0) (catch_all 0)
+    end
+
+    try_table (catch $a 0) (catch $a 0) (catch_all 0)
+    end
+
+    try_table (result i32) (catch $a 0)
+      i32.const 0
+    end
+    drop
+
+    try_table (result i32) (catch $a 0) (catch $a 0)
+      i32.const 0
+    end
+    drop
+
+    try_table (result i32) (catch_all 0)
+      i32.const 0
+    end
+    drop
+
+    try_table (result i32) (catch $a 0) (catch_all 0)
+      i32.const 0
+    end
+    drop
+
+    try_table (result i32) (catch $a 0) (catch $a 0) (catch_all 0)
+      i32.const 0
+    end
+    drop
+  )
+)

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -193,6 +193,9 @@ fn skip_validation(test: &Path) -> bool {
         "/proposals/gc/type-equivalence.wast",
         "/proposals/gc/type-rec.wast",
         "/proposals/gc/type-subtyping.wast",
+        "/exnref/exnref.wast",
+        "/exnref/throw_ref.wast",
+        "/exnref/try_table.wast",
     ];
     let test_path = test.to_str().unwrap().replace("\\", "/"); // for windows paths
     if broken.iter().any(|x| test_path.contains(x)) {


### PR DESCRIPTION
These types and instructions are part of the exception handling rework tracked in (https://github.com/WebAssembly/exception-handling/issues/281).