### PR TITLE
Fix some issues with future encodings

### DIFF
--- a/crates/wit-component/src/encoding/wit/mod.rs
+++ b/crates/wit-component/src/encoding/wit/mod.rs
@@ -33,11 +33,9 @@ fn use_v2_encoding() -> bool {
 /// The binary returned can be [`decode`d](crate::decode) to recover the WIT
 /// package provided.
 pub fn encode(use_v2: Option<bool>, resolve: &Resolve, package: PackageId) -> Result<Vec<u8>> {
-    if use_v2.unwrap_or_else(use_v2_encoding) {
-        v2::encode(resolve, package)
-    } else {
-        v1::encode(resolve, package)
-    }
+    let mut component = encode_component(use_v2, resolve, package)?;
+    component.raw_custom_section(&crate::base_producers().raw_custom_section());
+    Ok(component.finish())
 }
 
 /// Exactly like `encode`, except gives an unfinished `ComponentBuilder` in case you need
@@ -55,14 +53,6 @@ pub fn encode_component(
 }
 
 /// Encodes a `world` as a component type.
-pub fn encode_world(
-    use_v2: Option<bool>,
-    resolve: &Resolve,
-    world_id: WorldId,
-) -> Result<ComponentType> {
-    if use_v2.unwrap_or_else(use_v2_encoding) {
-        v2::encode_world(resolve, world_id)
-    } else {
-        v1::encode_world(resolve, world_id)
-    }
+pub fn encode_world(resolve: &Resolve, world_id: WorldId) -> Result<ComponentType> {
+    v1::encode_world(resolve, world_id)
 }

--- a/crates/wit-component/src/encoding/wit/v1.rs
+++ b/crates/wit-component/src/encoding/wit/v1.rs
@@ -27,14 +27,6 @@ use wit_parser::*;
 ///
 /// The binary returned can be [`decode`d](crate::decode) to recover the WIT
 /// package provided.
-pub fn encode(resolve: &Resolve, package: PackageId) -> Result<Vec<u8>> {
-    let mut component = encode_component(resolve, package)?;
-    component.raw_custom_section(&crate::base_producers().raw_custom_section());
-    Ok(component.finish())
-}
-
-/// Exactly like `encode`, except gives an unfinished `ComponentBuilder` in case you need
-/// to append anything else before finishing.
 pub fn encode_component(resolve: &Resolve, package: PackageId) -> Result<ComponentBuilder> {
     let mut encoder = Encoder {
         component: ComponentBuilder::default(),

--- a/crates/wit-component/src/targets.rs
+++ b/crates/wit-component/src/targets.rs
@@ -16,7 +16,7 @@ pub fn targets(resolve: &Resolve, world: WorldId, component_to_test: &[u8]) -> R
     // (2) Encode the world to a component type and embed a new component which
     // imports the encoded component type.
     let test_component_idx = {
-        let component_ty = encode_world(None, resolve, world)?;
+        let component_ty = encode_world(resolve, world)?;
         let mut component = ComponentBuilder::default();
         let component_ty_idx = component.type_component(&component_ty);
         component.import(


### PR DESCRIPTION
Currently there's a few encoding changes in-flight in wasm-tools. Two relevant ones here are:

* How WIT packages are encoded (`WIT_COMPONENT_ENCODING_V2`, #1252)
* How type information is embedded in core wasm files (`WIT_COMPONENT_NEW_ENCODE`, #1260)

Currently these don't end up playing well together. If the new WIT package encoding is used then it breaks when combined with the new metadata encoding. This commit seeks to rectify this situation. Currently this wasn't previously tested on CI due to this particular combination of flags not being on in the tests.

The fixes here largely amount to refactoring to delete some duplicated code. Previously the v1/v2 split introduced an `encode_world` that was defined in both modules, but the output was different for both modules and only one would work when fed to decoding. This commit removes this split and leaves only one canonical `encode_world` function since it should be the same for both as well.

This then additionally updates `WIT_COMPONENT_NEW_ENCODE=1` to preserve a lookalike format of a WIT package. Furthermore `decode_world` is updated to expect this structure as well. The intention is that the encoded metadata is as-if there was a single world in a WIT package.

These refactorings fix the prior buggy behavior between the two new encodings. Note that this was only exposed through `WIT_COMPONENT_NEW_ENCODE=1` which was only very recently added. Previous builds using only `WIT_COMPONENT_ENCODING_V2=1` should continue to work fine and produce the same output as before.