### PR TITLE
Fix failing assertion in compose encoding

### DIFF
--- a/crates/wasm-compose/src/encoding.rs
+++ b/crates/wasm-compose/src/encoding.rs
@@ -880,10 +880,7 @@ impl<'a> TypeEncoder<'a> {
             let prev = state.cur.type_defs.insert(key, value);
             // Resource aliases will already have been added to the table, but
             // other types should not have been:
-            assert!(
-                prev.is_none()
-                    || (matches!(id, ComponentAnyTypeId::Resource(_)) && prev == Some(value))
-            );
+            assert!(prev.is_none() || matches!(id, ComponentAnyTypeId::Resource(_)));
             state.cur.add_type_export(key, name);
         }
         export


### PR DESCRIPTION
This assertion was expanded while addressing the final feedback in the PR to [Implement Resources in Compose](https://github.com/bytecodealliance/wasm-tools/pull/1261).

Currently, with the expanded assertion, when composing a component that exports `wasi:http/incoming-handler` with another that imports it, the assertion fails with:

`thread 'main' panicked at 'assertion failed: prev.is_none() ||\n  (matches!(id, ComponentAnyTypeId :: Resource(_)) && prev == Some(value))`

And specifically the condition that fails `prev == Some(value)` where, in this particular instance, `prev=Some(5)` != `value=6`.

I'm not entirely sure of the "why" here but have confirmed that reverting to the old assertion seems to "correct" this.