### PR TITLE
Fix `--name-unnamed` and branch labels

### DIFF
--- a/crates/wasmprinter/tests/all.rs
+++ b/crates/wasmprinter/tests/all.rs
@@ -202,7 +202,7 @@ fn label_shadowing_block_confusion() {
         (func (;0;) (type 0)
           block $a
             block $a
-              br 1 (;@1;)
+              br 1
             end
           end
         )

--- a/tests/cli/print-unnamed.wat
+++ b/tests/cli/print-unnamed.wat
@@ -1,0 +1,34 @@
+;; RUN: print --name-unnamed %
+
+(module
+  (func
+    (block $a
+      (block ;; unnamed
+        (block $c
+          i32.const 0
+          br_table $a 1 $c
+        )
+      )
+    )
+    (block $c
+      (block ;; unnamed
+        (block $a
+          i32.const 0
+          br_table $a 1 $c
+        )
+      )
+    )
+    (block $a ;; 3
+      (block $a ;; 2
+        (block $a ;; 1
+          i32.const 0
+          br_table
+            0 ;; -> a/1
+            1 ;; -> a/2
+            2 ;; -> a/3
+            3 ;; -> function label
+        )
+      )
+    )
+  )
+)

--- a/tests/cli/print-unnamed.wat.stdout
+++ b/tests/cli/print-unnamed.wat.stdout
@@ -1,0 +1,29 @@
+(module
+  (type $#type0 (;0;) (func))
+  (func $#func0 (;0;) (type $#type0)
+    block $a
+      block $#label1
+        block $c
+          i32.const 0
+          br_table $a $#label1 $c
+        end
+      end
+    end
+    block $c
+      block $#label1
+        block $a
+          i32.const 0
+          br_table $a $#label1 $c
+        end
+      end
+    end
+    block $a
+      block $a
+        block $a
+          i32.const 0
+          br_table $a 1 2 3
+        end
+      end
+    end
+  )
+)

--- a/tests/snapshots/local/br-confusion.wat.print
+++ b/tests/snapshots/local/br-confusion.wat.print
@@ -3,7 +3,7 @@
   (func (;0;) (type 0)
     block $a
       block $a
-        br 1 (;@1;)
+        br 1
       end
     end
   )

--- a/tests/snapshots/local/br_table_loop_multi.wat.print
+++ b/tests/snapshots/local/br_table_loop_multi.wat.print
@@ -6,7 +6,7 @@
     local.get 1
     loop (type 1) (param i32) ;; label = @1
       i32.const -458751
-      br_table 0 (;@1;) 1 (;@0;) 0 (;@1;)
+      br_table 0 (;@1;) 1 0 (;@1;)
       unreachable
     end
     unreachable

--- a/tests/snapshots/local/function-references/call_ref/br_on_null.wast/5.print
+++ b/tests/snapshots/local/function-references/call_ref/br_on_null.wast/5.print
@@ -5,17 +5,17 @@
   (type (;3;) (func (param externref)))
   (func (;0;) (type 1) (param $r (ref null $t))
     local.get $r
-    br_on_null 0 (;@0;)
+    br_on_null 0
     drop
   )
   (func (;1;) (type 2) (param $r funcref)
     local.get $r
-    br_on_null 0 (;@0;)
+    br_on_null 0
     drop
   )
   (func (;2;) (type 3) (param $r externref)
     local.get $r
-    br_on_null 0 (;@0;)
+    br_on_null 0
     drop
   )
 )

--- a/tests/snapshots/local/gc/type-subtyping.wast/17.print
+++ b/tests/snapshots/local/gc/type-subtyping.wast/17.print
@@ -71,46 +71,46 @@
       table.get 0
       ref.cast (ref $t2)
     end
-    br 0 (;@0;)
+    br 0
   )
   (func (;4;) (type 3)
     block (result (ref null $t1)) ;; label = @1
       i32.const 0
       call_indirect (type $t1)
     end
-    br 0 (;@0;)
+    br 0
   )
   (func (;5;) (type 3)
     block (result (ref null $t1)) ;; label = @1
       i32.const 0
       call_indirect (type $t2)
     end
-    br 0 (;@0;)
+    br 0
   )
   (func (;6;) (type 3)
     block (result (ref null $t1)) ;; label = @1
       i32.const 1
       call_indirect (type $t2)
     end
-    br 0 (;@0;)
+    br 0
   )
   (func (;7;) (type 3)
     i32.const 0
     table.get 0
     ref.cast (ref $t1)
-    br 0 (;@0;)
+    br 0
   )
   (func (;8;) (type 3)
     i32.const 0
     table.get 0
     ref.cast (ref $t2)
-    br 0 (;@0;)
+    br 0
   )
   (func (;9;) (type 3)
     i32.const 1
     table.get 0
     ref.cast (ref $t2)
-    br 0 (;@0;)
+    br 0
   )
   (table (;0;) 3 3 funcref)
   (export "run" (func 3))

