### PR TITLE
wasmparser: Use type-specific identifiers pervasively

### DIFF
--- a/crates/wasm-compose/src/graph.rs
+++ b/crates/wasm-compose/src/graph.rs
@@ -10,7 +10,7 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering},
 };
 use wasmparser::{
-    types::{ComponentEntityType, TypeId, Types, TypesRef},
+    types::{ComponentEntityType, ComponentInstanceTypeId, Types, TypesRef},
     Chunk, ComponentExternalKind, ComponentTypeRef, Encoding, Parser, Payload, ValidPayload,
     Validator, WasmFeatures,
 };
@@ -277,7 +277,7 @@ impl<'a> Component<'a> {
     /// Finds a compatible instance export on the component for the given instance type.
     pub(crate) fn find_compatible_export(
         &self,
-        ty: TypeId,
+        ty: ComponentInstanceTypeId,
         types: TypesRef,
     ) -> Option<ExportIndex> {
         self.exports
@@ -298,8 +298,12 @@ impl<'a> Component<'a> {
 
     /// Checks to see if an instance of this component would be a
     /// subtype of the given instance type.
-    pub(crate) fn is_instance_subtype_of(&self, ty: TypeId, types: TypesRef) -> bool {
-        let exports = types[ty].unwrap_component_instance().exports.iter();
+    pub(crate) fn is_instance_subtype_of(
+        &self,
+        ty: ComponentInstanceTypeId,
+        types: TypesRef,
+    ) -> bool {
+        let exports = types[ty].exports.iter();
 
         for (k, b) in exports {
             match self.exports.get_full(k.as_str()) {

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -760,6 +760,16 @@ pub enum StructuralType {
     Struct(StructType),
 }
 
+impl StructuralType {
+    /// Unwrap a `FuncType` or panic.
+    pub fn unwrap_func(&self) -> &FuncType {
+        match self {
+            Self::Func(f) => f,
+            _ => panic!("not a func"),
+        }
+    }
+}
+
 /// Represents a subtype of possible other types in a WebAssembly module.
 #[derive(Debug, Clone)]
 pub struct SubType {
@@ -769,6 +779,13 @@ pub struct SubType {
     pub supertype_idx: Option<u32>,
     /// The structural type of the subtype.
     pub structural_type: StructuralType,
+}
+
+impl SubType {
+    /// Unwrap a `FuncType` or panic.
+    pub fn unwrap_func(&self) -> &FuncType {
+        self.structural_type.unwrap_func()
+    }
 }
 
 /// Represents a recursive type group in a WebAssembly module.

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -18,7 +18,7 @@ use crate::{
 use super::{
     check_max, combine_type_sizes,
     operators::{ty_to_str, OperatorValidator, OperatorValidatorAllocations},
-    types::{CoreTypeId, EntityType, TypeAlloc, TypeIdentifierImpl, TypeList},
+    types::{CoreTypeId, EntityType, TypeAlloc, TypeIdentifier, TypeList},
 };
 
 // Section order for WebAssembly modules.

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -640,7 +640,13 @@ impl Printer {
             states.last().unwrap().core.types.len() as u32,
         )?;
         let ty = match ty {
-            CoreType::Func(ty) => {
+            CoreType::Sub(ty) => {
+                let ty = match &ty.structural_type {
+                    StructuralType::Func(f) => f,
+                    StructuralType::Array(_) | StructuralType::Struct(_) => {
+                        unreachable!("Wasm GC types cannot appear in components yet")
+                    }
+                };
                 self.result.push(' ');
                 self.start_group("func");
                 self.print_func_type(states.last().unwrap(), &ty, None)?;
@@ -648,7 +654,7 @@ impl Printer {
                 Some(SubType {
                     is_final: true,
                     supertype_idx: None,
-                    structural_type: StructuralType::Func(ty),
+                    structural_type: StructuralType::Func(ty.clone()),
                 })
             }
             CoreType::Module(decls) => {

--- a/tests/local/component-model/resources.wast
+++ b/tests/local/component-model/resources.wast
@@ -488,7 +488,7 @@
     (type $x u32)
     (instance (instantiate $c (with "x" (type $x))))
   )
-  "expected resource, found type")
+  "expected resource, found defined type")
 
 (assert_invalid
   (component
@@ -499,7 +499,7 @@
     (type $x (resource (rep i32)))
     (instance (instantiate $c (with "x" (type $x))))
   )
-  "expected type, found resource")
+  "expected defined type, found resource")
 
 (assert_invalid
   (component


### PR DESCRIPTION
This commit changes `wasmparser` from the uni-typed `TypeId` identifier to a myriad of type-specific identifiers, such as `ComponentInstanceTypeId` and `ComponentDefinedTypeId`. There are also identifiers for any kind of type within some group, such as `ComponentAnyTypeId` for any kind of component type and `AnyTypeId` for any kind of type, component or core.

The `wasmparser::Types` arena can be indexed by any of these leaf type identifiers, which all implement the `TypeIdentifier` trait. The resulting indexed data is the particular type, e.g. a `ComponentFuncType`, rather than the uni-typed `wasmparser::Type`.

There was a lot of ocean boiling involved here. Apologies in advance for the pain of this upgrade! That said, it should provide type safety benefits moving forward and sets the stage for further identifier refactors for core types that are necessary for Wasm GC.

If you are upgrading and were using `TypeId` before, and don't want to spend time gaining type safety on your type lookups, then just use `AnyTypeId` instead of the old `TypeId`. They are morally identical. Alternatively, if you know a particular `TypeId` was always a component function, for example, and you always did `types[id].unwrap_component_func()`, then you can switch to using `ComponentFuncTypeId`.