### PR TITLE
Add support for the custom-page-sizes proposal

### DIFF
--- a/crates/wasm-encoder/src/core/data.rs
+++ b/crates/wasm-encoder/src/core/data.rs
@@ -18,6 +18,7 @@ use crate::{encode_section, encoding_size, ConstExpr, Encode, Section, SectionId
 ///     maximum: None,
 ///     memory64: false,
 ///     shared: false,
+///     page_size: None,
 /// });
 ///
 /// let mut data = DataSection::new();

--- a/crates/wasm-encoder/src/core/data.rs
+++ b/crates/wasm-encoder/src/core/data.rs
@@ -18,7 +18,7 @@ use crate::{encode_section, encoding_size, ConstExpr, Encode, Section, SectionId
 ///     maximum: None,
 ///     memory64: false,
 ///     shared: false,
-///     page_size: None,
+///     page_size_log2: None,
 /// });
 ///
 /// let mut data = DataSection::new();

--- a/crates/wasm-encoder/src/core/imports.rs
+++ b/crates/wasm-encoder/src/core/imports.rs
@@ -103,6 +103,7 @@ impl TryFrom<wasmparser::TypeRef> for EntityType {
 ///         maximum: None,
 ///         memory64: false,
 ///         shared: false,
+///         page_size: None,
 ///     }
 /// );
 ///

--- a/crates/wasm-encoder/src/core/imports.rs
+++ b/crates/wasm-encoder/src/core/imports.rs
@@ -103,7 +103,7 @@ impl TryFrom<wasmparser::TypeRef> for EntityType {
 ///         maximum: None,
 ///         memory64: false,
 ///         shared: false,
-///         page_size: None,
+///         page_size_log2: None,
 ///     }
 /// );
 ///

--- a/crates/wasm-encoder/src/core/memories.rs
+++ b/crates/wasm-encoder/src/core/memories.rs
@@ -75,25 +75,42 @@ pub struct MemoryType {
     pub memory64: bool,
     /// Whether or not this memory is shared.
     pub shared: bool,
+    /// A custom page size for this memory.
+    ///
+    /// The default page size for Wasm memories is 64KiB, i.e. 2<sup>16</sup> or
+    /// `65536`.
+    ///
+    /// After the introduction of [the custom-page-sizes
+    /// proposal](https://github.com/WebAssembly/custom-page-sizes), Wasm can
+    /// customize the page size. It must be a power of two that is less than or
+    /// equal to 64KiB. Attempting to encode an invalid page size may panic.
+    pub page_size: Option<u32>,
 }
 
 impl Encode for MemoryType {
     fn encode(&self, sink: &mut Vec<u8>) {
         let mut flags = 0;
         if self.maximum.is_some() {
-            flags |= 0b001;
+            flags |= 0b0001;
         }
         if self.shared {
-            flags |= 0b010;
+            flags |= 0b0010;
         }
         if self.memory64 {
-            flags |= 0b100;
+            flags |= 0b0100;
         }
-
+        if self.page_size.is_some() {
+            flags |= 0b1000;
+        }
         sink.push(flags);
         self.minimum.encode(sink);
         if let Some(max) = self.maximum {
             max.encode(sink);
+        }
+        if let Some(p) = self.page_size {
+            assert!(p.is_power_of_two());
+            assert!(p <= (1 << 16));
+            p.ilog2().encode(sink);
         }
     }
 }
@@ -106,6 +123,7 @@ impl From<wasmparser::MemoryType> for MemoryType {
             maximum: memory_ty.maximum,
             memory64: memory_ty.memory64,
             shared: memory_ty.shared,
+            page_size: memory_ty.page_size,
         }
     }
 }

--- a/crates/wasm-encoder/src/core/memories.rs
+++ b/crates/wasm-encoder/src/core/memories.rs
@@ -15,7 +15,7 @@ use crate::{encode_section, Encode, Section, SectionId};
 ///     maximum: None,
 ///     memory64: false,
 ///     shared: false,
-///     page_size: None,
+///     page_size_log2: None,
 /// });
 ///
 /// let mut module = Module::new();

--- a/crates/wasm-encoder/src/core/memories.rs
+++ b/crates/wasm-encoder/src/core/memories.rs
@@ -15,6 +15,7 @@ use crate::{encode_section, Encode, Section, SectionId};
 ///     maximum: None,
 ///     memory64: false,
 ///     shared: false,
+///     page_size: None,
 /// });
 ///
 /// let mut module = Module::new();

--- a/crates/wasm-encoder/src/core/memories.rs
+++ b/crates/wasm-encoder/src/core/memories.rs
@@ -76,7 +76,7 @@ pub struct MemoryType {
     pub memory64: bool,
     /// Whether or not this memory is shared.
     pub shared: bool,
-    /// A custom page size for this memory.
+    /// The log base 2 of a custom page size for this memory.
     ///
     /// The default page size for Wasm memories is 64KiB, i.e. 2<sup>16</sup> or
     /// `65536`.
@@ -85,7 +85,7 @@ pub struct MemoryType {
     /// proposal](https://github.com/WebAssembly/custom-page-sizes), Wasm can
     /// customize the page size. It must be a power of two that is less than or
     /// equal to 64KiB. Attempting to encode an invalid page size may panic.
-    pub page_size: Option<u32>,
+    pub page_size_log2: Option<u32>,
 }
 
 impl Encode for MemoryType {
@@ -100,7 +100,7 @@ impl Encode for MemoryType {
         if self.memory64 {
             flags |= 0b0100;
         }
-        if self.page_size.is_some() {
+        if self.page_size_log2.is_some() {
             flags |= 0b1000;
         }
         sink.push(flags);
@@ -108,10 +108,8 @@ impl Encode for MemoryType {
         if let Some(max) = self.maximum {
             max.encode(sink);
         }
-        if let Some(p) = self.page_size {
-            assert!(p.is_power_of_two());
-            assert!(p <= (1 << 16));
-            p.ilog2().encode(sink);
+        if let Some(p) = self.page_size_log2 {
+            p.encode(sink);
         }
     }
 }
@@ -124,7 +122,7 @@ impl From<wasmparser::MemoryType> for MemoryType {
             maximum: memory_ty.maximum,
             memory64: memory_ty.memory64,
             shared: memory_ty.shared,
-            page_size: memory_ty.page_size,
+            page_size_log2: memory_ty.page_size_log2,
         }
     }
 }

--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -160,7 +160,7 @@ pub fn memory_type(
         minimum: ty.initial,
         maximum: ty.maximum,
         shared: ty.shared,
-        page_size: ty.page_size,
+        page_size_log2: ty.page_size_log2,
     })
 }
 

--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -160,6 +160,7 @@ pub fn memory_type(
         minimum: ty.initial,
         maximum: ty.maximum,
         shared: ty.shared,
+        page_size: ty.page_size,
     })
 }
 

--- a/crates/wasm-shrink/src/lib.rs
+++ b/crates/wasm-shrink/src/lib.rs
@@ -236,6 +236,7 @@ impl ShrinkRun {
             component_model: false,
             function_references: false,
             gc: false,
+            custom_page_sizes: false,
             component_model_values: false,
             component_model_nested_names: false,
 

--- a/crates/wasm-smith/src/config.rs
+++ b/crates/wasm-smith/src/config.rs
@@ -313,6 +313,12 @@ define_config! {
         /// Defaults to `false`.
         pub gc_enabled: bool = false,
 
+        /// Determines whether the custom-page-sizes proposal is enabled when
+        /// generating a Wasm module.
+        ///
+        /// Defaults to `false`.
+        pub custom_page_sizes_enabled: bool = false,
+
         /// Returns whether we should generate custom sections or not. Defaults
         /// to false.
         pub generate_custom_sections: bool = false,
@@ -715,6 +721,7 @@ impl<'a> Arbitrary<'a> for Config {
             export_everything: false,
             tail_call_enabled: false,
             gc_enabled: false,
+            custom_page_sizes_enabled: false,
             generate_custom_sections: false,
             allow_invalid_funcs: false,
         })

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -2542,7 +2542,7 @@ pub(crate) fn arbitrary_memtype(u: &mut Unstructured, config: &Config) -> Result
         maximum,
         memory64,
         shared,
-        page_size,
+        page_size_log2: page_size,
     })
 }
 

--- a/crates/wasm-smith/src/core/code_builder.rs
+++ b/crates/wasm-smith/src/core/code_builder.rs
@@ -5203,10 +5203,12 @@ fn memory_offset(u: &mut Unstructured, module: &Module, memory_index: u32) -> Re
     assert!(a + b + c != 0);
 
     let memory_type = &module.memories[memory_index as usize];
-    let min = memory_type.minimum.saturating_mul(crate::WASM_PAGE_SIZE);
+    let min = memory_type
+        .minimum
+        .saturating_mul(crate::page_size(memory_type).into());
     let max = memory_type
         .maximum