--- a/tests/snapshots/local/unreachable-valid.wast/0.print
+++ b/tests/snapshots/local/unreachable-valid.wast/0.print
@@ -3,7 +3,7 @@
   (func (;0;) (type 0)
     f32.const 0x1p+0 (;=1;)
     f32.const 0x1p+1 (;=2;)
-    br 0 (;@0;)
+    br 0
     i32.add
     drop
   )

--- a/tests/snapshots/testsuite/binary.wast/108.print
+++ b/tests/snapshots/testsuite/binary.wast/108.print
@@ -5,7 +5,7 @@
       i32.const 1
       if ;; label = @2
         i32.const 1
-        br_table 2 (;@0;)
+        br_table 2
       end
     end
   )

--- a/tests/snapshots/testsuite/br_if.wast/0.print
+++ b/tests/snapshots/testsuite/br_if.wast/0.print
@@ -161,7 +161,7 @@
     loop ;; label = @1
       call $dummy
       local.get 0
-      br_if 1 (;@0;)
+      br_if 1
     end
   )
   (func (;18;) (type 2) (result i32)

--- a/tests/snapshots/testsuite/br_table.wast/0.print
+++ b/tests/snapshots/testsuite/br_table.wast/0.print
@@ -235,7 +235,7 @@
     loop (result i32) ;; label = @1
       i32.const 3
       i32.const 0
-      br_table 1 (;@0;) 1 (;@0;)
+      br_table 1 1
       i32.const 1
     end
   )
@@ -244,7 +244,7 @@
       call $dummy
       i32.const 4
       i32.const -1
-      br_table 1 (;@0;) 1 (;@0;) 1 (;@0;)
+      br_table 1 1 1
       i32.const 2
     end
   )
@@ -254,7 +254,7 @@
       call $dummy
       i32.const 5
       i32.const 1
-      br_table 1 (;@0;) 1 (;@0;) 1 (;@0;)
+      br_table 1 1 1
     end
   )
   (func (;23;) (type 2) (result i32)

--- a/tests/snapshots/testsuite/func.wast/0.print
+++ b/tests/snapshots/testsuite/func.wast/0.print
@@ -286,41 +286,41 @@
     return
   )
   (func (;74;) (type $sig)
-    br 0 (;@0;)
+    br 0
   )
   (func (;75;) (type $sig-2) (result i32)
     i32.const 79
-    br 0 (;@0;)
+    br 0
   )
   (func (;76;) (type 13) (result i64)
     i64.const 7979
-    br 0 (;@0;)
+    br 0
   )
   (func (;77;) (type 14) (result f32)
     f32.const 0x1.3f999ap+6 (;=79.9;)
-    br 0 (;@0;)
+    br 0
   )
   (func (;78;) (type 15) (result f64)
     f64.const 0x1.3f28f5c28f5c3p+6 (;=79.79;)
-    br 0 (;@0;)
+    br 0
   )
   (func (;79;) (type 10) (result i32 f64)
     i32.const 79
     f64.const 0x1.3f28f5c28f5c3p+6 (;=79.79;)
-    br 0 (;@0;)
+    br 0
   )
   (func (;80;) (type 21) (result i32 i32 i32)
     i32.const 1
     i32.const 2
     i32.const 3
-    br 0 (;@0;)
+    br 0
   )
   (func (;81;) (type $sig-2) (result i32)
     block (result i32) ;; label = @1
       call $dummy
       i32.const 77
     end
-    br 0 (;@0;)
+    br 0
   )
   (func (;82;) (type 22) (result i32 i64)
     block (type 22) (result i32 i64) ;; label = @1
@@ -328,16 +328,16 @@
       i32.const 1
       i64.const 2
     end
-    br 0 (;@0;)
+    br 0
   )
   (func (;83;) (type $sig-3) (param i32)
     local.get 0
-    br_if 0 (;@0;)
+    br_if 0
   )
   (func (;84;) (type 23) (param i32) (result i32)
     i32.const 50
     local.get 0
-    br_if 0 (;@0;)
+    br_if 0
     drop
     i32.const 51
   )
