### PR TITLE
Add support for using symlink for dependency dir in the `deps` dir

### DIFF
--- a/crates/wit-parser/src/resolve.rs
+++ b/crates/wit-parser/src/resolve.rs
@@ -236,10 +236,11 @@ impl Resolve {
         for dep in entries {
             let path = dep.path();
 
-            let pkg = if dep.file_type()?.is_dir() {
-                // If this entry is a directory then always parse it as an
-                // `UnresolvedPackage` since it's intentional to not support
-                // recursive `deps` directories.
+            let pkg = if dep.file_type()?.is_dir() || path.metadata()?.is_dir() {
+                // If this entry is a directory or a symlink point to a
+                // directory then always parse it as an `UnresolvedPackage`
+                // since it's intentional to not support recursive `deps`
+                // directories.
                 UnresolvedPackage::parse_dir(&path)
                     .with_context(|| format!("failed to parse package: {}", path.display()))?
             } else {


### PR DESCRIPTION
Using a symlink as a dependency directory in the `deps` directory will result in "package not found", which is confusing and there is no reason not to support it.
This patch fixes this behavior to provide a better experience for tools using the `wit-parser` crate.