### PR TITLE
`wasm-encoder`: Add `From<wasmparser::Foo> for Foo` impls

### DIFF
--- a/crates/wasm-encoder/Cargo.toml
+++ b/crates/wasm-encoder/Cargo.toml
@@ -15,6 +15,10 @@ A low-level WebAssembly encoder.
 [dependencies]
 leb128 = { workspace = true }
 
+# Enable this dependency to get a bunch of `From<wasmparser::Foo> for
+# wasm_encoder::Foo` impls.
+wasmparser = { optional = true, path = "../wasmparser" }
+
 [dev-dependencies]
 anyhow = { workspace = true }
 tempfile = "3.2.0"

--- a/crates/wasm-encoder/src/core/exports.rs
+++ b/crates/wasm-encoder/src/core/exports.rs
@@ -25,6 +25,19 @@ impl Encode for ExportKind {
     }
 }
 
+#[cfg(feature = "wasmparser")]
+impl From<wasmparser::ExternalKind> for ExportKind {
+    fn from(external_kind: wasmparser::ExternalKind) -> Self {
+        match external_kind {
+            wasmparser::ExternalKind::Func => ExportKind::Func,
+            wasmparser::ExternalKind::Table => ExportKind::Table,
+            wasmparser::ExternalKind::Memory => ExportKind::Memory,
+            wasmparser::ExternalKind::Global => ExportKind::Global,
+            wasmparser::ExternalKind::Tag => ExportKind::Tag,
+        }
+    }
+}
+
 /// An encoder for the export section of WebAssembly module.
 ///
 /// # Example

--- a/crates/wasm-encoder/src/core/globals.rs
+++ b/crates/wasm-encoder/src/core/globals.rs
@@ -88,3 +88,13 @@ impl Encode for GlobalType {
         sink.push(self.mutable as u8);
     }
 }
+
+#[cfg(feature = "wasmparser")]
+impl From<wasmparser::GlobalType> for GlobalType {
+    fn from(global_ty: wasmparser::GlobalType) -> Self {
+        GlobalType {
+            val_type: global_ty.content_type.into(),
+            mutable: global_ty.mutable,
+        }
+    }
+}

--- a/crates/wasm-encoder/src/core/imports.rs
+++ b/crates/wasm-encoder/src/core/imports.rs
@@ -73,6 +73,19 @@ impl From<TagType> for EntityType {
     }
 }
 
+#[cfg(feature = "wasmparser")]
+impl From<wasmparser::TypeRef> for EntityType {
+    fn from(type_ref: wasmparser::TypeRef) -> Self {
+        match type_ref {
+            wasmparser::TypeRef::Func(i) => EntityType::Function(i),
+            wasmparser::TypeRef::Table(t) => EntityType::Table(t.into()),
+            wasmparser::TypeRef::Memory(m) => EntityType::Memory(m.into()),
+            wasmparser::TypeRef::Global(g) => EntityType::Global(g.into()),
+            wasmparser::TypeRef::Tag(t) => EntityType::Tag(t.into()),
+        }
+    }
+}
+
 /// An encoder for the import section of WebAssembly modules.
 ///
 /// # Example

--- a/crates/wasm-encoder/src/core/memories.rs
+++ b/crates/wasm-encoder/src/core/memories.rs
@@ -97,3 +97,15 @@ impl Encode for MemoryType {
         }
     }
 }
+
+#[cfg(feature = "wasmparser")]
+impl From<wasmparser::MemoryType> for MemoryType {
+    fn from(memory_ty: wasmparser::MemoryType) -> Self {
+        MemoryType {
+            minimum: memory_ty.initial,
+            maximum: memory_ty.maximum,
+            memory64: memory_ty.memory64,
+            shared: memory_ty.shared,
+        }
+    }
+}

--- a/crates/wasm-encoder/src/core/tables.rs
+++ b/crates/wasm-encoder/src/core/tables.rs
@@ -102,3 +102,14 @@ impl Encode for TableType {
         }
     }
 }
+
+#[cfg(feature = "wasmparser")]
+impl From<wasmparser::TableType> for TableType {
+    fn from(table_ty: wasmparser::TableType) -> Self {
+        TableType {
+            element_type: table_ty.element_type.into(),
+            minimum: table_ty.initial,
+            maximum: table_ty.maximum,
+        }
+    }
+}

