### PR TITLE
wast: Make `V128Const`, `V128Pattern` and `NanPattern` clonable

### DIFF
--- a/crates/wast/src/core/expr.rs
+++ b/crates/wast/src/core/expr.rs
@@ -1731,7 +1731,7 @@ impl<'a> Parse<'a> for BrOnCastFail<'a> {
 }
 
 /// Different ways to specify a `v128.const` instruction
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub enum V128Const {
     I8x16([i8; 16]),

--- a/crates/wast/src/core/wast.rs
+++ b/crates/wast/src/core/wast.rs
@@ -151,7 +151,7 @@ impl Peek for WastRetCore<'_> {
 }
 
 /// Either a NaN pattern (`nan:canonical`, `nan:arithmetic`) or a value of type `T`.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[allow(missing_docs)]
 pub enum NanPattern<T> {
     CanonicalNan,
@@ -181,7 +181,7 @@ where
 ///
 /// This implementation is necessary because only float types can include NaN patterns; otherwise
 /// it is largely similar to the implementation of `V128Const`.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 #[allow(missing_docs)]
 pub enum V128Pattern {
     I8x16([i8; 16]),


### PR DESCRIPTION
Derive `Clone` for `V128Const`, `V128Pattern` and `NanPattern`.

Closes #1444 