@@ -345,7 +345,7 @@
     i32.const 50
     i64.const 51
     local.get 0
-    br_if 0 (;@0;)
+    br_if 0
     drop
     drop
     i32.const 51
@@ -353,33 +353,33 @@
   )
   (func (;86;) (type $sig-3) (param i32)
     local.get 0
-    br_table 0 (;@0;) 0 (;@0;) 0 (;@0;)
+    br_table 0 0 0
   )
   (func (;87;) (type 23) (param i32) (result i32)
     i32.const 50
     local.get 0
-    br_table 0 (;@0;) 0 (;@0;)
+    br_table 0 0
     i32.const 51
   )
   (func (;88;) (type 24) (param i32) (result i32 i64)
     i32.const 50
     i64.const 51
     local.get 0
-    br_table 0 (;@0;) 0 (;@0;)
+    br_table 0 0
     i32.const 51
     i64.const 52
   )
   (func (;89;) (type $sig-3) (param i32)
     block ;; label = @1
       local.get 0
-      br_table 0 (;@1;) 1 (;@0;) 0 (;@1;)
+      br_table 0 (;@1;) 1 0 (;@1;)
     end
   )
   (func (;90;) (type 23) (param i32) (result i32)
     block (result i32) ;; label = @1
       i32.const 50
       local.get 0
-      br_table 0 (;@1;) 1 (;@0;) 0 (;@1;)
+      br_table 0 (;@1;) 1 0 (;@1;)
       i32.const 51
     end
     i32.const 2
@@ -390,7 +390,7 @@
       i32.const 50
       i32.const 51
       local.get 0
-      br_table 0 (;@1;) 1 (;@0;) 0 (;@1;)
+      br_table 0 (;@1;) 1 0 (;@1;)
       i32.const 51
       i32.const -3
     end

--- a/tests/snapshots/testsuite/proposals/exception-handling/binary.wast/108.print
+++ b/tests/snapshots/testsuite/proposals/exception-handling/binary.wast/108.print
@@ -5,7 +5,7 @@
       i32.const 1
       if ;; label = @2
         i32.const 1
-        br_table 2 (;@0;)
+        br_table 2
       end
     end
   )

--- a/tests/snapshots/testsuite/proposals/exception-handling/try_table.wast/44.print
+++ b/tests/snapshots/testsuite/proposals/exception-handling/try_table.wast/44.print
@@ -2,29 +2,29 @@
   (type (;0;) (func))
   (type (;1;) (func (result exnref)))
   (func (;0;) (type 0)
-    try_table (catch $e 0 (;@0;)) (catch $e 0 (;@0;)) ;; label = @1
+    try_table (catch $e 0) (catch $e 0) ;; label = @1
     end
   )
   (func (;1;) (type 0)
-    try_table (catch_all 0 (;@0;)) (catch $e 0 (;@0;)) ;; label = @1
+    try_table (catch_all 0) (catch $e 0) ;; label = @1
     end
   )
   (func (;2;) (type 0)
-    try_table (catch_all 0 (;@0;)) (catch_all 0 (;@0;)) ;; label = @1
+    try_table (catch_all 0) (catch_all 0) ;; label = @1
     end
   )
   (func (;3;) (type 1) (result exnref)
-    try_table (catch_ref $e 0 (;@0;)) (catch_ref $e 0 (;@0;)) ;; label = @1
+    try_table (catch_ref $e 0) (catch_ref $e 0) ;; label = @1
     end
     unreachable
   )
   (func (;4;) (type 1) (result exnref)
-    try_table (catch_all_ref 0 (;@0;)) (catch_ref $e 0 (;@0;)) ;; label = @1
+    try_table (catch_all_ref 0) (catch_ref $e 0) ;; label = @1
     end
     unreachable
   )
   (func (;5;) (type 1) (result exnref)
-    try_table (catch_all_ref 0 (;@0;)) (catch_all_ref 0 (;@0;)) ;; label = @1
+    try_table (catch_all_ref 0) (catch_all_ref 0) ;; label = @1
     end
     unreachable
   )