-        .map(|max| max.saturating_mul(crate::WASM_PAGE_SIZE))
+        .map(|max| max.saturating_mul(crate::page_size(memory_type).into()))
         .unwrap_or(u64::MAX);
 
     let (min, max, true_max) = match (memory_type.memory64, module.config.disallow_traps) {

--- a/crates/wasm-smith/src/core/code_builder/no_traps.rs
+++ b/crates/wasm-smith/src/core/code_builder/no_traps.rs
@@ -37,7 +37,10 @@ pub(crate) fn load<'a>(
             // []
             insts.push(Instruction::MemorySize(memarg.memory_index));
             // [mem_size_in_pages:address_type]
-            insts.push(int_const_inst(address_type, 65_536));
+            insts.push(int_const_inst(
+                address_type,
+                crate::page_size(memory).into(),
+            ));
             // [mem_size_in_pages:address_type wasm_page_size:address_type]
             insts.push(int_mul_inst(address_type));
             // [mem_size_in_bytes:address_type]
@@ -116,7 +119,10 @@ pub(crate) fn store<'a>(
     // []
     insts.push(Instruction::MemorySize(memarg.memory_index));
     // [mem_size_in_pages:address_type]
-    insts.push(int_const_inst(address_type, 65_536));
+    insts.push(int_const_inst(
+        address_type,
+        crate::page_size(memory).into(),
+    ));
     // [mem_size_in_pages:address_type wasm_page_size:address_type]
     insts.push(int_mul_inst(address_type));
     // [mem_size_in_bytes:address_type]

--- a/crates/wasm-smith/src/lib.rs
+++ b/crates/wasm-smith/src/lib.rs
@@ -63,11 +63,15 @@ use arbitrary::{Result, Unstructured};
 pub use component::Component;
 pub use config::{Config, MemoryOffsetChoices};
 use std::{collections::HashSet, fmt::Write, str};
+use wasm_encoder::MemoryType;
 
 #[cfg(feature = "_internal_cli")]
 pub use config::InternalOptionalConfig;
 
-const WASM_PAGE_SIZE: u64 = 65_536;
+pub(crate) fn page_size(mem: &MemoryType) -> u32 {
+    const DEFAULT_WASM_PAGE_SIZE: u32 = 65_536;
+    mem.page_size.unwrap_or(DEFAULT_WASM_PAGE_SIZE)
+}
 
 /// Do something an arbitrary number of times.
 ///

--- a/crates/wasm-smith/src/lib.rs
+++ b/crates/wasm-smith/src/lib.rs
@@ -70,7 +70,7 @@ pub use config::InternalOptionalConfig;
 
 pub(crate) fn page_size(mem: &MemoryType) -> u32 {
     const DEFAULT_WASM_PAGE_SIZE: u32 = 65_536;
-    mem.page_size.unwrap_or(DEFAULT_WASM_PAGE_SIZE)
+    mem.page_size_log2.unwrap_or(DEFAULT_WASM_PAGE_SIZE)
 }
 
 /// Do something an arbitrary number of times.

--- a/crates/wasm-smith/tests/common/mod.rs
+++ b/crates/wasm-smith/tests/common/mod.rs
@@ -17,6 +17,7 @@ pub fn parser_features_from_config(config: &Config) -> WasmFeatures {
         tail_call: config.tail_call_enabled,
         function_references: config.gc_enabled,
         gc: config.gc_enabled,
+        custom_page_sizes: config.custom_page_sizes_enabled,
 
         threads: false,
         shared_everything_threads: false,

--- a/crates/wasm-smith/tests/core.rs
+++ b/crates/wasm-smith/tests/core.rs
@@ -3,6 +3,9 @@ use rand::{rngs::SmallRng, RngCore, SeedableRng};
 use wasm_smith::{Config, Module};
 use wasmparser::{Validator, WasmFeatures};
 
+mod common;
+use common::{parser_features_from_config, validate};
+
 #[test]
 fn smoke_test_module() {
     let mut rng = SmallRng::seed_from_u64(0);
@@ -150,44 +153,4 @@ fn wasm_features() -> WasmFeatures {
         gc: true,
         ..WasmFeatures::default()
     }
-}
-
-fn parser_features_from_config(config: &Config) -> WasmFeatures {
-    WasmFeatures {
-        mutable_global: true,
-        saturating_float_to_int: config.saturating_float_to_int_enabled,
-        sign_extension: config.sign_extension_ops_enabled,
-        reference_types: config.reference_types_enabled,
-        multi_value: config.multi_value_enabled,
-        bulk_memory: config.bulk_memory_enabled,
-        simd: config.simd_enabled,
-        relaxed_simd: config.relaxed_simd_enabled,
-        multi_memory: config.max_memories > 1,
-        exceptions: config.exceptions_enabled,
-        memory64: config.memory64_enabled,
-        tail_call: config.tail_call_enabled,
-
-        threads: false,
-        shared_everything_threads: false,
-        floats: true,
-        extended_const: false,
-        component_model: false,
-        function_references: false,
-        memory_control: false,
-        gc: false,
-        component_model_values: false,
-        component_model_nested_names: false,
-    }
-}
-
-fn validate(validator: &mut Validator, bytes: &[u8]) {
-    let err = match validator.validate_all(bytes) {
-        Ok(_) => return,
-        Err(e) => e,
-    };
-    drop(std::fs::write("test.wasm", &bytes));
-    if let Ok(text) = wasmprinter::print_bytes(bytes) {
-        drop(std::fs::write("test.wat", &text));
-    }
-    panic!("wasm failed to validate: {}", err);
 }

--- a/crates/wasm-smith/tests/exports.rs
+++ b/crates/wasm-smith/tests/exports.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "wasmparser")]
+
 use arbitrary::{Arbitrary, Unstructured};
 use rand::{rngs::SmallRng, RngCore, SeedableRng};
 use wasm_smith::{Config, Module};
