### PR TITLE
`wasmparser`: Fix `From<wasmparser::StructType> for StructType`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,7 @@ jobs:
       shell: bash
     - run: cargo test --locked --all
     - run: cargo test --locked -p wasmparser --benches
+    - run: cargo test --locked -p wasm-encoder --all-features
     - run: cargo build --manifest-path crates/wast/Cargo.toml --no-default-features
     - run: cargo build --manifest-path crates/wast/Cargo.toml --no-default-features --features wasm-module
     - run: cmake -S ${{github.workspace}}/examples -B ${{github.workspace}}/examples/build -DCMAKE_BUILD_TYPE=Release

--- a/crates/wasm-encoder/src/core/types.rs
+++ b/crates/wasm-encoder/src/core/types.rs
@@ -103,7 +103,7 @@ pub struct StructType {
 impl From<wasmparser::StructType> for StructType {
     fn from(struct_ty: wasmparser::StructType) -> Self {
         StructType {
-            fields: struct_ty.fields.into_iter().map(Into::into).collect(),
+            fields: struct_ty.fields.iter().cloned().map(Into::into).collect(),
         }
     }
 }


### PR DESCRIPTION
`Box<[T]>` doesn't implement `into_iter`, it is actually just calling `&[T]`'s version of `into_iter` which doesn't actually give ownership.

Also, test `wasm-encoder` with this feature enabled in CI.