### PR TITLE
Fix incorrect errors returned from merging worlds

### DIFF
--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -1907,7 +1907,7 @@ impl ComponentEncoder {
         let world = self
             .metadata
             .merge(metadata)
-            .context("failed merge WIT package sets together")?;
+            .context("failed merge WIT metadata for module with previous metadata")?;
         self.main_module_exports
             .extend(self.metadata.resolve.worlds[world].exports.keys().cloned());
         self.module = if let Some(producers) = &self.metadata.producers {


### PR DESCRIPTION
This commit fixes a bug in `Resolve::merge` which is one of the workhorses of the `wasm-tools component new` subcommand. Previously it was assumed that `Resolve::packages` always listed packages in topological order, but `Resolve::merge` updated the internal state of `Resolve` to violate this invariant. This happened because new packages which might be dependencies of existing packages (through newly discovered interfaces for example) would be appended at the end.

After wrestling with a few options to solve this issue I've settled on relaxing the invariants of `Resolve` such that it does not always contain a topologically sorted list of packages. Instead a new method, `topological_packages`, is explicitly used to order the packages within `Resolve`. This method is then used as part of `Resolve::merge` which relies on visiting in a topological order.

For testing this it wasn't previously found via fuzzing because fuzzing does not execute `Resolve::merge`. Extra validation about topological-sorted-ness caught the problem in the `merge` tests, however. The fuzzer for WIT has been updated to test merging and assert validity now as well too.