--- a/tests/snapshots/testsuite/proposals/function-references/binary.wast/108.print
+++ b/tests/snapshots/testsuite/proposals/function-references/binary.wast/108.print
@@ -5,7 +5,7 @@
       i32.const 1
       if ;; label = @2
         i32.const 1
-        br_table 2 (;@0;)
+        br_table 2
       end
     end
   )

--- a/tests/snapshots/testsuite/proposals/function-references/br_on_null.wast/5.print
+++ b/tests/snapshots/testsuite/proposals/function-references/br_on_null.wast/5.print
@@ -5,17 +5,17 @@
   (type (;3;) (func (param externref)))
   (func (;0;) (type 1) (param $r (ref null $t))
     local.get $r
-    br_on_null 0 (;@0;)
+    br_on_null 0
     drop
   )
   (func (;1;) (type 2) (param $r funcref)
     local.get $r
-    br_on_null 0 (;@0;)
+    br_on_null 0
     drop
   )
   (func (;2;) (type 3) (param $r externref)
     local.get $r
-    br_on_null 0 (;@0;)
+    br_on_null 0
     drop
   )
 )

--- a/tests/snapshots/testsuite/proposals/function-references/br_table.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/function-references/br_table.wast/0.print
@@ -236,7 +236,7 @@
     loop (result i32) ;; label = @1
       i32.const 3
       i32.const 0
-      br_table 1 (;@0;) 1 (;@0;)
+      br_table 1 1
       i32.const 1
     end
   )
@@ -245,7 +245,7 @@
       call $dummy
       i32.const 4
       i32.const -1
-      br_table 1 (;@0;) 1 (;@0;) 1 (;@0;)
+      br_table 1 1 1
       i32.const 2
     end
   )
@@ -255,7 +255,7 @@
       call $dummy
       i32.const 5
       i32.const 1
-      br_table 1 (;@0;) 1 (;@0;) 1 (;@0;)
+      br_table 1 1 1
     end
   )
   (func (;23;) (type 2) (result i32)

--- a/tests/snapshots/testsuite/proposals/function-references/func.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/function-references/func.wast/0.print
@@ -287,41 +287,41 @@
     return
   )
   (func (;74;) (type $sig)
-    br 0 (;@0;)
+    br 0
   )
   (func (;75;) (type $sig-2) (result i32)
     i32.const 79
-    br 0 (;@0;)
+    br 0
   )
   (func (;76;) (type 13) (result i64)
     i64.const 7979
-    br 0 (;@0;)
+    br 0
   )
   (func (;77;) (type 14) (result f32)
     f32.const 0x1.3f999ap+6 (;=79.9;)
-    br 0 (;@0;)
+    br 0
   )
   (func (;78;) (type 15) (result f64)
     f64.const 0x1.3f28f5c28f5c3p+6 (;=79.79;)
-    br 0 (;@0;)
+    br 0
   )
   (func (;79;) (type 10) (result i32 f64)
     i32.const 79
     f64.const 0x1.3f28f5c28f5c3p+6 (;=79.79;)
-    br 0 (;@0;)
+    br 0
   )
   (func (;80;) (type 21) (result i32 i32 i32)
     i32.const 1
     i32.const 2
     i32.const 3
-    br 0 (;@0;)
+    br 0
   )
   (func (;81;) (type $sig-2) (result i32)
     block (result i32) ;; label = @1
       call $dummy
       i32.const 77
     end
-    br 0 (;@0;)
+    br 0
   )
   (func (;82;) (type 22) (result i32 i64)
     block (type 22) (result i32 i64) ;; label = @1
@@ -329,16 +329,16 @@
       i32.const 1
       i64.const 2
     end
-    br 0 (;@0;)
+    br 0
   )
   (func (;83;) (type $sig-3) (param i32)
     local.get 0
-    br_if 0 (;@0;)
+    br_if 0
   )
   (func (;84;) (type 23) (param i32) (result i32)
     i32.const 50
     local.get 0
-    br_if 0 (;@0;)
+    br_if 0
     drop
     i32.const 51
   )
