### PR TITLE
Replace custom "test harnesses" with `libtest-mimic`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -617,6 +617,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "escape8259"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba4f4911e3666fcd7826997b4745c8224295a6f3072f1418c3067b97a67557ee"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +933,18 @@ dependencies = [
  "arbitrary",
  "cc",
  "once_cell",
+]
+
+[[package]]
+name = "libtest-mimic"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f0f4c6f44ecfd52e8b443f2ad18f2b996540135771561283c2352ce56a1c70b"
+dependencies = [
+ "clap 4.5.2",
+ "escape8259",
+ "termcolor",
+ "threadpool",
 ]
 
 [[package]]
@@ -1274,6 +1295,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
 name = "ruzstd"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1496,6 +1523,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.52",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]
@@ -1830,6 +1866,7 @@ dependencies = [
  "env_logger",
  "gimli 0.28.1",
  "is_executable",
+ "libtest-mimic",
  "log",
  "pretty_assertions",
  "rayon",
@@ -2212,8 +2249,8 @@ dependencies = [
  "anyhow",
  "bumpalo",
  "leb128",
+ "libtest-mimic",
  "memchr",
- "rayon",
  "unicode-width",
  "wasm-encoder 0.201.0",
  "wasmparser 0.201.0",
@@ -2464,9 +2501,9 @@ dependencies = [
  "env_logger",
  "id-arena",
  "indexmap 2.2.5",
+ "libtest-mimic",
  "log",
  "pretty_assertions",
- "rayon",
  "semver",
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ url = "2.0.0"
 pretty_assertions = "1.3.0"
 semver = "1.0.0"
 smallvec = "1.11.1"
+libtest-mimic = "0.7.0"
 
 wasm-compose = { version = "0.201.0", path = "crates/wasm-compose" }
 wasm-encoder = { version = "0.201.0", path = "crates/wasm-encoder" }
@@ -136,6 +137,7 @@ tempfile = "3.1"
 diff = "0.1"
 wast = { path = 'crates/wast' }
 pretty_assertions = { workspace = true }
+libtest-mimic = { workspace = true }
 
 [[test]]
 name = "cli"

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -24,7 +24,7 @@ bumpalo = "3.14.0"
 
 [dev-dependencies]
 anyhow = { workspace = true }
-rayon = { workspace = true }
+libtest-mimic = { workspace = true }
 wasmparser = { path = "../wasmparser" }
 wat = { path = "../wat" }
 

--- a/crates/wast/tests/parse-fail.rs
+++ b/crates/wast/tests/parse-fail.rs
@@ -4,46 +4,28 @@
 //! Use `BLESS=1` in the environment to auto-update `*.err` files. Be sure to
 //! look at the diff!
 
-use rayon::prelude::*;
+use libtest_mimic::{Arguments, Trial};
 use std::env;
 use std::path::{Path, PathBuf};
 
 fn main() {
     let mut tests = Vec::new();
     find_tests("tests/parse-fail".as_ref(), &mut tests);
-    let filter = std::env::args().nth(1);
-
     let bless = env::var("BLESS").is_ok();
-    let tests = tests
-        .iter()
-        .filter(|test| {
-            if let Some(filter) = &filter {
-                if let Some(s) = test.file_name().and_then(|s| s.to_str()) {
-                    if !s.contains(filter) {
-                        return false;
-                    }
-                }
-            }
-            true
-        })
-        .collect::<Vec<_>>();
 
-    println!("running {} tests\n", tests.len());
-
-    let errors = tests
-        .par_iter()
-        .filter_map(|test| run_test(test, bless).err())
-        .collect::<Vec<_>>();
-
-    if !errors.is_empty() {
-        for msg in errors.iter() {
-            eprintln!("{}", msg);
-        }
-
-        panic!("{} tests failed", errors.len())
+    let mut trials = Vec::new();
+    for test in tests {
+        let trial = Trial::test(format!("{test:?}"), move || {
+            run_test(&test, bless).map_err(|e| format!("{e:?}").into())
+        });
+        trials.push(trial);
     }
 
-    println!("test result: ok. {} passed\n", tests.len());
+    let mut args = Arguments::from_args();
+    if cfg!(target_family = "wasm") && !cfg!(target_feature = "atomics") {
+        args.test_threads = Some(1);
+    }
+    libtest_mimic::run(&args, trials).exit();
 }
 
 fn run_test(test: &Path, bless: bool) -> anyhow::Result<()> {

--- a/crates/wit-parser/Cargo.toml
+++ b/crates/wit-parser/Cargo.toml
@@ -44,11 +44,11 @@ decoding = ['dep:wasmparser']
 wat = ['decoding', 'dep:wat']
 
 [dev-dependencies]
-rayon = "1"
 env_logger = { workspace = true }
 pretty_assertions = { workspace = true }
 serde_json = { workspace = true }
 wit-parser = { path = '.', features = ['serde', 'wat'] }
+libtest-mimic = { workspace = true }
 
 [[test]]
 name = "all"

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -51,7 +51,10 @@ fn main() {
         trials.push(trial);
     }
 
-    let args = Arguments::from_args();
+    let mut args = Arguments::from_args();
+    if cfg!(target_family = "wasm") && !cfg!(target_feature = "atomics") {
+        args.test_threads = Some(1);
+    }
     libtest_mimic::run(&args, trials).exit();
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -26,59 +26,33 @@
 //! to look at the diff!
 
 use anyhow::{anyhow, bail, Context, Result};
+use libtest_mimic::{Arguments, Trial};
 use pretty_assertions::StrComparison;
-use rayon::prelude::*;
 use std::env;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
 
 fn main() {
-    // This test suite can't run on wasm since it involves spawning
-    // subprocesses.
-    if cfg!(target_family = "wasm") {
-        return;
-    }
-
     let mut tests = Vec::new();
     find_tests("tests/cli".as_ref(), &mut tests);
-    let filter = std::env::args().nth(1);
-
     let bless = env::var("BLESS").is_ok();
-    let tests = tests
-        .iter()
-        .filter(|test| {
-            if let Some(filter) = &filter {
-                if let Some(s) = test.file_name().and_then(|s| s.to_str()) {
-                    if !s.contains(filter) {
-                        return false;
-                    }
-                }
-            }
-            true
-        })
-        .collect::<Vec<_>>();
 
-    println!("running {} tests\n", tests.len());
-
-    let errors = tests
-        .par_iter()
-        .filter_map(|test| {
-            run_test(test, bless)
+    let mut trials = Vec::new();
+    for test in tests {
+        let trial = Trial::test(format!("{test:?}"), move || {
+            run_test(&test, bless)
                 .with_context(|| format!("failed test {test:?}"))
-                .err()
+                .map_err(|e| format!("{e:?}").into())
         })
-        .collect::<Vec<_>>();
-
-    if !errors.is_empty() {
-        for msg in errors.iter() {
-            eprintln!("{:?}", msg);
-        }
-
-        panic!("{} tests failed", errors.len())
+        // This test suite can't run on wasm since it involves spawning
+        // subprocesses.
+        .with_ignored_flag(cfg!(target_family = "wasm"));
+        trials.push(trial);
     }
 
-    println!("test result: ok. {} passed\n", tests.len());
+    let args = Arguments::from_args();
+    libtest_mimic::run(&args, trials).exit();
 }
 
 fn wasm_tools_exe() -> Command {


### PR DESCRIPTION
There's a number of tests suites in this repository which are based on "drop a file here and it's a test now". Up to now these have been powered by a custom "test harness" copied around which implements at filtering mechanism but little else. The `libtest-mimic` crate provides a `test`-crate-lookalike API which enables dynamically building the list of tests at program start time (aka read the filesystem) and then afterwards looks and feels similar to the `test` crate's CLI and UX.

This enables a nicer dev experience when running these tests and additionally enables using runners like `cargo nextest` with this repository.