### PR TITLE
Bump crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
 name = "wasm-compose"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "glob",
@@ -1702,9 +1702,9 @@ dependencies = [
  "serde_derive",
  "serde_yaml",
  "smallvec",
- "wasm-encoder 0.41.1",
- "wasmparser 0.121.1",
- "wasmprinter 0.2.79",
+ "wasm-encoder 0.41.2",
+ "wasmparser 0.121.2",
+ "wasmprinter 0.2.80",
  "wat",
  "wit-component",
 ]
@@ -1720,17 +1720,17 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.41.1"
+version = "0.41.2"
 dependencies = [
  "anyhow",
  "leb128",
  "tempfile",
- "wasmparser 0.121.1",
+ "wasmparser 0.121.2",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.10.18"
+version = "0.10.19"
 dependencies = [
  "anyhow",
  "clap 4.4.18",
@@ -1739,14 +1739,14 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder 0.41.1",
- "wasmparser 0.121.1",
+ "wasm-encoder 0.41.2",
+ "wasmparser 0.121.2",
  "wat",
 ]
 
 [[package]]
 name = "wasm-mutate"
-version = "0.2.47"
+version = "0.2.48"
 dependencies = [
  "anyhow",
  "clap 4.4.18",
@@ -1755,9 +1755,9 @@ dependencies = [
  "log",
  "rand",
  "thiserror",
- "wasm-encoder 0.41.1",
- "wasmparser 0.121.1",
- "wasmprinter 0.2.79",
+ "wasm-encoder 0.41.2",
+ "wasmparser 0.121.2",
+ "wasmprinter 0.2.80",
  "wat",
 ]
 
@@ -1774,14 +1774,14 @@ dependencies = [
  "num_cpus",
  "rand",
  "wasm-mutate",
- "wasmparser 0.121.1",
- "wasmprinter 0.2.79",
+ "wasmparser 0.121.2",
+ "wasmprinter 0.2.80",
  "wasmtime",
 ]
 
 [[package]]
 name = "wasm-shrink"
-version = "0.1.48"
+version = "0.1.49"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1790,14 +1790,14 @@ dependencies = [
  "log",
  "rand",
  "wasm-mutate",
- "wasmparser 0.121.1",
- "wasmprinter 0.2.79",
+ "wasmparser 0.121.2",
+ "wasmprinter 0.2.80",
  "wat",
 ]
 
 [[package]]
 name = "wasm-smith"
-version = "0.15.2"
+version = "0.16.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -1810,15 +1810,15 @@ dependencies = [
  "rand",
  "serde",
  "serde_derive",
- "wasm-encoder 0.41.1",
- "wasmparser 0.121.1",
- "wasmprinter 0.2.79",
+ "wasm-encoder 0.41.2",
+ "wasmparser 0.121.2",
+ "wasmprinter 0.2.80",
  "wat",
 ]
 
 [[package]]
 name = "wasm-tools"
-version = "1.0.58"
+version = "1.0.59"
 dependencies = [
  "addr2line 0.21.0",
  "anyhow",
@@ -1841,13 +1841,13 @@ dependencies = [
  "tempfile",
  "termcolor",
  "wasm-compose",
- "wasm-encoder 0.41.1",
+ "wasm-encoder 0.41.2",
  "wasm-metadata",
  "wasm-mutate",
  "wasm-shrink",
  "wasm-smith",
- "wasmparser 0.121.1",
- "wasmprinter 0.2.79",
+ "wasmparser 0.121.2",
+ "wasmprinter 0.2.80",
  "wast",
  "wat",
  "wit-component",
@@ -1863,8 +1863,8 @@ dependencies = [
  "wasm-mutate",
  "wasm-shrink",
  "wasm-smith",
- "wasmparser 0.121.1",
- "wasmprinter 0.2.79",
+ "wasmparser 0.121.2",
+ "wasmprinter 0.2.80",
  "wast",
  "wat",
 ]
@@ -1879,11 +1879,11 @@ dependencies = [
  "libfuzzer-sys",
  "log",
  "tempfile",
- "wasm-encoder 0.41.1",
+ "wasm-encoder 0.41.2",
  "wasm-mutate",
  "wasm-smith",
- "wasmparser 0.121.1",
- "wasmprinter 0.2.79",
+ "wasmparser 0.121.2",
+ "wasmprinter 0.2.80",
  "wasmtime",
  "wast",
  "wat",
@@ -1915,7 +1915,7 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.121.1"
+version = "0.121.2"
 dependencies = [
  "anyhow",
  "bitflags 2.4.2",
@@ -1926,7 +1926,7 @@ dependencies = [
  "once_cell",
  "rayon",
  "semver",
- "wasm-encoder 0.41.1",
+ "wasm-encoder 0.41.2",
  "wast",
  "wat",
 ]
@@ -1943,13 +1943,13 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.2.79"
+version = "0.2.80"
 dependencies = [
  "anyhow",
  "diff",
  "rayon",
  "tempfile",
- "wasmparser 0.121.1",
+ "wasmparser 0.121.2",
  "wast",
  "wat",
 ]
@@ -2207,7 +2207,7 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "71.0.0"
+version = "71.0.1"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -2215,14 +2215,14 @@ dependencies = [
  "memchr",
  "rayon",
  "unicode-width",
- "wasm-encoder 0.41.1",
- "wasmparser 0.121.1",
+ "wasm-encoder 0.41.2",
+ "wasmparser 0.121.2",
  "wat",
 ]
 
 [[package]]
 name = "wat"
-version = "1.0.86"
+version = "1.0.87"
 dependencies = [
  "wast",
 ]
@@ -2418,7 +2418,7 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "wit-component"
-version = "0.20.2"
+version = "0.20.3"
 dependencies = [
  "anyhow",
  "bitflags 2.4.2",
@@ -2430,10 +2430,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.41.1",
+ "wasm-encoder 0.41.2",
  "wasm-metadata",
- "wasmparser 0.121.1",
- "wasmprinter 0.2.79",
+ "wasmparser 0.121.2",
+ "wasmprinter 0.2.80",
  "wasmtime",
  "wast",
  "wat",
@@ -2482,13 +2482,13 @@ dependencies = [
  "env_logger",
  "libfuzzer-sys",
  "log",
- "wasmprinter 0.2.79",
+ "wasmprinter 0.2.80",
  "wit-parser 0.13.2",
 ]
 
 [[package]]
 name = "wit-smith"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "arbitrary",
  "clap 4.4.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-tools"
-version = "1.0.58"
+version = "1.0.59"
 authors = ["The Wasmtime Project Developers"]
 edition.workspace = true
 description = "CLI tools for interoperating with WebAssembly files"
@@ -56,19 +56,19 @@ pretty_assertions = "1.3.0"
 semver = "1.0.0"
 smallvec = "1.11.1"
 
-wasm-compose = { version = "0.5.3", path = "crates/wasm-compose" }
-wasm-encoder = { version = "0.41.1", path = "crates/wasm-encoder" }
-wasm-metadata = { version = "0.10.18", path = "crates/wasm-metadata" }
-wasm-mutate = { version = "0.2.47", path = "crates/wasm-mutate" }
-wasm-shrink = { version = "0.1.48", path = "crates/wasm-shrink" }
-wasm-smith = { version = "0.15.2", path = "crates/wasm-smith" }
-wasmparser = { version = "0.121.1", path = "crates/wasmparser" }
-wasmprinter = { version = "0.2.79", path = "crates/wasmprinter" }
-wast = { version = "71.0.0", path = "crates/wast" }
-wat = { version = "1.0.86", path = "crates/wat" }
-wit-component = { version = "0.20.2", path = "crates/wit-component" }
+wasm-compose = { version = "0.5.4", path = "crates/wasm-compose" }
+wasm-encoder = { version = "0.41.2", path = "crates/wasm-encoder" }
+wasm-metadata = { version = "0.10.19", path = "crates/wasm-metadata" }
+wasm-mutate = { version = "0.2.48", path = "crates/wasm-mutate" }
+wasm-shrink = { version = "0.1.49", path = "crates/wasm-shrink" }
+wasm-smith = { version = "0.16.0", path = "crates/wasm-smith" }
+wasmparser = { version = "0.121.2", path = "crates/wasmparser" }
+wasmprinter = { version = "0.2.80", path = "crates/wasmprinter" }
+wast = { version = "71.0.1", path = "crates/wast" }
+wat = { version = "1.0.87", path = "crates/wat" }
+wit-component = { version = "0.20.3", path = "crates/wit-component" }
 wit-parser = { version = "0.13.2", path = "crates/wit-parser" }
-wit-smith = { version = "0.1.28", path = "crates/wit-smith" }
+wit-smith = { version = "0.1.29", path = "crates/wit-smith" }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/wasm-compose/Cargo.toml
+++ b/crates/wasm-compose/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-compose"
-version = "0.5.3"
+version = "0.5.4"
 edition.workspace = true
 authors = ["Peter Huene <peter@huene.dev>"]
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasm-encoder/Cargo.toml
+++ b/crates/wasm-encoder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-encoder"
-version = "0.41.1"
+version = "0.41.2"
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasm-metadata/Cargo.toml
+++ b/crates/wasm-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-metadata"
-version = "0.10.18"
+version = "0.10.19"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-metadata"

--- a/crates/wasm-mutate/Cargo.toml
+++ b/crates/wasm-mutate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-mutate"
-version = "0.2.47"
+version = "0.2.48"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-mutate"

--- a/crates/wasm-shrink/Cargo.toml
+++ b/crates/wasm-shrink/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-shrink"
 name = "wasm-shrink"
-version = "0.1.48"
+version = "0.1.49"
 
 [lints]
 workspace = true

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "wasm-smith"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-smith"
-version = "0.15.2"
+version = "0.16.0"
 exclude = ["/benches/corpus"]
 
 [[bench]]

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmparser"
-version = "0.121.1"
+version = "0.121.2"
 authors = ["Yury Delendik <ydelendik@mozilla.com>"]
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser"

--- a/crates/wasmprinter/Cargo.toml
+++ b/crates/wasmprinter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmprinter"
-version = "0.2.79"
+version = "0.2.80"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wast"
-version = "71.0.0"
+version = "71.0.1"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wat/Cargo.toml
+++ b/crates/wat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wat"
-version = "1.0.86"
+version = "1.0.87"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wit-component/Cargo.toml
+++ b/crates/wit-component/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-component"
 authors = ["Peter Huene <peter@huene.dev>"]
-version = "0.20.2"
+version = "0.20.3"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"

--- a/crates/wit-smith/Cargo.toml
+++ b/crates/wit-smith/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 name = "wit-smith"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-smith"
-version = "0.1.28"
+version = "0.1.29"
 
 [lints]
 workspace = true


### PR DESCRIPTION
Getting #1412 on crates.io both on the `main` branch as well as the historical branch.