### PR TITLE
Add migration code for `f32`/`f64`.

### DIFF
--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -6,7 +6,7 @@ use wit_parser::*;
 
 // NB: keep in sync with `crates/wit-parser/src/ast/lex.rs`
 const PRINT_SEMICOLONS_DEFAULT: bool = true;
-const PRINT_F32_F64_DEFAULT: bool = true;
+const PRINT_F32_F64_DEFAULT: bool = false;
 
 /// A utility for printing WebAssembly interface definitions to a string.
 pub struct WitPrinter {

--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -6,6 +6,7 @@ use wit_parser::*;
 
 // NB: keep in sync with `crates/wit-parser/src/ast/lex.rs`
 const PRINT_SEMICOLONS_DEFAULT: bool = true;
+const PRINT_F32_F64_DEFAULT: bool = true;
 
 /// A utility for printing WebAssembly interface definitions to a string.
 pub struct WitPrinter {
@@ -19,6 +20,7 @@ pub struct WitPrinter {
     emit_docs: bool,
 
     print_semicolons: bool,
+    print_f32_f64: bool,
 }
 
 impl Default for WitPrinter {
@@ -30,6 +32,10 @@ impl Default for WitPrinter {
             print_semicolons: match std::env::var("WIT_REQUIRE_SEMICOLONS") {
                 Ok(s) => s == "1",
                 Err(_) => PRINT_SEMICOLONS_DEFAULT,
+            },
+            print_f32_f64: match std::env::var("WIT_REQUIRE_F32_F64") {
+                Ok(s) => s == "1",
+                Err(_) => PRINT_F32_F64_DEFAULT,
             },
         }
     }
@@ -437,8 +443,20 @@ impl WitPrinter {
             Type::S16 => self.output.push_str("s16"),
             Type::S32 => self.output.push_str("s32"),
             Type::S64 => self.output.push_str("s64"),
-            Type::Float32 => self.output.push_str("float32"),
-            Type::Float64 => self.output.push_str("float64"),
+            Type::Float32 => {
+                if self.print_f32_f64 {
+                    self.output.push_str("f32")
+                } else {
+                    self.output.push_str("float32")
+                }
+            }
+            Type::Float64 => {
+                if self.print_f32_f64 {
+                    self.output.push_str("f64")
+                } else {
+                    self.output.push_str("float64")
+                }
+            }
             Type::Char => self.output.push_str("char"),
             Type::String => self.output.push_str("string"),
 

--- a/crates/wit-parser/src/ast/lex.rs
+++ b/crates/wit-parser/src/ast/lex.rs
@@ -13,6 +13,7 @@ pub struct Tokenizer<'a> {
     span_offset: u32,
     chars: CrlfFold<'a>,
     require_semicolons: bool,
+    require_f32_f64: bool,
 }
 
 #[derive(Clone)]
@@ -118,12 +119,14 @@ pub enum Error {
 
 // NB: keep in sync with `crates/wit-component/src/printing.rs`.
 const REQUIRE_SEMICOLONS_BY_DEFAULT: bool = true;
+const REQUIRE_F32_F64_BY_DEFAULT: bool = true;
 
 impl<'a> Tokenizer<'a> {
     pub fn new(
         input: &'a str,
         span_offset: u32,
         require_semicolons: Option<bool>,
+        require_f32_f64: Option<bool>,
     ) -> Result<Tokenizer<'a>> {
         detect_invalid_input(input)?;
 
@@ -137,6 +140,12 @@ impl<'a> Tokenizer<'a> {
                 match std::env::var("WIT_REQUIRE_SEMICOLONS") {
                     Ok(s) => s == "1",
                     Err(_) => REQUIRE_SEMICOLONS_BY_DEFAULT,
+                }
+            }),
+            require_f32_f64: require_f32_f64.unwrap_or_else(|| {
+                match std::env::var("WIT_REQUIRE_F32_F64") {
+                    Ok(s) => s == "1",
+                    Err(_) => REQUIRE_F32_F64_BY_DEFAULT,
                 }
             }),
         };
@@ -285,8 +294,10 @@ impl<'a> Tokenizer<'a> {
                     "s16" => S16,
                     "s32" => S32,
                     "s64" => S64,
-                    "f32" | "float32" => Float32,
-                    "f64" | "float64" => Float64,
+                    "f32" => Float32,
+                    "f64" => Float64,
+                    "float32" if !self.require_f32_f64 => Float32,
+                    "float64" if !self.require_f32_f64 => Float64,
                     "char" => Char,
                     "resource" => Resource,
                     "own" => Own,

--- a/crates/wit-parser/src/ast/lex.rs
+++ b/crates/wit-parser/src/ast/lex.rs
@@ -119,7 +119,7 @@ pub enum Error {
 
 // NB: keep in sync with `crates/wit-component/src/printing.rs`.
 const REQUIRE_SEMICOLONS_BY_DEFAULT: bool = true;
-const REQUIRE_F32_F64_BY_DEFAULT: bool = true;
+const REQUIRE_F32_F64_BY_DEFAULT: bool = false;
 
 impl<'a> Tokenizer<'a> {
     pub fn new(
@@ -665,7 +665,7 @@ fn test_validate_id() {
 #[test]
 fn test_tokenizer() {
     fn collect(s: &str) -> Result<Vec<Token>> {
-        let mut t = Tokenizer::new(s, 0, Some(true))?;
+        let mut t = Tokenizer::new(s, 0, Some(true), None)?;
         let mut tokens = Vec::new();
         while let Some(token) = t.next()? {
             tokens.push(token.1);


### PR DESCRIPTION
Add a `WIT_REQUIRE_F32_F64` environment variable controlling whether the `float32` and `float64` syntax is acccepted, similar to the transition for semicolons.