### PR TITLE
Build a WASI release binary in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,9 @@ jobs:
         - build: aarch64-linux
           os: ubuntu-latest
           target: aarch64-unknown-linux-gnu
+        - build: wasm32-wasi
+          os: ubuntu-latest
+          target: wasm32-wasi
     steps:
     - uses: actions/checkout@v4
       with:
@@ -40,6 +43,7 @@ jobs:
     - uses: bytecodealliance/wasmtime/.github/actions/binary-compatible-builds@v17.0.1
       with:
         name: ${{ matrix.build }}
+      if: matrix.build != 'wasm32-wasi'
     - run: |
         echo CARGO_BUILD_TARGET=${{ matrix.target }} >> $GITHUB_ENV
         rustup target add ${{ matrix.target }}

--- a/ci/build-tarballs.sh
+++ b/ci/build-tarballs.sh
@@ -19,6 +19,8 @@ fmt=tar
 if [ "$platform" = "x86_64-windows" ]; then
   cp target/release/wasm-tools.exe tmp/$bin_pkgname
   fmt=zip
+elif [ "$target" = "wasm32-wasi" ]; then
+  cp target/wasm32-wasi/release/wasm-tools.wasm tmp/$bin_pkgname
 elif [ "$target" = "" ]; then
   cp target/release/wasm-tools tmp/$bin_pkgname
 else


### PR DESCRIPTION
This commit adds to the list of release binaries created in CI to publish a wasm32-wasi binary alongside the others. I don't expect it to be used that often but it's a neat showcase.