### PR TITLE
threads: add initial flags for shared-everything-threads

### DIFF
--- a/crates/wasm-shrink/src/lib.rs
+++ b/crates/wasm-shrink/src/lib.rs
@@ -223,6 +223,7 @@ impl ShrinkRun {
             bulk_memory: true,
             simd: true,
             threads: true,
+            shared_everything_threads: false,
             tail_call: true,
             multi_memory: true,
             exceptions: true,

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -218,6 +218,9 @@ pub struct WasmFeatures {
     pub relaxed_simd: bool,
     /// The WebAssembly threads proposal (enabled by default)
     pub threads: bool,
+    /// The WebAssembly shared-everything-threads proposal; includes new
+    /// component model built-ins.
+    pub shared_everything_threads: bool,
     /// The WebAssembly tail-call proposal (enabled by default)
     pub tail_call: bool,
     /// Whether or not floating-point instructions are enabled.
@@ -266,6 +269,7 @@ impl WasmFeatures {
             simd: true,
             relaxed_simd: true,
             threads: true,
+            shared_everything_threads: true,
             tail_call: true,
             floats: true,
             multi_memory: true,
@@ -377,6 +381,7 @@ impl Default for WasmFeatures {
             gc: false,
             component_model_values: false,
             component_model_nested_names: false,
+            shared_everything_threads: false,
 
             // On-by-default features (phase 4 or greater).
             mutable_global: true,

--- a/src/bin/wasm-tools/validate.rs
+++ b/src/bin/wasm-tools/validate.rs
@@ -102,6 +102,9 @@ fn parse_features(arg: &str) -> Result<WasmFeatures> {
         ("function-references", |f| &mut f.function_references),
         ("simd", |f| &mut f.simd),
         ("threads", |f| &mut f.threads),
+        ("shared-everything-threads", |f| {
+            &mut f.shared_everything_threads
+        }),
         ("bulk-memory", |f| &mut f.bulk_memory),
         ("multi-value", |f| &mut f.multi_value),
         ("tail-call", |f| &mut f.tail_call),

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -578,6 +578,7 @@ impl TestState {
     fn wasmparser_validator_for(&self, test: &Path) -> Validator {
         let mut features = WasmFeatures {
             threads: true,
+            shared_everything_threads: false,
             reference_types: true,
             simd: true,
             relaxed_simd: true,
@@ -637,6 +638,10 @@ impl TestState {
                 "tail-call" => features.tail_call = true,
                 "memory64" => features.memory64 = true,
                 "component-model" => features.component_model = true,
+                "shared-everything-threads" => {
+                    features.component_model = true;
+                    features.shared_everything_threads = true;
+                }
                 "multi-memory" => features.multi_memory = true,
                 "extended-const" => features.extended_const = true,
                 "function-references" => features.function_references = true,


### PR DESCRIPTION
The [shared-everything-threads] proposal adds new `shared` annotations in more places, new atomic instructions, new component model thread intrinsics, etc. This change just sets the ground work by adding the shared-everything-threads flags in all the places I found to be needed; more PRs to follow.

[shared-everything-threads]: https://github.com/WebAssembly/shared-everything-threads