### PR TITLE
Make self argument for guest exported resources a Pointer (rep)

### DIFF
--- a/crates/wit-parser/src/abi.rs
+++ b/crates/wit-parser/src/abi.rs
@@ -1,5 +1,3 @@
-use std::assert_matches::assert_matches;
-
 use crate::{Function, Handle, Int, Resolve, Type, TypeDefKind};
 
 /// A core WebAssembly signature with params and results.
@@ -162,7 +160,7 @@ impl Resolve {
                 // But this contextual information isn't available, yet.
                 // See https://github.com/bytecodealliance/wasm-tools/pull/1438 for more details.
                 params.get_mut(0).map(|p| {
-                    assert_matches!(p, &WasmType::I32);
+                    assert!(matches!(*p, WasmType::I32));
                     *p = WasmType::Pointer;
                 });
             }

--- a/crates/wit-parser/src/abi.rs
+++ b/crates/wit-parser/src/abi.rs
@@ -159,10 +159,8 @@ impl Resolve {
                 // resource Handles and then use either I32 or Pointer in abi::push_flat().
                 // But this contextual information isn't available, yet.
                 // See https://github.com/bytecodealliance/wasm-tools/pull/1438 for more details.
-                params.get_mut(0).map(|p| {
-                    assert!(matches!(*p, WasmType::I32));
-                    *p = WasmType::Pointer;
-                });
+                assert!(matches!(p[0], WasmType::I32));
+                p[0] = WasmType::Pointer;
             }
         }
 

--- a/crates/wit-parser/src/abi.rs
+++ b/crates/wit-parser/src/abi.rs
@@ -159,8 +159,8 @@ impl Resolve {
                 // resource Handles and then use either I32 or Pointer in abi::push_flat().
                 // But this contextual information isn't available, yet.
                 // See https://github.com/bytecodealliance/wasm-tools/pull/1438 for more details.
-                assert!(matches!(p[0], WasmType::I32));
-                p[0] = WasmType::Pointer;
+                assert!(matches!(params[0], WasmType::I32));
+                params[0] = WasmType::Pointer;
             }
         }
 

--- a/crates/wit-parser/src/abi.rs
+++ b/crates/wit-parser/src/abi.rs
@@ -148,6 +148,14 @@ impl Resolve {
             params.truncate(0);
             params.push(WasmType::Pointer);
             indirect_params = true;
+        } else {
+            if matches!(
+                (&func.kind, variant),
+                (crate::FunctionKind::Method(_), AbiVariant::GuestExport)
+            ) {
+                // guest exported methods receive resource rep as first argument
+                params.get_mut(0).map(|p| *p = WasmType::Pointer);
+            }
         }
 
         let mut results = Vec::new();


### PR DESCRIPTION
This solution feels inelegant, ideally you would distinguish between imported and exported resource Handles and then use either I32 or Pointer in abi::push_flat().

But it clearly fixes the problem of the self argument in respect to that rep is 64 bit on wasm64 (and potential native uses).

Apart from removing the related casting in https://github.com/bytecodealliance/wit-bindgen/blob/main/crates/rust/src/bindgen.rs#L444 and some linker symbol changes in wit-bindgen this is all which is needed to enable native (e.g. x86_64) WIT interfaces.

See https://github.com/bytecodealliance/wit-bindgen/blob/73e5c68d88714e5073bfa93836f8dd6d456b4b0b/crates/rust/src/interface.rs#L581-L589 for above mentioned linker symbol code.