### PR TITLE
Enable the `gc/global.wast` spec test

### DIFF
--- a/crates/wasmparser/src/readers/core/elements.rs
+++ b/crates/wasmparser/src/readers/core/elements.rs
@@ -20,7 +20,7 @@ use crate::{
 use std::ops::Range;
 
 /// Represents a core WebAssembly element segment.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Element<'a> {
     /// The kind of the element segment.
     pub kind: ElementKind<'a>,
@@ -31,7 +31,7 @@ pub struct Element<'a> {
 }
 
 /// The kind of element segment.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum ElementKind<'a> {
     /// The element segment is passive.
     Passive,
@@ -47,7 +47,7 @@ pub enum ElementKind<'a> {
 }
 
 /// Represents the items of an element segment.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum ElementItems<'a> {
     /// This element contains function indices.
     Functions(SectionLimited<'a, u32>),

--- a/crates/wasmparser/src/readers/core/init.rs
+++ b/crates/wasmparser/src/readers/core/init.rs
@@ -37,6 +37,13 @@ impl<'a> ConstExpr<'a> {
     pub fn get_operators_reader(&self) -> OperatorsReader<'a> {
         OperatorsReader::new(self.get_binary_reader())
     }
+
+    pub(crate) fn to_owned(&self) -> OwnedConstExpr {
+        OwnedConstExpr {
+            offset: self.offset,
+            data: self.data.to_vec(),
+        }
+    }
 }
 
 impl<'a> FromReader<'a> for ConstExpr<'a> {
@@ -47,5 +54,19 @@ impl<'a> FromReader<'a> for ConstExpr<'a> {
             reader.remaining_buffer(),
             reader.original_position(),
         ))
