### PR TITLE
Bump crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1702,7 +1702,7 @@ checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
 
 [[package]]
 name = "wasm-compose"
-version = "0.4.16"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "glob",
@@ -1716,9 +1716,9 @@ dependencies = [
  "serde_derive",
  "serde_yaml",
  "smallvec",
- "wasm-encoder 0.38.1",
- "wasmparser 0.118.1",
- "wasmprinter 0.2.75",
+ "wasm-encoder 0.39.0",
+ "wasmparser 0.119.0",
+ "wasmprinter 0.2.76",
  "wat",
  "wit-component",
 ]
@@ -1734,17 +1734,17 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.38.1"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "leb128",
  "tempfile",
- "wasmparser 0.118.1",
+ "wasmparser 0.119.0",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.10.14"
+version = "0.10.15"
 dependencies = [
  "anyhow",
  "clap 4.4.8",
@@ -1753,14 +1753,14 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder 0.38.1",
- "wasmparser 0.118.1",
+ "wasm-encoder 0.39.0",
+ "wasmparser 0.119.0",
  "wat",
 ]
 
 [[package]]
 name = "wasm-mutate"
-version = "0.2.43"
+version = "0.2.44"
 dependencies = [
  "anyhow",
  "clap 4.4.8",
@@ -1769,9 +1769,9 @@ dependencies = [
  "log",
  "rand",
  "thiserror",
- "wasm-encoder 0.38.1",
- "wasmparser 0.118.1",
- "wasmprinter 0.2.75",
+ "wasm-encoder 0.39.0",
+ "wasmparser 0.119.0",
+ "wasmprinter 0.2.76",
  "wat",
 ]
 
@@ -1788,14 +1788,14 @@ dependencies = [
  "num_cpus",
  "rand",
  "wasm-mutate",
- "wasmparser 0.118.1",
- "wasmprinter 0.2.75",
+ "wasmparser 0.119.0",
+ "wasmprinter 0.2.76",
  "wasmtime",
 ]
 
 [[package]]
 name = "wasm-shrink"
-version = "0.1.44"
+version = "0.1.45"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1804,14 +1804,14 @@ dependencies = [
  "log",
  "rand",
  "wasm-mutate",
- "wasmparser 0.118.1",
- "wasmprinter 0.2.75",
+ "wasmparser 0.119.0",
+ "wasmprinter 0.2.76",
  "wat",
 ]
 
 [[package]]
 name = "wasm-smith"
-version = "0.13.1"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -1824,15 +1824,15 @@ dependencies = [
  "rand",
  "serde",
  "serde_derive",
- "wasm-encoder 0.38.1",
- "wasmparser 0.118.1",
- "wasmprinter 0.2.75",
+ "wasm-encoder 0.39.0",
+ "wasmparser 0.119.0",
+ "wasmprinter 0.2.76",
  "wat",
 ]
 
 [[package]]
 name = "wasm-tools"
-version = "1.0.54"
+version = "1.0.55"
 dependencies = [
  "addr2line 0.21.0",
  "anyhow",
@@ -1854,17 +1854,17 @@ dependencies = [
  "tempfile",
  "termcolor",
  "wasm-compose",
- "wasm-encoder 0.38.1",
+ "wasm-encoder 0.39.0",
  "wasm-metadata",
  "wasm-mutate",
  "wasm-shrink",
  "wasm-smith",
- "wasmparser 0.118.1",
- "wasmprinter 0.2.75",
+ "wasmparser 0.119.0",
+ "wasmprinter 0.2.76",
  "wast",
  "wat",
  "wit-component",
- "wit-parser 0.13.0",
+ "wit-parser 0.13.1",
  "wit-smith",
 ]
 
@@ -1876,8 +1876,8 @@ dependencies = [
  "wasm-mutate",
  "wasm-shrink",
  "wasm-smith",
- "wasmparser 0.118.1",
- "wasmprinter 0.2.75",
+ "wasmparser 0.119.0",
+ "wasmprinter 0.2.76",
  "wast",
  "wat",
 ]
@@ -1892,16 +1892,16 @@ dependencies = [
  "libfuzzer-sys",
  "log",
  "tempfile",
- "wasm-encoder 0.38.1",
+ "wasm-encoder 0.39.0",
  "wasm-mutate",
  "wasm-smith",
- "wasmparser 0.118.1",
- "wasmprinter 0.2.75",
+ "wasmparser 0.119.0",
+ "wasmprinter 0.2.76",
  "wasmtime",
  "wast",
  "wat",
  "wit-component",
- "wit-parser 0.13.0",
+ "wit-parser 0.13.1",
  "wit-smith",
 ]
 
@@ -1927,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.118.1"
+version = "0.119.0"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -1938,7 +1938,7 @@ dependencies = [
  "once_cell",
  "rayon",
  "semver",
- "wasm-encoder 0.38.1",
+ "wasm-encoder 0.39.0",
  "wast",
  "wat",
 ]
@@ -1955,13 +1955,13 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.2.75"
+version = "0.2.76"
 dependencies = [
  "anyhow",
  "diff",
  "rayon",
  "tempfile",
- "wasmparser 0.118.1",
+ "wasmparser 0.119.0",
  "wast",
  "wat",
 ]
@@ -2219,21 +2219,21 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "69.0.1"
+version = "70.0.0"
 dependencies = [
  "anyhow",
  "leb128",
  "memchr",
  "rayon",
  "unicode-width",
- "wasm-encoder 0.38.1",
- "wasmparser 0.118.1",
+ "wasm-encoder 0.39.0",
+ "wasmparser 0.119.0",
  "wat",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.82"
+version = "1.0.83"
 dependencies = [
  "wast",
 ]
@@ -2363,7 +2363,7 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "wit-component"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -2375,14 +2375,14 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.38.1",
+ "wasm-encoder 0.39.0",
  "wasm-metadata",
- "wasmparser 0.118.1",
- "wasmprinter 0.2.75",
+ "wasmparser 0.119.0",
+ "wasmprinter 0.2.76",
  "wasmtime",
  "wast",
  "wat",
- "wit-parser 0.13.0",
+ "wit-parser 0.13.1",
 ]
 
 [[package]]
@@ -2403,7 +2403,7 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -2427,13 +2427,13 @@ dependencies = [
  "env_logger",
  "libfuzzer-sys",
  "log",
- "wasmprinter 0.2.75",
- "wit-parser 0.13.0",
+ "wasmprinter 0.2.76",
+ "wit-parser 0.13.1",
 ]
 
 [[package]]
 name = "wit-smith"
-version = "0.1.24"
+version = "0.1.25"
 dependencies = [
  "arbitrary",
  "clap 4.4.8",
@@ -2441,7 +2441,7 @@ dependencies = [
  "log",
  "semver",
  "wit-component",
- "wit-parser 0.13.0",
+ "wit-parser 0.13.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-tools"
-version = "1.0.54"
+version = "1.0.55"
 authors = ["The Wasmtime Project Developers"]
 edition.workspace = true
 description = "CLI tools for interoperating with WebAssembly files"
@@ -46,19 +46,19 @@ pretty_assertions = "1.3.0"
 semver = "1.0.0"
 smallvec = "1.11.1"
 
-wasm-compose = { version = "0.4.16", path = "crates/wasm-compose" }
-wasm-encoder = { version = "0.38.1", path = "crates/wasm-encoder" }
-wasm-metadata = { version = "0.10.14", path = "crates/wasm-metadata" }
-wasm-mutate = { version = "0.2.43", path = "crates/wasm-mutate" }
-wasm-shrink = { version = "0.1.44", path = "crates/wasm-shrink" }
-wasm-smith = { version = "0.13.1", path = "crates/wasm-smith" }
-wasmparser = { version = "0.118.1", path = "crates/wasmparser" }
-wasmprinter = { version = "0.2.75", path = "crates/wasmprinter" }
-wast = { version = "69.0.1", path = "crates/wast" }
-wat = { version = "1.0.82", path = "crates/wat" }
-wit-component = { version = "0.19.0", path = "crates/wit-component" }
-wit-parser = { version = "0.13.0", path = "crates/wit-parser" }
-wit-smith = { version = "0.1.24", path = "crates/wit-smith" }
+wasm-compose = { version = "0.5.0", path = "crates/wasm-compose" }
+wasm-encoder = { version = "0.39.0", path = "crates/wasm-encoder" }
+wasm-metadata = { version = "0.10.15", path = "crates/wasm-metadata" }
+wasm-mutate = { version = "0.2.44", path = "crates/wasm-mutate" }
+wasm-shrink = { version = "0.1.45", path = "crates/wasm-shrink" }
+wasm-smith = { version = "0.14.0", path = "crates/wasm-smith" }
+wasmparser = { version = "0.119.0", path = "crates/wasmparser" }
+wasmprinter = { version = "0.2.76", path = "crates/wasmprinter" }
+wast = { version = "70.0.0", path = "crates/wast" }
+wat = { version = "1.0.83", path = "crates/wat" }
+wit-component = { version = "0.19.1", path = "crates/wit-component" }
+wit-parser = { version = "0.13.1", path = "crates/wit-parser" }
+wit-smith = { version = "0.1.25", path = "crates/wit-smith" }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/wasm-compose/Cargo.toml
+++ b/crates/wasm-compose/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-compose"
-version = "0.4.16"
+version = "0.5.0"
 edition.workspace = true
 authors = ["Peter Huene <peter@huene.dev>"]
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasm-encoder/Cargo.toml
+++ b/crates/wasm-encoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-encoder"
-version = "0.38.1"
+version = "0.39.0"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasm-metadata/Cargo.toml
+++ b/crates/wasm-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-metadata"
-version = "0.10.14"
+version = "0.10.15"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-metadata"

--- a/crates/wasm-mutate/Cargo.toml
+++ b/crates/wasm-mutate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-mutate"
-version = "0.2.43"
+version = "0.2.44"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-mutate"

--- a/crates/wasm-shrink/Cargo.toml
+++ b/crates/wasm-shrink/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-shrink"
 name = "wasm-shrink"
-version = "0.1.44"
+version = "0.1.45"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "wasm-smith"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-smith"
-version = "0.13.1"
+version = "0.14.0"
 exclude = ["/benches/corpus"]
 
 [[bench]]

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.118.1"
+version = "0.119.0"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser"

--- a/crates/wasmprinter/Cargo.toml
+++ b/crates/wasmprinter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmprinter"
-version = "0.2.75"
+version = "0.2.76"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wast"
-version = "69.0.1"
+version = "70.0.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wat/Cargo.toml
+++ b/crates/wat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wat"
-version = "1.0.82"
+version = "1.0.83"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wit-component/Cargo.toml
+++ b/crates/wit-component/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-component"
 authors = ["Peter Huene <peter@huene.dev>"]
-version = "0.19.0"
+version = "0.19.1"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"

--- a/crates/wit-parser/Cargo.toml
+++ b/crates/wit-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-parser"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.13.0"
+version = "0.13.1"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"

--- a/crates/wit-smith/Cargo.toml
+++ b/crates/wit-smith/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 name = "wit-smith"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-smith"
-version = "0.1.24"
+version = "0.1.25"
 
 [dependencies]
 arbitrary = { workspace = true, features = ["derive"] }


### PR DESCRIPTION
Release recent work such as:

* Initial support for the GC proposal in validation.
* Updates to exception-handling validation/printing/etc.
* Support for parsing the `linking` custom section.
* Print the name of label targets in wasm-to-text.
* Support for new names in imports in validation of components.

And more!