### PR TITLE
wasmparser: Get `array_{fill,init_{data,elem}}.wast` GC spec tests passing

### DIFF
--- a/crates/wasm-encoder/src/core/code.rs
+++ b/crates/wasm-encoder/src/core/code.rs
@@ -567,8 +567,14 @@ pub enum Instruction<'a> {
         array_type_index_dst: u32,
         array_type_index_src: u32,
     },
-    ArrayInitData(u32, u32),
-    ArrayInitElem(u32, u32),
+    ArrayInitData {
+        array_type_index: u32,
+        array_data_index: u32,
+    },
+    ArrayInitElem {
+        array_type_index: u32,
+        array_elem_index: u32,
+    },
 
     RefTestNonNull(HeapType),
     RefTestNullable(HeapType),
@@ -1515,17 +1521,23 @@ impl Encode for Instruction<'_> {
                 array_type_index_dst.encode(sink);
                 array_type_index_src.encode(sink);
             }
-            Instruction::ArrayInitData(type_index, data_index) => {
+            Instruction::ArrayInitData {
+                array_type_index,
+                array_data_index,
+            } => {
                 sink.push(0xfb);
                 sink.push(0x12);
-                type_index.encode(sink);
-                data_index.encode(sink);
+                array_type_index.encode(sink);
+                array_data_index.encode(sink);
             }
-            Instruction::ArrayInitElem(type_index, elem_index) => {
+            Instruction::ArrayInitElem {
+                array_type_index,
+                array_elem_index,
+            } => {
                 sink.push(0xfb);
                 sink.push(0x13);
-                type_index.encode(sink);
-                elem_index.encode(sink);
+                array_type_index.encode(sink);
+                array_elem_index.encode(sink);
             }
             Instruction::RefTestNonNull(heap_type) => {
                 sink.push(0xfb);

--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -396,6 +396,7 @@ pub fn op(t: &mut dyn Translator, op: &Operator<'_>) -> Result<Instruction<'stat
         (build ArrayGetS $type_index:ident) => (I::ArrayGetS($type_index));
         (build ArrayGetU $type_index:ident) => (I::ArrayGetU($type_index));
         (build ArraySet $type_index:ident) => (I::ArraySet($type_index));
+        (build ArrayFill $type_index:ident) => (I::ArrayFill($type_index));
         (build $op:ident $($arg:ident)*) => (I::$op { $($arg),* });
     }
 

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -1046,13 +1046,25 @@ impl<'a> BinaryReader<'a> {
                 visitor.visit_array_set(type_index)
             }
             0x0f => visitor.visit_array_len(),
-
+            0x10 => {
+                let type_index = self.read_var_u32()?;
+                visitor.visit_array_fill(type_index)
+            }
             0x11 => {
                 let type_index_dst = self.read_var_u32()?;
                 let type_index_src = self.read_var_u32()?;
                 visitor.visit_array_copy(type_index_dst, type_index_src)
             }
-
+            0x12 => {
+                let type_index = self.read_var_u32()?;
+                let data_index = self.read_var_u32()?;
+                visitor.visit_array_init_data(type_index, data_index)
+            }
+            0x13 => {
+                let type_index = self.read_var_u32()?;
+                let elem_index = self.read_var_u32()?;
+                visitor.visit_array_init_elem(type_index, elem_index)
+            }
             0x14 => visitor.visit_ref_test_non_null(self.read()?),
             0x15 => visitor.visit_ref_test_nullable(self.read()?),
             0x16 => visitor.visit_ref_cast_non_null(self.read()?),

--- a/crates/wasmparser/src/lib.rs
+++ b/crates/wasmparser/src/lib.rs
@@ -327,7 +327,10 @@ macro_rules! for_each_operator {
             @gc ArrayGetU { array_type_index: u32 } => visit_array_get_u
             @gc ArraySet { array_type_index: u32 } => visit_array_set
             @gc ArrayLen => visit_array_len
+            @gc ArrayFill { array_type_index: u32 } => visit_array_fill
             @gc ArrayCopy { array_type_index_dst: u32, array_type_index_src: u32 } => visit_array_copy
+            @gc ArrayInitData { array_type_index: u32, array_data_index: u32 } => visit_array_init_data
+            @gc ArrayInitElem { array_type_index: u32, array_elem_index: u32 } => visit_array_init_elem
             @gc RefTestNonNull { hty: $crate::HeapType } => visit_ref_test_non_null
             @gc RefTestNullable { hty: $crate::HeapType } => visit_ref_test_nullable
             @gc RefCastNonNull { hty: $crate::HeapType } => visit_ref_cast_non_null

--- a/crates/wasmprinter/src/operator.rs
+++ b/crates/wasmprinter/src/operator.rs
@@ -1027,7 +1027,10 @@ macro_rules! define_visit {
     (name ArrayGetU) => ("array.get_u");
     (name ArraySet) => ("array.set");
     (name ArrayLen) => ("array.len");
+    (name ArrayFill) => ("array.fill");
     (name ArrayCopy) => ("array.copy");
+    (name ArrayInitData) => ("array.init_data");
+    (name ArrayInitElem) => ("array.init_elem");
     (name AnyConvertExtern) => ("any.convert_extern");
     (name ExternConvertAny) => ("extern.convert_any");
     (name RefTestNonNull) => ("ref.test");

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -144,9 +144,6 @@ fn skip_test(test: &Path, contents: &[u8]) -> bool {
 fn skip_validation(test: &Path) -> bool {
     let broken = &[
         "gc/gc-struct.wat",
-        "proposals/gc/array_fill.wast",
-        "proposals/gc/array_init_data.wast",
-        "proposals/gc/array_init_elem.wast",
         "proposals/gc/br_on_cast.wast",
         "proposals/gc/br_on_cast_fail.wast",
         "proposals/gc/extern.wast",

--- a/tests/snapshots/testsuite/proposals/gc/array_fill.wast/3.print
+++ b/tests/snapshots/testsuite/proposals/gc/array_fill.wast/3.print
@@ -1,0 +1,31 @@
+(module
+  (type $arr8 (;0;) (array i8))
+  (type $arr8_mut (;1;) (array (mut i8)))
+  (type (;2;) (func (param i32) (result i32)))
+  (type (;3;) (func))
+  (type (;4;) (func (param i32 i32 i32)))
+  (func (;0;) (type 2) (param $1 i32) (result i32)
+    global.get $g_arr8_mut
+    local.get $1
+    array.get_u $arr8_mut
+  )
+  (func (;1;) (type 3)
+    ref.null 1
+    i32.const 0
+    i32.const 0
+    i32.const 0
+    array.fill $arr8_mut
+  )
+  (func (;2;) (type 4) (param $1 i32) (param $2 i32) (param $3 i32)
+    global.get $g_arr8_mut
+    local.get $1
+    local.get $2
+    local.get $3
+    array.fill $arr8_mut
+  )
+  (global $g_arr8 (;0;) (ref 0) i32.const 10 i32.const 12 array.new $arr8)
+  (global $g_arr8_mut (;1;) (mut (ref 1)) i32.const 12 array.new_default $arr8_mut)
+  (export "array_get_nth" (func 0))
+  (export "array_fill-null" (func 1))
+  (export "array_fill" (func 2))
+)

--- a/tests/snapshots/testsuite/proposals/gc/array_init_data.wast/2.print
+++ b/tests/snapshots/testsuite/proposals/gc/array_init_data.wast/2.print
@@ -1,0 +1,52 @@
+(module
+  (type $arr8 (;0;) (array i8))
+  (type $arr8_mut (;1;) (array (mut i8)))
+  (type $arr16_mut (;2;) (array (mut i16)))
+  (type (;3;) (func (param i32) (result i32)))
+  (type (;4;) (func))
+  (type (;5;) (func (param i32 i32 i32)))
+  (func (;0;) (type 3) (param $1 i32) (result i32)
+    global.get $g_arr8_mut
+    local.get $1
+    array.get_u $arr8_mut
+  )
+  (func (;1;) (type 3) (param $1 i32) (result i32)
+    global.get $g_arr16_mut
+    local.get $1
+    array.get_u $arr16_mut
+  )
+  (func (;2;) (type 4)
+    ref.null 1
+    i32.const 0
+    i32.const 0
+    i32.const 0
+    array.init_data $arr8_mut $d1
+  )
+  (func (;3;) (type 5) (param $1 i32) (param $2 i32) (param $3 i32)
+    global.get $g_arr8_mut
+    local.get $1
+    local.get $2
+    local.get $3
+    array.init_data $arr8_mut $d1
+  )
+  (func (;4;) (type 5) (param $1 i32) (param $2 i32) (param $3 i32)
+    global.get $g_arr16_mut
+    local.get $1
+    local.get $2
+    local.get $3
+    array.init_data $arr16_mut $d1
+  )
+  (func (;5;) (type 4)
+    data.drop $d1
+  )
+  (global $g_arr8 (;0;) (ref 0) i32.const 10 i32.const 12 array.new $arr8)
+  (global $g_arr8_mut (;1;) (mut (ref 1)) i32.const 12 array.new_default $arr8_mut)
+  (global $g_arr16_mut (;2;) (ref 2) i32.const 6 array.new_default $arr16_mut)
+  (export "array_get_nth" (func 0))
+  (export "array_get_nth_i16" (func 1))
+  (export "array_init_data-null" (func 2))
+  (export "array_init_data" (func 3))
+  (export "array_init_data_i16" (func 4))
+  (export "drop_segs" (func 5))
+  (data $d1 (;0;) "abcdefghijkl")
+)

--- a/tests/snapshots/testsuite/proposals/gc/array_init_elem.wast/3.print
+++ b/tests/snapshots/testsuite/proposals/gc/array_init_elem.wast/3.print
@@ -1,0 +1,42 @@
+(module
+  (type $t_f (;0;) (func))
+  (type $arrref (;1;) (array (ref 0)))
+  (type $arrref_mut (;2;) (array (mut funcref)))
+  (type (;3;) (func (param i32)))
+  (type (;4;) (func (param i32 i32 i32)))
+  (func $dummy (;0;) (type $t_f))
+  (func (;1;) (type 3) (param $1 i32)
+    i32.const 0
+    global.get $g_arrref_mut
+    local.get $1
+    array.get $arrref_mut
+    table.set $t
+    i32.const 0
+    call_indirect (type $t_f)
+  )
+  (func (;2;) (type $t_f)
+    ref.null 2
+    i32.const 0
+    i32.const 0
+    i32.const 0
+    array.init_elem $arrref_mut $e1
+  )
+  (func (;3;) (type 4) (param $1 i32) (param $2 i32) (param $3 i32)
+    global.get $g_arrref_mut
+    local.get $1
+    local.get $2
+    local.get $3
+    array.init_elem $arrref_mut $e1
+  )
+  (func (;4;) (type $t_f)
+    elem.drop $e1
+  )
+  (table $t (;0;) 1 funcref)
+  (global $g_arrref (;0;) (ref 1) ref.func $dummy i32.const 12 array.new $arrref)
+  (global $g_arrref_mut (;1;) (ref 2) i32.const 12 array.new_default $arrref_mut)
+  (export "array_call_nth" (func 1))
+  (export "array_init_elem-null" (func 2))
+  (export "array_init_elem" (func 3))
+  (export "drop_segs" (func 4))
+  (elem $e1 (;0;) func $dummy $dummy $dummy $dummy $dummy $dummy $dummy $dummy $dummy $dummy $dummy $dummy)
+)


### PR DESCRIPTION
Implements

* `array.fill`
* `array.init_data`
* `array.init_elem`