### PR TITLE
Bump version numbers and try to future-proof

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,7 +1704,7 @@ checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-compose"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "glob",
@@ -1717,9 +1717,9 @@ dependencies = [
  "serde_derive",
  "serde_yaml",
  "smallvec",
- "wasm-encoder 0.34.1",
- "wasmparser 0.114.0",
- "wasmprinter 0.2.69",
+ "wasm-encoder 0.35.0",
+ "wasmparser 0.115.0",
+ "wasmprinter 0.2.70",
  "wat",
  "wit-component",
 ]
@@ -1735,17 +1735,17 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "leb128",
  "tempfile",
- "wasmparser 0.114.0",
+ "wasmparser 0.115.0",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.10.8"
+version = "0.10.9"
 dependencies = [
  "anyhow",
  "clap 4.3.22",
@@ -1754,14 +1754,14 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder 0.34.1",
- "wasmparser 0.114.0",
+ "wasm-encoder 0.35.0",
+ "wasmparser 0.115.0",
  "wat",
 ]
 
 [[package]]
 name = "wasm-mutate"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "anyhow",
  "clap 4.3.22",
@@ -1770,9 +1770,9 @@ dependencies = [
  "log",
  "rand",
  "thiserror",
- "wasm-encoder 0.34.1",
- "wasmparser 0.114.0",
- "wasmprinter 0.2.69",
+ "wasm-encoder 0.35.0",
+ "wasmparser 0.115.0",
+ "wasmprinter 0.2.70",
  "wat",
 ]
 
@@ -1789,14 +1789,14 @@ dependencies = [
  "num_cpus",
  "rand",
  "wasm-mutate",
- "wasmparser 0.114.0",
- "wasmprinter 0.2.69",
+ "wasmparser 0.115.0",
+ "wasmprinter 0.2.70",
  "wasmtime",
 ]
 
 [[package]]
 name = "wasm-shrink"
-version = "0.1.38"
+version = "0.1.39"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1805,14 +1805,14 @@ dependencies = [
  "log",
  "rand",
  "wasm-mutate",
- "wasmparser 0.114.0",
- "wasmprinter 0.2.69",
+ "wasmparser 0.115.0",
+ "wasmprinter 0.2.70",
  "wat",
 ]
 
 [[package]]
 name = "wasm-smith"
