### PR TITLE
Enable threads, multi-memory, and relaxed-simd by default

### DIFF
--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -214,11 +214,11 @@ pub struct WasmFeatures {
     pub bulk_memory: bool,
     /// The WebAssembly SIMD proposal (enabled by default)
     pub simd: bool,
-    /// The WebAssembly Relaxed SIMD proposal
+    /// The WebAssembly Relaxed SIMD proposal (enabled by default)
     pub relaxed_simd: bool,
-    /// The WebAssembly threads proposal
+    /// The WebAssembly threads proposal (enabled by default)
     pub threads: bool,
-    /// The WebAssembly tail-call proposal
+    /// The WebAssembly tail-call proposal (enabled by default)
     pub tail_call: bool,
     /// Whether or not floating-point instructions are enabled.
     ///
@@ -231,7 +231,7 @@ pub struct WasmFeatures {
     /// across hosts which can lead to host-dependent execution which some
     /// runtimes may not desire.
     pub floats: bool,
-    /// The WebAssembly multi memory proposal
+    /// The WebAssembly multi memory proposal (enabled by default)
     pub multi_memory: bool,
     /// The WebAssembly exception handling proposal
     pub exceptions: bool,
@@ -354,9 +354,6 @@ impl Default for WasmFeatures {
     fn default() -> WasmFeatures {
         WasmFeatures {
             // Off-by-default features.
-            relaxed_simd: false,
-            threads: false,
-            multi_memory: false,
             exceptions: false,
             memory64: false,
             extended_const: false,
@@ -376,6 +373,9 @@ impl Default for WasmFeatures {
             tail_call: true,
             simd: true,
             floats: true,
+            relaxed_simd: true,
+            threads: true,
+            multi_memory: true,
         }
     }
 }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -603,7 +603,16 @@ impl TestState {
         };
         for part in test.iter().filter_map(|t| t.to_str()) {
             match part {
-                "testsuite" => features = WasmFeatures::default(),
+                "testsuite" => {
+                    features = WasmFeatures::default();
+
+                    // NB: when these proposals are merged upstream in the spec
+                    // repo then this should be removed. Currently this hasn't
+                    // happened so this is required to get tests passing for
+                    // when these proposals are enabled by default.
+                    features.multi_memory = false;
+                    features.threads = false;
+                }
                 "missing-features" => {
                     features = WasmFeatures::default();
                     features.simd = false;


### PR DESCRIPTION
This commit reflects the stage 4 advancement of these proposals and updates the default feature set to include these three proposals. Each proposal can still be individually be disabled if desired.