### PR TITLE
Remove support for encoding old component metadata format

### DIFF
--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -94,7 +94,7 @@ const INDIRECT_TABLE_NAME: &str = "$imports";
 
 pub mod docs;
 mod wit;
-pub use wit::{encode, encode_component, encode_world};
+pub use wit::{encode, encode_world};
 
 mod types;
 use types::{InstanceTypeEncoder, RootTypeEncoder, ValtypeEncoder};

--- a/crates/wit-component/src/lib.rs
+++ b/crates/wit-component/src/lib.rs
@@ -216,7 +216,7 @@ pub fn embed_component_metadata(
     world: WorldId,
     encoding: StringEncoding,
 ) -> Result<()> {
-    let encoded = metadata::encode(&wit_resolver, world, encoding, None, None)?;
+    let encoded = metadata::encode(&wit_resolver, world, encoding, None)?;
 
     let section = wasm_encoder::CustomSection {
         name: "component-type".into(),

--- a/crates/wit-component/src/metadata.rs
+++ b/crates/wit-component/src/metadata.rs
@@ -47,7 +47,7 @@ use anyhow::{bail, Context, Result};
 use indexmap::IndexMap;
 use std::borrow::Cow;
 use wasm_encoder::{
-    ComponentBuilder, ComponentExportKind, ComponentType, ComponentTypeRef, CustomSection, Encode,
+    ComponentBuilder, ComponentExportKind, ComponentType, ComponentTypeRef, CustomSection,
 };
 use wasm_metadata::Producers;
 use wasmparser::types::ComponentAnyTypeId;
@@ -170,94 +170,34 @@ pub fn encode(
     world: WorldId,
     string_encoding: StringEncoding,
     extra_producers: Option<&Producers>,
-    use_next_encoding: Option<bool>,
 ) -> Result<Vec<u8>> {
-    enum EncodingFormat {
-        // The encoding of the previous format was:
-        //
-        //  * A version byte, at the time 0x03.
-        //  * A string-encoding byte.
-        //  * A string which is the name of a world.
-        //  * A wasm-encoded WIT package which contains the previous world.
-        //
-        // Note that this branch will be deleted in the near future.
-        Previous,
+    let ty = crate::encoding::encode_world(resolve, world)?;
 
-        // The current format.
-        Next,
+    let world = &resolve.worlds[world];
+    let mut outer_ty = ComponentType::new();
+    outer_ty.ty().component(&ty);
+    outer_ty.export(
+        &resolve.id_of_name(world.package.unwrap(), &world.name),
+        ComponentTypeRef::Component(0),
+    );
+
+    let mut builder = ComponentBuilder::default();
+
+    let string_encoding = encode_string_encoding(string_encoding);
+    builder.custom_section(&CustomSection {
+        name: CUSTOM_SECTION_NAME.into(),
+        data: Cow::Borrowed(&[CURRENT_VERSION, string_encoding]),
+    });
+
+    let ty = builder.type_component(&outer_ty);
+    builder.export(&world.name, ComponentExportKind::Type, ty, None);
+
+    let mut producers = crate::base_producers();
+    if let Some(p) = extra_producers {
+        producers.merge(&p);
     }
-
-    let format = match use_next_encoding {
-        Some(true) => EncodingFormat::Next,
-        Some(false) => EncodingFormat::Previous,
-        None => match std::env::var("WIT_COMPONENT_NEW_ENCODE") {
-            Ok(s) if s == "0" => EncodingFormat::Previous,
-            _ => EncodingFormat::Next,
-        },
-    };
-
-    let ret = match format {
-        EncodingFormat::Previous => {
-            let world = &resolve.worlds[world];
-            let pkg = &resolve.packages[world.package.unwrap()];
-            assert!(
-                resolve
-                    .packages
-                    .iter()
-                    .filter(|(_, p)| p.name == pkg.name)
-                    .count()
-                    == 1
-            );
-
-            let mut ret = Vec::new();
-            ret.push(0x03);
-            ret.push(encode_string_encoding(string_encoding));
-            world.name.encode(&mut ret);
-            // This appends a wasm binary encoded Component to the ret:
-            let mut component_builder =
-                crate::encoding::encode_component(None, resolve, world.package.unwrap())?;
-
-            let mut producers = crate::base_producers();
-            if let Some(p) = extra_producers {
-                producers.merge(&p);
-            }
-            component_builder.raw_custom_section(&producers.raw_custom_section());
-
-            ret.extend(component_builder.finish());
-            ret
-        }
-        EncodingFormat::Next => {
-            let ty = crate::encoding::encode_world(resolve, world)?;
-
-            let world = &resolve.worlds[world];
-            let mut outer_ty = ComponentType::new();
-            outer_ty.ty().component(&ty);
-            outer_ty.export(
-                &resolve.id_of_name(world.package.unwrap(), &world.name),
-                ComponentTypeRef::Component(0),
-            );
-
-            let mut builder = ComponentBuilder::default();
-
-            let string_encoding = encode_string_encoding(string_encoding);
-            builder.custom_section(&CustomSection {
-                name: CUSTOM_SECTION_NAME.into(),
-                data: Cow::Borrowed(&[CURRENT_VERSION, string_encoding]),
-            });
-
-            let ty = builder.type_component(&outer_ty);
-            builder.export(&world.name, ComponentExportKind::Type, ty, None);
-
-            let mut producers = crate::base_producers();
-            if let Some(p) = extra_producers {
-                producers.merge(&p);
-            }
-            builder.raw_custom_section(&producers.raw_custom_section());
-            builder.finish()
-        }
-    };
-
-    Ok(ret)
+    builder.raw_custom_section(&producers.raw_custom_section());
+    Ok(builder.finish())
 }
 
 fn decode_custom_section(wasm: &[u8]) -> Result<(Resolve, WorldId, StringEncoding)> {

--- a/crates/wit-component/tests/components.rs
+++ b/crates/wit-component/tests/components.rs
@@ -205,13 +205,8 @@ fn read_core_module(path: &Path, resolve: &Resolve, pkg: PackageId) -> Result<Ve
     let mut producers = wasm_metadata::Producers::empty();
     producers.add("processed-by", "my-fake-bindgen", "123.45");
 
-    let encoded = wit_component::metadata::encode(
-        resolve,
-        world,
-        StringEncoding::UTF8,
-        Some(&producers),
-        Some(true),
-    )?;
+    let encoded =
+        wit_component::metadata::encode(resolve, world, StringEncoding::UTF8, Some(&producers))?;
 
     let section = wasm_encoder::CustomSection {
         name: "component-type".into(),


### PR DESCRIPTION
This commit is a follow-up to #1260, #1270, and #1308. This is the next step in the transition to updating how type information is encoded in object files in core WebAssembly binaries when transforming them into a component. The old format has been enabled by default since the 1.0.54 release of `wasm-tools` in late November. and has been supported since the 1.0.51 release in early November.

Support has been preserved for continuing to emit the old format in case any tooling accidentally hadn't updated but now feels like the right time to remove the ability to emit the old format. The old format can still be parsed if historical object files are in use and the hope is that it's not too bad to leave that piece sticking around for awhile.