### PR TITLE
Explicitly fail to decode WIT from core wasm

### DIFF
--- a/crates/wit-component/src/decoding.rs
+++ b/crates/wit-component/src/decoding.rs
@@ -36,6 +36,9 @@ enum WitEncodingVersion {
 impl<'a> ComponentInfo<'a> {
     /// Creates a new component info by parsing the given WebAssembly component bytes.
     fn new(bytes: &'a [u8]) -> Result<Self> {
+        if !Parser::is_component(bytes) {
+            bail!("input is not a component wasm binary");
+        }
         let mut validator = Validator::new_with_features(WasmFeatures::all());
         let mut externs = Vec::new();
         let mut depth = 1;


### PR DESCRIPTION
This commit ensures that if a core wasm binary is fed into the WIT-decoding process it'll fail quickly with an up-front error message that it's not a component.