### PR TITLE
Add options to control the functions used to allocate memory

### DIFF
--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -1892,6 +1892,9 @@ pub struct ComponentEncoder {
     validate: bool,
     main_module_exports: IndexSet<WorldKey>,
     adapters: IndexMap<String, Adapter>,
+
+    realloc_via_memory_grow : bool,
+    alloc_stack_via_memory_grow : bool,
 }
 
 impl ComponentEncoder {
@@ -2028,6 +2031,24 @@ impl ComponentEncoder {
             },
         );
         Ok(self)
+    }
+
+    /// True if the realloc should use ememory.grow
+    /// The default is to use the main module realloc
+    /// Can be useful if cabi_realloc cannot be called before the host 
+    /// runtime is initialised.
+    pub fn realloc_via_memory_grow(mut self, value: bool) -> Self {
+        self.realloc_via_memory_grow = value;
+        self
+    }
+
+    /// True if the stack should be allocated via memory.grow
+    /// The default is to use the main module realloc
+    /// Can be useful if cabi_realloc cannot be called before the host 
+    /// runtime is initialised.
+    pub fn alloc_stack_via_memory_grow(mut self, value: bool) -> Self {
+        self.alloc_stack_via_memory_grow = value;
+        self
     }
 
     /// Encode the component and return the bytes.

