### PR TITLE
wit-component: Re-export `_start` while shared-everything link

### DIFF
--- a/crates/wit-component/src/linking/metadata.rs
+++ b/crates/wit-component/src/linking/metadata.rs
@@ -202,6 +202,9 @@ pub struct Metadata<'a> {
     /// Whether this module exports `_initialize`
     pub has_initialize: bool,
 
+    /// Whether this module exports `_start`
+    pub has_wasi_start: bool,
+
     /// Whether this module exports `__wasm_set_libraries`
     pub has_set_libraries: bool,
 
@@ -307,6 +310,7 @@ impl<'a> Metadata<'a> {
             has_data_relocs: false,
             has_ctors: false,
             has_initialize: false,
+            has_wasi_start: false,
             has_set_libraries: false,
             has_component_exports,
             env_imports: BTreeSet::new(),
@@ -496,6 +500,7 @@ impl<'a> Metadata<'a> {
                             "__wasm_apply_data_relocs" => result.has_data_relocs = true,
                             "__wasm_call_ctors" => result.has_ctors = true,
                             "_initialize" => result.has_initialize = true,
+                            "_start" => result.has_wasi_start = true,
                             "__wasm_set_libraries" => result.has_set_libraries = true,
                             _ => {
                                 let ty = match export.kind {


### PR DESCRIPTION
This is a bit of a hack to componentize a WASI preview1 command module with shared-everything linking. The `_start` function was not being exported, so `wasm-tools component link` was failing to link modules with `wasi_snapshot_preview1.command.wasm` adapter.