### PR TITLE
Enable new WIT encoding by default

### DIFF
--- a/crates/wit-component/src/encoding/wit/mod.rs
+++ b/crates/wit-component/src/encoding/wit/mod.rs
@@ -5,7 +5,7 @@ use wit_parser::{PackageId, Resolve, WorldId};
 mod v1;
 mod v2;
 
-const ENCODE_V2_BY_DEFAULT: bool = false;
+const ENCODE_V2_BY_DEFAULT: bool = true;
 
 fn use_v2_encoding() -> bool {
     match std::env::var("WIT_COMPONENT_ENCODING_V2") {


### PR DESCRIPTION
This commit enables the new encoding for WIT packages in WebAssembly components described in WebAssembly/component-model#248 and originally implemented in #1252. Support for the new encoding has been in a wasm-tools for a bit and it's also released with Wasmtime 14. This switch means that infrastructure will start being exposed to it by default now. Support for the old encoding remains to assist with interop as well. In a release or two support for creating the old encoding will be removed.