### PR TITLE
Don't generate exports named `memory` in wit-smith

### DIFF
--- a/crates/wit-smith/src/generate.rs
+++ b/crates/wit-smith/src/generate.rs
@@ -318,16 +318,14 @@ impl Generator {
 
 impl<'a> InterfaceGenerator<'a> {
     fn new(gen: &'a Generator, file: &'a mut File) -> InterfaceGenerator<'a> {
-        // Claim the name `memory` to avoid conflicting with the canonical ABI
-        // always using a linear memory named `memory`.
-        let mut unique_names = HashSet::new();
-        unique_names.insert("memory".to_string());
         InterfaceGenerator {
             gen,
             file,
             config: &gen.config,
             types_in_interface: Vec::new(),
-            unique_names,
+            // Claim the name `memory` to avoid conflicting with the canonical
+            // ABI always using a linear memory named `memory`.
+            unique_names: HashSet::from_iter(["memory".to_string()]),
         }
     }
 
@@ -413,11 +411,10 @@ impl<'a> InterfaceGenerator<'a> {
         let mut parts = Vec::new();
         let mut imported_interfaces = HashSet::new();
         let mut exported_interfaces = HashSet::new();
-        let mut export_names = HashSet::new();
 
-        // Claim the name `memory` to avoid conflicting with the canonical ABI
-        // always using a linear memory named `memory`.
-        export_names.insert("memory".to_string());
+        // Claim the name `memory` to avoid conflicting with the canonical
+        // ABI always using a linear memory named `memory`.
+        let mut export_names = HashSet::from_iter(["memory".to_string()]);
 
         while parts.len() < self.config.max_world_items && !u.is_empty() && u.arbitrary()? {
             let kind = u.arbitrary::<ItemKind>()?;

--- a/crates/wit-smith/src/generate.rs
+++ b/crates/wit-smith/src/generate.rs
@@ -415,6 +415,10 @@ impl<'a> InterfaceGenerator<'a> {
         let mut exported_interfaces = HashSet::new();
         let mut export_names = HashSet::new();
 
+        // Claim the name `memory` to avoid conflicting with the canonical ABI
+        // always using a linear memory named `memory`.
+        export_names.insert("memory".to_string());
+
         while parts.len() < self.config.max_world_items && !u.is_empty() && u.arbitrary()? {
             let kind = u.arbitrary::<ItemKind>()?;
             let (direction, named) = match kind {


### PR DESCRIPTION
This fixes a fuzz bug discovered last night and this applies a similar fix for interfaces which avoids using `memory` that clashes with the canonical name for linear memory itself.