### PR TITLE
Minimize bindgen type information

### DIFF
--- a/crates/wasm-encoder/src/component/builder.rs
+++ b/crates/wasm-encoder/src/component/builder.rs
@@ -373,6 +373,12 @@ impl ComponentBuilder {
     }
 
     /// Adds a new custom section to this component.
+    pub fn custom_section(&mut self, section: &CustomSection<'_>) {
+        self.flush();
+        self.component.section(section);
+    }
+
+    /// Adds a new custom section to this component.
     pub fn raw_custom_section(&mut self, section: &[u8]) {
         self.flush();
         self.component.section(&RawCustomSection(section));

--- a/crates/wit-component/src/lib.rs
+++ b/crates/wit-component/src/lib.rs
@@ -206,7 +206,7 @@ pub fn embed_component_metadata(
     world: WorldId,
     encoding: StringEncoding,
 ) -> Result<()> {
-    let encoded = metadata::encode(&wit_resolver, world, encoding, None)?;
+    let encoded = metadata::encode(&wit_resolver, world, encoding, None, None)?;
 
     let section = wasm_encoder::CustomSection {
         name: "component-type".into(),

--- a/crates/wit-component/tests/components.rs
+++ b/crates/wit-component/tests/components.rs
@@ -205,8 +205,13 @@ fn read_core_module(path: &Path, resolve: &Resolve, pkg: PackageId) -> Result<Ve
     let mut producers = wasm_metadata::Producers::empty();
     producers.add("processed-by", "my-fake-bindgen", "123.45");
 
-    let encoded =
-        wit_component::metadata::encode(resolve, world, StringEncoding::UTF8, Some(&producers))?;
+    let encoded = wit_component::metadata::encode(
+        resolve,
+        world,
+        StringEncoding::UTF8,
+        Some(&producers),
+        Some(true),
+    )?;
 
     let section = wasm_encoder::CustomSection {
         name: "component-type".into(),

--- a/crates/wit-component/tests/linking.rs
+++ b/crates/wit-component/tests/linking.rs
@@ -144,8 +144,13 @@ fn encode(wat: &str, wit: Option<&str>) -> Result<Vec<u8>> {
         let mut resolve = Resolve::default();
         let pkg = resolve.push(UnresolvedPackage::parse(Path::new("wit"), wit)?)?;
         let world = resolve.select_world(pkg, None)?;
-        let component_type =
-            wit_component::metadata::encode(&resolve, world, StringEncoding::UTF8, None)?;
+        let component_type = wit_component::metadata::encode(
+            &resolve,
+            world,
+            StringEncoding::UTF8,
+            None,
+            Some(true),
+        )?;
 
         let section = CustomSection {
             name: Cow::Borrowed("component-type"),

--- a/crates/wit-component/tests/wit.rs
+++ b/crates/wit-component/tests/wit.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "wat")]
+
 use anyhow::Result;
 use wit_component::{is_wasm_binary_or_wat, parse_wit_from_path};
 

--- a/crates/wit-parser/src/resolve.rs
+++ b/crates/wit-parser/src/resolve.rs
@@ -518,17 +518,22 @@ impl Resolve {
     /// Returns `None` for unnamed interfaces.
     pub fn id_of(&self, interface: InterfaceId) -> Option<String> {
         let interface = &self.interfaces[interface];
-        let package = &self.packages[interface.package.unwrap()];
+        Some(self.id_of_name(interface.package.unwrap(), interface.name.as_ref()?))
+    }
+
+    /// Returns the ID of the specified `name` within the `pkg`.
+    pub fn id_of_name(&self, pkg: PackageId, name: &str) -> String {
+        let package = &self.packages[pkg];
         let mut base = String::new();
         base.push_str(&package.name.namespace);
         base.push_str(":");
         base.push_str(&package.name.name);
         base.push_str("/");
-        base.push_str(interface.name.as_ref()?);
+        base.push_str(name);
         if let Some(version) = &package.name.version {
             base.push_str(&format!("@{version}"));
         }
-        Some(base)
+        base
     }
 
     /// Attempts to locate a world given the "default" package `pkg` and the

--- a/fuzz/src/roundtrip_wit.rs
+++ b/fuzz/src/roundtrip_wit.rs
@@ -34,10 +34,12 @@ pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
 
     // If there's hundreds or thousands of worlds only work with the first few
     // to avoid timing out this fuzzer with asan enabled.
+    let use_next = Some(u.arbitrary()?);
     for (id, _world) in resolve.worlds.iter().take(20) {
         let mut dummy = wit_component::dummy_module(&resolve, id);
         let metadata =
-            wit_component::metadata::encode(&resolve, id, StringEncoding::UTF8, None).unwrap();
+            wit_component::metadata::encode(&resolve, id, StringEncoding::UTF8, None, use_next)
+                .unwrap();
         let section = CustomSection {
             name: "component-type".into(),
             data: Cow::Borrowed(&metadata),


### PR DESCRIPTION
This commit is aimed at addressing bytecodealliance/wasmtime#7266 as well as a preexisting wart in wit-component. Guest bindings generators use `wit-component::metadata` to embed type information in compiled wasm modules. Currently this creates a custom section with a custom binary format. The binary format has a few prefix bytes/strings and then has a wasm-encoded WIT package with the world that was bound. The problem with this, as shown in the previous issue, is that the WIT package is possibly much larger than the world that was bound meaning that it has a lot more type information than necessary. This means that incompatibilities in interfaces that weren't actually used cause errors which is annoying to keep in sync and technically not necessary to warn/error about.

This commit aims to solve two separate problems at the same time:

* Type information will now be minimized storing only exactly what's needed for the bound world.
* The custom section format will become an actual component without any extra headers to make extraction/debugging easier.

Bindings generators currently all operate on worlds as the unit of generation, meaning that the metadata to include in this custom section is effectively a WIT world. Conveniently a WIT world can be exactly represented as a WebAssembly component types, and doubly conveniently there's already an `encode_world` function. This means that the custom section format for bindings generators is now a component which exports a single component type. The component type represents the world that was bound as part of the bindings generation process. Other minor details such as version information and string encoding selection is now stored in a custom section of the component created instead of in the header. Various guards are still in place against future versions but this should help make the format more easily debuggable and more understandable by being "simply a component" with some extra metadata.

The decoding process back into a WIT world needed a few minor updates for various reasons, but otherwise this integrated well into the existing structure of `wit-component`.

As with other breaking changes coming into components at this point all this new support is disabled behind an environment variable by default. The hope is to release this to get support for the new format in a number of places and then switch over to the new format by default. Eventually down the road the old format will be deleted.