### PR TITLE
Break wasm-smith's default dependency on wasmparser

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,6 +119,11 @@ jobs:
       - run: cargo check --no-default-features --features metadata
       - run: cargo check --no-default-features --features wit-smith
       - run: cargo check --no-default-features --features addr2line
+      - run: |
+          if cargo tree -p wasm-smith --no-default-features -e no-dev | grep wasmparser; then
+            echo wasm-smith without default features should not depend on wasmparser
+            exit 1
+          fi
 
   doc:
     runs-on: ubuntu-latest

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -24,7 +24,7 @@ indexmap = { workspace = true }
 leb128 = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
-wasm-encoder = { workspace = true, features = ['wasmparser'] }
+wasm-encoder = { workspace = true }
 wasmparser = { workspace = true, optional = true }
 wat = { workspace = true, optional = true }
 
@@ -40,3 +40,4 @@ libfuzzer-sys = { workspace = true }
 
 [features]
 _internal_cli = ["anyhow", "clap", "flagset/serde", "serde", "serde_derive", "wasmparser", "wat"]
+wasmparser = ['dep:wasmparser', 'wasm-encoder/wasmparser']


### PR DESCRIPTION
This fixes a mistake introduced in #1330 which accidentally undid #1301.

Closes #1383