@@ -18,9 +20,9 @@ enum ExportType {
 fn smoke_test_single_export() {
     let test = r#"
         (module
-        	(func (export "foo") (param i32) (result i64)
-        		unreachable
-        	)
+            (func (export "foo") (param i32) (result i64)
+                unreachable
+            )
         )
         "#;
     smoke_test_exports(test, 11)
@@ -30,15 +32,15 @@ fn smoke_test_single_export() {
 fn smoke_test_multiple_exports() {
     let test = r#"
         (module
-        	(func (export "a") (param i32) (result i64)
-        		unreachable
-        	)
-        	(func (export "b")
-        		unreachable
-        	)
-        	(func (export "c")
-        		unreachable
-        	)
+            (func (export "a") (param i32) (result i64)
+                unreachable
+            )
+            (func (export "b")
+                unreachable
+            )
+            (func (export "c")
+                unreachable
+            )
         )
         "#;
     smoke_test_exports(test, 12)
@@ -48,9 +50,9 @@ fn smoke_test_multiple_exports() {
 fn smoke_test_exported_global() {
     let test = r#"
         (module
-        	(func (export "a") (param i32 i32 f32 f64) (result f32)
-        		unreachable
-        	)
+            (func (export "a") (param i32 i32 f32 f64) (result f32)
+                unreachable
+            )
             (global (export "glob") f64 f64.const 0)
         )
         "#;

--- a/crates/wasmparser/src/limits.rs
+++ b/crates/wasmparser/src/limits.rs
@@ -22,8 +22,6 @@ pub const MAX_WASM_EXPORTS: usize = 100_000;
 pub const MAX_WASM_GLOBALS: usize = 1_000_000;
 pub const MAX_WASM_ELEMENT_SEGMENTS: usize = 100_000;
 pub const MAX_WASM_DATA_SEGMENTS: usize = 100_000;
-pub const MAX_WASM_MEMORY32_PAGES: u64 = 65536;
-pub const MAX_WASM_MEMORY64_PAGES: u64 = 1 << 48;
 pub const MAX_WASM_STRING_SIZE: usize = 100_000;
 pub const MAX_WASM_FUNCTION_SIZE: usize = 128 * 1024;
 pub const MAX_WASM_FUNCTION_LOCALS: usize = 50000;
@@ -37,6 +35,20 @@ pub const MAX_WASM_TAGS: usize = 1_000_000;
 pub const MAX_WASM_BR_TABLE_SIZE: usize = MAX_WASM_FUNCTION_SIZE;
 pub const MAX_WASM_STRUCT_FIELDS: usize = 10_000;
 pub const MAX_WASM_CATCHES: usize = 10_000;
+
+pub const DEFAULT_WASM_PAGE_SIZE: u64 = 1 << 16;
+
+pub fn max_wasm_memory32_pages(page_size: u64) -> u64 {
+    assert!(page_size.is_power_of_two());
+    assert!(page_size <= DEFAULT_WASM_PAGE_SIZE);
+    (1 << 32) / page_size
+}
+
+pub fn max_wasm_memory64_pages(page_size: u64) -> u64 {
+    assert!(page_size.is_power_of_two());
+    assert!(page_size <= DEFAULT_WASM_PAGE_SIZE);
+    u64::try_from((1_u128 << 64) / u128::from(page_size)).unwrap_or(u64::MAX)
+}
 
 // Component-related limits
 pub const MAX_WASM_MODULE_SIZE: usize = 1024 * 1024 * 1024; //= 1 GiB

--- a/crates/wasmparser/src/readers/core/memories.rs
+++ b/crates/wasmparser/src/readers/core/memories.rs
@@ -54,13 +54,8 @@ impl<'a> FromReader<'a> for MemoryType {
             } else {
                 Some(reader.read_var_u32()?.into())
             },
-            page_size: if has_page_size {
-                let pos = reader.original_position();
-                let log = reader.read_var_u32()?;
-                if log > 16 {
-                    bail!(pos, "invalid custom page size")
-                }
-                Some(1 << log)
+            page_size_log2: if has_page_size {
+                Some(reader.read_var_u32()?)
             } else {
                 None
             },

--- a/crates/wasmparser/src/readers/core/memories.rs
+++ b/crates/wasmparser/src/readers/core/memories.rs
@@ -22,13 +22,16 @@ impl<'a> FromReader<'a> for MemoryType {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
         let pos = reader.original_position();
         let flags = reader.read_u8()?;
-        if (flags & !0b111) != 0 {
+
+        if (flags & !0b1111) != 0 {
             bail!(pos, "invalid memory limits flags");
         }
 
-        let memory64 = flags & 0b100 != 0;
-        let shared = flags & 0b010 != 0;
-        let has_max = flags & 0b001 != 0;
+        let memory64 = flags & 0b0100 != 0;
+        let shared = flags & 0b0010 != 0;
+        let has_max = flags & 0b0001 != 0;
+        let has_page_size = flags & 0b1000 != 0;
+
         Ok(MemoryType {
             memory64,
             shared,
@@ -50,6 +53,16 @@ impl<'a> FromReader<'a> for MemoryType {
                 Some(reader.read_var_u64()?)
             } else {
                 Some(reader.read_var_u32()?.into())
+            },
+            page_size: if has_page_size {
+                let pos = reader.original_position();
+                let log = reader.read_var_u32()?;
+                if log > 16 {
+                    bail!(pos, "invalid custom page size")
+                }
+                Some(1 << log)
+            } else {
+                None
             },
         })
     }

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -1513,7 +1513,7 @@ pub struct MemoryType {
     /// valid wasm memories when `shared` is `true`.
     pub maximum: Option<u64>,
 
-    /// The memory's custom page size.
+    /// The log base 2 of the memory's custom page size.
     ///
     /// Memory pages are, by default, 64KiB large (i.e. 2<sup>16</sup> or
     /// `65536`).
@@ -1521,7 +1521,7 @@ pub struct MemoryType {
     /// [The custom-page-sizes proposal] allows changing it to other values.
     ///
     /// [The custom-page-sizes proposal]: https://github.com/WebAssembly/custom-page-sizes
-    pub page_size: Option<u32>,
+    pub page_size_log2: Option<u32>,
 }
 
 impl MemoryType {

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -1512,6 +1512,16 @@ pub struct MemoryType {
     /// be at most `u32::MAX` for valid types. This field is always present for
     /// valid wasm memories when `shared` is `true`.
     pub maximum: Option<u64>,
+
+    /// The memory's custom page size.
+    ///
+    /// Memory pages are, by default, 64KiB large (i.e. 2<sup>16</sup> or
+    /// `65536`).
+    ///
+    /// [The custom-page-sizes proposal] allows changing it to other values.
+    ///
+    /// [The custom-page-sizes proposal]: https://github.com/WebAssembly/custom-page-sizes
+    pub page_size: Option<u32>,
 }
 
 impl MemoryType {

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -1522,7 +1522,7 @@ mod tests {
                 shared: false,
                 initial: 1,
                 maximum: Some(5),
-                page_size: None,
+                page_size_log2: None,
             }
         );
 

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -250,6 +250,9 @@ pub struct WasmFeatures {
     pub memory_control: bool,
     /// The WebAssembly gc proposal
     pub gc: bool,
+    /// The WebAssembly [custom-page-sizes
+    /// proposal](https://github.com/WebAssembly/custom-page-sizes).
+    pub custom_page_sizes: bool,
     /// Support for the `value` type in the component model proposal.
     pub component_model_values: bool,
     /// Support for the nested namespaces and projects in component model names.
@@ -280,6 +283,7 @@ impl WasmFeatures {
             function_references: true,
             memory_control: true,
             gc: true,
+            custom_page_sizes: true,
             component_model_values: true,
             component_model_nested_names: true,
         }
@@ -379,6 +383,7 @@ impl Default for WasmFeatures {
             function_references: false,
             memory_control: false,
             gc: false,
+            custom_page_sizes: false,
             component_model_values: false,
             component_model_nested_names: false,
             shared_everything_threads: false,

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -1521,7 +1521,8 @@ mod tests {
                 memory64: false,
                 shared: false,
                 initial: 1,
-                maximum: Some(5)
+                maximum: Some(5),
+                page_size: None,
             }
         );
 

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -876,7 +876,7 @@ impl Module {
         offset: usize,
     ) -> Result<()> {
         self.check_limits(ty.initial, ty.maximum, offset)?;
-        let page_size = if let Some(page_size_log2) = ty.page_size_log2 {
+        let (page_size, page_size_log2) = if let Some(page_size_log2) = ty.page_size_log2 {
             if !features.custom_page_sizes {
                 return Err(BinaryReaderError::new(
                     "the custom page sizes proposal must be enabled to \
@@ -884,17 +884,17 @@ impl Module {
                     offset,
                 ));
             }
+            if page_size_log2 > 16 {
+                return Err(BinaryReaderError::new("invalid custom page size", offset));
+            }
             let page_size = 1_u64 << page_size_log2;
             debug_assert!(page_size.is_power_of_two());
-            if page_size > DEFAULT_WASM_PAGE_SIZE {
-                return Err(BinaryReaderError::new(
-                    "invalid custom page size: {page_size}",
-                    offset,
-                ));
-            }
-            page_size
+            debug_assert!(page_size <= DEFAULT_WASM_PAGE_SIZE);
+            (page_size, page_size_log2)
         } else {
-            DEFAULT_WASM_PAGE_SIZE
+            let page_size_log2 = 16;
+            debug_assert_eq!(DEFAULT_WASM_PAGE_SIZE, 1 << page_size_log2);
+            (DEFAULT_WASM_PAGE_SIZE, page_size_log2)
         };
         let (true_maximum, err) = if ty.memory64 {
             if !features.memory64 {
@@ -907,7 +907,7 @@ impl Module {
                 max_wasm_memory64_pages(page_size),
                 format!(
                     "memory size must be at most 2**{} pages",
-                    64 - page_size.ilog2()
+                    64 - page_size_log2
                 ),
             )
         } else {

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -876,7 +876,7 @@ impl Module {
         offset: usize,
     ) -> Result<()> {
         self.check_limits(ty.initial, ty.maximum, offset)?;
-        let page_size = if let Some(page_size) = ty.page_size {
+        let page_size = if let Some(page_size_log2) = ty.page_size_log2 {
             if !features.custom_page_sizes {
                 return Err(BinaryReaderError::new(
                     "the custom page sizes proposal must be enabled to \
@@ -884,13 +884,15 @@ impl Module {
                     offset,
                 ));
             }
-            if u64::from(page_size) > DEFAULT_WASM_PAGE_SIZE || !page_size.is_power_of_two() {
+            let page_size = 1_u64 << page_size_log2;
+            debug_assert!(page_size.is_power_of_two());
+            if page_size > DEFAULT_WASM_PAGE_SIZE {
                 return Err(BinaryReaderError::new(
                     "invalid custom page size: {page_size}",
                     offset,
                 ));
             }
-            u64::from(page_size)
+            page_size
         } else {
             DEFAULT_WASM_PAGE_SIZE
         };

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -8,7 +8,7 @@
 
 #![deny(missing_docs)]
 
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use std::collections::{HashMap, HashSet};
 use std::fmt::{self, Write};
 use std::marker;
@@ -1077,7 +1077,9 @@ impl Printer {
             self.result.push_str(" shared");
         }
         if let Some(p) = ty.page_size_log2 {
-            let p = 1 << p;
+            let p = 1_u64
+                .checked_shl(p)
+                .ok_or_else(|| anyhow!("left shift overflow").context("invalid page size"))?;
             write!(self.result, "(pagesize {p:#x})")?;
         }
         Ok(())

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -1076,8 +1076,9 @@ impl Printer {
         if ty.shared {
             self.result.push_str(" shared");
         }
-        if let Some(p) = ty.page_size {
-            write!(self.result, "(pagesize {p})")?;
+        if let Some(p) = ty.page_size_log2 {
+            let p = 1 << p;
+            write!(self.result, "(pagesize {p:#x})")?;
         }
         Ok(())
     }

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -1076,6 +1076,9 @@ impl Printer {
         if ty.shared {
             self.result.push_str(" shared");
         }
+        if let Some(p) = ty.page_size {
+            write!(self.result, "(pagesize {p})")?;
+        }
         Ok(())
     }
 

--- a/crates/wast/src/component/binary.rs
+++ b/crates/wast/src/component/binary.rs
@@ -640,23 +640,23 @@ impl From<core::TableType<'_>> for wasm_encoder::TableType {
 
 impl From<core::MemoryType> for wasm_encoder::MemoryType {
     fn from(ty: core::MemoryType) -> Self {
-        let (minimum, maximum, memory64, shared, page_size) = match ty {
+        let (minimum, maximum, memory64, shared, page_size_log2) = match ty {
             core::MemoryType::B32 {
                 limits,
                 shared,
-                page_size,
+                page_size_log2,
             } => (
                 limits.min.into(),
                 limits.max.map(Into::into),
                 false,
                 shared,
-                page_size,
+                page_size_log2,
             ),
             core::MemoryType::B64 {
                 limits,
                 shared,
-                page_size,
-            } => (limits.min, limits.max, true, shared, page_size),
+                page_size_log2,
+            } => (limits.min, limits.max, true, shared, page_size_log2),
         };
 
         Self {
@@ -664,7 +664,7 @@ impl From<core::MemoryType> for wasm_encoder::MemoryType {
             maximum,
             memory64,
             shared,
-            page_size,
+            page_size_log2,
         }
     }
 }

--- a/crates/wast/src/component/binary.rs
+++ b/crates/wast/src/component/binary.rs
@@ -640,11 +640,23 @@ impl From<core::TableType<'_>> for wasm_encoder::TableType {
 
 impl From<core::MemoryType> for wasm_encoder::MemoryType {
     fn from(ty: core::MemoryType) -> Self {
-        let (minimum, maximum, memory64, shared) = match ty {
-            core::MemoryType::B32 { limits, shared } => {
-                (limits.min.into(), limits.max.map(Into::into), false, shared)
-            }
-            core::MemoryType::B64 { limits, shared } => (limits.min, limits.max, true, shared),
+        let (minimum, maximum, memory64, shared, page_size) = match ty {
+            core::MemoryType::B32 {
+                limits,
+                shared,
+                page_size,
+            } => (
+                limits.min.into(),
+                limits.max.map(Into::into),
+                false,
+                shared,
+                page_size,
+            ),
+            core::MemoryType::B64 {
+                limits,
+                shared,
+                page_size,
+            } => (limits.min, limits.max, true, shared, page_size),
         };
 
         Self {
@@ -652,6 +664,7 @@ impl From<core::MemoryType> for wasm_encoder::MemoryType {
             maximum,
             memory64,
             shared,
+            page_size,
         }
     }
 }

--- a/crates/wast/src/core/binary.rs
+++ b/crates/wast/src/core/binary.rs
@@ -475,32 +475,30 @@ impl Encode for MemoryType {
             MemoryType::B32 {
                 limits,
                 shared,
-                page_size,
+                page_size_log2,
             } => {
                 let flag_max = limits.max.is_some() as u8;
                 let flag_shared = *shared as u8;
-                let flag_page_size = page_size.is_some() as u8;
+                let flag_page_size = page_size_log2.is_some() as u8;
                 let flags = flag_max | (flag_shared << 1) | (flag_page_size << 3);
                 e.push(flags);
                 limits.min.encode(e);
                 if let Some(max) = limits.max {
                     max.encode(e);
                 }
-                if let Some(p) = page_size {
-                    assert!(p.is_power_of_two());
-                    assert!(*p <= (1 << 16));
-                    p.ilog2().encode(e);
+                if let Some(p) = page_size_log2 {
+                    p.encode(e);
                 }
             }
             MemoryType::B64 {
                 limits,
                 shared,
-                page_size,
+                page_size_log2,
             } => {
                 let flag_max = limits.max.is_some();
                 let flag_shared = *shared;
                 let flag_mem64 = true;
-                let flag_page_size = page_size.is_some();
+                let flag_page_size = page_size_log2.is_some();
                 let flags = ((flag_max as u8) << 0)
                     | ((flag_shared as u8) << 1)
                     | ((flag_mem64 as u8) << 2)
@@ -510,10 +508,8 @@ impl Encode for MemoryType {
                 if let Some(max) = limits.max {
                     max.encode(e);
                 }
-                if let Some(p) = page_size {
-                    assert!(p.is_power_of_two());
-                    assert!(*p <= (1 << 16));
-                    p.ilog2().encode(e);
+                if let Some(p) = page_size_log2 {
+                    p.encode(e);
                 }
             }
         }

--- a/crates/wast/src/core/binary.rs
+++ b/crates/wast/src/core/binary.rs
@@ -472,24 +472,48 @@ impl Encode for Limits {
 impl Encode for MemoryType {
     fn encode(&self, e: &mut Vec<u8>) {
         match self {
-            MemoryType::B32 { limits, shared } => {
+            MemoryType::B32 {
+                limits,
+                shared,
+                page_size,
+            } => {
                 let flag_max = limits.max.is_some() as u8;
                 let flag_shared = *shared as u8;
-                let flags = flag_max | (flag_shared << 1);
+                let flag_page_size = page_size.is_some() as u8;
+                let flags = flag_max | (flag_shared << 1) | (flag_page_size << 3);
                 e.push(flags);
                 limits.min.encode(e);
                 if let Some(max) = limits.max {
                     max.encode(e);
                 }
+                if let Some(p) = page_size {
+                    assert!(p.is_power_of_two());
+                    assert!(*p <= (1 << 16));
+                    p.ilog2().encode(e);
+                }
             }
-            MemoryType::B64 { limits, shared } => {
-                let flag_max = limits.max.is_some() as u8;
-                let flag_shared = *shared as u8;
-                let flags = flag_max | (flag_shared << 1) | 0x04;
+            MemoryType::B64 {
+                limits,
+                shared,
+                page_size,
+            } => {
+                let flag_max = limits.max.is_some();
+                let flag_shared = *shared;
+                let flag_mem64 = true;
+                let flag_page_size = page_size.is_some();
+                let flags = ((flag_max as u8) << 0)
+                    | ((flag_shared as u8) << 1)
+                    | ((flag_mem64 as u8) << 2)
+                    | ((flag_page_size as u8) << 3);
                 e.push(flags);
                 limits.min.encode(e);
                 if let Some(max) = limits.max {
                     max.encode(e);
+                }
+                if let Some(p) = page_size {
+                    assert!(p.is_power_of_two());
+                    assert!(*p <= (1 << 16));
+                    p.ilog2().encode(e);
                 }
             }
         }

--- a/crates/wast/src/core/memory.rs
+++ b/crates/wast/src/core/memory.rs
@@ -59,7 +59,10 @@ impl<'a> Parse<'a> for Memory<'a> {
                 import,
                 ty: parser.parse()?,
             }
-        } else if l.peek::<LParen>()? || parser.peek2::<LParen>()? {
+        } else if l.peek::<LParen>()?
+            || ((parser.peek::<kw::i32>()? || parser.peek::<kw::i64>()?)
+                && parser.peek2::<LParen>()?)
+        {
             let is_32 = if parser.parse::<Option<kw::i32>>()?.is_some() {
                 true
             } else {

--- a/crates/wast/src/core/resolve/deinline_import_export.rs
+++ b/crates/wast/src/core/resolve/deinline_import_export.rs
@@ -50,7 +50,7 @@ pub fn run(fields: &mut Vec<ModuleField>) {
                     // field here instead, switching this to a `Normal` memory.
                     MemoryKind::Inline { is_32, ref data } => {
                         let len = data.iter().map(|l| l.len()).sum::<usize>() as u32;
-                        let pages = (len + page_size() - 1) / page_size();
+                        let pages = (len + default_page_size() - 1) / default_page_size();
                         let kind = MemoryKind::Normal(if is_32 {
                             MemoryType::B32 {
                                 limits: Limits {
@@ -58,6 +58,7 @@ pub fn run(fields: &mut Vec<ModuleField>) {
                                     max: Some(pages),
                                 },
                                 shared: false,
+                                page_size: None,
                             }
                         } else {
                             MemoryType::B64 {
@@ -66,6 +67,7 @@ pub fn run(fields: &mut Vec<ModuleField>) {
                                     max: Some(u64::from(pages)),
                                 },
                                 shared: false,
+                                page_size: None,
                             }
                         });
                         let data = match mem::replace(&mut m.kind, kind) {
@@ -212,7 +214,7 @@ pub fn run(fields: &mut Vec<ModuleField>) {
         fields.push(item);
     }
 
-    fn page_size() -> u32 {
+    fn default_page_size() -> u32 {
         1 << 16
     }
 }

--- a/crates/wast/src/core/resolve/deinline_import_export.rs
+++ b/crates/wast/src/core/resolve/deinline_import_export.rs
@@ -58,7 +58,7 @@ pub fn run(fields: &mut Vec<ModuleField>) {
                                     max: Some(pages),
                                 },
                                 shared: false,
-                                page_size: None,
+                                page_size_log2: None,
                             }
                         } else {
                             MemoryType::B64 {
@@ -67,7 +67,7 @@ pub fn run(fields: &mut Vec<ModuleField>) {
                                     max: Some(u64::from(pages)),
                                 },
                                 shared: false,
-                                page_size: None,
+                                page_size_log2: None,
                             }
                         });
                         let data = match mem::replace(&mut m.kind, kind) {

--- a/crates/wast/src/core/types.rs
+++ b/crates/wast/src/core/types.rs
@@ -2,6 +2,7 @@ use crate::core::*;
 use crate::kw;
 use crate::parser::{Cursor, Parse, Parser, Peek, Result};
 use crate::token::{Id, Index, LParen, NameAnnotation, Span};
+use crate::Error;
 use std::mem;
 
 /// The value types for a wasm module.
@@ -489,6 +490,8 @@ pub enum MemoryType {
         limits: Limits,
         /// Whether or not this is a shared (atomic) memory type
         shared: bool,
+        /// The custom page size for this memory, if any.
+        page_size: Option<u32>,
     },
     /// A 64-bit memory
     B64 {
@@ -496,7 +499,29 @@ pub enum MemoryType {
         limits: Limits64,
         /// Whether or not this is a shared (atomic) memory type
         shared: bool,
+        /// The custom page size for this memory, if any.
+        page_size: Option<u32>,
     },
+}
+
+fn page_size(parser: Parser<'_>) -> Result<Option<u32>> {
+    if parser.peek::<LParen>()? {
+        Ok(Some(parser.parens(|parser| {
+            parser.parse::<kw::pagesize>()?;
+            let span = parser.cur_span();
+            let size = parser.parse::<u32>()?;
+            if size.is_power_of_two() && size <= (1 << 16) {
+                Ok(size)
+            } else {
+                Err(Error::new(
+                    span,
+                    format!("invalid custom page size: {size}"),
+                ))
+            }
+        })?))
+    } else {
+        Ok(None)
+    }
 }
 
 impl<'a> Parse<'a> for MemoryType {
@@ -505,12 +530,22 @@ impl<'a> Parse<'a> for MemoryType {
             parser.parse::<kw::i64>()?;
             let limits = parser.parse()?;
             let shared = parser.parse::<Option<kw::shared>>()?.is_some();
-            Ok(MemoryType::B64 { limits, shared })
+            let page_size = page_size(parser)?;
+            Ok(MemoryType::B64 {
+                limits,
+                shared,
+                page_size,
+            })
         } else {
             parser.parse::<Option<kw::i32>>()?;
             let limits = parser.parse()?;
             let shared = parser.parse::<Option<kw::shared>>()?.is_some();
-            Ok(MemoryType::B32 { limits, shared })
+            let page_size = page_size(parser)?;
+            Ok(MemoryType::B32 {
+                limits,
+                shared,
+                page_size,
+            })
         }
     }
 }

--- a/crates/wast/src/core/types.rs
+++ b/crates/wast/src/core/types.rs
@@ -491,7 +491,7 @@ pub enum MemoryType {
         /// Whether or not this is a shared (atomic) memory type
         shared: bool,
         /// The custom page size for this memory, if any.
-        page_size: Option<u32>,
+        page_size_log2: Option<u32>,
     },
     /// A 64-bit memory
     B64 {
@@ -500,7 +500,7 @@ pub enum MemoryType {
         /// Whether or not this is a shared (atomic) memory type
         shared: bool,
         /// The custom page size for this memory, if any.
-        page_size: Option<u32>,
+        page_size_log2: Option<u32>,
     },
 }
 
@@ -510,8 +510,8 @@ fn page_size(parser: Parser<'_>) -> Result<Option<u32>> {
             parser.parse::<kw::pagesize>()?;
             let span = parser.cur_span();
             let size = parser.parse::<u32>()?;
-            if size.is_power_of_two() && size <= (1 << 16) {
-                Ok(size)
+            if size.is_power_of_two() {
+                Ok(size.ilog2())
             } else {
                 Err(Error::new(
                     span,
@@ -534,7 +534,7 @@ impl<'a> Parse<'a> for MemoryType {
             Ok(MemoryType::B64 {
                 limits,
                 shared,
-                page_size,
+                page_size_log2: page_size,
             })
         } else {
             parser.parse::<Option<kw::i32>>()?;
@@ -544,7 +544,7 @@ impl<'a> Parse<'a> for MemoryType {
             Ok(MemoryType::B32 {
                 limits,
                 shared,
-                page_size,
+                page_size_log2: page_size,
             })
         }
     }

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -457,6 +457,7 @@ pub mod kw {
     custom_keyword!(offset);
     custom_keyword!(outer);
     custom_keyword!(own);
+    custom_keyword!(pagesize);
     custom_keyword!(param);
     custom_keyword!(parent);
     custom_keyword!(passive);

--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -584,7 +584,7 @@ impl<'a> Module<'a> {
                 maximum: mem.ty.maximum,
                 shared: mem.ty.shared,
                 memory64: mem.ty.memory64,
-                page_size: mem.ty.page_size,
+                page_size_log2: mem.ty.page_size_log2,
             };
             match &mem.def {
                 Definition::Import(m, n) => {

--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -584,6 +584,7 @@ impl<'a> Module<'a> {
                 maximum: mem.ty.maximum,
                 shared: mem.ty.shared,
                 memory64: mem.ty.memory64,
+                page_size: mem.ty.page_size,
             };
             match &mem.def {
                 Definition::Import(m, n) => {

--- a/crates/wit-component/src/linking.rs
+++ b/crates/wit-component/src/linking.rs
@@ -482,6 +482,7 @@ fn make_env_module<'a>(
             maximum: None,
             memory64: false,
             shared: false,
+            page_size: None,
         });
         exports.export("memory", ExportKind::Memory, 0);
         module.section(&memories);
@@ -550,6 +551,7 @@ fn make_init_module(
             maximum: None,
             memory64: false,
             shared: false,
+            page_size: None,
         },
     );
     imports.import(

--- a/crates/wit-component/src/linking.rs
+++ b/crates/wit-component/src/linking.rs
@@ -482,7 +482,7 @@ fn make_env_module<'a>(
             maximum: None,
             memory64: false,
             shared: false,
-            page_size: None,
+            page_size_log2: None,
         });
         exports.export("memory", ExportKind::Memory, 0);
         module.section(&memories);
@@ -551,7 +551,7 @@ fn make_init_module(
             maximum: None,
             memory64: false,
             shared: false,
-            page_size: None,
+            page_size_log2: None,
         },
     );
     imports.import(

--- a/fuzz/src/validate.rs
+++ b/fuzz/src/validate.rs
@@ -49,6 +49,7 @@ pub fn validate_raw_bytes(u: &mut Unstructured<'_>) -> Result<()> {
         memory_control: u.arbitrary()?,
         function_references: u.arbitrary()?,
         gc: u.arbitrary()?,
+        custom_page_sizes: u.arbitrary()?,
         component_model_values: u.arbitrary()?,
         component_model_nested_names: u.arbitrary()?,
     });

--- a/tests/cli/dump/alias2.wat.stdout
+++ b/tests/cli/dump/alias2.wat.stdout
@@ -136,7 +136,7 @@
    0x165 | 70 00 01    | [table 0] Table { ty: TableType { element_type: funcref, initial: 1, maximum: None }, init: RefNull }
    0x168 | 05 03       | memory section
    0x16a | 01          | 1 count
-   0x16b | 00 01       | [memory 0] MemoryType { memory64: false, shared: false, initial: 1, maximum: None, page_size: None }
+   0x16b | 00 01       | [memory 0] MemoryType { memory64: false, shared: false, initial: 1, maximum: None, page_size_log2: None }
    0x16d | 06 04       | global section
    0x16f | 01          | 1 count
    0x170 | 7f 00       | [global 0] GlobalType { content_type: I32, mutable: false, shared: false }
@@ -169,7 +169,7 @@
    0x1aa | 04          | 4 count
    0x1ab | 00 01 31 00 | import [func 0] Import { module: "", name: "1", ty: Func(0) }
          | 00         
-   0x1b0 | 00 01 32 02 | import [memory 0] Import { module: "", name: "2", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None, page_size: None }) }
+   0x1b0 | 00 01 32 02 | import [memory 0] Import { module: "", name: "2", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None, page_size_log2: None }) }
          | 00 01      
    0x1b6 | 00 01 33 03 | import [global 0] Import { module: "", name: "3", ty: Global(GlobalType { content_type: I32, mutable: false, shared: false }) }
          | 7f 00      

--- a/tests/cli/dump/alias2.wat.stdout
+++ b/tests/cli/dump/alias2.wat.stdout
@@ -136,7 +136,7 @@
    0x165 | 70 00 01    | [table 0] Table { ty: TableType { element_type: funcref, initial: 1, maximum: None }, init: RefNull }
    0x168 | 05 03       | memory section
    0x16a | 01          | 1 count
-   0x16b | 00 01       | [memory 0] MemoryType { memory64: false, shared: false, initial: 1, maximum: None }
+   0x16b | 00 01       | [memory 0] MemoryType { memory64: false, shared: false, initial: 1, maximum: None, page_size: None }
    0x16d | 06 04       | global section
    0x16f | 01          | 1 count
    0x170 | 7f 00       | [global 0] GlobalType { content_type: I32, mutable: false, shared: false }
@@ -169,7 +169,7 @@
    0x1aa | 04          | 4 count
    0x1ab | 00 01 31 00 | import [func 0] Import { module: "", name: "1", ty: Func(0) }
          | 00         
-   0x1b0 | 00 01 32 02 | import [memory 0] Import { module: "", name: "2", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None }) }
+   0x1b0 | 00 01 32 02 | import [memory 0] Import { module: "", name: "2", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None, page_size: None }) }
          | 00 01      
    0x1b6 | 00 01 33 03 | import [global 0] Import { module: "", name: "3", ty: Global(GlobalType { content_type: I32, mutable: false, shared: false }) }
          | 7f 00      

--- a/tests/cli/dump/bundled.wat.stdout
+++ b/tests/cli/dump/bundled.wat.stdout
@@ -33,7 +33,7 @@
     0x62 | 00          | [func 0] type 0
     0x63 | 05 03       | memory section
     0x65 | 01          | 1 count
-    0x66 | 00 00       | [memory 0] MemoryType { memory64: false, shared: false, initial: 0, maximum: None, page_size: None }
+    0x66 | 00 00       | [memory 0] MemoryType { memory64: false, shared: false, initial: 0, maximum: None, page_size_log2: None }
     0x68 | 07 11       | export section
     0x6a | 02          | 2 count
     0x6b | 03 6d 65 6d | export Export { name: "mem", kind: Memory, index: 0 }

--- a/tests/cli/dump/bundled.wat.stdout
+++ b/tests/cli/dump/bundled.wat.stdout
@@ -33,7 +33,7 @@
     0x62 | 00          | [func 0] type 0
     0x63 | 05 03       | memory section
     0x65 | 01          | 1 count
-    0x66 | 00 00       | [memory 0] MemoryType { memory64: false, shared: false, initial: 0, maximum: None }
+    0x66 | 00 00       | [memory 0] MemoryType { memory64: false, shared: false, initial: 0, maximum: None, page_size: None }
     0x68 | 07 11       | export section
     0x6a | 02          | 2 count
     0x6b | 03 6d 65 6d | export Export { name: "mem", kind: Memory, index: 0 }

--- a/tests/cli/dump/module-types.wat.stdout
+++ b/tests/cli/dump/module-types.wat.stdout
@@ -2,7 +2,7 @@
       | 0d 00 01 00
   0x8 | 03 23       | core type section
   0xa | 01          | 1 count
-  0xb | 50 05 01 60 | [core type 0] Module([Type(SubType { is_final: true, supertype_idx: None, composite_type: Func(FuncType { params: [], results: [] }) }), Import(Import { module: "", name: "f", ty: Func(0) }), Import(Import { module: "", name: "g", ty: Global(GlobalType { content_type: I32, mutable: false, shared: false }) }), Import(Import { module: "", name: "t", ty: Table(TableType { element_type: funcref, initial: 1, maximum: None }) }), Import(Import { module: "", name: "m", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None }) })])
+  0xb | 50 05 01 60 | [core type 0] Module([Type(SubType { is_final: true, supertype_idx: None, composite_type: Func(FuncType { params: [], results: [] }) }), Import(Import { module: "", name: "f", ty: Func(0) }), Import(Import { module: "", name: "g", ty: Global(GlobalType { content_type: I32, mutable: false, shared: false }) }), Import(Import { module: "", name: "t", ty: Table(TableType { element_type: funcref, initial: 1, maximum: None }) }), Import(Import { module: "", name: "m", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None, page_size: None }) })])
       | 00 00 00 00
       | 01 66 00 00
       | 00 00 01 67

--- a/tests/cli/dump/module-types.wat.stdout
+++ b/tests/cli/dump/module-types.wat.stdout
@@ -2,7 +2,7 @@
       | 0d 00 01 00
   0x8 | 03 23       | core type section
   0xa | 01          | 1 count
-  0xb | 50 05 01 60 | [core type 0] Module([Type(SubType { is_final: true, supertype_idx: None, composite_type: Func(FuncType { params: [], results: [] }) }), Import(Import { module: "", name: "f", ty: Func(0) }), Import(Import { module: "", name: "g", ty: Global(GlobalType { content_type: I32, mutable: false, shared: false }) }), Import(Import { module: "", name: "t", ty: Table(TableType { element_type: funcref, initial: 1, maximum: None }) }), Import(Import { module: "", name: "m", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None, page_size: None }) })])
+  0xb | 50 05 01 60 | [core type 0] Module([Type(SubType { is_final: true, supertype_idx: None, composite_type: Func(FuncType { params: [], results: [] }) }), Import(Import { module: "", name: "f", ty: Func(0) }), Import(Import { module: "", name: "g", ty: Global(GlobalType { content_type: I32, mutable: false, shared: false }) }), Import(Import { module: "", name: "t", ty: Table(TableType { element_type: funcref, initial: 1, maximum: None }) }), Import(Import { module: "", name: "m", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None, page_size_log2: None }) })])
       | 00 00 00 00
       | 01 66 00 00
       | 00 00 01 67

--- a/tests/cli/dump/simple.wat.stdout
+++ b/tests/cli/dump/simple.wat.stdout
@@ -20,7 +20,7 @@
  0x24 | 70 00 01    | [table 0] Table { ty: TableType { element_type: funcref, initial: 1, maximum: None }, init: RefNull }
  0x27 | 05 03       | memory section
  0x29 | 01          | 1 count
- 0x2a | 00 01       | [memory 0] MemoryType { memory64: false, shared: false, initial: 1, maximum: None }
+ 0x2a | 00 01       | [memory 0] MemoryType { memory64: false, shared: false, initial: 1, maximum: None, page_size: None }
  0x2c | 06 06       | global section
  0x2e | 01          | 1 count
  0x2f | 7f 00       | [global 0] GlobalType { content_type: I32, mutable: false, shared: false }

--- a/tests/cli/dump/simple.wat.stdout
+++ b/tests/cli/dump/simple.wat.stdout
@@ -20,7 +20,7 @@
  0x24 | 70 00 01    | [table 0] Table { ty: TableType { element_type: funcref, initial: 1, maximum: None }, init: RefNull }
  0x27 | 05 03       | memory section
  0x29 | 01          | 1 count
- 0x2a | 00 01       | [memory 0] MemoryType { memory64: false, shared: false, initial: 1, maximum: None, page_size: None }
+ 0x2a | 00 01       | [memory 0] MemoryType { memory64: false, shared: false, initial: 1, maximum: None, page_size_log2: None }
  0x2c | 06 06       | global section
  0x2e | 01          | 1 count
  0x2f | 7f 00       | [global 0] GlobalType { content_type: I32, mutable: false, shared: false }

--- a/tests/local/custom-page-sizes/custom-page-sizes-invalid.wast
+++ b/tests/local/custom-page-sizes/custom-page-sizes-invalid.wast
@@ -1,0 +1,12 @@
+(assert_malformed
+ (module binary
+   "\00asm" "\01\00\00\00"
+   "\05\04\01"                ;; Memory section
+
+   ;; memory 0
+   "\08"                      ;; flags w/ custom page size
+   "\00"                      ;; minimum = 0
+   "\11"                      ;; pagesize = 2**17
+ )
+ "invalid custom page size"
+)

--- a/tests/local/custom-page-sizes/custom-page-sizes-invalid.wast
+++ b/tests/local/custom-page-sizes/custom-page-sizes-invalid.wast
@@ -1,8 +1,11 @@
+(assert_malformed
+  (module quote "(memory 0 (pagesize 3))")
+  "invalid custom page size"
+)
+
 ;; Power of two page size that is larger than 64KiB.
 (assert_invalid
-  (module
-    (memory 0 (pagesize 0x20000))
-  )
+  (module (memory 0 (pagesize 0x20000)))
   "invalid custom page size"
 )
 

--- a/tests/local/custom-page-sizes/custom-page-sizes-invalid.wast
+++ b/tests/local/custom-page-sizes/custom-page-sizes-invalid.wast
@@ -1,12 +1,22 @@
-(assert_malformed
- (module binary
-   "\00asm" "\01\00\00\00"
-   "\05\04\01"                ;; Memory section
+;; Power of two page size that is larger than 64KiB.
+(assert_invalid
+  (module
+    (memory 0 (pagesize 0x20000))
+  )
+  "invalid custom page size"
+)
 
-   ;; memory 0
-   "\08"                      ;; flags w/ custom page size
-   "\00"                      ;; minimum = 0
-   "\11"                      ;; pagesize = 2**17
- )
- "invalid custom page size"
+;; Power of two page size that cannot fit in a u64 to exercise checks against
+;; shift overflow.
+(assert_malformed
+  (module binary
+    "\00asm" "\01\00\00\00"
+    "\05\04\01"                ;; Memory section
+
+    ;; memory 0
+    "\08"                      ;; flags w/ custom page size
+    "\00"                      ;; minimum = 0
+    "\41"                      ;; pagesize = 2**65
+  )
+  "invalid custom page size"
 )

--- a/tests/local/custom-page-sizes/custom-page-sizes.wast
+++ b/tests/local/custom-page-sizes/custom-page-sizes.wast
@@ -1,0 +1,118 @@
+;; Check all the valid custom page sizes.
+(module (memory 1 (pagesize 1)))
+(module (memory 1 (pagesize 2)))
+(module (memory 1 (pagesize 4)))
+(module (memory 1 (pagesize 8)))
+(module (memory 1 (pagesize 16)))
+(module (memory 1 (pagesize 32)))
+(module (memory 1 (pagesize 64)))
+(module (memory 1 (pagesize 128)))
+(module (memory 1 (pagesize 256)))
+(module (memory 1 (pagesize 512)))
+(module (memory 1 (pagesize 1024)))
+(module (memory 1 (pagesize 2048)))
+(module (memory 1 (pagesize 4096)))
+(module (memory 1 (pagesize 8192)))
+(module (memory 1 (pagesize 16384)))
+(module (memory 1 (pagesize 32768)))
+(module (memory 1 (pagesize 65536)))
+
+;; Check them all again with maximums specified.
+(module (memory 1 2 (pagesize 1)))
+(module (memory 1 2 (pagesize 2)))
+(module (memory 1 2 (pagesize 4)))
+(module (memory 1 2 (pagesize 8)))
+(module (memory 1 2 (pagesize 16)))
+(module (memory 1 2 (pagesize 32)))
+(module (memory 1 2 (pagesize 64)))
+(module (memory 1 2 (pagesize 128)))
+(module (memory 1 2 (pagesize 256)))
+(module (memory 1 2 (pagesize 512)))
+(module (memory 1 2 (pagesize 1024)))
+(module (memory 1 2 (pagesize 2048)))
+(module (memory 1 2 (pagesize 4096)))
+(module (memory 1 2 (pagesize 8192)))
+(module (memory 1 2 (pagesize 16384)))
+(module (memory 1 2 (pagesize 32768)))
+(module (memory 1 2 (pagesize 65536)))
+
+;; Check the behavior of memories with page size 1.
+(module
+  (memory 0 (pagesize 1))
+  (func (export "size") (result i32)
+    memory.size
+  )
+  (func (export "grow") (param i32) (result i32)
+    (memory.grow (local.get 0))
+  )
+  (func (export "load") (param i32) (result i32)
+    (i32.load8_u (local.get 0))
+  )
+  (func (export "store") (param i32 i32)
+    (i32.store (local.get 0) (local.get 1))
+  )
+)
+
+(assert_return (invoke "size") (i32.const 0))
+(assert_trap (invoke "load" (i32.const 0)) "out of bounds memory access")
+
+(assert_return (invoke "grow" (i32.const 65536)) (i32.const 0))
+(assert_return (invoke "size") (i32.const 65536))
+(assert_return (invoke "load" (i32.const 65535)) (i32.const 0))
+(assert_return (invoke "store" (i32.const 65535) (i32.const 1)))
+(assert_return (invoke "load" (i32.const 65535)) (i32.const 1))
+(assert_trap (invoke "load" (i32.const 65536)) "out of bounds memory access")
+
+(assert_return (invoke "grow" (i32.const 65536)) (i32.const 65536))
+(assert_return (invoke "size") (i32.const 131072))
+(assert_return (invoke "load" (i32.const 131071)) (i32.const 0))
+(assert_return (invoke "store" (i32.const 131071) (i32.const 1)))
+(assert_return (invoke "load" (i32.const 131071)) (i32.const 1))
+(assert_trap (invoke "load" (i32.const 131072)) "out of bounds memory access")
+
+;; Check the behavior of memories with page size 4.
+(module
+  (memory 0 (pagesize 4))
+  (func (export "size") (result i32)
+    memory.size
+  )
+  (func (export "grow") (param i32) (result i32)
+    (memory.grow (local.get 0))
+  )
+  (func (export "load") (param i32) (result i32)
+    (i32.load (local.get 0))
+  )
+  (func (export "store") (param i32 i32)
+    (i32.store (local.get 0) (local.get 1))
+  )
+)
+
+(assert_return (invoke "size") (i32.const 0))
+(assert_trap (invoke "load" (i32.const 0)) "out of bounds memory access")
+
+(assert_return (invoke "grow" (i32.const 65536)) (i32.const 0))
+(assert_return (invoke "size") (i32.const 65536))
+(assert_return (invoke "load" (i32.const 262143)) (i32.const 0))
+(assert_return (invoke "store" (i32.const 262143) (i32.const 1)))
+(assert_return (invoke "load" (i32.const 262143)) (i32.const 1))
+(assert_trap (invoke "load" (i32.const 262144)) "out of bounds memory access")
+
+(assert_return (invoke "grow" (i32.const 65536)) (i32.const 65536))
+(assert_return (invoke "size") (i32.const 131072))
+(assert_return (invoke "load" (i32.const 524287)) (i32.const 0))
+(assert_return (invoke "store" (i32.const 524287) (i32.const 1)))
+(assert_return (invoke "load" (i32.const 524287)) (i32.const 1))
+(assert_trap (invoke "load" (i32.const 524288)) "out of bounds memory access")
+
+;; Although smaller page sizes let us get to memories larger than 2**16 pages,
+;; we can't do that with the default page size, even if we explicitly state it
+;; as a custom page size.
+(module
+  (memory 0 (pagesize 65536))
+  (func (export "grow") (param i32) (result i32)
+    (memory.grow (local.get 0))
+  )
+)
+(assert_return (invoke "size") (i32.const 0))
+(assert_return (invoke "grow" (i32.const 65537)) (i32.const -1))
+(assert_return (invoke "size") (i32.const 0))

--- a/tests/local/missing-features/custom-page-sizes.wast
+++ b/tests/local/missing-features/custom-page-sizes.wast
@@ -1,0 +1,5 @@
+(assert_invalid
+  (module
+    (memory 0 (pagesize 1))
+  )
+  "the custom page sizes proposal must be enabled to customize a memory's page size")

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -597,6 +597,7 @@ impl TestState {
             function_references: true,
             memory_control: true,
             gc: true,
+            custom_page_sizes: true,
             component_model_values: true,
             component_model_nested_names: false,
         };
@@ -624,6 +625,7 @@ impl TestState {
                     features.bulk_memory = false;
                     features.function_references = false;
                     features.gc = false;
+                    features.custom_page_sizes = false;
                     features.component_model = false;
                     features.component_model_values = false;
                     features.shared_everything_threads = false;
@@ -652,6 +654,7 @@ impl TestState {
                     features.function_references = true;
                     features.gc = true;
                 }
+                "custom-page-sizes" => features.custom_page_sizes = true,
                 "import-extended.wast" => {
                     features.component_model_nested_names = true;
                 }
@@ -791,7 +794,10 @@ fn error_matches(error: &str, message: &str) -> bool {
 
     if message == "malformed limits flags" {
         return error.contains("invalid memory limits flags")
-            || error.contains("invalid table resizable limits flags");
+            || error.contains("invalid table resizable limits flags")
+            // These tests need to be updated for the new limits flags in the
+            // custom-page-sizes-proposal.
+            || error.contains("unexpected end-of-file");
     }
 
     if message == "zero flag expected" {

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes-invalid.wast.json
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes-invalid.wast.json
@@ -1,0 +1,12 @@
+{
+  "source_filename": "tests/local/custom-page-sizes/custom-page-sizes-invalid.wast",
+  "commands": [
+    {
+      "type": "assert_malformed",
+      "line": 2,
+      "filename": "custom-page-sizes-invalid.0.wasm",
+      "text": "invalid custom page size",
+      "module_type": "binary"
+    }
+  ]
+}

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes-invalid.wast.json
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes-invalid.wast.json
@@ -2,9 +2,16 @@
   "source_filename": "tests/local/custom-page-sizes/custom-page-sizes-invalid.wast",
   "commands": [
     {
-      "type": "assert_malformed",
-      "line": 2,
+      "type": "assert_invalid",
+      "line": 3,
       "filename": "custom-page-sizes-invalid.0.wasm",
+      "text": "invalid custom page size",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 12,
+      "filename": "custom-page-sizes-invalid.1.wasm",
       "text": "invalid custom page size",
       "module_type": "binary"
     }

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes-invalid.wast.json
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes-invalid.wast.json
@@ -2,16 +2,23 @@
   "source_filename": "tests/local/custom-page-sizes/custom-page-sizes-invalid.wast",
   "commands": [
     {
+      "type": "assert_malformed",
+      "line": 2,
+      "filename": "custom-page-sizes-invalid.0.wat",
+      "text": "invalid custom page size",
+      "module_type": "text"
+    },
+    {
       "type": "assert_invalid",
-      "line": 3,
-      "filename": "custom-page-sizes-invalid.0.wasm",
+      "line": 8,
+      "filename": "custom-page-sizes-invalid.1.wasm",
       "text": "invalid custom page size",
       "module_type": "binary"
     },
     {
       "type": "assert_malformed",
-      "line": 12,
-      "filename": "custom-page-sizes-invalid.1.wasm",
+      "line": 15,
+      "filename": "custom-page-sizes-invalid.2.wasm",
       "text": "invalid custom page size",
       "module_type": "binary"
     }

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast.json
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast.json
@@ -1,0 +1,736 @@
+{
+  "source_filename": "tests/local/custom-page-sizes/custom-page-sizes.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 2,
+      "filename": "custom-page-sizes.0.wasm"
+    },
+    {
+      "type": "module",
+      "line": 3,
+      "filename": "custom-page-sizes.1.wasm"
+    },
+    {
+      "type": "module",
+      "line": 4,
+      "filename": "custom-page-sizes.2.wasm"
+    },
+    {
+      "type": "module",
+      "line": 5,
+      "filename": "custom-page-sizes.3.wasm"
+    },
+    {
+      "type": "module",
+      "line": 6,
+      "filename": "custom-page-sizes.4.wasm"
+    },
+    {
+      "type": "module",
+      "line": 7,
+      "filename": "custom-page-sizes.5.wasm"
+    },
+    {
+      "type": "module",
+      "line": 8,
+      "filename": "custom-page-sizes.6.wasm"
+    },
+    {
+      "type": "module",
+      "line": 9,
+      "filename": "custom-page-sizes.7.wasm"
+    },
+    {
+      "type": "module",
+      "line": 10,
+      "filename": "custom-page-sizes.8.wasm"
+    },
+    {
+      "type": "module",
+      "line": 11,
+      "filename": "custom-page-sizes.9.wasm"
+    },
+    {
+      "type": "module",
+      "line": 12,
+      "filename": "custom-page-sizes.10.wasm"
+    },
+    {
+      "type": "module",
+      "line": 13,
+      "filename": "custom-page-sizes.11.wasm"
+    },
+    {
+      "type": "module",
+      "line": 14,
+      "filename": "custom-page-sizes.12.wasm"
+    },
+    {
+      "type": "module",
+      "line": 15,
+      "filename": "custom-page-sizes.13.wasm"
+    },
+    {
+      "type": "module",
+      "line": 16,
+      "filename": "custom-page-sizes.14.wasm"
+    },
+    {
+      "type": "module",
+      "line": 17,
+      "filename": "custom-page-sizes.15.wasm"
+    },
+    {
+      "type": "module",
+      "line": 18,
+      "filename": "custom-page-sizes.16.wasm"
+    },
+    {
+      "type": "module",
+      "line": 21,
+      "filename": "custom-page-sizes.17.wasm"
+    },
+    {
+      "type": "module",
+      "line": 22,
+      "filename": "custom-page-sizes.18.wasm"
+    },
+    {
+      "type": "module",
+      "line": 23,
+      "filename": "custom-page-sizes.19.wasm"
+    },
+    {
+      "type": "module",
+      "line": 24,
+      "filename": "custom-page-sizes.20.wasm"
+    },
+    {
+      "type": "module",
+      "line": 25,
+      "filename": "custom-page-sizes.21.wasm"
+    },
+    {
+      "type": "module",
+      "line": 26,
+      "filename": "custom-page-sizes.22.wasm"
+    },
+    {
+      "type": "module",
+      "line": 27,
+      "filename": "custom-page-sizes.23.wasm"
+    },
+    {
+      "type": "module",
+      "line": 28,
+      "filename": "custom-page-sizes.24.wasm"
+    },
+    {
+      "type": "module",
+      "line": 29,
+      "filename": "custom-page-sizes.25.wasm"
+    },
+    {
+      "type": "module",
+      "line": 30,
+      "filename": "custom-page-sizes.26.wasm"
+    },
+    {
+      "type": "module",
+      "line": 31,
+      "filename": "custom-page-sizes.27.wasm"
+    },
+    {
+      "type": "module",
+      "line": 32,
+      "filename": "custom-page-sizes.28.wasm"
+    },
+    {
+      "type": "module",
+      "line": 33,
+      "filename": "custom-page-sizes.29.wasm"
+    },
+    {
+      "type": "module",
+      "line": 34,
+      "filename": "custom-page-sizes.30.wasm"
+    },
+    {
+      "type": "module",
+      "line": 35,
+      "filename": "custom-page-sizes.31.wasm"
+    },
+    {
+      "type": "module",
+      "line": 36,
+      "filename": "custom-page-sizes.32.wasm"
+    },
+    {
+      "type": "module",
+      "line": 37,
+      "filename": "custom-page-sizes.33.wasm"
+    },
+    {
+      "type": "module",
+      "line": 40,
+      "filename": "custom-page-sizes.34.wasm"
+    },
+    {
+      "type": "assert_return",
+      "line": 56,
+      "action": {
+        "type": "invoke",
+        "field": "size",
+        "args": []
+      },
+      "expected": [
+        {
+          "type": "i32",
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "type": "assert_trap",
+      "line": 57,
+      "action": {
+        "type": "invoke",
+        "field": "load",
+        "args": [
+          {
+            "type": "i32",
+            "value": "0"
+          }
+        ]
+      },
+      "text": "out of bounds memory access"
+    },
+    {
+      "type": "assert_return",
+      "line": 59,
+      "action": {
+        "type": "invoke",
+        "field": "grow",
+        "args": [
+          {
+            "type": "i32",
+            "value": "65536"
+          }
+        ]
+      },
+      "expected": [
+        {
+          "type": "i32",
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "type": "assert_return",
+      "line": 60,
+      "action": {
+        "type": "invoke",
+        "field": "size",
+        "args": []
+      },
+      "expected": [
+        {
+          "type": "i32",
+          "value": "65536"
+        }
+      ]
+    },
+    {
+      "type": "assert_return",
+      "line": 61,
+      "action": {
+        "type": "invoke",
+        "field": "load",
+        "args": [
+          {
+            "type": "i32",
+            "value": "65535"
+          }
+        ]
+      },
+      "expected": [
+        {
+          "type": "i32",
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "type": "assert_return",
+      "line": 62,
+      "action": {
+        "type": "invoke",
+        "field": "store",
+        "args": [
+          {
+            "type": "i32",
+            "value": "65535"
+          },
+          {
+            "type": "i32",
+            "value": "1"
+          }
+        ]
+      },
+      "expected": []
+    },
+    {
+      "type": "assert_return",
+      "line": 63,
+      "action": {
+        "type": "invoke",
+        "field": "load",
+        "args": [
+          {
+            "type": "i32",
+            "value": "65535"
+          }
+        ]
+      },
+      "expected": [
+        {
+          "type": "i32",
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "type": "assert_trap",
+      "line": 64,
+      "action": {
+        "type": "invoke",
+        "field": "load",
+        "args": [
+          {
+            "type": "i32",
+            "value": "65536"
+          }
+        ]
+      },
+      "text": "out of bounds memory access"
+    },
+    {
+      "type": "assert_return",
+      "line": 66,
+      "action": {
+        "type": "invoke",
+        "field": "grow",
+        "args": [
+          {
+            "type": "i32",
+            "value": "65536"
+          }
+        ]
+      },
+      "expected": [
+        {
+          "type": "i32",
+          "value": "65536"
+        }
+      ]
+    },
+    {
+      "type": "assert_return",
+      "line": 67,
+      "action": {
+        "type": "invoke",
+        "field": "size",
+        "args": []
+      },
+      "expected": [
+        {
+          "type": "i32",
+          "value": "131072"
+        }
+      ]
+    },
+    {
+      "type": "assert_return",
+      "line": 68,
+      "action": {
+        "type": "invoke",
+        "field": "load",
+        "args": [
+          {
+            "type": "i32",
+            "value": "131071"
+          }
+        ]
+      },
+      "expected": [
+        {
+          "type": "i32",
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "type": "assert_return",
+      "line": 69,
+      "action": {
+        "type": "invoke",
+        "field": "store",
+        "args": [
+          {
+            "type": "i32",
+            "value": "131071"
+          },
+          {
+            "type": "i32",
+            "value": "1"
+          }
+        ]
+      },
+      "expected": []
+    },
+    {
+      "type": "assert_return",
+      "line": 70,
+      "action": {
+        "type": "invoke",
+        "field": "load",
+        "args": [
+          {
+            "type": "i32",
+            "value": "131071"
+          }
+        ]
+      },
+      "expected": [
+        {
+          "type": "i32",
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "type": "assert_trap",
+      "line": 71,
+      "action": {
+        "type": "invoke",
+        "field": "load",
+        "args": [
+          {
+            "type": "i32",
+            "value": "131072"
+          }
+        ]
+      },
+      "text": "out of bounds memory access"
+    },
+    {
+      "type": "module",
+      "line": 74,
+      "filename": "custom-page-sizes.35.wasm"
+    },
+    {
+      "type": "assert_return",
+      "line": 90,
+      "action": {
+        "type": "invoke",
+        "field": "size",
+        "args": []
+      },
+      "expected": [
+        {
+          "type": "i32",
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "type": "assert_trap",
+      "line": 91,
+      "action": {
+        "type": "invoke",
+        "field": "load",
+        "args": [
+          {
+            "type": "i32",
+            "value": "0"
+          }
+        ]
+      },
+      "text": "out of bounds memory access"
+    },
+    {
+      "type": "assert_return",
+      "line": 93,
+      "action": {
+        "type": "invoke",
+        "field": "grow",
+        "args": [
+          {
+            "type": "i32",
+            "value": "65536"
+          }
+        ]
+      },
+      "expected": [
+        {
+          "type": "i32",
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "type": "assert_return",
+      "line": 94,
+      "action": {
+        "type": "invoke",
+        "field": "size",
+        "args": []
+      },
+      "expected": [
+        {
+          "type": "i32",
+          "value": "65536"
+        }
+      ]
+    },
+    {
+      "type": "assert_return",
+      "line": 95,
+      "action": {
+        "type": "invoke",
+        "field": "load",
+        "args": [
+          {
+            "type": "i32",
+            "value": "262143"
+          }
+        ]
+      },
+      "expected": [
+        {
+          "type": "i32",
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "type": "assert_return",
+      "line": 96,
+      "action": {
+        "type": "invoke",
+        "field": "store",
+        "args": [
+          {
+            "type": "i32",
+            "value": "262143"
+          },
+          {
+            "type": "i32",
+            "value": "1"
+          }
+        ]
+      },
+      "expected": []
+    },
+    {
+      "type": "assert_return",
+      "line": 97,
+      "action": {
+        "type": "invoke",
+        "field": "load",
+        "args": [
+          {
+            "type": "i32",
+            "value": "262143"
+          }
+        ]
+      },
+      "expected": [
+        {
+          "type": "i32",
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "type": "assert_trap",
+      "line": 98,
+      "action": {
+        "type": "invoke",
+        "field": "load",
+        "args": [
+          {
+            "type": "i32",
+            "value": "262144"
+          }
+        ]
+      },
+      "text": "out of bounds memory access"
+    },
+    {
+      "type": "assert_return",
+      "line": 100,
+      "action": {
+        "type": "invoke",
+        "field": "grow",
+        "args": [
+          {
+            "type": "i32",
+            "value": "65536"
+          }
+        ]
+      },
+      "expected": [
+        {
+          "type": "i32",
+          "value": "65536"
+        }
+      ]
+    },
+    {
+      "type": "assert_return",
+      "line": 101,
+      "action": {
+        "type": "invoke",
+        "field": "size",
+        "args": []
+      },
+      "expected": [
+        {
+          "type": "i32",
+          "value": "131072"
+        }
+      ]
+    },
+    {
+      "type": "assert_return",
+      "line": 102,
+      "action": {
+        "type": "invoke",
+        "field": "load",
+        "args": [
+          {
+            "type": "i32",
+            "value": "524287"
+          }
+        ]
+      },
+      "expected": [
+        {
+          "type": "i32",
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "type": "assert_return",
+      "line": 103,
+      "action": {
+        "type": "invoke",
+        "field": "store",
+        "args": [
+          {
+            "type": "i32",
+            "value": "524287"
+          },
+          {
+            "type": "i32",
+            "value": "1"
+          }
+        ]
+      },
+      "expected": []
+    },
+    {
+      "type": "assert_return",
+      "line": 104,
+      "action": {
+        "type": "invoke",
+        "field": "load",
+        "args": [
+          {
+            "type": "i32",
+            "value": "524287"
+          }
+        ]
+      },
+      "expected": [
+        {
+          "type": "i32",
+          "value": "1"
+        }
+      ]
+    },
+    {
+      "type": "assert_trap",
+      "line": 105,
+      "action": {
+        "type": "invoke",
+        "field": "load",
+        "args": [
+          {
+            "type": "i32",
+            "value": "524288"
+          }
+        ]
+      },
+      "text": "out of bounds memory access"
+    },
+    {
+      "type": "module",
+      "line": 110,
+      "filename": "custom-page-sizes.36.wasm"
+    },
+    {
+      "type": "assert_return",
+      "line": 116,
+      "action": {
+        "type": "invoke",
+        "field": "size",
+        "args": []
+      },
+      "expected": [
+        {
+          "type": "i32",
+          "value": "0"
+        }
+      ]
+    },
+    {
+      "type": "assert_return",
+      "line": 117,
+      "action": {
+        "type": "invoke",
+        "field": "grow",
+        "args": [
+          {
+            "type": "i32",
+            "value": "65537"
+          }
+        ]
+      },
+      "expected": [
+        {
+          "type": "i32",
+          "value": "-1"
+        }
+      ]
+    },
+    {
+      "type": "assert_return",
+      "line": 118,
+      "action": {
+        "type": "invoke",
+        "field": "size",
+        "args": []
+      },
+      "expected": [
+        {
+          "type": "i32",
+          "value": "0"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/0.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/0.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1(pagesize 1))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/0.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/0.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1(pagesize 1))
+  (memory (;0;) 1(pagesize 0x1))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/1.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/1.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1(pagesize 2))
+  (memory (;0;) 1(pagesize 0x2))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/1.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/1.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1(pagesize 2))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/10.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/10.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1(pagesize 1024))
+  (memory (;0;) 1(pagesize 0x400))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/10.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/10.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1(pagesize 1024))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/11.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/11.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1(pagesize 2048))
+  (memory (;0;) 1(pagesize 0x800))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/11.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/11.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1(pagesize 2048))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/12.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/12.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1(pagesize 4096))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/12.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/12.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1(pagesize 4096))
+  (memory (;0;) 1(pagesize 0x1000))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/13.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/13.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1(pagesize 8192))
+  (memory (;0;) 1(pagesize 0x2000))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/13.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/13.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1(pagesize 8192))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/14.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/14.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1(pagesize 16384))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/14.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/14.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1(pagesize 16384))
+  (memory (;0;) 1(pagesize 0x4000))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/15.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/15.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1(pagesize 32768))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/15.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/15.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1(pagesize 32768))
+  (memory (;0;) 1(pagesize 0x8000))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/16.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/16.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1(pagesize 65536))
+  (memory (;0;) 1(pagesize 0x10000))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/16.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/16.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1(pagesize 65536))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/17.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/17.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1 2(pagesize 1))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/17.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/17.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1 2(pagesize 1))
+  (memory (;0;) 1 2(pagesize 0x1))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/18.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/18.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1 2(pagesize 2))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/18.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/18.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1 2(pagesize 2))
+  (memory (;0;) 1 2(pagesize 0x2))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/19.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/19.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1 2(pagesize 4))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/19.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/19.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1 2(pagesize 4))
+  (memory (;0;) 1 2(pagesize 0x4))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/2.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/2.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1(pagesize 4))
+  (memory (;0;) 1(pagesize 0x4))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/2.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/2.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1(pagesize 4))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/20.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/20.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1 2(pagesize 8))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/20.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/20.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1 2(pagesize 8))
+  (memory (;0;) 1 2(pagesize 0x8))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/21.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/21.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1 2(pagesize 16))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/21.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/21.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1 2(pagesize 16))
+  (memory (;0;) 1 2(pagesize 0x10))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/22.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/22.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1 2(pagesize 32))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/22.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/22.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1 2(pagesize 32))
+  (memory (;0;) 1 2(pagesize 0x20))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/23.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/23.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1 2(pagesize 64))
+  (memory (;0;) 1 2(pagesize 0x40))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/23.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/23.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1 2(pagesize 64))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/24.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/24.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1 2(pagesize 128))
+  (memory (;0;) 1 2(pagesize 0x80))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/24.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/24.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1 2(pagesize 128))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/25.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/25.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1 2(pagesize 256))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/25.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/25.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1 2(pagesize 256))
+  (memory (;0;) 1 2(pagesize 0x100))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/26.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/26.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1 2(pagesize 512))
+  (memory (;0;) 1 2(pagesize 0x200))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/26.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/26.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1 2(pagesize 512))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/27.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/27.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1 2(pagesize 1024))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/27.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/27.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1 2(pagesize 1024))
+  (memory (;0;) 1 2(pagesize 0x400))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/28.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/28.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1 2(pagesize 2048))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/28.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/28.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1 2(pagesize 2048))
+  (memory (;0;) 1 2(pagesize 0x800))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/29.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/29.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1 2(pagesize 4096))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/29.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/29.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1 2(pagesize 4096))
+  (memory (;0;) 1 2(pagesize 0x1000))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/3.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/3.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1(pagesize 8))
+  (memory (;0;) 1(pagesize 0x8))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/3.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/3.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1(pagesize 8))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/30.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/30.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1 2(pagesize 8192))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/30.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/30.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1 2(pagesize 8192))
+  (memory (;0;) 1 2(pagesize 0x2000))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/31.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/31.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1 2(pagesize 16384))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/31.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/31.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1 2(pagesize 16384))
+  (memory (;0;) 1 2(pagesize 0x4000))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/32.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/32.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1 2(pagesize 32768))
+  (memory (;0;) 1 2(pagesize 0x8000))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/32.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/32.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1 2(pagesize 32768))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/33.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/33.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1 2(pagesize 65536))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/33.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/33.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1 2(pagesize 65536))
+  (memory (;0;) 1 2(pagesize 0x10000))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/34.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/34.print
@@ -18,7 +18,7 @@
     local.get 1
     i32.store
   )
