### PR TITLE
Silently ignore non-doc-comment comments.

### DIFF
--- a/crates/wit-parser/src/ast/resolve.rs
+++ b/crates/wit-parser/src/ast/resolve.rs
@@ -1280,10 +1280,9 @@ impl<'a> Resolver<'a> {
     fn docs(&mut self, doc: &super::Docs<'_>) -> Docs {
         let mut lines = vec![];
         for doc in doc.docs.iter() {
-            if let Some(doc) = doc.strip_prefix("/**") {
-                lines.push(doc.strip_suffix("*/").unwrap().trim());
-            } else {
-                lines.push(doc.trim_start_matches('/').trim());
+            // Comments which are not doc-comments are silently ignored
+            if let Some(doc) = doc.strip_prefix("/// ") {
+                lines.push(doc);
             }
         }
         let contents = if lines.is_empty() {


### PR DESCRIPTION
As part of bytecodealliance/wasm-tools#1362, silently ignore comments that aren't `///` comments. This won't break any actual code; it just means that documentation comments won't show up in generated bindings unless the `///` syntax is used.

All wit files I've seen already use `///` syntax for comments, so I expect the impact of this change will be low.