### PR TITLE
Print the name of label targets

### DIFF
--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -62,7 +62,6 @@ struct CoreState {
     tags: u32,
     globals: u32,
     tables: u32,
-    labels: u32,
     modules: u32,
     instances: u32,
     func_names: HashMap<u32, Naming>,
@@ -1153,7 +1152,6 @@ impl Printer {
         }
         locals.finish(&mut self.result);
 
-        state.core.labels = 0;
         let nesting_start = self.nesting;
         body.allow_memarg64(true);
 

--- a/crates/wasmprinter/tests/all.rs
+++ b/crates/wasmprinter/tests/all.rs
@@ -176,11 +176,11 @@ fn label_shadowing_block() {
       (module
         (type (;0;) (func))
         (func (;0;) (type 0)
-          block $a ;; label = @1
-            br 0 (;@1;)
+          block $a
+            br $a
           end
-          block $a ;; label = @1
-            br 0 (;@1;)
+          block $a
+            br $a
           end
         )
       )
@@ -200,8 +200,8 @@ fn label_shadowing_block_confusion() {
       (module
         (type (;0;) (func))
         (func (;0;) (type 0)
-          block $a ;; label = @1
-            block $a ;; label = @2
+          block $a
+            block $a
               br 1 (;@1;)
             end
           end

--- a/tests/local/br-confusion.wat
+++ b/tests/local/br-confusion.wat
@@ -1,9 +1,10 @@
 (module
   (type (;0;) (func))
   (func (;0;) (type 0)
-    block $l
-      i32.const 0
-      br_table $l $l
+    block $a
+      block $a
+        br 1 (;@1;)
+      end
     end
   )
 )

--- a/tests/snapshots/local/br-confusion.wat.print
+++ b/tests/snapshots/local/br-confusion.wat.print
@@ -1,9 +1,10 @@
 (module
   (type (;0;) (func))
   (func (;0;) (type 0)
-    block $l
-      i32.const 0
-      br_table $l $l
+    block $a
+      block $a
+        br 1 (;@1;)
+      end
     end
   )
 )

--- a/tests/snapshots/local/function-references/call_ref/br_on_non_null.wast/0.print
+++ b/tests/snapshots/local/function-references/call_ref/br_on_non_null.wast/0.print
@@ -3,18 +3,18 @@
   (type (;1;) (func (param (ref 0)) (result i32)))
   (type (;2;) (func (param (ref null 0)) (result i32)))
   (func $nn (;0;) (type 1) (param $r (ref 0)) (result i32)
-    block $l (result (ref 0)) ;; label = @1
+    block $l (result (ref 0))
       local.get $r
-      br_on_non_null 0 (;@1;)
+      br_on_non_null $l
       i32.const -1
       return
     end
     call_ref $t
   )
   (func $n (;1;) (type 2) (param $r (ref null 0)) (result i32)
-    block $l (result (ref 0)) ;; label = @1
+    block $l (result (ref 0))
       local.get $r
-      br_on_non_null 0 (;@1;)
+      br_on_non_null $l
       i32.const -1
       return
     end
@@ -36,9 +36,9 @@
     call $n
   )
   (func (;6;) (type $t) (result i32)
-    block $l ;; label = @1
+    block $l
       unreachable
-      br_on_null 0 (;@1;)
+      br_on_null $l
       call_ref $t
       return
     end

--- a/tests/snapshots/local/function-references/call_ref/br_on_non_null.wast/6.print
+++ b/tests/snapshots/local/function-references/call_ref/br_on_non_null.wast/6.print
@@ -8,10 +8,10 @@
     i32.mul
   )
   (func $a (;1;) (type 1) (param $n i32) (param $r (ref null 0)) (result i32)
-    block $l (type 2) (result i32 (ref 0)) ;; label = @1
+    block $l (type 2) (result i32 (ref 0))
       local.get $n
       local.get $r
-      br_on_non_null 0 (;@1;)
+      br_on_non_null $l
       return
     end
     call_ref $t

--- a/tests/snapshots/local/function-references/call_ref/br_on_null.wast/0.print
+++ b/tests/snapshots/local/function-references/call_ref/br_on_null.wast/0.print
@@ -3,18 +3,18 @@
   (type (;1;) (func (param (ref 0)) (result i32)))
   (type (;2;) (func (param (ref null 0)) (result i32)))
   (func $nn (;0;) (type 1) (param $r (ref 0)) (result i32)
-    block $l ;; label = @1
+    block $l
       local.get $r
-      br_on_null 0 (;@1;)
+      br_on_null $l
       call_ref $t
       return
     end
     i32.const -1
   )
   (func $n (;1;) (type 2) (param $r (ref null 0)) (result i32)
-    block $l ;; label = @1
+    block $l
       local.get $r
-      br_on_null 0 (;@1;)
+      br_on_null $l
       call_ref $t
       return
     end
@@ -36,9 +36,9 @@
     call $n
   )
   (func (;6;) (type $t) (result i32)
-    block $l ;; label = @1
+    block $l
       unreachable
-      br_on_null 0 (;@1;)
+      br_on_null $l
       call_ref $t
       return
     end

--- a/tests/snapshots/local/function-references/call_ref/br_on_null.wast/6.print
+++ b/tests/snapshots/local/function-references/call_ref/br_on_null.wast/6.print
@@ -7,10 +7,10 @@
     i32.mul
   )
   (func $a (;1;) (type 1) (param $n i32) (param $r (ref null 0)) (result i32)
-    block $l (result i32) ;; label = @1
+    block $l (result i32)
       local.get $n
       local.get $r
-      br_on_null 0 (;@1;)
+      br_on_null $l
       call_ref $t
       return
     end

--- a/tests/snapshots/local/fuzz1.wat.print
+++ b/tests/snapshots/local/fuzz1.wat.print
@@ -174,16 +174,16 @@
       i32.sub
       global.set $hangLimit
     end
-    block $label$0 (result i64) ;; label = @1
+    block $label$0 (result i64)
       nop
-      block $label$1 (result i64) ;; label = @2
+      block $label$1 (result i64)
         i32.const -2147483647
         if (result i32) ;; label = @3
           local.get $0
         else
-          block $label$4 (result i32) ;; label = @4
-            block $label$5 (result i32) ;; label = @5
-              loop $label$6 (result i32) ;; label = @6
+          block $label$4 (result i32)
+            block $label$5 (result i32)
+              loop $label$6 (result i32)
                 block ;; label = @7
                   global.get $hangLimit
                   i32.eqz
@@ -200,13 +200,13 @@
                   nop
                   i32.const 8388608
                   i32.eqz
-                  br_if 1 (;@6;)
+                  br_if $label$6
                   local.get $0
                 end
               end
               i32.eqz
               if (result f32) ;; label = @6
-                block $label$7 (result f32) ;; label = @7
+                block $label$7 (result f32)
                   f32.const -nan:0x7fffda (;=NaN;)
                 end
               else
@@ -222,7 +222,7 @@
             end
             global.get $global$0
             i32.eqz
-            br_if 0 (;@4;)
+            br_if $label$4
           end
         end
         local.tee $0

--- a/tests/snapshots/local/gc/gc-ref.wat.print
+++ b/tests/snapshots/local/gc/gc-ref.wat.print
@@ -27,10 +27,10 @@
     block (result (ref 1)) ;; label = @1
       unreachable
     end
-    block $f1 (type $f1) (param (ref 0)) ;; label = @1
+    block $f1 (type $f1) (param (ref 0))
       unreachable
     end
-    block $f2 (result (ref 1)) ;; label = @1
+    block $f2 (result (ref 1))
       unreachable
     end
     loop (type $f1) (param (ref 0)) ;; label = @1
@@ -39,10 +39,10 @@
     loop (result (ref 1)) ;; label = @1
       unreachable
     end
-    loop $f1 (type $f1) (param (ref 0)) ;; label = @1
+    loop $f1 (type $f1) (param (ref 0))
       unreachable
     end
-    loop $f2 (result (ref 1)) ;; label = @1
+    loop $f2 (result (ref 1))
       unreachable
     end
     drop
@@ -57,12 +57,12 @@
       unreachable
     end
     drop
-    if $f1 (type $f1) (param (ref 0)) ;; label = @1
+    if $f1 (type $f1) (param (ref 0))
       unreachable
     else
       unreachable
     end
-    if $f2 (result (ref 1)) ;; label = @1
+    if $f2 (result (ref 1))
       unreachable
     else
       unreachable

--- a/tests/snapshots/testsuite/align.wast/106.print
+++ b/tests/snapshots/testsuite/align.wast/106.print
@@ -7,13 +7,13 @@
     (local f32 f32)
     f32.const 0x1.4p+3 (;=10;)
     local.set 1
-    block $4 ;; label = @1
-      block $2 ;; label = @2
-        block $1 ;; label = @3
-          block $default ;; label = @4
-            block $0 ;; label = @5
+    block $4
+      block $2
+        block $1
+          block $default
+            block $0
               local.get 0
-              br_table 0 (;@5;) 1 (;@4;) 2 (;@3;) 3 (;@2;) 4 (;@1;)
+              br_table $0 $default $1 $2 $4
             end
             i32.const 0
             local.get 1
@@ -21,7 +21,7 @@
             i32.const 0
             f32.load
             local.set 2
-            br 3 (;@1;)
+            br $4
           end
           i32.const 0
           local.get 1
@@ -29,7 +29,7 @@
           i32.const 0
           f32.load align=1
           local.set 2
-          br 2 (;@1;)
+          br $4
         end
         i32.const 0
         local.get 1
@@ -37,7 +37,7 @@
         i32.const 0
         f32.load align=2
         local.set 2
-        br 1 (;@1;)
+        br $4
       end
       i32.const 0
       local.get 1
@@ -52,14 +52,14 @@
     (local f64 f64)
     f64.const 0x1.4p+3 (;=10;)
     local.set 1
-    block $8 ;; label = @1
-      block $4 ;; label = @2
-        block $2 ;; label = @3
-          block $1 ;; label = @4
-            block $default ;; label = @5
-              block $0 ;; label = @6
+    block $8
+      block $4
+        block $2
+          block $1
+            block $default
+              block $0
                 local.get 0
-                br_table 0 (;@6;) 1 (;@5;) 2 (;@4;) 3 (;@3;) 4 (;@2;) 5 (;@1;)
+                br_table $0 $default $1 $2 $4 $8
               end
               i32.const 0
               local.get 1
@@ -67,7 +67,7 @@
               i32.const 0
               f64.load
               local.set 2
-              br 4 (;@1;)
+              br $8
             end
             i32.const 0
             local.get 1
@@ -75,7 +75,7 @@
             i32.const 0
             f64.load align=1
             local.set 2
-            br 3 (;@1;)
+            br $8
           end
           i32.const 0
           local.get 1
@@ -83,7 +83,7 @@
           i32.const 0
           f64.load align=2
           local.set 2
-          br 2 (;@1;)
+          br $8
         end
         i32.const 0
         local.get 1
@@ -91,7 +91,7 @@
         i32.const 0
         f64.load align=4
         local.set 2
-        br 1 (;@1;)
+        br $8
       end
       i32.const 0
       local.get 1
@@ -106,14 +106,14 @@
     (local i32 i32)
     i32.const 10
     local.set 2
-    block $32 ;; label = @1
-      block $16u ;; label = @2
-        block $16s ;; label = @3
-          block $8u ;; label = @4
-            block $8s ;; label = @5
-              block $0 ;; label = @6
+    block $32
+      block $16u
+        block $16s
+          block $8u
+            block $8s
+              block $0
                 local.get 0
-                br_table 0 (;@6;) 1 (;@5;) 2 (;@4;) 3 (;@3;) 4 (;@2;) 5 (;@1;)
+                br_table $0 $8s $8u $16s $16u $32
               end
               local.get 1
               i32.const 0
@@ -137,7 +137,7 @@
                 i32.load8_s
                 local.set 3
               end
-              br 4 (;@1;)
+              br $32
             end
             local.get 1
             i32.const 0
@@ -161,7 +161,7 @@
               i32.load8_u
               local.set 3
             end
-            br 3 (;@1;)
+            br $32
           end
           local.get 1
           i32.const 0
@@ -196,7 +196,7 @@
             i32.load16_s
             local.set 3
           end
-          br 2 (;@1;)
+          br $32
         end
         local.get 1
         i32.const 0
@@ -231,7 +231,7 @@
           i32.load16_u
           local.set 3
         end
-        br 1 (;@1;)
+        br $32
       end
       local.get 1
       i32.const 0
@@ -284,16 +284,16 @@
     (local i64 i64)
     i64.const 10
     local.set 2
-    block $64 ;; label = @1
-      block $32u ;; label = @2
-        block $32s ;; label = @3
-          block $16u ;; label = @4
-            block $16s ;; label = @5
-              block $8u ;; label = @6
-                block $8s ;; label = @7
-                  block $0 ;; label = @8
+    block $64
+      block $32u
+        block $32s
+          block $16u
+            block $16s
+              block $8u
+                block $8s
+                  block $0
                     local.get 0
-                    br_table 0 (;@8;) 1 (;@7;) 2 (;@6;) 3 (;@5;) 4 (;@4;) 5 (;@3;) 6 (;@2;) 7 (;@1;)
+                    br_table $0 $8s $8u $16s $16u $32s $32u $64
                   end
                   local.get 1
                   i32.const 0
@@ -317,7 +317,7 @@
                     i64.load8_s
                     local.set 3
                   end
-                  br 6 (;@1;)
+                  br $64
                 end
                 local.get 1
                 i32.const 0
@@ -341,7 +341,7 @@
                   i64.load8_u
                   local.set 3
                 end
-                br 5 (;@1;)
+                br $64
               end
               local.get 1
               i32.const 0
@@ -376,7 +376,7 @@
                 i64.load16_s
                 local.set 3
               end
-              br 4 (;@1;)
+              br $64
             end
             local.get 1
             i32.const 0
@@ -411,7 +411,7 @@
               i64.load16_u
               local.set 3
             end
-            br 3 (;@1;)
+            br $64
           end
           local.get 1
           i32.const 0
@@ -457,7 +457,7 @@
             i64.load32_s
             local.set 3
           end
-          br 2 (;@1;)
+          br $64
         end
         local.get 1
         i32.const 0
@@ -503,7 +503,7 @@
           i64.load32_u
           local.set 3
         end
-        br 1 (;@1;)
+        br $64
       end
       local.get 1
       i32.const 0

--- a/tests/snapshots/testsuite/block.wast/0.print
+++ b/tests/snapshots/testsuite/block.wast/0.print
@@ -14,7 +14,7 @@
   (func (;1;) (type $block-sig-1)
     block ;; label = @1
     end
-    block $l ;; label = @1
+    block $l
     end
   )
   (func (;2;) (type $block-sig-2) (result i32)

--- a/tests/snapshots/testsuite/br_table.wast/0.print
+++ b/tests/snapshots/testsuite/br_table.wast/0.print
@@ -762,11 +762,11 @@
     end
   )
   (func (;69;) (type 8) (param i32 externref) (result externref)
-    block $l1 (result externref) ;; label = @1
-      block $l2 (result externref) ;; label = @2
+    block $l1 (result externref)
+      block $l2 (result externref)
         local.get 1
         local.get 0
-        br_table 1 (;@1;) 0 (;@2;) 1 (;@1;)
+        br_table $l1 $l2 $l1
       end
     end
   )

--- a/tests/snapshots/testsuite/fac.wast/0.print
+++ b/tests/snapshots/testsuite/fac.wast/0.print
@@ -67,13 +67,13 @@
     local.set $i
     i64.const 1
     local.set $res
-    block $done ;; label = @1
-      loop $loop ;; label = @2
+    block $done
+      loop $loop
         local.get $i
         i64.const 0
         i64.eq
         if ;; label = @3
-          br 2 (;@1;)
+          br $done
         else
           local.get $i
           local.get $res
@@ -84,7 +84,7 @@
           i64.sub
           local.set $i
         end
-        br 0 (;@2;)
+        br $loop
       end
     end
     local.get $res
@@ -127,7 +127,7 @@
   (func (;7;) (type 0) (param i64) (result i64)
     i64.const 1
     local.get 0
-    loop $l (type 3) (param i64 i64) (result i64) ;; label = @1
+    loop $l (type 3) (param i64 i64) (result i64)
       call $pick1
       call $pick1
       i64.mul
@@ -137,7 +137,7 @@
       call $pick0
       i64.const 0
       i64.gt_u
-      br_if 0 (;@1;)
+      br_if $l
       drop
       return
     end

--- a/tests/snapshots/testsuite/float_exprs.wast/358.print
+++ b/tests/snapshots/testsuite/float_exprs.wast/358.print
@@ -8,8 +8,8 @@
   )
   (func (;1;) (type 0) (param $n i32) (param $z f32)
     (local $i i32)
-    block $exit ;; label = @1
-      loop $cont ;; label = @2
+    block $exit
+      loop $cont
         local.get $i
         local.get $i
         f32.load
@@ -23,7 +23,7 @@
         local.get $i
         local.get $n
         i32.lt_u
-        br_if 0 (;@2;)
+        br_if $cont
       end
     end
   )

--- a/tests/snapshots/testsuite/float_exprs.wast/372.print
+++ b/tests/snapshots/testsuite/float_exprs.wast/372.print
@@ -8,8 +8,8 @@
   )
   (func (;1;) (type 0) (param $n i32) (param $z f64)
     (local $i i32)
-    block $exit ;; label = @1
-      loop $cont ;; label = @2
+    block $exit
+      loop $cont
         local.get $i
         local.get $i
         f64.load
@@ -23,7 +23,7 @@
         local.get $i
         local.get $n
         i32.lt_u
-        br_if 0 (;@2;)
+        br_if $cont
       end
     end
   )

--- a/tests/snapshots/testsuite/float_exprs.wast/626.print
+++ b/tests/snapshots/testsuite/float_exprs.wast/626.print
@@ -2,8 +2,8 @@
   (type (;0;) (func (param i32 i32) (result f32)))
   (func (;0;) (type 0) (param $p i32) (param $n i32) (result f32)
     (local $sum f32) (local $c f32) (local $t f32)
-    block $exit ;; label = @1
-      loop $top ;; label = @2
+    block $exit
+      loop $top
         local.get $c
         local.get $p
         f32.load
@@ -27,15 +27,15 @@
         i32.const -1
         i32.add
         local.tee $n
-        br_if 0 (;@2;)
+        br_if $top
       end
     end
     local.get $sum
   )
   (func (;1;) (type 0) (param $p i32) (param $n i32) (result f32)
     (local $sum f32)
-    block $exit ;; label = @1
-      loop $top ;; label = @2
+    block $exit
+      loop $top
         local.get $sum
         local.get $p
         f32.load
@@ -50,7 +50,7 @@
         i32.add
         local.set $n
         local.get $n
-        br_if 0 (;@2;)
+        br_if $top
       end
     end
     local.get $sum

--- a/tests/snapshots/testsuite/float_exprs.wast/629.print
+++ b/tests/snapshots/testsuite/float_exprs.wast/629.print
@@ -2,8 +2,8 @@
   (type (;0;) (func (param i32 i32) (result f64)))
   (func (;0;) (type 0) (param $p i32) (param $n i32) (result f64)
     (local $sum f64) (local $c f64) (local $t f64)
-    block $exit ;; label = @1
-      loop $top ;; label = @2
+    block $exit
+      loop $top
         local.get $c
         local.get $p
         f64.load
@@ -27,15 +27,15 @@
         i32.const -1
         i32.add
         local.tee $n
-        br_if 0 (;@2;)
+        br_if $top
       end
     end
     local.get $sum
   )
   (func (;1;) (type 0) (param $p i32) (param $n i32) (result f64)
     (local $sum f64)
-    block $exit ;; label = @1
-      loop $top ;; label = @2
+    block $exit
+      loop $top
         local.get $sum
         local.get $p
         f64.load
@@ -50,7 +50,7 @@
         i32.add
         local.set $n
         local.get $n
-        br_if 0 (;@2;)
+        br_if $top
       end
     end
     local.get $sum

--- a/tests/snapshots/testsuite/float_exprs.wast/794.print
+++ b/tests/snapshots/testsuite/float_exprs.wast/794.print
@@ -2,7 +2,7 @@
   (type (;0;) (func (param f32 f32) (result f32)))
   (type (;1;) (func (param f64 f64) (result f64)))
   (func (;0;) (type 0) (param $0 f32) (param $1 f32) (result f32)
-    loop $label$0 ;; label = @1
+    loop $label$0
       local.get $0
       local.get $0
       f32.add
@@ -15,9 +15,9 @@
       f32.add
       f32.const 0x0p+0 (;=0;)
       f32.eq
-      br_if 0 (;@1;)
+      br_if $label$0
     end
-    loop $label$2 ;; label = @1
+    loop $label$2
       local.get $0
       local.get $1
       f32.const 0x1p+0 (;=1;)
@@ -30,12 +30,12 @@
       f32.sub
       f32.const 0x0p+0 (;=0;)
       f32.ne
-      br_if 0 (;@1;)
+      br_if $label$2
     end
     local.get $1
   )
   (func (;1;) (type 1) (param $0 f64) (param $1 f64) (result f64)
-    loop $label$0 ;; label = @1
+    loop $label$0
       local.get $0
       local.get $0
       f64.add
@@ -48,9 +48,9 @@
       f64.add
       f64.const 0x0p+0 (;=0;)
       f64.eq
-      br_if 0 (;@1;)
+      br_if $label$0
     end
-    loop $label$2 ;; label = @1
+    loop $label$2
       local.get $0
       local.get $1
       f64.const 0x1p+0 (;=1;)
@@ -63,7 +63,7 @@
       f64.sub
       f64.const 0x0p+0 (;=0;)
       f64.ne
-      br_if 0 (;@1;)
+      br_if $label$2
     end
     local.get $1
   )

--- a/tests/snapshots/testsuite/float_exprs.wast/817.print
+++ b/tests/snapshots/testsuite/float_exprs.wast/817.print
@@ -5,7 +5,7 @@
     (local $x f32) (local $result f32)
     f32.const 0x1p+0 (;=1;)
     local.set $x
-    loop $loop ;; label = @1
+    loop $loop
       local.get $x
       local.tee $result
       f32.const 0x1p-1 (;=0.5;)
@@ -15,7 +15,7 @@
       f32.add
       f32.const 0x1p+0 (;=1;)
       f32.gt
-      br_if 0 (;@1;)
+      br_if $loop
     end
     local.get $result
   )
@@ -23,7 +23,7 @@
     (local $x f64) (local $result f64)
     f64.const 0x1p+0 (;=1;)
     local.set $x
-    loop $loop ;; label = @1
+    loop $loop
       local.get $x
       local.tee $result
       f64.const 0x1p-1 (;=0.5;)
@@ -33,7 +33,7 @@
       f64.add
       f64.const 0x1p+0 (;=1;)
       f64.gt
-      br_if 0 (;@1;)
+      br_if $loop
     end
     local.get $result
   )

--- a/tests/snapshots/testsuite/if.wast/0.print
+++ b/tests/snapshots/testsuite/if.wast/0.print
@@ -25,10 +25,10 @@
     else
     end
     local.get 0
-    if $l ;; label = @1
+    if $l
     end
     local.get 0
-    if $l ;; label = @1
+    if $l
     else
     end
   )

--- a/tests/snapshots/testsuite/labels.wast/0.print
+++ b/tests/snapshots/testsuite/labels.wast/0.print
@@ -2,9 +2,9 @@
   (type (;0;) (func (result i32)))
   (type (;1;) (func (param i32) (result i32)))
   (func (;0;) (type 0) (result i32)
-    block $exit (result i32) ;; label = @1
+    block $exit (result i32)
       i32.const 1
-      br 0 (;@1;)
+      br $exit
       i32.const 0
     end
   )
@@ -12,8 +12,8 @@
     (local $i i32)
     i32.const 0
     local.set $i
-    block $exit (result i32) ;; label = @1
-      loop $cont (result i32) ;; label = @2
+    block $exit (result i32)
+      loop $cont (result i32)
         local.get $i
         i32.const 1
         i32.add
@@ -23,9 +23,9 @@
         i32.eq
         if ;; label = @3
           local.get $i
-          br 2 (;@1;)
+          br $exit
         end
-        br 0 (;@2;)
+        br $cont
       end
     end
   )
@@ -33,8 +33,8 @@
     (local $i i32)
     i32.const 0
     local.set $i
-    block $exit (result i32) ;; label = @1
-      loop $cont (result i32) ;; label = @2
+    block $exit (result i32)
+      loop $cont (result i32)
         local.get $i
         i32.const 1
         i32.add
@@ -43,20 +43,20 @@
         i32.const 5
         i32.eq
         if ;; label = @3
-          br 1 (;@2;)
+          br $cont
         end
         local.get $i
         i32.const 8
         i32.eq
         if ;; label = @3
           local.get $i
-          br 2 (;@1;)
+          br $exit
         end
         local.get $i
         i32.const 1
         i32.add
         local.set $i
-        br 0 (;@2;)
+        br $cont
       end
     end
   )
@@ -64,8 +64,8 @@
     (local $i i32)
     i32.const 0
     local.set $i
-    block $exit (result i32) ;; label = @1
-      loop $cont (result i32) ;; label = @2
+    block $exit (result i32)
+      loop $cont (result i32)
         local.get $i
         i32.const 1
         i32.add
@@ -75,7 +75,7 @@
         i32.eq
         if ;; label = @3
           local.get $i
-          br 2 (;@1;)
+          br $exit
         end
         local.get $i
       end
@@ -85,8 +85,8 @@
     (local $i i32)
     i32.const 1
     local.set $i
-    block $exit (result i32) ;; label = @1
-      loop $cont (result i32) ;; label = @2
+    block $exit (result i32)
+      loop $cont (result i32)
         local.get $i
         local.get $i
         i32.add
@@ -96,14 +96,14 @@
         i32.gt_u
         if ;; label = @3
           local.get $i
-          br 2 (;@1;)
+          br $exit
         end
-        br 0 (;@2;)
+        br $cont
       end
     end
   )
   (func (;5;) (type 0) (result i32)
-    loop $l (result i32) ;; label = @1
+    loop $l (result i32)
       i32.const 1
     end
     i32.const 1
@@ -122,8 +122,8 @@
     local.set $i
     block ;; label = @1
       i32.const 1
-      if $l ;; label = @2
-        br 0 (;@2;)
+      if $l
+        br $l
         i32.const 666
         local.set $i
       end
@@ -132,8 +132,8 @@
       i32.add
       local.set $i
       i32.const 1
-      if $l ;; label = @2
-        br 0 (;@2;)
+      if $l
+        br $l
         i32.const 666
         local.set $i
       else
@@ -145,8 +145,8 @@
       i32.add
       local.set $i
       i32.const 1
-      if $l ;; label = @2
-        br 0 (;@2;)
+      if $l
+        br $l
         i32.const 666
         local.set $i
       else
@@ -158,11 +158,11 @@
       i32.add
       local.set $i
       i32.const 0
-      if $l ;; label = @2
+      if $l
         i32.const 888
         local.set $i
       else
-        br 0 (;@2;)
+        br $l
         i32.const 666
         local.set $i
       end
@@ -171,11 +171,11 @@
       i32.add
       local.set $i
       i32.const 0
-      if $l ;; label = @2
+      if $l
         i32.const 888
         local.set $i
       else
-        br 0 (;@2;)
+        br $l
         i32.const 666
         local.set $i
       end
@@ -257,23 +257,23 @@
     local.get $i
   )
   (func (;9;) (type 1) (param i32) (result i32)
-    block $ret (result i32) ;; label = @1
+    block $ret (result i32)
       i32.const 10
-      block $exit (result i32) ;; label = @2
-        block $0 ;; label = @3
-          block $default ;; label = @4
-            block $3 ;; label = @5
-              block $2 ;; label = @6
-                block $1 ;; label = @7
+      block $exit (result i32)
+        block $0
+          block $default
+            block $3
+              block $2
+                block $1
                   local.get 0
-                  br_table 4 (;@3;) 0 (;@7;) 1 (;@6;) 2 (;@5;) 3 (;@4;)
+                  br_table $0 $1 $2 $3 $default
                 end
               end
               i32.const 2
-              br 3 (;@2;)
+              br $exit
             end
             i32.const 3
-            br 3 (;@1;)
+            br $ret
           end
         end
         i32.const 5
@@ -282,12 +282,12 @@
     end
   )
   (func (;10;) (type 1) (param i32) (result i32)
-    block $default ;; label = @1
-      block $1 ;; label = @2
-        block $0 ;; label = @3
+    block $default
+      block $1
+        block $0
           local.get 0
-          br_table 0 (;@3;) 1 (;@2;)
-          br 2 (;@1;)
+          br_table $0 $1
+          br $default
         end
         i32.const 0
         return
@@ -299,16 +299,16 @@
     (local $i i32)
     i32.const 0
     local.set $i
-    block $outer (result i32) ;; label = @1
-      block $inner ;; label = @2
+    block $outer (result i32)
+      block $inner
         i32.const 0
-        br_if 0 (;@2;)
+        br_if $inner
         local.get $i
         i32.const 1
         i32.or
         local.set $i
         i32.const 1
-        br_if 0 (;@2;)
+        br_if $inner
         local.get $i
         i32.const 2
         i32.or
@@ -322,7 +322,7 @@
         local.get $i
       end
       i32.const 0
-      br_if 0 (;@1;)
+      br_if $outer
       drop
       local.get $i
       i32.const 8
@@ -336,7 +336,7 @@
         local.get $i
       end
       i32.const 1
-      br_if 0 (;@1;)
+      br_if $outer
       drop
       local.get $i
       i32.const 32
@@ -346,27 +346,27 @@
     end
   )
   (func (;12;) (type 0) (result i32)
-    block $l0 (result i32) ;; label = @1
-      block $l1 (result i32) ;; label = @2
+    block $l0 (result i32)
+      block $l1 (result i32)
         i32.const 1
-        br 0 (;@2;)
+        br $l1
       end
       i32.const 1
-      br_if 0 (;@1;)
+      br_if $l0
       drop
       i32.const 0
     end
   )
   (func (;13;) (type 0) (result i32)
-    block $l0 (result i32) ;; label = @1
+    block $l0 (result i32)
       i32.const 1
       if ;; label = @2
-        block $l1 (result i32) ;; label = @3
+        block $l1 (result i32)
           i32.const 1
-          br 0 (;@3;)
+          br $l1
         end
         i32.const 1
-        br_if 1 (;@1;)
+        br_if $l0
         drop
       end
       i32.const 0
@@ -374,7 +374,7 @@
   )
   (func (;14;) (type 0) (result i32)
     (local $i1 i32)
-    block $l0 (result i32) ;; label = @1
+    block $l0 (result i32)
       block (result i32) ;; label = @2
         i32.const 1
         local.set $i1
@@ -385,7 +385,7 @@
         local.set $i1
         local.get $i1
       end
-      br_if 0 (;@1;)
+      br_if $l0
       drop
       i32.const 0
     end
@@ -395,19 +395,19 @@
     local.get $i1
   )
   (func (;15;) (type 0) (result i32)
-    block $l0 (result i32) ;; label = @1
+    block $l0 (result i32)
       i32.const 1
       if ;; label = @2
-        block $l1 (result i32) ;; label = @3
+        block $l1 (result i32)
           i32.const 1
-          br 0 (;@3;)
+          br $l1
         end
-        br 1 (;@1;)
+        br $l0
       else
         block ;; label = @3
-          block $l1 (result i32) ;; label = @4
+          block $l1 (result i32)
             i32.const 1
-            br 0 (;@4;)
+            br $l1
           end
           drop
         end
@@ -416,21 +416,21 @@
     end
   )
   (func (;16;) (type 0) (result i32)
-    block $l1 (result i32) ;; label = @1
+    block $l1 (result i32)
       i32.const 1
-      br 0 (;@1;)
+      br $l1
       i32.const 2
       i32.xor
     end
   )
   (func (;17;) (type 0) (result i32)
-    block $l1 (result i32) ;; label = @1
-      block $l1 (result i32) ;; label = @2
+    block $l1 (result i32)
+      block $l1 (result i32)
         i32.const 2
       end
-      block $l1 (result i32) ;; label = @2
+      block $l1 (result i32)
         i32.const 3
-        br 0 (;@2;)
+        br $l1
       end
       i32.add
     end

--- a/tests/snapshots/testsuite/left-to-right.wast/0.print
+++ b/tests/snapshots/testsuite/left-to-right.wast/0.print
@@ -958,12 +958,12 @@
     end
   )
   (func (;129;) (type 5) (result i32)
-    block $a (result i32) ;; label = @1
+    block $a (result i32)
       call $reset
-      block $b (result i32) ;; label = @2
+      block $b (result i32)
         call $i32_left
         call $i32_right
-        br_table 1 (;@1;) 0 (;@2;)
+        br_table $a $b
       end
       drop
       call $get

--- a/tests/snapshots/testsuite/local_get.wast/0.print
+++ b/tests/snapshots/testsuite/local_get.wast/0.print
@@ -117,10 +117,10 @@
     end
   )
   (func (;13;) (type 4) (param i32) (result i32)
-    block $l0 (result i32) ;; label = @1
+    block $l0 (result i32)
       local.get 0
       i32.const 1
-      br_if 0 (;@1;)
+      br_if $l0
     end
   )
   (func (;14;) (type 4) (param i32) (result i32)

--- a/tests/snapshots/testsuite/loop.wast/0.print
+++ b/tests/snapshots/testsuite/loop.wast/0.print
@@ -17,7 +17,7 @@
   (func (;1;) (type $block-sig-1)
     loop ;; label = @1
     end
-    loop $l ;; label = @1
+    loop $l
     end
   )
   (func (;2;) (type $block-sig-2) (result i32)

--- a/tests/snapshots/testsuite/memory_copy.wast/4183.print
+++ b/tests/snapshots/testsuite/memory_copy.wast/4183.print
@@ -12,7 +12,7 @@
     memory.copy
   )
   (func (;1;) (type 1) (param $from i32) (param $to i32) (param $expected i32) (result i32)
-    loop $cont ;; label = @1
+    loop $cont
       local.get $from
       local.get $to
       i32.eq
@@ -29,7 +29,7 @@
         i32.const 1
         i32.add
         local.set $from
-        br 1 (;@1;)
+        br $cont
       end
     end
     local.get $from

--- a/tests/snapshots/testsuite/memory_copy.wast/4188.print
+++ b/tests/snapshots/testsuite/memory_copy.wast/4188.print
@@ -12,7 +12,7 @@
     memory.copy
   )
   (func (;1;) (type 1) (param $from i32) (param $to i32) (param $expected i32) (result i32)
-    loop $cont ;; label = @1
+    loop $cont
       local.get $from
       local.get $to
       i32.eq
@@ -29,7 +29,7 @@
         i32.const 1
         i32.add
         local.set $from
-        br 1 (;@1;)
+        br $cont
       end
     end
     local.get $from

--- a/tests/snapshots/testsuite/memory_copy.wast/4201.print
+++ b/tests/snapshots/testsuite/memory_copy.wast/4201.print
@@ -16,7 +16,7 @@
     memory.copy
   )
   (func (;1;) (type 1) (param $from i32) (param $to i32) (param $expected i32) (result i32)
-    loop $cont ;; label = @1
+    loop $cont
       local.get $from
       local.get $to
       i32.eq
@@ -33,7 +33,7 @@
         i32.const 1
         i32.add
         local.set $from
-        br 1 (;@1;)
+        br $cont
       end
     end
     local.get $from

--- a/tests/snapshots/testsuite/memory_copy.wast/4217.print
+++ b/tests/snapshots/testsuite/memory_copy.wast/4217.print
@@ -804,7 +804,7 @@
     memory.copy
   )
   (func (;1;) (type 1) (param $from i32) (param $to i32) (param $expected i32) (result i32)
-    loop $cont ;; label = @1
+    loop $cont
       local.get $from
       local.get $to
       i32.eq
@@ -821,7 +821,7 @@
         i32.const 1
         i32.add
         local.set $from
-        br 1 (;@1;)
+        br $cont
       end
     end
     local.get $from

--- a/tests/snapshots/testsuite/memory_fill.wast/0.print
+++ b/tests/snapshots/testsuite/memory_fill.wast/0.print
@@ -2,7 +2,7 @@
   (type (;0;) (func (param i32 i32 i32) (result i32)))
   (type (;1;) (func))
   (func (;0;) (type 0) (param $from i32) (param $to i32) (param $expected i32) (result i32)
-    loop $cont ;; label = @1
+    loop $cont
       local.get $from
       local.get $to
       i32.eq
@@ -19,7 +19,7 @@
         i32.const 1
         i32.add
         local.set $from
-        br 1 (;@1;)
+        br $cont
       end
     end
     local.get $from

--- a/tests/snapshots/testsuite/memory_fill.wast/11.print
+++ b/tests/snapshots/testsuite/memory_fill.wast/11.print
@@ -2,7 +2,7 @@
   (type (;0;) (func (param i32 i32 i32) (result i32)))
   (type (;1;) (func))
   (func (;0;) (type 0) (param $from i32) (param $to i32) (param $expected i32) (result i32)
-    loop $cont ;; label = @1
+    loop $cont
       local.get $from
       local.get $to
       i32.eq
@@ -19,7 +19,7 @@
         i32.const 1
         i32.add
         local.set $from
-        br 1 (;@1;)
+        br $cont
       end
     end
     local.get $from

--- a/tests/snapshots/testsuite/memory_fill.wast/13.print
+++ b/tests/snapshots/testsuite/memory_fill.wast/13.print
@@ -2,7 +2,7 @@
   (type (;0;) (func (param i32 i32 i32) (result i32)))
   (type (;1;) (func))
   (func (;0;) (type 0) (param $from i32) (param $to i32) (param $expected i32) (result i32)
-    loop $cont ;; label = @1
+    loop $cont
       local.get $from
       local.get $to
       i32.eq
@@ -19,7 +19,7 @@
         i32.const 1
         i32.add
         local.set $from
-        br 1 (;@1;)
+        br $cont
       end
     end
     local.get $from

--- a/tests/snapshots/testsuite/memory_fill.wast/15.print
+++ b/tests/snapshots/testsuite/memory_fill.wast/15.print
@@ -2,7 +2,7 @@
   (type (;0;) (func (param i32 i32 i32) (result i32)))
   (type (;1;) (func))
   (func (;0;) (type 0) (param $from i32) (param $to i32) (param $expected i32) (result i32)
-    loop $cont ;; label = @1
+    loop $cont
       local.get $from
       local.get $to
       i32.eq
@@ -19,7 +19,7 @@
         i32.const 1
         i32.add
         local.set $from
-        br 1 (;@1;)
+        br $cont
       end
     end
     local.get $from

--- a/tests/snapshots/testsuite/memory_fill.wast/20.print
+++ b/tests/snapshots/testsuite/memory_fill.wast/20.print
@@ -2,7 +2,7 @@
   (type (;0;) (func (param i32 i32 i32) (result i32)))
   (type (;1;) (func))
   (func (;0;) (type 0) (param $from i32) (param $to i32) (param $expected i32) (result i32)
-    loop $cont ;; label = @1
+    loop $cont
       local.get $from
       local.get $to
       i32.eq
@@ -19,7 +19,7 @@
         i32.const 1
         i32.add
         local.set $from
-        br 1 (;@1;)
+        br $cont
       end
     end
     local.get $from

--- a/tests/snapshots/testsuite/memory_fill.wast/4.print
+++ b/tests/snapshots/testsuite/memory_fill.wast/4.print
@@ -2,7 +2,7 @@
   (type (;0;) (func (param i32 i32 i32) (result i32)))
   (type (;1;) (func))
   (func (;0;) (type 0) (param $from i32) (param $to i32) (param $expected i32) (result i32)
-    loop $cont ;; label = @1
+    loop $cont
       local.get $from
       local.get $to
       i32.eq
@@ -19,7 +19,7 @@
         i32.const 1
         i32.add
         local.set $from
-        br 1 (;@1;)
+        br $cont
       end
     end
     local.get $from

--- a/tests/snapshots/testsuite/memory_fill.wast/6.print
+++ b/tests/snapshots/testsuite/memory_fill.wast/6.print
@@ -2,7 +2,7 @@
   (type (;0;) (func (param i32 i32 i32) (result i32)))
   (type (;1;) (func))
   (func (;0;) (type 0) (param $from i32) (param $to i32) (param $expected i32) (result i32)
-    loop $cont ;; label = @1
+    loop $cont
       local.get $from
       local.get $to
       i32.eq
@@ -19,7 +19,7 @@
         i32.const 1
         i32.add
         local.set $from
-        br 1 (;@1;)
+        br $cont
       end
     end
     local.get $from

--- a/tests/snapshots/testsuite/memory_fill.wast/8.print
+++ b/tests/snapshots/testsuite/memory_fill.wast/8.print
@@ -2,7 +2,7 @@
   (type (;0;) (func (param i32 i32 i32) (result i32)))
   (type (;1;) (func))
   (func (;0;) (type 0) (param $from i32) (param $to i32) (param $expected i32) (result i32)
-    loop $cont ;; label = @1
+    loop $cont
       local.get $from
       local.get $to
       i32.eq
@@ -19,7 +19,7 @@
         i32.const 1
         i32.add
         local.set $from
-        br 1 (;@1;)
+        br $cont
       end
     end
     local.get $from

--- a/tests/snapshots/testsuite/memory_fill.wast/91.print
+++ b/tests/snapshots/testsuite/memory_fill.wast/91.print
@@ -2,7 +2,7 @@
   (type (;0;) (func (param i32 i32 i32) (result i32)))
   (type (;1;) (func (param i32 i32 i32)))
   (func (;0;) (type 0) (param $from i32) (param $to i32) (param $expected i32) (result i32)
-    loop $cont ;; label = @1
+    loop $cont
       local.get $from
       local.get $to
       i32.eq
@@ -19,7 +19,7 @@
         i32.const 1
         i32.add
         local.set $from
-        br 1 (;@1;)
+        br $cont
       end
     end
     local.get $from

--- a/tests/snapshots/testsuite/memory_fill.wast/94.print
+++ b/tests/snapshots/testsuite/memory_fill.wast/94.print
@@ -2,7 +2,7 @@
   (type (;0;) (func (param i32 i32 i32) (result i32)))
   (type (;1;) (func (param i32 i32 i32)))
   (func (;0;) (type 0) (param $from i32) (param $to i32) (param $expected i32) (result i32)
-    loop $cont ;; label = @1
+    loop $cont
       local.get $from
       local.get $to
       i32.eq
@@ -19,7 +19,7 @@
         i32.const 1
         i32.add
         local.set $from
-        br 1 (;@1;)
+        br $cont
       end
     end
     local.get $from

--- a/tests/snapshots/testsuite/memory_fill.wast/97.print
+++ b/tests/snapshots/testsuite/memory_fill.wast/97.print
@@ -2,7 +2,7 @@
   (type (;0;) (func (param i32 i32 i32) (result i32)))
   (type (;1;) (func (param i32 i32 i32)))
   (func (;0;) (type 0) (param $from i32) (param $to i32) (param $expected i32) (result i32)
-    loop $cont ;; label = @1
+    loop $cont
       local.get $from
       local.get $to
       i32.eq
@@ -19,7 +19,7 @@
         i32.const 1
         i32.add
         local.set $from
-        br 1 (;@1;)
+        br $cont
       end
     end
     local.get $from

--- a/tests/snapshots/testsuite/memory_init.wast/221.print
+++ b/tests/snapshots/testsuite/memory_init.wast/221.print
@@ -2,7 +2,7 @@
   (type (;0;) (func (param i32 i32 i32) (result i32)))
   (type (;1;) (func (param i32 i32)))
   (func (;0;) (type 0) (param $from i32) (param $to i32) (param $expected i32) (result i32)
-    loop $cont ;; label = @1
+    loop $cont
       local.get $from
       local.get $to
       i32.eq
@@ -19,7 +19,7 @@
         i32.const 1
         i32.add
         local.set $from
-        br 1 (;@1;)
+        br $cont
       end
     end
     local.get $from

--- a/tests/snapshots/testsuite/memory_init.wast/224.print
+++ b/tests/snapshots/testsuite/memory_init.wast/224.print
@@ -2,7 +2,7 @@
   (type (;0;) (func (param i32 i32 i32) (result i32)))
   (type (;1;) (func (param i32 i32)))
   (func (;0;) (type 0) (param $from i32) (param $to i32) (param $expected i32) (result i32)
-    loop $cont ;; label = @1
+    loop $cont
       local.get $from
       local.get $to
       i32.eq
@@ -19,7 +19,7 @@
         i32.const 1
         i32.add
         local.set $from
-        br 1 (;@1;)
+        br $cont
       end
     end
     local.get $from

--- a/tests/snapshots/testsuite/memory_init.wast/227.print
+++ b/tests/snapshots/testsuite/memory_init.wast/227.print
@@ -2,7 +2,7 @@
   (type (;0;) (func (param i32 i32 i32) (result i32)))
   (type (;1;) (func (param i32 i32)))
   (func (;0;) (type 0) (param $from i32) (param $to i32) (param $expected i32) (result i32)
-    loop $cont ;; label = @1
+    loop $cont
       local.get $from
       local.get $to
       i32.eq
@@ -19,7 +19,7 @@
         i32.const 1
         i32.add
         local.set $from
-        br 1 (;@1;)
+        br $cont
       end
     end
     local.get $from

--- a/tests/snapshots/testsuite/memory_init.wast/230.print
+++ b/tests/snapshots/testsuite/memory_init.wast/230.print
@@ -2,7 +2,7 @@
   (type (;0;) (func (param i32 i32 i32) (result i32)))
   (type (;1;) (func (param i32 i32)))
   (func (;0;) (type 0) (param $from i32) (param $to i32) (param $expected i32) (result i32)
-    loop $cont ;; label = @1
+    loop $cont
       local.get $from
       local.get $to
       i32.eq
@@ -19,7 +19,7 @@
         i32.const 1
         i32.add
         local.set $from
-        br 1 (;@1;)
+        br $cont
       end
     end
     local.get $from

--- a/tests/snapshots/testsuite/memory_init.wast/233.print
+++ b/tests/snapshots/testsuite/memory_init.wast/233.print
@@ -2,7 +2,7 @@
   (type (;0;) (func (param i32 i32 i32) (result i32)))
   (type (;1;) (func (param i32 i32)))
   (func (;0;) (type 0) (param $from i32) (param $to i32) (param $expected i32) (result i32)
-    loop $cont ;; label = @1
+    loop $cont
       local.get $from
       local.get $to
       i32.eq
@@ -19,7 +19,7 @@
         i32.const 1
         i32.add
         local.set $from
-        br 1 (;@1;)
+        br $cont
       end
     end
     local.get $from

--- a/tests/snapshots/testsuite/memory_init.wast/236.print
+++ b/tests/snapshots/testsuite/memory_init.wast/236.print
@@ -2,7 +2,7 @@
   (type (;0;) (func (param i32 i32 i32) (result i32)))
   (type (;1;) (func (param i32 i32)))
   (func (;0;) (type 0) (param $from i32) (param $to i32) (param $expected i32) (result i32)
-    loop $cont ;; label = @1
+    loop $cont
       local.get $from
       local.get $to
       i32.eq
@@ -19,7 +19,7 @@
         i32.const 1
         i32.add
         local.set $from
-        br 1 (;@1;)
+        br $cont
       end
     end
     local.get $from

--- a/tests/snapshots/testsuite/proposals/function-references/br_on_non_null.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/function-references/br_on_non_null.wast/0.print
@@ -3,18 +3,18 @@
   (type (;1;) (func (param (ref 0)) (result i32)))
   (type (;2;) (func (param (ref null 0)) (result i32)))
   (func $nn (;0;) (type 1) (param $r (ref 0)) (result i32)
-    block $l (result (ref 0)) ;; label = @1
+    block $l (result (ref 0))
       local.get $r
-      br_on_non_null 0 (;@1;)
+      br_on_non_null $l
       i32.const -1
       return
     end
     call_ref $t
   )
   (func $n (;1;) (type 2) (param $r (ref null 0)) (result i32)
-    block $l (result (ref 0)) ;; label = @1
+    block $l (result (ref 0))
       local.get $r
-      br_on_non_null 0 (;@1;)
+      br_on_non_null $l
       i32.const -1
       return
     end
@@ -36,9 +36,9 @@
     call $n
   )
   (func (;6;) (type $t) (result i32)
-    block $l (result (ref 0)) ;; label = @1
+    block $l (result (ref 0))
       unreachable
-      br_on_non_null 0 (;@1;)
+      br_on_non_null $l
       i32.const -1
       return
     end

--- a/tests/snapshots/testsuite/proposals/function-references/br_on_non_null.wast/6.print
+++ b/tests/snapshots/testsuite/proposals/function-references/br_on_non_null.wast/6.print
@@ -8,10 +8,10 @@
     i32.mul
   )
   (func $a (;1;) (type 1) (param $n i32) (param $r (ref null 0)) (result i32)
-    block $l (type 2) (result i32 (ref 0)) ;; label = @1
+    block $l (type 2) (result i32 (ref 0))
       local.get $n
       local.get $r
-      br_on_non_null 0 (;@1;)
+      br_on_non_null $l
       return
     end
     call_ref $t

--- a/tests/snapshots/testsuite/proposals/function-references/br_on_null.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/function-references/br_on_null.wast/0.print
@@ -3,18 +3,18 @@
   (type (;1;) (func (param (ref 0)) (result i32)))
   (type (;2;) (func (param (ref null 0)) (result i32)))
   (func $nn (;0;) (type 1) (param $r (ref 0)) (result i32)
-    block $l ;; label = @1
+    block $l
       local.get $r
-      br_on_null 0 (;@1;)
+      br_on_null $l
       call_ref $t
       return
     end
     i32.const -1
   )
   (func $n (;1;) (type 2) (param $r (ref null 0)) (result i32)
-    block $l ;; label = @1
+    block $l
       local.get $r
-      br_on_null 0 (;@1;)
+      br_on_null $l
       call_ref $t
       return
     end
@@ -36,9 +36,9 @@
     call $n
   )
   (func (;6;) (type $t) (result i32)
-    block $l ;; label = @1
+    block $l
       unreachable
-      br_on_null 0 (;@1;)
+      br_on_null $l
       call_ref $t
       return
     end

--- a/tests/snapshots/testsuite/proposals/function-references/br_on_null.wast/6.print
+++ b/tests/snapshots/testsuite/proposals/function-references/br_on_null.wast/6.print
@@ -7,10 +7,10 @@
     i32.mul
   )
   (func $a (;1;) (type 1) (param $n i32) (param $r (ref null 0)) (result i32)
-    block $l (result i32) ;; label = @1
+    block $l (result i32)
       local.get $n
       local.get $r
-      br_on_null 0 (;@1;)
+      br_on_null $l
       call_ref $t
       return
     end

--- a/tests/snapshots/testsuite/proposals/function-references/br_table.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/function-references/br_table.wast/0.print
@@ -763,11 +763,11 @@
     end
   )
   (func (;69;) (type 8) (param i32 externref) (result externref)
-    block $l1 (result externref) ;; label = @1
-      block $l2 (result externref) ;; label = @2
+    block $l1 (result externref)
+      block $l2 (result externref)
         local.get 1
         local.get 0
-        br_table 1 (;@1;) 0 (;@2;) 1 (;@1;)
+        br_table $l1 $l2 $l1
       end
     end
   )
@@ -785,61 +785,61 @@
   )
   (func $tf (;71;) (type $t))
   (func (;72;) (type 9) (param i32) (result funcref)
-    block $l1 (result funcref) ;; label = @1
-      block $l2 (result (ref null 1)) ;; label = @2
+    block $l1 (result funcref)
+      block $l2 (result (ref null 1))
         i32.const 0
         table.get $t
         local.get 0
-        br_table 1 (;@1;) 1 (;@1;) 0 (;@2;)
+        br_table $l1 $l1 $l2
       end
     end
   )
   (func (;73;) (type 9) (param i32) (result funcref)
-    block $l1 (result funcref) ;; label = @1
-      block $l2 (result (ref null 1)) ;; label = @2
+    block $l1 (result funcref)
+      block $l2 (result (ref null 1))
         i32.const 0
         table.get $t
         local.get 0
-        br_table 0 (;@2;) 0 (;@2;) 1 (;@1;)
+        br_table $l2 $l2 $l1
       end
     end
   )
   (func (;74;) (type 9) (param i32) (result funcref)
-    block $l1 (result funcref) ;; label = @1
-      block $l2 (result (ref null 1)) ;; label = @2
+    block $l1 (result funcref)
+      block $l2 (result (ref null 1))
         i32.const 0
         table.get $t
         local.get 0
-        br_table 0 (;@2;) 1 (;@1;) 0 (;@2;)
+        br_table $l2 $l1 $l2
       end
     end
   )
   (func (;75;) (type 9) (param i32) (result funcref)
-    block $l1 (result funcref) ;; label = @1
-      block $l2 (result (ref null 1)) ;; label = @2
+    block $l1 (result funcref)
+      block $l2 (result (ref null 1))
         i32.const 0
         table.get $t
         local.get 0
-        br_table 1 (;@1;) 0 (;@2;) 1 (;@1;)
+        br_table $l1 $l2 $l1
       end
     end
   )
   (func (;76;) (type 9) (param i32) (result funcref)
-    block $l1 (result funcref) ;; label = @1
-      block $l2 (result (ref null 1)) ;; label = @2
+    block $l1 (result funcref)
+      block $l2 (result (ref null 1))
         ref.null 1
         local.get 0
-        br_table 1 (;@1;) 0 (;@2;) 1 (;@1;)
+        br_table $l1 $l2 $l1
       end
     end
   )
   (func (;77;) (type 9) (param i32) (result funcref)
-    block $l1 (result funcref) ;; label = @1
-      block $l2 (result (ref null 1)) ;; label = @2
-        block $l3 (result (ref 1)) ;; label = @3
+    block $l1 (result funcref)
+      block $l2 (result (ref null 1))
+        block $l3 (result (ref 1))
           ref.func $tf
           local.get 0
-          br_table 0 (;@3;) 1 (;@2;) 2 (;@1;)
+          br_table $l3 $l2 $l1
         end
       end
     end

--- a/tests/snapshots/testsuite/proposals/function-references/if.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/function-references/if.wast/0.print
@@ -25,10 +25,10 @@
     else
     end
     local.get 0
-    if $l ;; label = @1
+    if $l
     end
     local.get 0
-    if $l ;; label = @1
+    if $l
     else
     end
   )

--- a/tests/snapshots/testsuite/proposals/function-references/local_get.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/function-references/local_get.wast/0.print
@@ -117,10 +117,10 @@
     end
   )
   (func (;13;) (type 4) (param i32) (result i32)
-    block $l0 (result i32) ;; label = @1
+    block $l0 (result i32)
       local.get 0
       i32.const 1
-      br_if 0 (;@1;)
+      br_if $l0
     end
   )
   (func (;14;) (type 4) (param i32) (result i32)

--- a/tests/snapshots/testsuite/proposals/gc/br_on_non_null.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/gc/br_on_non_null.wast/0.print
@@ -3,18 +3,18 @@
   (type (;1;) (func (param (ref 0)) (result i32)))
   (type (;2;) (func (param (ref null 0)) (result i32)))
   (func $nn (;0;) (type 1) (param $r (ref 0)) (result i32)
-    block $l (result (ref 0)) ;; label = @1
+    block $l (result (ref 0))
       local.get $r
-      br_on_non_null 0 (;@1;)
+      br_on_non_null $l
       i32.const -1
       return
     end
     call_ref $t
   )
   (func $n (;1;) (type 2) (param $r (ref null 0)) (result i32)
-    block $l (result (ref 0)) ;; label = @1
+    block $l (result (ref 0))
       local.get $r
-      br_on_non_null 0 (;@1;)
+      br_on_non_null $l
       i32.const -1
       return
     end
@@ -36,9 +36,9 @@
     call $n
   )
   (func (;6;) (type $t) (result i32)
-    block $l (result (ref 0)) ;; label = @1
+    block $l (result (ref 0))
       unreachable
-      br_on_non_null 0 (;@1;)
+      br_on_non_null $l
       i32.const -1
       return
     end

--- a/tests/snapshots/testsuite/proposals/gc/br_on_non_null.wast/6.print
+++ b/tests/snapshots/testsuite/proposals/gc/br_on_non_null.wast/6.print
@@ -8,10 +8,10 @@
     i32.mul
   )
   (func $a (;1;) (type 1) (param $n i32) (param $r (ref null 0)) (result i32)
-    block $l (type 2) (result i32 (ref 0)) ;; label = @1
+    block $l (type 2) (result i32 (ref 0))
       local.get $n
       local.get $r
-      br_on_non_null 0 (;@1;)
+      br_on_non_null $l
       return
     end
     call_ref $t

--- a/tests/snapshots/testsuite/proposals/gc/br_on_null.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/gc/br_on_null.wast/0.print
@@ -3,18 +3,18 @@
   (type (;1;) (func (param (ref 0)) (result i32)))
   (type (;2;) (func (param (ref null 0)) (result i32)))
   (func $nn (;0;) (type 1) (param $r (ref 0)) (result i32)
-    block $l ;; label = @1
+    block $l
       local.get $r
-      br_on_null 0 (;@1;)
+      br_on_null $l
       call_ref $t
       return
     end
     i32.const -1
   )
   (func $n (;1;) (type 2) (param $r (ref null 0)) (result i32)
-    block $l ;; label = @1
+    block $l
       local.get $r
-      br_on_null 0 (;@1;)
+      br_on_null $l
       call_ref $t
       return
     end
@@ -36,9 +36,9 @@
     call $n
   )
   (func (;6;) (type $t) (result i32)
-    block $l ;; label = @1
+    block $l
       unreachable
-      br_on_null 0 (;@1;)
+      br_on_null $l
       call_ref $t
       return
     end

--- a/tests/snapshots/testsuite/proposals/gc/br_on_null.wast/6.print
+++ b/tests/snapshots/testsuite/proposals/gc/br_on_null.wast/6.print
@@ -7,10 +7,10 @@
     i32.mul
   )
   (func $a (;1;) (type 1) (param $n i32) (param $r (ref null 0)) (result i32)
-    block $l (result i32) ;; label = @1
+    block $l (result i32)
       local.get $n
       local.get $r
-      br_on_null 0 (;@1;)
+      br_on_null $l
       call_ref $t
       return
     end

--- a/tests/snapshots/testsuite/proposals/gc/br_table.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/gc/br_table.wast/0.print
@@ -763,11 +763,11 @@
     end
   )
   (func (;69;) (type 8) (param i32 externref) (result externref)
-    block $l1 (result externref) ;; label = @1
-      block $l2 (result externref) ;; label = @2
+    block $l1 (result externref)
+      block $l2 (result externref)
         local.get 1
         local.get 0
-        br_table 1 (;@1;) 0 (;@2;) 1 (;@1;)
+        br_table $l1 $l2 $l1
       end
     end
   )
@@ -785,61 +785,61 @@
   )
   (func $tf (;71;) (type $t))
   (func (;72;) (type 9) (param i32) (result funcref)
-    block $l1 (result funcref) ;; label = @1
-      block $l2 (result (ref null 1)) ;; label = @2
+    block $l1 (result funcref)
+      block $l2 (result (ref null 1))
         i32.const 0
         table.get $t
         local.get 0
-        br_table 1 (;@1;) 1 (;@1;) 0 (;@2;)
+        br_table $l1 $l1 $l2
       end
     end
   )
   (func (;73;) (type 9) (param i32) (result funcref)
-    block $l1 (result funcref) ;; label = @1
-      block $l2 (result (ref null 1)) ;; label = @2
+    block $l1 (result funcref)
+      block $l2 (result (ref null 1))
         i32.const 0
         table.get $t
         local.get 0
-        br_table 0 (;@2;) 0 (;@2;) 1 (;@1;)
+        br_table $l2 $l2 $l1
       end
     end
   )
   (func (;74;) (type 9) (param i32) (result funcref)
-    block $l1 (result funcref) ;; label = @1
-      block $l2 (result (ref null 1)) ;; label = @2
+    block $l1 (result funcref)
+      block $l2 (result (ref null 1))
         i32.const 0
         table.get $t
         local.get 0
-        br_table 0 (;@2;) 1 (;@1;) 0 (;@2;)
+        br_table $l2 $l1 $l2
       end
     end
   )
   (func (;75;) (type 9) (param i32) (result funcref)
-    block $l1 (result funcref) ;; label = @1
-      block $l2 (result (ref null 1)) ;; label = @2
+    block $l1 (result funcref)
+      block $l2 (result (ref null 1))
         i32.const 0
         table.get $t
         local.get 0
-        br_table 1 (;@1;) 0 (;@2;) 1 (;@1;)
+        br_table $l1 $l2 $l1
       end
     end
   )
   (func (;76;) (type 9) (param i32) (result funcref)
-    block $l1 (result funcref) ;; label = @1
-      block $l2 (result (ref null 1)) ;; label = @2
+    block $l1 (result funcref)
+      block $l2 (result (ref null 1))
         ref.null 1
         local.get 0
-        br_table 1 (;@1;) 0 (;@2;) 1 (;@1;)
+        br_table $l1 $l2 $l1
       end
     end
   )
   (func (;77;) (type 9) (param i32) (result funcref)
-    block $l1 (result funcref) ;; label = @1
-      block $l2 (result (ref null 1)) ;; label = @2
-        block $l3 (result (ref 1)) ;; label = @3
+    block $l1 (result funcref)
+      block $l2 (result (ref null 1))
+        block $l3 (result (ref 1))
           ref.func $tf
           local.get 0
-          br_table 0 (;@3;) 1 (;@2;) 2 (;@1;)
+          br_table $l3 $l2 $l1
         end
       end
     end

--- a/tests/snapshots/testsuite/proposals/gc/if.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/gc/if.wast/0.print
@@ -25,10 +25,10 @@
     else
     end
     local.get 0
-    if $l ;; label = @1
+    if $l
     end
     local.get 0
-    if $l ;; label = @1
+    if $l
     else
     end
   )

--- a/tests/snapshots/testsuite/proposals/gc/local_get.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/gc/local_get.wast/0.print
@@ -117,10 +117,10 @@
     end
   )
   (func (;13;) (type 4) (param i32) (result i32)
-    block $l0 (result i32) ;; label = @1
+    block $l0 (result i32)
       local.get 0
       i32.const 1
-      br_if 0 (;@1;)
+      br_if $l0
     end
   )
   (func (;14;) (type 4) (param i32) (result i32)

--- a/tests/snapshots/testsuite/proposals/memory64/align64.wast/106.print
+++ b/tests/snapshots/testsuite/proposals/memory64/align64.wast/106.print
@@ -7,13 +7,13 @@
     (local f32 f32)
     f32.const 0x1.4p+3 (;=10;)
     local.set 1
-    block $4 ;; label = @1
-      block $2 ;; label = @2
-        block $1 ;; label = @3
-          block $default ;; label = @4
-            block $0 ;; label = @5
+    block $4
+      block $2
+        block $1
+          block $default
+            block $0
               local.get 0
-              br_table 0 (;@5;) 1 (;@4;) 2 (;@3;) 3 (;@2;) 4 (;@1;)
+              br_table $0 $default $1 $2 $4
             end
             i64.const 0
             local.get 1
@@ -21,7 +21,7 @@
             i64.const 0
             f32.load
             local.set 2
-            br 3 (;@1;)
+            br $4
           end
           i64.const 0
           local.get 1
@@ -29,7 +29,7 @@
           i64.const 0
           f32.load align=1
           local.set 2
-          br 2 (;@1;)
+          br $4
         end
         i64.const 0
         local.get 1
@@ -37,7 +37,7 @@
         i64.const 0
         f32.load align=2
         local.set 2
-        br 1 (;@1;)
+        br $4
       end
       i64.const 0
       local.get 1
@@ -52,14 +52,14 @@
     (local f64 f64)
     f64.const 0x1.4p+3 (;=10;)
     local.set 1
-    block $8 ;; label = @1
-      block $4 ;; label = @2
-        block $2 ;; label = @3
-          block $1 ;; label = @4
-            block $default ;; label = @5
-              block $0 ;; label = @6
+    block $8
+      block $4
+        block $2
+          block $1
+            block $default
+              block $0
                 local.get 0
-                br_table 0 (;@6;) 1 (;@5;) 2 (;@4;) 3 (;@3;) 4 (;@2;) 5 (;@1;)
+                br_table $0 $default $1 $2 $4 $8
               end
               i64.const 0
               local.get 1
@@ -67,7 +67,7 @@
               i64.const 0
               f64.load
               local.set 2
-              br 4 (;@1;)
+              br $8
             end
             i64.const 0
             local.get 1
@@ -75,7 +75,7 @@
             i64.const 0
             f64.load align=1
             local.set 2
-            br 3 (;@1;)
+            br $8
           end
           i64.const 0
           local.get 1
@@ -83,7 +83,7 @@
           i64.const 0
           f64.load align=2
           local.set 2
-          br 2 (;@1;)
+          br $8
         end
         i64.const 0
         local.get 1
@@ -91,7 +91,7 @@
         i64.const 0
         f64.load align=4
         local.set 2
-        br 1 (;@1;)
+        br $8
       end
       i64.const 0
       local.get 1
@@ -106,14 +106,14 @@
     (local i32 i32)
     i32.const 10
     local.set 2
-    block $32 ;; label = @1
-      block $16u ;; label = @2
-        block $16s ;; label = @3
-          block $8u ;; label = @4
-            block $8s ;; label = @5
-              block $0 ;; label = @6
+    block $32
+      block $16u
+        block $16s
+          block $8u
+            block $8s
+              block $0
                 local.get 0
-                br_table 0 (;@6;) 1 (;@5;) 2 (;@4;) 3 (;@3;) 4 (;@2;) 5 (;@1;)
+                br_table $0 $8s $8u $16s $16u $32
               end
               local.get 1
               i32.const 0
@@ -137,7 +137,7 @@
                 i32.load8_s
                 local.set 3
               end
-              br 4 (;@1;)
+              br $32
             end
             local.get 1
             i32.const 0
@@ -161,7 +161,7 @@
               i32.load8_u
               local.set 3
             end
-            br 3 (;@1;)
+            br $32
           end
           local.get 1
           i32.const 0
@@ -196,7 +196,7 @@
             i32.load16_s
             local.set 3
           end
-          br 2 (;@1;)
+          br $32
         end
         local.get 1
         i32.const 0
@@ -231,7 +231,7 @@
           i32.load16_u
           local.set 3
         end
-        br 1 (;@1;)
+        br $32
       end
       local.get 1
       i32.const 0
@@ -284,16 +284,16 @@
     (local i64 i64)
     i64.const 10
     local.set 2
-    block $64 ;; label = @1
-      block $32u ;; label = @2
-        block $32s ;; label = @3
-          block $16u ;; label = @4
-            block $16s ;; label = @5
-              block $8u ;; label = @6
-                block $8s ;; label = @7
-                  block $0 ;; label = @8
+    block $64
+      block $32u
+        block $32s
+          block $16u
+            block $16s
+              block $8u
+                block $8s
+                  block $0
                     local.get 0
-                    br_table 0 (;@8;) 1 (;@7;) 2 (;@6;) 3 (;@5;) 4 (;@4;) 5 (;@3;) 6 (;@2;) 7 (;@1;)
+                    br_table $0 $8s $8u $16s $16u $32s $32u $64
                   end
                   local.get 1
                   i32.const 0
@@ -317,7 +317,7 @@
                     i64.load8_s
                     local.set 3
                   end
-                  br 6 (;@1;)
+                  br $64
                 end
                 local.get 1
                 i32.const 0
@@ -341,7 +341,7 @@
                   i64.load8_u
                   local.set 3
                 end
-                br 5 (;@1;)
+                br $64
               end
               local.get 1
               i32.const 0
@@ -376,7 +376,7 @@
                 i64.load16_s
                 local.set 3
               end
-              br 4 (;@1;)
+              br $64
             end
             local.get 1
             i32.const 0
@@ -411,7 +411,7 @@
               i64.load16_u
               local.set 3
             end
-            br 3 (;@1;)
+            br $64
           end
           local.get 1
           i32.const 0
@@ -457,7 +457,7 @@
             i64.load32_s
             local.set 3
           end
-          br 2 (;@1;)
+          br $64
         end
         local.get 1
         i32.const 0
@@ -503,7 +503,7 @@
           i64.load32_u
           local.set 3
         end
-        br 1 (;@1;)
+        br $64
       end
       local.get 1
       i32.const 0

--- a/tests/snapshots/testsuite/proposals/multi-memory/align0.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/multi-memory/align0.wast/0.print
@@ -4,13 +4,13 @@
     (local f32 f32)
     f32.const 0x1.4p+3 (;=10;)
     local.set 1
-    block $4 ;; label = @1
-      block $2 ;; label = @2
-        block $1 ;; label = @3
-          block $default ;; label = @4
-            block $0 ;; label = @5
+    block $4
+      block $2
+        block $1
+          block $default
+            block $0
               local.get 0
-              br_table 0 (;@5;) 1 (;@4;) 2 (;@3;) 3 (;@2;) 4 (;@1;)
+              br_table $0 $default $1 $2 $4
             end
             i32.const 0
             local.get 1
@@ -18,7 +18,7 @@
             i32.const 0
             f32.load $mem1
             local.set 2
-            br 3 (;@1;)
+            br $4
           end
           i32.const 0
           local.get 1
@@ -26,7 +26,7 @@
           i32.const 0
           f32.load $mem1 align=1
           local.set 2
-          br 2 (;@1;)
+          br $4
         end
         i32.const 0
         local.get 1
@@ -34,7 +34,7 @@
         i32.const 0
         f32.load $mem1 align=2
         local.set 2
-        br 1 (;@1;)
+        br $4
       end
       i32.const 0
       local.get 1

--- a/tests/snapshots/testsuite/proposals/multi-memory/float_exprs0.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/multi-memory/float_exprs0.wast/0.print
@@ -8,8 +8,8 @@
   )
   (func (;1;) (type 0) (param $n i32) (param $z f64)
     (local $i i32)
-    block $exit ;; label = @1
-      loop $cont ;; label = @2
+    block $exit
+      loop $cont
         local.get $i
         local.get $i
         f64.load $m
@@ -23,7 +23,7 @@
         local.get $i
         local.get $n
         i32.lt_u
-        br_if 0 (;@2;)
+        br_if $cont
       end
     end
   )

--- a/tests/snapshots/testsuite/proposals/multi-memory/float_exprs1.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/multi-memory/float_exprs1.wast/0.print
@@ -2,8 +2,8 @@
   (type (;0;) (func (param i32 i32) (result f32)))
   (func (;0;) (type 0) (param $p i32) (param $n i32) (result f32)
     (local $sum f32) (local $c f32) (local $t f32)
-    block $exit ;; label = @1
-      loop $top ;; label = @2
+    block $exit
+      loop $top
         local.get $c
         local.get $p
         f32.load $m
@@ -27,15 +27,15 @@
         i32.const -1
         i32.add
         local.tee $n
-        br_if 0 (;@2;)
+        br_if $top
       end
     end
     local.get $sum
   )
   (func (;1;) (type 0) (param $p i32) (param $n i32) (result f32)
     (local $sum f32)
-    block $exit ;; label = @1
-      loop $top ;; label = @2
+    block $exit
+      loop $top
         local.get $sum
         local.get $p
         f32.load $m
@@ -50,7 +50,7 @@
         i32.add
         local.set $n
         local.get $n
-        br_if 0 (;@2;)
+        br_if $top
       end
     end
     local.get $sum

--- a/tests/snapshots/testsuite/proposals/multi-memory/store.wast/20.print
+++ b/tests/snapshots/testsuite/proposals/multi-memory/store.wast/20.print
@@ -14,7 +14,7 @@
     (local $i i32)
     i32.const 20
     local.set $i
-    loop $cont ;; label = @1
+    loop $cont
       local.get $i
       i32.const 23
       i32.eq
@@ -27,14 +27,14 @@
       i32.const 1
       i32.add
       local.set $i
-      br 0 (;@1;)
+      br $cont
     end
   )
   (func (;3;) (type 1)
     (local $i i32)
     i32.const 50
     local.set $i
-    loop $cont ;; label = @1
+    loop $cont
       local.get $i
       i32.const 54
       i32.eq
@@ -47,7 +47,7 @@
       i32.const 1
       i32.add
       local.set $i
-      br 0 (;@1;)
+      br $cont
     end
   )
   (memory $mem2 (;1;) 3)

--- a/tests/snapshots/testsuite/stack.wast/0.print
+++ b/tests/snapshots/testsuite/stack.wast/0.print
@@ -8,13 +8,13 @@
     local.set $i
     i64.const 1
     local.set $res
-    block $done ;; label = @1
-      loop $loop ;; label = @2
+    block $done
+      loop $loop
         local.get $i
         i64.const 0
         i64.eq
         if ;; label = @3
-          br 2 (;@1;)
+          br $done
         else
           local.get $i
           local.get $res
@@ -25,7 +25,7 @@
           i64.sub
           local.set $i
         end
-        br 0 (;@2;)
+        br $loop
       end
     end
     local.get $res
@@ -36,13 +36,13 @@
     local.set $i
     i64.const 1
     local.set $res
-    block $done ;; label = @1
-      loop $loop ;; label = @2
+    block $done
+      loop $loop
         local.get $i
         i64.const 0
         i64.eq
         if ;; label = @3
-          br 2 (;@1;)
+          br $done
         else
           local.get $i
           local.get $res
@@ -53,7 +53,7 @@
           i64.sub
           local.set $i
         end
-        br 0 (;@2;)
+        br $loop
       end
     end
     local.get $res
@@ -64,13 +64,13 @@
     local.set $i
     i64.const 1
     local.set $res
-    block $done ;; label = @1
-      loop $loop ;; label = @2
+    block $done
+      loop $loop
         local.get $i
         i64.const 0
         i64.eq
-        if $body ;; label = @3
-          br 2 (;@1;)
+        if $body
+          br $done
         else
           local.get $i
           local.get $res
@@ -81,7 +81,7 @@
           i64.sub
           local.set $i
         end
-        br 0 (;@2;)
+        br $loop
       end
     end
     local.get $res
@@ -92,13 +92,13 @@
     local.set $i
     i64.const 1
     local.set $res
-    block $done ;; label = @1
-      loop $loop ;; label = @2
+    block $done
+      loop $loop
         local.get $i
         i64.const 0
         i64.eq
         if ;; label = @3
-          br 2 (;@1;)
+          br $done
         else
           local.get $i
           local.get $res
@@ -109,7 +109,7 @@
           i64.sub
           local.set $i
         end
-        br 0 (;@2;)
+        br $loop
       end
     end
     local.get $res
@@ -120,13 +120,13 @@
     local.set $i
     i64.const 1
     local.set $res
-    block $done ;; label = @1
-      loop $loop ;; label = @2
+    block $done
+      loop $loop
         local.get $i
         i64.const 0
         i64.eq
         if ;; label = @3
-          br 2 (;@1;)
+          br $done
         else
           local.get $i
           local.get $res
@@ -137,7 +137,7 @@
           i64.sub
           local.set $i
         end
-        br 0 (;@2;)
+        br $loop
       end
     end
     local.get $res

--- a/tests/snapshots/testsuite/switch.wast/0.print
+++ b/tests/snapshots/testsuite/switch.wast/0.print
@@ -6,18 +6,18 @@
     (local $j i32)
     i32.const 100
     local.set $j
-    block $switch ;; label = @1
-      block $7 ;; label = @2
-        block $default ;; label = @3
-          block $6 ;; label = @4
-            block $5 ;; label = @5
-              block $4 ;; label = @6
-                block $3 ;; label = @7
-                  block $2 ;; label = @8
-                    block $1 ;; label = @9
-                      block $0 ;; label = @10
+    block $switch
+      block $7
+        block $default
+          block $6
+            block $5
+              block $4
+                block $3
+                  block $2
+                    block $1
+                      block $0
                         local.get $i
-                        br_table 0 (;@10;) 1 (;@9;) 2 (;@8;) 3 (;@7;) 4 (;@6;) 5 (;@5;) 6 (;@4;) 8 (;@2;) 7 (;@3;)
+                        br_table $0 $1 $2 $3 $4 $5 $6 $7 $default
                       end
                       local.get $i
                       return
@@ -29,13 +29,13 @@
                 local.get $i
                 i32.sub
                 local.set $j
-                br 5 (;@1;)
+                br $switch
               end
-              br 4 (;@1;)
+              br $switch
             end
             i32.const 101
             local.set $j
-            br 3 (;@1;)
+            br $switch
           end
           i32.const 101
           local.set $j
@@ -51,19 +51,19 @@
     (local $j i64)
     i64.const 100
     local.set $j
-    block $switch (result i64) ;; label = @1
-      block $7 ;; label = @2
-        block $default ;; label = @3
-          block $4 ;; label = @4
-            block $5 ;; label = @5
-              block $6 ;; label = @6
-                block $3 ;; label = @7
-                  block $2 ;; label = @8
-                    block $1 ;; label = @9
-                      block $0 ;; label = @10
+    block $switch (result i64)
+      block $7
+        block $default
+          block $4
+            block $5
+              block $6
+                block $3
+                  block $2
+                    block $1
+                      block $0
                         local.get $i
                         i32.wrap_i64
-                        br_table 0 (;@10;) 1 (;@9;) 2 (;@8;) 3 (;@7;) 6 (;@4;) 5 (;@5;) 4 (;@6;) 8 (;@2;) 7 (;@3;)
+                        br_table $0 $1 $2 $3 $4 $5 $6 $7 $default
                       end
                       local.get $i
                       return
@@ -74,7 +74,7 @@
                 i64.const 0
                 local.get $i
                 i64.sub
-                br 5 (;@1;)
+                br $switch
               end
               i64.const 101
               local.set $j
@@ -82,27 +82,27 @@
           end
         end
         local.get $j
-        br 1 (;@1;)
+        br $switch
       end
       i64.const -5
     end
     return
   )
   (func (;2;) (type 0) (param $i i32) (result i32)
-    block $2 (result i32) ;; label = @1
+    block $2 (result i32)
       i32.const 10
-      block $1 (result i32) ;; label = @2
+      block $1 (result i32)
         i32.const 100
-        block $0 (result i32) ;; label = @3
+        block $0 (result i32)
           i32.const 1000
-          block $default (result i32) ;; label = @4
+          block $default (result i32)
             i32.const 2
             local.get $i
             i32.mul
             i32.const 3
             local.get $i
             i32.and
-            br_table 1 (;@3;) 2 (;@2;) 3 (;@1;) 0 (;@4;)
+            br_table $0 $1 $2 $default
           end
           i32.add
         end

--- a/tests/snapshots/testsuite/token.wast/20.print
+++ b/tests/snapshots/testsuite/token.wast/20.print
@@ -1,9 +1,9 @@
 (module
   (type (;0;) (func))
   (func (;0;) (type 0)
-    block $l ;; label = @1
+    block $l
       i32.const 0
-      br_table 0 (;@1;) 0 (;@1;)
+      br_table $l $l
     end
   )
 )

--- a/tests/snapshots/testsuite/token.wast/22.print
+++ b/tests/snapshots/testsuite/token.wast/22.print
@@ -1,9 +1,9 @@
 (module
   (type (;0;) (func))
   (func (;0;) (type 0)
-    block $l ;; label = @1
+    block $l
       i32.const 0
-      br_table 0 (;@1;) 0 (;@1;)
+      br_table $l $l
     end
   )
 )

--- a/tests/snapshots/testsuite/token.wast/24.print
+++ b/tests/snapshots/testsuite/token.wast/24.print
@@ -1,9 +1,9 @@
 (module
   (type (;0;) (func))
   (func (;0;) (type 0)
-    block $l0 ;; label = @1
+    block $l0
       i32.const 0
-      br_table 0 (;@1;)
+      br_table $l0
     end
   )
 )

--- a/tests/snapshots/testsuite/token.wast/25.print
+++ b/tests/snapshots/testsuite/token.wast/25.print
@@ -1,9 +1,9 @@
 (module
   (type (;0;) (func))
   (func (;0;) (type 0)
-    block $l$l ;; label = @1
+    block $l$l
       i32.const 0
-      br_table 0 (;@1;)
+      br_table $l$l
     end
   )
 )


### PR DESCRIPTION
This commit updates `wasmprinter` to print the target label name for instructions such as `br` and friends. This is done by maintaining a stack matching the stack of blocks that are entered, and the relative depth is looked up in this stack to then consult the name label name map contained in the label name subsection.

Closes #841