### PR TITLE
Remove working tree files for publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,6 +80,7 @@ jobs:
         tag_name: v${{ steps.tag.outputs.version }}
 
     - run: |
+        rm -rf dist main.log
         rustc ci/publish.rs
         ./publish publish
       env:


### PR DESCRIPTION
Avoids an error encountered during publishing where everything published except for `wasm-tools` itself because Cargo was warning about a dirty source tree.