### PR TITLE
Bump crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,7 +1688,7 @@ checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
 name = "wasm-compose"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "anyhow",
  "glob",
@@ -1730,7 +1730,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.10.19"
+version = "0.10.20"
 dependencies = [
  "anyhow",
  "clap 4.4.18",
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-smith"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -1818,7 +1818,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-tools"
-version = "1.0.59"
+version = "1.0.60"
 dependencies = [
  "addr2line 0.21.0",
  "anyhow",
@@ -1851,7 +1851,7 @@ dependencies = [
  "wast",
  "wat",
  "wit-component",
- "wit-parser 0.13.2",
+ "wit-parser 0.14.0",
  "wit-smith",
 ]
 
@@ -1888,7 +1888,7 @@ dependencies = [
  "wast",
  "wat",
  "wit-component",
- "wit-parser 0.13.2",
+ "wit-parser 0.14.0",
  "wit-smith",
 ]
 
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.87"
+version = "1.0.88"
 dependencies = [
  "wast",
 ]
@@ -2418,7 +2418,7 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "wit-component"
-version = "0.20.3"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "bitflags 2.4.2",
@@ -2437,7 +2437,7 @@ dependencies = [
  "wasmtime",
  "wast",
  "wat",
- "wit-parser 0.13.2",
+ "wit-parser 0.14.0",
 ]
 
 [[package]]
@@ -2458,7 +2458,7 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -2474,7 +2474,7 @@ dependencies = [
  "unicode-xid",
  "wasmparser 0.121.2",
  "wat",
- "wit-parser 0.13.2",
+ "wit-parser 0.14.0",
 ]
 
 [[package]]
@@ -2486,12 +2486,12 @@ dependencies = [
  "libfuzzer-sys",
  "log",
  "wasmprinter 0.2.80",
- "wit-parser 0.13.2",
+ "wit-parser 0.14.0",
 ]
 
 [[package]]
 name = "wit-smith"
-version = "0.1.29"
+version = "0.1.30"
 dependencies = [
  "arbitrary",
  "clap 4.4.18",
@@ -2499,7 +2499,7 @@ dependencies = [
  "log",
  "semver",
  "wit-component",
- "wit-parser 0.13.2",
+ "wit-parser 0.14.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-tools"
-version = "1.0.59"
+version = "1.0.60"
 authors = ["The Wasmtime Project Developers"]
 edition.workspace = true
 description = "CLI tools for interoperating with WebAssembly files"
@@ -56,19 +56,19 @@ pretty_assertions = "1.3.0"
 semver = "1.0.0"
 smallvec = "1.11.1"
 
-wasm-compose = { version = "0.5.4", path = "crates/wasm-compose" }
+wasm-compose = { version = "0.5.5", path = "crates/wasm-compose" }
 wasm-encoder = { version = "0.41.2", path = "crates/wasm-encoder" }
-wasm-metadata = { version = "0.10.19", path = "crates/wasm-metadata" }
+wasm-metadata = { version = "0.10.20", path = "crates/wasm-metadata" }
 wasm-mutate = { version = "0.2.48", path = "crates/wasm-mutate" }
 wasm-shrink = { version = "0.1.49", path = "crates/wasm-shrink" }
-wasm-smith = { version = "0.16.0", path = "crates/wasm-smith" }
+wasm-smith = { version = "0.16.1", path = "crates/wasm-smith" }
 wasmparser = { version = "0.121.2", path = "crates/wasmparser" }
 wasmprinter = { version = "0.2.80", path = "crates/wasmprinter" }
 wast = { version = "71.0.1", path = "crates/wast" }
-wat = { version = "1.0.87", path = "crates/wat" }
-wit-component = { version = "0.20.3", path = "crates/wit-component" }
-wit-parser = { version = "0.13.2", path = "crates/wit-parser" }
-wit-smith = { version = "0.1.29", path = "crates/wit-smith" }
+wat = { version = "1.0.88", path = "crates/wat" }
+wit-component = { version = "0.21.0", path = "crates/wit-component" }
+wit-parser = { version = "0.14.0", path = "crates/wit-parser" }
+wit-smith = { version = "0.1.30", path = "crates/wit-smith" }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/wasm-compose/Cargo.toml
+++ b/crates/wasm-compose/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-compose"
-version = "0.5.4"
+version = "0.5.5"
 edition.workspace = true
 authors = ["Peter Huene <peter@huene.dev>"]
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wasm-metadata/Cargo.toml
+++ b/crates/wasm-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-metadata"
-version = "0.10.19"
+version = "0.10.20"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-metadata"

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "wasm-smith"
 readme = "./README.md"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-smith"
-version = "0.16.0"
+version = "0.16.1"
 exclude = ["/benches/corpus"]
 
 [[bench]]

--- a/crates/wat/Cargo.toml
+++ b/crates/wat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wat"
-version = "1.0.87"
+version = "1.0.88"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"

--- a/crates/wit-component/Cargo.toml
+++ b/crates/wit-component/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-component"
 authors = ["Peter Huene <peter@huene.dev>"]
-version = "0.20.3"
+version = "0.21.0"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"

--- a/crates/wit-parser/Cargo.toml
+++ b/crates/wit-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wit-parser"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
-version = "0.13.2"
+version = "0.14.0"
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"

--- a/crates/wit-smith/Cargo.toml
+++ b/crates/wit-smith/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 name = "wit-smith"
 repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-smith"
-version = "0.1.29"
+version = "0.1.30"
 
 [lints]
 workspace = true


### PR DESCRIPTION
I realize I already bumped earlier today as well but wanted to additionally include #1407 and #1408 for downstream integrations.