--- a/crates/wasm-encoder/src/core/tags.rs
+++ b/crates/wasm-encoder/src/core/tags.rs
@@ -68,6 +68,15 @@ pub enum TagKind {
     Exception = 0x0,
 }
 
+#[cfg(feature = "wasmparser")]
+impl From<wasmparser::TagKind> for TagKind {
+    fn from(kind: wasmparser::TagKind) -> Self {
+        match kind {
+            wasmparser::TagKind::Exception => TagKind::Exception,
+        }
+    }
+}
+
 /// A tag's type.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TagType {
@@ -81,5 +90,15 @@ impl Encode for TagType {
     fn encode(&self, sink: &mut Vec<u8>) {
         sink.push(self.kind as u8);
         self.func_type_idx.encode(sink);
+    }
+}
+
+#[cfg(feature = "wasmparser")]
+impl From<wasmparser::TagType> for TagType {
+    fn from(tag_ty: wasmparser::TagType) -> Self {
+        TagType {
+            kind: tag_ty.kind.into(),
+            func_type_idx: tag_ty.func_type_idx,
+        }
     }
 }

--- a/crates/wasm-encoder/src/core/types.rs
+++ b/crates/wasm-encoder/src/core/types.rs
@@ -85,7 +85,7 @@ pub struct StructType {
 impl From<wasmparser::StructType> for StructType {
     fn from(struct_ty: wasmparser::StructType) -> Self {
         StructType {
-            fields: struct_ty.fields.iter().cloned().map(Into::into).collect(),
+            fields: struct_ty.fields.into_iter().map(Into::into).collect(),
         }
     }
 }

--- a/crates/wasm-encoder/src/core/types.rs
+++ b/crates/wasm-encoder/src/core/types.rs
@@ -11,6 +11,17 @@ pub struct SubType {
     pub structural_type: StructuralType,
 }
 
+#[cfg(feature = "wasmparser")]
+impl From<wasmparser::SubType> for SubType {
+    fn from(sub_ty: wasmparser::SubType) -> Self {
+        SubType {
+            is_final: sub_ty.is_final,
+            supertype_idx: sub_ty.supertype_idx,
+            structural_type: sub_ty.structural_type.into(),
+        }
+    }
+}
+
 /// Represents a structural type in a WebAssembly module.
 #[derive(Debug, Clone)]
 pub enum StructuralType {
@@ -22,6 +33,17 @@ pub enum StructuralType {
     Struct(StructType),
 }
 
+#[cfg(feature = "wasmparser")]
+impl From<wasmparser::StructuralType> for StructuralType {
+    fn from(structural_ty: wasmparser::StructuralType) -> Self {
+        match structural_ty {
+            wasmparser::StructuralType::Func(f) => StructuralType::Func(f.into()),
+            wasmparser::StructuralType::Array(a) => StructuralType::Array(a.into()),
+            wasmparser::StructuralType::Struct(s) => StructuralType::Struct(s.into()),
+        }
+    }
+}
+
 /// Represents a type of a function in a WebAssembly module.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct FuncType {
@@ -31,15 +53,41 @@ pub struct FuncType {
     len_params: usize,
 }
 
+#[cfg(feature = "wasmparser")]
+impl From<wasmparser::FuncType> for FuncType {
+    fn from(func_ty: wasmparser::FuncType) -> Self {
+        FuncType::new(
+            func_ty.params().iter().cloned().map(Into::into),
+            func_ty.results().iter().cloned().map(Into::into),
+        )
+    }
+}
+
 /// Represents a type of an array in a WebAssembly module.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct ArrayType(pub FieldType);
+
+#[cfg(feature = "wasmparser")]
+impl From<wasmparser::ArrayType> for ArrayType {
+    fn from(array_ty: wasmparser::ArrayType) -> Self {
+        ArrayType(array_ty.0.into())
+    }
+}
 
 /// Represents a type of a struct in a WebAssembly module.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct StructType {
     /// Struct fields.
     pub fields: Box<[FieldType]>,
+}
+
+#[cfg(feature = "wasmparser")]
+impl From<wasmparser::StructType> for StructType {
+    fn from(struct_ty: wasmparser::StructType) -> Self {
+        StructType {
+            fields: struct_ty.fields.iter().cloned().map(Into::into).collect(),
+        }
+    }
 }
 
 /// Field type in structural types (structs, arrays).
@@ -51,6 +99,16 @@ pub struct FieldType {
     pub mutable: bool,
 }
 
+#[cfg(feature = "wasmparser")]
+impl From<wasmparser::FieldType> for FieldType {
+    fn from(field_ty: wasmparser::FieldType) -> Self {
+        FieldType {
+            element_type: field_ty.element_type.into(),
+            mutable: field_ty.mutable,
+        }
+    }
+}
+
 /// Storage type for structural type fields.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub enum StorageType {
@@ -60,6 +118,17 @@ pub enum StorageType {
     I16,
     /// A value type.
     Val(ValType),
+}
+
+#[cfg(feature = "wasmparser")]
+impl From<wasmparser::StorageType> for StorageType {
+    fn from(storage_ty: wasmparser::StorageType) -> Self {
+        match storage_ty {
+            wasmparser::StorageType::I8 => StorageType::I8,
+            wasmparser::StorageType::I16 => StorageType::I16,
+            wasmparser::StorageType::Val(v) => StorageType::Val(v.into()),
+        }
+    }
 }
 
 /// The type of a core WebAssembly value.
@@ -83,6 +152,20 @@ pub enum ValType {
     /// generalization here is due to the implementation of the
     /// function-references proposal.
     Ref(RefType),
+}
+
+#[cfg(feature = "wasmparser")]
+impl From<wasmparser::ValType> for ValType {
+    fn from(val_ty: wasmparser::ValType) -> Self {
+        match val_ty {
+            wasmparser::ValType::I32 => ValType::I32,
+            wasmparser::ValType::I64 => ValType::I64,
+            wasmparser::ValType::F32 => ValType::F32,
+            wasmparser::ValType::F64 => ValType::F64,
+            wasmparser::ValType::V128 => ValType::V128,
+            wasmparser::ValType::Ref(r) => ValType::Ref(r.into()),
+        }
+    }
 }
 
 impl FuncType {
@@ -191,6 +274,16 @@ impl Encode for RefType {
     }
 }
 
+#[cfg(feature = "wasmparser")]
+impl From<wasmparser::RefType> for RefType {
+    fn from(ref_type: wasmparser::RefType) -> Self {
+        RefType {
+            nullable: ref_type.is_nullable(),
+            heap_type: ref_type.heap_type().into(),
+        }
+    }
+}
+
 impl From<RefType> for ValType {
     fn from(ty: RefType) -> ValType {
         ValType::Ref(ty)
@@ -241,6 +334,25 @@ impl Encode for HeapType {
             // Note that this is encoded as a signed type rather than unsigned
             // as it's decoded as an s33
             HeapType::Indexed(i) => i64::from(*i).encode(sink),
+        }
+    }
+}
+
+#[cfg(feature = "wasmparser")]
+impl From<wasmparser::HeapType> for HeapType {
+    fn from(heap_type: wasmparser::HeapType) -> Self {
+        match heap_type {
+            wasmparser::HeapType::Indexed(i) => HeapType::Indexed(i),
+            wasmparser::HeapType::Func => HeapType::Func,
+            wasmparser::HeapType::Extern => HeapType::Extern,
+            wasmparser::HeapType::Any => HeapType::Any,
+            wasmparser::HeapType::None => HeapType::None,
+            wasmparser::HeapType::NoExtern => HeapType::NoExtern,
+            wasmparser::HeapType::NoFunc => HeapType::NoFunc,
+            wasmparser::HeapType::Eq => HeapType::Eq,
+            wasmparser::HeapType::Struct => HeapType::Struct,
+            wasmparser::HeapType::Array => HeapType::Array,
+            wasmparser::HeapType::I31 => HeapType::I31,
         }
     }
 }


### PR DESCRIPTION
This adds a new optional dependency on `wasmparser` from `wasm-encoder`. When the optional dependency is enabled, we add a bunch of `From` impls to convert from the `wasmparser` type to the `wasm_encoder` type. This isn't 100% exhaustive yet, but we can always add more impls as we need them. This was enough for the conversions that Winliner wanted, fwiw.

Fixes #1115