@@ -346,7 +346,7 @@
     i32.const 50
     i64.const 51
     local.get 0
-    br_if 0 (;@0;)
+    br_if 0
     drop
     drop
     i32.const 51
@@ -354,33 +354,33 @@
   )
   (func (;86;) (type $sig-3) (param i32)
     local.get 0
-    br_table 0 (;@0;) 0 (;@0;) 0 (;@0;)
+    br_table 0 0 0
   )
   (func (;87;) (type 23) (param i32) (result i32)
     i32.const 50
     local.get 0
-    br_table 0 (;@0;) 0 (;@0;)
+    br_table 0 0
     i32.const 51
   )
   (func (;88;) (type 25) (param i32) (result f32 i64)
     f32.const 0x1.9p+5 (;=50;)
     i64.const 51
     local.get 0
-    br_table 0 (;@0;) 0 (;@0;)
+    br_table 0 0
     f32.const 0x1.98p+5 (;=51;)
     i64.const 52
   )
   (func (;89;) (type $sig-3) (param i32)
     block ;; label = @1
       local.get 0
-      br_table 0 (;@1;) 1 (;@0;) 0 (;@1;)
+      br_table 0 (;@1;) 1 0 (;@1;)
     end
   )
   (func (;90;) (type 23) (param i32) (result i32)
     block (result i32) ;; label = @1
       i32.const 50
       local.get 0
-      br_table 0 (;@1;) 1 (;@0;) 0 (;@1;)
+      br_table 0 (;@1;) 1 0 (;@1;)
       i32.const 51
     end
     i32.const 2
@@ -391,7 +391,7 @@
       i32.const 50
       i32.const 51
       local.get 0
-      br_table 0 (;@1;) 1 (;@0;) 0 (;@1;)
+      br_table 0 (;@1;) 1 0 (;@1;)
       i32.const 51
       i32.const -3
     end

--- a/tests/snapshots/testsuite/proposals/gc/binary.wast/108.print
+++ b/tests/snapshots/testsuite/proposals/gc/binary.wast/108.print
@@ -5,7 +5,7 @@
       i32.const 1
       if ;; label = @2
         i32.const 1
-        br_table 2 (;@0;)
+        br_table 2
       end
     end
   )

--- a/tests/snapshots/testsuite/proposals/gc/br_on_cast.wast/30.print
+++ b/tests/snapshots/testsuite/proposals/gc/br_on_cast.wast/30.print
@@ -6,21 +6,21 @@
   (func (;0;) (type 1) (param (ref any)) (result (ref $t))
     block (result (ref any)) ;; label = @1
       local.get 0
-      br_on_cast 1 (;@0;) (ref any) (ref $t)
+      br_on_cast 1 (ref any) (ref $t)
     end
     unreachable
   )
   (func (;1;) (type 2) (param anyref) (result (ref $t))
     block (result anyref) ;; label = @1
       local.get 0
-      br_on_cast 1 (;@0;) anyref (ref $t)
+      br_on_cast 1 anyref (ref $t)
     end
     unreachable
   )
   (func (;2;) (type 3) (param anyref) (result (ref null $t))
     block (result anyref) ;; label = @1
       local.get 0
-      br_on_cast 1 (;@0;) anyref (ref null $t)
+      br_on_cast 1 anyref (ref null $t)
     end
     unreachable
   )

