### PR TITLE
Teach wasm-tools strip to not take out any component-type sections

### DIFF
--- a/src/bin/wasm-tools/strip.rs
+++ b/src/bin/wasm-tools/strip.rs
@@ -46,8 +46,8 @@ impl Opts {
                 return to_delete.is_match(name);
             }
 
-            // Finally default strip everything but the `name` section.
-            name != "name"
+            // Finally default strip everything but the `name` and any `component-type` sections.
+            name != "name" && !name.starts_with("component-type:")
         };
 
         let mut output = Vec::new();


### PR DESCRIPTION
Removing component-type custom sections completely breaks a lot of tooling - I think it makes sense to avoid removing these sections unless the user explicitly asks for it. 