### PR TITLE
threads: add atomic versions of `global.get|set`

### DIFF
--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -108,6 +108,13 @@ pub trait Translator {
         memarg(self.as_obj(), arg)
     }
 
+    fn translate_ordering(&mut self, arg: &wasmparser::Ordering) -> Result<Ordering> {
+        Ok(match arg {
+            wasmparser::Ordering::SeqCst => Ordering::SeqCst,
+            wasmparser::Ordering::AcqRel => Ordering::AcqRel,
+        })
+    }
+
     fn remap(&mut self, item: Item, idx: u32) -> Result<u32> {
         let _ = item;
         Ok(idx)
@@ -370,6 +377,7 @@ pub fn op(t: &mut dyn Translator, op: &Operator<'_>) -> Result<Instruction<'stat
         (map $arg:ident from_ref_type) => (t.translate_refty($arg)?);
         (map $arg:ident to_ref_type) => (t.translate_refty($arg)?);
         (map $arg:ident memarg) => (t.translate_memarg($arg)?);
+        (map $arg:ident ordering) => (t.translate_ordering($arg)?);
         (map $arg:ident local_index) => (*$arg);
         (map $arg:ident value) => ($arg);
         (map $arg:ident lane) => (*$arg);

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -278,7 +278,7 @@ impl<'a> BinaryReader<'a> {
     }
 
     fn read_ordering(&mut self) -> Result<Ordering> {
-        let byte = self.read_u8()?;
+        let byte = self.read_var_u32()?;
         match byte {
             0 => Ok(Ordering::SeqCst),
             1 => Ok(Ordering::AcqRel),

--- a/crates/wasmparser/src/lib.rs
+++ b/crates/wasmparser/src/lib.rs
@@ -468,6 +468,12 @@ macro_rules! for_each_operator {
             @threads I64AtomicRmw16CmpxchgU { memarg: $crate::MemArg } => visit_i64_atomic_rmw16_cmpxchg_u
             @threads I64AtomicRmw32CmpxchgU { memarg: $crate::MemArg } => visit_i64_atomic_rmw32_cmpxchg_u
 
+            // Also 0xFE prefixed operators
+            // shared-everything threads
+            // https://github.com/WebAssembly/shared-everything-threads
+            @shared_everything_threads GlobalAtomicGet { ordering: $crate::Ordering, global_index: u32 } => visit_global_atomic_get
+            @shared_everything_threads GlobalAtomicSet { ordering: $crate::Ordering, global_index: u32 } => visit_global_atomic_set
+
             // 0xFD operators
             // 128-bit SIMD
             // - https://github.com/webassembly/simd

--- a/crates/wasmparser/src/readers/core/operators.rs
+++ b/crates/wasmparser/src/readers/core/operators.rs
@@ -107,6 +107,24 @@ impl V128 {
     }
 }
 
+/// Represents the memory ordering for atomic instructions.
+///
+/// For an in-depth explanation of memory orderings, see the C++ documentation
+/// for [`memory_order`] or the Rust documentation for [`atomic::Ordering`].
+///
+/// [`memory_order`]: https://en.cppreference.com/w/cpp/atomic/memory_order
+/// [`atomic::Ordering`]: https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub enum Ordering {
+    /// For a load, it acquires; this orders all operations before the last
+    /// "releasing" store. For a store, it releases; this orders all operations
+    /// before it at the next "acquiring" load.
+    AcqRel,
+    /// Like `AcqRel` but all threads see all sequentially consistent operations
+    /// in the same order.
+    SeqCst,
+}
+
 macro_rules! define_operator {
     ($(@$proposal:ident $op:ident $({ $($payload:tt)* })? => $visit:ident)*) => {
         /// Instructions as defined [here].

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -1076,9 +1076,8 @@ impl RefType {
 
     /// Create a new `RefType`.
     ///
-    /// Returns `None` when the heap type's type index (if any) is
-    /// beyond this crate's implementation limits and therfore is not
-    /// representable.
+    /// Returns `None` when the heap type's type index (if any) is beyond this
+    /// crate's implementation limits and therefore is not representable.
     pub fn new(nullable: bool, heap_type: HeapType) -> Option<Self> {
         let nullable32 = Self::NULLABLE_BIT * (nullable as u32);
         match heap_type {

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -780,6 +780,15 @@ impl ValType {
         }
     }
 
+    /// Whether the type is `shared`.
+    pub fn is_shared(&self) -> bool {
+        match *self {
+            Self::I32 | Self::I64 | Self::F32 | Self::F64 | Self::V128 => true,
+            // TODO: parsing of `shared` refs is not yet implemented.
+            Self::Ref(_) => false,
+        }
+    }
+
     /// Maps any `UnpackedIndex` via the specified closure.
     pub(crate) fn remap_indices(
         &mut self,

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -132,7 +132,7 @@ impl ModuleState {
         offset: usize,
     ) -> Result<()> {
         self.module
-            .check_global_type(&mut global.ty, features, offset)?;
+            .check_global_type(&mut global.ty, features, offset, types)?;
         self.check_const_expr(&global.init_expr, global.ty.content_type, features, types)?;
         self.module.assert_mut().globals.push(global.ty);
         Ok(())
@@ -842,7 +842,7 @@ impl Module {
                 EntityType::Tag(self.types[t.func_type_idx as usize])
             }
             TypeRef::Global(t) => {
-                self.check_global_type(t, features, offset)?;
+                self.check_global_type(t, features, offset, types)?;
                 EntityType::Global(*t)
             }
         })
@@ -1052,14 +1052,28 @@ impl Module {
         ty: &mut GlobalType,
         features: &WasmFeatures,
         offset: usize,
+        types: &TypeList,
     ) -> Result<()> {
-        if ty.shared && !features.contains(WasmFeatures::SHARED_EVERYTHING_THREADS) {
-            return Err(BinaryReaderError::new(
-                "shared globals require the shared-everything-threads proposal",
-                offset,
-            ));
+        self.check_value_type(&mut ty.content_type, features, offset)?;
+        if ty.shared {
+            if !features.contains(WasmFeatures::SHARED_EVERYTHING_THREADS) {
+                return Err(BinaryReaderError::new(
+                    "shared globals require the shared-everything-threads proposal",
+                    offset,
+                ));
+            }
+            let ty = ty.content_type;
+            if !(ty == ValType::I32
+                || ty == ValType::I64
+                || types.valtype_is_subtype(ty, RefType::ANYREF.into()))
+            {
+                return Err(BinaryReaderError::new(
+                    "invalid type: shared globals must be i32, i64 or a subtype of anyref",
+                    offset,
+                ));
+            }
         }
-        self.check_value_type(&mut ty.content_type, features, offset)
+        Ok(())
     }
 
     fn check_limits<T>(&self, initial: T, maximum: Option<T>, offset: usize) -> Result<()>

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -1061,6 +1061,12 @@ impl Module {
                     offset,
                 ));
             }
+            if !ty.content_type.is_shared() {
+                return Err(BinaryReaderError::new(
+                    "shared globals must have a shared value type",
+                    offset,
+                ));
+            }
         }
         Ok(())
     }

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -132,7 +132,7 @@ impl ModuleState {
         offset: usize,
     ) -> Result<()> {
         self.module
-            .check_global_type(&mut global.ty, features, offset, types)?;
+            .check_global_type(&mut global.ty, features, offset)?;
         self.check_const_expr(&global.init_expr, global.ty.content_type, features, types)?;
         self.module.assert_mut().globals.push(global.ty);
         Ok(())
@@ -842,7 +842,7 @@ impl Module {
                 EntityType::Tag(self.types[t.func_type_idx as usize])
             }
             TypeRef::Global(t) => {
-                self.check_global_type(t, features, offset, types)?;
+                self.check_global_type(t, features, offset)?;
                 EntityType::Global(*t)
             }
         })
@@ -1052,23 +1052,12 @@ impl Module {
         ty: &mut GlobalType,
         features: &WasmFeatures,
         offset: usize,
-        types: &TypeList,
     ) -> Result<()> {
         self.check_value_type(&mut ty.content_type, features, offset)?;
         if ty.shared {
             if !features.contains(WasmFeatures::SHARED_EVERYTHING_THREADS) {
                 return Err(BinaryReaderError::new(
                     "shared globals require the shared-everything-threads proposal",
-                    offset,
-                ));
-            }
-            let ty = ty.content_type;
-            if !(ty == ValType::I32
-                || ty == ValType::I64
-                || types.valtype_is_subtype(ty, RefType::ANYREF.into()))
-            {
-                return Err(BinaryReaderError::new(
-                    "invalid type: shared globals must be i32, i64 or a subtype of anyref",
                     offset,
                 ));
             }

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -1637,9 +1637,10 @@ where
         // unshared globals.
         if let Some(ty) = self.resources.global_at(global_index) {
             let ty = ty.content_type;
-            // TODO: need to express that any ValType::Ref(..) must be a subtype
-            // (<:) of `anyref`.
-            if !(ty == ValType::I32 || ty == ValType::I64) {
+            if !(ty == ValType::I32
+                || ty == ValType::I64
+                || self.resources.is_subtype(ty, RefType::ANYREF.into()))
+            {
                 bail!(
                     self.offset,
                     "invalid type: `global.atomic.get` only allows `i32`, `i64` and subtypes of `anyref`"
@@ -1684,9 +1685,10 @@ where
                 );
             }
             let ty = ty.content_type;
-            // TODO: need to express that any ValType::Ref(..) must be a subtype
-            // (<:) of `anyref`.
-            if !(ty == ValType::I32 || ty == ValType::I64) {
+            if !(ty == ValType::I32
+                || ty == ValType::I64
+                || self.resources.is_subtype(ty, RefType::ANYREF.into()))
+            {
                 bail!(
                     self.offset,
                     "invalid type: `global.atomic.set` only allows `i32`, `i64` and subtypes of `anyref`"

--- a/crates/wasmprinter/src/operator.rs
+++ b/crates/wasmprinter/src/operator.rs
@@ -1,7 +1,7 @@
 use super::{Printer, State};
 use anyhow::{anyhow, bail, Result};
 use std::fmt::Write;
-use wasmparser::{BlockType, BrTable, Catch, MemArg, RefType, TryTable, VisitOperator};
+use wasmparser::{BlockType, BrTable, Catch, MemArg, Ordering, RefType, TryTable, VisitOperator};
 
 pub struct PrintOperator<'a, 'b> {
     pub(super) printer: &'a mut Printer,
@@ -319,6 +319,18 @@ impl<'a, 'b> PrintOperator<'a, 'b> {
             let align = 1 << memarg.align;
             write!(self.result(), " align={}", align)?;
         }
+        Ok(())
+    }
+
+    fn ordering(&mut self, ordering: Ordering) -> Result<()> {
+        write!(
+            self.result(),
+            "{}",
+            match ordering {
+                Ordering::SeqCst => "seq_cst",
+                Ordering::AcqRel => "acq_rel",
+            }
+        )?;
         Ok(())
     }
 
@@ -1122,6 +1134,8 @@ macro_rules! define_visit {
     (name Catch) => ("catch");
     (name CatchAll) => ("catch_all");
     (name Delegate) => ("delegate");
+    (name GlobalAtomicGet) => ("global.atomic.get");
+    (name GlobalAtomicSet) => ("global.atomic.set");
 }
 
 impl<'a> VisitOperator<'a> for PrintOperator<'_, '_> {

--- a/crates/wast/src/core/binary.rs
+++ b/crates/wast/src/core/binary.rs
@@ -800,6 +800,23 @@ impl Encode for MemArg<'_> {
     }
 }
 
+impl Encode for Ordering {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        let flag: u8 = match self {
+            Ordering::SeqCst => 0,
+            Ordering::AcqRel => 1,
+        };
+        flag.encode(buf);
+    }
+}
+
+impl Encode for OrderedAccess<'_> {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        self.ordering.encode(buf);
+        self.index.encode(buf);
+    }
+}
+
 impl Encode for LoadOrStoreLane<'_> {
     fn encode(&self, e: &mut Vec<u8>) {
         self.memarg.encode(e);

--- a/crates/wast/src/core/expr.rs
+++ b/crates/wast/src/core/expr.rs
@@ -800,6 +800,10 @@ instructions! {
         I64AtomicRmw16CmpxchgU(MemArg<2>) : [0xfe, 0x4d] : "i64.atomic.rmw16.cmpxchg_u",
         I64AtomicRmw32CmpxchgU(MemArg<4>) : [0xfe, 0x4e] : "i64.atomic.rmw32.cmpxchg_u",
 
+        // proposal: shared-everything-threads
+        GlobalAtomicGet(OrderedAccess<'a>) : [0xfe, 0x4f] : "global.atomic.get",
+        GlobalAtomicSet(OrderedAccess<'a>) : [0xfe, 0x50] : "global.atomic.set",
+
         // proposal: simd
         //
         // https://webassembly.github.io/simd/core/binary/instructions.html
@@ -1727,6 +1731,55 @@ impl<'a> Parse<'a> for BrOnCastFail<'a> {
             from_type: parser.parse()?,
             to_type: parser.parse()?,
         })
+    }
+}
+
+/// The memory ordering for atomic instructions.
+///
+/// For an in-depth explanation of memory orderings, see the C++ documentation
+/// for [`memory_order`] or the Rust documentation for [`atomic::Ordering`].
+///
+/// [`memory_order`]: https://en.cppreference.com/w/cpp/atomic/memory_order
+/// [`atomic::Ordering`]: https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html
+#[derive(Debug)]
+pub enum Ordering {
+    /// Like `AcqRel` but all threads see all sequentially consistent operations
+    /// in the same order.
+    AcqRel,
+    /// For a load, it acquires; this orders all operations before the last
+    /// "releasing" store. For a store, it releases; this orders all operations
+    /// before it at the next "acquiring" load.
+    SeqCst,
+}
+
+impl<'a> Parse<'a> for Ordering {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        if parser.peek::<kw::seq_cst>()? {
+            parser.parse::<kw::seq_cst>()?;
+            Ok(Ordering::SeqCst)
+        } else if parser.peek::<kw::acq_rel>()? {
+            parser.parse::<kw::acq_rel>()?;
+            Ok(Ordering::AcqRel)
+        } else {
+            Err(parser.error("expected a memory ordering: `seq_cst` or `acq_rel`"))
+        }
+    }
+}
+
+/// Extra data associated with the `global.atomic.*` instructions.
+#[derive(Debug)]
+pub struct OrderedAccess<'a> {
+    /// The memory ordering for this atomic instruction.
+    pub ordering: Ordering,
+    /// The index of the global to access.
+    pub index: Index<'a>,
+}
+
+impl<'a> Parse<'a> for OrderedAccess<'a> {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        let ordering = parser.parse()?;
+        let index = parser.parse()?;
+        Ok(OrderedAccess { ordering, index })
     }
 }
 

--- a/crates/wast/src/core/expr.rs
+++ b/crates/wast/src/core/expr.rs
@@ -1741,7 +1741,7 @@ impl<'a> Parse<'a> for BrOnCastFail<'a> {
 ///
 /// [`memory_order`]: https://en.cppreference.com/w/cpp/atomic/memory_order
 /// [`atomic::Ordering`]: https://doc.rust-lang.org/std/sync/atomic/enum.Ordering.html
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum Ordering {
     /// Like `AcqRel` but all threads see all sequentially consistent operations
     /// in the same order.
@@ -1767,7 +1767,7 @@ impl<'a> Parse<'a> for Ordering {
 }
 
 /// Extra data associated with the `global.atomic.*` instructions.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct OrderedAccess<'a> {
     /// The memory ordering for this atomic instruction.
     pub ordering: Ordering,

--- a/crates/wast/src/core/resolve/names.rs
+++ b/crates/wast/src/core/resolve/names.rs
@@ -457,6 +457,10 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
                 self.resolver.resolve(i, Ns::Global)?;
             }
 
+            GlobalAtomicSet(i) | GlobalAtomicGet(i) => {
+                self.resolver.resolve(&mut i.index, Ns::Global)?;
+            }
+
             LocalSet(i) | LocalGet(i) | LocalTee(i) => {
                 assert!(self.scopes.len() > 0);
                 // Resolve a local by iterating over scopes from most recent

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -472,12 +472,14 @@ pub mod kw {
     custom_keyword!(ref_null = "ref.null");
     custom_keyword!(register);
     custom_keyword!(rec);
+    custom_keyword!(acq_rel);
     custom_keyword!(rep);
     custom_keyword!(resource);
     custom_keyword!(resource_new = "resource.new");
     custom_keyword!(resource_drop = "resource.drop");
     custom_keyword!(resource_rep = "resource.rep");
     custom_keyword!(result);
+    custom_keyword!(seq_cst);
     custom_keyword!(shared);
     custom_keyword!(start);
     custom_keyword!(sub);

--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -1046,6 +1046,7 @@ macro_rules! define_visit {
     (mark_live $self:ident $arg:ident field_index) => {};
     (mark_live $self:ident $arg:ident from_type_nullable) => {};
     (mark_live $self:ident $arg:ident to_type_nullable) => {};
+    (mark_live $self:ident $arg:ident ordering) => {};
     (mark_live $self:ident $arg:ident try_table) => {unimplemented!();};
 }
 
@@ -1094,6 +1095,13 @@ impl Encoder {
             offset: ty.offset,
             align: ty.align.into(),
             memory_index: self.memories.remap(ty.memory),
+        }
+    }
+
+    fn ordering(&self, ord: Ordering) -> wasm_encoder::Ordering {
+        match ord {
+            Ordering::AcqRel => wasm_encoder::Ordering::AcqRel,
+            Ordering::SeqCst => wasm_encoder::Ordering::SeqCst,
         }
     }
 
@@ -1213,6 +1221,7 @@ macro_rules! define_encode {
     // Individual cases of mapping one argument type to another, similar to the
     // `define_visit` macro above.
     (map $self:ident $arg:ident memarg) => {$self.memarg($arg)};
+    (map $self:ident $arg:ident ordering) => {$self.ordering($arg)};
     (map $self:ident $arg:ident blockty) => {$self.blockty($arg)};
     (map $self:ident $arg:ident hty) => {$self.heapty($arg)};
     (map $self:ident $arg:ident from_ref_type) => {$self.refty($arg)};

--- a/tests/local/missing-features/globals.wast
+++ b/tests/local/missing-features/globals.wast
@@ -32,3 +32,10 @@
     (global (import "spectest" "global_i64") (shared mut i64))
   )
   "shared globals require the shared-everything-threads proposal")
+
+(assert_invalid
+  (module
+    (global $a (import "spectest" "global_i32") i32)
+    (func (result i32) (global.atomic.get seq_cst $a))
+  )
+  "shared-everything-threads support is not enabled")

--- a/tests/local/shared-everything-threads/global.wast
+++ b/tests/local/shared-everything-threads/global.wast
@@ -23,18 +23,20 @@
 (assert_invalid
   (module
     (global $a (shared i32) (i32.const 0))
-    (func (export "set-shared") (global.atomic.set seq_cst $a (f32.const 1.0)))
+    (func (export "set-shared") (global.atomic.set seq_cst $a (i32.const 1)))
   )
   "global is immutable")
 
 (assert_invalid
   (module
     (global $a (shared mut f64) (f64.const 0))
+    (func (export "set-shared") (global.atomic.set acq_rel $a (f64.const 1.0)))
   )
   "invalid type")
 
 (assert_invalid
   (module
     (global $a (import "spectest" "global_ref") (shared funcref))
+    (func (export "get-shared") (result funcref) (global.atomic.get seq_cst $a))
   )
   "invalid type")

--- a/tests/local/shared-everything-threads/global.wast
+++ b/tests/local/shared-everything-threads/global.wast
@@ -1,12 +1,31 @@
 ;; Styled after ../../testsuite/global.wast
 
 (module
-  (global (import "spectest" "global_i32") (shared i32))
-  (global (import "spectest" "global_f64") (shared mut f64))
-  (global $a (shared i64) (i64.const 0))
-  (global $b (shared mut i64) (i64.const 1))
+  (global $a (import "spectest" "global_i32") (shared i32))
+  (global $b (import "spectest" "global_i64") (shared mut i64))
+  (global $c (shared i32) (i32.const 0))
+  (global $d (shared mut i64) (i64.const 1))
+
+  (func (export "get-a-seqcst") (result i32) (global.atomic.get seq_cst $a))
+  (func (export "get-c-acqrel") (result i32) (global.atomic.get acq_rel $c))
+  (func (export "set-b-seqcst") (global.atomic.set seq_cst $b (i64.const 1)))
+  (func (export "set-d-acqrel") (global.atomic.set acq_rel $d (i64.const 2)))
 )
 
 (assert_malformed
   (module quote "(global (mut shared i64) (i64.const -1))")
   "unexpected token")
+
+(assert_invalid
+  (module
+    (global $a (shared f32) (f32.const 0))
+    (func (export "set-shared") (global.atomic.set seq_cst $a (f32.const 1.0)))
+  )
+  "global is immutable")
+
+(assert_invalid
+  (module
+    (global $a (shared mut f64) (f64.const 0))
+    (func (export "set-shared") (global.atomic.set seq_cst $a (f64.const 1.0)))
+  )
+  "invalid type")

--- a/tests/local/shared-everything-threads/global.wast
+++ b/tests/local/shared-everything-threads/global.wast
@@ -3,13 +3,17 @@
 (module
   (global $a (import "spectest" "global_i32") (shared i32))
   (global $b (import "spectest" "global_i64") (shared mut i64))
-  (global $c (shared i32) (i32.const 0))
-  (global $d (shared mut i64) (i64.const 1))
+  (global $c (import "spectest" "global_ref") (shared eqref))
+  (global $d (shared i32) (i32.const 0))
+  (global $e (shared mut i64) (i64.const 1))
+  (global $f (shared mut anyref) (ref.null any))
 
   (func (export "get-a-seqcst") (result i32) (global.atomic.get seq_cst $a))
-  (func (export "get-c-acqrel") (result i32) (global.atomic.get acq_rel $c))
   (func (export "set-b-seqcst") (global.atomic.set seq_cst $b (i64.const 1)))
-  (func (export "set-d-acqrel") (global.atomic.set acq_rel $d (i64.const 2)))
+  (func (export "get-c-seqcst") (result eqref) (global.atomic.get seq_cst $c))
+  (func (export "get-d-acqrel") (result i32) (global.atomic.get acq_rel $d))
+  (func (export "set-e-acqrel") (global.atomic.set acq_rel $e (i64.const 2)))
+  (func (export "set-f-acqrel") (param $a anyref) (global.atomic.set acq_rel $f (local.get $a)))
 )
 
 (assert_malformed
@@ -18,7 +22,7 @@
 
 (assert_invalid
   (module
-    (global $a (shared f32) (f32.const 0))
+    (global $a (shared i32) (i32.const 0))
     (func (export "set-shared") (global.atomic.set seq_cst $a (f32.const 1.0)))
   )
   "global is immutable")
@@ -26,6 +30,11 @@
 (assert_invalid
   (module
     (global $a (shared mut f64) (f64.const 0))
-    (func (export "set-shared") (global.atomic.set seq_cst $a (f64.const 1.0)))
+  )
+  "invalid type")
+
+(assert_invalid
+  (module
+    (global $a (import "spectest" "global_ref") (shared funcref))
   )
   "invalid type")

--- a/tests/local/shared-everything-threads/global.wast
+++ b/tests/local/shared-everything-threads/global.wast
@@ -3,17 +3,13 @@
 (module
   (global $a (import "spectest" "global_i32") (shared i32))
   (global $b (import "spectest" "global_i64") (shared mut i64))
-  (global $c (import "spectest" "global_ref") (shared eqref))
   (global $d (shared i32) (i32.const 0))
   (global $e (shared mut i64) (i64.const 1))
-  (global $f (shared mut anyref) (ref.null any))
 
   (func (export "get-a-seqcst") (result i32) (global.atomic.get seq_cst $a))
   (func (export "set-b-seqcst") (global.atomic.set seq_cst $b (i64.const 1)))
-  (func (export "get-c-seqcst") (result eqref) (global.atomic.get seq_cst $c))
   (func (export "get-d-acqrel") (result i32) (global.atomic.get acq_rel $d))
   (func (export "set-e-acqrel") (global.atomic.set acq_rel $e (i64.const 2)))
-  (func (export "set-f-acqrel") (param $a anyref) (global.atomic.set acq_rel $f (local.get $a)))
 )
 
 (assert_malformed
@@ -37,6 +33,5 @@
 (assert_invalid
   (module
     (global $a (import "spectest" "global_ref") (shared funcref))
-    (func (export "get-shared") (result funcref) (global.atomic.get seq_cst $a))
   )
-  "invalid type")
+  "shared value type")

--- a/tests/snapshots/local/missing-features/globals.wast.json
+++ b/tests/snapshots/local/missing-features/globals.wast.json
@@ -35,6 +35,13 @@
       "filename": "globals.4.wasm",
       "text": "shared globals require the shared-everything-threads proposal",
       "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 37,
+      "filename": "globals.5.wasm",
+      "text": "shared-everything-threads support is not enabled",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/shared-everything-threads/global.wast.json
+++ b/tests/snapshots/local/shared-everything-threads/global.wast.json
@@ -29,7 +29,7 @@
     },
     {
       "type": "assert_invalid",
-      "line": 37,
+      "line": 38,
       "filename": "global.4.wasm",
       "text": "invalid type",
       "module_type": "binary"

--- a/tests/snapshots/local/shared-everything-threads/global.wast.json
+++ b/tests/snapshots/local/shared-everything-threads/global.wast.json
@@ -8,22 +8,29 @@
     },
     {
       "type": "assert_malformed",
-      "line": 16,
+      "line": 20,
       "filename": "global.1.wat",
       "text": "unexpected token",
       "module_type": "text"
     },
     {
       "type": "assert_invalid",
-      "line": 20,
+      "line": 24,
       "filename": "global.2.wasm",
       "text": "global is immutable",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 27,
+      "line": 31,
       "filename": "global.3.wasm",
+      "text": "invalid type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 37,
+      "filename": "global.4.wasm",
       "text": "invalid type",
       "module_type": "binary"
     }

--- a/tests/snapshots/local/shared-everything-threads/global.wast.json
+++ b/tests/snapshots/local/shared-everything-threads/global.wast.json
@@ -8,10 +8,24 @@
     },
     {
       "type": "assert_malformed",
-      "line": 11,
+      "line": 16,
       "filename": "global.1.wat",
       "text": "unexpected token",
       "module_type": "text"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 20,
+      "filename": "global.2.wasm",
+      "text": "global is immutable",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 27,
+      "filename": "global.3.wasm",
+      "text": "invalid type",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/shared-everything-threads/global.wast.json
+++ b/tests/snapshots/local/shared-everything-threads/global.wast.json
@@ -8,30 +8,30 @@
     },
     {
       "type": "assert_malformed",
-      "line": 20,
+      "line": 16,
       "filename": "global.1.wat",
       "text": "unexpected token",
       "module_type": "text"
     },
     {
       "type": "assert_invalid",
-      "line": 24,
+      "line": 20,
       "filename": "global.2.wasm",
       "text": "global is immutable",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 31,
+      "line": 27,
       "filename": "global.3.wasm",
       "text": "invalid type",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 38,
+      "line": 34,
       "filename": "global.4.wasm",
-      "text": "invalid type",
+      "text": "shared value type",
       "module_type": "binary"
     }
   ]

