### PR TITLE
Fix parsing of `(data)`.

### DIFF
--- a/crates/wast/src/core/memory.rs
+++ b/crates/wast/src/core/memory.rs
@@ -133,7 +133,7 @@ impl<'a> Parse<'a> for Data<'a> {
         let id = parser.parse()?;
         let name = parser.parse()?;
 
-        let kind = if parser.peek::<&[u8]>()? {
+        let kind = if parser.peek::<&[u8]>()? || parser.peek::<RParen>()? {
             DataKind::Passive
 
         // ... and otherwise we must be attached to a particular memory as well

--- a/crates/wast/src/token.rs
+++ b/crates/wast/src/token.rs
@@ -677,6 +677,22 @@ impl Peek for LParen {
     }
 }
 
+/// A convenience type to use with [`Parser::peek`](crate::parser::Parser::peek)
+/// to see if the next token is the end of an s-expression.
+pub struct RParen {
+    _priv: (),
+}
+
+impl Peek for RParen {
+    fn peek(cursor: Cursor<'_>) -> Result<bool> {
+        cursor.peek_rparen()
+    }
+
+    fn display() -> &'static str {
+        "right paren"
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/tests/cli/dump/simple.wat
+++ b/tests/cli/dump/simple.wat
@@ -17,5 +17,6 @@
   (func (local i32) i32.const 0)
   (data (i32.const 8) "y")
   (data "x")
+  (data)
   (@custom "name-of-section" "content")
 )

--- a/tests/cli/dump/simple.wat.stdout
+++ b/tests/cli/dump/simple.wat.stdout
@@ -59,17 +59,19 @@
  0x60 | 01 7f       | 1 locals of type I32
  0x62 | 41 00       | i32_const value:0
  0x64 | 0b          | end
- 0x65 | 0b 0a       | data section
- 0x67 | 02          | 2 count
+ 0x65 | 0b 0c       | data section
+ 0x67 | 03          | 3 count
  0x68 | 00          | data memory[0]
  0x69 | 41 08       | i32_const value:8
  0x6b | 0b          | end
  0x6c |-------------| ... 1 bytes of data
  0x6e | 01 01       | data passive
  0x70 |-------------| ... 1 bytes of data
- 0x71 | 00 17       | custom section
- 0x73 | 0f 6e 61 6d | name: "name-of-section"
+ 0x71 | 01 00       | data passive
+ 0x73 |-------------| ... 0 bytes of data
+ 0x73 | 00 17       | custom section
+ 0x75 | 0f 6e 61 6d | name: "name-of-section"
       | 65 2d 6f 66
       | 2d 73 65 63
       | 74 69 6f 6e
- 0x83 |-------------| ... 7 bytes of data
+ 0x85 |-------------| ... 7 bytes of data


### PR DESCRIPTION
When parsing a passive data segment, accept an empty list of datastrings.

Fixes #1441.