### PR TITLE
Turn on semicolons-in-WIT by default

### DIFF
--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -5,7 +5,7 @@ use std::mem;
 use wit_parser::*;
 
 // NB: keep in sync with `crates/wit-parser/src/ast/lex.rs`
-const PRINT_SEMICOLONS_DEFAULT: bool = false;
+const PRINT_SEMICOLONS_DEFAULT: bool = true;
 
 /// A utility for printing WebAssembly interface definitions to a string.
 pub struct WitPrinter {

--- a/crates/wit-component/tests/components/adapt-empty-interface/component.wit.print
+++ b/crates/wit-component/tests/components/adapt-empty-interface/component.wit.print
@@ -1,4 +1,4 @@
-package root:component
+package root:component;
 
 world root {
 }

--- a/crates/wit-component/tests/components/adapt-export-default/component.wit.print
+++ b/crates/wit-component/tests/components/adapt-export-default/component.wit.print
@@ -1,5 +1,5 @@
-package root:component
+package root:component;
 
 world root {
-  export entrypoint: func()
+  export entrypoint: func();
 }

--- a/crates/wit-component/tests/components/adapt-export-namespaced/component.wit.print
+++ b/crates/wit-component/tests/components/adapt-export-namespaced/component.wit.print
@@ -1,5 +1,5 @@
-package root:component
+package root:component;
 
 world root {
-  export foo:foo/new
+  export foo:foo/new;
 }

--- a/crates/wit-component/tests/components/adapt-export-reallocs/component.wit.print
+++ b/crates/wit-component/tests/components/adapt-export-reallocs/component.wit.print
@@ -1,9 +1,9 @@
-package root:component
+package root:component;
 
 world root {
   import new: interface {
-    read: func(amt: u32) -> list<u8>
+    read: func(amt: u32) -> list<u8>;
   }
 
-  export entrypoint: func(args: list<string>)
+  export entrypoint: func(args: list<string>);
 }

--- a/crates/wit-component/tests/components/adapt-export-save-args/component.wit.print
+++ b/crates/wit-component/tests/components/adapt-export-save-args/component.wit.print
@@ -1,5 +1,5 @@
-package root:component
+package root:component;
 
 world root {
-  export entrypoint: func(nargs: u32)
+  export entrypoint: func(nargs: u32);
 }

--- a/crates/wit-component/tests/components/adapt-export-with-post-return/component.wit.print
+++ b/crates/wit-component/tests/components/adapt-export-with-post-return/component.wit.print
@@ -1,5 +1,5 @@
-package root:component
+package root:component;
 
 world root {
-  export foo:foo/new
+  export foo:foo/new;
 }

--- a/crates/wit-component/tests/components/adapt-import-only-used-in-adapter/component.wit.print
+++ b/crates/wit-component/tests/components/adapt-import-only-used-in-adapter/component.wit.print
@@ -1,9 +1,9 @@
-package root:component
+package root:component;
 
 world root {
-  import foo:foo/adapter-imports
-  import foo: func(x: string)
+  import foo:foo/adapter-imports;
+  import foo: func(x: string);
 
-  export bar: func()
-  export adapter-bar: func(x: string)
+  export bar: func();
+  export adapter-bar: func(x: string);
 }

--- a/crates/wit-component/tests/components/adapt-inject-stack-with-adapt-realloc/component.wit.print
+++ b/crates/wit-component/tests/components/adapt-inject-stack-with-adapt-realloc/component.wit.print
@@ -1,7 +1,7 @@
-package root:component
+package root:component;
 
 world root {
   import new: interface {
-    get-two: func() -> (a: u32, b: u32)
+    get-two: func() -> (a: u32, b: u32);
   }
 }

--- a/crates/wit-component/tests/components/adapt-inject-stack-with-realloc-no-state/component.wit.print
+++ b/crates/wit-component/tests/components/adapt-inject-stack-with-realloc-no-state/component.wit.print
@@ -1,7 +1,7 @@
-package root:component
+package root:component;
 
 world root {
   import new: interface {
-    get-two: func() -> (a: u32, b: u32)
+    get-two: func() -> (a: u32, b: u32);
   }
 }

--- a/crates/wit-component/tests/components/adapt-inject-stack-with-realloc/component.wit.print
+++ b/crates/wit-component/tests/components/adapt-inject-stack-with-realloc/component.wit.print
@@ -1,7 +1,7 @@
-package root:component
+package root:component;
 
 world root {
   import new: interface {
-    get-two: func() -> (a: u32, b: u32)
+    get-two: func() -> (a: u32, b: u32);
   }
 }

--- a/crates/wit-component/tests/components/adapt-inject-stack-with-reallocing-adapter/component.wit.print
+++ b/crates/wit-component/tests/components/adapt-inject-stack-with-reallocing-adapter/component.wit.print
@@ -1,7 +1,7 @@
-package root:component
+package root:component;
 
 world root {
   import new: interface {
-    get-two: func() -> (a: u32, b: u32)
+    get-two: func() -> (a: u32, b: u32);
   }
 }

--- a/crates/wit-component/tests/components/adapt-inject-stack/component.wit.print
+++ b/crates/wit-component/tests/components/adapt-inject-stack/component.wit.print
@@ -1,7 +1,7 @@
-package root:component
+package root:component;
 
 world root {
   import new: interface {
-    get-two: func() -> (a: u32, b: u32)
+    get-two: func() -> (a: u32, b: u32);
   }
 }

--- a/crates/wit-component/tests/components/adapt-list-return/component.wit.print
+++ b/crates/wit-component/tests/components/adapt-list-return/component.wit.print
@@ -1,7 +1,7 @@
-package root:component
+package root:component;
 
 world root {
   import new: interface {
-    read: func() -> list<u8>
+    read: func() -> list<u8>;
   }
 }

--- a/crates/wit-component/tests/components/adapt-memory-simple/component.wit.print
+++ b/crates/wit-component/tests/components/adapt-memory-simple/component.wit.print
@@ -1,7 +1,7 @@
-package root:component
+package root:component;
 
 world root {
   import new: interface {
-    log: func(s: string)
+    log: func(s: string);
   }
 }

--- a/crates/wit-component/tests/components/adapt-multiple/component.wit.print
+++ b/crates/wit-component/tests/components/adapt-multiple/component.wit.print
@@ -1,10 +1,10 @@
-package root:component
+package root:component;
 
 world root {
   import other1: interface {
-    foo: func()
+    foo: func();
   }
   import other2: interface {
-    bar: func()
+    bar: func();
   }
 }

--- a/crates/wit-component/tests/components/adapt-preview1/component.wit.print
+++ b/crates/wit-component/tests/components/adapt-preview1/component.wit.print
@@ -1,8 +1,8 @@
-package root:component
+package root:component;
 
 world root {
   import foo: interface {
-    foo: func()
+    foo: func();
   }
-  import foo:foo/my-wasi
+  import foo:foo/my-wasi;
 }

--- a/crates/wit-component/tests/components/adapt-unused/component.wit.print
+++ b/crates/wit-component/tests/components/adapt-unused/component.wit.print
@@ -1,4 +1,4 @@
-package root:component
+package root:component;
 
 world root {
 }

--- a/crates/wit-component/tests/components/bare-funcs/component.wit.print
+++ b/crates/wit-component/tests/components/bare-funcs/component.wit.print
@@ -1,9 +1,9 @@
-package root:component
+package root:component;
 
 world root {
-  import foo: func()
-  import bar: func() -> string
+  import foo: func();
+  import bar: func() -> string;
 
-  export baz: func()
-  export foo2: func(x: string) -> option<list<u8>>
+  export baz: func();
+  export foo2: func(x: string) -> option<list<u8>>;
 }

--- a/crates/wit-component/tests/components/empty/component.wit.print
+++ b/crates/wit-component/tests/components/empty/component.wit.print
@@ -1,4 +1,4 @@
-package root:component
+package root:component;
 
 world root {
 }

--- a/crates/wit-component/tests/components/ensure-default-type-exports/component.wit.print
+++ b/crates/wit-component/tests/components/ensure-default-type-exports/component.wit.print
@@ -1,7 +1,7 @@
-package root:component
+package root:component;
 
 world root {
-  import foo:foo/foo
+  import foo:foo/foo;
 
-  export a: func(b: u8)
+  export a: func(b: u8);
 }

--- a/crates/wit-component/tests/components/export-interface-using-import/component.wit.print
+++ b/crates/wit-component/tests/components/export-interface-using-import/component.wit.print
@@ -1,9 +1,9 @@
-package root:component
+package root:component;
 
 world root {
-  import foo:foo/foo
+  import foo:foo/foo;
 
   export x: interface {
-    use foo:foo/foo.{r}
+    use foo:foo/foo.{r};
   }
 }

--- a/crates/wit-component/tests/components/export-name-shuffling/component.wit.print
+++ b/crates/wit-component/tests/components/export-name-shuffling/component.wit.print
@@ -1,10 +1,10 @@
-package root:component
+package root:component;
 
 world root {
-  export foo:foo/name
+  export foo:foo/name;
   export name: interface {
-    use foo:foo/name.{foo}
+    use foo:foo/name.{foo};
 
-    a: func(f: foo)
+    a: func(f: foo);
   }
 }

--- a/crates/wit-component/tests/components/export-resource/component.wit.print
+++ b/crates/wit-component/tests/components/export-resource/component.wit.print
@@ -1,10 +1,10 @@
-package root:component
+package root:component;
 
 world root {
   export foo: interface {
     resource a {
-      constructor()
-      other-new: static func() -> a
+      constructor();
+      other-new: static func() -> a;
     }
   }
 }

--- a/crates/wit-component/tests/components/export-type-name-conflict/component.wit.print
+++ b/crates/wit-component/tests/components/export-type-name-conflict/component.wit.print
@@ -1,11 +1,11 @@
-package root:component
+package root:component;
 
 world root {
-  import foo:foo/foo
+  import foo:foo/foo;
 
   export bar: interface {
-    use foo:foo/foo.{foo as bar}
+    use foo:foo/foo.{foo as bar};
 
-    foo: func() -> bar
+    foo: func() -> bar;
   }
 }

--- a/crates/wit-component/tests/components/export-with-type-alias/component.wit.print
+++ b/crates/wit-component/tests/components/export-with-type-alias/component.wit.print
@@ -1,5 +1,5 @@
-package root:component
+package root:component;
 
 world root {
-  export foo:foo/foo
+  export foo:foo/foo;
 }

--- a/crates/wit-component/tests/components/exports/component.wit.print
+++ b/crates/wit-component/tests/components/exports/component.wit.print
@@ -1,9 +1,9 @@
-package root:component
+package root:component;
 
 world root {
-  export a: func()
-  export b: func(a: s8, b: s16, c: s32, d: s64) -> string
-  export c: func() -> tuple<s8, s16, s32, s64>
+  export a: func();
+  export b: func(a: s8, b: s16, c: s32, d: s64) -> string;
+  export c: func() -> tuple<s8, s16, s32, s64>;
   export bar: interface {
     flags x {
       a,
@@ -11,7 +11,7 @@ world root {
       c,
     }
 
-    a: func(x: x)
+    a: func(x: x);
   }
   export foo: interface {
     variant x {
@@ -20,10 +20,10 @@ world root {
       c(s64),
     }
 
-    a: func()
+    a: func();
 
-    b: func(x: string) -> x
+    b: func(x: string) -> x;
 
-    c: func(x: x) -> string
+    c: func(x: x) -> string;
   }
 }

--- a/crates/wit-component/tests/components/import-and-export-resource/component.wit.print
+++ b/crates/wit-component/tests/components/import-and-export-resource/component.wit.print
@@ -1,8 +1,8 @@
-package root:component
+package root:component;
 
 world root {
-  import foo:bar/foo
-  use foo:bar/foo.{a}
+  import foo:bar/foo;
+  use foo:bar/foo.{a};
 
-  export foo:bar/foo
+  export foo:bar/foo;
 }

--- a/crates/wit-component/tests/components/import-conflict/component.wit.print
+++ b/crates/wit-component/tests/components/import-conflict/component.wit.print
@@ -1,7 +1,7 @@
-package root:component
+package root:component;
 
 world root {
-  import foo:foo/bar
-  import foo:foo/baz
-  import foo:foo/foo
+  import foo:foo/bar;
+  import foo:foo/baz;
+  import foo:foo/foo;
 }

--- a/crates/wit-component/tests/components/import-empty-interface/component.wit.print
+++ b/crates/wit-component/tests/components/import-empty-interface/component.wit.print
@@ -1,4 +1,4 @@
-package root:component
+package root:component;
 
 world root {
 }

--- a/crates/wit-component/tests/components/import-export-same-iface-name/component.wit.print
+++ b/crates/wit-component/tests/components/import-export-same-iface-name/component.wit.print
@@ -1,8 +1,8 @@
-package root:component
+package root:component;
 
 world root {
-  import foo:dep/the-name
-  import foo:foo/the-name
+  import foo:dep/the-name;
+  import foo:foo/the-name;
 
-  export foo:foo/the-name
+  export foo:foo/the-name;
 }

--- a/crates/wit-component/tests/components/import-export/component.wit.print
+++ b/crates/wit-component/tests/components/import-export/component.wit.print
@@ -1,14 +1,14 @@
-package root:component
+package root:component;
 
 world root {
   import foo: interface {
-    a: func() -> string
+    a: func() -> string;
   }
 
-  export a: func(x: string) -> tuple<string, u32, string>
+  export a: func(x: string) -> tuple<string, u32, string>;
   export bar: interface {
-    a: func()
+    a: func();
 
-    b: func() -> string
+    b: func() -> string;
   }
 }

--- a/crates/wit-component/tests/components/import-in-adapter-and-main-module/component.wit.print
+++ b/crates/wit-component/tests/components/import-in-adapter-and-main-module/component.wit.print
@@ -1,16 +1,16 @@
-package root:component
+package root:component;
 
 world root {
-  import foo:shared-dependency/doc
-  import foo:shared-dependency/types
+  import foo:shared-dependency/doc;
+  import foo:shared-dependency/types;
   import main-dep: interface {
-    use foo:shared-dependency/types.{a-typedef}
+    use foo:shared-dependency/types.{a-typedef};
 
-    foo: func() -> a-typedef
+    foo: func() -> a-typedef;
   }
   import adapter-dep: interface {
-    use foo:shared-dependency/types.{a-typedef}
+    use foo:shared-dependency/types.{a-typedef};
 
-    foo: func() -> a-typedef
+    foo: func() -> a-typedef;
   }
 }

--- a/crates/wit-component/tests/components/import-partial-export-full/component.wit.print
+++ b/crates/wit-component/tests/components/import-partial-export-full/component.wit.print
@@ -1,8 +1,8 @@
-package root:component
+package root:component;
 
 world root {
-  import a:b/name
-  use a:b/name.{name}
+  import a:b/name;
+  use a:b/name.{name};
 
-  export a:b/name
+  export a:b/name;
 }

--- a/crates/wit-component/tests/components/import-resource-in-interface/component.wit.print
+++ b/crates/wit-component/tests/components/import-resource-in-interface/component.wit.print
@@ -1,10 +1,10 @@
-package root:component
+package root:component;
 
 world root {
   import foo: interface {
     resource a {
-      constructor()
-      other-new: static func() -> a
+      constructor();
+      other-new: static func() -> a;
     }
   }
 }

--- a/crates/wit-component/tests/components/import-resource-simple/component.wit.print
+++ b/crates/wit-component/tests/components/import-resource-simple/component.wit.print
@@ -1,8 +1,8 @@
-package root:component
+package root:component;
 
 world root {
   resource a {
-    constructor()
-    other-new: static func() -> a
+    constructor();
+    other-new: static func() -> a;
   }
 }

--- a/crates/wit-component/tests/components/imports/component.wit.print
+++ b/crates/wit-component/tests/components/imports/component.wit.print
@@ -1,4 +1,4 @@
-package root:component
+package root:component;
 
 world root {
   import bar: interface {
@@ -6,24 +6,24 @@ world root {
       a: u8,
     }
 
-    bar1: func(x: string)
+    bar1: func(x: string);
 
-    bar2: func(x: x)
+    bar2: func(x: x);
   }
   import baz: interface {
-    type x = s8
+    type x = s8;
 
-    baz1: func(x: list<string>)
+    baz1: func(x: list<string>);
 
-    baz2: func()
+    baz2: func();
 
-    baz3: func(x: x)
+    baz3: func(x: x);
   }
   import foo: interface {
-    foo1: func()
+    foo1: func();
 
-    foo2: func(x: u8)
+    foo2: func(x: u8);
 
-    foo3: func(x: float32)
+    foo3: func(x: float32);
   }
 }

--- a/crates/wit-component/tests/components/lift-options/component.wit.print
+++ b/crates/wit-component/tests/components/lift-options/component.wit.print
@@ -1,5 +1,5 @@
-package root:component
+package root:component;
 
 world root {
-  export foo:foo/my-default
+  export foo:foo/my-default;
 }

--- a/crates/wit-component/tests/components/link-bare-funcs/component.wit.print
+++ b/crates/wit-component/tests/components/link-bare-funcs/component.wit.print
@@ -1,9 +1,9 @@
-package root:component
+package root:component;
 
 world root {
-  import foo1: func()
-  import bar: func() -> string
+  import foo1: func();
+  import bar: func() -> string;
 
-  export baz: func()
-  export foo2: func(x: string) -> option<list<u8>>
+  export baz: func();
+  export foo2: func(x: string) -> option<list<u8>>;
 }

--- a/crates/wit-component/tests/components/link-circular/component.wit.print
+++ b/crates/wit-component/tests/components/link-circular/component.wit.print
@@ -1,7 +1,7 @@
-package root:component
+package root:component;
 
 world root {
-  import test:test/test
+  import test:test/test;
 
-  export test:test/test
+  export test:test/test;
 }

--- a/crates/wit-component/tests/components/link-dl-openable/component.wit.print
+++ b/crates/wit-component/tests/components/link-dl-openable/component.wit.print
@@ -1,7 +1,7 @@
-package root:component
+package root:component;
 
 world root {
-  import test:test/test
+  import test:test/test;
 
-  export test:test/test
+  export test:test/test;
 }

--- a/crates/wit-component/tests/components/link-duplicate-symbols/component.wit.print
+++ b/crates/wit-component/tests/components/link-duplicate-symbols/component.wit.print
@@ -1,7 +1,7 @@
-package root:component
+package root:component;
 
 world root {
-  import test:test/test
+  import test:test/test;
 
-  export test:test/test
+  export test:test/test;
 }

--- a/crates/wit-component/tests/components/link-got-func/component.wit.print
+++ b/crates/wit-component/tests/components/link-got-func/component.wit.print
@@ -1,7 +1,7 @@
-package root:component
+package root:component;
 
 world root {
-  import test:test/test
+  import test:test/test;
 
-  export test:test/test
+  export test:test/test;
 }

--- a/crates/wit-component/tests/components/link-initialize/component.wit.print
+++ b/crates/wit-component/tests/components/link-initialize/component.wit.print
@@ -1,7 +1,7 @@
-package root:component
+package root:component;
 
 world root {
-  import test:test/test
+  import test:test/test;
 
-  export test:test/test
+  export test:test/test;
 }

--- a/crates/wit-component/tests/components/link-resources/component.wit.print
+++ b/crates/wit-component/tests/components/link-resources/component.wit.print
@@ -1,6 +1,6 @@
-package root:component
+package root:component;
 
 world root {
-  export test:test/foo
-  export test:test/bar
+  export test:test/foo;
+  export test:test/bar;
 }

--- a/crates/wit-component/tests/components/link-stubs/component.wit.print
+++ b/crates/wit-component/tests/components/link-stubs/component.wit.print
@@ -1,7 +1,7 @@
-package root:component
+package root:component;
 
 world root {
-  import test:test/test
+  import test:test/test;
 
-  export test:test/test
+  export test:test/test;
 }

--- a/crates/wit-component/tests/components/link-weak-import/component.wit.print
+++ b/crates/wit-component/tests/components/link-weak-import/component.wit.print
@@ -1,7 +1,7 @@
-package root:component
+package root:component;
 
 world root {
-  import test:test/test
+  import test:test/test;
 
-  export test:test/test
+  export test:test/test;
 }

--- a/crates/wit-component/tests/components/link/component.wit.print
+++ b/crates/wit-component/tests/components/link/component.wit.print
@@ -1,7 +1,7 @@
-package root:component
+package root:component;
 
 world root {
-  import test:test/test
+  import test:test/test;
 
-  export test:test/test
+  export test:test/test;
 }

--- a/crates/wit-component/tests/components/live-exports-dead-imports/component.wit.print
+++ b/crates/wit-component/tests/components/live-exports-dead-imports/component.wit.print
@@ -1,5 +1,5 @@
-package root:component
+package root:component;
 
 world root {
-  export foo:foo/a
+  export foo:foo/a;
 }

--- a/crates/wit-component/tests/components/lower-options/component.wit.print
+++ b/crates/wit-component/tests/components/lower-options/component.wit.print
@@ -1,5 +1,5 @@
-package root:component
+package root:component;
 
 world root {
-  import foo:foo/foo
+  import foo:foo/foo;
 }

--- a/crates/wit-component/tests/components/many-same-names/component.wit.print
+++ b/crates/wit-component/tests/components/many-same-names/component.wit.print
@@ -1,10 +1,10 @@
-package root:component
+package root:component;
 
 world root {
-  export foo:foo/name
+  export foo:foo/name;
   export name: interface {
-    use foo:foo/name.{r2}
+    use foo:foo/name.{r2};
 
-    a: func()
+    a: func();
   }
 }

--- a/crates/wit-component/tests/components/no-realloc-required/component.wit.print
+++ b/crates/wit-component/tests/components/no-realloc-required/component.wit.print
@@ -1,7 +1,7 @@
-package root:component
+package root:component;
 
 world root {
   import foo: interface {
-    log: func(s: string)
+    log: func(s: string);
   }
 }

--- a/crates/wit-component/tests/components/post-return/component.wit.print
+++ b/crates/wit-component/tests/components/post-return/component.wit.print
@@ -1,5 +1,5 @@
-package root:component
+package root:component;
 
 world root {
-  export a: func() -> string
+  export a: func() -> string;
 }

--- a/crates/wit-component/tests/components/rename-import-interface/component.wit.print
+++ b/crates/wit-component/tests/components/rename-import-interface/component.wit.print
@@ -1,5 +1,5 @@
-package root:component
+package root:component;
 
 world root {
-  import foo:foo/foo
+  import foo:foo/foo;
 }

--- a/crates/wit-component/tests/components/rename-interface/component.wit.print
+++ b/crates/wit-component/tests/components/rename-interface/component.wit.print
@@ -1,10 +1,10 @@
-package root:component
+package root:component;
 
 world root {
-  import foo:foo/foo
+  import foo:foo/foo;
   import other-name: interface {
-    use foo:foo/foo.{bar}
+    use foo:foo/foo.{bar};
 
-    a: func() -> bar
+    a: func() -> bar;
   }
 }

--- a/crates/wit-component/tests/components/resource-intrinsics-with-just-import/component.wit.print
+++ b/crates/wit-component/tests/components/resource-intrinsics-with-just-import/component.wit.print
@@ -1,7 +1,7 @@
-package root:component
+package root:component;
 
 world root {
   import foo: interface {
-    resource a
+    resource a;
   }
 }

--- a/crates/wit-component/tests/components/resource-used-through-import/component.wit.print
+++ b/crates/wit-component/tests/components/resource-used-through-import/component.wit.print
@@ -1,11 +1,11 @@
-package root:component
+package root:component;
 
 world root {
-  import foo:bar/a
+  import foo:bar/a;
 
   export b: interface {
-    use foo:bar/a.{r}
+    use foo:bar/a.{r};
 
-    foo: func() -> r
+    foo: func() -> r;
   }
 }

--- a/crates/wit-component/tests/components/resource-using-export/component.wit.print
+++ b/crates/wit-component/tests/components/resource-using-export/component.wit.print
@@ -1,10 +1,10 @@
-package root:component
+package root:component;
 
 world root {
-  export foo:bar/foo
+  export foo:bar/foo;
   export anon: interface {
-    use foo:bar/foo.{handle}
+    use foo:bar/foo.{handle};
 
-    f: func() -> handle
+    f: func() -> handle;
   }
 }

--- a/crates/wit-component/tests/components/simple/component.wit.print
+++ b/crates/wit-component/tests/components/simple/component.wit.print
@@ -1,7 +1,7 @@
-package root:component
+package root:component;
 
 world root {
-  export a: func()
-  export b: func() -> string
-  export c: func(x: string) -> string
+  export a: func();
+  export b: func() -> string;
+  export c: func(x: string) -> string;
 }

--- a/crates/wit-component/tests/components/tricky-order/component.wit.print
+++ b/crates/wit-component/tests/components/tricky-order/component.wit.print
@@ -1,11 +1,11 @@
-package root:component
+package root:component;
 
 world root {
-  import foo:foo/name1
-  import foo:foo/name2
+  import foo:foo/name1;
+  import foo:foo/name2;
 
   export name: interface {
-    use foo:foo/name1.{name}
-    use foo:foo/name2.{name as name1}
+    use foo:foo/name1.{name};
+    use foo:foo/name2.{name as name1};
   }
 }

--- a/crates/wit-component/tests/components/tricky-resources/component.wit.print
+++ b/crates/wit-component/tests/components/tricky-resources/component.wit.print
@@ -1,11 +1,11 @@
-package root:component
+package root:component;
 
 world root {
-  export foo:bar/a
-  export foo:bar/b
+  export foo:bar/a;
+  export foo:bar/b;
   export some-name: interface {
-    use foo:bar/b.{r}
+    use foo:bar/b.{r};
 
-    f: func() -> r
+    f: func() -> r;
   }
 }

--- a/crates/wit-component/tests/components/tricky-resources2/component.wit.print
+++ b/crates/wit-component/tests/components/tricky-resources2/component.wit.print
@@ -1,10 +1,10 @@
-package root:component
+package root:component;
 
 world root {
-  export foo:bar/a
+  export foo:bar/a;
   export anon: interface {
-    use foo:bar/a.{r}
+    use foo:bar/a.{r};
 
-    foo: func() -> r
+    foo: func() -> r;
   }
 }

--- a/crates/wit-component/tests/components/tricky-resources3/component.wit.print
+++ b/crates/wit-component/tests/components/tricky-resources3/component.wit.print
@@ -1,9 +1,9 @@
-package root:component
+package root:component;
 
 world root {
-  export foo:bar/foo
-  export foo:bar/name
+  export foo:bar/foo;
+  export foo:bar/name;
   export name: interface {
-    use foo:bar/name.{name}
+    use foo:bar/name.{name};
   }
 }

--- a/crates/wit-component/tests/components/tricky-resources4/component.wit.print
+++ b/crates/wit-component/tests/components/tricky-resources4/component.wit.print
@@ -1,8 +1,8 @@
-package root:component
+package root:component;
 
 world root {
-  export foo:bar/name
+  export foo:bar/name;
   export name: interface {
-    use foo:bar/name.{handle}
+    use foo:bar/name.{handle};
   }
 }

--- a/crates/wit-component/tests/components/unused-import/component.wit.print
+++ b/crates/wit-component/tests/components/unused-import/component.wit.print
@@ -1,5 +1,5 @@
-package root:component
+package root:component;
 
 world root {
-  import foo:foo/foo
+  import foo:foo/foo;
 }

--- a/crates/wit-component/tests/components/worlds-with-type-renamings/component.wit.print
+++ b/crates/wit-component/tests/components/worlds-with-type-renamings/component.wit.print
@@ -1,8 +1,8 @@
-package root:component
+package root:component;
 
 world root {
-  import foo:foo/i
-  use foo:foo/i.{some-type as other-name}
+  import foo:foo/i;
+  use foo:foo/i.{some-type as other-name};
 
-  export foo:foo/i
+  export foo:foo/i;
 }

--- a/crates/wit-component/tests/components/worlds-with-types/component.wit.print
+++ b/crates/wit-component/tests/components/worlds-with-types/component.wit.print
@@ -1,11 +1,11 @@
-package root:component
+package root:component;
 
 world root {
-  type t = u32
+  type t = u32;
 
   record r {
     x: t,
   }
 
-  export a: func(r: r) -> t
+  export a: func(r: r) -> t;
 }

--- a/crates/wit-component/tests/interfaces/console.wit.print
+++ b/crates/wit-component/tests/interfaces/console.wit.print
@@ -1,6 +1,6 @@
-package foo:console
+package foo:console;
 
 interface console {
-  log: func(arg: string)
+  log: func(arg: string);
 }
 

--- a/crates/wit-component/tests/interfaces/diamond-disambiguate/foo.wit.print
+++ b/crates/wit-component/tests/interfaces/diamond-disambiguate/foo.wit.print
@@ -1,20 +1,20 @@
-package foo:foo
+package foo:foo;
 
 interface shared1 {
-  type t1 = u8
+  type t1 = u8;
 }
 
 interface shared2 {
-  type t2 = u8
+  type t2 = u8;
 }
 
 world w1 {
-  import shared1
+  import shared1;
   import foo: interface {
-    use shared1.{t1}
+    use shared1.{t1};
   }
-  import shared2
+  import shared2;
   import bar: interface {
-    use shared2.{t2}
+    use shared2.{t2};
   }
 }

--- a/crates/wit-component/tests/interfaces/diamond.wit.print
+++ b/crates/wit-component/tests/interfaces/diamond.wit.print
@@ -1,4 +1,4 @@
-package foo:foo
+package foo:foo;
 
 interface shared-items {
   enum the-enum {
@@ -7,28 +7,28 @@ interface shared-items {
 }
 
 world w1 {
-  import shared-items
+  import shared-items;
   import foo: interface {
-    use shared-items.{the-enum}
+    use shared-items.{the-enum};
   }
   import bar: interface {
-    use shared-items.{the-enum}
+    use shared-items.{the-enum};
   }
 }
 world w2 {
-  import shared-items
+  import shared-items;
   import foo: interface {
-    use shared-items.{the-enum}
+    use shared-items.{the-enum};
   }
 
   export bar: interface {
-    use shared-items.{the-enum}
+    use shared-items.{the-enum};
   }
 }
 world w3 {
-  import shared-items
+  import shared-items;
 
   export bar: interface {
-    use shared-items.{the-enum}
+    use shared-items.{the-enum};
   }
 }

--- a/crates/wit-component/tests/interfaces/doc-comments/foo.wit.print
+++ b/crates/wit-component/tests/interfaces/doc-comments/foo.wit.print
@@ -1,10 +1,10 @@
 /// package docs;
-package foo:foo
+package foo:foo;
 
 /// interface docs
 interface coverage-iface {
   /// basic typedef docs
-  type t = u32
+  type t = u32;
 
   /// record typedef docs
   record r {
@@ -33,15 +33,15 @@ interface coverage-iface {
 
   resource res {
     /// constructor docs
-    constructor()
+    constructor();
     /// method docs
-    m: func()
+    m: func();
     /// static func docs
-    s: static func()
+    s: static func();
   }
 
   /// interface func docs
-  f: func()
+  f: func();
 }
 
 /// other comment forms
@@ -49,30 +49,30 @@ interface coverage-iface {
 interface other-comment-forms {
   /// one doc line
   /// another doc line
-  multiple-lines-split: func()
+  multiple-lines-split: func();
 
   /// mixed forms; line doc
   /// plus block doc
   ///       multi-line
-  mixed-forms: func()
+  mixed-forms: func();
 }
 
 /// world docs
 world coverage-world {
   /// world func import docs
-  import imp: func()
+  import imp: func();
 
   /// world typedef docs
-  type t = u32
+  type t = u32;
 
   /// world func export docs
-  export exp: func()
+  export exp: func();
   /// world inline interface docs
   export i: interface {
     /// inline interface typedef docs
-    type t = u32
+    type t = u32;
 
     /// inline interface func docs
-    f: func()
+    f: func();
   }
 }

--- a/crates/wit-component/tests/interfaces/empty.wit.print
+++ b/crates/wit-component/tests/interfaces/empty.wit.print
@@ -1,14 +1,14 @@
-package foo:empty
+package foo:empty;
 
 interface empty {
 }
 
 world empty-world {
-  import empty
+  import empty;
   import empty: interface {
   }
 
-  export empty
+  export empty;
   export empty2: interface {
   }
 }

--- a/crates/wit-component/tests/interfaces/export-other-packages-interface/foo.wit.print
+++ b/crates/wit-component/tests/interfaces/export-other-packages-interface/foo.wit.print
@@ -1,5 +1,5 @@
-package foo:foo
+package foo:foo;
 
 world foo {
-  export foo:the-dep/the-interface
+  export foo:the-dep/the-interface;
 }

--- a/crates/wit-component/tests/interfaces/exports.wit.print
+++ b/crates/wit-component/tests/interfaces/exports.wit.print
@@ -1,13 +1,13 @@
-package foo:foo
+package foo:foo;
 
 interface foo {
   record my-struct {
     a: u32,
   }
 
-  my-function: func(a: my-struct) -> string
+  my-function: func(a: my-struct) -> string;
 }
 
 world export-foo {
-  export foo
+  export foo;
 }

--- a/crates/wit-component/tests/interfaces/flags.wit.print
+++ b/crates/wit-component/tests/interfaces/flags.wit.print
@@ -1,4 +1,4 @@
-package foo:%flags
+package foo:%flags;
 
 interface imports {
   flags flag1 {
@@ -149,21 +149,21 @@ interface imports {
     b63,
   }
 
-  roundtrip-flag1: func(x: flag1) -> flag1
+  roundtrip-flag1: func(x: flag1) -> flag1;
 
-  roundtrip-flag2: func(x: flag2) -> flag2
+  roundtrip-flag2: func(x: flag2) -> flag2;
 
-  roundtrip-flag4: func(x: flag4) -> flag4
+  roundtrip-flag4: func(x: flag4) -> flag4;
 
-  roundtrip-flag8: func(x: flag8) -> flag8
+  roundtrip-flag8: func(x: flag8) -> flag8;
 
-  roundtrip-flag16: func(x: flag16) -> flag16
+  roundtrip-flag16: func(x: flag16) -> flag16;
 
-  roundtrip-flag32: func(x: flag32) -> flag32
+  roundtrip-flag32: func(x: flag32) -> flag32;
 
-  roundtrip-flag64: func(x: flag64) -> flag64
+  roundtrip-flag64: func(x: flag64) -> flag64;
 }
 
 world flags-world {
-  import imports
+  import imports;
 }

--- a/crates/wit-component/tests/interfaces/floats.wit.print
+++ b/crates/wit-component/tests/interfaces/floats.wit.print
@@ -1,15 +1,15 @@
-package foo:floats
+package foo:floats;
 
 interface floats {
-  float32-param: func(x: float32)
+  float32-param: func(x: float32);
 
-  float64-param: func(x: float64)
+  float64-param: func(x: float64);
 
-  float32-result: func() -> float32
+  float32-result: func() -> float32;
 
-  float64-result: func() -> float64
+  float64-result: func() -> float64;
 }
 
 world floats-world {
-  import floats
+  import floats;
 }

--- a/crates/wit-component/tests/interfaces/foreign-use-chain/foo.wit.print
+++ b/crates/wit-component/tests/interfaces/foreign-use-chain/foo.wit.print
@@ -1,6 +1,6 @@
-package foo:foo
+package foo:foo;
 
 world foo {
-  import foo:bar/the-interface
-  import foo:bar/bar
+  import foo:bar/the-interface;
+  import foo:bar/bar;
 }

--- a/crates/wit-component/tests/interfaces/import-and-export.wit.print
+++ b/crates/wit-component/tests/interfaces/import-and-export.wit.print
@@ -1,15 +1,15 @@
-package foo:foo
+package foo:foo;
 
 interface foo {
-  foo: func()
+  foo: func();
 }
 
 interface bar {
-  bar: func()
+  bar: func();
 }
 
 world import-and-export {
-  import foo
+  import foo;
 
-  export bar
+  export bar;
 }

--- a/crates/wit-component/tests/interfaces/integers.wit.print
+++ b/crates/wit-component/tests/interfaces/integers.wit.print
@@ -1,45 +1,45 @@
-package foo:foo
+package foo:foo;
 
 interface integers {
-  a1: func(x: u8)
+  a1: func(x: u8);
 
-  a2: func(x: s8)
+  a2: func(x: s8);
 
-  a3: func(x: u16)
+  a3: func(x: u16);
 
-  a4: func(x: s16)
+  a4: func(x: s16);
 
-  a5: func(x: u32)
+  a5: func(x: u32);
 
-  a6: func(x: s32)
+  a6: func(x: s32);
 
-  a7: func(x: u64)
+  a7: func(x: u64);
 
-  a8: func(x: s64)
+  a8: func(x: s64);
 
-  a9: func(p1: u8, p2: s8, p3: u16, p4: s16, p5: u32, p6: s32, p7: u64, p8: s64)
+  a9: func(p1: u8, p2: s8, p3: u16, p4: s16, p5: u32, p6: s32, p7: u64, p8: s64);
 
-  r1: func() -> u8
+  r1: func() -> u8;
 
-  r2: func() -> s8
+  r2: func() -> s8;
 
-  r3: func() -> u16
+  r3: func() -> u16;
 
-  r4: func() -> s16
+  r4: func() -> s16;
 
-  r5: func() -> u32
+  r5: func() -> u32;
 
-  r6: func() -> s32
+  r6: func() -> s32;
 
-  r7: func() -> u64
+  r7: func() -> u64;
 
-  r8: func() -> s64
+  r8: func() -> s64;
 
-  pair-ret: func() -> tuple<s64, u8>
+  pair-ret: func() -> tuple<s64, u8>;
 
-  multi-ret: func() -> (a: s64, b: u8)
+  multi-ret: func() -> (a: s64, b: u8);
 }
 
 world integers-world {
-  import integers
+  import integers;
 }

--- a/crates/wit-component/tests/interfaces/lists.wit.print
+++ b/crates/wit-component/tests/interfaces/lists.wit.print
@@ -1,4 +1,4 @@
-package foo:foo
+package foo:foo;
 
 interface lists {
   record other-record {
@@ -32,65 +32,65 @@ interface lists {
     d(list<other-variant>),
   }
 
-  type load-store-all-sizes = list<tuple<string, u8, s8, u16, s16, u32, s32, u64, s64, float32, float64, char>>
+  type load-store-all-sizes = list<tuple<string, u8, s8, u16, s16, u32, s32, u64, s64, float32, float64, char>>;
 
-  list-u8-param: func(x: list<u8>)
+  list-u8-param: func(x: list<u8>);
 
-  list-u16-param: func(x: list<u16>)
+  list-u16-param: func(x: list<u16>);
 
-  list-u32-param: func(x: list<u32>)
+  list-u32-param: func(x: list<u32>);
 
-  list-u64-param: func(x: list<u64>)
+  list-u64-param: func(x: list<u64>);
 
-  list-s8-param: func(x: list<s8>)
+  list-s8-param: func(x: list<s8>);
 
-  list-s16-param: func(x: list<s16>)
+  list-s16-param: func(x: list<s16>);
 
-  list-s32-param: func(x: list<s32>)
+  list-s32-param: func(x: list<s32>);
 
-  list-s64-param: func(x: list<s64>)
+  list-s64-param: func(x: list<s64>);
 
-  list-float32-param: func(x: list<float32>)
+  list-float32-param: func(x: list<float32>);
 
-  list-float64-param: func(x: list<float64>)
+  list-float64-param: func(x: list<float64>);
 
-  list-u8-ret: func() -> list<u8>
+  list-u8-ret: func() -> list<u8>;
 
-  list-u16-ret: func() -> list<u16>
+  list-u16-ret: func() -> list<u16>;
 
-  list-u32-ret: func() -> list<u32>
+  list-u32-ret: func() -> list<u32>;
 
-  list-u64-ret: func() -> list<u64>
+  list-u64-ret: func() -> list<u64>;
 
-  list-s8-ret: func() -> list<s8>
+  list-s8-ret: func() -> list<s8>;
 
-  list-s16-ret: func() -> list<s16>
+  list-s16-ret: func() -> list<s16>;
 
-  list-s32-ret: func() -> list<s32>
+  list-s32-ret: func() -> list<s32>;
 
-  list-s64-ret: func() -> list<s64>
+  list-s64-ret: func() -> list<s64>;
 
-  list-float32-ret: func() -> list<float32>
+  list-float32-ret: func() -> list<float32>;
 
-  list-float64-ret: func() -> list<float64>
+  list-float64-ret: func() -> list<float64>;
 
-  tuple-list: func(x: list<tuple<u8, s8>>) -> list<tuple<s64, u32>>
+  tuple-list: func(x: list<tuple<u8, s8>>) -> list<tuple<s64, u32>>;
 
-  string-list-arg: func(a: list<string>)
+  string-list-arg: func(a: list<string>);
 
-  string-list-ret: func() -> list<string>
+  string-list-ret: func() -> list<string>;
 
-  tuple-string-list: func(x: list<tuple<u8, string>>) -> list<tuple<string, u8>>
+  tuple-string-list: func(x: list<tuple<u8, string>>) -> list<tuple<string, u8>>;
 
-  string-list: func(x: list<string>) -> list<string>
+  string-list: func(x: list<string>) -> list<string>;
 
-  record-list: func(x: list<some-record>) -> list<other-record>
+  record-list: func(x: list<some-record>) -> list<other-record>;
 
-  variant-list: func(x: list<some-variant>) -> list<other-variant>
+  variant-list: func(x: list<some-variant>) -> list<other-variant>;
 
-  load-store-everything: func(a: load-store-all-sizes) -> load-store-all-sizes
+  load-store-everything: func(a: load-store-all-sizes) -> load-store-all-sizes;
 }
 
 world lists-world {
-  import lists
+  import lists;
 }

--- a/crates/wit-component/tests/interfaces/multi-doc/foo.wit.print
+++ b/crates/wit-component/tests/interfaces/multi-doc/foo.wit.print
@@ -1,4 +1,4 @@
-package foo:foo
+package foo:foo;
 
 interface b {
   record the-type {
@@ -7,14 +7,14 @@ interface b {
 }
 
 interface a {
-  use b.{the-type}
+  use b.{the-type};
 }
 
 interface b2 {
-  use b.{the-type}
+  use b.{the-type};
 }
 
 interface a2 {
-  use b.{the-type}
+  use b.{the-type};
 }
 

--- a/crates/wit-component/tests/interfaces/multiple-use.wit.print
+++ b/crates/wit-component/tests/interfaces/multiple-use.wit.print
@@ -1,18 +1,18 @@
-package foo:multiuse
+package foo:multiuse;
 
 interface foo {
-  type t1 = u8
+  type t1 = u8;
 
-  type t2 = u8
+  type t2 = u8;
 }
 
 interface bar {
-  type u = u8
+  type u = u8;
 }
 
 interface baz {
-  use foo.{t1}
-  use bar.{u}
-  use foo.{t2}
+  use foo.{t1};
+  use bar.{u};
+  use foo.{t2};
 }
 

--- a/crates/wit-component/tests/interfaces/pkg-use-chain/chain.wit.print
+++ b/crates/wit-component/tests/interfaces/pkg-use-chain/chain.wit.print
@@ -1,11 +1,11 @@
-package foo:chain
+package foo:chain;
 
 interface a {
-  type a = u8
+  type a = u8;
 }
 
 interface def {
-  use a.{a}
+  use a.{a};
 
   enum name {
     other,
@@ -13,6 +13,6 @@ interface def {
 }
 
 interface foo {
-  use def.{name}
+  use def.{name};
 }
 

--- a/crates/wit-component/tests/interfaces/pkg-use-chain2/foo.wit.print
+++ b/crates/wit-component/tests/interfaces/pkg-use-chain2/foo.wit.print
@@ -1,4 +1,4 @@
-package foo:foo
+package foo:foo;
 
 interface other {
   record name {
@@ -7,7 +7,7 @@ interface other {
 }
 
 interface bar {
-  use other.{name as the-name}
+  use other.{name as the-name};
 
   enum name {
     a,
@@ -15,6 +15,6 @@ interface bar {
 }
 
 interface foo {
-  use bar.{the-name}
+  use bar.{the-name};
 }
 

--- a/crates/wit-component/tests/interfaces/preserve-dep-type-order/foo.wit.print
+++ b/crates/wit-component/tests/interfaces/preserve-dep-type-order/foo.wit.print
@@ -1,9 +1,9 @@
-package foo:foo
+package foo:foo;
 
 interface foo {
-  use foo:dep/foo.{ty}
+  use foo:dep/foo.{ty};
 }
 
 world bar {
-  import foo:dep/foo
+  import foo:dep/foo;
 }

--- a/crates/wit-component/tests/interfaces/preserve-foreign-reexport/foo.wit.print
+++ b/crates/wit-component/tests/interfaces/preserve-foreign-reexport/foo.wit.print
@@ -1,5 +1,5 @@
-package foo:foo
+package foo:foo;
 
 world foo {
-  export foo:my-dep/my-interface
+  export foo:my-dep/my-interface;
 }

--- a/crates/wit-component/tests/interfaces/print-keyword.wit.print
+++ b/crates/wit-component/tests/interfaces/print-keyword.wit.print
@@ -1,9 +1,9 @@
-package foo:foo
+package foo:foo;
 
 interface %interface {
-  type %type = u32
+  type %type = u32;
 
-  type %world = %type
+  type %world = %type;
 
   record %record {
     %variant: %world,

--- a/crates/wit-component/tests/interfaces/records.wit.print
+++ b/crates/wit-component/tests/interfaces/records.wit.print
@@ -1,4 +1,4 @@
-package foo:records
+package foo:records;
 
 interface records {
   record single {
@@ -30,35 +30,35 @@ interface records {
     e: really-flags,
   }
 
-  type int-typedef = s32
+  type int-typedef = s32;
 
-  type tuple-typedef2 = tuple<int-typedef>
+  type tuple-typedef2 = tuple<int-typedef>;
 
-  tuple-arg: func(x: tuple<char, u32>)
+  tuple-arg: func(x: tuple<char, u32>);
 
-  tuple-result: func() -> tuple<char, u32>
+  tuple-result: func() -> tuple<char, u32>;
 
-  single-arg: func(x: single)
+  single-arg: func(x: single);
 
-  single-result: func() -> single
+  single-result: func() -> single;
 
-  scalar-arg: func(x: scalars)
+  scalar-arg: func(x: scalars);
 
-  scalar-result: func() -> scalars
+  scalar-result: func() -> scalars;
 
-  flags-arg: func(x: really-flags)
+  flags-arg: func(x: really-flags);
 
-  flags-result: func() -> really-flags
+  flags-result: func() -> really-flags;
 
-  aggregate-arg: func(x: aggregates)
+  aggregate-arg: func(x: aggregates);
 
-  aggregate-result: func() -> aggregates
+  aggregate-result: func() -> aggregates;
 
-  typedef-inout: func(e: tuple-typedef2) -> s32
+  typedef-inout: func(e: tuple-typedef2) -> s32;
 }
 
 world records-world {
-  import records
+  import records;
 
-  export records
+  export records;
 }

--- a/crates/wit-component/tests/interfaces/reference-out-of-order.wit.print
+++ b/crates/wit-component/tests/interfaces/reference-out-of-order.wit.print
@@ -1,4 +1,4 @@
-package foo:foo
+package foo:foo;
 
 interface foo {
   record r {
@@ -17,15 +17,15 @@ interface foo {
     s(u32),
   }
 
-  a: func(x: r)
+  a: func(x: r);
 
-  b: func(x: v)
+  b: func(x: v);
 
-  c: func(x: r-no-string)
+  c: func(x: r-no-string);
 
-  d: func(x: v-no-string)
+  d: func(x: v-no-string);
 }
 
 world foo-world {
-  import foo
+  import foo;
 }

--- a/crates/wit-component/tests/interfaces/resources.wit.print
+++ b/crates/wit-component/tests/interfaces/resources.wit.print
@@ -1,70 +1,70 @@
-package foo:bar
+package foo:bar;
 
 interface foo {
   resource bar {
-    constructor()
-    a: static func()
-    b: func()
+    constructor();
+    a: static func();
+    b: func();
   }
 
-  type t = bar
+  type t = bar;
 
-  type t2 = own<bar>
+  type t2 = own<bar>;
 
-  a: func(x: bar) -> bar
+  a: func(x: bar) -> bar;
 }
 
 interface baz {
-  use foo.{bar, t}
+  use foo.{bar, t};
 
-  a: func(x: bar) -> bar
+  a: func(x: bar) -> bar;
 
-  b: func() -> t
+  b: func() -> t;
 }
 
 interface implicit-own-handles {
-  resource a
+  resource a;
 
-  b: func(a1: a, a2: a) -> a
+  b: func(a1: a, a2: a) -> a;
 
-  c: func() -> list<a>
+  c: func() -> list<a>;
 }
 
 interface implicit-own-handles2 {
   resource a {
-    constructor(a: list<a>)
+    constructor(a: list<a>);
   }
 
   resource b {
-    constructor(a: list<b>, b: b)
+    constructor(a: list<b>, b: b);
   }
 
   resource c {
-    a: static func(a: c) -> c
+    a: static func(a: c) -> c;
   }
 }
 
 world some-world {
   import anon: interface {
     resource a {
-      constructor()
-      b: static func()
-      c: func()
+      constructor();
+      b: static func();
+      c: func();
     }
   }
-  import foo
-  import baz
-  use baz.{bar}
+  import foo;
+  import baz;
+  use baz.{bar};
 
   resource a {
-    constructor()
+    constructor();
   }
 
-  export x: func() -> a
-  export y: func() -> bar
+  export x: func() -> a;
+  export y: func() -> bar;
 }
 world implicit-own-handles3 {
   resource a {
-    constructor(a: list<a>, b: list<a>)
+    constructor(a: list<a>, b: list<a>);
   }
 }

--- a/crates/wit-component/tests/interfaces/simple-deps/foo.wit.print
+++ b/crates/wit-component/tests/interfaces/simple-deps/foo.wit.print
@@ -1,6 +1,6 @@
-package foo:foo
+package foo:foo;
 
 interface foo {
-  use foo:some-dep/types.{some-type}
+  use foo:some-dep/types.{some-type};
 }
 

--- a/crates/wit-component/tests/interfaces/simple-multi/foo.wit.print
+++ b/crates/wit-component/tests/interfaces/simple-multi/foo.wit.print
@@ -1,4 +1,4 @@
-package foo:foo
+package foo:foo;
 
 interface bar {
 }

--- a/crates/wit-component/tests/interfaces/simple-use.wit.print
+++ b/crates/wit-component/tests/interfaces/simple-use.wit.print
@@ -1,4 +1,4 @@
-package foo:foo
+package foo:foo;
 
 interface types {
   enum level {
@@ -8,8 +8,8 @@ interface types {
 }
 
 interface console {
-  use types.{level}
+  use types.{level};
 
-  log: func(level: level, msg: string)
+  log: func(level: level, msg: string);
 }
 

--- a/crates/wit-component/tests/interfaces/simple-world.wit.print
+++ b/crates/wit-component/tests/interfaces/simple-world.wit.print
@@ -1,9 +1,9 @@
-package foo:foo
+package foo:foo;
 
 interface console {
-  log: func(arg: string)
+  log: func(arg: string);
 }
 
 world the-world {
-  import console
+  import console;
 }

--- a/crates/wit-component/tests/interfaces/single-named-result.wit.print
+++ b/crates/wit-component/tests/interfaces/single-named-result.wit.print
@@ -1,6 +1,6 @@
-package foo:foo
+package foo:foo;
 
 interface foo {
-  a: func() -> (a: u32)
+  a: func() -> (a: u32);
 }
 

--- a/crates/wit-component/tests/interfaces/type-alias.wit.print
+++ b/crates/wit-component/tests/interfaces/type-alias.wit.print
@@ -1,15 +1,15 @@
-package foo:foo
+package foo:foo;
 
 interface foo {
-  type a = u8
+  type a = u8;
 
-  type b = a
+  type b = a;
 
-  f: func(a: a) -> b
+  f: func(a: a) -> b;
 }
 
 world my-world {
-  import foo
+  import foo;
 
-  export foo
+  export foo;
 }

--- a/crates/wit-component/tests/interfaces/type-alias2.wit.print
+++ b/crates/wit-component/tests/interfaces/type-alias2.wit.print
@@ -1,15 +1,15 @@
-package foo:foo
+package foo:foo;
 
 interface foo {
   flags a {
     b,
   }
 
-  type b = a
+  type b = a;
 
-  f: func() -> b
+  f: func() -> b;
 }
 
 world my-world {
-  export foo
+  export foo;
 }

--- a/crates/wit-component/tests/interfaces/upstream-deps-same-name/foo.wit.print
+++ b/crates/wit-component/tests/interfaces/upstream-deps-same-name/foo.wit.print
@@ -1,7 +1,7 @@
-package foo:foo
+package foo:foo;
 
 interface a {
-  use foo:a/the-name.{ty}
-  use foo:b/the-name.{ty as ty2}
+  use foo:a/the-name.{ty};
+  use foo:b/the-name.{ty as ty2};
 }
 

--- a/crates/wit-component/tests/interfaces/use-chain.wit.print
+++ b/crates/wit-component/tests/interfaces/use-chain.wit.print
@@ -1,18 +1,18 @@
-package foo:foo
+package foo:foo;
 
 interface foo {
-  type a = u32
+  type a = u32;
 
-  type b = a
+  type b = a;
 
-  type c = b
+  type c = b;
 }
 
 interface bar {
-  use foo.{c}
+  use foo.{c};
 }
 
 interface baz {
-  use bar.{c}
+  use bar.{c};
 }
 

--- a/crates/wit-component/tests/interfaces/use-for-type.wit.print
+++ b/crates/wit-component/tests/interfaces/use-for-type.wit.print
@@ -1,14 +1,14 @@
-package foo:foo
+package foo:foo;
 
 interface foo {
 }
 
 interface bar {
-  type t = u8
+  type t = u8;
 }
 
 interface baz {
-  use bar.{t}
+  use bar.{t};
 
   record bar {
     a: t,

--- a/crates/wit-component/tests/interfaces/variants.wit.print
+++ b/crates/wit-component/tests/interfaces/variants.wit.print
@@ -1,4 +1,4 @@
-package foo:variants
+package foo:variants;
 
 interface variants {
   enum e1 {
@@ -53,43 +53,43 @@ interface variants {
     bad2,
   }
 
-  e1-arg: func(x: e1)
+  e1-arg: func(x: e1);
 
-  e1-result: func() -> e1
+  e1-result: func() -> e1;
 
-  v1-arg: func(x: v1)
+  v1-arg: func(x: v1);
 
-  v1-result: func() -> v1
+  v1-result: func() -> v1;
 
-  bool-arg: func(x: bool)
+  bool-arg: func(x: bool);
 
-  bool-result: func() -> bool
+  bool-result: func() -> bool;
 
-  option-arg: func(a: option<bool>, b: option<tuple<u32>>, c: option<u32>, d: option<e1>, e: option<float32>, g: option<option<bool>>)
+  option-arg: func(a: option<bool>, b: option<tuple<u32>>, c: option<u32>, d: option<e1>, e: option<float32>, g: option<option<bool>>);
 
-  option-result: func() -> tuple<option<bool>, option<tuple<u32>>, option<u32>, option<e1>, option<float32>, option<option<bool>>>
+  option-result: func() -> tuple<option<bool>, option<tuple<u32>>, option<u32>, option<e1>, option<float32>, option<option<bool>>>;
 
-  casts: func(a: casts1, b: casts2, c: casts3, d: casts4, e: casts5, f: casts6) -> tuple<casts1, casts2, casts3, casts4, casts5, casts6>
+  casts: func(a: casts1, b: casts2, c: casts3, d: casts4, e: casts5, f: casts6) -> tuple<casts1, casts2, casts3, casts4, casts5, casts6>;
 
-  expected-arg: func(a: result, b: result<_, e1>, c: result<e1>, d: result<tuple<u32>, tuple<u32>>, e: result<u32, v1>, f: result<string, list<u8>>)
+  expected-arg: func(a: result, b: result<_, e1>, c: result<e1>, d: result<tuple<u32>, tuple<u32>>, e: result<u32, v1>, f: result<string, list<u8>>);
 
-  expected-result: func() -> tuple<result, result<_, e1>, result<e1>, result<tuple<u32>, tuple<u32>>, result<u32, v1>, result<string, list<u8>>>
+  expected-result: func() -> tuple<result, result<_, e1>, result<e1>, result<tuple<u32>, tuple<u32>>, result<u32, v1>, result<string, list<u8>>>;
 
-  return-expected-sugar: func() -> result<s32, my-errno>
+  return-expected-sugar: func() -> result<s32, my-errno>;
 
-  return-expected-sugar2: func() -> result<_, my-errno>
+  return-expected-sugar2: func() -> result<_, my-errno>;
 
-  return-expected-sugar3: func() -> result<my-errno, my-errno>
+  return-expected-sugar3: func() -> result<my-errno, my-errno>;
 
-  return-expected-sugar4: func() -> result<tuple<s32, u32>, my-errno>
+  return-expected-sugar4: func() -> result<tuple<s32, u32>, my-errno>;
 
-  return-option-sugar: func() -> option<s32>
+  return-option-sugar: func() -> option<s32>;
 
-  return-option-sugar2: func() -> option<my-errno>
+  return-option-sugar2: func() -> option<my-errno>;
 
-  expected-simple: func() -> result<u32, s32>
+  expected-simple: func() -> result<u32, s32>;
 }
 
 world variants-world {
-  import variants
+  import variants;
 }

--- a/crates/wit-component/tests/interfaces/wasi-http/http.wit.print
+++ b/crates/wit-component/tests/interfaces/wasi-http/http.wit.print
@@ -1,8 +1,8 @@
-package wasi:http
+package wasi:http;
 
 interface types {
-  use wasi:io/streams.{input-stream, output-stream}
-  use wasi:poll/poll.{pollable}
+  use wasi:io/streams.{input-stream, output-stream};
+  use wasi:poll/poll.{pollable};
 
   variant method {
     get,
@@ -30,19 +30,19 @@ interface types {
     unexpected-error(string),
   }
 
-  type fields = u32
+  type fields = u32;
 
-  type headers = fields
+  type headers = fields;
 
-  type trailers = fields
+  type trailers = fields;
 
-  type incoming-stream = input-stream
+  type incoming-stream = input-stream;
 
-  type outgoing-stream = output-stream
+  type outgoing-stream = output-stream;
 
-  type incoming-request = u32
+  type incoming-request = u32;
 
-  type outgoing-request = u32
+  type outgoing-request = u32;
 
   record request-options {
     connect-timeout-ms: option<u32>,
@@ -50,102 +50,102 @@ interface types {
     between-bytes-timeout-ms: option<u32>,
   }
 
-  type response-outparam = u32
+  type response-outparam = u32;
 
-  type status-code = u16
+  type status-code = u16;
 
-  type incoming-response = u32
+  type incoming-response = u32;
 
-  type outgoing-response = u32
+  type outgoing-response = u32;
 
-  type future-incoming-response = u32
+  type future-incoming-response = u32;
 
-  drop-fields: func(fields: fields)
+  drop-fields: func(fields: fields);
 
-  new-fields: func(entries: list<tuple<string, string>>) -> fields
+  new-fields: func(entries: list<tuple<string, string>>) -> fields;
 
-  fields-get: func(fields: fields, name: string) -> list<string>
+  fields-get: func(fields: fields, name: string) -> list<string>;
 
-  fields-set: func(fields: fields, name: string, value: list<string>)
+  fields-set: func(fields: fields, name: string, value: list<string>);
 
-  fields-delete: func(fields: fields, name: string)
+  fields-delete: func(fields: fields, name: string);
 
-  fields-append: func(fields: fields, name: string, value: string)
+  fields-append: func(fields: fields, name: string, value: string);
 
-  fields-entries: func(fields: fields) -> list<tuple<string, string>>
+  fields-entries: func(fields: fields) -> list<tuple<string, string>>;
 
-  fields-clone: func(fields: fields) -> fields
+  fields-clone: func(fields: fields) -> fields;
 
-  finish-incoming-stream: func(s: incoming-stream) -> option<trailers>
+  finish-incoming-stream: func(s: incoming-stream) -> option<trailers>;
 
-  finish-outgoing-stream: func(s: outgoing-stream, trailers: option<trailers>)
+  finish-outgoing-stream: func(s: outgoing-stream, trailers: option<trailers>);
 
-  drop-incoming-request: func(request: incoming-request)
+  drop-incoming-request: func(request: incoming-request);
 
-  drop-outgoing-request: func(request: outgoing-request)
+  drop-outgoing-request: func(request: outgoing-request);
 
-  incoming-request-method: func(request: incoming-request) -> method
+  incoming-request-method: func(request: incoming-request) -> method;
 
-  incoming-request-path: func(request: incoming-request) -> string
+  incoming-request-path: func(request: incoming-request) -> string;
 
-  incoming-request-query: func(request: incoming-request) -> string
+  incoming-request-query: func(request: incoming-request) -> string;
 
-  incoming-request-scheme: func(request: incoming-request) -> option<scheme>
+  incoming-request-scheme: func(request: incoming-request) -> option<scheme>;
 
-  incoming-request-authority: func(request: incoming-request) -> string
+  incoming-request-authority: func(request: incoming-request) -> string;
 
-  incoming-request-headers: func(request: incoming-request) -> headers
+  incoming-request-headers: func(request: incoming-request) -> headers;
 
-  incoming-request-consume: func(request: incoming-request) -> result<incoming-stream>
+  incoming-request-consume: func(request: incoming-request) -> result<incoming-stream>;
 
-  new-outgoing-request: func(method: method, path: string, query: string, scheme: option<scheme>, authority: string, headers: headers) -> outgoing-request
+  new-outgoing-request: func(method: method, path: string, query: string, scheme: option<scheme>, authority: string, headers: headers) -> outgoing-request;
 
-  outgoing-request-write: func(request: outgoing-request) -> result<outgoing-stream>
+  outgoing-request-write: func(request: outgoing-request) -> result<outgoing-stream>;
 
-  drop-response-outparam: func(response: response-outparam)
+  drop-response-outparam: func(response: response-outparam);
 
-  set-response-outparam: func(param: response-outparam, response: result<outgoing-response, error>) -> result
+  set-response-outparam: func(param: response-outparam, response: result<outgoing-response, error>) -> result;
 
-  drop-incoming-response: func(response: incoming-response)
+  drop-incoming-response: func(response: incoming-response);
 
-  drop-outgoing-response: func(response: outgoing-response)
+  drop-outgoing-response: func(response: outgoing-response);
 
-  incoming-response-status: func(response: incoming-response) -> status-code
+  incoming-response-status: func(response: incoming-response) -> status-code;
 
-  incoming-response-headers: func(response: incoming-response) -> headers
+  incoming-response-headers: func(response: incoming-response) -> headers;
 
-  incoming-response-consume: func(response: incoming-response) -> result<incoming-stream>
+  incoming-response-consume: func(response: incoming-response) -> result<incoming-stream>;
 
-  new-outgoing-response: func(status-code: status-code, headers: headers) -> outgoing-response
+  new-outgoing-response: func(status-code: status-code, headers: headers) -> outgoing-response;
 
-  outgoing-response-write: func(response: outgoing-response) -> result<outgoing-stream>
+  outgoing-response-write: func(response: outgoing-response) -> result<outgoing-stream>;
 
-  drop-future-incoming-response: func(f: future-incoming-response)
+  drop-future-incoming-response: func(f: future-incoming-response);
 
-  future-incoming-response-get: func(f: future-incoming-response) -> option<result<incoming-response, error>>
+  future-incoming-response-get: func(f: future-incoming-response) -> option<result<incoming-response, error>>;
 
-  listen-to-future-incoming-response: func(f: future-incoming-response) -> pollable
+  listen-to-future-incoming-response: func(f: future-incoming-response) -> pollable;
 }
 
 interface incoming-handler {
-  use types.{incoming-request, response-outparam}
+  use types.{incoming-request, response-outparam};
 
-  handle: func(request: incoming-request, response-out: response-outparam)
+  handle: func(request: incoming-request, response-out: response-outparam);
 }
 
 interface outgoing-handler {
-  use types.{outgoing-request, request-options, future-incoming-response}
+  use types.{outgoing-request, request-options, future-incoming-response};
 
-  handle: func(request: outgoing-request, options: option<request-options>) -> future-incoming-response
+  handle: func(request: outgoing-request, options: option<request-options>) -> future-incoming-response;
 }
 
 world proxy {
-  import wasi:random/random
-  import wasi:logging/handler
-  import wasi:poll/poll
-  import wasi:io/streams
-  import types
-  import outgoing-handler
+  import wasi:random/random;
+  import wasi:logging/handler;
+  import wasi:poll/poll;
+  import wasi:io/streams;
+  import types;
+  import outgoing-handler;
 
-  export incoming-handler
+  export incoming-handler;
 }

--- a/crates/wit-component/tests/interfaces/world-inline-interface.wit.print
+++ b/crates/wit-component/tests/interfaces/world-inline-interface.wit.print
@@ -1,4 +1,4 @@
-package foo:foo
+package foo:foo;
 
 world has-inline {
   import foo: interface {

--- a/crates/wit-component/tests/interfaces/world-pkg-conflict/foo.wit.print
+++ b/crates/wit-component/tests/interfaces/world-pkg-conflict/foo.wit.print
@@ -1,11 +1,11 @@
-package foo:foo
+package foo:foo;
 
 interface a {
-  type t = u32
+  type t = u32;
 }
 
 interface foo {
-  use a.{t}
+  use a.{t};
 }
 
 world c {

--- a/crates/wit-component/tests/interfaces/world-top-level.wit.print
+++ b/crates/wit-component/tests/interfaces/world-top-level.wit.print
@@ -1,19 +1,19 @@
-package foo:foo
+package foo:foo;
 
 world foo {
   import some-interface: interface {
   }
-  import foo: func()
-  import bar: func(arg: u32)
+  import foo: func();
+  import bar: func(arg: u32);
 
-  export foo2: func()
-  export bar2: func() -> u32
+  export foo2: func();
+  export bar2: func() -> u32;
   export another-interface: interface {
   }
 }
 world just-import {
-  import foo: func()
+  import foo: func();
 }
 world just-export {
-  export foo: func()
+  export foo: func();
 }

--- a/crates/wit-component/tests/interfaces/worlds-with-types.wit.print
+++ b/crates/wit-component/tests/interfaces/worlds-with-types.wit.print
@@ -1,24 +1,24 @@
-package foo:foo
+package foo:foo;
 
 interface import-me {
-  type foo = u32
+  type foo = u32;
 }
 
 world simple {
-  import a: func(a: foo) -> bar
+  import a: func(a: foo) -> bar;
 
   record foo {
     f: u8,
   }
 
-  type bar = foo
+  type bar = foo;
 
-  export b: func(a: foo) -> bar
+  export b: func(a: foo) -> bar;
 }
 world with-imports {
-  import import-me
-  import a: func(a: foo)
-  use import-me.{foo}
+  import import-me;
+  import a: func(a: foo);
+  use import-me.{foo};
 
-  export b: func(a: foo)
+  export b: func(a: foo);
 }

--- a/crates/wit-component/tests/merge/success/merge/foo.wit
+++ b/crates/wit-component/tests/merge/success/merge/foo.wit
@@ -1,10 +1,10 @@
-package foo:foo
+package foo:foo;
 
 interface only-into {
   record r {
   }
 
-  foo: func() -> r
+  foo: func() -> r;
 }
 
 interface shared-only-into {
@@ -12,36 +12,36 @@ interface shared-only-into {
     c1,
   }
 
-  bar: func(x: v)
+  bar: func(x: v);
 }
 
 interface shared-items {
-  type a = u32
+  type a = u32;
 }
 
 interface only-from {
   record r {
   }
 
-  foo: func() -> r
+  foo: func() -> r;
 }
 
 interface shared-only-from {
-  use foo:only-from-dep/a.{a}
+  use foo:only-from-dep/a.{a};
 
   variant v {
     c1,
   }
 
-  bar: func(x: v)
+  bar: func(x: v);
 }
 
 world shared-world {
-  import shared-items
+  import shared-items;
   import d: interface {
   }
 
-  type c = u32
+  type c = u32;
 
-  export shared-items
+  export shared-items;
 }

--- a/crates/wit-component/tests/merge/success/merge/from.wit
+++ b/crates/wit-component/tests/merge/success/merge/from.wit
@@ -1,8 +1,8 @@
-package foo:%from
+package foo:%from;
 
 interface a {
-  use foo:foo/only-from.{r}
+  use foo:foo/only-from.{r};
 
-  foo: func()
+  foo: func();
 }
 

--- a/crates/wit-component/tests/merge/success/merge/into.wit
+++ b/crates/wit-component/tests/merge/success/merge/into.wit
@@ -1,8 +1,8 @@
-package foo:into
+package foo:into;
 
 interface b {
-  use foo:foo/only-into.{r}
+  use foo:foo/only-into.{r};
 
-  foo: func()
+  foo: func();
 }
 

--- a/crates/wit-component/tests/merge/success/merge/only-from-dep.wit
+++ b/crates/wit-component/tests/merge/success/merge/only-from-dep.wit
@@ -1,6 +1,6 @@
-package foo:only-from-dep
+package foo:only-from-dep;
 
 interface a {
-  type a = u32
+  type a = u32;
 }
 

--- a/crates/wit-parser/src/ast/lex.rs
+++ b/crates/wit-parser/src/ast/lex.rs
@@ -117,7 +117,7 @@ pub enum Error {
 }
 
 // NB: keep in sync with `crates/wit-component/src/printing.rs`.
-const REQUIRE_SEMICOLONS_BY_DEFAULT: bool = false;
+const REQUIRE_SEMICOLONS_BY_DEFAULT: bool = true;
 
 impl<'a> Tokenizer<'a> {
     pub fn new(

--- a/crates/wit-parser/src/resolve.rs
+++ b/crates/wit-parser/src/resolve.rs
@@ -1818,7 +1818,7 @@ mod tests {
         parse_into(
             &mut resolve,
             r#"
-                package foo:bar@0.1.0
+                package foo:bar@0.1.0;
 
                 world foo {}
             "#,
@@ -1826,7 +1826,7 @@ mod tests {
         parse_into(
             &mut resolve,
             r#"
-                package foo:baz@0.1.0
+                package foo:baz@0.1.0;
 
                 world foo {}
             "#,
@@ -1834,7 +1834,7 @@ mod tests {
         parse_into(
             &mut resolve,
             r#"
-                package foo:baz@0.2.0
+                package foo:baz@0.2.0;
 
                 world foo {}
             "#,
@@ -1843,7 +1843,7 @@ mod tests {
         let dummy = parse_into(
             &mut resolve,
             r#"
-                package foo:dummy
+                package foo:dummy;
 
                 world foo {}
             "#,

--- a/tests/cli/print-core-wasm-wit.wit.stdout
+++ b/tests/cli/print-core-wasm-wit.wit.stdout
@@ -1,5 +1,5 @@
-package root:root
+package root:root;
 
 world root {
-  import foo:foo/my-interface
+  import foo:foo/my-interface;
 }


### PR DESCRIPTION
This commit updates tooling to require semicolons and print semicolons by default in WIT files. This is the next step of this rollout plan now that a month or so has passed since the original change. Tooling still supports optionally not parsing or printing semicolons, as configured with `WIT_REQUIRE_SEMICOLONS=0`. If this continues to be smooth the next step will be to remove support for no-semicolons in the future.