### PR TITLE
Use `serde_derive` instead of the `derive` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,12 +649,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flagset"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda653ca797810c02f7ca4b804b40b8b95ae046eb989d356bce17919a8c25499"
-dependencies = [
- "serde",
-]
+checksum = "d52a7e408202050813e6f1d9addadcaafef3dca7530c7ddfb005d4081cce6779"
 
 [[package]]
 name = "flate2"
@@ -1717,6 +1714,7 @@ dependencies = [
  "petgraph",
  "pretty_assertions",
  "serde",
+ "serde_derive",
  "serde_yaml",
  "smallvec",
  "wasm-encoder 0.33.2",
@@ -1753,6 +1751,7 @@ dependencies = [
  "clap 4.3.22",
  "indexmap 2.0.0",
  "serde",
+ "serde_derive",
  "serde_json",
  "spdx",
  "wasm-encoder 0.33.2",
@@ -1823,6 +1822,7 @@ dependencies = [
  "libfuzzer-sys",
  "rand",
  "serde",
+ "serde_derive",
  "wasm-encoder 0.33.2",
  "wasmparser 0.113.3",
  "wasmprinter 0.2.68",
@@ -1848,6 +1848,7 @@ dependencies = [
  "regex",
  "rustc-demangle",
  "serde",
+ "serde_derive",
  "serde_json",
  "tempfile",
  "termcolor",
@@ -2360,6 +2361,7 @@ dependencies = [
  "log",
  "pretty_assertions",
  "serde",
+ "serde_derive",
  "serde_json",
  "wasm-encoder 0.33.2",
  "wasm-metadata",
@@ -2401,6 +2403,7 @@ dependencies = [
  "rayon",
  "semver",
  "serde",
+ "serde_derive",
  "serde_json",
  "unicode-xid",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,8 @@ log = "0.4.17"
 num_cpus = "1.13"
 rand = { version = "0.8.4", features = ["small_rng"] }
 rayon = "1.3"
-serde = { version = "1.0.166", features = ["derive"] }
+serde = "1.0.166"
+serde_derive = "1.0.166"
 serde_json = { version = "1" }
 wasmtime = { version = "12.0.0", default-features = false, features = ['cranelift', 'component-model'] }
 url = "2.0.0"
@@ -77,6 +78,7 @@ wasmprinter = { workspace = true }
 # Dependencies of `smith`
 arbitrary = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 wasm-smith = { workspace = true, features = ["_internal_cli"], optional = true }
 
@@ -156,7 +158,7 @@ default = [
 validate = ['dep:wasmparser', 'rayon']
 print = []
 parse = []
-smith = ['wasm-smith', 'arbitrary', 'serde', 'serde_json']
+smith = ['wasm-smith', 'arbitrary', 'serde', 'serde_derive', 'serde_json']
 shrink = ['wasm-shrink', 'is_executable']
 mutate = ['wasm-mutate']
 dump = ['dep:wasmparser']

--- a/crates/wasm-compose/Cargo.toml
+++ b/crates/wasm-compose/Cargo.toml
@@ -17,6 +17,7 @@ wasmparser = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 anyhow = { workspace = true }
 serde = { workspace = true }
+serde_derive = { workspace = true }
 petgraph = "0.6.2"
 log = { workspace = true }
 serde_yaml = "0.9.22"

--- a/crates/wasm-compose/src/config.rs
+++ b/crates/wasm-compose/src/config.rs
@@ -2,7 +2,7 @@
 
 use anyhow::{Context, Result};
 use indexmap::IndexMap;
-use serde::Deserialize;
+use serde_derive::Deserialize;
 use std::{
     fs,
     path::{Path, PathBuf},

--- a/crates/wasm-metadata/Cargo.toml
+++ b/crates/wasm-metadata/Cargo.toml
@@ -13,6 +13,7 @@ wasmparser = { workspace = true }
 wasm-encoder = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 serde = { workspace = true }
+serde_derive = { workspace = true }
 serde_json = { version = "1" }
 spdx = "0.10.1"
 

--- a/crates/wasm-metadata/src/lib.rs
+++ b/crates/wasm-metadata/src/lib.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use indexmap::{map::Entry, IndexMap};
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use spdx::Expression;
 use std::borrow::Cow;
 use std::fmt;

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -21,6 +21,7 @@ flagset = "0.4"
 indexmap = { workspace = true }
 leb128 = { workspace = true }
 serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
 wasm-encoder = { workspace = true }
 wasmparser = { workspace = true }
 
@@ -34,4 +35,4 @@ wat = { path = "../wat" }
 libfuzzer-sys = { workspace = true }
 
 [features]
-_internal_cli = ["serde", "flagset/serde"]
+_internal_cli = ["serde", "serde_derive"]

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -1721,7 +1721,7 @@ flags! {
     /// Enumerate the categories of instructions defined in the [WebAssembly
     /// specification](https://webassembly.github.io/spec/core/syntax/instructions.html).
     #[allow(missing_docs)]
-    #[cfg_attr(feature = "_internal_cli", derive(serde::Deserialize))]
+    #[cfg_attr(feature = "_internal_cli", derive(serde_derive::Deserialize))]
     pub enum InstructionKind: u16 {
         Numeric,
         Vector,

--- a/crates/wit-component/Cargo.toml
+++ b/crates/wit-component/Cargo.toml
@@ -24,6 +24,7 @@ indexmap = { workspace = true }
 wast = { workspace = true }
 wat = { workspace = true }
 serde = { workspace = true }
+serde_derive = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]

--- a/crates/wit-component/src/encoding/docs.rs
+++ b/crates/wit-component/src/encoding/docs.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Result};
 use indexmap::IndexMap;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use wasm_encoder::{CustomSection, Encode};
 use wit_parser::{Docs, InterfaceId, PackageId, Resolve, TypeId, WorldId, WorldItem, WorldKey};
 

--- a/crates/wit-parser/Cargo.toml
+++ b/crates/wit-parser/Cargo.toml
@@ -21,7 +21,8 @@ unicode-xid = "0.2.2"
 log = { workspace = true }
 url = { workspace = true }
 semver = { workspace = true }
-serde.workspace = true
+serde = { workspace = true }
+serde_derive = { workspace = true }
 serde_json = "1.0.105"
 
 [dev-dependencies]

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use id_arena::{Arena, Id};
 use indexmap::IndexMap;
 use semver::Version;
-use serde::Serialize;
+use serde_derive::Serialize;
 use std::borrow::Cow;
 use std::fmt;
 use std::path::Path;

--- a/crates/wit-parser/src/resolve.rs
+++ b/crates/wit-parser/src/resolve.rs
@@ -9,7 +9,7 @@ use crate::{
 use anyhow::{anyhow, bail, Context, Result};
 use id_arena::{Arena, Id};
 use indexmap::{IndexMap, IndexSet};
-use serde::Serialize;
+use serde_derive::Serialize;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::mem;
 use std::path::{Path, PathBuf};

--- a/crates/wit-parser/src/serde_.rs
+++ b/crates/wit-parser/src/serde_.rs
@@ -3,6 +3,7 @@ use id_arena::{Arena, Id};
 use indexmap::IndexMap;
 use serde::ser::{SerializeMap, SerializeSeq, Serializer};
 use serde::Serialize;
+use serde_derive::Serialize;
 
 pub fn serialize_none<S>(serializer: S) -> Result<S::Ok, S::Error>
 where

--- a/crates/wit-parser/src/serde_.rs
+++ b/crates/wit-parser/src/serde_.rs
@@ -3,7 +3,6 @@ use id_arena::{Arena, Id};
 use indexmap::IndexMap;
 use serde::ser::{SerializeMap, SerializeSeq, Serializer};
 use serde::Serialize;
-use serde_derive::Serialize;
 
 pub fn serialize_none<S>(serializer: S) -> Result<S::Ok, S::Error>
 where
@@ -100,7 +99,7 @@ where
     seq.end()
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, PartialEq, serde_derive::Serialize)]
 struct Param {
     #[serde(skip_serializing_if = "String::is_empty")]
     pub name: String,

--- a/src/bin/wasm-tools/smith.rs
+++ b/src/bin/wasm-tools/smith.rs
@@ -79,7 +79,7 @@ pub struct Opts {
     general: wasm_tools::GeneralOpts,
 }
 
-#[derive(Default, Debug, Parser, Clone, serde::Deserialize)]
+#[derive(Default, Debug, Parser, Clone, serde_derive::Deserialize)]
 #[serde(rename_all = "kebab-case")]
 struct Config {
     #[clap(long = "min-types")]


### PR DESCRIPTION
I noticed recently that `wit-component` was relatively slow to compile and it's going to be an introductory requirement for any Rust crates so I wanted to optimize its build a little bit. This is the first optimization which is to disable the `derive` feature of the `serde` crate to enable build build pipelining opportunities.

This is the same as bytecodealliance/wasmtime#6917