-version = "0.12.20"
+version = "0.12.21"
 dependencies = [
  "arbitrary",
  "criterion",
@@ -1823,15 +1823,15 @@ dependencies = [
  "rand",
  "serde",
  "serde_derive",
- "wasm-encoder 0.34.1",
- "wasmparser 0.114.0",
- "wasmprinter 0.2.69",
+ "wasm-encoder 0.35.0",
+ "wasmparser 0.115.0",
+ "wasmprinter 0.2.70",
  "wat",
 ]
 
 [[package]]
 name = "wasm-tools"
-version = "1.0.46"
+version = "1.0.47"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -1853,13 +1853,13 @@ dependencies = [
  "tempfile",
  "termcolor",
  "wasm-compose",
- "wasm-encoder 0.34.1",
+ "wasm-encoder 0.35.0",
  "wasm-metadata",
  "wasm-mutate",
  "wasm-shrink",
  "wasm-smith",
- "wasmparser 0.114.0",
- "wasmprinter 0.2.69",
+ "wasmparser 0.115.0",
+ "wasmprinter 0.2.70",
  "wast",
  "wat",
  "wit-component",
@@ -1875,8 +1875,8 @@ dependencies = [
  "wasm-mutate",
  "wasm-shrink",
  "wasm-smith",
- "wasmparser 0.114.0",
- "wasmprinter 0.2.69",
+ "wasmparser 0.115.0",
+ "wasmprinter 0.2.70",
  "wast",
  "wat",
 ]
@@ -1891,11 +1891,11 @@ dependencies = [
  "libfuzzer-sys",
  "log",
  "tempfile",
- "wasm-encoder 0.34.1",
+ "wasm-encoder 0.35.0",
  "wasm-mutate",
  "wasm-smith",
- "wasmparser 0.114.0",
- "wasmprinter 0.2.69",
+ "wasmparser 0.115.0",
+ "wasmprinter 0.2.70",
  "wasmtime",
  "wast",
  "wat",
@@ -1916,7 +1916,7 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.114.0"
+version = "0.115.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1926,7 +1926,7 @@ dependencies = [
  "once_cell",
  "rayon",
  "semver",
- "wasm-encoder 0.34.1",
+ "wasm-encoder 0.35.0",
  "wast",
  "wat",
 ]
@@ -1943,13 +1943,13 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.2.69"
+version = "0.2.70"
 dependencies = [
  "anyhow",
  "diff",
  "rayon",
  "tempfile",
- "wasmparser 0.114.0",
+ "wasmparser 0.115.0",
  "wast",
  "wat",
 ]
@@ -2207,21 +2207,21 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "66.0.1"
+version = "66.0.2"
 dependencies = [
  "anyhow",
  "leb128",
  "memchr",
  "rayon",
  "unicode-width",
- "wasm-encoder 0.34.1",
- "wasmparser 0.114.0",
+ "wasm-encoder 0.35.0",
+ "wasmparser 0.115.0",
  "wat",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.76"
+version = "1.0.77"
 dependencies = [
  "wast",
 ]
@@ -2351,7 +2351,7 @@ checksum = "bd1df36d9fd0bbe4849461de9b969f765170f4e0f90497d580a235d515722b10"
 
 [[package]]
 name = "wit-component"
-version = "0.14.6"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "bitflags 2.4.0",
@@ -2363,10 +2363,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.34.1",
+ "wasm-encoder 0.35.0",
  "wasm-metadata",
- "wasmparser 0.114.0",
- "wasmprinter 0.2.69",
+ "wasmparser 0.115.0",
+ "wasmprinter 0.2.70",
  "wasmtime",
  "wast",
  "wat",
@@ -2415,13 +2415,13 @@ dependencies = [
  "env_logger",
  "libfuzzer-sys",
  "log",
- "wasmprinter 0.2.69",
+ "wasmprinter 0.2.70",
  "wit-parser 0.12.0",
 ]
 
 [[package]]
 name = "wit-smith"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "arbitrary",
  "clap 4.3.22",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-tools"
-version = "1.0.46"
+version = "1.0.47"
 authors = ["The Wasmtime Project Developers"]
 edition.workspace = true
 description = "CLI tools for interoperating with WebAssembly files"
@@ -45,19 +45,19 @@ url = "2.0.0"
 pretty_assertions = "1.3.0"
 semver = "1.0.0"
 
-wasm-compose = { version = "0.4.8", path = "crates/wasm-compose" }
-wasm-encoder = { version = "0.34.1", path = "crates/wasm-encoder" }
-wasm-metadata = { version = "0.10.8", path = "crates/wasm-metadata" }
-wasm-mutate = { version = "0.2.37", path = "crates/wasm-mutate" }
-wasm-shrink = { version = "0.1.38", path = "crates/wasm-shrink" }
-wasm-smith = { version = "0.12.20", path = "crates/wasm-smith" }
-wasmparser = { version = "0.114.0", path = "crates/wasmparser" }
-wasmprinter = { version = "0.2.69", path = "crates/wasmprinter" }
-wast = { version = "66.0.1", path = "crates/wast" }
-wat = { version = "1.0.76", path = "crates/wat" }
-wit-component = { version = "0.14.6", path = "crates/wit-component" }
+wasm-compose = { version = "0.4.9", path = "crates/wasm-compose" }
+wasm-encoder = { version = "0.35.0", path = "crates/wasm-encoder" }
+wasm-metadata = { version = "0.10.9", path = "crates/wasm-metadata" }
+wasm-mutate = { version = "0.2.38", path = "crates/wasm-mutate" }
+wasm-shrink = { version = "0.1.39", path = "crates/wasm-shrink" }
+wasm-smith = { version = "0.12.21", path = "crates/wasm-smith" }
+wasmparser = { version = "0.115.0", path = "crates/wasmparser" }
+wasmprinter = { version = "0.2.70", path = "crates/wasmprinter" }
+wast = { version = "66.0.2", path = "crates/wast" }
+wat = { version = "1.0.77", path = "crates/wat" }
+wit-component = { version = "0.15.0", path = "crates/wit-component" }
 wit-parser = { version = "0.12.0", path = "crates/wit-parser" }
-wit-smith = { version = "0.1.16", path = "crates/wit-smith" }
+wit-smith = { version = "0.1.17", path = "crates/wit-smith" }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/ci/publish.rs
+++ b/ci/publish.rs
@@ -49,6 +49,17 @@ const NO_VERIFY: &[&str] = &[
     "wasmparser",
 ];
 
+/// A mapping from a crate to those crates which have a public dependency on
+/// that crate.
+///
+/// This is used so that when a major version bump of the left-hand-side is done
+/// then it must also force major version bumps of everything on the
+/// right-hand-side.
+const PUBLIC_DEPS: &[(&str, &[&str])] = &[
+    ("wasmparser", &["wasm-encoder"]),
+    ("wit-parser", &["wit-component"]),
+];
+
 #[derive(Clone)]
 struct Crate {
     manifest: PathBuf,
@@ -74,7 +85,7 @@ fn main() {
 
     match &env::args().nth(1).expect("must have one argument")[..] {
         "bump" => {
-            let bumps = env::args()
+            let mut bumps = env::args()
                 .skip(2)
                 .map(|s| {
                     if let Some(s) = s.strip_suffix(":major") {
@@ -86,6 +97,21 @@ fn main() {
                     }
                 })
                 .collect::<Vec<_>>();
+
+            // For all major version bumps automatically do a major version
+            // bump those crates which have a public dependency on it.
+            let mut extra = Vec::new();
+            for (name, _) in bumps.iter().filter(|(_, major)| *major) {
+                if let Some((_, public_deps)) = PUBLIC_DEPS.iter().find(|(n, _)| name == n) {
+                    extra.extend(public_deps.iter().map(|name| (name.to_string(), true)));
+                }
+            }
+            bumps.extend(extra);
+
+            // Move all major bumps first in the case of duplicate keys to
+            // ensure that major bumps are seen first.
+            bumps.sort_by_key(|(_, major)| if *major { 0 } else { 1 });
+
             for (i, mut krate) in crates.clone().into_iter().enumerate() {
                 bump_version(&mut krate, &mut crates, &bumps);
                 crates[i] = krate;

--- a/ci/publish.rs
+++ b/ci/publish.rs
@@ -58,6 +58,7 @@ const NO_VERIFY: &[&str] = &[
 const PUBLIC_DEPS: &[(&str, &[&str])] = &[
     ("wasmparser", &["wasm-encoder"]),
     ("wit-parser", &["wit-component"]),
+    ("wasm-metadata", &["wit-component"]),
 ];
 
 #[derive(Clone)]

--- a/crates/wasm-compose/Cargo.toml
+++ b/crates/wasm-compose/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-compose"
-version = "0.4.8"
+version = "0.4.9"
 edition.workspace = true
 authors = ["Peter Huene <peter@huene.dev>"]
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasm-encoder/Cargo.toml
+++ b/crates/wasm-encoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-encoder"
-version = "0.34.1"
+version = "0.35.0"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasm-metadata/Cargo.toml
+++ b/crates/wasm-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-metadata"
-version = "0.10.8"
+version = "0.10.9"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-metadata"

--- a/crates/wasm-mutate/Cargo.toml
+++ b/crates/wasm-mutate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-mutate"
-version = "0.2.37"
+version = "0.2.38"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-mutate"

--- a/crates/wasm-shrink/Cargo.toml
+++ b/crates/wasm-shrink/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-shrink"
 name = "wasm-shrink"
-version = "0.1.38"
+version = "0.1.39"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "wasm-smith"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-smith"
-version = "0.12.20"
+version = "0.12.21"
 exclude = ["/benches/corpus"]
 
 [[bench]]

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.114.0"
+version = "0.115.0"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser"

--- a/crates/wasmprinter/Cargo.toml
+++ b/crates/wasmprinter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmprinter"
-version = "0.2.69"
+version = "0.2.70"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wast"
-version = "66.0.1"
+version = "66.0.2"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wat/Cargo.toml
+++ b/crates/wat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wat"
-version = "1.0.76"
+version = "1.0.77"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wit-component/Cargo.toml
+++ b/crates/wit-component/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-component"
 authors = ["Peter Huene <peter@huene.dev>"]
-version = "0.14.6"
+version = "0.15.0"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"

--- a/crates/wit-smith/Cargo.toml
+++ b/crates/wit-smith/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 name = "wit-smith"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-smith"
-version = "0.1.16"
+version = "0.1.17"
 
 [dependencies]
 arbitrary = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
This attempts to address a mistake in https://github.com/bytecodealliance/wasm-tools/pull/1247 where that PR bumped a major version of `wit-parser` but mistakenly forgot to bump the major version of `wit-component`. (I forgot to see that!) This caused downstream issues and broke builds such as in https://github.com/bytecodealliance/wit-bindgen/pull/698.

I've updated the `publish.rs` script to have knowledge of public dependencies and automaticlaly force a major version bump of wit-component, for example, if wit-parser has a major version bump. 

This PR additionally bumps version numbers and I'll yank the buggy versions after these are published.