### PR TITLE
Make import_name CLI arg optional

### DIFF
--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -116,7 +116,7 @@ pub struct NewOpts {
     ///
     /// If the old import name is not found, it is ignored.
     #[clap(long = "import-name", value_name = "[OLD]=NEW", value_parser = parse_import_name)]
-    import_names: Option<HashMap<String, String>>,
+    import_names: Vec<(String, String)>,
 
     #[clap(flatten)]
     io: wasm_tools::InputOutput,

--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -116,7 +116,7 @@ pub struct NewOpts {
     ///
     /// If the old import name is not found, it is ignored.
     #[clap(long = "import-name", value_name = "[OLD]=NEW", value_parser = parse_import_name)]
-    import_names: HashMap<String, String>,
+    import_names: Option<HashMap<String, String>>,
 
     #[clap(flatten)]
     io: wasm_tools::InputOutput,
@@ -153,7 +153,7 @@ impl NewOpts {
         encoder = encoder.realloc_via_memory_grow(self.realloc_via_memory_grow);
 
         let bytes = encoder
-            .import_name_map(self.import_names)
+            .import_name_map(self.import_names.unwrap_or_else(|| HashMap::new()))
             .encode()
             .context("failed to encode a component from module")?;
 

--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -153,7 +153,7 @@ impl NewOpts {
         encoder = encoder.realloc_via_memory_grow(self.realloc_via_memory_grow);
 
         let bytes = encoder
-            .import_name_map(self.import_names.unwrap_or_else(|| HashMap::new()))
+            .import_name_map(self.import_names.into_iter().collect())
             .encode()
             .context("failed to encode a component from module")?;
 


### PR DESCRIPTION
I could be wrong, but I think the intention was for this to be optional in https://github.com/bytecodealliance/wasm-tools/pull/1322

This PR makes it an `Option<>`