### PR TITLE
Update skipping of tests from spec test suite

### DIFF
--- a/crates/wast/src/core/types.rs
+++ b/crates/wast/src/core/types.rs
@@ -259,9 +259,6 @@ impl<'a> Parse<'a> for RefType<'a> {
         if l.peek::<kw::funcref>()? {
             parser.parse::<kw::funcref>()?;
             Ok(RefType::func())
-        } else if l.peek::<kw::anyfunc>()? {
-            parser.parse::<kw::anyfunc>()?;
-            Ok(RefType::func())
         } else if l.peek::<kw::externref>()? {
             parser.parse::<kw::externref>()?;
             Ok(RefType::r#extern())
@@ -321,7 +318,6 @@ impl<'a> Parse<'a> for RefType<'a> {
 impl<'a> Peek for RefType<'a> {
     fn peek(cursor: Cursor<'_>) -> Result<bool> {
         Ok(kw::funcref::peek(cursor)?
-            || /* legacy */ kw::anyfunc::peek(cursor)?
             || kw::externref::peek(cursor)?
             || kw::exnref::peek(cursor)?
             || kw::anyref::peek(cursor)?

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -376,7 +376,6 @@ pub mod kw {
     custom_keyword!(after);
     custom_keyword!(alias);
     custom_keyword!(any);
-    custom_keyword!(anyfunc);
     custom_keyword!(anyref);
     custom_keyword!(arg);
     custom_keyword!(array);

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -136,34 +136,8 @@ fn find_tests() -> Vec<PathBuf> {
 /// Note that this is used to skip tests for all crates, not just one at a
 /// time. There's further filters applied while testing.
 fn skip_test(test: &Path, contents: &[u8]) -> bool {
-    let broken = &[
-        // I don't really have any idea what's going on with the expected syntax
-        // errors and expected error messages in these tests. They seem like
-        // they're from left field considering other conventions, so let's just
-        // ignore these until the proposal is further along.
-        "exception-handling/try_delegate.wast",
-        "exception-handling/try_catch.wast",
-        "exception-handling/throw.wast",
-        // This is an empty file which currently doesn't parse
-        "multi-memory/memory_copy1.wast",
-    ];
-    let test_path = test.to_str().unwrap().replace("\\", "/"); // for windows paths
-    if broken.iter().any(|x| test_path.contains(x)) {
-        return true;
-    }
-
-    if let Ok(contents) = str::from_utf8(contents) {
-        // Skip tests that are supposed to fail
-        if contents.contains(";; ERROR") {
-            return true;
-        }
-        // These tests are acually ones that run with the `*.wast` files from the
-        // official test suite, and we slurp those up elsewhere anyway.
-        if contents.contains("STDIN_FILE") {
-            return true;
-        }
-    }
-
+    // currently no tests are skipped
+    let _ = (test, contents);
     false
 }
 
@@ -171,29 +145,30 @@ fn skip_validation(test: &Path) -> bool {
     let broken = &[
         "gc/gc-array.wat",
         "gc/gc-struct.wat",
-        "/proposals/gc/array.wast",
-        "/proposals/gc/array_copy.wast",
-        "/proposals/gc/array_fill.wast",
-        "/proposals/gc/array_init_data.wast",
-        "/proposals/gc/array_init_elem.wast",
-        "/proposals/gc/br_on_cast.wast",
-        "/proposals/gc/br_on_cast_fail.wast",
-        "/proposals/gc/extern.wast",
-        "/proposals/gc/ref_cast.wast",
-        "/proposals/gc/ref_eq.wast",
-        "/proposals/gc/ref_test.wast",
-        "/proposals/gc/struct.wast",
-        "/proposals/gc/type-subtyping.wast",
-        "/proposals/exception-handling/try_table.wast",
-        "/proposals/exception-handling/throw_ref.wast",
-        "/proposals/exception-handling/ref_null.wast",
-        "/exnref/exnref.wast",
-        "/exnref/throw_ref.wast",
-        "/exnref/try_table.wast",
-        "obsolete-keywords.wast",
+        "proposals/gc/array.wast",
+        "proposals/gc/array_copy.wast",
+        "proposals/gc/array_fill.wast",
+        "proposals/gc/array_init_data.wast",
+        "proposals/gc/array_init_elem.wast",
+        "proposals/gc/br_on_cast.wast",
+        "proposals/gc/br_on_cast_fail.wast",
+        "proposals/gc/extern.wast",
+        "proposals/gc/ref_cast.wast",
+        "proposals/gc/ref_eq.wast",
+        "proposals/gc/ref_test.wast",
+        "proposals/gc/struct.wast",
+        "proposals/gc/type-subtyping.wast",
+        "exnref/exnref.wast",
+        "exnref/throw_ref.wast",
+        "exnref/try_table.wast",
+        "exception-handling/ref_null.wast",
+        "exception-handling/throw.wast",
+        "exception-handling/throw_ref.wast",
+        "exception-handling/try_catch.wast",
+        "exception-handling/try_delegate.wast",
+        "exception-handling/try_table.wast",
     ];
-    let test_path = test.to_str().unwrap().replace("\\", "/"); // for windows paths
-    if broken.iter().any(|x| test_path.contains(x)) {
+    if broken.iter().any(|x| test.ends_with(x)) {
         return true;
     }
 
@@ -852,6 +827,10 @@ fn error_matches(error: &str, message: &str) -> bool {
 
     if message == "sub type" {
         return error.contains("subtype");
+    }
+
+    if message.starts_with("unknown operator") {
+        return error.starts_with("unknown operator") || error.starts_with("unexpected token");
     }
 
     return false;

--- a/tests/snapshots/testsuite/proposals/multi-memory/memory_copy1.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/multi-memory/memory_copy1.wast/0.print
@@ -1,0 +1,24 @@
+(module
+  (type (;0;) (func (param i32 i32 i32)))
+  (type (;1;) (func (param i32) (result i32)))
+  (func (;0;) (type 0) (param i32 i32 i32)
+    local.get 0
+    local.get 1
+    local.get 2
+    memory.copy $mem0 $mem3
+  )
+  (func (;1;) (type 1) (param i32) (result i32)
+    local.get 0
+    i32.load8_u
+  )
+  (memory $mem0 (;0;) 1 1)
+  (memory $mem1 (;1;) 1 1)
+  (memory $mem2 (;2;) 1 1)
+  (memory $mem3 (;3;) 1 1)
+  (export "copy" (func 0))
+  (export "load8_u" (func 1))
+  (data (;0;) (i32.const 0) "\ff\11D\ee")
+  (data (;1;) (memory $mem1) (i32.const 0) "\ee\22U\ff")
+  (data (;2;) (memory $mem2) (i32.const 0) "\dd3f\00")
+  (data (;3;) (memory $mem3) (i32.const 0) "\aa\bb\cc\dd")
+)


### PR DESCRIPTION
* Enable the `obsolete-keywords.wast` test by removing parsing of `anyfunc`.
* Move all tests out of `skip_test` now that everything in the spec testsuite submodule can be parsed with `wast`.
* Update the logic in `skip_validation` slightly.