### PR TITLE
Fix trivial typo in define_types.rs

### DIFF
--- a/crates/wasmparser/src/define_types.rs
+++ b/crates/wasmparser/src/define_types.rs
@@ -572,7 +572,7 @@ macro_rules! define_core_wasm_types {
             /// Create a new `RefType`.
             ///
             /// Returns `None` when the heap type's type index (if any) is
-            /// beyond this crate's implementation limits and therfore is not
+            /// beyond this crate's implementation limits and therefore is not
             /// representable.
             pub fn new(nullable: bool, heap_type: HeapType) -> Option<Self> {
                 let nullable32 = Self::NULLABLE_BIT * (nullable as u32);


### PR DESCRIPTION
A trivial typo which I found when merging recent changes into my downstream fork.