### PR TITLE
Change error message to align with test suite expectations

### DIFF
--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -593,7 +593,7 @@ impl Module {
             debug_assert!(supertype_index.is_canonical());
             let sup_id = self.at_packed_index(types, rec_group, supertype_index, offset)?;
             if types[sup_id].is_final {
-                bail!(offset, "supertype must not be final");
+                bail!(offset, "sub type cannot have a final super type");
             }
             if !types.matches(id, sup_id) {
                 bail!(offset, "subtype must match supertype");

--- a/tests/local/gc/gc-subtypes-invalid.wast
+++ b/tests/local/gc/gc-subtypes-invalid.wast
@@ -5,7 +5,7 @@
     (type $a (func))
     (type $b (sub $a (func))) ;; invalid
   )
-  "supertype must not be final"
+  "sub type cannot have a final super type"
 )
 (assert_invalid
   (module
@@ -13,7 +13,7 @@
     (type $b (sub final $a (func)))
     (type $c (sub $b (func))) ;; invalid
   )
-  "supertype must not be final"
+  "sub type cannot have a final super type"
 )
 (assert_invalid
   (module
@@ -147,5 +147,5 @@
     (type $a (func)) ;; types without `(sub )` are considered final
     (type (sub $a (func)))
   )
-  "supertype must not be final"
+  "sub type cannot have a final super type"
 )


### PR DESCRIPTION
Not enough to enable new tests on its own but the next set of changes is big enough I want to just split this out and land it first.