-  (memory (;0;) 0(pagesize 1))
+  (memory (;0;) 0(pagesize 0x1))
   (export "size" (func 0))
   (export "grow" (func 1))
   (export "load" (func 2))

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/34.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/34.print
@@ -1,0 +1,26 @@
+(module
+  (type (;0;) (func (result i32)))
+  (type (;1;) (func (param i32) (result i32)))
+  (type (;2;) (func (param i32 i32)))
+  (func (;0;) (type 0) (result i32)
+    memory.size
+  )
+  (func (;1;) (type 1) (param i32) (result i32)
+    local.get 0
+    memory.grow
+  )
+  (func (;2;) (type 1) (param i32) (result i32)
+    local.get 0
+    i32.load8_u
+  )
+  (func (;3;) (type 2) (param i32 i32)
+    local.get 0
+    local.get 1
+    i32.store
+  )
+  (memory (;0;) 0(pagesize 1))
+  (export "size" (func 0))
+  (export "grow" (func 1))
+  (export "load" (func 2))
+  (export "store" (func 3))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/4.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/4.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1(pagesize 16))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/4.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/4.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1(pagesize 16))
+  (memory (;0;) 1(pagesize 0x10))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/49.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/49.print
@@ -1,0 +1,26 @@
+(module
+  (type (;0;) (func (result i32)))
+  (type (;1;) (func (param i32) (result i32)))
+  (type (;2;) (func (param i32 i32)))
+  (func (;0;) (type 0) (result i32)
+    memory.size
+  )
+  (func (;1;) (type 1) (param i32) (result i32)
+    local.get 0
+    memory.grow
+  )
+  (func (;2;) (type 1) (param i32) (result i32)
+    local.get 0
+    i32.load
+  )
+  (func (;3;) (type 2) (param i32 i32)
+    local.get 0
+    local.get 1
+    i32.store
+  )
+  (memory (;0;) 0(pagesize 4))
+  (export "size" (func 0))
+  (export "grow" (func 1))
+  (export "load" (func 2))
+  (export "store" (func 3))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/49.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/49.print
@@ -18,7 +18,7 @@
     local.get 1
     i32.store
   )
