### PR TITLE
Add mutations to remove local usage

### DIFF
--- a/crates/wasm-mutate/src/mutators/peephole/rules.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/rules.rs
@@ -598,7 +598,11 @@ impl PeepholeMutator {
             for i in 0..20 {
                 let name = format!("remove-local.set{i}");
                 let lhs = format!("(local.set.{i} ?x)");
-                self.add_rewrite(&mut rules, &name, &lhs, "nop", &[])
+                self.add_rewrite(&mut rules, &name, &lhs, "nop", &[]);
+
+                let name = format!("remove-local.tee{i}");
+                let lhs = format!("(local.tee.{i} ?x)");
+                self.add_rewrite(&mut rules, &name, &lhs, "?x", &[]);
             }
         }
 

--- a/crates/wasm-mutate/src/mutators/peephole/rules.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/rules.rs
@@ -594,6 +594,12 @@ impl PeepholeMutator {
                         if self.is_type("?x", PrimitiveTypeInfo::I64)
                 );
             }
+
+            for i in 0..20 {
+                let name = format!("remove-local.set{i}");
+                let lhs = format!("(local.set.{i} ?x)");
+                self.add_rewrite(&mut rules, &name, &lhs, "nop", &[])
+            }
         }
 
         rules


### PR DESCRIPTION
Won't remove locals just yet but now removal of `local.{set,tee}` can happen.