### PR TITLE
wasm-encoder: adds reference instructions from GC MVP

### DIFF
--- a/crates/wasm-encoder/src/core/code.rs
+++ b/crates/wasm-encoder/src/core/code.rs
@@ -1,4 +1,4 @@
-use crate::{encode_section, Encode, HeapType, Section, SectionId, ValType};
+use crate::{encode_section, Encode, HeapType, RefType, Section, SectionId, ValType};
 use std::borrow::Cow;
 
 /// An encoder for the code section.
@@ -523,6 +523,33 @@ pub enum Instruction<'a> {
     RefAsNonNull,
 
     // GC types instructions.
+    StructNew(u32),
+    StructNewDefault(u32),
+    StructGet(u32, u32),
+    StructGetS(u32, u32),
+    StructGetU(u32, u32),
+    StructSet(u32, u32),
+
+    ArrayNew(u32),
+    ArrayNewDefault(u32),
+    ArrayNewFixed(u32, u32),
+    ArrayNewData(u32, u32),
+    ArrayNewElem(u32, u32),
+    ArrayGet(u32),
+    ArrayGetS(u32),
+    ArrayGetU(u32),
+    ArraySet(u32),
+    ArrayLen,
+    ArrayFill(u32),
+    ArrayCopy(u32),
+    ArrayInitData(u32, u32),
+    ArrayInitElem(u32, u32),
+
+    RefTest(RefType),
+    RefCast(RefType),
+    AnyConvertExtern,
+    ExternConvertAny,
+
     RefI31,
     I31GetS,
     I31GetU,
@@ -1321,6 +1348,155 @@ impl Encode for Instruction<'_> {
             Instruction::RefAsNonNull => sink.push(0xd4),
 
             // GC instructions.
+            Instruction::StructNew(type_index) => {
+                sink.push(0xfb);
+                sink.push(0x00);
+                type_index.encode(sink)
+            }
+            Instruction::StructNewDefault(type_index) => {
+                sink.push(0xfb);
+                sink.push(0x01);
+                type_index.encode(sink)
+            }
+            Instruction::StructGet(type_index, field_index) => {
+                sink.push(0xfb);
+                sink.push(0x02);
+                type_index.encode(sink);
+                field_index.encode(sink)
+            }
+            Instruction::StructGetS(type_index, field_index) => {
+                sink.push(0xfb);
+                sink.push(0x03);
+                type_index.encode(sink);
+                field_index.encode(sink)
+            }
+            Instruction::StructGetU(type_index, field_index) => {
+                sink.push(0xfb);
+                sink.push(0x04);
+                type_index.encode(sink);
+                field_index.encode(sink)
+            }
+            Instruction::StructSet(type_index, field_index) => {
+                sink.push(0xfb);
+                sink.push(0x05);
+                type_index.encode(sink);
+                field_index.encode(sink)
+            }
+
+            Instruction::ArrayNew(type_index) => {
+                sink.push(0xfb);
+                sink.push(0x06);
+                type_index.encode(sink)
+            }
+            Instruction::ArrayNewDefault(type_index) => {
+                sink.push(0xfb);
+                sink.push(0x07);
+                type_index.encode(sink)
+            }
+            Instruction::ArrayNewFixed(type_index, size) => {
+                sink.push(0xfb);
+                sink.push(0x08);
+                type_index.encode(sink);
+                size.encode(sink)
+            }
+            Instruction::ArrayNewData(type_index, data_index) => {
+                sink.push(0xfb);
+                sink.push(0x09);
+                type_index.encode(sink);
+                data_index.encode(sink)
+            }
+            Instruction::ArrayNewElem(type_index, elem_index) => {
+                sink.push(0xfb);
+                sink.push(0x0a);
+                type_index.encode(sink);
+                elem_index.encode(sink)
+            }
+            Instruction::ArrayGet(type_index) => {
+                sink.push(0xfb);
+                sink.push(0x0b);
+                type_index.encode(sink)
+            }
+            Instruction::ArrayGetS(type_index) => {
+                sink.push(0xfb);
+                sink.push(0x0c);
+                type_index.encode(sink)
+            }
+            Instruction::ArrayGetU(type_index) => {
+                sink.push(0xfb);
+                sink.push(0x0d);
+                type_index.encode(sink)
+            }
+            Instruction::ArraySet(type_index) => {
+                sink.push(0xfb);
+                sink.push(0x0e);
+                type_index.encode(sink)
+            }
+            Instruction::ArrayLen => {
+                sink.push(0xfb);
+                sink.push(0x0f)
+            }
+            Instruction::ArrayFill(type_index) => {
+                sink.push(0xfb);
+                sink.push(0x10);
+                type_index.encode(sink)
+            }
+            Instruction::ArrayCopy(type_index) => {
+                sink.push(0xfb);
+                sink.push(0x11);
+                type_index.encode(sink)
+            }
+            Instruction::ArrayInitData(type_index, data_index) => {
+                sink.push(0xfb);
+                sink.push(0x12);
+                type_index.encode(sink);
+                data_index.encode(sink)
+            }
+            Instruction::ArrayInitElem(type_index, elem_index) => {
+                sink.push(0xfb);
+                sink.push(0x13);
+                type_index.encode(sink);
+                elem_index.encode(sink)
+            }
+            Instruction::RefTest(RefType {
+                nullable: false,
+                heap_type,
+            }) => {
+                sink.push(0xfb);
+                sink.push(0x14);
+                heap_type.encode(sink)
+            }
+            Instruction::RefTest(RefType {
+                nullable: true,
+                heap_type,
+            }) => {
+                sink.push(0xfb);
+                sink.push(0x15);
+                heap_type.encode(sink)
+            }
+            Instruction::RefCast(RefType {
+                nullable: false,
+                heap_type,
+            }) => {
+                sink.push(0xfb);
+                sink.push(0x16);
+                heap_type.encode(sink)
+            }
+            Instruction::RefCast(RefType {
+                nullable: true,
+                heap_type,
+            }) => {
+                sink.push(0xfb);
+                sink.push(0x17);
+                heap_type.encode(sink)
+            }
+            Instruction::AnyConvertExtern => {
+                sink.push(0xfb);
+                sink.push(0x1a)
+            }
+            Instruction::ExternConvertAny => {
+                sink.push(0xfb);
+                sink.push(0x1b)
+            }
             Instruction::RefI31 => {
                 sink.push(0xfb);
                 sink.push(0x1c)


### PR DESCRIPTION
Fixes #1283 

I had a look and it was easy enough to add these instructions, so I just went ahead and did it. Feel free to just close this PR if you've already done this work as part of another PR.

Reference: https://webassembly.github.io/gc/core/binary/instructions.html#reference-instructions