--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -1894,7 +1894,6 @@ pub struct ComponentEncoder {
     adapters: IndexMap<String, Adapter>,
 
     realloc_via_memory_grow: bool,
-    alloc_stack_via_memory_grow: bool,
 }
 
 impl ComponentEncoder {
@@ -2033,21 +2032,12 @@ impl ComponentEncoder {
         Ok(self)
     }
 
-    /// True if the realloc should use ememory.grow
+    /// True if the realloc and stack alloction should use ememory.grow
     /// The default is to use the main module realloc
     /// Can be useful if cabi_realloc cannot be called before the host
     /// runtime is initialised.
     pub fn realloc_via_memory_grow(mut self, value: bool) -> Self {
         self.realloc_via_memory_grow = value;
-        self
-    }
-
-    /// True if the stack should be allocated via memory.grow
-    /// The default is to use the main module realloc
-    /// Can be useful if cabi_realloc cannot be called before the host
-    /// runtime is initialised.
-    pub fn alloc_stack_via_memory_grow(mut self, value: bool) -> Self {
-        self.alloc_stack_via_memory_grow = value;
         self
     }
 

--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -1893,8 +1893,8 @@ pub struct ComponentEncoder {
     main_module_exports: IndexSet<WorldKey>,
     adapters: IndexMap<String, Adapter>,
 
-    realloc_via_memory_grow : bool,
-    alloc_stack_via_memory_grow : bool,
+    realloc_via_memory_grow: bool,
+    alloc_stack_via_memory_grow: bool,
 }
 
 impl ComponentEncoder {
@@ -2035,7 +2035,7 @@ impl ComponentEncoder {
 
     /// True if the realloc should use ememory.grow
     /// The default is to use the main module realloc
-    /// Can be useful if cabi_realloc cannot be called before the host 
+    /// Can be useful if cabi_realloc cannot be called before the host
     /// runtime is initialised.
     pub fn realloc_via_memory_grow(mut self, value: bool) -> Self {
         self.realloc_via_memory_grow = value;
@@ -2044,7 +2044,7 @@ impl ComponentEncoder {
 
     /// True if the stack should be allocated via memory.grow
     /// The default is to use the main module realloc
-    /// Can be useful if cabi_realloc cannot be called before the host 
+    /// Can be useful if cabi_realloc cannot be called before the host
     /// runtime is initialised.
     pub fn alloc_stack_via_memory_grow(mut self, value: bool) -> Self {
         self.alloc_stack_via_memory_grow = value;

--- a/crates/wit-component/src/encoding/world.rs
+++ b/crates/wit-component/src/encoding/world.rs
@@ -145,7 +145,6 @@ impl<'a> ComponentWorld<'a> {
                         } else {
                             self.info.realloc
                         },
-                        self.encoder.alloc_stack_via_memory_grow,
                     )
                     .context("failed to reduce input adapter module to its minimal size")?,
                 )

--- a/crates/wit-component/src/encoding/world.rs
+++ b/crates/wit-component/src/encoding/world.rs
@@ -137,7 +137,13 @@ impl<'a> ComponentWorld<'a> {
                 );
 
                 Cow::Owned(
-                    crate::gc::run(wasm, &required, self.info.realloc)
+                    crate::gc::run(wasm, &required, 
+                        if self.encoder.realloc_via_memory_grow {
+                            None 
+                        } else {
+                            self.info.realloc
+                        },
+                         self.encoder.alloc_stack_via_memory_grow)
                         .context("failed to reduce input adapter module to its minimal size")?,
                 )
             };

--- a/crates/wit-component/src/encoding/world.rs
+++ b/crates/wit-component/src/encoding/world.rs
@@ -137,14 +137,17 @@ impl<'a> ComponentWorld<'a> {
                 );
 
                 Cow::Owned(
-                    crate::gc::run(wasm, &required, 
+                    crate::gc::run(
+                        wasm,
+                        &required,
                         if self.encoder.realloc_via_memory_grow {
-                            None 
+                            None
                         } else {
                             self.info.realloc
                         },
-                         self.encoder.alloc_stack_via_memory_grow)
-                        .context("failed to reduce input adapter module to its minimal size")?,
+                        self.encoder.alloc_stack_via_memory_grow,
+                    )
+                    .context("failed to reduce input adapter module to its minimal size")?,
                 )
             };
             let info = validate_adapter_module(

--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -21,7 +21,7 @@ pub fn run<T>(
     wasm: &[u8],
     required: &IndexMap<String, T>,
     main_module_realloc: Option<&str>,
-    alloc_stack_via_memory_grow : bool,
+    alloc_stack_via_memory_grow: bool,
 ) -> Result<Vec<u8>> {
     assert!(!required.is_empty());
 
@@ -539,7 +539,11 @@ impl<'a> Module<'a> {
 
     /// Encodes this `Module` to a new wasm module which is gc'd and only
     /// contains the items that are live as calculated by the `liveness` pass.
-    fn encode(&mut self, main_module_realloc: Option<&str>, alloc_stack_via_memory_grow : bool) -> Result<Vec<u8>> {
+    fn encode(
+        &mut self,
+        main_module_realloc: Option<&str>,
+        alloc_stack_via_memory_grow: bool,
+    ) -> Result<Vec<u8>> {
         // Data structure used to track the mapping of old index to new index
         // for all live items.
         let mut map = Encoder::default();
@@ -794,13 +798,19 @@ impl<'a> Module<'a> {
                 allocation_state,
             ));
 
-            if realloc_via_memorry_grow_required.is_some() && realloc_via_memorry_grow_required.unwrap() {
+            if realloc_via_memorry_grow_required.is_some()
+                && realloc_via_memorry_grow_required.unwrap()
+            {
                 funcs.function(add_realloc_type(&mut types));
                 code.function(&realloc_via_memory_grow());
             }
-       }
+        }
 
-        if sp.is_some() && (realloc_index.is_none() || allocation_state.is_none() || alloc_stack_via_memory_grow) {
+        if sp.is_some()
+            && (realloc_index.is_none()
+                || allocation_state.is_none()
+                || alloc_stack_via_memory_grow)
+        {
             // Either the main module does _not_ export a realloc function, or it is not safe to use for stack
             // allocation because we have no way to short-circuit reentrance, so we'll use `memory.grow` instead.
             realloc_index = Some(num_func_imports + funcs.len());

--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -21,6 +21,7 @@ pub fn run<T>(
     wasm: &[u8],
     required: &IndexMap<String, T>,
     main_module_realloc: Option<&str>,
+    alloc_stack_via_memory_grow : bool,
 ) -> Result<Vec<u8>> {
     assert!(!required.is_empty());
 
@@ -52,7 +53,7 @@ pub fn run<T>(
     }
     assert!(!module.exports.is_empty());
     module.liveness()?;
-    module.encode(main_module_realloc)
+    module.encode(main_module_realloc, alloc_stack_via_memory_grow)
 }
 
 fn always_keep(name: &str) -> bool {
@@ -538,7 +539,7 @@ impl<'a> Module<'a> {
 
     /// Encodes this `Module` to a new wasm module which is gc'd and only
     /// contains the items that are live as calculated by the `liveness` pass.
-    fn encode(&mut self, main_module_realloc: Option<&str>) -> Result<Vec<u8>> {
+    fn encode(&mut self, main_module_realloc: Option<&str>, alloc_stack_via_memory_grow : bool) -> Result<Vec<u8>> {
         // Data structure used to track the mapping of old index to new index
         // for all live items.
         let mut map = Encoder::default();
@@ -707,6 +708,7 @@ impl<'a> Module<'a> {
             num_func_imports += 1;
         }
 
+        let mut realloc_via_memory_grow_index = None;
         for (i, func) in local {
             map.funcs.push(i);
             let ty = map.types.remap(func.ty);
@@ -715,6 +717,7 @@ impl<'a> Module<'a> {
                     // The adapter is importing `cabi_realloc` from the main module, but the main module isn't
                     // exporting it.  In this case, we need to define a local function it can call instead.
                     realloc_index = Some(num_func_imports + funcs.len());
+                    realloc_via_memory_grow_index = realloc_index;
                     funcs.function(ty);
                     code.function(&realloc_via_memory_grow());
                 }
@@ -773,15 +776,31 @@ impl<'a> Module<'a> {
             code.function(&func);
         }
 
+        let mut realloc_via_memorry_grow_required = None;
         if lazy_stack_init_index.is_some() {
+            let mut alloc_stack_index = realloc_index;
+
+            if alloc_stack_via_memory_grow {
+                if realloc_via_memory_grow_index.is_none() {
+                    realloc_via_memory_grow_index = Some(num_func_imports + funcs.len());
+                    realloc_via_memorry_grow_required = Some(true);
+                }
+                alloc_stack_index = realloc_via_memory_grow_index;
+            }
+
             code.function(&allocate_stack_via_realloc(
-                realloc_index.unwrap(),
+                alloc_stack_index.unwrap(),
                 sp.unwrap(),
                 allocation_state,
             ));
-        }
 
-        if sp.is_some() && (realloc_index.is_none() || allocation_state.is_none()) {
+            if realloc_via_memorry_grow_required.is_some() && realloc_via_memorry_grow_required.unwrap() {
+                funcs.function(add_realloc_type(&mut types));
+                code.function(&realloc_via_memory_grow());
+            }
+       }
+
+        if sp.is_some() && (realloc_index.is_none() || allocation_state.is_none() || alloc_stack_via_memory_grow) {
             // Either the main module does _not_ export a realloc function, or it is not safe to use for stack
             // allocation because we have no way to short-circuit reentrance, so we'll use `memory.grow` instead.
             realloc_index = Some(num_func_imports + funcs.len());

--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -107,6 +107,14 @@ pub struct NewOpts {
     /// Print the output in the WebAssembly text format instead of binary.
     #[clap(long, short = 't')]
     wat: bool,
+
+    /// Use memory.grow to realloc memory.
+    #[clap(long, short = 'r')]
+    realloc_via_memory_grow: bool,
+
+    /// Use memory.grow for stack allocation.
+    #[clap(long, short = 's')]
+    alloc_stack_via_memory_grow: bool,
 }
 
 impl NewOpts {
@@ -124,6 +132,9 @@ impl NewOpts {
         for (name, wasm) in self.adapters.iter() {
             encoder = encoder.adapter(name, wasm)?;
         }
+
+        encoder = encoder.realloc_via_memory_grow(self.realloc_via_memory_grow);
+        encoder = encoder.alloc_stack_via_memory_grow(self.alloc_stack_via_memory_grow);
 
         let bytes = encoder
             .encode()

--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -108,13 +108,9 @@ pub struct NewOpts {
     #[clap(long, short = 't')]
     wat: bool,
 
-    /// Use memory.grow to realloc memory.
-    #[clap(long, short = 'r')]
+    /// Use memory.grow to realloc memory and stack allocation.
+    #[clap(long)]
     realloc_via_memory_grow: bool,
-
-    /// Use memory.grow for stack allocation.
-    #[clap(long, short = 's')]
-    alloc_stack_via_memory_grow: bool,
 }
 
 impl NewOpts {
@@ -134,7 +130,6 @@ impl NewOpts {
         }
 
         encoder = encoder.realloc_via_memory_grow(self.realloc_via_memory_grow);
-        encoder = encoder.alloc_stack_via_memory_grow(self.alloc_stack_via_memory_grow);
 
         let bytes = encoder
             .encode()


### PR DESCRIPTION
This PR adds 2 options to control how realloc and the stack allocation is implemented.  The options if supplied will make these functions use `memory.grow` rather than the `cabi_realloc` (if supplied) of the component.

My first PR here, and pretty new to Rust, so feedback welcomed!

Discussed over in zulip.

Thanks,