### PR TITLE
Gate types coming through `ref.null`

### DIFF
--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -2243,6 +2243,11 @@ where
         Ok(())
     }
     fn visit_ref_null(&mut self, mut heap_type: HeapType) -> Self::Output {
+        if let Some(ty) = RefType::new(true, heap_type) {
+            self.features
+                .check_ref_type(ty)
+                .map_err(|e| BinaryReaderError::new(e, self.offset))?;
+        }
         self.resources
             .check_heap_type(&mut heap_type, self.offset)?;
         let ty = ValType::Ref(

--- a/tests/local/missing-features/reference-types/gc.wast
+++ b/tests/local/missing-features/reference-types/gc.wast
@@ -28,3 +28,6 @@
 (assert_invalid
   (module (func (block (result i31ref) unreachable)))
   "heap types not supported without the gc feature")
+(assert_invalid
+  (module (func ref.null array drop))
+  "heap types not supported without the gc feature")


### PR DESCRIPTION
This fixes a regression from #1299 where `ref.null array`, a wasm GC instruction, wasn't being properly gated by the `gc` feature.