### PR TITLE
Implement a subcommand to list a component's imports and exports

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,6 +158,7 @@ jobs:
       - run: cargo check --no-default-features --features wit-smith
       - run: cargo check --no-default-features --features addr2line
       - run: cargo check --no-default-features --features json-from-wast
+      - run: cargo check --no-default-features --features world
       - run: cargo check --no-default-features --features completion
       - run: cargo check --no-default-features -p wit-parser
       - run: cargo check --no-default-features -p wit-parser --features wat

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Many crates in this repository (located in `crates/*`) both have unit tests
 $ cargo test -p wasmparser
 ```
 
-Running all tests can be done by fist ensuring that the spec test suite is
+Running all tests can be done by first ensuring that the spec test suite is
 checked out:
 
 ```

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,6 +167,7 @@ default = [
   'addr2line',
   'completion',
   'json-from-wast',
+  'world',
 ]
 
 # Each subcommand is gated behind a feature and lists the dependencies it needs
@@ -194,3 +195,4 @@ wit-smith = ['dep:wit-smith', 'arbitrary']
 addr2line = ['dep:addr2line', 'dep:gimli', 'dep:wasmparser']
 completion = ['dep:clap_complete']
 json-from-wast = ['dep:serde_derive', 'dep:serde_json', 'dep:wast', 'dep:serde']
+world = ['wasm-compose', 'dep:serde_derive', 'dep:serde_json', 'dep:serde']

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ that can be use programmatically as well:
 | `wasm-tools addr2line` |  | Translate wasm offsets to filename/line numbers with DWARF |
 | `wasm-tools completion` |  | Generate shell completion scripts for `wasm-tools` |
 | `wasm-tools json-from-wast` |  | Convert a `*.wast` file into JSON commands |
+| `wasm-tools world` |  | Show imports and exports for a wasm component |
 
 [wasmparser]: https://crates.io/crates/wasmparser
 [wat]: https://crates.io/crates/wat

