### PR TITLE
threads: add `shared` globals

### DIFF
--- a/crates/fuzz-stats/src/bin/failed-instantiations.rs
+++ b/crates/fuzz-stats/src/bin/failed-instantiations.rs
@@ -102,8 +102,9 @@ impl State {
         let mut config = wasm_smith::Config::arbitrary(&mut u)?;
         config.allow_start_export = false;
 
-        // Wasmtime doesn't support this proposal yet.
+        // Wasmtime doesn't support these proposals yet.
         config.gc_enabled = false;
+        config.shared_everything_threads_enabled = false;
 
         let mut wasm = wasm_smith::Module::new(config, &mut u)?;
         wasm.ensure_termination(10_000).unwrap();

--- a/crates/wasm-encoder/src/core/globals.rs
+++ b/crates/wasm-encoder/src/core/globals.rs
@@ -14,6 +14,7 @@ use crate::{encode_section, ConstExpr, Encode, Section, SectionId, ValType};
 ///     GlobalType {
 ///         val_type: ValType::I32,
 ///         mutable: false,
+///         shared: false,
 ///     },
 ///     &ConstExpr::i32_const(42),
 /// );
@@ -80,12 +81,21 @@ pub struct GlobalType {
     pub val_type: ValType,
     /// Whether this global is mutable or not.
     pub mutable: bool,
+    /// Whether this global is shared or not.
+    pub shared: bool,
 }
 
 impl Encode for GlobalType {
     fn encode(&self, sink: &mut Vec<u8>) {
         self.val_type.encode(sink);
-        sink.push(self.mutable as u8);
+        let mut flag = 0;
+        if self.mutable {
+            flag |= 0b01;
+        }
+        if self.shared {
+            flag |= 0b10;
+        }
+        sink.push(flag);
     }
 }
 
@@ -96,6 +106,7 @@ impl TryFrom<wasmparser::GlobalType> for GlobalType {
         Ok(GlobalType {
             val_type: global_ty.content_type.try_into()?,
             mutable: global_ty.mutable,
+            shared: global_ty.shared,
         })
     }
 }

