### PR TITLE
Add a `semver-check` subcommand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ rustc-demangle = { version = "0.1.21", optional = true }
 cpp_demangle = { version = "0.4.0", optional = true }
 
 # Dependencies of `component`
-wit-component = { workspace = true, optional = true, features = ['dummy-module', 'wat'] }
+wit-component = { workspace = true, optional = true, features = ['dummy-module', 'wat', 'semver-check'] }
 wit-parser = { workspace = true, optional = true }
 wast = { workspace = true, optional = true }
 

--- a/crates/wit-component/Cargo.toml
+++ b/crates/wit-component/Cargo.toml
@@ -43,3 +43,4 @@ wasmtime = { workspace = true }
 [features]
 dummy-module = ['dep:wat']
 wat = ['dep:wast', 'dep:wat']
+semver-check = ['dummy-module']

--- a/crates/wit-component/src/lib.rs
+++ b/crates/wit-component/src/lib.rs
@@ -14,7 +14,6 @@ mod encoding;
 mod gc;
 mod linking;
 mod printing;
-mod semver_check;
 mod targets;
 mod validation;
 
@@ -22,7 +21,6 @@ pub use decoding::{decode, decode_reader, DecodedWasm};
 pub use encoding::{encode, ComponentEncoder};
 pub use linking::Linker;
 pub use printing::*;
-pub use semver_check::*;
 pub use targets::*;
 
 pub mod metadata;
@@ -31,6 +29,11 @@ pub mod metadata;
 pub use dummy::dummy_module;
 #[cfg(feature = "dummy-module")]
 mod dummy;
+
+#[cfg(feature = "semver-check")]
+mod semver_check;
+#[cfg(feature = "semver-check")]
+pub use semver_check::*;
 
 /// Supported string encoding formats.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/crates/wit-component/src/lib.rs
+++ b/crates/wit-component/src/lib.rs
@@ -14,6 +14,7 @@ mod encoding;
 mod gc;
 mod linking;
 mod printing;
+mod semver_check;
 mod targets;
 mod validation;
 
@@ -21,6 +22,7 @@ pub use decoding::{decode, decode_reader, DecodedWasm};
 pub use encoding::{encode, ComponentEncoder};
 pub use linking::Linker;
 pub use printing::*;
+pub use semver_check::*;
 pub use targets::*;
 
 pub mod metadata;

--- a/crates/wit-component/src/semver_check.rs
+++ b/crates/wit-component/src/semver_check.rs
@@ -1,0 +1,101 @@
+use crate::{
+    dummy_module, embed_component_metadata, encoding::encode_world, ComponentEncoder,
+    StringEncoding,
+};
+use anyhow::{Context, Result};
+use wasm_encoder::{ComponentBuilder, ComponentExportKind, ComponentTypeRef};
+use wasmparser::{Validator, WasmFeatures};
+use wit_parser::{Resolve, WorldId};
+
+/// Tests whether `new` is a semver-compatible upgrade from the world `prev`.
+///
+/// This function is will test whether a WIT-level semver-compatible predicate
+/// holds. Internally this will ignore all versions associated with packages and
+/// will instead test for structural equality between types and such. For
+/// example `new` is allowed to have more imports and fewer exports, but types
+/// and such must have the exact same structure otherwise (e.g. function params,
+/// record fields, etc).
+//
+// NB: the general implementation strategy here is similar to the `targets`
+// function where components are synthesized and we effectively rely on
+// wasmparser to figure out everything for us. Specifically what happens is:
+//
+// 1. A dummy component representing `prev` is created.
+// 2. A component importing a component of shape `new` is created.
+// 3. The component from (2) is instantiated with the component from (1).
+//
+// If that all type-checks and is valid then the semver compatible predicate
+// holds. Otherwise something has gone wrong.
+//
+// Note that this does not produce great error messages, so this implementation
+// likely wants to be improved in the future.
+pub fn semver_check(mut resolve: Resolve, prev: WorldId, new: WorldId) -> Result<()> {
+    // First up clear out all version information. This is required to ensure
+    // that the strings line up for wasmparser's validation which does exact
+    // string matching.
+    //
+    // This can leave `resolve` in a weird state which is why this function
+    // takes ownership of `resolve`. Specifically the internal maps for package
+    // names won't be updated and additionally this could leave two packages
+    // with the same name (e.g. no version) which would be a bit odd.
+    //
+    // NB: this will probably cause confusing errors below if a world imports
+    // two versions of a package's interfaces. I think that'll result in weird
+    // wasmparser validation errors as there would be two imports of the same
+    // name for example.
+    for (_id, pkg) in resolve.packages.iter_mut() {
+        pkg.name.version = None;
+    }
+
+    // Component that will be validated at the end.
+    let mut root_component = ComponentBuilder::default();
+
+    // (1) above - create a dummy component which has the shape of `prev`.
+    let mut prev_as_module = dummy_module(&resolve, prev);
+    embed_component_metadata(&mut prev_as_module, &resolve, prev, StringEncoding::UTF8)
+        .context("failed to embed component metadata")?;
+    let prev_as_component = ComponentEncoder::default()
+        .module(&prev_as_module)
+        .context("failed to register previous world encoded as a module")?
+        .encode()
+        .context("failed to encode previous world as a component")?;
+    let component_to_test_idx = root_component.component_raw(&prev_as_component);
+
+    // (2) above - create a component which imports a component of the shape of
+    // `new`.
+    let test_component_idx = {
+        let component_ty =
+            encode_world(&resolve, new).context("failed to encode the new world as a type")?;
+        let mut component = ComponentBuilder::default();
+        let component_ty_idx = component.type_component(&component_ty);
+        component.import(
+            &resolve.worlds[new].name,
+            ComponentTypeRef::Component(component_ty_idx),
+        );
+        root_component.component(component)
+    };
+
+    // (3) Instantiate the component from (2) with the component to test from (1).
+    root_component.instantiate(
+        test_component_idx,
+        [(
+            resolve.worlds[new].name.clone(),
+            ComponentExportKind::Component,
+            component_to_test_idx,
+        )],
+    );
+    let bytes = root_component.finish();
+
+    // The final step is validating that this component is indeed valid. If any
+    // error message is produced here an attempt is made to make it more
+    // understandable but there's only but so good these errors can be with this
+    // strategy.
+    Validator::new_with_features(WasmFeatures {
+        component_model: true,
+        ..Default::default()
+    })
+    .validate_all(&bytes)
+    .context("new world is not semver-compatible with the previous world")?;
+
+    Ok(())
+}