--- a/tests/snapshots/testsuite/proposals/gc/br_on_cast_fail.wast/30.print
+++ b/tests/snapshots/testsuite/proposals/gc/br_on_cast_fail.wast/30.print
@@ -5,19 +5,19 @@
   (func (;0;) (type 1) (param (ref any)) (result (ref any))
     block (result (ref $t)) ;; label = @1
       local.get 0
-      br_on_cast_fail 1 (;@0;) (ref any) (ref $t)
+      br_on_cast_fail 1 (ref any) (ref $t)
     end
   )
   (func (;1;) (type 2) (param anyref) (result anyref)
     block (result (ref $t)) ;; label = @1
       local.get 0
-      br_on_cast_fail 1 (;@0;) anyref (ref $t)
+      br_on_cast_fail 1 anyref (ref $t)
     end
   )
   (func (;2;) (type 2) (param anyref) (result anyref)
     block (result (ref null $t)) ;; label = @1
       local.get 0
-      br_on_cast_fail 1 (;@0;) anyref (ref null $t)
+      br_on_cast_fail 1 anyref (ref null $t)
     end
   )
 )

--- a/tests/snapshots/testsuite/proposals/gc/br_on_null.wast/5.print
+++ b/tests/snapshots/testsuite/proposals/gc/br_on_null.wast/5.print
@@ -5,17 +5,17 @@
   (type (;3;) (func (param externref)))
   (func (;0;) (type 1) (param $r (ref null $t))
     local.get $r
-    br_on_null 0 (;@0;)
+    br_on_null 0
     drop
   )
   (func (;1;) (type 2) (param $r funcref)
     local.get $r
-    br_on_null 0 (;@0;)
+    br_on_null 0
     drop
   )
   (func (;2;) (type 3) (param $r externref)
     local.get $r
-    br_on_null 0 (;@0;)
+    br_on_null 0
     drop
   )
 )

--- a/tests/snapshots/testsuite/proposals/gc/br_table.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/gc/br_table.wast/0.print
@@ -236,7 +236,7 @@
     loop (result i32) ;; label = @1
       i32.const 3
       i32.const 0
-      br_table 1 (;@0;) 1 (;@0;)
+      br_table 1 1
       i32.const 1
     end
   )
@@ -245,7 +245,7 @@
       call $dummy
       i32.const 4
       i32.const -1
-      br_table 1 (;@0;) 1 (;@0;) 1 (;@0;)
+      br_table 1 1 1
       i32.const 2
     end
   )
@@ -255,7 +255,7 @@
       call $dummy
       i32.const 5
       i32.const 1
-      br_table 1 (;@0;) 1 (;@0;) 1 (;@0;)
+      br_table 1 1 1
     end
   )
   (func (;23;) (type 2) (result i32)

--- a/tests/snapshots/testsuite/proposals/gc/func.wast/0.print
+++ b/tests/snapshots/testsuite/proposals/gc/func.wast/0.print
@@ -287,41 +287,41 @@
     return
   )
   (func (;74;) (type $sig)
-    br 0 (;@0;)
+    br 0
   )
   (func (;75;) (type $sig-2) (result i32)
     i32.const 79
-    br 0 (;@0;)
+    br 0
   )
   (func (;76;) (type 13) (result i64)
     i64.const 7979
-    br 0 (;@0;)
+    br 0
   )
   (func (;77;) (type 14) (result f32)
     f32.const 0x1.3f999ap+6 (;=79.9;)
-    br 0 (;@0;)
+    br 0
   )
   (func (;78;) (type 15) (result f64)
     f64.const 0x1.3f28f5c28f5c3p+6 (;=79.79;)
-    br 0 (;@0;)
+    br 0
   )
   (func (;79;) (type 10) (result i32 f64)
     i32.const 79
     f64.const 0x1.3f28f5c28f5c3p+6 (;=79.79;)
-    br 0 (;@0;)
+    br 0
   )
   (func (;80;) (type 21) (result i32 i32 i32)
     i32.const 1
     i32.const 2
     i32.const 3
-    br 0 (;@0;)
+    br 0
   )
   (func (;81;) (type $sig-2) (result i32)
     block (result i32) ;; label = @1
       call $dummy
       i32.const 77
     end
-    br 0 (;@0;)
+    br 0
   )
   (func (;82;) (type 22) (result i32 i64)
     block (type 22) (result i32 i64) ;; label = @1
@@ -329,16 +329,16 @@
       i32.const 1
       i64.const 2
     end
-    br 0 (;@0;)
+    br 0
   )
   (func (;83;) (type $sig-3) (param i32)
     local.get 0
-    br_if 0 (;@0;)
+    br_if 0
   )
   (func (;84;) (type 23) (param i32) (result i32)
     i32.const 50
     local.get 0
-    br_if 0 (;@0;)
+    br_if 0
     drop
     i32.const 51
   )
