### PR TITLE
`wasmparser`: Get more GC spec tests passing

### DIFF
--- a/crates/wasm-encoder/src/core/code.rs
+++ b/crates/wasm-encoder/src/core/code.rs
@@ -1,4 +1,4 @@
-use crate::{encode_section, Encode, HeapType, Section, SectionId, ValType};
+use crate::{encode_section, Encode, HeapType, RefType, Section, SectionId, ValType};
 use std::borrow::Cow;
 
 /// An encoder for the code section.
@@ -593,17 +593,13 @@ pub enum Instruction<'a> {
     RefCastNullable(HeapType),
     BrOnCast {
         relative_depth: u32,
-        from_type_nullable: bool,
-        from_heap_type: HeapType,
-        to_type_nullable: bool,
-        to_heap_type: HeapType,
+        from_ref_type: RefType,
+        to_ref_type: RefType,
     },
     BrOnCastFail {
         relative_depth: u32,
-        from_type_nullable: bool,
-        from_heap_type: HeapType,
-        to_type_nullable: bool,
-        to_heap_type: HeapType,
+        from_ref_type: RefType,
+        to_ref_type: RefType,
     },
     AnyConvertExtern,
     ExternConvertAny,
@@ -1598,33 +1594,31 @@ impl Encode for Instruction<'_> {
             }
             Instruction::BrOnCast {
                 relative_depth,
-                from_type_nullable,
-                from_heap_type,
-                to_type_nullable,
-                to_heap_type,
+                from_ref_type,
+                to_ref_type,
             } => {
                 sink.push(0xfb);
                 sink.push(0x18);
-                let cast_flags = (from_type_nullable as u8) | ((to_type_nullable as u8) << 1);
+                let cast_flags =
+                    (from_ref_type.nullable as u8) | ((to_ref_type.nullable as u8) << 1);
                 relative_depth.encode(sink);
                 sink.push(cast_flags);
-                from_heap_type.encode(sink);
-                to_heap_type.encode(sink);
+                from_ref_type.heap_type.encode(sink);
+                to_ref_type.heap_type.encode(sink);
             }
             Instruction::BrOnCastFail {
                 relative_depth,
-                from_type_nullable,
-                from_heap_type,
-                to_type_nullable,
-                to_heap_type,
+                from_ref_type,
+                to_ref_type,
             } => {
                 sink.push(0xfb);
                 sink.push(0x19);
-                let cast_flags = (from_type_nullable as u8) | ((to_type_nullable as u8) << 1);
+                let cast_flags =
+                    (from_ref_type.nullable as u8) | ((to_ref_type.nullable as u8) << 1);
                 relative_depth.encode(sink);
                 sink.push(cast_flags);
-                from_heap_type.encode(sink);
-                to_heap_type.encode(sink);
+                from_ref_type.heap_type.encode(sink);
+                to_ref_type.heap_type.encode(sink);
             }
             Instruction::AnyConvertExtern => {
                 sink.push(0xfb);

--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -363,8 +363,8 @@ pub fn op(t: &mut dyn Translator, op: &Operator<'_>) -> Result<Instruction<'stat
         (map $arg:ident flags) => (());
         (map $arg:ident ty) => (t.translate_ty($arg)?);
         (map $arg:ident hty) => (t.translate_heapty($arg)?);
-        (map $arg:ident from_heap_type) => (t.translate_heapty($arg)?);
-        (map $arg:ident to_heap_type) => (t.translate_heapty($arg)?);
+        (map $arg:ident from_ref_type) => (t.translate_refty($arg)?);
+        (map $arg:ident to_ref_type) => (t.translate_refty($arg)?);
         (map $arg:ident memarg) => (t.translate_memarg($arg)?);
         (map $arg:ident local_index) => (*$arg);
         (map $arg:ident value) => ($arg);

--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -363,12 +363,17 @@ pub fn op(t: &mut dyn Translator, op: &Operator<'_>) -> Result<Instruction<'stat
         (map $arg:ident flags) => (());
         (map $arg:ident ty) => (t.translate_ty($arg)?);
         (map $arg:ident hty) => (t.translate_heapty($arg)?);
+        (map $arg:ident from_heap_type) => (t.translate_heapty($arg)?);
+        (map $arg:ident to_heap_type) => (t.translate_heapty($arg)?);
         (map $arg:ident memarg) => (t.translate_memarg($arg)?);
         (map $arg:ident local_index) => (*$arg);
         (map $arg:ident value) => ($arg);
         (map $arg:ident lane) => (*$arg);
         (map $arg:ident lanes) => (*$arg);
         (map $arg:ident array_size) => (*$arg);
+        (map $arg:ident field_index) => (*$arg);
+        (map $arg:ident from_type_nullable) => (*$arg);
+        (map $arg:ident to_type_nullable) => (*$arg);
 
         // This case takes the arguments of a wasmparser instruction and creates
         // a wasm-encoder instruction. There are a few special cases for where
@@ -392,6 +397,7 @@ pub fn op(t: &mut dyn Translator, op: &Operator<'_>) -> Result<Instruction<'stat
         });
         (build MemoryGrow $mem:ident $_:ident) => (I::MemoryGrow($mem));
         (build MemorySize $mem:ident $_:ident) => (I::MemorySize($mem));
+        (build StructNew $type_index:ident) => (I::StructNew($type_index));
         (build ArrayGet $type_index:ident) => (I::ArrayGet($type_index));
         (build ArrayGetS $type_index:ident) => (I::ArrayGetS($type_index));
         (build ArrayGetU $type_index:ident) => (I::ArrayGetU($type_index));

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -978,6 +978,7 @@ impl<'a> BinaryReader<'a> {
             0xd0 => visitor.visit_ref_null(self.read()?),
             0xd1 => visitor.visit_ref_is_null(),
             0xd2 => visitor.visit_ref_func(self.read_var_u32()?),
+            0xd3 => visitor.visit_ref_eq(),
             0xd4 => visitor.visit_ref_as_non_null(),
             0xd5 => visitor.visit_br_on_null(self.read_var_u32()?),
             0xd6 => visitor.visit_br_on_non_null(self.read_var_u32()?),

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -1001,11 +1001,34 @@ impl<'a> BinaryReader<'a> {
     {
         let code = self.read_var_u32()?;
         Ok(match code {
+            0x0 => {
+                let type_index = self.read_var_u32()?;
+                visitor.visit_struct_new(type_index)
+            }
             0x01 => {
                 let type_index = self.read_var_u32()?;
                 visitor.visit_struct_new_default(type_index)
             }
-
+            0x02 => {
+                let type_index = self.read_var_u32()?;
+                let field_index = self.read_var_u32()?;
+                visitor.visit_struct_get(type_index, field_index)
+            }
+            0x03 => {
+                let type_index = self.read_var_u32()?;
+                let field_index = self.read_var_u32()?;
+                visitor.visit_struct_get_s(type_index, field_index)
+            }
+            0x04 => {
+                let type_index = self.read_var_u32()?;
+                let field_index = self.read_var_u32()?;
+                visitor.visit_struct_get_u(type_index, field_index)
+            }
+            0x05 => {
+                let type_index = self.read_var_u32()?;
+                let field_index = self.read_var_u32()?;
+                visitor.visit_struct_set(type_index, field_index)
+            }
             0x06 => {
                 let type_index = self.read_var_u32()?;
                 visitor.visit_array_new(type_index)
@@ -1069,6 +1092,48 @@ impl<'a> BinaryReader<'a> {
             0x15 => visitor.visit_ref_test_nullable(self.read()?),
             0x16 => visitor.visit_ref_cast_non_null(self.read()?),
             0x17 => visitor.visit_ref_cast_nullable(self.read()?),
+            0x18 => {
+                let pos = self.original_position();
+                let cast_flags = self.read_u8()?;
+                let relative_depth = self.read_var_u32()?;
+                let (from_type_nullable, to_type_nullable) = match cast_flags {
+                    0 => (false, false),
+                    1 => (true, false),
+                    2 => (false, true),
+                    3 => (true, true),
+                    _ => bail!(pos, "invalid cast flags: {cast_flags:08b}"),
+                };
+                let from_heap_type = self.read()?;
+                let to_heap_type = self.read()?;
+                visitor.visit_br_on_cast(
+                    relative_depth,
+                    from_type_nullable,
+                    from_heap_type,
+                    to_type_nullable,
+                    to_heap_type,
+                )
+            }
+            0x19 => {
+                let pos = self.original_position();
+                let cast_flags = self.read_u8()?;
+                let relative_depth = self.read_var_u32()?;
+                let (from_type_nullable, to_type_nullable) = match cast_flags {
+                    0 => (false, false),
+                    1 => (true, false),
+                    2 => (false, true),
+                    3 => (true, true),
+                    _ => bail!(pos, "invalid cast flags: {cast_flags:08b}"),
+                };
+                let from_heap_type = self.read()?;
+                let to_heap_type = self.read()?;
+                visitor.visit_br_on_cast_fail(
+                    relative_depth,
+                    from_type_nullable,
+                    from_heap_type,
+                    to_type_nullable,
+                    to_heap_type,
+                )
+            }
 
             0x1a => visitor.visit_any_convert_extern(),
             0x1b => visitor.visit_extern_convert_any(),

--- a/crates/wasmparser/src/lib.rs
+++ b/crates/wasmparser/src/lib.rs
@@ -343,17 +343,13 @@ macro_rules! for_each_operator {
             @gc RefCastNullable { hty: $crate::HeapType } => visit_ref_cast_nullable
             @gc BrOnCast {
                 relative_depth: u32,
-                from_type_nullable: bool,
-                from_heap_type: $crate::HeapType,
-                to_type_nullable: bool,
-                to_heap_type: $crate::HeapType
+                from_ref_type: $crate::RefType,
+                to_ref_type: $crate::RefType
             } => visit_br_on_cast
             @gc BrOnCastFail {
                 relative_depth: u32,
-                from_type_nullable: bool,
-                from_heap_type: $crate::HeapType,
-                to_type_nullable: bool,
-                to_heap_type: $crate::HeapType
+                from_ref_type: $crate::RefType,
+                to_ref_type: $crate::RefType
             } => visit_br_on_cast_fail
             @gc AnyConvertExtern => visit_any_convert_extern
             @gc ExternConvertAny => visit_extern_convert_any

--- a/crates/wasmparser/src/lib.rs
+++ b/crates/wasmparser/src/lib.rs
@@ -184,6 +184,7 @@ macro_rules! for_each_operator {
             @reference_types RefNull { hty: $crate::HeapType } => visit_ref_null
             @reference_types RefIsNull => visit_ref_is_null
             @reference_types RefFunc { function_index: u32 } => visit_ref_func
+            @gc RefEq => visit_ref_eq
             @mvp I32Eqz => visit_i32_eqz
             @mvp I32Eq => visit_i32_eq
             @mvp I32Ne => visit_i32_ne

--- a/crates/wasmparser/src/lib.rs
+++ b/crates/wasmparser/src/lib.rs
@@ -316,7 +316,12 @@ macro_rules! for_each_operator {
             // 0xFB prefixed operators
             // Garbage Collection
             // http://github.com/WebAssembly/gc
+            @gc StructNew { struct_type_index: u32 } => visit_struct_new
             @gc StructNewDefault { struct_type_index: u32 } => visit_struct_new_default
+            @gc StructGet { struct_type_index: u32, field_index: u32 } => visit_struct_get
+            @gc StructGetS { struct_type_index: u32, field_index: u32 } => visit_struct_get_s
+            @gc StructGetU { struct_type_index: u32, field_index: u32 } => visit_struct_get_u
+                @gc StructSet { struct_type_index: u32, field_index: u32 } => visit_struct_set
             @gc ArrayNew { array_type_index: u32 } => visit_array_new
             @gc ArrayNewDefault { array_type_index: u32 } => visit_array_new_default
             @gc ArrayNewFixed { array_type_index: u32, array_size: u32 } => visit_array_new_fixed
@@ -335,6 +340,20 @@ macro_rules! for_each_operator {
             @gc RefTestNullable { hty: $crate::HeapType } => visit_ref_test_nullable
             @gc RefCastNonNull { hty: $crate::HeapType } => visit_ref_cast_non_null
             @gc RefCastNullable { hty: $crate::HeapType } => visit_ref_cast_nullable
+            @gc BrOnCast {
+                relative_depth: u32,
+                from_type_nullable: bool,
+                from_heap_type: $crate::HeapType,
+                to_type_nullable: bool,
+                to_heap_type: $crate::HeapType
+            } => visit_br_on_cast
+            @gc BrOnCastFail {
+                relative_depth: u32,
+                from_type_nullable: bool,
+                from_heap_type: $crate::HeapType,
+                to_type_nullable: bool,
+                to_heap_type: $crate::HeapType
+            } => visit_br_on_cast_fail
             @gc AnyConvertExtern => visit_any_convert_extern
             @gc ExternConvertAny => visit_extern_convert_any
             @gc RefI31 => visit_ref_i31

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -1028,6 +1028,21 @@ impl RefType {
         }
     }
 
+    /// Compute the [type difference] between the two given ref types.
+    ///
+    /// [type difference]: https://webassembly.github.io/gc/core/valid/conventions.html#aux-reftypediff
+    pub fn difference(a: RefType, b: RefType) -> RefType {
+        RefType::new(
+            if b.is_nullable() {
+                false
+            } else {
+                a.is_nullable()
+            },
+            a.heap_type(),
+        )
+        .unwrap()
+    }
+
     /// Is this a reference to an concrete type?
     pub const fn is_concrete_type_ref(&self) -> bool {
         self.as_u32() & Self::CONCRETE_BIT != 0

--- a/crates/wasmparser/src/resources.rs
+++ b/crates/wasmparser/src/resources.rs
@@ -82,15 +82,22 @@ pub trait WasmModuleResources {
             .check_value_type(*t)
             .map_err(|s| BinaryReaderError::new(s, offset))?;
         match t {
-            ValType::Ref(r) => {
-                let nullable = r.is_nullable();
-                let mut hty = r.heap_type();
-                self.check_heap_type(&mut hty, offset)?;
-                *r = RefType::new(nullable, hty).unwrap();
-                Ok(())
-            }
+            ValType::Ref(r) => self.check_ref_type(r, offset),
             ValType::I32 | ValType::I64 | ValType::F32 | ValType::F64 | ValType::V128 => Ok(()),
         }
+    }
+
+    /// Check and canonicalize a reference type.
+    fn check_ref_type(
+        &self,
+        ref_type: &mut RefType,
+        offset: usize,
+    ) -> Result<(), BinaryReaderError> {
+        let is_nullable = ref_type.is_nullable();
+        let mut heap_ty = ref_type.heap_type();
+        self.check_heap_type(&mut heap_ty, offset)?;
+        *ref_type = RefType::new(is_nullable, heap_ty).unwrap();
+        Ok(())
     }
 
     /// Checks that a `HeapType` is valid and then additionally place it in its

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -455,6 +455,14 @@ impl ModuleState {
 
             // These are valid const expressions with the gc proposal is
             // enabled.
+            (@visit $self:ident visit_struct_new $type_index:ident) => {{
+                $self.validate_gc("struct.new")?;
+                $self.validator().visit_struct_new($type_index)
+            }};
+            (@visit $self:ident visit_struct_new_default $type_index:ident) => {{
+                $self.validate_gc("struct.new")?;
+                $self.validator().visit_struct_new_default($type_index)
+            }};
             (@visit $self:ident visit_array_new $type_index:ident) => {{
                 $self.validate_gc("array.new")?;
                 $self.validator().visit_array_new($type_index)

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -460,7 +460,7 @@ impl ModuleState {
                 $self.validator().visit_struct_new($type_index)
             }};
             (@visit $self:ident visit_struct_new_default $type_index:ident) => {{
-                $self.validate_gc("struct.new")?;
+                $self.validate_gc("struct.new_default")?;
                 $self.validator().visit_struct_new_default($type_index)
             }};
             (@visit $self:ident visit_array_new $type_index:ident) => {{

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -2496,6 +2496,11 @@ where
         self.push_operand(ty)?;
         Ok(())
     }
+    fn visit_ref_eq(&mut self) -> Self::Output {
+        self.pop_operand(Some(RefType::EQ.nullable().into()))?;
+        self.pop_operand(Some(RefType::EQ.nullable().into()))?;
+        self.push_operand(ValType::I32)
+    }
     fn visit_v128_load(&mut self, memarg: MemArg) -> Self::Output {
         let ty = self.check_memarg(memarg)?;
         self.pop_operand(Some(ty))?;

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -24,9 +24,9 @@
 
 use crate::{
     limits::MAX_WASM_FUNCTION_LOCALS, ArrayType, BinaryReaderError, BlockType, BrTable,
-    CompositeType, FuncType, HeapType, Ieee32, Ieee64, MemArg, RefType, Result, StorageType,
-    StructType, SubType, UnpackedIndex, ValType, VisitOperator, WasmFeatures, WasmModuleResources,
-    V128,
+    CompositeType, FieldType, FuncType, HeapType, Ieee32, Ieee64, MemArg, RefType, Result,
+    StorageType, StructType, SubType, UnpackedIndex, ValType, VisitOperator, WasmFeatures,
+    WasmModuleResources, V128,
 };
 use std::ops::{Deref, DerefMut};
 
@@ -167,6 +167,16 @@ enum MaybeType {
 const _: () = {
     assert!(std::mem::size_of::<MaybeType>() == 4);
 };
+
+impl std::fmt::Display for MaybeType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MaybeType::Bot => write!(f, "bot"),
+            MaybeType::HeapBot => write!(f, "heap-bot"),
+            MaybeType::Type(ty) => std::fmt::Display::fmt(ty, f),
+        }
+    }
+}
 
 impl From<ValType> for MaybeType {
     fn from(ty: ValType) -> MaybeType {
@@ -1082,6 +1092,16 @@ where
                 "expected struct type at index {at}, found {sub_ty}"
             )
         }
+    }
+
+    fn struct_field_at(&self, struct_type_index: u32, field_index: u32) -> Result<FieldType> {
+        self.struct_type_at(struct_type_index)?
+            .fields
+            .get(usize::try_from(field_index).unwrap())
+            .copied()
+            .ok_or_else(|| {
+                BinaryReaderError::new("unknown field: field index out of bounds", self.offset)
+            })
     }
 
     fn array_type_at(&self, at: u32) -> Result<&'resources ArrayType> {
@@ -3512,6 +3532,14 @@ where
         self.pop_operand(Some(ValType::I32))?;
         Ok(())
     }
+    fn visit_struct_new(&mut self, struct_type_index: u32) -> Self::Output {
+        let struct_ty = self.struct_type_at(struct_type_index)?;
+        for ty in struct_ty.fields.iter().rev() {
+            self.pop_operand(Some(ty.element_type.unpack()))?;
+        }
+        self.push_concrete_ref(false, struct_type_index)?;
+        Ok(())
+    }
     fn visit_struct_new_default(&mut self, type_index: u32) -> Self::Output {
         let ty = self.struct_type_at(type_index)?;
         for field in ty.fields.iter() {
@@ -3523,16 +3551,50 @@ where
                 );
             }
         }
-
-        let mut heap_ty = HeapType::Concrete(UnpackedIndex::Module(type_index));
-        // Call `check_heap_type` to canonicalize the module index into an id.
-        self.resources.check_heap_type(&mut heap_ty, self.offset)?;
-
-        let ref_ty = RefType::new(false, heap_ty).ok_or_else(|| {
-            format_err!(self.offset, "implementation limit: type index too large")
-        })?;
-
-        self.push_operand(ref_ty)
+        self.push_concrete_ref(false, type_index)?;
+        Ok(())
+    }
+    fn visit_struct_get(&mut self, struct_type_index: u32, field_index: u32) -> Self::Output {
+        let field_ty = self.struct_field_at(struct_type_index, field_index)?;
+        if field_ty.element_type.is_packed() {
+            bail!(
+                self.offset,
+                "can only use struct.get with non-packed storage types"
+            )
+        }
+        self.pop_concrete_ref(true, struct_type_index)?;
+        self.push_operand(field_ty.element_type.unpack())
+    }
+    fn visit_struct_get_s(&mut self, struct_type_index: u32, field_index: u32) -> Self::Output {
+        let field_ty = self.struct_field_at(struct_type_index, field_index)?;
+        if !field_ty.element_type.is_packed() {
+            bail!(
+                self.offset,
+                "cannot use struct.get_s with non-packed storage types"
+            )
+        }
+        self.pop_concrete_ref(true, struct_type_index)?;
+        self.push_operand(field_ty.element_type.unpack())
+    }
+    fn visit_struct_get_u(&mut self, struct_type_index: u32, field_index: u32) -> Self::Output {
+        let field_ty = self.struct_field_at(struct_type_index, field_index)?;
+        if !field_ty.element_type.is_packed() {
+            bail!(
+                self.offset,
+                "cannot use struct.get_u with non-packed storage types"
+            )
+        }
+        self.pop_concrete_ref(true, struct_type_index)?;
+        self.push_operand(field_ty.element_type.unpack())
+    }
+    fn visit_struct_set(&mut self, struct_type_index: u32, field_index: u32) -> Self::Output {
+        let field_ty = self.struct_field_at(struct_type_index, field_index)?;
+        if !field_ty.mutable {
+            bail!(self.offset, "invalid struct.set: struct field is immutable")
+        }
+        self.pop_operand(Some(field_ty.element_type.unpack()))?;
+        self.pop_concrete_ref(true, struct_type_index)?;
+        Ok(())
     }
     fn visit_array_new(&mut self, type_index: u32) -> Self::Output {
         let array_ty = self.array_type_at(type_index)?;
@@ -3793,6 +3855,109 @@ where
     }
     fn visit_ref_cast_nullable(&mut self, heap_type: HeapType) -> Self::Output {
         self.check_ref_cast(true, heap_type)
+    }
+    fn visit_br_on_cast(
+        &mut self,
+        relative_depth: u32,
+        from_type_nullable: bool,
+        from_heap_type: HeapType,
+        to_type_nullable: bool,
+        to_heap_type: HeapType,
+    ) -> Self::Output {
+        let mut from_ty = RefType::new(from_type_nullable, from_heap_type).ok_or_else(|| {
+            BinaryReaderError::new("implementation limit: type index too large", self.offset)
+        })?;
+        self.resources.check_ref_type(&mut from_ty, self.offset)?;
+
+        let mut to_ty = RefType::new(to_type_nullable, to_heap_type).ok_or_else(|| {
+            BinaryReaderError::new("implementation limit: type index too large", self.offset)
+        })?;
+        self.resources.check_ref_type(&mut to_ty, self.offset)?;
+
+        if !self.resources.is_subtype(to_ty.into(), from_ty.into()) {
+            bail!(
+                self.offset,
+                "type mismatch: expected {from_ty}, found {to_ty}"
+            );
+        }
+
+        let (block_ty, _frame_kind) = self.jump(relative_depth)?;
+        let result_tys = self.results(block_ty)?;
+        for (i, ty) in result_tys.clone().rev().enumerate() {
+            if i == 0 {
+                if !self.resources.is_subtype(to_ty.into(), ty) {
+                    bail!(
+                        self.offset,
+                        "type mismatch: casting to type {to_ty}, but it does not match label \
+                         result type {ty}"
+                    )
+                }
+                self.pop_operand(Some(from_ty.into()))?;
+            } else {
+                self.pop_operand(Some(ty))?;
+            }
+        }
+        for ty in result_tys.clone().take(result_tys.len().saturating_sub(1)) {
+            self.push_operand(ty)?;
+        }
+        let diff_ty = RefType::difference(from_ty, to_ty);
+        self.push_operand(diff_ty)?;
+        Ok(())
+    }
+    fn visit_br_on_cast_fail(
+        &mut self,
+        relative_depth: u32,
+        from_type_nullable: bool,
+        from_heap_type: HeapType,
+        to_type_nullable: bool,
+        to_heap_type: HeapType,
+    ) -> Self::Output {
+        let mut from_ty = RefType::new(from_type_nullable, from_heap_type).ok_or_else(|| {
+            BinaryReaderError::new("implementation limit: type index too large", self.offset)
+        })?;
+        self.resources.check_ref_type(&mut from_ty, self.offset)?;
+
+        let mut to_ty = RefType::new(to_type_nullable, to_heap_type).ok_or_else(|| {
+            BinaryReaderError::new("implementation limit: type index too large", self.offset)
+        })?;
+        self.resources.check_ref_type(&mut to_ty, self.offset)?;
+
+        if !self.resources.is_subtype(to_ty.into(), from_ty.into()) {
+            bail!(
+                self.offset,
+                "type mismatch: expected {from_ty}, found {to_ty}"
+            );
+        }
+
+        let (block_ty, _frame_kind) = self.jump(relative_depth)?;
+        let result_tys = self.results(block_ty)?;
+
+        let diff_ty = RefType::difference(from_ty, to_ty);
+        let Some(result_ref_ty) = result_tys.clone().last() else {
+            bail!(
+                self.offset,
+                "type mismatch: expected a reference type, found nothing"
+            )
+        };
+        if !self.resources.is_subtype(diff_ty.into(), result_ref_ty) {
+            bail!(
+                self.offset,
+                "type mismatch: expected label result type {result_ref_ty}, found {diff_ty}"
+            )
+        }
+
+        for (i, ty) in result_tys.clone().rev().enumerate() {
+            if i == 0 {
+                self.pop_operand(Some(from_ty.into()))?;
+            } else {
+                self.pop_operand(Some(ty))?;
+            }
+        }
+        for ty in result_tys.clone().take(result_tys.len().saturating_sub(1)) {
+            self.push_operand(ty)?;
+        }
+        self.push_operand(to_ty)?;
+        Ok(())
     }
     fn visit_ref_i31(&mut self) -> Self::Output {
         self.pop_operand(Some(ValType::I32))?;

--- a/crates/wasmprinter/src/operator.rs
+++ b/crates/wasmprinter/src/operator.rs
@@ -238,6 +238,11 @@ impl<'a, 'b> PrintOperator<'a, 'b> {
         self.printer.print_idx(&self.state.core.type_names, idx)
     }
 
+    fn field_index(&mut self, idx: u32) -> Result<()> {
+        write!(&mut self.printer.result, "{idx}")?;
+        Ok(())
+    }
+
     fn data_index(&mut self, idx: u32) -> Result<()> {
         self.printer.print_idx(&self.state.core.data_names, idx)
     }
@@ -470,6 +475,48 @@ macro_rules! define_visit {
         let rty = RefType::new(true, $hty)
             .ok_or_else(|| anyhow!("implementation limit: type index too large"))?;
         $self.printer.print_reftype(rty)?;
+    );
+    (
+        payload
+        $self:ident
+        BrOnCast
+        $relative_depth:ident
+        $from_type_nullable:ident
+        $from_heap_type:ident
+        $to_type_nullable:ident
+        $to_heap_type:ident
+    ) => (
+        $self.push_str(" ");
+        $self.relative_depth($relative_depth)?;
+        $self.push_str(" ");
+        let from_ty = RefType::new($from_type_nullable, $from_heap_type)
+            .ok_or_else(|| anyhow!("implementation limit: type index too large"))?;
+        $self.printer.print_reftype(from_ty)?;
+        $self.push_str(" ");
+        let to_ty = RefType::new($to_type_nullable, $to_heap_type)
+            .ok_or_else(|| anyhow!("implementation limit: type index too large"))?;
+        $self.printer.print_reftype(to_ty)?;
+    );
+    (
+        payload
+        $self:ident
+        BrOnCastFail
+        $relative_depth:ident
+        $from_type_nullable:ident
+        $from_heap_type:ident
+        $to_type_nullable:ident
+        $to_heap_type:ident
+    ) => (
+        $self.push_str(" ");
+        $self.relative_depth($relative_depth)?;
+        $self.push_str(" ");
+        let from_ty = RefType::new($from_type_nullable, $from_heap_type)
+            .ok_or_else(|| anyhow!("implementation limit: type index too large"))?;
+        $self.printer.print_reftype(from_ty)?;
+        $self.push_str(" ");
+        let to_ty = RefType::new($to_type_nullable, $to_heap_type)
+            .ok_or_else(|| anyhow!("implementation limit: type index too large"))?;
+        $self.printer.print_reftype(to_ty)?;
     );
     (payload $self:ident $op:ident $($arg:ident)*) => (
         $(
@@ -1016,7 +1063,12 @@ macro_rules! define_visit {
     (name I16x8RelaxedQ15mulrS) => ("i16x8.relaxed_q15mulr_s");
     (name I16x8RelaxedDotI8x16I7x16S) => ("i16x8.relaxed_dot_i8x16_i7x16_s");
     (name I32x4RelaxedDotI8x16I7x16AddS) => ("i32x4.relaxed_dot_i8x16_i7x16_add_s");
+    (name StructNew) => ("struct.new");
     (name StructNewDefault) => ("struct.new_default");
+    (name StructGet) => ("struct.get");
+    (name StructGetS) => ("struct.get_s");
+    (name StructGetU) => ("struct.get_u");
+    (name StructSet) => ("struct.set");
     (name ArrayNew) => ("array.new");
     (name ArrayNewDefault) => ("array.new_default");
     (name ArrayNewFixed) => ("array.new_fixed");
@@ -1037,6 +1089,8 @@ macro_rules! define_visit {
     (name RefTestNullable) => ("ref.test");
     (name RefCastNonNull) => ("ref.cast");
     (name RefCastNullable) => ("ref.cast");
+    (name BrOnCast) => ("br_on_cast");
+    (name BrOnCastFail) => ("br_on_cast_fail");
     (name RefI31) => ("ref.i31");
     (name I31GetS) => ("i31.get_s");
     (name I31GetU) => ("i31.get_u");

--- a/crates/wasmprinter/src/operator.rs
+++ b/crates/wasmprinter/src/operator.rs
@@ -243,6 +243,14 @@ impl<'a, 'b> PrintOperator<'a, 'b> {
         Ok(())
     }
 
+    fn from_ref_type(&mut self, ref_ty: RefType) -> Result<()> {
+        self.printer.print_reftype(ref_ty)
+    }
+
+    fn to_ref_type(&mut self, ref_ty: RefType) -> Result<()> {
+        self.printer.print_reftype(ref_ty)
+    }
+
     fn data_index(&mut self, idx: u32) -> Result<()> {
         self.printer.print_idx(&self.state.core.data_names, idx)
     }
@@ -475,48 +483,6 @@ macro_rules! define_visit {
         let rty = RefType::new(true, $hty)
             .ok_or_else(|| anyhow!("implementation limit: type index too large"))?;
         $self.printer.print_reftype(rty)?;
-    );
-    (
-        payload
-        $self:ident
-        BrOnCast
-        $relative_depth:ident
-        $from_type_nullable:ident
-        $from_heap_type:ident
-        $to_type_nullable:ident
-        $to_heap_type:ident
-    ) => (
-        $self.push_str(" ");
-        $self.relative_depth($relative_depth)?;
-        $self.push_str(" ");
-        let from_ty = RefType::new($from_type_nullable, $from_heap_type)
-            .ok_or_else(|| anyhow!("implementation limit: type index too large"))?;
-        $self.printer.print_reftype(from_ty)?;
-        $self.push_str(" ");
-        let to_ty = RefType::new($to_type_nullable, $to_heap_type)
-            .ok_or_else(|| anyhow!("implementation limit: type index too large"))?;
-        $self.printer.print_reftype(to_ty)?;
-    );
-    (
-        payload
-        $self:ident
-        BrOnCastFail
-        $relative_depth:ident
-        $from_type_nullable:ident
-        $from_heap_type:ident
-        $to_type_nullable:ident
-        $to_heap_type:ident
-    ) => (
-        $self.push_str(" ");
-        $self.relative_depth($relative_depth)?;
-        $self.push_str(" ");
-        let from_ty = RefType::new($from_type_nullable, $from_heap_type)
-            .ok_or_else(|| anyhow!("implementation limit: type index too large"))?;
-        $self.printer.print_reftype(from_ty)?;
-        $self.push_str(" ");
-        let to_ty = RefType::new($to_type_nullable, $to_heap_type)
-            .ok_or_else(|| anyhow!("implementation limit: type index too large"))?;
-        $self.printer.print_reftype(to_ty)?;
     );
     (payload $self:ident $op:ident $($arg:ident)*) => (
         $(

--- a/crates/wasmprinter/src/operator.rs
+++ b/crates/wasmprinter/src/operator.rs
@@ -592,6 +592,7 @@ macro_rules! define_visit {
     (name TableGrow) => ("table.grow");
     (name RefAsNonNull) => ("ref.as_non_null");
     (name RefNull) => ("ref.null");
+    (name RefEq) => ("ref.eq");
     (name RefIsNull) => ("ref.is_null");
     (name RefFunc) => ("ref.func");
     (name I32Const) => ("i32.const");

--- a/crates/wast/src/names.rs
+++ b/crates/wast/src/names.rs
@@ -54,7 +54,10 @@ impl<'a> Namespace<'a> {
         if let Some(_prev) = self.names.insert(name, index) {
             return Err(Error::new(
                 name.span(),
-                format!("duplicate identifier `{}` for {}", name.name(), desc),
+                format!(
+                    "duplicate identifier: duplicate {desc} named `{}`",
+                    name.name()
+                ),
             ));
         }
         Ok(())

--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -1018,6 +1018,8 @@ macro_rules! define_visit {
     (mark_live $self:ident $arg:ident blockty) => {$self.blockty($arg);};
     (mark_live $self:ident $arg:ident ty) => {$self.valty($arg)};
     (mark_live $self:ident $arg:ident hty) => {$self.heapty($arg)};
+    (mark_live $self:ident $arg:ident from_heap_type) => {$self.heapty($arg);};
+    (mark_live $self:ident $arg:ident to_heap_type) => {$self.heapty($arg);};
     (mark_live $self:ident $arg:ident lane) => {};
     (mark_live $self:ident $arg:ident lanes) => {};
     (mark_live $self:ident $arg:ident flags) => {};
@@ -1033,6 +1035,9 @@ macro_rules! define_visit {
     (mark_live $self:ident $arg:ident elem_index) => {};
     (mark_live $self:ident $arg:ident array_elem_index) => {};
     (mark_live $self:ident $arg:ident array_size) => {};
+    (mark_live $self:ident $arg:ident field_index) => {};
+    (mark_live $self:ident $arg:ident from_type_nullable) => {};
+    (mark_live $self:ident $arg:ident to_type_nullable) => {};
 }
 
 impl<'a> VisitOperator<'a> for Module<'a> {
@@ -1196,6 +1201,8 @@ macro_rules! define_encode {
     (map $self:ident $arg:ident memarg) => {$self.memarg($arg)};
     (map $self:ident $arg:ident blockty) => {$self.blockty($arg)};
     (map $self:ident $arg:ident hty) => {$self.heapty($arg)};
+    (map $self:ident $arg:ident from_heap_type) => {$self.heapty($arg)};
+    (map $self:ident $arg:ident to_heap_type) => {$self.heapty($arg)};
     (map $self:ident $arg:ident tag_index) => {$arg};
     (map $self:ident $arg:ident relative_depth) => {$arg};
     (map $self:ident $arg:ident function_index) => {$self.funcs.remap($arg)};
@@ -1224,6 +1231,9 @@ macro_rules! define_encode {
     (map $self:ident $arg:ident mem_byte) => {$arg};
     (map $self:ident $arg:ident value) => {$arg};
     (map $self:ident $arg:ident array_size) => {$arg};
+    (map $self:ident $arg:ident field_index) => {$arg};
+    (map $self:ident $arg:ident from_type_nullable) => {$arg};
+    (map $self:ident $arg:ident to_type_nullable) => {$arg};
     (map $self:ident $arg:ident targets) => ((
         $arg.targets().map(|i| i.unwrap()).collect::<Vec<_>>().into(),
         $arg.default(),

--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -475,9 +475,13 @@ impl<'a> Module<'a> {
 
     fn valty(&mut self, ty: ValType) {
         match ty {
-            ValType::Ref(r) => self.heapty(r.heap_type()),
+            ValType::Ref(r) => self.refty(r),
             ValType::I32 | ValType::I64 | ValType::F32 | ValType::F64 | ValType::V128 => {}
         }
+    }
+
+    fn refty(&mut self, ty: RefType) {
+        self.heapty(ty.heap_type())
     }
 
     fn heapty(&mut self, ty: HeapType) {
@@ -1018,8 +1022,8 @@ macro_rules! define_visit {
     (mark_live $self:ident $arg:ident blockty) => {$self.blockty($arg);};
     (mark_live $self:ident $arg:ident ty) => {$self.valty($arg)};
     (mark_live $self:ident $arg:ident hty) => {$self.heapty($arg)};
-    (mark_live $self:ident $arg:ident from_heap_type) => {$self.heapty($arg);};
-    (mark_live $self:ident $arg:ident to_heap_type) => {$self.heapty($arg);};
+    (mark_live $self:ident $arg:ident from_ref_type) => {$self.refty($arg);};
+    (mark_live $self:ident $arg:ident to_ref_type) => {$self.refty($arg);};
     (mark_live $self:ident $arg:ident lane) => {};
     (mark_live $self:ident $arg:ident lanes) => {};
     (mark_live $self:ident $arg:ident flags) => {};
@@ -1201,8 +1205,8 @@ macro_rules! define_encode {
     (map $self:ident $arg:ident memarg) => {$self.memarg($arg)};
     (map $self:ident $arg:ident blockty) => {$self.blockty($arg)};
     (map $self:ident $arg:ident hty) => {$self.heapty($arg)};
-    (map $self:ident $arg:ident from_heap_type) => {$self.heapty($arg)};
-    (map $self:ident $arg:ident to_heap_type) => {$self.heapty($arg)};
+    (map $self:ident $arg:ident from_ref_type) => {$self.refty($arg)};
+    (map $self:ident $arg:ident to_ref_type) => {$self.refty($arg)};
     (map $self:ident $arg:ident tag_index) => {$arg};
     (map $self:ident $arg:ident relative_depth) => {$arg};
     (map $self:ident $arg:ident function_index) => {$self.funcs.remap($arg)};

--- a/tests/local/gc/gc-struct.wat
+++ b/tests/local/gc/gc-struct.wat
@@ -9,15 +9,25 @@
   (type (struct (field (mut i32)) (field (mut i32))))
 
   (type $a (struct (field $field_a f32)))
-  (type $b (struct (field $field_b f32)))
+  (type $b (struct (field $field_b (mut f32))))
 
   (type (struct (field $field_a externref)))
   (type (struct (field $field_b externref) (field $field_c funcref)))
 
-  (func
+  (func (param (ref $a) (ref $b))
+    f32.const 1.0
     struct.new $a
+    drop
+
     struct.new_default $a
+    drop
+
+    local.get 0
     struct.get $a $field_a
+    drop
+
+    local.get 1
+    f32.const 1.0
     struct.set $b $field_b
   )
 )

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -143,8 +143,6 @@ fn skip_test(test: &Path, contents: &[u8]) -> bool {
 
 fn skip_validation(test: &Path) -> bool {
     let broken = &[
-        "proposals/gc/extern.wast",
-        "proposals/gc/ref_eq.wast",
         "exnref/exnref.wast",
         "exnref/throw_ref.wast",
         "exnref/try_table.wast",

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -143,12 +143,8 @@ fn skip_test(test: &Path, contents: &[u8]) -> bool {
 
 fn skip_validation(test: &Path) -> bool {
     let broken = &[
-        "gc/gc-struct.wat",
-        "proposals/gc/br_on_cast.wast",
-        "proposals/gc/br_on_cast_fail.wast",
         "proposals/gc/extern.wast",
         "proposals/gc/ref_eq.wast",
-        "proposals/gc/struct.wast",
         "exnref/exnref.wast",
         "exnref/throw_ref.wast",
         "exnref/try_table.wast",

--- a/tests/snapshots/local/gc/gc-struct.wat.print
+++ b/tests/snapshots/local/gc/gc-struct.wat.print
@@ -1,0 +1,26 @@
+(module
+  (type (;0;) (struct))
+  (type (;1;) (struct (field i32)))
+  (type (;2;) (struct (field (mut i32))))
+  (type (;3;) (struct (field i32) (field i32)))
+  (type (;4;) (struct (field i32) (field (mut i32))))
+  (type (;5;) (struct (field (mut i32)) (field (mut i32))))
+  (type $a (;6;) (struct (field f32)))
+  (type $b (;7;) (struct (field (mut f32))))
+  (type (;8;) (struct (field externref)))
+  (type (;9;) (struct (field externref) (field funcref)))
+  (type (;10;) (func (param (ref 6) (ref 7))))
+  (func (;0;) (type 10) (param (ref 6) (ref 7))
+    f32.const 0x1p+0 (;=1;)
+    struct.new $a
+    drop
+    struct.new_default $a
+    drop
+    local.get 0
+    struct.get $a 0
+    drop
+    local.get 1
+    f32.const 0x1p+0 (;=1;)
+    struct.set $b 0
+  )
+)

--- a/tests/snapshots/testsuite/proposals/gc/br_on_cast.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/gc/br_on_cast.wast/0.print
@@ -1,0 +1,106 @@
+(module
+  (type $ft (;0;) (func (result i32)))
+  (type $st (;1;) (struct (field i16)))
+  (type $at (;2;) (array i8))
+  (type (;3;) (func (param externref)))
+  (type (;4;) (func (param i32) (result i32)))
+  (type (;5;) (func (param structref) (result (ref 1))))
+  (type (;6;) (func (param structref) (result (ref 2))))
+  (func $f (;0;) (type $ft) (result i32)
+    i32.const 9
+  )
+  (func (;1;) (type 3) (param $x externref)
+    i32.const 0
+    ref.null any
+    table.set 0
+    i32.const 1
+    i32.const 7
+    ref.i31
+    table.set 0
+    i32.const 2
+    i32.const 6
+    struct.new $st
+    table.set 0
+    i32.const 3
+    i32.const 5
+    i32.const 3
+    array.new $at
+    table.set 0
+    i32.const 4
+    local.get $x
+    any.convert_extern
+    table.set 0
+  )
+  (func (;2;) (type 4) (param $i i32) (result i32)
+    block $l
+      local.get $i
+      table.get 0
+      br_on_null $l
+      i32.const -1
+      return
+    end
+    i32.const 0
+  )
+  (func (;3;) (type 4) (param $i i32) (result i32)
+    block $l (result (ref i31))
+      local.get $i
+      table.get 0
+      br_on_cast $l anyref (ref i31)
+      i32.const -1
+      return
+    end
+    i31.get_u
+  )
+  (func (;4;) (type 4) (param $i i32) (result i32)
+    block $l (result (ref struct))
+      local.get $i
+      table.get 0
+      br_on_cast $l anyref (ref struct)
+      i32.const -1
+      return
+    end
+    block $l2 (type 5) (param structref) (result (ref 1))
+      block $l3 (type 6) (param structref) (result (ref 2))
+        br_on_cast $l2 structref (ref 1)
+        br_on_cast $l3 anyref (ref 2)
+        i32.const -2
+        return
+      end
+      i32.const 0
+      array.get_u $at
+      return
+    end
+    struct.get_s $st 0
+  )
+  (func (;5;) (type 4) (param $i i32) (result i32)
+    block $l (result (ref array))
+      local.get $i
+      table.get 0
+      br_on_cast $l anyref (ref array)
+      i32.const -1
+      return
+    end
+    array.len
+  )
+  (func (;6;) (type 4) (param $i i32) (result i32)
+    block $l (result structref)
+      block (result (ref any)) ;; label = @2
+        local.get $i
+        table.get 0
+        br_on_cast $l anyref structref
+      end
+      i32.const 0
+      return
+    end
+    i32.const 1
+    return
+  )
+  (table (;0;) 10 anyref)
+  (export "init" (func 1))
+  (export "br_on_null" (func 2))
+  (export "br_on_i31" (func 3))
+  (export "br_on_struct" (func 4))
+  (export "br_on_array" (func 5))
+  (export "null-diff" (func 6))
+  (elem (;0;) declare func $f)
+)

--- a/tests/snapshots/testsuite/proposals/gc/br_on_cast.wast/27.print
+++ b/tests/snapshots/testsuite/proposals/gc/br_on_cast.wast/27.print
@@ -1,0 +1,268 @@
+(module
+  (type $t0 (;0;) (sub (struct)))
+  (type $t1 (;1;) (sub $t0 (;0;) (struct (field i32))))
+  (type $t1' (;2;) (sub $t0 (;0;) (struct (field i32))))
+  (type $t2 (;3;) (sub $t1 (;1;) (struct (field i32) (field i32))))
+  (type $t2' (;4;) (sub $t1' (;2;) (struct (field i32) (field i32))))
+  (type $t3 (;5;) (sub $t0 (;0;) (struct (field i32) (field i32))))
+  (type $t0' (;6;) (sub $t0 (;0;) (struct)))
+  (type $t4 (;7;) (sub $t0' (;6;) (struct (field i32) (field i32))))
+  (type (;8;) (func))
+  (func $init (;0;) (type 8)
+    i32.const 0
+    struct.new_default $t0
+    table.set 0
+    i32.const 10
+    struct.new_default $t0'
+    table.set 0
+    i32.const 1
+    struct.new_default $t1
+    table.set 0
+    i32.const 11
+    struct.new_default $t1'
+    table.set 0
+    i32.const 2
+    struct.new_default $t2
+    table.set 0
+    i32.const 12
+    struct.new_default $t2'
+    table.set 0
+    i32.const 3
+    struct.new_default $t3
+    table.set 0
+    i32.const 4
+    struct.new_default $t4
+    table.set 0
+  )
+  (func (;1;) (type 8)
+    call $init
+    block $l (result structref)
+      block (result structref) ;; label = @2
+        ref.null struct
+        br_on_cast 0 (;@2;) structref (ref 0)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 0
+        table.get 0
+        br_on_cast 0 (;@2;) structref (ref 0)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 1
+        table.get 0
+        br_on_cast 0 (;@2;) structref (ref 0)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 2
+        table.get 0
+        br_on_cast 0 (;@2;) structref (ref 0)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 3
+        table.get 0
+        br_on_cast 0 (;@2;) structref (ref 0)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 4
+        table.get 0
+        br_on_cast 0 (;@2;) structref (ref 0)
+      end
+      drop
+      block (result structref) ;; label = @2
+        ref.null struct
+        br_on_cast 0 (;@2;) structref (ref 1)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 1
+        table.get 0
+        br_on_cast 0 (;@2;) structref (ref 1)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 2
+        table.get 0
+        br_on_cast 0 (;@2;) structref (ref 1)
+      end
+      drop
+      block (result structref) ;; label = @2
+        ref.null struct
+        br_on_cast 0 (;@2;) structref (ref 3)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 2
+        table.get 0
+        br_on_cast 0 (;@2;) structref (ref 3)
+      end
+      drop
+      block (result structref) ;; label = @2
+        ref.null struct
+        br_on_cast 0 (;@2;) structref (ref 5)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 3
+        table.get 0
+        br_on_cast 0 (;@2;) structref (ref 5)
+      end
+      drop
+      block (result structref) ;; label = @2
+        ref.null struct
+        br_on_cast 0 (;@2;) structref (ref 7)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 4
+        table.get 0
+        br_on_cast 0 (;@2;) structref (ref 7)
+      end
+      drop
+      i32.const 0
+      table.get 0
+      br_on_cast $l anyref (ref 1)
+      i32.const 3
+      table.get 0
+      br_on_cast $l anyref (ref 1)
+      i32.const 4
+      table.get 0
+      br_on_cast $l anyref (ref 1)
+      i32.const 0
+      table.get 0
+      br_on_cast $l anyref (ref 3)
+      i32.const 1
+      table.get 0
+      br_on_cast $l anyref (ref 3)
+      i32.const 3
+      table.get 0
+      br_on_cast $l anyref (ref 3)
+      i32.const 4
+      table.get 0
+      br_on_cast $l anyref (ref 3)
+      i32.const 0
+      table.get 0
+      br_on_cast $l anyref (ref 5)
+      i32.const 1
+      table.get 0
+      br_on_cast $l anyref (ref 5)
+      i32.const 2
+      table.get 0
+      br_on_cast $l anyref (ref 5)
+      i32.const 4
+      table.get 0
+      br_on_cast $l anyref (ref 5)
+      i32.const 0
+      table.get 0
+      br_on_cast $l anyref (ref 7)
+      i32.const 1
+      table.get 0
+      br_on_cast $l anyref (ref 7)
+      i32.const 2
+      table.get 0
+      br_on_cast $l anyref (ref 7)
+      i32.const 3
+      table.get 0
+      br_on_cast $l anyref (ref 7)
+      return
+    end
+    unreachable
+  )
+  (func (;2;) (type 8)
+    call $init
+    block $l
+      block (result structref) ;; label = @2
+        i32.const 0
+        table.get 0
+        br_on_cast 0 (;@2;) structref (ref 6)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 1
+        table.get 0
+        br_on_cast 0 (;@2;) structref (ref 6)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 2
+        table.get 0
+        br_on_cast 0 (;@2;) structref (ref 6)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 3
+        table.get 0
+        br_on_cast 0 (;@2;) structref (ref 6)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 4
+        table.get 0
+        br_on_cast 0 (;@2;) structref (ref 6)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 10
+        table.get 0
+        br_on_cast 0 (;@2;) structref (ref 0)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 11
+        table.get 0
+        br_on_cast 0 (;@2;) structref (ref 0)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 12
+        table.get 0
+        br_on_cast 0 (;@2;) structref (ref 0)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 1
+        table.get 0
+        br_on_cast 0 (;@2;) structref (ref 2)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 2
+        table.get 0
+        br_on_cast 0 (;@2;) structref (ref 2)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 11
+        table.get 0
+        br_on_cast 0 (;@2;) structref (ref 1)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 12
+        table.get 0
+        br_on_cast 0 (;@2;) structref (ref 1)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 2
+        table.get 0
+        br_on_cast 0 (;@2;) structref (ref 4)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 12
+        table.get 0
+        br_on_cast 0 (;@2;) structref (ref 3)
+      end
+      drop
+      return
+    end
+    unreachable
+  )
+  (table (;0;) 20 structref)
+  (export "test-sub" (func 1))
+  (export "test-canon" (func 2))
+)

--- a/tests/snapshots/testsuite/proposals/gc/br_on_cast.wast/30.print
+++ b/tests/snapshots/testsuite/proposals/gc/br_on_cast.wast/30.print
@@ -1,0 +1,27 @@
+(module
+  (type $t (;0;) (struct))
+  (type (;1;) (func (param (ref any)) (result (ref 0))))
+  (type (;2;) (func (param anyref) (result (ref 0))))
+  (type (;3;) (func (param anyref) (result (ref null 0))))
+  (func (;0;) (type 1) (param (ref any)) (result (ref 0))
+    block (result (ref any)) ;; label = @1
+      local.get 0
+      br_on_cast 1 (;@0;) (ref any) (ref 0)
+    end
+    unreachable
+  )
+  (func (;1;) (type 2) (param anyref) (result (ref 0))
+    block (result anyref) ;; label = @1
+      local.get 0
+      br_on_cast 1 (;@0;) anyref (ref 0)
+    end
+    unreachable
+  )
+  (func (;2;) (type 3) (param anyref) (result (ref null 0))
+    block (result anyref) ;; label = @1
+      local.get 0
+      br_on_cast 1 (;@0;) anyref (ref null 0)
+    end
+    unreachable
+  )
+)

--- a/tests/snapshots/testsuite/proposals/gc/br_on_cast_fail.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/gc/br_on_cast_fail.wast/0.print
@@ -1,0 +1,110 @@
+(module
+  (type $ft (;0;) (func (result i32)))
+  (type $st (;1;) (struct (field i16)))
+  (type $at (;2;) (array i8))
+  (type (;3;) (func (param externref)))
+  (type (;4;) (func (param i32) (result i32)))
+  (type (;5;) (func (param structref) (result (ref 1))))
+  (type (;6;) (func (param structref) (result (ref 2))))
+  (func $f (;0;) (type $ft) (result i32)
+    i32.const 9
+  )
+  (func (;1;) (type 3) (param $x externref)
+    i32.const 0
+    ref.null any
+    table.set 0
+    i32.const 1
+    i32.const 7
+    ref.i31
+    table.set 0
+    i32.const 2
+    i32.const 6
+    struct.new $st
+    table.set 0
+    i32.const 3
+    i32.const 5
+    i32.const 3
+    array.new $at
+    table.set 0
+    i32.const 4
+    local.get $x
+    any.convert_extern
+    table.set 0
+  )
+  (func (;2;) (type 4) (param $i i32) (result i32)
+    block $l (result (ref any))
+      local.get $i
+      table.get 0
+      br_on_non_null $l
+      i32.const 0
+      return
+    end
+    i32.const -1
+    return
+  )
+  (func (;3;) (type 4) (param $i i32) (result i32)
+    block $l (result anyref)
+      local.get $i
+      table.get 0
+      br_on_cast_fail $l anyref (ref i31)
+      i31.get_u
+      return
+    end
+    i32.const -1
+    return
+  )
+  (func (;4;) (type 4) (param $i i32) (result i32)
+    block $l (result anyref)
+      local.get $i
+      table.get 0
+      br_on_cast_fail $l anyref (ref struct)
+      block $l2 (type 5) (param structref) (result (ref 1))
+        block $l3 (type 6) (param structref) (result (ref 2))
+          br_on_cast $l2 structref (ref 1)
+          br_on_cast $l3 anyref (ref 2)
+          i32.const -2
+          return
+        end
+        i32.const 0
+        array.get_u $at
+        return
+      end
+      struct.get_s $st 0
+      return
+    end
+    i32.const -1
+    return
+  )
+  (func (;5;) (type 4) (param $i i32) (result i32)
+    block $l (result anyref)
+      local.get $i
+      table.get 0
+      br_on_cast_fail $l anyref (ref array)
+      array.len
+      return
+    end
+    i32.const -1
+    return
+  )
+  (func (;6;) (type 4) (param $i i32) (result i32)
+    block $l (result (ref any))
+      block (result structref) ;; label = @2
+        local.get $i
+        table.get 0
+        br_on_cast_fail $l anyref structref
+      end
+      i32.const 1
+      return
+    end
+    i32.const 0
+    return
+  )
+  (table (;0;) 10 anyref)
+  (export "init" (func 1))
+  (export "br_on_non_null" (func 2))
+  (export "br_on_non_i31" (func 3))
+  (export "br_on_non_struct" (func 4))
+  (export "br_on_non_array" (func 5))
+  (export "null-diff" (func 6))
+  (elem (;0;) declare func $f)
+)

--- a/tests/snapshots/testsuite/proposals/gc/br_on_cast_fail.wast/27.print
+++ b/tests/snapshots/testsuite/proposals/gc/br_on_cast_fail.wast/27.print
@@ -1,0 +1,281 @@
+(module
+  (type $t0 (;0;) (sub (struct)))
+  (type $t1 (;1;) (sub $t0 (;0;) (struct (field i32))))
+  (type $t1' (;2;) (sub $t0 (;0;) (struct (field i32))))
+  (type $t2 (;3;) (sub $t1 (;1;) (struct (field i32) (field i32))))
+  (type $t2' (;4;) (sub $t1' (;2;) (struct (field i32) (field i32))))
+  (type $t3 (;5;) (sub $t0 (;0;) (struct (field i32) (field i32))))
+  (type $t0' (;6;) (sub $t0 (;0;) (struct)))
+  (type $t4 (;7;) (sub $t0' (;6;) (struct (field i32) (field i32))))
+  (type (;8;) (func))
+  (func $init (;0;) (type 8)
+    i32.const 0
+    struct.new_default $t0
+    table.set 0
+    i32.const 10
+    struct.new_default $t0
+    table.set 0
+    i32.const 1
+    struct.new_default $t1
+    table.set 0
+    i32.const 11
+    struct.new_default $t1'
+    table.set 0
+    i32.const 2
+    struct.new_default $t2
+    table.set 0
+    i32.const 12
+    struct.new_default $t2'
+    table.set 0
+    i32.const 3
+    struct.new_default $t3
+    table.set 0
+    i32.const 4
+    struct.new_default $t4
+    table.set 0
+  )
+  (func (;1;) (type 8)
+    call $init
+    block $l (result structref)
+      ref.null struct
+      br_on_cast_fail $l structref (ref null 0)
+      i32.const 0
+      table.get 0
+      br_on_cast_fail $l structref (ref null 0)
+      i32.const 1
+      table.get 0
+      br_on_cast_fail $l structref (ref null 0)
+      i32.const 2
+      table.get 0
+      br_on_cast_fail $l structref (ref null 0)
+      i32.const 3
+      table.get 0
+      br_on_cast_fail $l structref (ref null 0)
+      i32.const 4
+      table.get 0
+      br_on_cast_fail $l structref (ref null 0)
+      i32.const 0
+      table.get 0
+      br_on_cast_fail $l structref (ref 0)
+      i32.const 1
+      table.get 0
+      br_on_cast_fail $l structref (ref 0)
+      i32.const 2
+      table.get 0
+      br_on_cast_fail $l structref (ref 0)
+      i32.const 3
+      table.get 0
+      br_on_cast_fail $l structref (ref 0)
+      i32.const 4
+      table.get 0
+      br_on_cast_fail $l structref (ref 0)
+      ref.null struct
+      br_on_cast_fail $l structref (ref null 1)
+      i32.const 1
+      table.get 0
+      br_on_cast_fail $l structref (ref null 1)
+      i32.const 2
+      table.get 0
+      br_on_cast_fail $l structref (ref null 1)
+      i32.const 1
+      table.get 0
+      br_on_cast_fail $l structref (ref 1)
+      i32.const 2
+      table.get 0
+      br_on_cast_fail $l structref (ref 1)
+      ref.null struct
+      br_on_cast_fail $l structref (ref null 3)
+      i32.const 2
+      table.get 0
+      br_on_cast_fail $l structref (ref null 3)
+      i32.const 2
+      table.get 0
+      br_on_cast_fail $l structref (ref 3)
+      ref.null struct
+      br_on_cast_fail $l structref (ref null 5)
+      i32.const 3
+      table.get 0
+      br_on_cast_fail $l structref (ref null 5)
+      i32.const 3
+      table.get 0
+      br_on_cast_fail $l structref (ref 5)
+      ref.null struct
+      br_on_cast_fail $l structref (ref null 7)
+      i32.const 4
+      table.get 0
+      br_on_cast_fail $l structref (ref null 7)
+      i32.const 4
+      table.get 0
+      br_on_cast_fail $l structref (ref 7)
+      block (result structref) ;; label = @2
+        ref.null struct
+        br_on_cast_fail 0 (;@2;) structref (ref 0)
+      end
+      drop
+      block (result structref) ;; label = @2
+        ref.null struct
+        br_on_cast_fail 0 (;@2;) structref (ref 1)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 0
+        table.get 0
+        br_on_cast_fail 0 (;@2;) structref (ref 1)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 3
+        table.get 0
+        br_on_cast_fail 0 (;@2;) structref (ref 1)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 4
+        table.get 0
+        br_on_cast_fail 0 (;@2;) structref (ref 1)
+      end
+      drop
+      block (result structref) ;; label = @2
+        ref.null struct
+        br_on_cast_fail 0 (;@2;) structref (ref 3)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 0
+        table.get 0
+        br_on_cast_fail 0 (;@2;) structref (ref 3)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 1
+        table.get 0
+        br_on_cast_fail 0 (;@2;) structref (ref 3)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 3
+        table.get 0
+        br_on_cast_fail 0 (;@2;) structref (ref 3)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 4
+        table.get 0
+        br_on_cast_fail 0 (;@2;) structref (ref 3)
+      end
+      drop
+      block (result structref) ;; label = @2
+        ref.null struct
+        br_on_cast_fail 0 (;@2;) structref (ref 5)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 0
+        table.get 0
+        br_on_cast_fail 0 (;@2;) structref (ref 5)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 1
+        table.get 0
+        br_on_cast_fail 0 (;@2;) structref (ref 5)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 2
+        table.get 0
+        br_on_cast_fail 0 (;@2;) structref (ref 5)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 4
+        table.get 0
+        br_on_cast_fail 0 (;@2;) structref (ref 5)
+      end
+      drop
+      block (result structref) ;; label = @2
+        ref.null struct
+        br_on_cast_fail 0 (;@2;) structref (ref 7)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 0
+        table.get 0
+        br_on_cast_fail 0 (;@2;) structref (ref 7)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 1
+        table.get 0
+        br_on_cast_fail 0 (;@2;) structref (ref 7)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 2
+        table.get 0
+        br_on_cast_fail 0 (;@2;) structref (ref 7)
+      end
+      drop
+      block (result structref) ;; label = @2
+        i32.const 3
+        table.get 0
+        br_on_cast_fail 0 (;@2;) structref (ref 7)
+      end
+      drop
+      return
+    end
+    unreachable
+  )
+  (func (;2;) (type 8)
+    call $init
+    block $l (result structref)
+      i32.const 0
+      table.get 0
+      br_on_cast_fail $l structref (ref 0)
+      i32.const 1
+      table.get 0
+      br_on_cast_fail $l structref (ref 0)
+      i32.const 2
+      table.get 0
+      br_on_cast_fail $l structref (ref 0)
+      i32.const 3
+      table.get 0
+      br_on_cast_fail $l structref (ref 0)
+      i32.const 4
+      table.get 0
+      br_on_cast_fail $l structref (ref 0)
+      i32.const 10
+      table.get 0
+      br_on_cast_fail $l structref (ref 0)
+      i32.const 11
+      table.get 0
+      br_on_cast_fail $l structref (ref 0)
+      i32.const 12
+      table.get 0
+      br_on_cast_fail $l structref (ref 0)
+      i32.const 1
+      table.get 0
+      br_on_cast_fail $l structref (ref 2)
+      i32.const 2
+      table.get 0
+      br_on_cast_fail $l structref (ref 2)
+      i32.const 11
+      table.get 0
+      br_on_cast_fail $l structref (ref 1)
+      i32.const 12
+      table.get 0
+      br_on_cast_fail $l structref (ref 1)
+      i32.const 2
+      table.get 0
+      br_on_cast_fail $l structref (ref 4)
+      i32.const 12
+      table.get 0
+      br_on_cast_fail $l structref (ref 3)
+      return
+    end
+    unreachable
+  )
+  (table (;0;) 20 structref)
+  (export "test-sub" (func 1))
+  (export "test-canon" (func 2))
+)

--- a/tests/snapshots/testsuite/proposals/gc/br_on_cast_fail.wast/30.print
+++ b/tests/snapshots/testsuite/proposals/gc/br_on_cast_fail.wast/30.print
@@ -1,0 +1,23 @@
+(module
+  (type $t (;0;) (struct))
+  (type (;1;) (func (param (ref any)) (result (ref any))))
+  (type (;2;) (func (param anyref) (result anyref)))
+  (func (;0;) (type 1) (param (ref any)) (result (ref any))
+    block (result (ref 0)) ;; label = @1
+      local.get 0
+      br_on_cast_fail 1 (;@0;) (ref any) (ref 0)
+    end
+  )
+  (func (;1;) (type 2) (param anyref) (result anyref)
+    block (result (ref 0)) ;; label = @1
+      local.get 0
+      br_on_cast_fail 1 (;@0;) anyref (ref 0)
+    end
+  )
+  (func (;2;) (type 2) (param anyref) (result anyref)
+    block (result (ref null 0)) ;; label = @1
+      local.get 0
+      br_on_cast_fail 1 (;@0;) anyref (ref null 0)
+    end
+  )
+)

--- a/tests/snapshots/testsuite/proposals/gc/extern.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/gc/extern.wast/0.print
@@ -1,0 +1,57 @@
+(module
+  (type $ft (;0;) (func))
+  (type $st (;1;) (struct))
+  (type $at (;2;) (array i8))
+  (type (;3;) (func (param externref)))
+  (type (;4;) (func (param externref) (result anyref)))
+  (type (;5;) (func (param anyref) (result externref)))
+  (type (;6;) (func (param i32) (result externref)))
+  (type (;7;) (func (param i32) (result anyref)))
+  (func $f (;0;) (type $ft))
+  (func (;1;) (type 3) (param $x externref)
+    i32.const 0
+    ref.null any
+    table.set 0
+    i32.const 1
+    i32.const 7
+    ref.i31
+    table.set 0
+    i32.const 2
+    struct.new_default $st
+    table.set 0
+    i32.const 3
+    i32.const 0
+    array.new_default $at
+    table.set 0
+    i32.const 4
+    local.get $x
+    any.convert_extern
+    table.set 0
+  )
+  (func (;2;) (type 4) (param externref) (result anyref)
+    local.get 0
+    any.convert_extern
+  )
+  (func (;3;) (type 5) (param anyref) (result externref)
+    local.get 0
+    extern.convert_any
+  )
+  (func (;4;) (type 6) (param i32) (result externref)
+    local.get 0
+    table.get 0
+    extern.convert_any
+  )
+  (func (;5;) (type 7) (param i32) (result anyref)
+    local.get 0
+    table.get 0
+    extern.convert_any
+    any.convert_extern
+  )
+  (table (;0;) 10 anyref)
+  (export "init" (func 1))
+  (export "internalize" (func 2))
+  (export "externalize" (func 3))
+  (export "externalize-i" (func 4))
+  (export "externalize-ii" (func 5))
+  (elem (;0;) declare func $f)
+)

--- a/tests/snapshots/testsuite/proposals/gc/ref_eq.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/gc/ref_eq.wast/0.print
@@ -1,0 +1,55 @@
+(module
+  (type $st (;0;) (sub (struct)))
+  (type $st' (;1;) (sub (struct (field i32))))
+  (type $at (;2;) (array i8))
+  (type $st-sub1 (;3;) (sub $st (;0;) (struct)))
+  (type $st-sub2 (;4;) (sub $st (;0;) (struct)))
+  (type $st'-sub1 (;5;) (sub $st' (;1;) (struct (field i32))))
+  (type $st'-sub2 (;6;) (sub $st' (;1;) (struct (field i32))))
+  (type (;7;) (func))
+  (type (;8;) (func (param i32 i32) (result i32)))
+  (func (;0;) (type 7)
+    i32.const 0
+    ref.null eq
+    table.set 0
+    i32.const 1
+    ref.null i31
+    table.set 0
+    i32.const 2
+    i32.const 7
+    ref.i31
+    table.set 0
+    i32.const 3
+    i32.const 7
+    ref.i31
+    table.set 0
+    i32.const 4
+    i32.const 8
+    ref.i31
+    table.set 0
+    i32.const 5
+    struct.new_default $st
+    table.set 0
+    i32.const 6
+    struct.new_default $st
+    table.set 0
+    i32.const 7
+    i32.const 0
+    array.new_default $at
+    table.set 0
+    i32.const 8
+    i32.const 0
+    array.new_default $at
+    table.set 0
+  )
+  (func (;1;) (type 8) (param $i i32) (param $j i32) (result i32)
+    local.get $i
+    table.get 0
+    local.get $j
+    table.get 0
+    ref.eq
+  )
+  (table (;0;) 20 eqref)
+  (export "init" (func 0))
+  (export "eq" (func 1))
+)

--- a/tests/snapshots/testsuite/proposals/gc/struct.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/gc/struct.wast/0.print
@@ -1,0 +1,10 @@
+(module
+  (type (;0;) (struct))
+  (type (;1;) (struct))
+  (type (;2;) (struct (field i8)))
+  (type (;3;) (struct (field i8) (field i8) (field i8) (field i8)))
+  (type (;4;) (struct (field i32) (field i32)))
+  (type (;5;) (struct (field i8) (field i16) (field i32) (field i64) (field f32) (field f64) (field anyref) (field funcref) (field (ref 0)) (field (ref null 1))))
+  (type (;6;) (struct (field i32) (field i64) (field i8) (field i31ref) (field anyref)))
+  (type (;7;) (struct (field i32) (field f32) (field f64) (field i32)))
+)

--- a/tests/snapshots/testsuite/proposals/gc/struct.wast/16.print
+++ b/tests/snapshots/testsuite/proposals/gc/struct.wast/16.print
@@ -1,0 +1,18 @@
+(module
+  (type $t (;0;) (struct (field i32) (field (mut i32))))
+  (type (;1;) (func))
+  (func (;0;) (type 1)
+    (local (ref null 0))
+    local.get 0
+    struct.get $t 1
+    drop
+  )
+  (func (;1;) (type 1)
+    (local (ref null 0))
+    local.get 0
+    i32.const 0
+    struct.set $t 1
+  )
+  (export "struct.get-null" (func 0))
+  (export "struct.set-null" (func 1))
+)

--- a/tests/snapshots/testsuite/proposals/gc/struct.wast/19.print
+++ b/tests/snapshots/testsuite/proposals/gc/struct.wast/19.print
@@ -1,0 +1,85 @@
+(module
+  (type $s (;0;) (struct (field i8) (field (mut i8)) (field i16) (field (mut i16))))
+  (type (;1;) (func (result i32 i32)))
+  (type (;2;) (func (param i32) (result i32 i32)))
+  (func (;0;) (type 1) (result i32 i32)
+    global.get 0
+    struct.get_s $s 0
+    global.get 0
+    struct.get_u $s 0
+  )
+  (func (;1;) (type 1) (result i32 i32)
+    global.get 1
+    struct.get_s $s 0
+    global.get 1
+    struct.get_u $s 0
+  )
+  (func (;2;) (type 1) (result i32 i32)
+    global.get 0
+    struct.get_s $s 1
+    global.get 0
+    struct.get_u $s 1
+  )
+  (func (;3;) (type 1) (result i32 i32)
+    global.get 1
+    struct.get_s $s 1
+    global.get 1
+    struct.get_u $s 1
+  )
+  (func (;4;) (type 1) (result i32 i32)
+    global.get 0
+    struct.get_s $s 2
+    global.get 0
+    struct.get_u $s 2
+  )
+  (func (;5;) (type 1) (result i32 i32)
+    global.get 1
+    struct.get_s $s 2
+    global.get 1
+    struct.get_u $s 2
+  )
+  (func (;6;) (type 1) (result i32 i32)
+    global.get 0
+    struct.get_s $s 3
+    global.get 0
+    struct.get_u $s 3
+  )
+  (func (;7;) (type 1) (result i32 i32)
+    global.get 1
+    struct.get_s $s 3
+    global.get 1
+    struct.get_u $s 3
+  )
+  (func (;8;) (type 2) (param i32) (result i32 i32)
+    global.get 0
+    local.get 0
+    struct.set $s 1
+    global.get 0
+    struct.get_s $s 1
+    global.get 0
+    struct.get_u $s 1
+  )
+  (func (;9;) (type 2) (param i32) (result i32 i32)
+    global.get 0
+    local.get 0
+    struct.set $s 3
+    global.get 0
+    struct.get_s $s 3
+    global.get 0
+    struct.get_u $s 3
+  )
+  (global (;0;) (ref 0) i32.const 0 i32.const 1 i32.const 2 i32.const 3 struct.new $s)
+  (global (;1;) (ref 0) i32.const 254 i32.const 255 i32.const 65534 i32.const 65535 struct.new $s)
+  (export "g0" (global 0))
+  (export "g1" (global 1))
+  (export "get_packed_g0_0" (func 0))
+  (export "get_packed_g1_0" (func 1))
+  (export "get_packed_g0_1" (func 2))
+  (export "get_packed_g1_1" (func 3))
+  (export "get_packed_g0_2" (func 4))
+  (export "get_packed_g1_2" (func 5))
+  (export "get_packed_g0_3" (func 6))
+  (export "get_packed_g1_3" (func 7))
+  (export "set_get_packed_g0_1" (func 8))
+  (export "set_get_packed_g0_3" (func 9))
+)

--- a/tests/snapshots/testsuite/proposals/gc/struct.wast/2.print
+++ b/tests/snapshots/testsuite/proposals/gc/struct.wast/2.print
@@ -1,0 +1,9 @@
+(module
+  (rec
+    (type $s0 (;0;) (struct (field (ref 0)) (field (ref 1)) (field (ref 0)) (field (ref 1))))
+    (type $s1 (;1;) (struct (field (ref 0)) (field (ref 1)) (field (ref 0)) (field (ref 1))))
+  )
+  (type $forward (;2;) (struct))
+  (type (;3;) (func (param (ref 2))))
+  (func (;0;) (type 3) (param (ref 2)))
+)

--- a/tests/snapshots/testsuite/proposals/gc/struct.wast/5.print
+++ b/tests/snapshots/testsuite/proposals/gc/struct.wast/5.print
@@ -1,0 +1,20 @@
+(module
+  (type (;0;) (struct (field i32)))
+  (type $t1 (;1;) (struct (field i32) (field f32)))
+  (type $t2 (;2;) (struct (field i32) (field i32) (field i64)))
+  (type (;3;) (func (param (ref 0)) (result i32)))
+  (type (;4;) (func (param (ref 1)) (result f32)))
+  (type (;5;) (func (param (ref 2)) (result i64)))
+  (func (;0;) (type 3) (param (ref 0)) (result i32)
+    local.get 0
+    struct.get 0 0
+  )
+  (func (;1;) (type 4) (param (ref 1)) (result f32)
+    local.get 0
+    struct.get $t1 1
+  )
+  (func (;2;) (type 5) (param (ref 2)) (result i64)
+    local.get 0
+    struct.get $t2 2
+  )
+)

--- a/tests/snapshots/testsuite/proposals/gc/struct.wast/7.print
+++ b/tests/snapshots/testsuite/proposals/gc/struct.wast/7.print
@@ -1,0 +1,76 @@
+(module
+  (type $vec (;0;) (struct (field f32) (field (mut f32)) (field f32)))
+  (type (;1;) (func (result anyref)))
+  (type (;2;) (func (param (ref 0)) (result f32)))
+  (type (;3;) (func (result f32)))
+  (type (;4;) (func (param (ref 0) f32) (result f32)))
+  (type (;5;) (func (param f32) (result f32)))
+  (func (;0;) (type 1) (result anyref)
+    struct.new_default $vec
+  )
+  (func $get_0_0 (;1;) (type 2) (param $v (ref 0)) (result f32)
+    local.get $v
+    struct.get $vec 0
+  )
+  (func (;2;) (type 3) (result f32)
+    struct.new_default $vec
+    call $get_0_0
+  )
+  (func $get_vec_0 (;3;) (type 2) (param $v (ref 0)) (result f32)
+    local.get $v
+    struct.get $vec 0
+  )
+  (func (;4;) (type 3) (result f32)
+    struct.new_default $vec
+    call $get_vec_0
+  )
+  (func $get_0_y (;5;) (type 2) (param $v (ref 0)) (result f32)
+    local.get $v
+    struct.get $vec 1
+  )
+  (func (;6;) (type 3) (result f32)
+    struct.new_default $vec
+    call $get_0_y
+  )
+  (func $get_vec_y (;7;) (type 2) (param $v (ref 0)) (result f32)
+    local.get $v
+    struct.get $vec 1
+  )
+  (func (;8;) (type 3) (result f32)
+    struct.new_default $vec
+    call $get_vec_y
+  )
+  (func $set_get_y (;9;) (type 4) (param $v (ref 0)) (param $y f32) (result f32)
+    local.get $v
+    local.get $y
+    struct.set $vec 1
+    local.get $v
+    struct.get $vec 1
+  )
+  (func (;10;) (type 5) (param $y f32) (result f32)
+    struct.new_default $vec
+    local.get $y
+    call $set_get_y
+  )
+  (func $set_get_1 (;11;) (type 4) (param $v (ref 0)) (param $y f32) (result f32)
+    local.get $v
+    local.get $y
+    struct.set $vec 1
+    local.get $v
+    struct.get $vec 1
+  )
+  (func (;12;) (type 5) (param $y f32) (result f32)
+    struct.new_default $vec
+    local.get $y
+    call $set_get_1
+  )
+  (global (;0;) (ref 0) f32.const 0x1p+0 (;=1;) f32.const 0x1p+1 (;=2;) f32.const 0x1.8p+1 (;=3;) struct.new $vec)
+  (global (;1;) (ref 0) struct.new_default $vec)
+  (export "new" (func 0))
+  (export "get_0_0" (func 2))
+  (export "get_vec_0" (func 4))
+  (export "get_0_y" (func 6))
+  (export "get_vec_y" (func 8))
+  (export "set_get_y" (func 10))
+  (export "set_get_1" (func 12))
+)


### PR DESCRIPTION
Newly passing tests:

* `br_on_cast.wast`
* `br_on_cast_fail.wast`
* `struct.wast`

Newly implemented instructions:

* `struct.new`
* `struct.get`
* `struct.get_s`
* `struct.get_u`
* `struct.set`
* `br_on_cast`
* `br_on_cast_fail`