### PR TITLE
Allow renaming imports in `ComponentEncoder`. 

### DIFF
--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -2143,10 +2143,8 @@ world test {
 }
 "#,
                 )
-                .context("failed to parse wit for publishing")
                 .unwrap(),
             )
-            .context("failed to resolve wit for publishing")
             .unwrap();
 
         let world = resolve.select_world(pkg, None).unwrap();


### PR DESCRIPTION
This commit adds an `import_name_map` option to `ComponentEncoder` to allow
renaming imports in the output component.

Language toolchains can use this option to substitute `unlocked-dep` and
`locked-dep` names in the components they build.