+    }
+}
+
+pub(crate) struct OwnedConstExpr {
+    offset: usize,
+    data: Vec<u8>,
+}
+
+impl OwnedConstExpr {
+    pub(crate) fn as_const_expr(&self) -> ConstExpr<'_> {
+        ConstExpr {
+            offset: self.offset,
+            data: &self.data,
+        }
     }
 }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -180,7 +180,6 @@ fn skip_validation(test: &Path) -> bool {
         "/proposals/gc/br_on_cast.wast",
         "/proposals/gc/br_on_cast_fail.wast",
         "/proposals/gc/extern.wast",
-        "/proposals/gc/global.wast",
         "/proposals/gc/ref_cast.wast",
         "/proposals/gc/ref_eq.wast",
         "/proposals/gc/ref_test.wast",

--- a/tests/snapshots/testsuite/proposals/gc/global.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/gc/global.wast/0.print
@@ -1,0 +1,328 @@
+(module
+  (type $check (;0;) (func (param i32 i32) (result i32)))
+  (type (;1;) (func (result i32)))
+  (type (;2;) (func (result i64)))
+  (type (;3;) (func (result externref)))
+  (type (;4;) (func (param i32)))
+  (type (;5;) (func (param i64)))
+  (type (;6;) (func (param externref)))
+  (type (;7;) (func (result f32)))
+  (type (;8;) (func (result f64)))
+  (type (;9;) (func (param f32)))
+  (type (;10;) (func (param f64)))
+  (type (;11;) (func))
+  (type (;12;) (func (param i32) (result i32)))
+  (import "spectest" "global_i32" (global (;0;) i32))
+  (import "spectest" "global_i64" (global (;1;) i64))
+  (func (;0;) (type 1) (result i32)
+    global.get $a
+  )
+  (func (;1;) (type 2) (result i64)
+    global.get $b
+  )
+  (func (;2;) (type 3) (result externref)
+    global.get $r
+  )
+  (func (;3;) (type 3) (result externref)
+    global.get $mr
+  )
+  (func (;4;) (type 1) (result i32)
+    global.get $x
+  )
+  (func (;5;) (type 2) (result i64)
+    global.get $y
+  )
+  (func (;6;) (type 1) (result i32)
+    global.get $z1
+  )
+  (func (;7;) (type 2) (result i64)
+    global.get $z2
+  )
+  (func (;8;) (type 4) (param i32)
+    local.get 0
+    global.set $x
+  )
+  (func (;9;) (type 5) (param i64)
+    local.get 0
+    global.set $y
+  )
+  (func (;10;) (type 6) (param externref)
+    local.get 0
+    global.set $mr
+  )
+  (func (;11;) (type 7) (result f32)
+    global.get 3
+  )
+  (func (;12;) (type 8) (result f64)
+    global.get 4
+  )
+  (func (;13;) (type 7) (result f32)
+    global.get 7
+  )
+  (func (;14;) (type 8) (result f64)
+    global.get 8
+  )
+  (func (;15;) (type 9) (param f32)
+    local.get 0
+    global.set 7
+  )
+  (func (;16;) (type 10) (param f64)
+    local.get 0
+    global.set 8
+  )
+  (func $dummy (;17;) (type 11))
+  (func (;18;) (type 1) (result i32)
+    global.get $x
+    i32.const 2
+    i32.const 3
+    select
+  )
+  (func (;19;) (type 1) (result i32)
+    i32.const 2
+    global.get $x
+    i32.const 3
+    select
+  )
+  (func (;20;) (type 1) (result i32)
+    i32.const 2
+    i32.const 3
+    global.get $x
+    select
+  )
+  (func (;21;) (type 1) (result i32)
+    loop (result i32) ;; label = @1
+      global.get $x
+      call $dummy
+      call $dummy
+    end
+  )
+  (func (;22;) (type 1) (result i32)
+    loop (result i32) ;; label = @1
+      call $dummy
+      global.get $x
+      call $dummy
+    end
+  )
+  (func (;23;) (type 1) (result i32)
+    loop (result i32) ;; label = @1
+      call $dummy
+      call $dummy
+      global.get $x
+    end
+  )
+  (func (;24;) (type 1) (result i32)
+    global.get $x
+    if (result i32) ;; label = @1
+      call $dummy
+      i32.const 2
+    else
+      call $dummy
+      i32.const 3
+    end
+  )
+  (func (;25;) (type 1) (result i32)
+    i32.const 1
+    if (result i32) ;; label = @1
+      global.get $x
+    else
+      i32.const 2
+    end
+  )
+  (func (;26;) (type 1) (result i32)
+    i32.const 0
+    if (result i32) ;; label = @1
+      i32.const 2
+    else
+      global.get $x
+    end
+  )
+  (func (;27;) (type 1) (result i32)
+    block (result i32) ;; label = @1
+      global.get $x
+      i32.const 2
+      br_if 0 (;@1;)
+      i32.const 3
+      return
+    end
+  )
+  (func (;28;) (type 1) (result i32)
+    block (result i32) ;; label = @1
+      i32.const 2
+      global.get $x
+      br_if 0 (;@1;)
+      i32.const 3
+      return
+    end
+  )
+  (func (;29;) (type 1) (result i32)
+    block (result i32) ;; label = @1
+      global.get $x
+      i32.const 2
+      br_table 0 (;@1;) 0 (;@1;)
+    end
+  )
+  (func (;30;) (type 1) (result i32)
+    block (result i32) ;; label = @1
+      i32.const 2
+      global.get $x
+      br_table 0 (;@1;) 0 (;@1;)
+    end
+  )
+  (func $func (;31;) (type $check) (param i32 i32) (result i32)
+    local.get 0
+  )
+  (func (;32;) (type 1) (result i32)
+    block (result i32) ;; label = @1
+      global.get $x
+      i32.const 2
+      i32.const 0
+      call_indirect (type $check)
+    end
+  )
+  (func (;33;) (type 1) (result i32)
+    block (result i32) ;; label = @1
+      i32.const 2
+      global.get $x
+      i32.const 0
+      call_indirect (type $check)
+    end
+  )
+  (func (;34;) (type 1) (result i32)
+    block (result i32) ;; label = @1
+      i32.const 2
+      i32.const 0
+      global.get $x
+      call_indirect (type $check)
+    end
+  )
+  (func (;35;) (type 11)
+    global.get $x
+    i32.const 1
+    i32.store
+  )
+  (func (;36;) (type 11)
+    i32.const 0
+    global.get $x
+    i32.store
+  )
+  (func (;37;) (type 1) (result i32)
+    global.get $x
+    i32.load
+  )
+  (func (;38;) (type 1) (result i32)
+    global.get $x
+    memory.grow
+  )
+  (func $f (;39;) (type 12) (param i32) (result i32)
+    local.get 0
+  )
+  (func (;40;) (type 1) (result i32)
+    global.get $x
+    call $f
+  )
+  (func (;41;) (type 1) (result i32)
+    global.get $x
+    return
+  )
+  (func (;42;) (type 11)
+    global.get $x
+    drop
+  )
+  (func (;43;) (type 1) (result i32)
+    block (result i32) ;; label = @1
+      global.get $x
+      br 0 (;@1;)
+    end
+  )
+  (func (;44;) (type 12) (param i32) (result i32)
+    global.get $x
+    local.set 0
+    local.get 0
+  )
+  (func (;45;) (type 12) (param i32) (result i32)
+    global.get $x
+    local.tee 0
+  )
+  (func (;46;) (type 1) (result i32)
+    global.get $x
+    global.set $x
+    global.get $x
+  )
+  (func (;47;) (type 1) (result i32)
+    global.get $x
+    i32.eqz
+  )
+  (func (;48;) (type 1) (result i32)
+    global.get $x
+    global.get $x
+    i32.mul
+  )
+  (func (;49;) (type 1) (result i32)
+    global.get 0
+    i32.const 1
+    i32.gt_u
+  )
+  (table (;0;) 1 1 funcref)
+  (memory (;0;) 1)
+  (global $a (;2;) i32 i32.const -2)
+  (global (;3;) f32 f32.const -0x1.8p+1 (;=-3;))
+  (global (;4;) f64 f64.const -0x1p+2 (;=-4;))
+  (global $b (;5;) i64 i64.const -5)
+  (global $x (;6;) (mut i32) i32.const -12)
+  (global (;7;) (mut f32) f32.const -0x1.ap+3 (;=-13;))
+  (global (;8;) (mut f64) f64.const -0x1.cp+3 (;=-14;))
+  (global $y (;9;) (mut i64) i64.const -15)
+  (global $z1 (;10;) i32 global.get 0)
+  (global $z2 (;11;) i64 global.get 1)
+  (global $r (;12;) externref ref.null extern)
+  (global $mr (;13;) (mut externref) ref.null extern)
+  (global (;14;) funcref ref.null func)
+  (export "get-a" (func 0))
+  (export "get-b" (func 1))
+  (export "get-r" (func 2))
+  (export "get-mr" (func 3))
+  (export "get-x" (func 4))
+  (export "get-y" (func 5))
+  (export "get-z1" (func 6))
+  (export "get-z2" (func 7))
+  (export "set-x" (func 8))
+  (export "set-y" (func 9))
+  (export "set-mr" (func 10))
+  (export "get-3" (func 11))
+  (export "get-4" (func 12))
+  (export "get-7" (func 13))
+  (export "get-8" (func 14))
+  (export "set-7" (func 15))
+  (export "set-8" (func 16))
+  (export "as-select-first" (func 18))
+  (export "as-select-mid" (func 19))
+  (export "as-select-last" (func 20))
+  (export "as-loop-first" (func 21))
+  (export "as-loop-mid" (func 22))
+  (export "as-loop-last" (func 23))
+  (export "as-if-condition" (func 24))
+  (export "as-if-then" (func 25))
+  (export "as-if-else" (func 26))
+  (export "as-br_if-first" (func 27))
+  (export "as-br_if-last" (func 28))
+  (export "as-br_table-first" (func 29))
+  (export "as-br_table-last" (func 30))
+  (export "as-call_indirect-first" (func 32))
+  (export "as-call_indirect-mid" (func 33))
+  (export "as-call_indirect-last" (func 34))
+  (export "as-store-first" (func 35))
+  (export "as-store-last" (func 36))
+  (export "as-load-operand" (func 37))
+  (export "as-memory.grow-value" (func 38))
+  (export "as-call-value" (func 40))
+  (export "as-return-value" (func 41))
+  (export "as-drop-operand" (func 42))
+  (export "as-br-value" (func 43))
+  (export "as-local.set-value" (func 44))
+  (export "as-local.tee-value" (func 45))
+  (export "as-global.set-value" (func 46))
+  (export "as-unary-operand" (func 47))
+  (export "as-binary-operand" (func 48))
+  (export "as-compare-operand" (func 49))
+  (elem (;0;) (i32.const 0) func $func)
+)

--- a/tests/snapshots/testsuite/proposals/gc/global.wast/107.print
+++ b/tests/snapshots/testsuite/proposals/gc/global.wast/107.print
@@ -1,0 +1,4 @@
+(module
+  (global (;0;) i32 i32.const 4)
+  (export "g" (global 0))
+)

--- a/tests/snapshots/testsuite/proposals/gc/global.wast/109.print
+++ b/tests/snapshots/testsuite/proposals/gc/global.wast/109.print
@@ -1,0 +1,28 @@
+(module
+  (type (;0;) (func))
+  (type (;1;) (func (param i32) (result funcref)))
+  (type (;2;) (func (param i32) (result i32)))
+  (import "G" "g" (global $g0 (;0;) i32))
+  (func $f (;0;) (type 0))
+  (func (;1;) (type 1) (param $i i32) (result funcref)
+    local.get $i
+    table.get $t
+  )
+  (func (;2;) (type 2) (param $i i32) (result i32)
+    local.get $i
+    i32.load
+  )
+  (table $t (;0;) 10 funcref global.get $gn)
+  (memory $m (;0;) 1)
+  (global $g1 (;1;) i32 i32.const 8)
+  (global $g2 (;2;) i32 global.get $g0)
+  (global $g3 (;3;) i32 global.get $g1)
+  (global $gn (;4;) funcref ref.null func)
+  (global $gf (;5;) funcref ref.func $f)
+  (export "get-elem" (func 1))
+  (export "get-data" (func 2))
+  (elem (;0;) (global.get $g2) funcref (ref.func $f))
+  (elem (;1;) (global.get $g3) funcref (global.get $gf))
+  (data (;0;) (global.get $g2) "DDDD")
+  (data (;1;) (global.get $g3) "\88\88\88\88")
+)

--- a/tests/snapshots/testsuite/proposals/gc/global.wast/61.print
+++ b/tests/snapshots/testsuite/proposals/gc/global.wast/61.print
@@ -1,0 +1,4 @@
+(module
+  (global (;0;) (mut f32) f32.const 0x0p+0 (;=0;))
+  (export "a" (global 0))
+)

--- a/tests/snapshots/testsuite/proposals/gc/global.wast/62.print
+++ b/tests/snapshots/testsuite/proposals/gc/global.wast/62.print
@@ -1,0 +1,4 @@
+(module
+  (global (;0;) (mut f32) f32.const 0x0p+0 (;=0;))
+  (export "a" (global 0))
+)

--- a/tests/snapshots/testsuite/proposals/gc/global.wast/78.print
+++ b/tests/snapshots/testsuite/proposals/gc/global.wast/78.print
@@ -1,0 +1,4 @@
+(module
+  (global (;0;) i32 i32.const 0)
+  (global (;1;) i32 global.get 0)
+)

--- a/tests/snapshots/testsuite/proposals/gc/global.wast/79.print
+++ b/tests/snapshots/testsuite/proposals/gc/global.wast/79.print
@@ -1,0 +1,4 @@
+(module
+  (global $g (;0;) i32 i32.const 0)
+  (global (;1;) i32 global.get $g)
+)

--- a/tests/snapshots/testsuite/proposals/gc/global.wast/81.print
+++ b/tests/snapshots/testsuite/proposals/gc/global.wast/81.print
@@ -1,0 +1,3 @@
+(module
+  (import "spectest" "global_i32" (global (;0;) i32))
+)

--- a/tests/snapshots/testsuite/proposals/gc/global.wast/84.print
+++ b/tests/snapshots/testsuite/proposals/gc/global.wast/84.print
@@ -1,0 +1,3 @@
+(module
+  (global (;0;) i32 i32.const 0)
+)


### PR DESCRIPTION
This involved queuing up table init expressions for later validation because:

* Tables (and their init expressions) come before globals definitions in the binary format,
* constant expressions can contain `global.get`s of defined globals now,
* and therefore a table init can validly reference a global before it is defined.

This is not ideal, but is fine, since we have some other end-of-module checking already in `validate_end`. However, that alone isn't good enough. Because constant expressions can contain `ref.func $f` instructions, which need to insert `$f` into the "referenced function" set, we need mutable access to the `Arc<Module>` when processing constant expressions. So we need to drain the unchecked table init expressions *before* processing each code body, when we still have unique access to the `Arc<Module>`. But not all Wasm modules have code sections, so at the same time, we still need to do the checking inside `validate_end`. And when there was a code section, the queue of table init expressions will have already been drained by the time we are in `validate_end`, so it is okay that we no longer have unique access to the `Arc<Module>` in that case.