@@ -346,7 +346,7 @@
     i32.const 50
     i64.const 51
     local.get 0
-    br_if 0 (;@0;)
+    br_if 0
     drop
     drop
     i32.const 51
@@ -354,33 +354,33 @@
   )
   (func (;86;) (type $sig-3) (param i32)
     local.get 0
-    br_table 0 (;@0;) 0 (;@0;) 0 (;@0;)
+    br_table 0 0 0
   )
   (func (;87;) (type 23) (param i32) (result i32)
     i32.const 50
     local.get 0
-    br_table 0 (;@0;) 0 (;@0;)
+    br_table 0 0
     i32.const 51
   )
   (func (;88;) (type 25) (param i32) (result f32 i64)
     f32.const 0x1.9p+5 (;=50;)
     i64.const 51
     local.get 0
-    br_table 0 (;@0;) 0 (;@0;)
+    br_table 0 0
     f32.const 0x1.98p+5 (;=51;)
     i64.const 52
   )
   (func (;89;) (type $sig-3) (param i32)
     block ;; label = @1
       local.get 0
-      br_table 0 (;@1;) 1 (;@0;) 0 (;@1;)
+      br_table 0 (;@1;) 1 0 (;@1;)
     end
   )
   (func (;90;) (type 23) (param i32) (result i32)
     block (result i32) ;; label = @1
       i32.const 50
       local.get 0
-      br_table 0 (;@1;) 1 (;@0;) 0 (;@1;)
+      br_table 0 (;@1;) 1 0 (;@1;)
       i32.const 51
     end
     i32.const 2
@@ -391,7 +391,7 @@
       i32.const 50
       i32.const 51
       local.get 0
-      br_table 0 (;@1;) 1 (;@0;) 0 (;@1;)
+      br_table 0 (;@1;) 1 0 (;@1;)
       i32.const 51
       i32.const -3
     end

--- a/tests/snapshots/testsuite/proposals/gc/type-equivalence.wast/10.print
+++ b/tests/snapshots/testsuite/proposals/gc/type-equivalence.wast/10.print
@@ -45,7 +45,7 @@
       i32.const 1
       call_indirect (type $t2)
     end
-    br 0 (;@0;)
+    br 0
   )
   (table (;0;) 2 2 funcref)
   (export "run" (func 2))

--- a/tests/snapshots/testsuite/proposals/gc/type-subtyping.wast/17.print
+++ b/tests/snapshots/testsuite/proposals/gc/type-subtyping.wast/17.print
@@ -71,46 +71,46 @@
       table.get 0
       ref.cast (ref $t2)
     end
-    br 0 (;@0;)
+    br 0
   )
   (func (;4;) (type 3)
     block (result (ref null $t1)) ;; label = @1
       i32.const 0
       call_indirect (type $t1)
     end
-    br 0 (;@0;)
+    br 0
   )
   (func (;5;) (type 3)
     block (result (ref null $t1)) ;; label = @1
       i32.const 0
       call_indirect (type $t2)
     end
-    br 0 (;@0;)
+    br 0
   )
   (func (;6;) (type 3)
     block (result (ref null $t1)) ;; label = @1
       i32.const 1
       call_indirect (type $t2)
     end
-    br 0 (;@0;)
+    br 0
   )
   (func (;7;) (type 3)
     i32.const 0
     table.get 0
     ref.cast (ref $t1)
-    br 0 (;@0;)
+    br 0
   )
   (func (;8;) (type 3)
     i32.const 0
     table.get 0
     ref.cast (ref $t2)
-    br 0 (;@0;)
+    br 0
   )
   (func (;9;) (type 3)
     i32.const 1
     table.get 0
     ref.cast (ref $t2)
-    br 0 (;@0;)
+    br 0
   )
   (table (;0;) 3 3 funcref)
   (export "run" (func 3))

