### PR TITLE
wasmparser: implement `peel_alias` in terms of `TypesRef`.

### DIFF
--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -1428,6 +1428,13 @@ impl<'a> TypesRef<'a> {
             TypesRefKind::Component(component) => Some(*component.exports.get(name)?),
         }
     }
+
+    /// Attempts to lookup the type id that `ty` is an alias of.
+    ///
+    /// Returns `None` if `ty` wasn't listed as aliasing a prior type.
+    pub fn peel_alias(&self, ty: TypeId) -> Option<TypeId> {
+        self.list.peel_alias(ty)
+    }
 }
 
 impl Index<TypeId> for TypesRef<'_> {
@@ -1719,7 +1726,7 @@ impl Types {
     ///
     /// Returns `None` if `ty` wasn't listed as aliasing a prior type.
     pub fn peel_alias(&self, ty: TypeId) -> Option<TypeId> {
-        self.list.peel_alias(ty)
+        self.as_ref().peel_alias(ty)
     }
 }
 


### PR DESCRIPTION
This PR exposes the `peel_alias` method on `TypesRef` and delegates the `Types` implementation to it.