### PR TITLE
Enable new format for embedding component types by default

### DIFF
--- a/crates/wit-component/src/metadata.rs
+++ b/crates/wit-component/src/metadata.rs
@@ -191,8 +191,8 @@ pub fn encode(
         Some(true) => EncodingFormat::Next,
         Some(false) => EncodingFormat::Previous,
         None => match std::env::var("WIT_COMPONENT_NEW_ENCODE") {
-            Ok(s) if s == "1" => EncodingFormat::Next,
-            _ => EncodingFormat::Previous,
+            Ok(s) if s == "0" => EncodingFormat::Previous,
+            _ => EncodingFormat::Next,
         },
     };
 


### PR DESCRIPTION
This commit enables the support for the new format of type information embedded in custom sections for `wit-component` first implemented in #1260. The new format minimizes type information to only that which was bound for the `world` selected as opposed to all packages and interfaces regardless of whether they're referenced or not.

A bug with this format was fixed with #1270 and shipped in Wasmtime 15 so there's at least one stable release that supports the old and the new without bugs. This commit turns on the new format by default while leaving in an environment variable to turn it off. This isn't expected to have any practical breakage at this time.