### PR TITLE
Display magic number mismatch in error

### DIFF
--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -1518,7 +1518,7 @@ impl<'a> BinaryReader<'a> {
         let magic_number = self.read_bytes(4)?;
         if magic_number != WASM_MAGIC_NUMBER {
             return Err(BinaryReaderError::new(
-                "magic header not detected: bad magic number",
+                format!("magic header not detected: bad magic number - expected={WASM_MAGIC_NUMBER:#x?} actual={magic_number:#x?}"),
                 self.original_position() - 4,
             ));
         }


### PR DESCRIPTION
I'm not sure if allocations in the unhappy path are something we'd rather avoid, but I ran into an issue where this change would have been somewhat helpful. 