### PR TITLE
Enable the component model feature by default

### DIFF
--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -372,7 +372,6 @@ impl Default for WasmFeatures {
             exceptions: false,
             memory64: false,
             extended_const: false,
-            component_model: false,
             function_references: false,
             memory_control: false,
             gc: false,
@@ -392,6 +391,7 @@ impl Default for WasmFeatures {
             relaxed_simd: true,
             threads: true,
             multi_memory: true,
+            component_model: true,
         }
     }
 }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -578,6 +578,7 @@ impl TestState {
             match part {
                 "testsuite" => {
                     features = WasmFeatures::default();
+                    features.component_model = false;
 
                     // NB: when these proposals are merged upstream in the spec
                     // repo then this should be removed. Currently this hasn't
@@ -597,6 +598,7 @@ impl TestState {
                     features.bulk_memory = false;
                     features.function_references = false;
                     features.gc = false;
+                    features.component_model = false;
                     features.component_model_values = false;
                 }
                 "floats-disabled.wast" => features.floats = false,


### PR DESCRIPTION
This commit enables the `WasmFeatures::component_model` field by default. This is not a phase 3 proposal in the Wasm CG at this time but this reflects the status of the component model within the WASI CG, however.