### PR TITLE
Bail when doing `wit_component::decode` on a component

### DIFF
--- a/tests/cli/component-new-existing-component.wat
+++ b/tests/cli/component-new-existing-component.wat
@@ -1,0 +1,2 @@
+;; FAIL: component new % -o component.wasm
+(component)

--- a/tests/cli/component-new-existing-component.wat.stderr
+++ b/tests/cli/component-new-existing-component.wat.stderr
@@ -1,0 +1,1 @@
+error: decoding a component is not supported


### PR DESCRIPTION
Ran into an issue where I was accidentally calling `wasm-tools component new` on a wasm binary that was already a component. Unfortunately, there's nothing that prevents this, and things only blow up deep inside the parser where an EOF error is returned. I believe there's no good reason for calling `wit_component::decode` with a component so this feels like the right place to return this error.