--- a/tests/snapshots/local/shared-everything-threads/global.wast/0.print
+++ b/tests/snapshots/local/shared-everything-threads/global.wast/0.print
@@ -1,26 +1,39 @@
 (module
   (type (;0;) (func (result i32)))
   (type (;1;) (func))
+  (type (;2;) (func (result eqref)))
+  (type (;3;) (func (param anyref)))
   (import "spectest" "global_i32" (global $a (;0;) (shared i32)))
   (import "spectest" "global_i64" (global $b (;1;) (shared mut i64)))
+  (import "spectest" "global_ref" (global $c (;2;) (shared eqref)))
   (func (;0;) (type 0) (result i32)
     global.atomic.get seq_cst $a
   )
-  (func (;1;) (type 0) (result i32)
-    global.atomic.get acq_rel $c
-  )
-  (func (;2;) (type 1)
+  (func (;1;) (type 1)
     i64.const 1
     global.atomic.set seq_cst $b
   )
-  (func (;3;) (type 1)
-    i64.const 2
-    global.atomic.set acq_rel $d
+  (func (;2;) (type 2) (result eqref)
+    global.atomic.get seq_cst $c
   )
-  (global $c (;2;) (shared i32) i32.const 0)
-  (global $d (;3;) (shared mut i64) i64.const 1)
+  (func (;3;) (type 0) (result i32)
+    global.atomic.get acq_rel $d
+  )
+  (func (;4;) (type 1)
+    i64.const 2
+    global.atomic.set acq_rel $e
+  )
+  (func (;5;) (type 3) (param $a anyref)
+    local.get $a
+    global.atomic.set acq_rel $f
+  )
+  (global $d (;3;) (shared i32) i32.const 0)
+  (global $e (;4;) (shared mut i64) i64.const 1)
+  (global $f (;5;) (shared mut anyref) ref.null any)
   (export "get-a-seqcst" (func 0))
-  (export "get-c-acqrel" (func 1))
-  (export "set-b-seqcst" (func 2))
-  (export "set-d-acqrel" (func 3))
+  (export "set-b-seqcst" (func 1))
+  (export "get-c-seqcst" (func 2))
+  (export "get-d-acqrel" (func 3))
+  (export "set-e-acqrel" (func 4))
+  (export "set-f-acqrel" (func 5))
 )

--- a/tests/snapshots/local/shared-everything-threads/global.wast/0.print
+++ b/tests/snapshots/local/shared-everything-threads/global.wast/0.print
@@ -1,11 +1,8 @@
 (module
   (type (;0;) (func (result i32)))
   (type (;1;) (func))
-  (type (;2;) (func (result eqref)))
-  (type (;3;) (func (param anyref)))
   (import "spectest" "global_i32" (global $a (;0;) (shared i32)))
   (import "spectest" "global_i64" (global $b (;1;) (shared mut i64)))
-  (import "spectest" "global_ref" (global $c (;2;) (shared eqref)))
   (func (;0;) (type 0) (result i32)
     global.atomic.get seq_cst $a
   )
@@ -13,27 +10,17 @@
     i64.const 1
     global.atomic.set seq_cst $b
   )
-  (func (;2;) (type 2) (result eqref)
-    global.atomic.get seq_cst $c
-  )
-  (func (;3;) (type 0) (result i32)
+  (func (;2;) (type 0) (result i32)
     global.atomic.get acq_rel $d
   )
-  (func (;4;) (type 1)
+  (func (;3;) (type 1)
     i64.const 2
     global.atomic.set acq_rel $e
   )
-  (func (;5;) (type 3) (param $a anyref)
-    local.get $a
-    global.atomic.set acq_rel $f
-  )
-  (global $d (;3;) (shared i32) i32.const 0)
-  (global $e (;4;) (shared mut i64) i64.const 1)
-  (global $f (;5;) (shared mut anyref) ref.null any)
+  (global $d (;2;) (shared i32) i32.const 0)
+  (global $e (;3;) (shared mut i64) i64.const 1)
   (export "get-a-seqcst" (func 0))
   (export "set-b-seqcst" (func 1))
-  (export "get-c-seqcst" (func 2))
-  (export "get-d-acqrel" (func 3))
-  (export "set-e-acqrel" (func 4))
-  (export "set-f-acqrel" (func 5))
+  (export "get-d-acqrel" (func 2))
+  (export "set-e-acqrel" (func 3))
 )

--- a/tests/snapshots/local/shared-everything-threads/global.wast/0.print
+++ b/tests/snapshots/local/shared-everything-threads/global.wast/0.print
@@ -1,6 +1,26 @@
 (module
-  (import "spectest" "global_i32" (global (;0;) (shared i32)))
-  (import "spectest" "global_f64" (global (;1;) (shared mut f64)))
-  (global $a (;2;) (shared i64) i64.const 0)
-  (global $b (;3;) (shared mut i64) i64.const 1)
+  (type (;0;) (func (result i32)))
+  (type (;1;) (func))
+  (import "spectest" "global_i32" (global $a (;0;) (shared i32)))
+  (import "spectest" "global_i64" (global $b (;1;) (shared mut i64)))
+  (func (;0;) (type 0) (result i32)
+    global.atomic.get seq_cst $a
+  )
+  (func (;1;) (type 0) (result i32)
+    global.atomic.get acq_rel $c
+  )
+  (func (;2;) (type 1)
+    i64.const 1
+    global.atomic.set seq_cst $b
+  )
+  (func (;3;) (type 1)
+    i64.const 2
+    global.atomic.set acq_rel $d
+  )
+  (global $c (;2;) (shared i32) i32.const 0)
+  (global $d (;3;) (shared mut i64) i64.const 1)
+  (export "get-a-seqcst" (func 0))
+  (export "get-c-acqrel" (func 1))
+  (export "set-b-seqcst" (func 2))
+  (export "set-d-acqrel" (func 3))
 )


### PR DESCRIPTION
The shared-everything-threads [proposal] allows marking globals as `shared` and thus adds `global.atomic.get|set` for choosing the memory ordering of these accesses. These changes also include the memory `ordering` flags for marking accesses as sequentially consistent (`seq_cst`) or acquire-release (`acq_rel`).

[proposal]: https://github.com/WebAssembly/shared-everything-threads