--- a/crates/wasm-mutate/src/mutators/peephole.rs
+++ b/crates/wasm-mutate/src/mutators/peephole.rs
@@ -309,6 +309,7 @@ impl PeepholeMutator {
                                     index: _,
                                     tpe: ty,
                                     mutable,
+                                    shared,
                                 } => {
                                     let (init, ty) = match ty {
                                         PrimitiveTypeInfo::I32 => {
@@ -329,8 +330,9 @@ impl PeepholeMutator {
                                         _ => unreachable!("Not valid for globals"),
                                     };
                                     let ty = wasm_encoder::GlobalType {
-                                        mutable: *mutable,
                                         val_type: ty,
+                                        mutable: *mutable,
+                                        shared: *shared,
                                     };
                                     // Add to globals
                                     new_global_section.global(ty, &init);

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder/expr2wasm.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder/expr2wasm.rs
@@ -23,6 +23,8 @@ pub enum ResourceRequest {
         tpe: PrimitiveTypeInfo,
         /// If its mutable
         mutable: bool,
+        /// If its shared
+        shared: bool,
     },
     // TODO add other needed resources here, for example, needed locals, needed
     // memory etc. Notice that how this resources are translated to Wasm code,
@@ -363,6 +365,7 @@ pub fn expr2wasm(
                             index: global_idx as usize,
                             tpe: PrimitiveTypeInfo::I32,
                             mutable: true,
+                            shared: false,
                         };
                         resources.push(request);
 
@@ -375,6 +378,7 @@ pub fn expr2wasm(
                             index: global_idx as usize,
                             tpe: PrimitiveTypeInfo::I64,
                             mutable: true,
+                            shared: false,
                         };
                         resources.push(request);
 
@@ -387,6 +391,7 @@ pub fn expr2wasm(
                             index: global_idx as usize,
                             tpe: PrimitiveTypeInfo::F32,
                             mutable: true,
+                            shared: false,
                         };
                         resources.push(request);
 
@@ -399,6 +404,7 @@ pub fn expr2wasm(
                             index: global_idx as usize,
                             tpe: PrimitiveTypeInfo::F64,
                             mutable: true,
+                            shared: false,
                         };
                         resources.push(request);
 

--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -170,6 +170,7 @@ pub fn global_type(
     Ok(wasm_encoder::GlobalType {
         val_type: t.translate_ty(&ty.content_type)?,
         mutable: ty.mutable,
+        shared: ty.shared,
     })
 }
 

--- a/crates/wasm-smith/src/component.rs
+++ b/crates/wasm-smith/src/component.rs
@@ -952,6 +952,7 @@ impl ComponentBuilder {
         Ok(crate::core::GlobalType {
             val_type: self.arbitrary_core_valtype(u)?,
             mutable: u.arbitrary()?,
+            shared: self.config.shared_everything_threads_enabled && u.arbitrary()?,
         })
     }
 

--- a/crates/wasm-smith/src/config.rs
+++ b/crates/wasm-smith/src/config.rs
@@ -568,6 +568,18 @@ define_config! {
         /// Defaults to `false`.
         pub threads_enabled: bool = false,
 
+        /// Determines whether the shared-everything-threads proposal is
+        /// enabled.
+        ///
+        /// The [shared-everything-threads proposal] involves shared attributes
+        /// on more things, even more new atomic instructions, TLS support, new
+        /// component model intrinsics, etc.
+        ///
+        /// [threads proposal]: https://github.com/WebAssembly/shared-everything-threads/blob/main/proposals/shared-everything-threads/Overview.md
+        ///
+        /// Defaults to `false`.
+        pub shared_everything_threads_enabled: bool = false,
+
         /// Indicates whether wasm-smith is allowed to generate invalid function
         /// bodies.
         ///
@@ -712,6 +724,7 @@ impl<'a> Arbitrary<'a> for Config {
             available_imports: None,
             exports: None,
             threads_enabled: false,
+            shared_everything_threads_enabled: false,
             export_everything: false,
             tail_call_enabled: false,
             gc_enabled: false,

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -1424,6 +1424,7 @@ impl Module {
         Ok(GlobalType {
             val_type: self.arbitrary_valtype(u)?,
             mutable: u.arbitrary()?,
+            shared: self.config.shared_everything_threads_enabled && u.arbitrary()?,
         })
     }
 
@@ -1756,6 +1757,7 @@ impl Module {
                         GlobalType {
                             val_type: convert_val_type(&global_type.content_type),
                             mutable: global_type.mutable,
+                            shared: global_type.shared,
                         },
                         u,
                     )?,

--- a/crates/wasm-smith/src/core/code_builder.rs
+++ b/crates/wasm-smith/src/core/code_builder.rs
@@ -870,6 +870,7 @@ impl CodeBuilderAllocations {
             module.globals.push(GlobalType {
                 val_type: ty,
                 mutable: true,
+                shared: false,
             });
             module.defined_globals.push((global_idx, init));
 

--- a/crates/wasm-smith/src/core/terminate.rs
+++ b/crates/wasm-smith/src/core/terminate.rs
@@ -23,6 +23,7 @@ impl Module {
         self.globals.push(GlobalType {
             val_type: ValType::I32,
             mutable: true,
+            shared: false,
         });
         self.defined_globals
             .push((fuel_global, ConstExpr::i32_const(default_fuel as i32)));

--- a/crates/wasmparser/src/readers/core/globals.rs
+++ b/crates/wasmparser/src/readers/core/globals.rs
@@ -37,13 +37,15 @@ impl<'a> FromReader<'a> for Global<'a> {
 
 impl<'a> FromReader<'a> for GlobalType {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        let content_type = reader.read()?;
+        let flags = reader.read_u8()?;
+        if flags > 0b11 {
+            bail!(reader.original_position() - 1, "malformed mutability")
+        }
         Ok(GlobalType {
-            content_type: reader.read()?,
-            mutable: match reader.read_u8()? {
-                0x00 => false,
-                0x01 => true,
-                _ => bail!(reader.original_position() - 1, "malformed mutability",),
-            },
+            content_type,
+            mutable: (flags & 0b01) > 0,
+            shared: (flags & 0b10) > 0,
         })
     }
 }

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -1505,6 +1505,8 @@ pub struct GlobalType {
     pub content_type: ValType,
     /// Whether or not the global is mutable.
     pub mutable: bool,
+    /// Whether or not the global is shared.
+    pub shared: bool,
 }
 
 /// Represents a tag kind.

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -1533,7 +1533,8 @@ mod tests {
             types.global_at(0),
             GlobalType {
                 content_type: ValType::I32,
-                mutable: true
+                mutable: true,
+                shared: false
             }
         );
 

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -1027,6 +1027,12 @@ impl Module {
         features: &WasmFeatures,
         offset: usize,
     ) -> Result<()> {
+        if ty.shared && !features.shared_everything_threads {
+            return Err(BinaryReaderError::new(
+                "shared globals require the shared-everything-threads proposal",
+                offset,
+            ));
+        }
         self.check_value_type(&mut ty.content_type, features, offset)
     }
 

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -1104,8 +1104,14 @@ impl Printer {
             self.print_name(&state.core.global_names, state.core.globals)?;
             self.result.push(' ');
         }
-        if ty.mutable {
-            self.result.push_str("(mut ");
+        if ty.shared || ty.mutable {
+            self.result.push('(');
+            if ty.shared {
+                self.result.push_str("shared ");
+            }
+            if ty.mutable {
+                self.result.push_str("mut ");
+            }
             self.print_valtype(state, ty.content_type)?;
             self.result.push(')');
         } else {

--- a/crates/wasmprinter/tests/all.rs
+++ b/crates/wasmprinter/tests/all.rs
@@ -277,3 +277,17 @@ fn no_panic_non_func_type() {
     .unwrap();
     wasmprinter::print_bytes(&bytes).unwrap();
 }
+
+#[test]
+fn shared_global() {
+    const MODULE: &str = r#"
+    (module
+        (global (;0;) (shared f32))
+    )"#;
+    let bytes = wat::parse_str(MODULE).unwrap();
+    let result = wasmprinter::print_bytes(&bytes).unwrap();
+    assert_eq!(
+        result.replace(" ", "").trim(),
+        MODULE.replace(" ", "").trim()
+    );
+}

--- a/crates/wast/src/component/binary.rs
+++ b/crates/wast/src/component/binary.rs
@@ -661,6 +661,7 @@ impl From<core::GlobalType<'_>> for wasm_encoder::GlobalType {
         Self {
             val_type: ty.ty.into(),
             mutable: ty.mutable,
+            shared: ty.shared,
         }
     }
 }

--- a/crates/wast/src/core/binary.rs
+++ b/crates/wast/src/core/binary.rs
@@ -493,11 +493,14 @@ impl Encode for MemoryType {
 impl<'a> Encode for GlobalType<'a> {
     fn encode(&self, e: &mut Vec<u8>) {
         self.ty.encode(e);
+        let mut flags = 0;
         if self.mutable {
-            e.push(0x01);
-        } else {
-            e.push(0x00);
+            flags |= 0b01;
         }
+        if self.shared {
+            flags |= 0b10;
+        }
+        e.push(flags);
     }
 }
 

--- a/crates/wast/src/core/types.rs
+++ b/crates/wast/src/core/types.rs
@@ -368,22 +368,35 @@ pub struct GlobalType<'a> {
     pub ty: ValType<'a>,
     /// Whether or not the global is mutable or not.
     pub mutable: bool,
+    /// Whether or not the global is shared.
+    pub shared: bool,
 }
 
 impl<'a> Parse<'a> for GlobalType<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
-        if parser.peek2::<kw::r#mut>()? {
+        if parser.peek2::<kw::shared>()? || parser.peek2::<kw::r#mut>()? {
             parser.parens(|p| {
-                p.parse::<kw::r#mut>()?;
+                let mut shared = false;
+                let mut mutable = false;
+                if parser.peek::<kw::shared>()? {
+                    p.parse::<kw::shared>()?;
+                    shared = true;
+                }
+                if parser.peek::<kw::r#mut>()? {
+                    p.parse::<kw::r#mut>()?;
+                    mutable = true;
+                }
                 Ok(GlobalType {
-                    ty: parser.parse()?,
-                    mutable: true,
+                    ty: p.parse()?,
+                    mutable,
+                    shared,
                 })
             })
         } else {
             Ok(GlobalType {
                 ty: parser.parse()?,
                 mutable: false,
+                shared: false,
             })
         }
     }

--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -615,8 +615,9 @@ impl<'a> Module<'a> {
         for (i, global) in self.live_globals() {
             map.globals.push(i);
             let ty = wasm_encoder::GlobalType {
-                mutable: global.ty.mutable,
                 val_type: map.valty(global.ty.content_type),
+                mutable: global.ty.mutable,
+                shared: global.ty.shared,
             };
             match &global.def {
                 Definition::Import(m, n) => {

--- a/crates/wit-component/src/linking.rs
+++ b/crates/wit-component/src/linking.rs
@@ -302,6 +302,7 @@ fn make_env_module<'a>(
                             EntityType::Global(wasm_encoder::GlobalType {
                                 val_type: ty.ty.into(),
                                 mutable: ty.mutable,
+                                shared: ty.shared,
                             })
                         }
                     },
@@ -350,6 +351,7 @@ fn make_env_module<'a>(
                 wasm_encoder::GlobalType {
                     val_type: ValType::I32,
                     mutable,
+                    shared: false, // TODO: determine if module is shared or not.
                 },
                 &const_u32(value),
             );
@@ -577,6 +579,7 @@ fn make_init_module(
                     wasm_encoder::GlobalType {
                         val_type: ValType::I32,
                         mutable,
+                        shared: false, // TODO: determine if module is shared or not.
                     },
                 );
                 get_and_increment(&mut global_count)
@@ -790,6 +793,7 @@ fn find_offset_exporter<'a>(
         ty: Type::Global(GlobalType {
             ty: ValueType::I32,
             mutable: false,
+            shared: false,
         }),
     };
 
@@ -898,6 +902,7 @@ fn resolve_symbols<'a>(
                         ty: Type::Global(GlobalType {
                             ty: ValueType::I32,
                             mutable: false,
+                            shared: false,
                         }),
                     },
                     flags: SymbolFlags::empty(),

--- a/crates/wit-component/src/linking/metadata.rs
+++ b/crates/wit-component/src/linking/metadata.rs
@@ -89,6 +89,7 @@ impl TryFrom<&FuncType> for FunctionType {
 pub struct GlobalType {
     pub ty: ValueType,
     pub mutable: bool,
+    pub shared: bool,
 }
 
 impl fmt::Display for GlobalType {
@@ -472,9 +473,11 @@ impl<'a> Metadata<'a> {
                                     TypeRef::Global(wasmparser::GlobalType {
                                         content_type,
                                         mutable,
+                                        shared,
                                     }) => Type::Global(GlobalType {
                                         ty: content_type.try_into()?,
                                         mutable,
+                                        shared,
                                     }),
                                     TypeRef::Func(ty) => Type::Function(FunctionType::try_from(
                                         &types[usize::try_from(ty).unwrap()],
@@ -537,6 +540,7 @@ impl<'a> Metadata<'a> {
                                         Type::Global(GlobalType {
                                             ty: ValueType::try_from(ty.content_type)?,
                                             mutable: ty.mutable,
+                                            shared: ty.shared,
                                         })
                                     }
                                     kind => {

--- a/tests/cli/dump/alias2.wat.stdout
+++ b/tests/cli/dump/alias2.wat.stdout
@@ -139,7 +139,7 @@
    0x16b | 00 01       | [memory 0] MemoryType { memory64: false, shared: false, initial: 1, maximum: None }
    0x16d | 06 04       | global section
    0x16f | 01          | 1 count
-   0x170 | 7f 00       | [global 0] GlobalType { content_type: I32, mutable: false }
+   0x170 | 7f 00       | [global 0] GlobalType { content_type: I32, mutable: false, shared: false }
    0x172 | 0b          | end
    0x173 | 07 11       | export section
    0x175 | 04          | 4 count
@@ -171,7 +171,7 @@
          | 00         
    0x1b0 | 00 01 32 02 | import [memory 0] Import { module: "", name: "2", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None }) }
          | 00 01      
-   0x1b6 | 00 01 33 03 | import [global 0] Import { module: "", name: "3", ty: Global(GlobalType { content_type: I32, mutable: false }) }
+   0x1b6 | 00 01 33 03 | import [global 0] Import { module: "", name: "3", ty: Global(GlobalType { content_type: I32, mutable: false, shared: false }) }
          | 7f 00      
    0x1bc | 00 01 34 01 | import [table 0] Import { module: "", name: "4", ty: Table(TableType { element_type: funcref, initial: 1, maximum: None }) }
          | 70 00 01   

--- a/tests/cli/dump/module-types.wat.stdout
+++ b/tests/cli/dump/module-types.wat.stdout
@@ -2,7 +2,7 @@
       | 0d 00 01 00
   0x8 | 03 23       | core type section
   0xa | 01          | 1 count
-  0xb | 50 05 01 60 | [core type 0] Module([Type(SubType { is_final: true, supertype_idx: None, composite_type: Func(FuncType { params: [], results: [] }) }), Import(Import { module: "", name: "f", ty: Func(0) }), Import(Import { module: "", name: "g", ty: Global(GlobalType { content_type: I32, mutable: false }) }), Import(Import { module: "", name: "t", ty: Table(TableType { element_type: funcref, initial: 1, maximum: None }) }), Import(Import { module: "", name: "m", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None }) })])
+  0xb | 50 05 01 60 | [core type 0] Module([Type(SubType { is_final: true, supertype_idx: None, composite_type: Func(FuncType { params: [], results: [] }) }), Import(Import { module: "", name: "f", ty: Func(0) }), Import(Import { module: "", name: "g", ty: Global(GlobalType { content_type: I32, mutable: false, shared: false }) }), Import(Import { module: "", name: "t", ty: Table(TableType { element_type: funcref, initial: 1, maximum: None }) }), Import(Import { module: "", name: "m", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None }) })])
       | 00 00 00 00
       | 01 66 00 00
       | 00 00 01 67

--- a/tests/cli/dump/simple.wat.stdout
+++ b/tests/cli/dump/simple.wat.stdout
@@ -23,7 +23,7 @@
  0x2a | 00 01       | [memory 0] MemoryType { memory64: false, shared: false, initial: 1, maximum: None }
  0x2c | 06 06       | global section
  0x2e | 01          | 1 count
- 0x2f | 7f 00       | [global 0] GlobalType { content_type: I32, mutable: false }
+ 0x2f | 7f 00       | [global 0] GlobalType { content_type: I32, mutable: false, shared: false }
  0x31 | 41 00       | i32_const value:0
  0x33 | 0b          | end
  0x34 | 07 05       | export section

--- a/tests/local/shared-everything-threads/global.wast
+++ b/tests/local/shared-everything-threads/global.wast
@@ -1,0 +1,10 @@
+;; Styled after ../../testsuite/global.wast
+
+(module
+  (global $a (shared i64) (i64.const 0))
+  (global $b (shared mut i64) (i64.const 1))
+)
+
+(assert_malformed
+  (module quote "(global (mut shared i64) (i64.const -1))")
+  "unexpected token")

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -842,5 +842,13 @@ fn error_matches(error: &str, message: &str) -> bool {
         return error.starts_with("type mismatch");
     }
 
+    if message == "malformed mutability" {
+        // When parsing a global `shared` type (e.g., `global (mut shared i32)
+        // ...`), many spec tests expect a `malformed mutability` error.
+        // Previously, `0x2` was an invalid flag but it now means `shared`. We
+        // accept a validation error instead.
+        return error.contains("require the shared-everything-threads proposal");
+    }
+
     return false;
 }

--- a/tests/snapshots/local/shared-everything-threads/global.wast.json
+++ b/tests/snapshots/local/shared-everything-threads/global.wast.json
@@ -1,0 +1,17 @@
+{
+  "source_filename": "tests/local/shared-everything-threads/global.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 3,
+      "filename": "global.0.wasm"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 9,
+      "filename": "global.1.wat",
+      "text": "unexpected token",
+      "module_type": "text"
+    }
+  ]
+}

--- a/tests/snapshots/local/shared-everything-threads/global.wast/0.print
+++ b/tests/snapshots/local/shared-everything-threads/global.wast/0.print
@@ -1,0 +1,4 @@
+(module
+  (global $a (;0;) (shared i64) i64.const 0)
+  (global $b (;1;) (shared mut i64) i64.const 1)
+)


### PR DESCRIPTION
This change allows wasm-tools to encode and decode `shared` global types as a part of the [shared-everything-threads] proposal. It includes some initial fuzzing support, though it all should be turned off by default.

[shared-everything-threads]: https://github.com/WebAssembly/shared-everything-threads