### PR TITLE
`wast`: Fix pointer provenance bug reported by MIRI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2232,6 +2232,7 @@ name = "wast"
 version = "70.0.1"
 dependencies = [
  "anyhow",
+ "bumpalo",
  "leb128",
  "memchr",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ repository = "https://github.com/bytecodealliance/wasm-tools"
 readme = "README.md"
 exclude = ['tests/wabt', 'tests/testsuite', 'tests/snapshots', 'ci']
 
+[lints]
+workspace = true
+
 [workspace]
 members = [
   'crates/c-api',
@@ -20,6 +23,12 @@ members = [
   'fuzz',
   'crates/wit-parser/fuzz',
 ]
+
+[workspace.lints.rust]
+unsafe_code = "deny"
+
+[workspace.lints.clippy]
+all = "allow"
 
 [workspace.package]
 edition = '2021'

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -17,6 +17,9 @@ doc = false
 test = false
 doctest = false
 
+[lints]
+workspace = true
+
 [dependencies]
 arbitrary = { workspace = true, features = ["derive"] }
 wasm-mutate = { workspace = true }

--- a/crates/c-api/src/lib.rs
+++ b/crates/c-api/src/lib.rs
@@ -5,7 +5,6 @@
 //! files of the `include` directory for this crate.
 
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
-
 // This crate fundamentally is doing a lot of unsafe FFI and stuff like that, so
 // it doesn't make sense to allow each individual unsafe block.
 #![allow(unsafe_code)]

--- a/crates/c-api/src/lib.rs
+++ b/crates/c-api/src/lib.rs
@@ -6,6 +6,10 @@
 
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 
+// This crate fundamentally is doing a lot of unsafe FFI and stuff like that, so
+// it doesn't make sense to allow each individual unsafe block.
+#![allow(unsafe_code)]
+
 use arbitrary::{Error, Unstructured};
 use wasm_smith::{Config, Module};
 

--- a/crates/fuzz-stats/Cargo.toml
+++ b/crates/fuzz-stats/Cargo.toml
@@ -12,6 +12,9 @@ rand = { workspace = true }
 wasm-smith = { workspace = true }
 wasmtime = { workspace = true }
 
+[lints]
+workspace = true
+
 [lib]
 doctest = false
 test = false

--- a/crates/wasm-compose/Cargo.toml
+++ b/crates/wasm-compose/Cargo.toml
@@ -10,6 +10,9 @@ homepage = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm
 documentation = "https://docs.rs/wasm-compose"
 description = "A library for composing WebAssembly components."
 
+[lints]
+workspace = true
+
 [dependencies]
 wat = { workspace = true }
 wasm-encoder = { workspace = true, features = ['wasmparser'] }

--- a/crates/wasm-encoder/Cargo.toml
+++ b/crates/wasm-encoder/Cargo.toml
@@ -12,6 +12,9 @@ description = """
 A low-level WebAssembly encoder.
 """
 
+[lints]
+workspace = true
+
 [dependencies]
 leb128 = { workspace = true }
 

--- a/crates/wasm-metadata/Cargo.toml
+++ b/crates/wasm-metadata/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-metadata"
 description = "Read and manipulate WebAssembly metadata"
 
+[lints]
+workspace = true
+
 [dependencies]
 clap = { workspace = true, optional = true }
 anyhow = { workspace = true }

--- a/crates/wasm-mutate-stats/Cargo.toml
+++ b/crates/wasm-mutate-stats/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 arbitrary = { workspace = true }

--- a/crates/wasm-mutate/Cargo.toml
+++ b/crates/wasm-mutate/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-mutate"
 description = "A WebAssembly test case mutator"
 
+[lints]
+workspace = true
+
 [dependencies]
 clap = { workspace = true, optional = true }
 thiserror = "1.0.28"

--- a/crates/wasm-shrink/Cargo.toml
+++ b/crates/wasm-shrink/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wa
 name = "wasm-shrink"
 version = "0.1.46"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 blake3 = "1.2.0"

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -15,6 +15,9 @@ exclude = ["/benches/corpus"]
 name = "corpus"
 harness = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true, optional = true }
 arbitrary = { workspace = true, features = ["derive"] }

--- a/crates/wasm-smith/src/lib.rs
+++ b/crates/wasm-smith/src/lib.rs
@@ -108,10 +108,7 @@ pub(crate) fn limited_str<'a>(max_size: usize, u: &mut Unstructured<'a>) -> Resu
         Err(e) => {
             let i = e.valid_up_to();
             let valid = u.bytes(i).unwrap();
-            let s = unsafe {
-                debug_assert!(str::from_utf8(valid).is_ok());
-                str::from_utf8_unchecked(valid)
-            };
+            let s = str::from_utf8(valid).unwrap();
             Ok(s)
         }
     }

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -12,6 +12,9 @@ A simple event-driven library for parsing WebAssembly binary files.
 edition.workspace = true
 exclude = ["benches/*.wasm"]
 
+[lints]
+workspace = true
+
 [dependencies]
 bitflags = "2.4.1"
 indexmap = { workspace = true }

--- a/crates/wasmparser/src/validator/names.rs
+++ b/crates/wasmparser/src/validator/names.rs
@@ -36,7 +36,10 @@ impl KebabStr {
     pub(crate) fn new_unchecked<'a>(s: impl AsRef<str> + 'a) -> &'a Self {
         // Safety: `KebabStr` is a transparent wrapper around `str`
         // Therefore transmuting `&str` to `&KebabStr` is safe.
