### PR TITLE
GC: wasmparser: re-enable some skipped GC test cases

### DIFF
--- a/tests/local/gc/gc-subtypes-invalid.wast
+++ b/tests/local/gc/gc-subtypes-invalid.wast
@@ -142,3 +142,10 @@
   )
   "duplicate identifier"
 )
+(assert_invalid
+  (module
+    (type $a (func)) ;; types without `(sub )` are considered final
+    (type (sub $a (func)))
+  )
+  "subtype must match supertype"
+)

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -167,12 +167,9 @@ fn skip_test(test: &Path, contents: &[u8]) -> bool {
 
 fn skip_validation(test: &Path) -> bool {
     let broken = &[
-        "function-references/type-equivalence.wast",
         "gc/gc-array.wat",
         "gc/gc-rec-sub.wat",
-        "gc/gc-ref.wat",
         "gc/gc-struct.wat",
-        "gc/type-equivalence.wast",
         "/proposals/gc/array.wast",
         "/proposals/gc/array_copy.wast",
         "/proposals/gc/array_fill.wast",

--- a/tests/snapshots/local/gc/gc-ref.wat.print
+++ b/tests/snapshots/local/gc/gc-ref.wat.print
@@ -1,0 +1,74 @@
+(module
+  (type $a (;0;) (struct))
+  (type $b (;1;) (struct))
+  (type $f1 (;2;) (func (param (ref 0))))
+  (type $f2 (;3;) (func (result (ref 1))))
+  (type (;4;) (func (param (ref 0))))
+  (type (;5;) (func (result (ref 0))))
+  (type (;6;) (func))
+  (func (;0;) (type $f1) (param (ref 0)))
+  (func (;1;) (type 4) (param (ref 0)))
+  (func (;2;) (type $f1) (param (ref 0)))
+  (func (;3;) (type $f1) (param (ref 0)))
+  (func (;4;) (type 5) (result (ref 0))
+    unreachable
+  )
+  (func (;5;) (type 6)
+    (local (ref 0))
+  )
+  (func (;6;) (type 6)
+    unreachable
+    unreachable
+    i32.const 0
+    select (result (ref 0))
+    block (type $f1) (param (ref 0)) ;; label = @1
+      unreachable
+    end
+    block (result (ref 1)) ;; label = @1
+      unreachable
+    end
+    block $f1 (type $f1) (param (ref 0)) ;; label = @1
+      unreachable
+    end
+    block $f2 (result (ref 1)) ;; label = @1
+      unreachable
+    end
+    loop (type $f1) (param (ref 0)) ;; label = @1
+      unreachable
+    end
+    loop (result (ref 1)) ;; label = @1
+      unreachable
+    end
+    loop $f1 (type $f1) (param (ref 0)) ;; label = @1
+      unreachable
+    end
+    loop $f2 (result (ref 1)) ;; label = @1
+      unreachable
+    end
+    drop
+    if (type $f1) (param (ref 0)) ;; label = @1
+      unreachable
+    else
+      unreachable
+    end
+    if (result (ref 1)) ;; label = @1
+      unreachable
+    else
+      unreachable
+    end
+    drop
+    if $f1 (type $f1) (param (ref 0)) ;; label = @1
+      unreachable
+    else
+      unreachable
+    end
+    if $f2 (result (ref 1)) ;; label = @1
+      unreachable
+    else
+      unreachable
+    end
+    drop
+  )
+  (global (;0;) (ref null 0) ref.null 0)
+  (global (;1;) (ref null 1) ref.null 1)
+)

--- a/tests/snapshots/local/gc/type-equivalence.wast/0.print
+++ b/tests/snapshots/local/gc/type-equivalence.wast/0.print
@@ -1,0 +1,14 @@
+(module
+  (type $t1 (;0;) (func (param f32 f32) (result f32)))
+  (type $t2 (;1;) (func (param f32 f32) (result f32)))
+  (type (;2;) (func (param (ref 0))))
+  (type (;3;) (func (param (ref 1))))
+  (func $f1 (;0;) (type 2) (param $r (ref 0))
+    local.get $r
+    call $f2
+  )
+  (func $f2 (;1;) (type 3) (param $r (ref 1))
+    local.get $r
+    call $f1
+  )
+)

--- a/tests/snapshots/local/gc/type-equivalence.wast/1.print
+++ b/tests/snapshots/local/gc/type-equivalence.wast/1.print
@@ -1,0 +1,17 @@
+(module
+  (type $s0 (;0;) (func (param i32) (result f32)))
+  (type $s1 (;1;) (func (param i32 (ref 0)) (result (ref 0))))
+  (type $s2 (;2;) (func (param i32 (ref 0)) (result (ref 0))))
+  (type $t1 (;3;) (func (param (ref 1)) (result (ref 2))))
+  (type $t2 (;4;) (func (param (ref 2)) (result (ref 1))))
+  (type (;5;) (func (param (ref 3))))
+  (type (;6;) (func (param (ref 4))))
+  (func $f1 (;0;) (type 5) (param $r (ref 3))
+    local.get $r
+    call $f2
+  )
+  (func $f2 (;1;) (type 6) (param $r (ref 4))
+    local.get $r
+    call $f1
+  )
+)

--- a/tests/snapshots/local/gc/type-equivalence.wast/10.print
+++ b/tests/snapshots/local/gc/type-equivalence.wast/10.print
@@ -1,0 +1,5 @@
+(module
+  (type $t2 (;0;) (func (param f32 f32) (result f32)))
+  (type (;1;) (func (param (ref 0))))
+  (import "M" "f" (func (;0;) (type 1)))
+)

--- a/tests/snapshots/local/gc/type-equivalence.wast/11.print
+++ b/tests/snapshots/local/gc/type-equivalence.wast/11.print
@@ -1,0 +1,12 @@
+(module
+  (type $s0 (;0;) (func (param i32) (result f32)))
+  (type $s1 (;1;) (func (param i32 (ref 0)) (result (ref 0))))
+  (type $s2 (;2;) (func (param i32 (ref 0)) (result (ref 0))))
+  (type $t1 (;3;) (func (param (ref 1)) (result (ref 2))))
+  (type $t2 (;4;) (func (param (ref 2)) (result (ref 1))))
+  (type (;5;) (func (param (ref 3))))
+  (func (;0;) (type 5) (param (ref 3)))
+  (func (;1;) (type 5) (param (ref 3)))
+  (export "f1" (func 0))
+  (export "f2" (func 1))
+)

--- a/tests/snapshots/local/gc/type-equivalence.wast/13.print
+++ b/tests/snapshots/local/gc/type-equivalence.wast/13.print
@@ -1,0 +1,13 @@
+(module
+  (type $s0 (;0;) (func (param i32) (result f32)))
+  (type $s1 (;1;) (func (param i32 (ref 0)) (result (ref 0))))
+  (type $s2 (;2;) (func (param i32 (ref 0)) (result (ref 0))))
+  (type $t1 (;3;) (func (param (ref 1)) (result (ref 2))))
+  (type $t2 (;4;) (func (param (ref 2)) (result (ref 1))))
+  (type (;5;) (func (param (ref 3))))
+  (type (;6;) (func (param (ref 4))))
+  (import "M" "f1" (func (;0;) (type 5)))
+  (import "M" "f1" (func (;1;) (type 6)))
+  (import "M" "f2" (func (;2;) (type 5)))
+  (import "M" "f2" (func (;3;) (type 5)))
+)

--- a/tests/snapshots/local/gc/type-equivalence.wast/2.print
+++ b/tests/snapshots/local/gc/type-equivalence.wast/2.print
@@ -1,0 +1,3 @@
+(module
+  (type $t (;0;) (func (result (ref 0))))
+)

--- a/tests/snapshots/local/gc/type-equivalence.wast/4.print
+++ b/tests/snapshots/local/gc/type-equivalence.wast/4.print
@@ -1,0 +1,20 @@
+(module
+  (type $t1 (;0;) (func (param f32 f32)))
+  (type $t2 (;1;) (func (param f32 f32)))
+  (type (;2;) (func))
+  (func $f1 (;0;) (type $t1) (param f32 f32))
+  (func $f2 (;1;) (type $t2) (param f32 f32))
+  (func (;2;) (type 2)
+    f32.const 0x1p+0 (;=1;)
+    f32.const 0x1p+1 (;=2;)
+    i32.const 1
+    call_indirect (type $t1)
+    f32.const 0x1p+0 (;=1;)
+    f32.const 0x1p+1 (;=2;)
+    i32.const 0
+    call_indirect (type $t2)
+  )
+  (table (;0;) 2 2 funcref)
+  (export "run" (func 2))
+  (elem (;0;) (i32.const 0) func $f1 $f2)
+)

--- a/tests/snapshots/local/gc/type-equivalence.wast/6.print
+++ b/tests/snapshots/local/gc/type-equivalence.wast/6.print
@@ -1,0 +1,41 @@
+(module
+  (type $s0 (;0;) (func (param i32)))
+  (type $s1 (;1;) (func (param i32 (ref 0))))
+  (type $s2 (;2;) (func (param i32 (ref 0))))
+  (type $t1 (;3;) (func (param (ref 1))))
+  (type $t2 (;4;) (func (param (ref 2))))
+  (type (;5;) (func))
+  (func $s1 (;0;) (type $s1) (param i32 (ref 0)))
+  (func $s2 (;1;) (type $s2) (param i32 (ref 0)))
+  (func $f1 (;2;) (type $t1) (param (ref 1)))
+  (func $f2 (;3;) (type $t2) (param (ref 2)))
+  (func (;4;) (type 5)
+    ref.func $s1
+    i32.const 0
+    call_indirect (type $t1)
+    ref.func $s1
+    i32.const 1
+    call_indirect (type $t1)
+    ref.func $s2
+    i32.const 0
+    call_indirect (type $t1)
+    ref.func $s2
+    i32.const 1
+    call_indirect (type $t1)
+    ref.func $s1
+    i32.const 0
+    call_indirect (type $t2)
+    ref.func $s1
+    i32.const 1
+    call_indirect (type $t2)
+    ref.func $s2
+    i32.const 0
+    call_indirect (type $t2)
+    ref.func $s2
+    i32.const 1
+    call_indirect (type $t2)
+  )
+  (table (;0;) 4 4 funcref)
+  (export "run" (func 4))
+  (elem (;0;) (i32.const 0) func $f1 $f2 $s1 $s2)
+)

--- a/tests/snapshots/local/gc/type-equivalence.wast/8.print
+++ b/tests/snapshots/local/gc/type-equivalence.wast/8.print
@@ -1,0 +1,6 @@
+(module
+  (type $t1 (;0;) (func (param f32 f32) (result f32)))
+  (type (;1;) (func (param (ref 0))))
+  (func (;0;) (type 1) (param (ref 0)))
+  (export "f" (func 0))
+)

--- a/tests/snapshots/testsuite/proposals/function-references/type-equivalence.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/function-references/type-equivalence.wast/0.print
@@ -1,0 +1,14 @@
+(module
+  (type $t1 (;0;) (func (param f32 f32) (result f32)))
+  (type $t2 (;1;) (func (param f32 f32) (result f32)))
+  (type (;2;) (func (param (ref 0))))
+  (type (;3;) (func (param (ref 1))))
+  (func $f1 (;0;) (type 2) (param $r (ref 0))
+    local.get $r
+    call $f2
+  )
+  (func $f2 (;1;) (type 3) (param $r (ref 1))
+    local.get $r
+    call $f1
+  )
+)

--- a/tests/snapshots/testsuite/proposals/function-references/type-equivalence.wast/1.print
+++ b/tests/snapshots/testsuite/proposals/function-references/type-equivalence.wast/1.print
@@ -1,0 +1,17 @@
+(module
+  (type $s0 (;0;) (func (param i32) (result f32)))
+  (type $s1 (;1;) (func (param i32 (ref 0)) (result (ref 0))))
+  (type $s2 (;2;) (func (param i32 (ref 0)) (result (ref 0))))
+  (type $t1 (;3;) (func (param (ref 1)) (result (ref 2))))
+  (type $t2 (;4;) (func (param (ref 2)) (result (ref 1))))
+  (type (;5;) (func (param (ref 3))))
+  (type (;6;) (func (param (ref 4))))
+  (func $f1 (;0;) (type 5) (param $r (ref 3))
+    local.get $r
+    call $f2
+  )
+  (func $f2 (;1;) (type 6) (param $r (ref 4))
+    local.get $r
+    call $f1
+  )
+)

--- a/tests/snapshots/testsuite/proposals/function-references/type-equivalence.wast/10.print
+++ b/tests/snapshots/testsuite/proposals/function-references/type-equivalence.wast/10.print
@@ -1,0 +1,5 @@
+(module
+  (type $t2 (;0;) (func (param f32 f32) (result f32)))
+  (type (;1;) (func (param (ref 0))))
+  (import "M" "f" (func (;0;) (type 1)))
+)

--- a/tests/snapshots/testsuite/proposals/function-references/type-equivalence.wast/11.print
+++ b/tests/snapshots/testsuite/proposals/function-references/type-equivalence.wast/11.print
@@ -1,0 +1,12 @@
+(module
+  (type $s0 (;0;) (func (param i32) (result f32)))
+  (type $s1 (;1;) (func (param i32 (ref 0)) (result (ref 0))))
+  (type $s2 (;2;) (func (param i32 (ref 0)) (result (ref 0))))
+  (type $t1 (;3;) (func (param (ref 1)) (result (ref 2))))
+  (type $t2 (;4;) (func (param (ref 2)) (result (ref 1))))
+  (type (;5;) (func (param (ref 3))))
+  (func (;0;) (type 5) (param (ref 3)))
+  (func (;1;) (type 5) (param (ref 3)))
+  (export "f1" (func 0))
+  (export "f2" (func 1))
+)

--- a/tests/snapshots/testsuite/proposals/function-references/type-equivalence.wast/13.print
+++ b/tests/snapshots/testsuite/proposals/function-references/type-equivalence.wast/13.print
@@ -1,0 +1,13 @@
+(module
+  (type $s0 (;0;) (func (param i32) (result f32)))
+  (type $s1 (;1;) (func (param i32 (ref 0)) (result (ref 0))))
+  (type $s2 (;2;) (func (param i32 (ref 0)) (result (ref 0))))
+  (type $t1 (;3;) (func (param (ref 1)) (result (ref 2))))
+  (type $t2 (;4;) (func (param (ref 2)) (result (ref 1))))
+  (type (;5;) (func (param (ref 3))))
+  (type (;6;) (func (param (ref 4))))
+  (import "N" "f1" (func (;0;) (type 5)))
+  (import "N" "f1" (func (;1;) (type 6)))
+  (import "N" "f2" (func (;2;) (type 5)))
+  (import "N" "f2" (func (;3;) (type 5)))
+)

--- a/tests/snapshots/testsuite/proposals/function-references/type-equivalence.wast/4.print
+++ b/tests/snapshots/testsuite/proposals/function-references/type-equivalence.wast/4.print
@@ -1,0 +1,20 @@
+(module
+  (type $t1 (;0;) (func (param f32 f32)))
+  (type $t2 (;1;) (func (param f32 f32)))
+  (type (;2;) (func))
+  (func $f1 (;0;) (type $t1) (param f32 f32))
+  (func $f2 (;1;) (type $t2) (param f32 f32))
+  (func (;2;) (type 2)
+    f32.const 0x1p+0 (;=1;)
+    f32.const 0x1p+1 (;=2;)
+    i32.const 1
+    call_indirect (type $t1)
+    f32.const 0x1p+0 (;=1;)
+    f32.const 0x1p+1 (;=2;)
+    i32.const 0
+    call_indirect (type $t2)
+  )
+  (table (;0;) 2 2 funcref)
+  (export "run" (func 2))
+  (elem (;0;) (i32.const 0) func $f1 $f2)
+)

--- a/tests/snapshots/testsuite/proposals/function-references/type-equivalence.wast/6.print
+++ b/tests/snapshots/testsuite/proposals/function-references/type-equivalence.wast/6.print
@@ -1,0 +1,41 @@
+(module
+  (type $s0 (;0;) (func (param i32)))
+  (type $s1 (;1;) (func (param i32 (ref 0))))
+  (type $s2 (;2;) (func (param i32 (ref 0))))
+  (type $t1 (;3;) (func (param (ref 1))))
+  (type $t2 (;4;) (func (param (ref 2))))
+  (type (;5;) (func))
+  (func $s1 (;0;) (type $s1) (param i32 (ref 0)))
+  (func $s2 (;1;) (type $s2) (param i32 (ref 0)))
+  (func $f1 (;2;) (type $t1) (param (ref 1)))
+  (func $f2 (;3;) (type $t2) (param (ref 2)))
+  (func (;4;) (type 5)
+    ref.func $s1
+    i32.const 0
+    call_indirect (type $t1)
+    ref.func $s1
+    i32.const 1
+    call_indirect (type $t1)
+    ref.func $s2
+    i32.const 0
+    call_indirect (type $t1)
+    ref.func $s2
+    i32.const 1
+    call_indirect (type $t1)
+    ref.func $s1
+    i32.const 0
+    call_indirect (type $t2)
+    ref.func $s1
+    i32.const 1
+    call_indirect (type $t2)
+    ref.func $s2
+    i32.const 0
+    call_indirect (type $t2)
+    ref.func $s2
+    i32.const 1
+    call_indirect (type $t2)
+  )
+  (table (;0;) 4 4 funcref)
+  (export "run" (func 4))
+  (elem (;0;) (i32.const 0) func $f1 $f2 $s1 $s2)
+)

--- a/tests/snapshots/testsuite/proposals/function-references/type-equivalence.wast/8.print
+++ b/tests/snapshots/testsuite/proposals/function-references/type-equivalence.wast/8.print
@@ -1,0 +1,6 @@
+(module
+  (type $t1 (;0;) (func (param f32 f32) (result f32)))
+  (type (;1;) (func (param (ref 0))))
+  (func (;0;) (type 1) (param (ref 0)))
+  (export "f" (func 0))
+)


### PR DESCRIPTION
Also, add an `assert_invalid` case for trying to subtype a standalone type defined without `(sub )`