### PR TITLE
implement from_reader for ComponentInfo for incremental wit decoding

### DIFF
--- a/crates/wasm-compose/src/encoding.rs
+++ b/crates/wasm-compose/src/encoding.rs
@@ -5,11 +5,8 @@ use anyhow::{anyhow, bail, Result};
 use indexmap::{IndexMap, IndexSet};
 use petgraph::EdgeDirection;
 use smallvec::SmallVec;
+use std::collections::{hash_map::Entry, HashMap};
 use std::mem;
-use std::{
-    borrow::Cow,
-    collections::{hash_map::Entry, HashMap},
-};
 use wasm_encoder::*;
 use wasmparser::{
     names::KebabString,

--- a/crates/wasmparser/src/readers/component/exports.rs
+++ b/crates/wasmparser/src/readers/component/exports.rs
@@ -65,9 +65,9 @@ impl ComponentExternalKind {
 
 /// Represents an export in a WebAssembly component.
 #[derive(Debug, Clone)]
-pub struct ComponentExport<'a> {
+pub struct ComponentExport {
     /// The name of the exported item.
-    pub name: ComponentExportName<'a>,
+    pub name: ComponentExportName,
     /// The kind of the export.
     pub kind: ComponentExternalKind,
     /// The index of the exported item.
@@ -77,9 +77,9 @@ pub struct ComponentExport<'a> {
 }
 
 /// A reader for the export section of a WebAssembly component.
-pub type ComponentExportSectionReader<'a> = SectionLimited<'a, ComponentExport<'a>>;
+pub type ComponentExportSectionReader<'a> = SectionLimited<'a, ComponentExport>;
 
-impl<'a> FromReader<'a> for ComponentExport<'a> {
+impl<'a> FromReader<'a> for ComponentExport {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
         Ok(ComponentExport {
             name: reader.read()?,
@@ -115,11 +115,11 @@ impl<'a> FromReader<'a> for ComponentExternalKind {
 }
 
 /// Represents the name of a component export.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 #[allow(missing_docs)]
-pub struct ComponentExportName<'a>(pub &'a str);
+pub struct ComponentExportName(pub String);
 
-impl<'a> FromReader<'a> for ComponentExportName<'a> {
+impl<'a> FromReader<'a> for ComponentExportName {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
         match reader.read_u8()? {
             0x00 => {}
@@ -130,6 +130,6 @@ impl<'a> FromReader<'a> for ComponentExportName<'a> {
             0x01 => {}
             x => return reader.invalid_leading_byte(x, "export name"),
         }
-        Ok(ComponentExportName(reader.read_string()?))
+        Ok(ComponentExportName(reader.read_string()?.to_owned()))
     }
 }

--- a/crates/wasmparser/src/readers/component/imports.rs
+++ b/crates/wasmparser/src/readers/component/imports.rs
@@ -76,15 +76,15 @@ impl<'a> FromReader<'a> for ComponentTypeRef {
 }
 
 /// Represents an import in a WebAssembly component
-#[derive(Debug, Copy, Clone)]
-pub struct ComponentImport<'a> {
+#[derive(Debug, Clone)]
+pub struct ComponentImport {
     /// The name of the imported item.
-    pub name: ComponentImportName<'a>,
+    pub name: ComponentImportName,
     /// The type reference for the import.
     pub ty: ComponentTypeRef,
 }
 
-impl<'a> FromReader<'a> for ComponentImport<'a> {
+impl<'a> FromReader<'a> for ComponentImport {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
         Ok(ComponentImport {
             name: reader.read()?,
@@ -106,14 +106,14 @@ impl<'a> FromReader<'a> for ComponentImport<'a> {
 ///     println!("Import: {:?}", import);
 /// }
 /// ```
-pub type ComponentImportSectionReader<'a> = SectionLimited<'a, ComponentImport<'a>>;
+pub type ComponentImportSectionReader<'a> = SectionLimited<'a, ComponentImport>;
 
 /// Represents the name of a component import.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 #[allow(missing_docs)]
-pub struct ComponentImportName<'a>(pub &'a str);
+pub struct ComponentImportName(pub String);
 
-impl<'a> FromReader<'a> for ComponentImportName<'a> {
+impl<'a> FromReader<'a> for ComponentImportName {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
         match reader.read_u8()? {
             0x00 => {}
@@ -124,6 +124,6 @@ impl<'a> FromReader<'a> for ComponentImportName<'a> {
             0x01 => {}
             x => return reader.invalid_leading_byte(x, "import name"),
         }
-        Ok(ComponentImportName(reader.read_string()?))
+        Ok(ComponentImportName(reader.read_string()?.to_owned()))
     }
 }

--- a/crates/wasmparser/src/readers/component/instances.rs
+++ b/crates/wasmparser/src/readers/component/instances.rs
@@ -110,7 +110,7 @@ pub enum ComponentInstance<'a> {
         args: Box<[ComponentInstantiationArg<'a>]>,
     },
     /// The instance is a from exporting local items.
-    FromExports(Box<[ComponentExport<'a>]>),
+    FromExports(Box<[ComponentExport]>),
 }
 
 /// A reader for the component instance section of a WebAssembly component.

--- a/crates/wasmparser/src/readers/component/types.rs
+++ b/crates/wasmparser/src/readers/component/types.rs
@@ -303,12 +303,12 @@ pub enum ComponentTypeDeclaration<'a> {
     /// The component type declaration is for an export.
     Export {
         /// The name of the export.
-        name: ComponentExportName<'a>,
+        name: ComponentExportName,
         /// The type reference for the export.
         ty: ComponentTypeRef,
     },
     /// The component type declaration is for an import.
-    Import(ComponentImport<'a>),
+    Import(ComponentImport),
 }
 
 impl<'a> FromReader<'a> for ComponentTypeDeclaration<'a> {
@@ -344,7 +344,7 @@ pub enum InstanceTypeDeclaration<'a> {
     /// The instance type declaration is for an export.
     Export {
         /// The name of the export.
-        name: ComponentExportName<'a>,
+        name: ComponentExportName,
         /// The type reference for the export.
         ty: ComponentTypeRef,
     },

--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -434,13 +434,13 @@ impl ComponentState {
         let mut entity = self.check_type_ref(&import.ty, features, types, offset)?;
         self.add_entity(
             &mut entity,
-            Some((import.name.0, ExternKind::Import)),
+            Some((&import.name.0, ExternKind::Import)),
             features,
             types,
             offset,
         )?;
         self.toplevel_imported_resources.validate_extern(
-            import.name.0,
+            &import.name.0,
             ExternKind::Import,
             &entity,
             types,
@@ -915,7 +915,7 @@ impl ComponentState {
 
     pub fn add_export(
         &mut self,
-        name: ComponentExportName<'_>,
+        name: ComponentExportName,
         mut ty: ComponentEntityType,
         features: &WasmFeatures,
         types: &mut TypeAlloc,
@@ -927,13 +927,13 @@ impl ComponentState {
         }
         self.add_entity(
             &mut ty,
-            Some((name.0, ExternKind::Export)),
+            Some((&name.0, ExternKind::Export)),
             features,
             types,
             offset,
         )?;
         self.toplevel_exported_resources.validate_extern(
-            name.0,
+            &name.0,
             ExternKind::Export,
             &ty,
             types,
@@ -2120,7 +2120,7 @@ impl ComponentState {
             };
 
             names.validate_extern(
-                export.name.0,
+                &export.name.0,
                 ExternKind::Export,
                 &ty,
                 types,

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -1695,7 +1695,7 @@ impl Printer {
                 ComponentTypeDeclaration::Export { name, ty } => {
                     self.start_group("export ");
                     self.print_component_kind_name(states.last_mut().unwrap(), ty.kind())?;
-                    self.print_str(name.0)?;
+                    self.print_str(&name.0)?;
                     self.result.push(' ');
                     self.print_component_import_ty(states.last_mut().unwrap(), &ty, false)?;
                     self.end_group();
@@ -1729,7 +1729,7 @@ impl Printer {
                 InstanceTypeDeclaration::Export { name, ty } => {
                     self.start_group("export ");
                     self.print_component_kind_name(states.last_mut().unwrap(), ty.kind())?;
-                    self.print_str(name.0)?;
+                    self.print_str(&name.0)?;
                     self.result.push(' ');
                     self.print_component_import_ty(states.last_mut().unwrap(), &ty, false)?;
                     self.end_group();
@@ -1893,7 +1893,7 @@ impl Printer {
         index: bool,
     ) -> Result<()> {
         self.start_group("import ");
-        self.print_str(import.name.0)?;
+        self.print_str(&import.name.0)?;
         self.result.push(' ');
         self.print_component_import_ty(state, &import.ty, index)?;
         self.end_group();
@@ -2008,7 +2008,7 @@ impl Printer {
         if named {
             self.print_component_kind_name(state, export.kind)?;
         }
-        self.print_str(export.name.0)?;
+        self.print_str(&export.name.0)?;
         self.result.push(' ');
         self.print_component_external_kind(state, export.kind, export.index)?;
         if let Some(ty) = &export.ty {

--- a/crates/wit-component/src/lib.rs
+++ b/crates/wit-component/src/lib.rs
@@ -17,7 +17,7 @@ mod printing;
 mod targets;
 mod validation;
 
-pub use decoding::{decode, DecodedWasm};
+pub use decoding::{decode, decode_reader, DecodedWasm};
 pub use encoding::{encode, ComponentEncoder};
 pub use linking::Linker;
 pub use printing::*;


### PR DESCRIPTION
For use cases with memory limitations, this PR enables the wit decoding from a wasm binary without needing to buffer the entirety of the binary.  For the original conversation see the [zulip thread](https://bytecodealliance.zulipchat.com/#narrow/stream/327223-wit-bindgen/topic/wit-decode.20on.20streams/near/397759913)