-  (memory (;0;) 0(pagesize 4))
+  (memory (;0;) 0(pagesize 0x4))
   (export "size" (func 0))
   (export "grow" (func 1))
   (export "load" (func 2))

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/5.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/5.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1(pagesize 32))
+  (memory (;0;) 1(pagesize 0x20))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/5.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/5.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1(pagesize 32))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/6.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/6.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1(pagesize 64))
+  (memory (;0;) 1(pagesize 0x40))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/6.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/6.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1(pagesize 64))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/64.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/64.print
@@ -1,0 +1,9 @@
+(module
+  (type (;0;) (func (param i32) (result i32)))
+  (func (;0;) (type 0) (param i32) (result i32)
+    local.get 0
+    memory.grow
+  )
+  (memory (;0;) 0(pagesize 65536))
+  (export "grow" (func 0))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/64.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/64.print
@@ -4,6 +4,6 @@
     local.get 0
     memory.grow
   )
-  (memory (;0;) 0(pagesize 65536))
+  (memory (;0;) 0(pagesize 0x10000))
   (export "grow" (func 0))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/7.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/7.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1(pagesize 128))
+  (memory (;0;) 1(pagesize 0x80))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/7.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/7.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1(pagesize 128))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/8.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/8.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1(pagesize 256))
+  (memory (;0;) 1(pagesize 0x100))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/8.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/8.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1(pagesize 256))
+)

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/9.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/9.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1(pagesize 512))
+  (memory (;0;) 1(pagesize 0x200))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/9.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/9.print
@@ -1,0 +1,3 @@
+(module
+  (memory (;0;) 1(pagesize 512))
+)

--- a/tests/snapshots/local/missing-features/custom-page-sizes.wast.json
+++ b/tests/snapshots/local/missing-features/custom-page-sizes.wast.json
@@ -1,0 +1,12 @@
+{
+  "source_filename": "tests/local/missing-features/custom-page-sizes.wast",
+  "commands": [
+    {
+      "type": "assert_invalid",
+      "line": 2,
+      "filename": "custom-page-sizes.0.wasm",
+      "text": "the custom page sizes proposal must be enabled to customize a memory's page size",
+      "module_type": "binary"
+    }
+  ]
+}


### PR DESCRIPTION
This pull request adds support for [the custom-page-sizes proposal](https://github.com/WebAssembly/custom-page-sizes) to:

* [x] `wasm-encoder`
* [x] `wasmparser`
* [x] `wast`
* [x] `wasmprinter`
* [x] `wasm-smith`

It additionally adds some `.wast` tests that I intend to eventually upstream into the proposal's spec test suite.