### PR TITLE
Remove text parsing support for let/func.bind

### DIFF
--- a/crates/wast/src/core/binary.rs
+++ b/crates/wast/src/core/binary.rs
@@ -749,19 +749,6 @@ impl Encode for BlockType<'_> {
     }
 }
 
-impl Encode for FuncBindType<'_> {
-    fn encode(&self, e: &mut Vec<u8>) {
-        self.ty.encode(e);
-    }
-}
-
-impl Encode for LetType<'_> {
-    fn encode(&self, e: &mut Vec<u8>) {
-        self.block.encode(e);
-        self.locals.encode(e);
-    }
-}
-
 impl Encode for LaneArg {
     fn encode(&self, e: &mut Vec<u8>) {
         self.lane.encode(e);
@@ -994,8 +981,7 @@ fn find_names<'a>(
                         | Instruction::Block(block)
                         | Instruction::Loop(block)
                         | Instruction::Try(block)
-                        | Instruction::TryTable(TryTable { block, .. })
-                        | Instruction::Let(LetType { block, .. }) => {
+                        | Instruction::TryTable(TryTable { block, .. }) => {
                             if let Some(name) = get_name(&block.label, &block.label_name) {
                                 label_names.push((label_idx, name));
                             }

--- a/crates/wast/src/core/expr.rs
+++ b/crates/wast/src/core/expr.rs
@@ -184,7 +184,6 @@ impl<'a> ExpressionParser<'a> {
                         // seen
                         i @ Instruction::Block(_)
                         | i @ Instruction::Loop(_)
-                        | i @ Instruction::Let(_)
                         | i @ Instruction::TryTable(_) => {
                             self.instrs.push(i);
                             self.stack.push(Level::EndWith(Instruction::End(None)));
@@ -468,8 +467,6 @@ instructions! {
         // function-references proposal
         CallRef(Index<'a>) : [0x14] : "call_ref",
         ReturnCallRef(Index<'a>) : [0x15] : "return_call_ref",
-        FuncBind(FuncBindType<'a>) : [0x16] : "func.bind",
-        Let(LetType<'a>) : [0x17] : "let",
 
         Drop : [0x1a] : "drop",
         Select(SelectTypes<'a>) : [] : "select",
@@ -1215,40 +1212,6 @@ impl<'a> TryTableCatchKind<'a> {
 pub struct TryTableCatch<'a> {
     pub kind: TryTableCatchKind<'a>,
     pub label: Index<'a>,
-}
-
-/// Extra information associated with the func.bind instruction.
-#[derive(Debug)]
-#[allow(missing_docs)]
-pub struct FuncBindType<'a> {
-    pub ty: TypeUse<'a, FunctionType<'a>>,
-}
-
-impl<'a> Parse<'a> for FuncBindType<'a> {
-    fn parse(parser: Parser<'a>) -> Result<Self> {
-        Ok(FuncBindType {
-            ty: parser
-                .parse::<TypeUse<'a, FunctionTypeNoNames<'a>>>()?
-                .into(),
-        })
-    }
-}
-
-/// Extra information associated with the let instruction.
-#[derive(Debug)]
-#[allow(missing_docs)]
-pub struct LetType<'a> {
-    pub block: Box<BlockType<'a>>,
-    pub locals: Box<[Local<'a>]>,
-}
-
-impl<'a> Parse<'a> for LetType<'a> {
-    fn parse(parser: Parser<'a>) -> Result<Self> {
-        Ok(LetType {
-            block: parser.parse()?,
-            locals: Local::parse_remainder(parser)?.into(),
-        })
-    }
 }
 
 /// Extra information associated with the `br_table` instruction.

--- a/crates/wast/src/core/resolve/names.rs
+++ b/crates/wast/src/core/resolve/names.rs
@@ -490,30 +490,6 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
                 self.resolver.resolve(i, Ns::Type)?;
             }
 
-            FuncBind(b) => {
-                self.resolver.resolve_type_use(&mut b.ty)?;
-            }
-
-            Let(t) => {
-                // Resolve (ref T) in locals
-                for local in t.locals.iter_mut() {
-                    self.resolver.resolve_valtype(&mut local.ty)?;
-                }
-
-                // Register all locals defined in this let
-                let mut scope = Namespace::default();
-                for local in t.locals.iter() {
-                    scope.register(local.id, "local")?;
-                }
-                self.scopes.push(scope);
-                self.blocks.push(ExprBlock {
-                    label: t.block.label,
-                    pushed_scope: true,
-                });
-
-                self.resolve_block_type(&mut t.block)?;
-            }
-
             Block(bt) | If(bt) | Loop(bt) | Try(bt) => {
                 self.blocks.push(ExprBlock {
                     label: bt.label,

--- a/crates/wast/src/core/resolve/types.rs
+++ b/crates/wast/src/core/resolve/types.rs
@@ -139,7 +139,6 @@ impl<'a> Expander<'a> {
             Instruction::Block(bt)
             | Instruction::If(bt)
             | Instruction::Loop(bt)
-            | Instruction::Let(LetType { block: bt, .. })
             | Instruction::Try(bt)
             | Instruction::TryTable(TryTable { block: bt, .. }) => {
                 // No expansion necessary, a type reference is already here.
@@ -173,9 +172,6 @@ impl<'a> Expander<'a> {
                     }
                 }
                 self.expand_type_use(&mut bt.ty);
-            }
-            Instruction::FuncBind(b) => {
-                self.expand_type_use(&mut b.ty);
             }
             Instruction::CallIndirect(c) | Instruction::ReturnCallIndirect(c) => {
                 self.expand_type_use(&mut c.ty);

--- a/tests/local/function-references/let-bad.wast
+++ b/tests/local/function-references/let-bad.wast
@@ -1,5 +1,0 @@
-(assert_invalid
-  (module
-    (func let)
-  )
-  "illegal opcode: 0x17")

--- a/tests/local/invalid-let.wast
+++ b/tests/local/invalid-let.wast
@@ -1,9 +1,0 @@
-(assert_invalid
-  (module
-    (func
-      let
-      else
-      else
-      local.get 1
-      ))
-  "illegal opcode: 0x17") ;; update this error once wasmparser is updated


### PR DESCRIPTION
These are historical vestiges of revisions of the function-references proposal I believe, and I'm not aware of any current proposals using these, so remove them.