--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -22,6 +22,7 @@ pub enum Opts {
     Embed(EmbedOpts),
     Targets(TargetsOpts),
     Link(LinkOpts),
+    SemverCheck(SemverCheckOpts),
 }
 
 impl Opts {
@@ -32,6 +33,7 @@ impl Opts {
             Opts::Embed(embed) => embed.run(),
             Opts::Targets(targets) => targets.run(),
             Opts::Link(link) => link.run(),
+            Opts::SemverCheck(s) => s.run(),
         }
     }
 
@@ -42,6 +44,7 @@ impl Opts {
             Opts::Embed(embed) => embed.general_opts(),
             Opts::Targets(targets) => targets.general_opts(),
             Opts::Link(link) => link.general_opts(),
+            Opts::SemverCheck(s) => s.general_opts(),
         }
     }
 }
@@ -658,6 +661,48 @@ impl TargetsOpts {
 
         wit_component::targets(&resolve, world, &component_to_test)?;
 
+        Ok(())
+    }
+}
+
+/// Tool for verifying whether one world is a semver compatible evolution of
+/// another.
+#[derive(Parser)]
+pub struct SemverCheckOpts {
+    #[clap(flatten)]
+    general: wasm_tools::GeneralOpts,
+
+    /// The WIT package containing the `prev` and `new` worlds used in
+    /// arguments.
+    ///
+    /// This can either be a directory, a path to a single `*.wit` file, or a
+    /// path to a wasm-encoded WIT package.
+    wit: PathBuf,
+
+    /// The "previous" world, or older version, of what's being tested.
+    ///
+    /// This is considered the baseline for the semver compatibility check.
+    #[clap(long)]
+    prev: String,
+
+    /// The "new" world which is the "prev" world but modified.
+    ///
+    /// This is what's being tested to see whether it is a backwards-compatible
+    /// evolution of the "prev" world specified.
+    #[clap(long)]
+    new: String,
+}
+
+impl SemverCheckOpts {
+    fn general_opts(&self) -> &wasm_tools::GeneralOpts {
+        &self.general
+    }
+
+    fn run(self) -> Result<()> {
+        let (resolve, package_id) = parse_wit_from_path(&self.wit)?;
+        let prev = resolve.select_world(package_id, Some(&self.prev))?;
+        let new = resolve.select_world(package_id, Some(&self.new))?;
+        wit_component::semver_check(resolve, prev, new)?;
         Ok(())
     }
 }