--- a/src/bin/wasm-tools/main.rs
+++ b/src/bin/wasm-tools/main.rs
@@ -74,6 +74,7 @@ subcommands! {
     (addr2line, "addr2line")
     (completion, "completion")
     (json_from_wast, "json-from-wast")
+    (world, "world")
 }
 
 fn main() -> ExitCode {

--- a/src/bin/wasm-tools/world.rs
+++ b/src/bin/wasm-tools/world.rs
@@ -1,0 +1,42 @@
+use anyhow::Result;
+use serde::Serialize;
+use wasm_compose::graph::Component;
+
+#[derive(Serialize, Clone, Debug)]
+struct ComponentImportsExports {
+    pub imports: Vec<String>,
+    pub exports: Vec<String>,
+}
+
+/// Debugging utility to list component imports and exports.
+#[derive(clap::Parser)]
+pub struct Opts {
+    #[clap(flatten)]
+    io: wasm_tools::InputOutput,
+}
+
+impl Opts {
+    pub fn general_opts(&self) -> &wasm_tools::GeneralOpts {
+        self.io.general_opts()
+    }
+
+    pub fn run(&self) -> Result<()> {
+        let input = self.io.parse_input_wasm()?;
+        let component = Component::from_bytes("demo", &input)?;
+
+        let imports = component
+            .imports()
+            .map(|(_idx, name, _ty)| name.to_string())
+            .collect();
+        let exports = component
+            .exports()
+            .map(|(_, name, _, _)| name.to_string())
+            .collect();
+        let world = ComponentImportsExports { exports, imports };
+
+        let output = serde_json::to_string_pretty(&world)?;
+        self.io.output(wasm_tools::Output::Json(&output))?;
+
+        Ok(())
+    }
+}

--- a/tests/cli/world-bundled.wat
+++ b/tests/cli/world-bundled.wat
@@ -1,0 +1,51 @@
+;; RUN: world %
+
+(component
+  (type $WasiFile (instance
+      (export "read" (func (param "len" u32) (result (list u8))))
+      (export "write" (func (param "buf" (list u8)) (result u32)))
+    ))
+  (import "wasi-file" (instance $real-wasi (type $WasiFile)))
+
+  (core module $libc
+    (memory (export "mem") 0)
+    (func (export "realloc") (param i32 i32 i32 i32) (result i32)
+      unreachable
+    )
+  )
+
+  (core instance $libc (instantiate $libc))
+
+  (core module $CHILD
+    (import "wasi-file" "read" (func $wasi-file (param i32 i32)))
+    (func $play (export "play")
+      unreachable
+    )
+  )
+
+  (core module $VIRTUALIZE
+    (import "wasi-file" "read" (func (param i32 i32)))
+    (func (export "read") (param i32 i32)
+      unreachable
+    )
+    (func (export "write") (param i32 i32 i32)
+      unreachable
+    )
+  )
+
+  (core func $real-wasi-read
+    (canon lower (func $real-wasi "read")
+      (memory $libc "mem")
+      (realloc (func $libc "realloc"))
+    )
+  )
+
+  (core instance $virt-wasi (instantiate $VIRTUALIZE (with "wasi-file" (instance (export "read" (func $real-wasi-read))))))
+  (core instance $child (instantiate $CHILD (with "wasi-file" (instance $virt-wasi))))
+  (func (export "work")
+    (canon lift (core func $child "play")
+      (memory $libc "mem")
+      (realloc (func $libc "realloc"))
+    )
+  )
+)

--- a/tests/cli/world-bundled.wat.stdout
+++ b/tests/cli/world-bundled.wat.stdout
@@ -1,0 +1,8 @@
+{
+  "imports": [
+    "wasi-file"
+  ],
+  "exports": [
+    "work"
+  ]
+}


### PR DESCRIPTION
I was running through the tutorial for [building and composing components](https://component-model.bytecodealliance.org/tutorial.html) earlier this week and I made a mistake when building one of the components where the component was not exporting what I thought it was and when I tried to compose the components, the import that was being looked for was simply not found. 

I looked through the existing tools and found that the information necessary to debug this is tucked away behind debug logs or is printed alongside so much other information that it's difficult to find. In either case, the information I needed to find this was not easily discoverable.

Based on that I thought it'd be useful to have a small and simple tool whose sole purpose is strictly to list a component's imports and exports with the hope that it'd be a useful tool for working with component composition. I wasn't sure about the use of `world` for the subcommand name, if there's a better one I'd be happy to change it.

Here's some example output just from the tutorial components:

```sh
$ cargo run -- world /tmp/calculator.wat 
   Compiling wasm-tools v1.201.0 (/home/ssnover/dev/wasm-tools)
    Finished dev [unoptimized + debuginfo] target(s) in 5.46s
     Running `/barge/cargo-target/debug/wasm-tools world /tmp/calculator.wat`
{
  "imports": [
    "docs:calculator/add@0.1.0",
    "wasi:cli/environment@0.2.0",
    "wasi:cli/exit@0.2.0",
    "wasi:io/error@0.2.0",
    "wasi:io/streams@0.2.0",
    "wasi:cli/stdin@0.2.0",
    "wasi:cli/stdout@0.2.0",
    "wasi:cli/stderr@0.2.0",
    "wasi:clocks/wall-clock@0.2.0",
    "wasi:filesystem/types@0.2.0",
    "wasi:filesystem/preopens@0.2.0"
  ],
  "exports": [
    "docs:calculator/calculate@0.1.0"
  ]
}

$ cargo run -- world /tmp/addr.wat 
    Finished dev [unoptimized + debuginfo] target(s) in 0.09s
     Running `/barge/cargo-target/debug/wasm-tools world /tmp/adder.wat`
{
  "imports": [
    "wasi:cli/environment@0.2.0",
    "wasi:cli/exit@0.2.0",
    "wasi:io/error@0.2.0",
    "wasi:io/streams@0.2.0",
    "wasi:cli/stdin@0.2.0",
    "wasi:cli/stdout@0.2.0",
    "wasi:cli/stderr@0.2.0",
    "wasi:clocks/wall-clock@0.2.0",
    "wasi:filesystem/types@0.2.0",
    "wasi:filesystem/preopens@0.2.0"
  ],
  "exports": [
    "docs:calculator/add@0.1.0"
  ]
}
```

Finally, I added a simple test based on the component in one of the `dump` tests, but am happy to add more tests if y'all think it'd be warranted.