### PR TITLE
Add `wasmparser` support for `ref.{test,cast}`

### DIFF
--- a/crates/wasm-encoder/src/core/code.rs
+++ b/crates/wasm-encoder/src/core/code.rs
@@ -1,4 +1,4 @@
-use crate::{encode_section, Encode, HeapType, RefType, Section, SectionId, ValType};
+use crate::{encode_section, Encode, HeapType, Section, SectionId, ValType};
 use std::borrow::Cow;
 
 /// An encoder for the code section.
@@ -546,8 +546,10 @@ pub enum Instruction<'a> {
     ArrayInitData(u32, u32),
     ArrayInitElem(u32, u32),
 
-    RefTest(RefType),
-    RefCast(RefType),
+    RefTestNonNull(HeapType),
+    RefTestNullable(HeapType),
+    RefCastNonNull(HeapType),
+    RefCastNullable(HeapType),
     AnyConvertExtern,
     ExternConvertAny,
 
@@ -1459,34 +1461,22 @@ impl Encode for Instruction<'_> {
                 type_index.encode(sink);
                 elem_index.encode(sink);
             }
-            Instruction::RefTest(RefType {
-                nullable: false,
-                heap_type,
-            }) => {
+            Instruction::RefTestNonNull(heap_type) => {
                 sink.push(0xfb);
                 sink.push(0x14);
                 heap_type.encode(sink);
             }
-            Instruction::RefTest(RefType {
-                nullable: true,
-                heap_type,
-            }) => {
+            Instruction::RefTestNullable(heap_type) => {
                 sink.push(0xfb);
                 sink.push(0x15);
                 heap_type.encode(sink);
             }
-            Instruction::RefCast(RefType {
-                nullable: false,
-                heap_type,
-            }) => {
+            Instruction::RefCastNonNull(heap_type) => {
                 sink.push(0xfb);
                 sink.push(0x16);
                 heap_type.encode(sink);
             }
-            Instruction::RefCast(RefType {
-                nullable: true,
-                heap_type,
-            }) => {
+            Instruction::RefCastNullable(heap_type) => {
                 sink.push(0xfb);
                 sink.push(0x17);
                 heap_type.encode(sink);

--- a/crates/wasm-shrink/tests/tests.rs
+++ b/crates/wasm-shrink/tests/tests.rs
@@ -29,7 +29,7 @@ fn shrink_to_empty_is_error() -> Result<()> {
     let result = WasmShrink::default().run(wasm(), |_| Ok(true));
     assert!(result.is_err());
     let err_msg = result.err().unwrap().to_string();
-    assert!(dbg!(err_msg).contains("empty Wasm module"));
+    assert!(err_msg.contains("empty Wasm module"));
     Ok(())
 }
 

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -1001,6 +1001,23 @@ impl<'a> BinaryReader<'a> {
     {
         let code = self.read_var_u32()?;
         Ok(match code {
+            0x14 => {
+                let ht = HeapType::from_reader(self)?;
+                visitor.visit_ref_test_non_null(ht)
+            }
+            0x15 => {
+                let ht = HeapType::from_reader(self)?;
+                visitor.visit_ref_test_nullable(ht)
+            }
+            0x16 => {
+                let ht = HeapType::from_reader(self)?;
+                visitor.visit_ref_cast_non_null(ht)
+            }
+            0x17 => {
+                let ht = HeapType::from_reader(self)?;
+                visitor.visit_ref_cast_nullable(ht)
+            }
+
             0x1c => visitor.visit_ref_i31(),
             0x1d => visitor.visit_i31_get_s(),
             0x1e => visitor.visit_i31_get_u(),

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -1001,22 +1001,10 @@ impl<'a> BinaryReader<'a> {
     {
         let code = self.read_var_u32()?;
         Ok(match code {
-            0x14 => {
-                let ht = HeapType::from_reader(self)?;
-                visitor.visit_ref_test_non_null(ht)
-            }
-            0x15 => {
-                let ht = HeapType::from_reader(self)?;
-                visitor.visit_ref_test_nullable(ht)
-            }
-            0x16 => {
-                let ht = HeapType::from_reader(self)?;
-                visitor.visit_ref_cast_non_null(ht)
-            }
-            0x17 => {
-                let ht = HeapType::from_reader(self)?;
-                visitor.visit_ref_cast_nullable(ht)
-            }
+            0x14 => visitor.visit_ref_test_non_null(self.read()?),
+            0x15 => visitor.visit_ref_test_nullable(self.read()?),
+            0x16 => visitor.visit_ref_cast_non_null(self.read()?),
+            0x17 => visitor.visit_ref_cast_nullable(self.read()?),
 
             0x1c => visitor.visit_ref_i31(),
             0x1d => visitor.visit_i31_get_s(),

--- a/crates/wasmparser/src/lib.rs
+++ b/crates/wasmparser/src/lib.rs
@@ -319,6 +319,10 @@ macro_rules! for_each_operator {
             @gc RefI31 => visit_ref_i31
             @gc I31GetS => visit_i31_get_s
             @gc I31GetU => visit_i31_get_u
+            @gc RefTestNonNull { hty: $crate::HeapType } => visit_ref_test_non_null
+            @gc RefTestNullable { hty: $crate::HeapType } => visit_ref_test_nullable
+            @gc RefCastNonNull { hty: $crate::HeapType } => visit_ref_cast_non_null
+            @gc RefCastNullable { hty: $crate::HeapType } => visit_ref_cast_nullable
 
             // 0xFC operators
             // Non-trapping Float-to-int Conversions

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -596,7 +596,7 @@ impl Module {
                 bail!(offset, "sub type cannot have a final super type");
             }
             if !types.matches(id, sup_id) {
-                bail!(offset, "subtype must match supertype");
+                bail!(offset, "sub type must match super type");
             }
         }
 

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -978,7 +978,9 @@ where
 
         let sub_ty = RefType::new(nullable, heap_type)
             .map(ValType::from)
-            .ok_or_else(|| BinaryReaderError::new("TODO FITZGEN", self.offset))?;
+            .ok_or_else(|| {
+                BinaryReaderError::new("implementation limit: type index too large", self.offset)
+            })?;
 
         let sup_ty = match self.pop_ref()? {
             None => bail!(

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -970,6 +970,48 @@ where
         Ok(())
     }
 
+    /// Common helper for `ref.test` and `ref.cast` downcasting/checking
+    /// instructions. Returns the given `heap_type` as a `ValType`.
+    fn check_downcast(&mut self, nullable: bool, mut heap_type: HeapType) -> Result<ValType> {
+        self.resources
+            .check_heap_type(&mut heap_type, self.offset)?;
+
+        let sub_ty = RefType::new(nullable, heap_type)
+            .map(ValType::from)
+            .ok_or_else(|| BinaryReaderError::new("TODO FITZGEN", self.offset))?;
+
+        let sup_ty = match self.pop_ref()? {
+            None => bail!(
+                self.offset,
+                "type mismatch: expected (ref null? ...), found bottom"
+            ),
+            Some(ty) => ty,
+        };
+
+        if !self.resources.is_subtype(sub_ty, sup_ty.into()) {
+            bail!(
+                self.offset,
+                "ref.test's heap type must be a sub type of the type on the stack"
+            );
+        }
+
+        Ok(sub_ty)
+    }
+
+    /// Common helper for both nullable and non-nullable variants of `ref.test`
+    /// instructions.
+    fn check_ref_test(&mut self, nullable: bool, heap_type: HeapType) -> Result<()> {
+        self.check_downcast(nullable, heap_type)?;
+        self.push_operand(ValType::I32)
+    }
+
+    /// Common helper for both nullable and non-nullable variants of `ref.cast`
+    /// instructions.
+    fn check_ref_cast(&mut self, nullable: bool, heap_type: HeapType) -> Result<()> {
+        let sub_ty = self.check_downcast(nullable, heap_type)?;
+        self.push_operand(sub_ty)
+    }
+
     fn func_type_at(&self, at: u32) -> Result<&'resources R::FuncType> {
         self.resources
             .func_type_at(at)
@@ -3386,6 +3428,18 @@ where
         self.pop_operand(Some(ty))?;
         self.pop_operand(Some(ValType::I32))?;
         Ok(())
+    }
+    fn visit_ref_test_non_null(&mut self, heap_type: HeapType) -> Self::Output {
+        self.check_ref_test(false, heap_type)
+    }
+    fn visit_ref_test_nullable(&mut self, heap_type: HeapType) -> Self::Output {
+        self.check_ref_test(true, heap_type)
+    }
+    fn visit_ref_cast_non_null(&mut self, heap_type: HeapType) -> Self::Output {
+        self.check_ref_cast(false, heap_type)
+    }
+    fn visit_ref_cast_nullable(&mut self, heap_type: HeapType) -> Self::Output {
+        self.check_ref_cast(true, heap_type)
     }
     fn visit_ref_i31(&mut self) -> Self::Output {
         self.pop_operand(Some(ValType::I32))?;

--- a/crates/wasmprinter/src/operator.rs
+++ b/crates/wasmprinter/src/operator.rs
@@ -1,7 +1,7 @@
 use super::{Printer, State};
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use std::fmt::Write;
-use wasmparser::{BlockType, BrTable, MemArg, VisitOperator};
+use wasmparser::{BlockType, BrTable, MemArg, RefType, VisitOperator};
 
 pub struct PrintOperator<'a, 'b> {
     pub(super) printer: &'a mut Printer,
@@ -315,6 +315,30 @@ macro_rules! define_visit {
                 chunk[0],
             )?;
         }
+    );
+    (payload $self:ident RefTestNonNull $hty:ident) => (
+        $self.push_str(" ");
+        let rty = RefType::new(false, $hty)
+            .ok_or_else(|| anyhow!("implementation limit: type index too large"))?;
+        $self.printer.print_reftype(rty)?;
+    );
+    (payload $self:ident RefTestNullable $hty:ident) => (
+        $self.push_str(" ");
+        let rty = RefType::new(true, $hty)
+            .ok_or_else(|| anyhow!("implementation limit: type index too large"))?;
+        $self.printer.print_reftype(rty)?;
+    );
+    (payload $self:ident RefCastNonNull $hty:ident) => (
+        $self.push_str(" ");
+        let rty = RefType::new(false, $hty)
+            .ok_or_else(|| anyhow!("implementation limit: type index too large"))?;
+        $self.printer.print_reftype(rty)?;
+    );
+    (payload $self:ident RefCastNullable $hty:ident) => (
+        $self.push_str(" ");
+        let rty = RefType::new(true, $hty)
+            .ok_or_else(|| anyhow!("implementation limit: type index too large"))?;
+        $self.printer.print_reftype(rty)?;
     );
     (payload $self:ident $op:ident $($arg:ident)*) => (
         $(
@@ -861,6 +885,10 @@ macro_rules! define_visit {
     (name I16x8RelaxedQ15mulrS) => ("i16x8.relaxed_q15mulr_s");
     (name I16x8RelaxedDotI8x16I7x16S) => ("i16x8.relaxed_dot_i8x16_i7x16_s");
     (name I32x4RelaxedDotI8x16I7x16AddS) => ("i32x4.relaxed_dot_i8x16_i7x16_add_s");
+    (name RefTestNonNull) => ("ref.test");
+    (name RefTestNullable) => ("ref.test");
+    (name RefCastNonNull) => ("ref.cast");
+    (name RefCastNullable) => ("ref.cast");
     (name RefI31) => ("ref.i31");
     (name I31GetS) => ("i31.get_s");
     (name I31GetU) => ("i31.get_u");

--- a/tests/local/gc/gc-rec-groups-invalid.wast
+++ b/tests/local/gc/gc-rec-groups-invalid.wast
@@ -27,4 +27,4 @@
       (type $t4 (sub $t2 (struct (field (ref $t3)))))
     )
   )
-  "subtype must match supertype")
+  "sub type must match super type")

--- a/tests/local/gc/gc-subtypes-invalid.wast
+++ b/tests/local/gc/gc-subtypes-invalid.wast
@@ -20,21 +20,21 @@
     (type $a (sub (func)))
     (type $b (sub $a (struct))) ;; invalid
   )
-  "subtype must match supertype"
+  "sub type must match super type"
 )
 (assert_invalid
   (module
     (type $a (sub (func)))
     (type $b (sub $a (func (param i32)))) ;; invalid
   )
-  "subtype must match supertype"
+  "sub type must match super type"
 )
 (assert_invalid
   (module
     (type $a (sub (struct (field i32))))
     (type $b (sub $a (struct (field i64)))) ;; invalid
   )
-  "subtype must match supertype"
+  "sub type must match super type"
 )
 (assert_invalid
   (module
@@ -45,21 +45,21 @@
     (type $g (sub (func (param (ref $e)) (result (ref $e)))))
     (type $i (sub $g (func (param (ref $f)) (result (ref $d))))) ;; invalid
   )
-  "subtype must match supertype"
+  "sub type must match super type"
 )
 (assert_invalid
   (module
     (type $o (sub (array i32)))
     (type (sub $o (array (mut i32)))) ;; invalid
   )
-  "subtype must match supertype"
+  "sub type must match super type"
 )
 (assert_invalid
   (module
     (type $o (sub (array i32)))
     (type (sub $o (array i64))) ;; invalid
   )
-  "subtype must match supertype"
+  "sub type must match super type"
 )
 (assert_invalid
   (module
@@ -68,7 +68,7 @@
     (type $s (sub $r (array (ref i31))))
     (type (sub $s (array (ref null i31)))) ;; invalid
   )
-  "subtype must match supertype"
+  "sub type must match super type"
 )
 (assert_invalid
   (module
@@ -77,7 +77,7 @@
     (type $ss (sub $rr (array (ref array))))
     (type (sub $ss (array (ref null array)))) ;; invalid
   )
-  "subtype must match supertype"
+  "sub type must match super type"
 )
 (assert_invalid
   (module
@@ -86,7 +86,7 @@
     (type $sss (sub $rrr (array (ref struct))))
     (type (sub $sss (array (ref null struct)))) ;; invalid
   )
-  "subtype must match supertype"
+  "sub type must match super type"
 )
 (assert_invalid
   (module
@@ -94,7 +94,7 @@
     (type $u (sub $t (array (ref null func))))
     (type (sub $u (array (mut (ref func))))) ;; invalid
   )
-  "subtype must match supertype"
+  "sub type must match super type"
 )
 (assert_invalid
   (module
@@ -102,7 +102,7 @@
     (type $u (sub $t (array (ref null func))))
     (type (sub $u (array (ref null extern)))) ;; invalid
   )
-  "subtype must match supertype"
+  "sub type must match super type"
 )
 (assert_invalid
   (module
@@ -110,7 +110,7 @@
     (type $u0 (sub $t0 (array (ref null extern))))
     (type (sub $u0 (array (mut (ref extern))))) ;; invalid
   )
-  "subtype must match supertype"
+  "sub type must match super type"
 )
 (assert_invalid
   (module
@@ -119,14 +119,14 @@
     (type $v0 (sub $u0 (array (ref extern))))
     (type (sub $v0 (array nullexternref))) ;; invalid
   )
-  "subtype must match supertype"
+  "sub type must match super type"
 )
 (assert_invalid
   (module
     (type $t (sub (array (mut funcref))))
     (type (sub $t (array nullexternref))) ;; invalid
   )
-  "subtype must match supertype"
+  "sub type must match super type"
 )
 (assert_invalid
   (module

--- a/tests/local/gc/type-subtyping.wast
+++ b/tests/local/gc/type-subtyping.wast
@@ -1,0 +1,805 @@
+;; Definitions
+
+(module
+  (type $e0 (sub (array i32)))
+  (type $e1 (sub $e0 (array i32)))
+
+  (type $e2 (sub (array anyref)))
+  (type $e3 (sub (array (ref null $e0))))
+  (type $e4 (sub (array (ref $e1))))
+
+  (type $m1 (sub (array (mut i32))))
+  (type $m2 (sub $m1 (array (mut i32))))
+)
+
+(module
+  (type $e0 (sub (struct)))
+  (type $e1 (sub $e0 (struct)))
+  (type $e2 (sub $e1 (struct (field i32))))
+  (type $e3 (sub $e2 (struct (field i32 (ref null $e0)))))
+  (type $e4 (sub $e3 (struct (field i32 (ref $e0) (mut i64)))))
+  (type $e5 (sub $e4 (struct (field i32 (ref $e1) (mut i64)))))
+)
+
+(module
+  (type $s (sub (struct)))
+  (type $s' (sub $s (struct)))
+
+  (type $f1 (sub (func (param (ref $s')) (result anyref))))
+  (type $f2 (sub $f1 (func (param (ref $s)) (result (ref any)))))
+  (type $f3 (sub $f2 (func (param (ref null $s)) (result (ref $s)))))
+  (type $f4 (sub $f3 (func (param (ref null struct)) (result (ref $s')))))
+)
+
+
+;; Recursive definitions
+
+(module
+  (type $t (sub (struct (field anyref))))
+  (rec (type $r (sub $t (struct (field (ref $r))))))
+  (type $t' (sub $r (struct (field (ref $r) i32))))
+)
+
+(module
+  (rec
+    (type $r1 (sub (struct (field i32 (ref $r1)))))
+  )
+  (rec
+    (type $r2 (sub $r1 (struct (field i32 (ref $r3)))))
+    (type $r3 (sub $r1 (struct (field i32 (ref $r2)))))
+  )
+)
+
+(module
+  (rec
+    (type $a1 (sub (struct (field i32 (ref $a2)))))
+    (type $a2 (sub (struct (field i64 (ref $a1)))))
+  )
+  (rec
+    (type $b1 (sub $a2 (struct (field i64 (ref $a1) i32))))
+    (type $b2 (sub $a1 (struct (field i32 (ref $a2) i32))))
+    (type $b3 (sub $a2 (struct (field i64 (ref $b2) i32))))
+  )
+)
+
+
+;; Subsumption
+
+(module
+  (rec
+    (type $t1 (sub (func (param i32 (ref $t3)))))
+    (type $t2 (sub $t1 (func (param i32 (ref $t2)))))
+    (type $t3 (sub $t2 (func (param i32 (ref $t1)))))
+  )
+
+  (func $f1 (param $r (ref $t1))
+    (call $f1 (local.get $r))
+  )
+  (func $f2 (param $r (ref $t2))
+    (call $f1 (local.get $r))
+    (call $f2 (local.get $r))
+  )
+  (func $f3 (param $r (ref $t3))
+    (call $f1 (local.get $r))
+    (call $f2 (local.get $r))
+    (call $f3 (local.get $r))
+  )
+)
+
+(module
+  (rec
+    (type $t1 (sub (func (result i32 (ref $u1)))))
+    (type $u1 (sub (func (result f32 (ref $t1)))))
+  )
+
+  (rec
+    (type $t2 (sub $t1 (func (result i32 (ref $u3)))))
+    (type $u2 (sub $u1 (func (result f32 (ref $t3)))))
+    (type $t3 (sub $t1 (func (result i32 (ref $u2)))))
+    (type $u3 (sub $u1 (func (result f32 (ref $t2)))))
+  )
+
+  (func $f1 (param $r (ref $t1))
+    (call $f1 (local.get $r))
+  )
+  (func $f2 (param $r (ref $t2))
+    (call $f1 (local.get $r))
+    (call $f2 (local.get $r))
+  )
+  (func $f3 (param $r (ref $t3))
+    (call $f1 (local.get $r))
+    (call $f3 (local.get $r))
+  )
+)
+
+(module
+  (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
+  (rec (type $f2 (sub (func))) (type (struct (field (ref $f2)))))
+  (rec (type $g1 (sub $f1 (func))) (type (struct)))
+  (rec (type $g2 (sub $f2 (func))) (type (struct)))
+  (func $g (type $g2))
+  (global (ref $g1) (ref.func $g))
+)
+
+(module
+  (rec (type $f1 (sub (func))) (type $s1 (sub (struct (field (ref $f1))))))
+  (rec (type $f2 (sub (func))) (type $s2 (sub (struct (field (ref $f2))))))
+  (rec
+    (type $g1 (sub $f1 (func)))
+    (type (sub $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
+  )
+  (rec
+    (type $g2 (sub $f2 (func)))
+    (type (sub $s2 (struct (field (ref $f1) (ref $f2) (ref $f1) (ref $f2) (ref $g2)))))
+  )
+  (func $g (type $g2))
+  (global (ref $g1) (ref.func $g))
+)
+
+(assert_invalid
+  (module
+    (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
+    (rec (type $f2 (sub (func))) (type (struct (field (ref $f1)))))
+    (rec (type $g1 (sub $f1 (func))) (type (struct)))
+    (rec (type $g2 (sub $f2 (func))) (type (struct)))
+    (func $g (type $g2))
+    (global (ref $g1) (ref.func $g))
+  )
+  "type mismatch"
+)
+
+(module
+  (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
+  (rec (type $f2 (sub (func))) (type (struct (field (ref $f2)))))
+  (rec (type $g (sub $f1 (func))) (type (struct)))
+  (func $g (type $g))
+  (global (ref $f1) (ref.func $g))
+)
+
+(module
+  (rec (type $f1 (sub (func))) (type $s1 (sub (struct (field (ref $f1))))))
+  (rec (type $f2 (sub (func))) (type $s2 (sub (struct (field (ref $f2))))))
+  (rec
+    (type $g1 (sub $f1 (func)))
+    (type (sub $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
+  )
+  (rec
+    (type $g2 (sub $f2 (func)))
+    (type (sub $s2 (struct (field (ref $f1) (ref $f2) (ref $f1) (ref $f2) (ref $g2)))))
+  )
+  (rec (type $h (sub $g2 (func))) (type (struct)))
+  (func $h (type $h))
+  (global (ref $f1) (ref.func $h))
+  (global (ref $g1) (ref.func $h))
+)
+
+
+(module
+  (rec (type $f11 (sub (func (result (ref func))))) (type $f12 (sub $f11 (func (result (ref $f11))))))
+  (rec (type $f21 (sub (func (result (ref func))))) (type $f22 (sub $f21 (func (result (ref $f21))))))
+  (func $f11 (type $f11) (unreachable))
+  (func $f12 (type $f12) (unreachable))
+  (global (ref $f11) (ref.func $f11))
+  (global (ref $f21) (ref.func $f11))
+  (global (ref $f12) (ref.func $f12))
+  (global (ref $f22) (ref.func $f12))
+)
+
+(module
+  (rec (type $f11 (sub (func (result (ref func))))) (type $f12 (sub $f11 (func (result (ref $f11))))))
+  (rec (type $f21 (sub (func (result (ref func))))) (type $f22 (sub $f21 (func (result (ref $f21))))))
+  (rec (type $g11 (sub $f11 (func (result (ref func))))) (type $g12 (sub $g11 (func (result (ref $g11))))))
+  (rec (type $g21 (sub $f21 (func (result (ref func))))) (type $g22 (sub $g21 (func (result (ref $g21))))))
+  (func $g11 (type $g11) (unreachable))
+  (func $g12 (type $g12) (unreachable))
+  (global (ref $f11) (ref.func $g11))
+  (global (ref $f21) (ref.func $g11))
+  (global (ref $f11) (ref.func $g12))
+  (global (ref $f21) (ref.func $g12))
+  (global (ref $g11) (ref.func $g11))
+  (global (ref $g21) (ref.func $g11))
+  (global (ref $g12) (ref.func $g12))
+  (global (ref $g22) (ref.func $g12))
+)
+
+(assert_invalid
+  (module
+    (rec (type $f11 (sub (func))) (type $f12 (sub $f11 (func))))
+    (rec (type $f21 (sub (func))) (type $f22 (sub $f11 (func))))
+    (func $f (type $f21))
+    (global (ref $f11) (ref.func $f))
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (rec (type $f01 (sub (func))) (type $f02 (sub $f01 (func))))
+    (rec (type $f11 (sub (func))) (type $f12 (sub $f01 (func))))
+    (rec (type $f21 (sub (func))) (type $f22 (sub $f11 (func))))
+    (func $f (type $f21))
+    (global (ref $f11) (ref.func $f))
+  )
+  "type mismatch"
+)
+
+
+;; Runtime types
+
+(module
+  (type $t0 (sub (func (result (ref null func)))))
+  (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
+  (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
+
+  (func $f0 (type $t0) (ref.null func))
+  (func $f1 (type $t1) (ref.null $t1))
+  (func $f2 (type $t2) (ref.null $t2))
+  (table funcref (elem $f0 $f1 $f2))
+
+  (func (export "run")
+    (block (result (ref null func)) (call_indirect (type $t0) (i32.const 0)))
+    (block (result (ref null func)) (call_indirect (type $t0) (i32.const 1)))
+    (block (result (ref null func)) (call_indirect (type $t0) (i32.const 2)))
+    (block (result (ref null $t1)) (call_indirect (type $t1) (i32.const 1)))
+    (block (result (ref null $t1)) (call_indirect (type $t1) (i32.const 2)))
+    (block (result (ref null $t2)) (call_indirect (type $t2) (i32.const 2)))
+
+    (block (result (ref null $t0)) (ref.cast (ref $t0) (table.get (i32.const 0))))
+    (block (result (ref null $t0)) (ref.cast (ref $t0) (table.get (i32.const 1))))
+    (block (result (ref null $t0)) (ref.cast (ref $t0) (table.get (i32.const 2))))
+    (block (result (ref null $t1)) (ref.cast (ref $t1) (table.get (i32.const 1))))
+    (block (result (ref null $t1)) (ref.cast (ref $t1) (table.get (i32.const 2))))
+    (block (result (ref null $t2)) (ref.cast (ref $t2) (table.get (i32.const 2))))
+    (br 0)
+  )
+
+  (func (export "fail1")
+    (block (result (ref null $t1)) (call_indirect (type $t1) (i32.const 0)))
+    (br 0)
+  )
+  (func (export "fail2")
+    (block (result (ref null $t1)) (call_indirect (type $t2) (i32.const 0)))
+    (br 0)
+  )
+  (func (export "fail3")
+    (block (result (ref null $t1)) (call_indirect (type $t2) (i32.const 1)))
+    (br 0)
+  )
+
+  (func (export "fail4")
+    (ref.cast (ref $t1) (table.get (i32.const 0)))
+    (br 0)
+  )
+  (func (export "fail5")
+    (ref.cast (ref $t2) (table.get (i32.const 0)))
+    (br 0)
+  )
+  (func (export "fail6")
+    (ref.cast (ref $t2) (table.get (i32.const 1)))
+    (br 0)
+  )
+)
+(assert_return (invoke "run"))
+(assert_trap (invoke "fail1") "indirect call")
+(assert_trap (invoke "fail2") "indirect call")
+(assert_trap (invoke "fail3") "indirect call")
+(assert_trap (invoke "fail4") "cast")
+(assert_trap (invoke "fail5") "cast")
+(assert_trap (invoke "fail6") "cast")
+
+(module
+  (type $t1 (sub (func)))
+  (type $t2 (sub final (func)))
+
+  (func $f1 (type $t1))
+  (func $f2 (type $t2))
+  (table funcref (elem $f1 $f2))
+
+  (func (export "fail1")
+    (block (call_indirect (type $t1) (i32.const 1)))
+  )
+  (func (export "fail2")
+    (block (call_indirect (type $t2) (i32.const 0)))
+  )
+
+  (func (export "fail3")
+    (ref.cast (ref $t1) (table.get (i32.const 1)))
+    (drop)
+  )
+  (func (export "fail4")
+    (ref.cast (ref $t2) (table.get (i32.const 0)))
+    (drop)
+  )
+)
+(assert_trap (invoke "fail1") "indirect call")
+(assert_trap (invoke "fail2") "indirect call")
+(assert_trap (invoke "fail3") "cast")
+(assert_trap (invoke "fail4") "cast")
+
+
+(module
+  (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
+  (rec (type $f2 (sub (func))) (type (struct (field (ref $f2)))))
+  (rec (type $g1 (sub $f1 (func))) (type (struct)))
+  (rec (type $g2 (sub $f2 (func))) (type (struct)))
+  (func $g (type $g2)) (elem declare func $g)
+  (func (export "run") (result i32)
+    (ref.test (ref $g1) (ref.func $g))
+  )
+)
+(assert_return (invoke "run") (i32.const 1))
+
+(module
+  (rec (type $f1 (sub (func))) (type $s1 (sub (struct (field (ref $f1))))))
+  (rec (type $f2 (sub (func))) (type $s2 (sub (struct (field (ref $f2))))))
+  (rec
+    (type $g1 (sub $f1 (func)))
+    (type (sub $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
+  )
+  (rec
+    (type $g2 (sub $f2 (func)))
+    (type (sub $s2 (struct (field (ref $f1) (ref $f2) (ref $f1) (ref $f2) (ref $g2)))))
+  )
+  (func $g (type $g2)) (elem declare func $g)
+  (func (export "run") (result i32)
+    (ref.test (ref $g1) (ref.func $g))
+  )
+)
+(assert_return (invoke "run") (i32.const 1))
+
+;; (module
+;;   (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
+;;   (rec (type $f2 (sub (func))) (type (struct (field (ref $f1)))))
+;;   (rec (type $g1 (sub $f1 (func))) (type (struct)))
+;;   (rec (type $g2 (sub $f2 (func))) (type (struct)))
+;;   (func $g (type $g2)) (elem declare func $g)
+;;   (func (export "run") (result i32)
+;;     (ref.test (ref $g1) (ref.func $g))
+;;   )
+;; )
+;; (assert_return (invoke "run") (i32.const 0))
+
+;; (module
+;;   (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
+;;   (rec (type $f2 (sub (func))) (type (struct (field (ref $f2)))))
+;;   (rec (type $g (sub $f1 (func))) (type (struct)))
+;;   (func $g (type $g)) (elem declare func $g)
+;;   (func (export "run") (result i32)
+;;     (ref.test (ref $f1) (ref.func $g))
+;;   )
+;; )
+;; (assert_return (invoke "run") (i32.const 1))
+
+;; (module
+;;   (rec (type $f1 (sub (func))) (type $s1 (sub (struct (field (ref $f1))))))
+;;   (rec (type $f2 (sub (func))) (type $s2 (sub (struct (field (ref $f2))))))
+;;   (rec
+;;     (type $g1 (sub $f1 (func)))
+;;     (type (sub $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
+;;   )
+;;   (rec
+;;     (type $g2 (sub $f2 (func)))
+;;     (type (sub $s2 (struct (field (ref $f1) (ref $f2) (ref $f1) (ref $f2) (ref $g2)))))
+;;   )
+;;   (rec (type $h (sub $g2 (func))) (type (struct)))
+;;   (func $h (type $h)) (elem declare func $h)
+;;   (func (export "run") (result i32 i32)
+;;     (ref.test (ref $f1) (ref.func $h))
+;;     (ref.test (ref $g1) (ref.func $h))
+;;   )
+;; )
+;; (assert_return (invoke "run") (i32.const 1) (i32.const 1))
+
+
+(module
+  (rec (type $f11 (sub (func (result (ref func))))) (type $f12 (sub $f11 (func (result (ref $f11))))))
+  (rec (type $f21 (sub (func (result (ref func))))) (type $f22 (sub $f21 (func (result (ref $f21))))))
+  (func $f11 (type $f11) (unreachable)) (elem declare func $f11)
+  (func $f12 (type $f12) (unreachable)) (elem declare func $f12)
+  (func (export "run") (result i32 i32 i32 i32)
+    (ref.test (ref $f11) (ref.func $f11))
+    (ref.test (ref $f21) (ref.func $f11))
+    (ref.test (ref $f12) (ref.func $f12))
+    (ref.test (ref $f22) (ref.func $f12))
+  )
+)
+(assert_return (invoke "run")
+  (i32.const 1) (i32.const 1) (i32.const 1) (i32.const 1)
+)
+
+;; (module
+;;   (rec (type $f11 (sub (func (result (ref func))))) (type $f12 (sub $f11 (func (result (ref $f11))))))
+;;   (rec (type $f21 (sub (func (result (ref func))))) (type $f22 (sub $f21 (func (result (ref $f21))))))
+;;   (rec (type $g11 (sub $f11 (func (result (ref func))))) (type $g12 (sub $g11 (func (result (ref $g11))))))
+;;   (rec (type $g21 (sub $f21 (func (result (ref func))))) (type $g22 (sub $g21 (func (result (ref $g21))))))
+;;   (func $g11 (type $g11) (unreachable)) (elem declare func $g11)
+;;   (func $g12 (type $g12) (unreachable)) (elem declare func $g12)
+;;   (func (export "run") (result i32 i32 i32 i32 i32 i32 i32 i32)
+;;     (ref.test (ref $f11) (ref.func $g11))
+;;     (ref.test (ref $f21) (ref.func $g11))
+;;     (ref.test (ref $f11) (ref.func $g12))
+;;     (ref.test (ref $f21) (ref.func $g12))
+;;     (ref.test (ref $g11) (ref.func $g11))
+;;     (ref.test (ref $g21) (ref.func $g11))
+;;     (ref.test (ref $g12) (ref.func $g12))
+;;     (ref.test (ref $g22) (ref.func $g12))
+;;   )
+;; )
+;; (assert_return (invoke "run")
+;;   (i32.const 1) (i32.const 1) (i32.const 1) (i32.const 1)
+;;   (i32.const 1) (i32.const 1) (i32.const 1) (i32.const 1)
+;; )
+
+;; (module
+;;   (rec (type $f11 (sub (func))) (type $f12 (sub $f11 (func))))
+;;   (rec (type $f21 (sub (func))) (type $f22 (sub $f11 (func))))
+;;   (func $f (type $f21)) (elem declare func $f)
+;;   (func (export "run") (result i32)
+;;     (ref.test (ref $f11) (ref.func $f))
+;;   )
+;; )
+;; (assert_return (invoke "run") (i32.const 0))
+
+;; (module
+;;   (rec (type $f01 (sub (func))) (type $f02 (sub $f01 (func))))
+;;   (rec (type $f11 (sub (func))) (type $f12 (sub $f01 (func))))
+;;   (rec (type $f21 (sub (func))) (type $f22 (sub $f11 (func))))
+;;   (func $f (type $f21)) (elem declare func $f)
+;;   (func (export "run") (result i32)
+;;     (ref.test (ref $f11) (ref.func $f))
+;;   )
+;; )
+;; (assert_return (invoke "run") (i32.const 0))
+
+
+
+;; Linking
+
+(module
+  (type $t0 (sub (func (result (ref null func)))))
+  (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
+  (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
+
+  (func (export "f0") (type $t0) (ref.null func))
+  (func (export "f1") (type $t1) (ref.null $t1))
+  (func (export "f2") (type $t2) (ref.null $t2))
+)
+(register "M")
+
+(module
+  (type $t0 (sub (func (result (ref null func)))))
+  (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
+  (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
+
+  (func (import "M" "f0") (type $t0))
+  (func (import "M" "f1") (type $t0))
+  (func (import "M" "f1") (type $t1))
+  (func (import "M" "f2") (type $t0))
+  (func (import "M" "f2") (type $t1))
+  (func (import "M" "f2") (type $t2))
+)
+
+(assert_unlinkable
+  (module
+    (type $t0 (sub (func (result (ref null func)))))
+    (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
+    (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
+    (func (import "M" "f0") (type $t1))
+  )
+  "incompatible import type"
+)
+
+(assert_unlinkable
+  (module
+    (type $t0 (sub (func (result (ref null func)))))
+    (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
+    (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
+    (func (import "M" "f0") (type $t2))
+  )
+  "incompatible import type"
+)
+
+(assert_unlinkable
+  (module
+    (type $t0 (sub (func (result (ref null func)))))
+    (rec (type $t1 (sub $t0 (func (result (ref null $t1))))))
+    (rec (type $t2 (sub $t1 (func (result (ref null $t2))))))
+    (func (import "M" "f1") (type $t2))
+  )
+  "incompatible import type"
+)
+
+(module
+  (type $t1 (sub (func)))
+  (type $t2 (sub final (func)))
+  (func (export "f1") (type $t1))
+  (func (export "f2") (type $t2))
+)
+(register "M2")
+
+(assert_unlinkable
+  (module
+    (type $t1 (sub (func)))
+    (type $t2 (sub final (func)))
+    (func (import "M2" "f1") (type $t2))
+  )
+  "incompatible import type"
+)
+(assert_unlinkable
+  (module
+    (type $t1 (sub (func)))
+    (type $t2 (sub final (func)))
+    (func (import "M2" "f2") (type $t1))
+  )
+  "incompatible import type"
+)
+
+
+(module
+  (rec (type $f2 (sub (func))) (type (struct (field (ref $f2)))))
+  (rec (type $g2 (sub $f2 (func))) (type (struct)))
+  (func (export "g") (type $g2))
+)
+(register "M3")
+(module
+  (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
+  (rec (type $g1 (sub $f1 (func))) (type (struct)))
+  (func (import "M3" "g") (type $g1))
+)
+
+(module
+  (rec (type $f1 (sub (func))) (type $s1 (sub (struct (field (ref $f1))))))
+  (rec (type $f2 (sub (func))) (type $s2 (sub (struct (field (ref $f2))))))
+  (rec
+    (type $g2 (sub $f2 (func)))
+    (type (sub $s2 (struct (field (ref $f1) (ref $f2) (ref $f1) (ref $f2) (ref $g2)))))
+  )
+  (func (export "g") (type $g2))
+)
+(register "M4")
+(module
+  (rec (type $f1 (sub (func))) (type $s1 (sub (struct (field (ref $f1))))))
+  (rec (type $f2 (sub (func))) (type $s2 (sub (struct (field (ref $f2))))))
+  (rec
+    (type $g1 (sub $f1 (func)))
+    (type (sub $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
+  )
+  (func (import "M4" "g") (type $g1))
+)
+
+(module
+  (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
+  (rec (type $f2 (sub (func))) (type (struct (field (ref $f1)))))
+  (rec (type $g2 (sub $f2 (func))) (type (struct)))
+  (func (export "g") (type $g2))
+)
+(register "M5")
+(assert_unlinkable
+  (module
+    (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
+    (rec (type $g1 (sub $f1 (func))) (type (struct)))
+    (func (import "M5" "g") (type $g1))
+  )
+  "incompatible import"
+)
+
+(module
+  (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
+  (rec (type $f2 (sub (func))) (type (struct (field (ref $f2)))))
+  (rec (type $g (sub $f1 (func))) (type (struct)))
+  (func (export "g") (type $g))
+)
+(register "M6")
+(module
+  (rec (type $f1 (sub (func))) (type (struct (field (ref $f1)))))
+  (rec (type $f2 (sub (func))) (type (struct (field (ref $f2)))))
+  (rec (type $g (sub $f1 (func))) (type (struct)))
+  (func (import "M6" "g") (type $f1))
+)
+
+(module
+  (rec (type $f1 (sub (func))) (type $s1 (sub (struct (field (ref $f1))))))
+  (rec (type $f2 (sub (func))) (type $s2 (sub (struct (field (ref $f2))))))
+  (rec
+    (type $g2 (sub $f2 (func)))
+    (type (sub $s2 (struct (field (ref $f1) (ref $f2) (ref $f1) (ref $f2) (ref $g2)))))
+  )
+  (rec (type $h (sub $g2 (func))) (type (struct)))
+  (func (export "h") (type $h))
+)
+(register "M7")
+(module
+  (rec (type $f1 (sub (func))) (type $s1 (sub (struct (field (ref $f1))))))
+  (rec (type $f2 (sub (func))) (type $s2 (sub (struct (field (ref $f2))))))
+  (rec
+    (type $g1 (sub $f1 (func)))
+    (type (sub $s1 (struct (field (ref $f1) (ref $f1) (ref $f2) (ref $f2) (ref $g1)))))
+  )
+  (rec (type $h (sub $g1 (func))) (type (struct)))
+  (func (import "M7" "h") (type $f1))
+  (func (import "M7" "h") (type $g1))
+)
+
+
+(module
+  (rec (type $f11 (sub (func (result (ref func))))) (type $f12 (sub $f11 (func (result (ref $f11))))))
+  (rec (type $f21 (sub (func (result (ref func))))) (type $f22 (sub $f21 (func (result (ref $f21))))))
+  (func (export "f11") (type $f11) (unreachable))
+  (func (export "f12") (type $f12) (unreachable))
+)
+(register "M8")
+(module
+  (rec (type $f11 (sub (func (result (ref func))))) (type $f12 (sub $f11 (func (result (ref $f11))))))
+  (rec (type $f21 (sub (func (result (ref func))))) (type $f22 (sub $f21 (func (result (ref $f21))))))
+  (func (import "M8" "f11") (type $f11))
+  (func (import "M8" "f11") (type $f21))
+  (func (import "M8" "f12") (type $f12))
+  (func (import "M8" "f12") (type $f22))
+)
+
+(module
+  (rec (type $f11 (sub (func (result (ref func))))) (type $f12 (sub $f11 (func (result (ref $f11))))))
+  (rec (type $f21 (sub (func (result (ref func))))) (type $f22 (sub $f21 (func (result (ref $f21))))))
+  (rec (type $g11 (sub $f11 (func (result (ref func))))) (type $g12 (sub $g11 (func (result (ref $g11))))))
+  (rec (type $g21 (sub $f21 (func (result (ref func))))) (type $g22 (sub $g21 (func (result (ref $g21))))))
+  (func (export "g11") (type $g11) (unreachable))
+  (func (export "g12") (type $g12) (unreachable))
+)
+(register "M9")
+(module
+  (rec (type $f11 (sub (func (result (ref func))))) (type $f12 (sub $f11 (func (result (ref $f11))))))
+  (rec (type $f21 (sub (func (result (ref func))))) (type $f22 (sub $f21 (func (result (ref $f21))))))
+  (rec (type $g11 (sub $f11 (func (result (ref func))))) (type $g12 (sub $g11 (func (result (ref $g11))))))
+  (rec (type $g21 (sub $f21 (func (result (ref func))))) (type $g22 (sub $g21 (func (result (ref $g21))))))
+  (func (import "M9" "g11") (type $f11))
+  (func (import "M9" "g11") (type $f21))
+  (func (import "M9" "g12") (type $f11))
+  (func (import "M9" "g12") (type $f21))
+  (func (import "M9" "g11") (type $g11))
+  (func (import "M9" "g11") (type $g21))
+  (func (import "M9" "g12") (type $g12))
+  (func (import "M9" "g12") (type $g22))
+)
+
+(module
+  (rec (type $f11 (sub (func))) (type $f12 (sub $f11 (func))))
+  (rec (type $f21 (sub (func))) (type $f22 (sub $f11 (func))))
+  (func (export "f") (type $f21))
+)
+(register "M10")
+(assert_unlinkable
+  (module
+    (rec (type $f11 (sub (func))) (type $f12 (sub $f11 (func))))
+    (func (import "M10" "f") (type $f11))
+  )
+  "incompatible import"
+)
+
+(module
+  (rec (type $f01 (sub (func))) (type $f02 (sub $f01 (func))))
+  (rec (type $f11 (sub (func))) (type $f12 (sub $f01 (func))))
+  (rec (type $f21 (sub (func))) (type $f22 (sub $f11 (func))))
+  (func (export "f") (type $f21))
+)
+(register "M11")
+(assert_unlinkable
+  (module
+    (rec (type $f01 (sub (func))) (type $f02 (sub $f01 (func))))
+    (rec (type $f11 (sub (func))) (type $f12 (sub $f01 (func))))
+    (func (import "M11" "f") (type $f11))
+  )
+  "incompatible import"
+)
+
+
+
+;; Finality violation
+
+(assert_invalid
+  (module
+    (type $t (func))
+    (type $s (sub $t (func)))
+  )
+  "sub type"
+)
+
+(assert_invalid
+  (module
+    (type $t (struct))
+    (type $s (sub $t (struct)))
+  )
+  "sub type"
+)
+
+(assert_invalid
+  (module
+    (type $t (sub final (func)))
+    (type $s (sub $t (func)))
+  )
+  "sub type"
+)
+
+(assert_invalid
+  (module
+    (type $t (sub (func)))
+    (type $s (sub final $t (func)))
+    (type $u (sub $s (func)))
+  )
+  "sub type"
+)
+
+
+
+;; Invalid subtyping definitions
+
+(assert_invalid
+  (module
+    (type $a0 (sub (array i32)))
+    (type $s0 (sub $a0 (struct)))
+  )
+  "sub type"
+)
+
+(assert_invalid
+  (module
+    (type $f0 (sub (func (param i32) (result i32))))
+    (type $s0 (sub $f0 (struct)))
+  )
+  "sub type"
+)
+
+(assert_invalid
+  (module
+    (type $s0 (sub (struct)))
+    (type $a0 (sub $s0 (array i32)))
+  )
+  "sub type"
+)
+
+(assert_invalid
+  (module
+    (type $f0 (sub (func (param i32) (result i32))))
+    (type $a0 (sub $f0 (array i32)))
+  )
+  "sub type"
+)
+
+(assert_invalid
+  (module
+    (type $s0 (sub (struct)))
+    (type $f0 (sub $s0 (func (param i32) (result i32))))
+  )
+  "sub type"
+)
+
+(assert_invalid
+  (module
+    (type $a0 (sub (array i32)))
+    (type $f0 (sub $a0 (func (param i32) (result i32))))
+  )
+  "sub type"
+)
+
+(assert_invalid
+  (module
+    (type $a0 (sub (array i32)))
+    (type $a1 (sub $a0 (array i64)))
+  )
+  "sub type"
+)
+
+(assert_invalid
+  (module
+    (type $s0 (sub (struct (field i32))))
+    (type $s1 (sub $s0 (struct (field i64))))
+  )
+  "sub type"
+)
+
+(assert_invalid
+  (module
+    (type $f0 (sub (func)))
+    (type $f1 (sub $f0 (func (param i32))))
+  )
+  "sub type"
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/0.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/0.print
@@ -1,0 +1,9 @@
+(module
+  (type $e0 (;0;) (sub (array i32)))
+  (type $e1 (;1;) (sub $e0 (;0;) (array i32)))
+  (type $e2 (;2;) (sub (array anyref)))
+  (type $e3 (;3;) (sub (array (ref null 0))))
+  (type $e4 (;4;) (sub (array (ref 1))))
+  (type $m1 (;5;) (sub (array (mut i32))))
+  (type $m2 (;6;) (sub $m1 (;5;) (array (mut i32))))
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/1.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/1.print
@@ -1,0 +1,8 @@
+(module
+  (type $e0 (;0;) (sub (struct)))
+  (type $e1 (;1;) (sub $e0 (;0;) (struct)))
+  (type $e2 (;2;) (sub $e1 (;1;) (struct (field i32))))
+  (type $e3 (;3;) (sub $e2 (;2;) (struct (field i32) (field (ref null 0)))))
+  (type $e4 (;4;) (sub $e3 (;3;) (struct (field i32) (field (ref 0)) (field (mut i64)))))
+  (type $e5 (;5;) (sub $e4 (;4;) (struct (field i32) (field (ref 1)) (field (mut i64)))))
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/11.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/11.print
@@ -1,0 +1,16 @@
+(module
+  (rec
+    (type $f1 (;0;) (sub (func)))
+    (type (;1;) (struct (field (ref 0))))
+  )
+  (rec
+    (type $f2 (;2;) (sub (func)))
+    (type (;3;) (struct (field (ref 2))))
+  )
+  (rec
+    (type $g (;4;) (sub $f1 (;0;) (func)))
+    (type (;5;) (struct))
+  )
+  (func $g (;0;) (type $g))
+  (global (;0;) (ref 0) ref.func $g)
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/12.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/12.print
@@ -1,0 +1,25 @@
+(module
+  (rec
+    (type $f1 (;0;) (sub (func)))
+    (type $s1 (;1;) (sub (struct (field (ref 0)))))
+  )
+  (rec
+    (type $f2 (;2;) (sub (func)))
+    (type $s2 (;3;) (sub (struct (field (ref 2)))))
+  )
+  (rec
+    (type $g1 (;4;) (sub $f1 (;0;) (func)))
+    (type (;5;) (sub $s1 (;1;) (struct (field (ref 0)) (field (ref 0)) (field (ref 2)) (field (ref 2)) (field (ref 4)))))
+  )
+  (rec
+    (type $g2 (;6;) (sub $f2 (;2;) (func)))
+    (type (;7;) (sub $s2 (;3;) (struct (field (ref 0)) (field (ref 2)) (field (ref 0)) (field (ref 2)) (field (ref 6)))))
+  )
+  (rec
+    (type $h (;8;) (sub $g2 (;6;) (func)))
+    (type (;9;) (struct))
+  )
+  (func $h (;0;) (type $h))
+  (global (;0;) (ref 0) ref.func $h)
+  (global (;1;) (ref 4) ref.func $h)
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/13.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/13.print
@@ -1,0 +1,20 @@
+(module
+  (rec
+    (type $f11 (;0;) (sub (func (result (ref func)))))
+    (type $f12 (;1;) (sub $f11 (;0;) (func (result (ref 0)))))
+  )
+  (rec
+    (type $f21 (;2;) (sub (func (result (ref func)))))
+    (type $f22 (;3;) (sub $f21 (;2;) (func (result (ref 2)))))
+  )
+  (func $f11 (;0;) (type $f11) (result (ref func))
+    unreachable
+  )
+  (func $f12 (;1;) (type $f12) (result (ref 0))
+    unreachable
+  )
+  (global (;0;) (ref 0) ref.func $f11)
+  (global (;1;) (ref 2) ref.func $f11)
+  (global (;2;) (ref 1) ref.func $f12)
+  (global (;3;) (ref 3) ref.func $f12)
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/14.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/14.print
@@ -1,0 +1,32 @@
+(module
+  (rec
+    (type $f11 (;0;) (sub (func (result (ref func)))))
+    (type $f12 (;1;) (sub $f11 (;0;) (func (result (ref 0)))))
+  )
+  (rec
+    (type $f21 (;2;) (sub (func (result (ref func)))))
+    (type $f22 (;3;) (sub $f21 (;2;) (func (result (ref 2)))))
+  )
+  (rec
+    (type $g11 (;4;) (sub $f11 (;0;) (func (result (ref func)))))
+    (type $g12 (;5;) (sub $g11 (;4;) (func (result (ref 4)))))
+  )
+  (rec
+    (type $g21 (;6;) (sub $f21 (;2;) (func (result (ref func)))))
+    (type $g22 (;7;) (sub $g21 (;6;) (func (result (ref 6)))))
+  )
+  (func $g11 (;0;) (type $g11) (result (ref func))
+    unreachable
+  )
+  (func $g12 (;1;) (type $g12) (result (ref 4))
+    unreachable
+  )
+  (global (;0;) (ref 0) ref.func $g11)
+  (global (;1;) (ref 2) ref.func $g11)
+  (global (;2;) (ref 0) ref.func $g12)
+  (global (;3;) (ref 2) ref.func $g12)
+  (global (;4;) (ref 4) ref.func $g11)
+  (global (;5;) (ref 6) ref.func $g11)
+  (global (;6;) (ref 5) ref.func $g12)
+  (global (;7;) (ref 7) ref.func $g12)
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/17.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/17.print
@@ -1,0 +1,124 @@
+(module
+  (type $t0 (;0;) (sub (func (result funcref))))
+  (rec
+    (type $t1 (;1;) (sub $t0 (;0;) (func (result (ref null 1)))))
+  )
+  (rec
+    (type $t2 (;2;) (sub $t1 (;1;) (func (result (ref null 2)))))
+  )
+  (type (;3;) (func))
+  (func $f0 (;0;) (type $t0) (result funcref)
+    ref.null func
+  )
+  (func $f1 (;1;) (type $t1) (result (ref null 1))
+    ref.null 1
+  )
+  (func $f2 (;2;) (type $t2) (result (ref null 2))
+    ref.null 2
+  )
+  (func (;3;) (type 3)
+    block (result funcref) ;; label = @1
+      i32.const 0
+      call_indirect (type $t0)
+    end
+    block (result funcref) ;; label = @1
+      i32.const 1
+      call_indirect (type $t0)
+    end
+    block (result funcref) ;; label = @1
+      i32.const 2
+      call_indirect (type $t0)
+    end
+    block (result (ref null 1)) ;; label = @1
+      i32.const 1
+      call_indirect (type $t1)
+    end
+    block (result (ref null 1)) ;; label = @1
+      i32.const 2
+      call_indirect (type $t1)
+    end
+    block (result (ref null 2)) ;; label = @1
+      i32.const 2
+      call_indirect (type $t2)
+    end
+    block (result (ref null 0)) ;; label = @1
+      i32.const 0
+      table.get 0
+      ref.cast (ref 0)
+    end
+    block (result (ref null 0)) ;; label = @1
+      i32.const 1
+      table.get 0
+      ref.cast (ref 0)
+    end
+    block (result (ref null 0)) ;; label = @1
+      i32.const 2
+      table.get 0
+      ref.cast (ref 0)
+    end
+    block (result (ref null 1)) ;; label = @1
+      i32.const 1
+      table.get 0
+      ref.cast (ref 1)
+    end
+    block (result (ref null 1)) ;; label = @1
+      i32.const 2
+      table.get 0
+      ref.cast (ref 1)
+    end
+    block (result (ref null 2)) ;; label = @1
+      i32.const 2
+      table.get 0
+      ref.cast (ref 2)
+    end
+    br 0 (;@0;)
+  )
+  (func (;4;) (type 3)
+    block (result (ref null 1)) ;; label = @1
+      i32.const 0
+      call_indirect (type $t1)
+    end
+    br 0 (;@0;)
+  )
+  (func (;5;) (type 3)
+    block (result (ref null 1)) ;; label = @1
+      i32.const 0
+      call_indirect (type $t2)
+    end
+    br 0 (;@0;)
+  )
+  (func (;6;) (type 3)
+    block (result (ref null 1)) ;; label = @1
+      i32.const 1
+      call_indirect (type $t2)
+    end
+    br 0 (;@0;)
+  )
+  (func (;7;) (type 3)
+    i32.const 0
+    table.get 0
+    ref.cast (ref 1)
+    br 0 (;@0;)
+  )
+  (func (;8;) (type 3)
+    i32.const 0
+    table.get 0
+    ref.cast (ref 2)
+    br 0 (;@0;)
+  )
+  (func (;9;) (type 3)
+    i32.const 1
+    table.get 0
+    ref.cast (ref 2)
+    br 0 (;@0;)
+  )
+  (table (;0;) 3 3 funcref)
+  (export "run" (func 3))
+  (export "fail1" (func 4))
+  (export "fail2" (func 5))
+  (export "fail3" (func 6))
+  (export "fail4" (func 7))
+  (export "fail5" (func 8))
+  (export "fail6" (func 9))
+  (elem (;0;) (i32.const 0) func $f0 $f1 $f2)
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/2.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/2.print
@@ -1,0 +1,8 @@
+(module
+  (type $s (;0;) (sub (struct)))
+  (type $s' (;1;) (sub $s (;0;) (struct)))
+  (type $f1 (;2;) (sub (func (param (ref 1)) (result anyref))))
+  (type $f2 (;3;) (sub $f1 (;2;) (func (param (ref 0)) (result (ref any)))))
+  (type $f3 (;4;) (sub $f2 (;3;) (func (param (ref null 0)) (result (ref 0)))))
+  (type $f4 (;5;) (sub $f3 (;4;) (func (param structref) (result (ref 1)))))
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/25.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/25.print
@@ -1,0 +1,36 @@
+(module
+  (type $t1 (;0;) (sub (func)))
+  (type $t2 (;1;) (func))
+  (func $f1 (;0;) (type $t1))
+  (func $f2 (;1;) (type $t2))
+  (func (;2;) (type $t1)
+    block ;; label = @1
+      i32.const 1
+      call_indirect (type $t1)
+    end
+  )
+  (func (;3;) (type $t1)
+    block ;; label = @1
+      i32.const 0
+      call_indirect (type $t2)
+    end
+  )
+  (func (;4;) (type $t1)
+    i32.const 1
+    table.get 0
+    ref.cast (ref 0)
+    drop
+  )
+  (func (;5;) (type $t1)
+    i32.const 0
+    table.get 0
+    ref.cast (ref 1)
+    drop
+  )
+  (table (;0;) 2 2 funcref)
+  (export "fail1" (func 2))
+  (export "fail2" (func 3))
+  (export "fail3" (func 4))
+  (export "fail4" (func 5))
+  (elem (;0;) (i32.const 0) func $f1 $f2)
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/3.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/3.print
@@ -1,0 +1,7 @@
+(module
+  (type $t (;0;) (sub (struct (field anyref))))
+  (rec
+    (type $r (;1;) (sub $t (;0;) (struct (field (ref 1)))))
+  )
+  (type $t' (;2;) (sub $r (;1;) (struct (field (ref 1)) (field i32))))
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/30.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/30.print
@@ -1,0 +1,26 @@
+(module
+  (rec
+    (type $f1 (;0;) (sub (func)))
+    (type (;1;) (struct (field (ref 0))))
+  )
+  (rec
+    (type $f2 (;2;) (sub (func)))
+    (type (;3;) (struct (field (ref 2))))
+  )
+  (rec
+    (type $g1 (;4;) (sub $f1 (;0;) (func)))
+    (type (;5;) (struct))
+  )
+  (rec
+    (type $g2 (;6;) (sub $f2 (;2;) (func)))
+    (type (;7;) (struct))
+  )
+  (type (;8;) (func (result i32)))
+  (func $g (;0;) (type $g2))
+  (func (;1;) (type 8) (result i32)
+    ref.func $g
+    ref.test (ref 4)
+  )
+  (export "run" (func 1))
+  (elem (;0;) declare func $g)
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/32.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/32.print
@@ -1,0 +1,26 @@
+(module
+  (rec
+    (type $f1 (;0;) (sub (func)))
+    (type $s1 (;1;) (sub (struct (field (ref 0)))))
+  )
+  (rec
+    (type $f2 (;2;) (sub (func)))
+    (type $s2 (;3;) (sub (struct (field (ref 2)))))
+  )
+  (rec
+    (type $g1 (;4;) (sub $f1 (;0;) (func)))
+    (type (;5;) (sub $s1 (;1;) (struct (field (ref 0)) (field (ref 0)) (field (ref 2)) (field (ref 2)) (field (ref 4)))))
+  )
+  (rec
+    (type $g2 (;6;) (sub $f2 (;2;) (func)))
+    (type (;7;) (sub $s2 (;3;) (struct (field (ref 0)) (field (ref 2)) (field (ref 0)) (field (ref 2)) (field (ref 6)))))
+  )
+  (type (;8;) (func (result i32)))
+  (func $g (;0;) (type $g2))
+  (func (;1;) (type 8) (result i32)
+    ref.func $g
+    ref.test (ref 4)
+  )
+  (export "run" (func 1))
+  (elem (;0;) declare func $g)
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/34.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/34.print
@@ -1,0 +1,30 @@
+(module
+  (rec
+    (type $f11 (;0;) (sub (func (result (ref func)))))
+    (type $f12 (;1;) (sub $f11 (;0;) (func (result (ref 0)))))
+  )
+  (rec
+    (type $f21 (;2;) (sub (func (result (ref func)))))
+    (type $f22 (;3;) (sub $f21 (;2;) (func (result (ref 2)))))
+  )
+  (type (;4;) (func (result i32 i32 i32 i32)))
+  (func $f11 (;0;) (type $f11) (result (ref func))
+    unreachable
+  )
+  (func $f12 (;1;) (type $f12) (result (ref 0))
+    unreachable
+  )
+  (func (;2;) (type 4) (result i32 i32 i32 i32)
+    ref.func $f11
+    ref.test (ref 0)
+    ref.func $f11
+    ref.test (ref 2)
+    ref.func $f12
+    ref.test (ref 1)
+    ref.func $f12
+    ref.test (ref 3)
+  )
+  (export "run" (func 2))
+  (elem (;0;) declare func $f11)
+  (elem (;1;) declare func $f12)
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/36.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/36.print
@@ -1,0 +1,21 @@
+(module
+  (type $t0 (;0;) (sub (func (result funcref))))
+  (rec
+    (type $t1 (;1;) (sub $t0 (;0;) (func (result (ref null 1)))))
+  )
+  (rec
+    (type $t2 (;2;) (sub $t1 (;1;) (func (result (ref null 2)))))
+  )
+  (func (;0;) (type $t0) (result funcref)
+    ref.null func
+  )
+  (func (;1;) (type $t1) (result (ref null 1))
+    ref.null 1
+  )
+  (func (;2;) (type $t2) (result (ref null 2))
+    ref.null 2
+  )
+  (export "f0" (func 0))
+  (export "f1" (func 1))
+  (export "f2" (func 2))
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/38.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/38.print
@@ -1,0 +1,15 @@
+(module
+  (type $t0 (;0;) (sub (func (result funcref))))
+  (rec
+    (type $t1 (;1;) (sub $t0 (;0;) (func (result (ref null 1)))))
+  )
+  (rec
+    (type $t2 (;2;) (sub $t1 (;1;) (func (result (ref null 2)))))
+  )
+  (import "M" "f0" (func (;0;) (type $t0)))
+  (import "M" "f1" (func (;1;) (type $t0)))
+  (import "M" "f1" (func (;2;) (type $t1)))
+  (import "M" "f2" (func (;3;) (type $t0)))
+  (import "M" "f2" (func (;4;) (type $t1)))
+  (import "M" "f2" (func (;5;) (type $t2)))
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/4.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/4.print
@@ -1,0 +1,9 @@
+(module
+  (rec
+    (type $r1 (;0;) (sub (struct (field i32) (field (ref 0)))))
+  )
+  (rec
+    (type $r2 (;1;) (sub $r1 (;0;) (struct (field i32) (field (ref 2)))))
+    (type $r3 (;2;) (sub $r1 (;0;) (struct (field i32) (field (ref 1)))))
+  )
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/42.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/42.print
@@ -1,0 +1,8 @@
+(module
+  (type $t1 (;0;) (sub (func)))
+  (type $t2 (;1;) (func))
+  (func (;0;) (type $t1))
+  (func (;1;) (type $t2))
+  (export "f1" (func 0))
+  (export "f2" (func 1))
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/46.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/46.print
@@ -1,0 +1,12 @@
+(module
+  (rec
+    (type $f2 (;0;) (sub (func)))
+    (type (;1;) (struct (field (ref 0))))
+  )
+  (rec
+    (type $g2 (;2;) (sub $f2 (;0;) (func)))
+    (type (;3;) (struct))
+  )
+  (func (;0;) (type $g2))
+  (export "g" (func 0))
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/48.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/48.print
@@ -1,0 +1,11 @@
+(module
+  (rec
+    (type $f1 (;0;) (sub (func)))
+    (type (;1;) (struct (field (ref 0))))
+  )
+  (rec
+    (type $g1 (;2;) (sub $f1 (;0;) (func)))
+    (type (;3;) (struct))
+  )
+  (import "M3" "g" (func (;0;) (type $g1)))
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/49.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/49.print
@@ -1,0 +1,16 @@
+(module
+  (rec
+    (type $f1 (;0;) (sub (func)))
+    (type $s1 (;1;) (sub (struct (field (ref 0)))))
+  )
+  (rec
+    (type $f2 (;2;) (sub (func)))
+    (type $s2 (;3;) (sub (struct (field (ref 2)))))
+  )
+  (rec
+    (type $g2 (;4;) (sub $f2 (;2;) (func)))
+    (type (;5;) (sub $s2 (;3;) (struct (field (ref 0)) (field (ref 2)) (field (ref 0)) (field (ref 2)) (field (ref 4)))))
+  )
+  (func (;0;) (type $g2))
+  (export "g" (func 0))
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/5.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/5.print
@@ -1,0 +1,11 @@
+(module
+  (rec
+    (type $a1 (;0;) (sub (struct (field i32) (field (ref 1)))))
+    (type $a2 (;1;) (sub (struct (field i64) (field (ref 0)))))
+  )
+  (rec
+    (type $b1 (;2;) (sub $a2 (;1;) (struct (field i64) (field (ref 0)) (field i32))))
+    (type $b2 (;3;) (sub $a1 (;0;) (struct (field i32) (field (ref 1)) (field i32))))
+    (type $b3 (;4;) (sub $a2 (;1;) (struct (field i64) (field (ref 3)) (field i32))))
+  )
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/51.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/51.print
@@ -1,0 +1,15 @@
+(module
+  (rec
+    (type $f1 (;0;) (sub (func)))
+    (type $s1 (;1;) (sub (struct (field (ref 0)))))
+  )
+  (rec
+    (type $f2 (;2;) (sub (func)))
+    (type $s2 (;3;) (sub (struct (field (ref 2)))))
+  )
+  (rec
+    (type $g1 (;4;) (sub $f1 (;0;) (func)))
+    (type (;5;) (sub $s1 (;1;) (struct (field (ref 0)) (field (ref 0)) (field (ref 2)) (field (ref 2)) (field (ref 4)))))
+  )
+  (import "M4" "g" (func (;0;) (type $g1)))
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/52.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/52.print
@@ -1,0 +1,16 @@
+(module
+  (rec
+    (type $f1 (;0;) (sub (func)))
+    (type (;1;) (struct (field (ref 0))))
+  )
+  (rec
+    (type $f2 (;2;) (sub (func)))
+    (type (;3;) (struct (field (ref 0))))
+  )
+  (rec
+    (type $g2 (;4;) (sub $f2 (;2;) (func)))
+    (type (;5;) (struct))
+  )
+  (func (;0;) (type $g2))
+  (export "g" (func 0))
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/55.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/55.print
@@ -1,0 +1,16 @@
+(module
+  (rec
+    (type $f1 (;0;) (sub (func)))
+    (type (;1;) (struct (field (ref 0))))
+  )
+  (rec
+    (type $f2 (;2;) (sub (func)))
+    (type (;3;) (struct (field (ref 2))))
+  )
+  (rec
+    (type $g (;4;) (sub $f1 (;0;) (func)))
+    (type (;5;) (struct))
+  )
+  (func (;0;) (type $g))
+  (export "g" (func 0))
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/57.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/57.print
@@ -1,0 +1,15 @@
+(module
+  (rec
+    (type $f1 (;0;) (sub (func)))
+    (type (;1;) (struct (field (ref 0))))
+  )
+  (rec
+    (type $f2 (;2;) (sub (func)))
+    (type (;3;) (struct (field (ref 2))))
+  )
+  (rec
+    (type $g (;4;) (sub $f1 (;0;) (func)))
+    (type (;5;) (struct))
+  )
+  (import "M6" "g" (func (;0;) (type $f1)))
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/58.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/58.print
@@ -1,0 +1,20 @@
+(module
+  (rec
+    (type $f1 (;0;) (sub (func)))
+    (type $s1 (;1;) (sub (struct (field (ref 0)))))
+  )
+  (rec
+    (type $f2 (;2;) (sub (func)))
+    (type $s2 (;3;) (sub (struct (field (ref 2)))))
+  )
+  (rec
+    (type $g2 (;4;) (sub $f2 (;2;) (func)))
+    (type (;5;) (sub $s2 (;3;) (struct (field (ref 0)) (field (ref 2)) (field (ref 0)) (field (ref 2)) (field (ref 4)))))
+  )
+  (rec
+    (type $h (;6;) (sub $g2 (;4;) (func)))
+    (type (;7;) (struct))
+  )
+  (func (;0;) (type $h))
+  (export "h" (func 0))
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/6.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/6.print
@@ -1,0 +1,28 @@
+(module
+  (rec
+    (type $t1 (;0;) (sub (func (param i32 (ref 2)))))
+    (type $t2 (;1;) (sub $t1 (;0;) (func (param i32 (ref 1)))))
+    (type $t3 (;2;) (sub $t2 (;1;) (func (param i32 (ref 0)))))
+  )
+  (type (;3;) (func (param (ref 0))))
+  (type (;4;) (func (param (ref 1))))
+  (type (;5;) (func (param (ref 2))))
+  (func $f1 (;0;) (type 3) (param $r (ref 0))
+    local.get $r
+    call $f1
+  )
+  (func $f2 (;1;) (type 4) (param $r (ref 1))
+    local.get $r
+    call $f1
+    local.get $r
+    call $f2
+  )
+  (func $f3 (;2;) (type 5) (param $r (ref 2))
+    local.get $r
+    call $f1
+    local.get $r
+    call $f2
+    local.get $r
+    call $f3
+  )
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/60.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/60.print
@@ -1,0 +1,20 @@
+(module
+  (rec
+    (type $f1 (;0;) (sub (func)))
+    (type $s1 (;1;) (sub (struct (field (ref 0)))))
+  )
+  (rec
+    (type $f2 (;2;) (sub (func)))
+    (type $s2 (;3;) (sub (struct (field (ref 2)))))
+  )
+  (rec
+    (type $g1 (;4;) (sub $f1 (;0;) (func)))
+    (type (;5;) (sub $s1 (;1;) (struct (field (ref 0)) (field (ref 0)) (field (ref 2)) (field (ref 2)) (field (ref 4)))))
+  )
+  (rec
+    (type $h (;6;) (sub $g1 (;4;) (func)))
+    (type (;7;) (struct))
+  )
+  (import "M7" "h" (func (;0;) (type $f1)))
+  (import "M7" "h" (func (;1;) (type $g1)))
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/61.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/61.print
@@ -1,0 +1,18 @@
+(module
+  (rec
+    (type $f11 (;0;) (sub (func (result (ref func)))))
+    (type $f12 (;1;) (sub $f11 (;0;) (func (result (ref 0)))))
+  )
+  (rec
+    (type $f21 (;2;) (sub (func (result (ref func)))))
+    (type $f22 (;3;) (sub $f21 (;2;) (func (result (ref 2)))))
+  )
+  (func (;0;) (type $f11) (result (ref func))
+    unreachable
+  )
+  (func (;1;) (type $f12) (result (ref 0))
+    unreachable
+  )
+  (export "f11" (func 0))
+  (export "f12" (func 1))
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/63.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/63.print
@@ -1,0 +1,14 @@
+(module
+  (rec
+    (type $f11 (;0;) (sub (func (result (ref func)))))
+    (type $f12 (;1;) (sub $f11 (;0;) (func (result (ref 0)))))
+  )
+  (rec
+    (type $f21 (;2;) (sub (func (result (ref func)))))
+    (type $f22 (;3;) (sub $f21 (;2;) (func (result (ref 2)))))
+  )
+  (import "M8" "f11" (func (;0;) (type $f11)))
+  (import "M8" "f11" (func (;1;) (type $f21)))
+  (import "M8" "f12" (func (;2;) (type $f12)))
+  (import "M8" "f12" (func (;3;) (type $f22)))
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/64.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/64.print
@@ -1,0 +1,26 @@
+(module
+  (rec
+    (type $f11 (;0;) (sub (func (result (ref func)))))
+    (type $f12 (;1;) (sub $f11 (;0;) (func (result (ref 0)))))
+  )
+  (rec
+    (type $f21 (;2;) (sub (func (result (ref func)))))
+    (type $f22 (;3;) (sub $f21 (;2;) (func (result (ref 2)))))
+  )
+  (rec
+    (type $g11 (;4;) (sub $f11 (;0;) (func (result (ref func)))))
+    (type $g12 (;5;) (sub $g11 (;4;) (func (result (ref 4)))))
+  )
+  (rec
+    (type $g21 (;6;) (sub $f21 (;2;) (func (result (ref func)))))
+    (type $g22 (;7;) (sub $g21 (;6;) (func (result (ref 6)))))
+  )
+  (func (;0;) (type $g11) (result (ref func))
+    unreachable
+  )
+  (func (;1;) (type $g12) (result (ref 4))
+    unreachable
+  )
+  (export "g11" (func 0))
+  (export "g12" (func 1))
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/66.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/66.print
@@ -1,0 +1,26 @@
+(module
+  (rec
+    (type $f11 (;0;) (sub (func (result (ref func)))))
+    (type $f12 (;1;) (sub $f11 (;0;) (func (result (ref 0)))))
+  )
+  (rec
+    (type $f21 (;2;) (sub (func (result (ref func)))))
+    (type $f22 (;3;) (sub $f21 (;2;) (func (result (ref 2)))))
+  )
+  (rec
+    (type $g11 (;4;) (sub $f11 (;0;) (func (result (ref func)))))
+    (type $g12 (;5;) (sub $g11 (;4;) (func (result (ref 4)))))
+  )
+  (rec
+    (type $g21 (;6;) (sub $f21 (;2;) (func (result (ref func)))))
+    (type $g22 (;7;) (sub $g21 (;6;) (func (result (ref 6)))))
+  )
+  (import "M9" "g11" (func (;0;) (type $f11)))
+  (import "M9" "g11" (func (;1;) (type $f21)))
+  (import "M9" "g12" (func (;2;) (type $f11)))
+  (import "M9" "g12" (func (;3;) (type $f21)))
+  (import "M9" "g11" (func (;4;) (type $g11)))
+  (import "M9" "g11" (func (;5;) (type $g21)))
+  (import "M9" "g12" (func (;6;) (type $g12)))
+  (import "M9" "g12" (func (;7;) (type $g22)))
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/67.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/67.print
@@ -1,0 +1,12 @@
+(module
+  (rec
+    (type $f11 (;0;) (sub (func)))
+    (type $f12 (;1;) (sub $f11 (;0;) (func)))
+  )
+  (rec
+    (type $f21 (;2;) (sub (func)))
+    (type $f22 (;3;) (sub $f11 (;0;) (func)))
+  )
+  (func (;0;) (type $f21))
+  (export "f" (func 0))
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/7.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/7.print
@@ -1,0 +1,31 @@
+(module
+  (rec
+    (type $t1 (;0;) (sub (func (result i32 (ref 1)))))
+    (type $u1 (;1;) (sub (func (result f32 (ref 0)))))
+  )
+  (rec
+    (type $t2 (;2;) (sub $t1 (;0;) (func (result i32 (ref 5)))))
+    (type $u2 (;3;) (sub $u1 (;1;) (func (result f32 (ref 4)))))
+    (type $t3 (;4;) (sub $t1 (;0;) (func (result i32 (ref 3)))))
+    (type $u3 (;5;) (sub $u1 (;1;) (func (result f32 (ref 2)))))
+  )
+  (type (;6;) (func (param (ref 0))))
+  (type (;7;) (func (param (ref 2))))
+  (type (;8;) (func (param (ref 4))))
+  (func $f1 (;0;) (type 6) (param $r (ref 0))
+    local.get $r
+    call $f1
+  )
+  (func $f2 (;1;) (type 7) (param $r (ref 2))
+    local.get $r
+    call $f1
+    local.get $r
+    call $f2
+  )
+  (func $f3 (;2;) (type 8) (param $r (ref 4))
+    local.get $r
+    call $f1
+    local.get $r
+    call $f3
+  )
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/70.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/70.print
@@ -1,0 +1,16 @@
+(module
+  (rec
+    (type $f01 (;0;) (sub (func)))
+    (type $f02 (;1;) (sub $f01 (;0;) (func)))
+  )
+  (rec
+    (type $f11 (;2;) (sub (func)))
+    (type $f12 (;3;) (sub $f01 (;0;) (func)))
+  )
+  (rec
+    (type $f21 (;4;) (sub (func)))
+    (type $f22 (;5;) (sub $f11 (;2;) (func)))
+  )
+  (func (;0;) (type $f21))
+  (export "f" (func 0))
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/8.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/8.print
@@ -1,0 +1,20 @@
+(module
+  (rec
+    (type $f1 (;0;) (sub (func)))
+    (type (;1;) (struct (field (ref 0))))
+  )
+  (rec
+    (type $f2 (;2;) (sub (func)))
+    (type (;3;) (struct (field (ref 2))))
+  )
+  (rec
+    (type $g1 (;4;) (sub $f1 (;0;) (func)))
+    (type (;5;) (struct))
+  )
+  (rec
+    (type $g2 (;6;) (sub $f2 (;2;) (func)))
+    (type (;7;) (struct))
+  )
+  (func $g (;0;) (type $g2))
+  (global (;0;) (ref 4) ref.func $g)
+)

--- a/tests/snapshots/local/gc/type-subtyping.wast/9.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/9.print
@@ -1,0 +1,20 @@
+(module
+  (rec
+    (type $f1 (;0;) (sub (func)))
+    (type $s1 (;1;) (sub (struct (field (ref 0)))))
+  )
+  (rec
+    (type $f2 (;2;) (sub (func)))
+    (type $s2 (;3;) (sub (struct (field (ref 2)))))
+  )
+  (rec
+    (type $g1 (;4;) (sub $f1 (;0;) (func)))
+    (type (;5;) (sub $s1 (;1;) (struct (field (ref 0)) (field (ref 0)) (field (ref 2)) (field (ref 2)) (field (ref 4)))))
+  )
+  (rec
+    (type $g2 (;6;) (sub $f2 (;2;) (func)))
+    (type (;7;) (sub $s2 (;3;) (struct (field (ref 0)) (field (ref 2)) (field (ref 0)) (field (ref 2)) (field (ref 6)))))
+  )
+  (func $g (;0;) (type $g2))
+  (global (;0;) (ref 4) ref.func $g)
+)


### PR DESCRIPTION
This also splits `wasm-encoder::Intruction::Ref{Test,Cast}` into nullable and
non-nullable forms, since that more directly aligns with the binary format where
there are actually different opcodes for nullable vs non-nullable variations (as
opposed to a bit on some immediate or something).