--- a/tests/cli/semver-check-add-export.wit
+++ b/tests/cli/semver-check-add-export.wit
@@ -1,0 +1,10 @@
+// FAIL: component semver-check % --prev prev --new new
+
+package a:b;
+
+world prev {
+}
+
+world new {
+  export a: func();
+}

--- a/tests/cli/semver-check-add-export.wit.stderr
+++ b/tests/cli/semver-check-add-export.wit.stderr
@@ -1,0 +1,5 @@
+error: new world is not semver-compatible with the previous world
+
+Caused by:
+    0: type mismatch for import `new`
+       missing export named `a` (at offset 0xff)

--- a/tests/cli/semver-check-add-imports.wit
+++ b/tests/cli/semver-check-add-imports.wit
@@ -1,0 +1,15 @@
+// RUN: component semver-check % --prev prev --new new
+
+package a:b;
+
+world prev {}
+
+interface new-interface {
+
+}
+
+world new {
+  import a: func();
+  import b: interface {}
+  import new-interface;
+}

--- a/tests/cli/semver-check-bump-version-add-function.wat
+++ b/tests/cli/semver-check-bump-version-add-function.wat
@@ -1,0 +1,23 @@
+;; RUN: component semver-check % --prev prev --new new
+
+(component
+  (type $prev (component
+    (export "a:b/prev" (component
+      (import "a:a/a@1.0.0" (instance
+        (export "f" (func))
+      ))
+    ))
+  ))
+  (export "prev" (type $prev))
+
+  (type $new (component
+    (export "a:b/new" (component
+      (import "a:a/a@1.0.1" (instance
+        (export "f" (func))
+        (export "f2" (func))
+      ))
+    ))
+  ))
+  (export "new" (type $new))
+)
+

--- a/tests/cli/semver-check-bump-version.wat
+++ b/tests/cli/semver-check-bump-version.wat
@@ -1,0 +1,21 @@
+;; RUN: component semver-check % --prev prev --new new
+
+(component
+  (type $prev (component
+    (export "a:b/prev" (component
+      (import "a:a/a@1.0.0" (instance
+        (export "f" (func))
+      ))
+    ))
+  ))
+  (export "prev" (type $prev))
+
+  (type $new (component
+    (export "a:b/new" (component
+      (import "a:a/a@1.0.1" (instance
+        (export "f" (func))
+      ))
+    ))
+  ))
+  (export "new" (type $new))
+)

--- a/tests/cli/semver-check-empty.wit
+++ b/tests/cli/semver-check-empty.wit
@@ -1,0 +1,7 @@
+// RUN: component semver-check % --prev prev --new new
+
+package a:b;
+
+world prev {}
+
+world new {}

--- a/tests/cli/semver-check-remove-exports.wit
+++ b/tests/cli/semver-check-remove-exports.wit
@@ -1,0 +1,13 @@
+// RUN: component semver-check % --prev prev --new new
+
+package a:b;
+
+interface new-interface {}
+
+world prev {
+  export a: func();
+  export b: interface {}
+  export new-interface;
+}
+
+world new {}

--- a/tests/cli/semver-check-remove-import.wit
+++ b/tests/cli/semver-check-remove-import.wit
@@ -1,0 +1,10 @@
+// FAIL: component semver-check % --prev prev --new new
+
+package a:b;
+
+world prev {
+  import a: func();
+}
+
+world new {
+}

--- a/tests/cli/semver-check-remove-import.wit.stderr
+++ b/tests/cli/semver-check-remove-import.wit.stderr
@@ -1,0 +1,5 @@
+error: new world is not semver-compatible with the previous world
+
+Caused by:
+    0: type mismatch for import `new`
+       missing import named `a` (at offset 0x128)


### PR DESCRIPTION
This issue is intended to address #1399. The assumption is that this will be used by WASI repositories (eventually) to ensure that the current `main` branch of the repository is semver-compatible with the last release of the repository.

This commit adds a new subcommand which looks like:

    wasm-tools component semver-check ./wit --prev old-world --new new-world

This will check that `new-world` is a semver-compatible evolution of `new-world`. Internally this works the same way as the `targets` subcommand where a component is synthesized on-the-fly which is then fed to `wasmparser` for validation to determine whether it's valid or not. Specifically a component of shape `old-world` is fed into an import of shape `new-world`, effectively answering the question of whether a component taking the "old" world can be instantiated with the "new" world.

Some basic CLI tests are added here as well showcasing various bits and bobs. Some further tooling will be needed to actually integrate this into WASI repositories but this should be at least one chunk of the necessary work.

Closes #1399