### PR TITLE
Make wit-component's `wat` dep optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,9 +100,7 @@ rustc-demangle = { version = "0.1.21", optional = true }
 cpp_demangle = { version = "0.4.0", optional = true }
 
 # Dependencies of `component`
-wit-component = { workspace = true, optional = true, features = [
-  'dummy-module',
-] }
+wit-component = { workspace = true, optional = true, features = ['dummy-module', 'wat'] }
 wit-parser = { workspace = true, optional = true }
 wast = { workspace = true, optional = true }
 

--- a/crates/wit-component/Cargo.toml
+++ b/crates/wit-component/Cargo.toml
@@ -21,8 +21,8 @@ anyhow = { workspace = true }
 log = "0.4.17"
 bitflags = "2.3.3"
 indexmap = { workspace = true }
-wast = { workspace = true }
-wat = { workspace = true }
+wast = { workspace = true, optional = true }
+wat = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
@@ -38,4 +38,5 @@ wat = { workspace = true }
 wasmtime = { workspace = true }
 
 [features]
-dummy-module = []
+dummy-module = ['dep:wat']
+wat = ['dep:wast', 'dep:wat']

--- a/crates/wit-component/src/lib.rs
+++ b/crates/wit-component/src/lib.rs
@@ -3,11 +3,11 @@
 #![deny(missing_docs)]
 
 use std::str::FromStr;
-use std::{borrow::Cow, fmt::Display, path::Path};
+use std::{borrow::Cow, fmt::Display};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 use wasm_encoder::{CanonicalOption, Encode, Section};
-use wit_parser::{PackageId, Resolve, UnresolvedPackage, WorldId};
+use wit_parser::{Resolve, WorldId};
 
 mod decoding;
 mod encoding;
@@ -85,7 +85,13 @@ pub(crate) fn base_producers() -> wasm_metadata::Producers {
 
 /// Parse a WIT file from a path that represents a top level 'wit' directory,
 /// normally containing a 'deps' folder.
-pub fn parse_wit_from_path(path: impl AsRef<Path>) -> Result<(Resolve, PackageId)> {
+#[cfg(feature = "wat")]
+pub fn parse_wit_from_path(
+    path: impl AsRef<std::path::Path>,
+) -> Result<(Resolve, wit_parser::PackageId)> {
+    use anyhow::Context;
+    use wit_parser::UnresolvedPackage;
+
     let mut resolver = Resolve::default();
     let id = match path.as_ref() {
         // Directories can be directly fed into the resolver
@@ -153,6 +159,7 @@ pub fn parse_wit_from_path(path: impl AsRef<Path>) -> Result<(Resolve, PackageId
 /// )
 /// "#));
 /// ```
+#[cfg(feature = "wat")]
 pub fn is_wasm_binary_or_wat(bytes: impl AsRef<[u8]>) -> bool {
     use wast::lexer::{Lexer, TokenKind};
 


### PR DESCRIPTION
The `wast` crate is a little hefty and many uses of the `wit-component` crate don't need it, so make it optional and enable it from the CLI where it's used.