--- a/tests/snapshots/testsuite/proposals/memory64/binary.wast/173.print
+++ b/tests/snapshots/testsuite/proposals/memory64/binary.wast/173.print
@@ -5,7 +5,7 @@
       i32.const 1
       if ;; label = @2
         i32.const 1
-        br_table 2 (;@0;)
+        br_table 2
       end
     end
   )

--- a/tests/snapshots/testsuite/proposals/multi-memory/binary.wast/98.print
+++ b/tests/snapshots/testsuite/proposals/multi-memory/binary.wast/98.print
@@ -5,7 +5,7 @@
       i32.const 1
       if ;; label = @2
         i32.const 1
-        br_table 2 (;@0;)
+        br_table 2
       end
     end
   )

--- a/tests/snapshots/testsuite/proposals/multi-memory/store.wast/20.print
+++ b/tests/snapshots/testsuite/proposals/multi-memory/store.wast/20.print
@@ -18,7 +18,7 @@
       local.get $i
       i32.const 23
       i32.eq
-      br_if 1 (;@0;)
+      br_if 1
       local.get $i
       local.get $i
       i32.load8_u
@@ -38,7 +38,7 @@
       local.get $i
       i32.const 54
       i32.eq
-      br_if 1 (;@0;)
+      br_if 1
       local.get $i
       local.get $i
       i32.load8_u $mem2

--- a/tests/snapshots/testsuite/token.wast/16.print
+++ b/tests/snapshots/testsuite/token.wast/16.print
@@ -1,6 +1,6 @@
 (module
   (type (;0;) (func))
   (func (;0;) (type 0)
-    br 0 (;@0;)
+    br 0
   )
 )

--- a/tests/snapshots/testsuite/token.wast/7.print
+++ b/tests/snapshots/testsuite/token.wast/7.print
@@ -1,7 +1,7 @@
 (module
   (type (;0;) (func))
   (func (;0;) (type 0)
-    br 0 (;@0;)
+    br 0
     nop
   )
 )

--- a/tests/snapshots/testsuite/unwind.wast/0.print
+++ b/tests/snapshots/testsuite/unwind.wast/0.print
@@ -9,19 +9,19 @@
   (func (;1;) (type 0)
     i32.const 3
     i64.const 1
-    br 0 (;@0;)
+    br 0
   )
   (func (;2;) (type 1) (result i32)
     i32.const 3
     i64.const 1
     i32.const 9
-    br 0 (;@0;)
+    br 0
   )
   (func (;3;) (type 0)
     i32.const 3
     i64.const 1
     i32.const 1
-    br_if 0 (;@0;)
+    br_if 0
     drop
     drop
   )
@@ -30,7 +30,7 @@
     i64.const 1
     i32.const 9
     i32.const 1
-    br_if 0 (;@0;)
+    br_if 0
     drop
     drop
   )
@@ -38,14 +38,14 @@
     i32.const 3
     i64.const 1
     i32.const 0
-    br_table 0 (;@0;)
+    br_table 0
   )
   (func (;6;) (type 1) (result i32)
     i32.const 3
     i64.const 1
     i32.const 9
     i32.const 0
-    br_table 0 (;@0;)
+    br_table 0
   )
   (func (;7;) (type 1) (result i32)
     i32.const 3


### PR DESCRIPTION
This commit fixes an issue where `wasm-tools print --name-unnamed` would produce an invalid `*.wat` file. This PR fixes a few off-by-one issues locally and commits a test as well.

Finally this additionally updates the printing of `@N` "helper labels" to avoid printing that if there's no actual target named `@N`, for example in the case of name conflicts or when a branch depth goes directly to the function itself.