-        unsafe { std::mem::transmute::<_, &Self>(s.as_ref()) }
+        #[allow(unsafe_code)]
+        unsafe {
+            std::mem::transmute::<_, &Self>(s.as_ref())
+        }
     }
 
     /// Gets the underlying string slice.

--- a/crates/wasmprinter/Cargo.toml
+++ b/crates/wasmprinter/Cargo.toml
@@ -12,6 +12,9 @@ description = """
 Rust converter from the WebAssembly binary format to the text format.
 """
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 wasmparser = { workspace = true }

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -12,6 +12,9 @@ description = """
 Customizable Rust parsers for the WebAssembly Text formats WAT and WAST
 """
 
+[lints]
+workspace = true
+
 [dependencies]
 leb128 = { workspace = true }
 unicode-width = "0.1.9"

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -17,6 +17,7 @@ leb128 = { workspace = true }
 unicode-width = "0.1.9"
 memchr = "2.4.1"
 wasm-encoder = { workspace = true }
+bumpalo = "3.14.0"
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/wast/src/parser.rs
+++ b/crates/wast/src/parser.rs
@@ -396,9 +396,9 @@ impl ParseBuffer<'_> {
     /// This will return a reference to `s`, but one that's safely rooted in the
     /// `Parser`.
     fn push_str(&self, s: Vec<u8>) -> &[u8] {
-        let s = Box::from(s);
-        let ret = &*s as *const [u8];
-        self.strings.borrow_mut().push(s);
+        let mut strings = self.strings.borrow_mut();
+        strings.push(Box::from(s));
+        let ret = &**strings.last().unwrap() as *const [u8];
         // This should be safe in that the address of `ret` isn't changing as
         // it's on the heap itself. Additionally the lifetime of this return
         // value is tied to the lifetime of `self` (nothing is deallocated

--- a/crates/wast/src/parser.rs
+++ b/crates/wast/src/parser.rs
@@ -65,6 +65,7 @@
 use crate::lexer::{Float, Integer, Lexer, Token, TokenKind};
 use crate::token::Span;
 use crate::Error;
+use bumpalo::Bump;
 use std::borrow::Cow;
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
@@ -303,7 +304,7 @@ pub struct ParseBuffer<'a> {
     cur: Cell<Position>,
     known_annotations: RefCell<HashMap<String, usize>>,
     depth: Cell<usize>,
-    strings: RefCell<Vec<Box<[u8]>>>,
+    strings: Bump,
 }
 
 /// The current position within a `Lexer` that we're at. This simultaneously
@@ -396,14 +397,7 @@ impl ParseBuffer<'_> {
     /// This will return a reference to `s`, but one that's safely rooted in the
     /// `Parser`.
     fn push_str(&self, s: Vec<u8>) -> &[u8] {
-        let mut strings = self.strings.borrow_mut();
-        strings.push(Box::from(s));
-        let ret = &**strings.last().unwrap() as *const [u8];
-        // This should be safe in that the address of `ret` isn't changing as
-        // it's on the heap itself. Additionally the lifetime of this return
-        // value is tied to the lifetime of `self` (nothing is deallocated
-        // early), so it should be safe to say the two have the same lifetime.
-        unsafe { &*ret }
+        self.strings.alloc_slice_copy(&s)
     }
 
     /// Lexes the next "significant" token from the `pos` specified.

--- a/crates/wat/Cargo.toml
+++ b/crates/wat/Cargo.toml
@@ -12,5 +12,8 @@ description = """
 Rust parser for the WebAssembly Text format, WAT
 """
 
+[lints]
+workspace = true
+
 [dependencies]
 wast = { workspace = true }

--- a/crates/wit-component/Cargo.toml
+++ b/crates/wit-component/Cargo.toml
@@ -12,6 +12,9 @@ description = """
 Tooling for working with `*.wit` and component files together.
 """
 
+[lints]
+workspace = true
+
 [dependencies]
 wasmparser = { workspace = true }
 wasm-encoder = { workspace = true }

--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -1150,7 +1150,6 @@ impl Encoder {
 macro_rules! define_encode {
     ($(@$p:ident $op:ident $({ $($arg:ident: $argty:ty),* })? => $visit:ident)*) => {
         $(
-            #[allow(clippy::drop_copy)]
             fn $visit(&mut self $(, $($arg: $argty),*)?)  {
                 #[allow(unused_imports)]
                 use wasm_encoder::Instruction::*;

--- a/crates/wit-parser/Cargo.toml
+++ b/crates/wit-parser/Cargo.toml
@@ -12,6 +12,9 @@ description = """
 Tooling for parsing `*.wit` files and working with their contents.
 """
 
+[lints]
+workspace = true
+
 [dependencies]
 id-arena = "2"
 anyhow = { workspace = true }

--- a/crates/wit-smith/Cargo.toml
+++ b/crates/wit-smith/Cargo.toml
@@ -7,6 +7,9 @@ name = "wit-smith"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-smith"
 version = "0.1.26"
 
+[lints]
+workspace = true
+
 [dependencies]
 arbitrary = { workspace = true, features = ["derive"] }
 wit-component = { workspace = true }


### PR DESCRIPTION
We need to re-derive the str pointer after moving the original `Box<str>` it was derived from.

Thanks to @Robbepop for finding this error!