### PR TITLE
Add additional error context to ComponentEncoder::encode

### DIFF
--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -2078,7 +2078,7 @@ impl ComponentEncoder {
             bail!("a module is required when encoding a component");
         }
 
-        let world = ComponentWorld::new(self)?;
+        let world = ComponentWorld::new(self).context("failed to decode world from module")?;
         let mut state = EncodingState {
             component: ComponentBuilder::default(),
             module_index: None,

--- a/crates/wit-component/src/encoding/world.rs
+++ b/crates/wit-component/src/encoding/world.rs
@@ -76,7 +76,8 @@ impl<'a> ComponentWorld<'a> {
             &encoder.metadata,
             &encoder.main_module_exports,
             &adapters,
-        )?;
+        )
+        .context("module was not valid")?;
 
         let mut ret = ComponentWorld {
             encoder,

--- a/crates/wit-component/tests/components/error-default-export-sig-mismatch/error.txt
+++ b/crates/wit-component/tests/components/error-default-export-sig-mismatch/error.txt
@@ -1,1 +1,5 @@
-type mismatch for function `a`: expected `[I32, I32] -> [I32]` but found `[] -> []`
+failed to decode world from module
+
+Caused by:
+    0: module was not valid
+    1: type mismatch for function `a`: expected `[I32, I32] -> [I32]` but found `[] -> []`

--- a/crates/wit-component/tests/components/error-empty-module-import/error.txt
+++ b/crates/wit-component/tests/components/error-empty-module-import/error.txt
@@ -1,1 +1,5 @@
-no top-level imported function `foo` specified
+failed to decode world from module
+
+Caused by:
+    0: module was not valid
+    1: no top-level imported function `foo` specified

--- a/crates/wit-component/tests/components/error-export-sig-mismatch/error.txt
+++ b/crates/wit-component/tests/components/error-export-sig-mismatch/error.txt
@@ -1,4 +1,6 @@
-failed to validate exported interface `foo`
+failed to decode world from module
 
 Caused by:
-    type mismatch for function `a`: expected `[I32, I32] -> [I32]` but found `[] -> []`
+    0: module was not valid
+    1: failed to validate exported interface `foo`
+    2: type mismatch for function `a`: expected `[I32, I32] -> [I32]` but found `[] -> []`

--- a/crates/wit-component/tests/components/error-import-resource-rep/error.txt
+++ b/crates/wit-component/tests/components/error-import-resource-rep/error.txt
@@ -1,1 +1,5 @@
-no top-level imported function `[resource-rep]a` specified
+failed to decode world from module
+
+Caused by:
+    0: module was not valid
+    1: no top-level imported function `[resource-rep]a` specified

--- a/crates/wit-component/tests/components/error-import-resource-wrong-signature/error.txt
+++ b/crates/wit-component/tests/components/error-import-resource-wrong-signature/error.txt
@@ -1,1 +1,5 @@
-type mismatch for function `[resource-drop]a`: expected `[I32] -> []` but found `[I32] -> [I32]`
+failed to decode world from module
+
+Caused by:
+    0: module was not valid
+    1: type mismatch for function `[resource-drop]a`: expected `[I32] -> []` but found `[I32] -> [I32]`

--- a/crates/wit-component/tests/components/error-import-sig-mismatch/error.txt
+++ b/crates/wit-component/tests/components/error-import-sig-mismatch/error.txt
@@ -1,4 +1,6 @@
-failed to validate import interface `foo`
+failed to decode world from module
 
 Caused by:
-    type mismatch for function `bar`: expected `[I32, I32] -> []` but found `[] -> []`
+    0: module was not valid
+    1: failed to validate import interface `foo`
+    2: type mismatch for function `bar`: expected `[I32, I32] -> []` but found `[] -> []`

--- a/crates/wit-component/tests/components/error-invalid-module-import/error.txt
+++ b/crates/wit-component/tests/components/error-invalid-module-import/error.txt
@@ -1,1 +1,5 @@
-module is only allowed to import functions
+failed to decode world from module
+
+Caused by:
+    0: module was not valid
+    1: module is only allowed to import functions

--- a/crates/wit-component/tests/components/error-missing-default-export/error.txt
+++ b/crates/wit-component/tests/components/error-missing-default-export/error.txt
@@ -1,1 +1,5 @@
-module does not export required function `a`
+failed to decode world from module
+
+Caused by:
+    0: module was not valid
+    1: module does not export required function `a`

--- a/crates/wit-component/tests/components/error-missing-export/error.txt
+++ b/crates/wit-component/tests/components/error-missing-export/error.txt
@@ -1,4 +1,6 @@
-failed to validate exported interface `foo`
+failed to decode world from module
 
 Caused by:
-    module does not export required function `foo#a`
+    0: module was not valid
+    1: failed to validate exported interface `foo`
+    2: module does not export required function `foo#a`

--- a/crates/wit-component/tests/components/error-missing-import-func/error.txt
+++ b/crates/wit-component/tests/components/error-missing-import-func/error.txt
@@ -1,1 +1,5 @@
-module requires an import interface named `foo`
+failed to decode world from module
+
+Caused by:
+    0: module was not valid
+    1: module requires an import interface named `foo`

--- a/crates/wit-component/tests/components/error-missing-import/error.txt
+++ b/crates/wit-component/tests/components/error-missing-import/error.txt
@@ -1,1 +1,5 @@
-module requires an import interface named `foo`
+failed to decode world from module
+
+Caused by:
+    0: module was not valid
+    1: module requires an import interface named `foo`


### PR DESCRIPTION
This would have helped me when investigating an issue. Changes to `wasm-parser`'s `BinaryReaderError` would be needed to make the errors here even clearer.  

Before:

```
error: failed to encode a component from module

Caused by:
    unexpected end-of-file (at offset 0xc)
```

After: 
```
error: failed to encode a component from module

Caused by:
    0: failed to decode world from module
    1: module was not valid
    2: unexpected end-of-file (at offset 0xc)
```