### PR TITLE
Make `FuncToValidate` fields public

### DIFF
--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -973,12 +973,12 @@ impl Validator {
         let state = self.module.as_mut().unwrap();
 
         let (index, ty) = state.next_code_index_and_type(offset)?;
-        Ok(FuncToValidate::new(
+        Ok(FuncToValidate {
             index,
             ty,
-            ValidatorResources(state.module.arc().clone()),
-            &self.features,
-        ))
+            resources: ValidatorResources(state.module.arc().clone()),
+            features: self.features,
+        })
     }
 
     /// Validates [`Payload::DataSection`](crate::Payload).

--- a/crates/wasmparser/src/validator/func.rs
+++ b/crates/wasmparser/src/validator/func.rs
@@ -10,31 +10,18 @@ use crate::{FunctionBody, Operator, WasmFeatures, WasmModuleResources};
 /// for sending to other threads while the original
 /// [`Validator`](crate::Validator) continues processing other functions.
 pub struct FuncToValidate<T> {
-    resources: T,
-    index: u32,
-    ty: u32,
-    features: WasmFeatures,
+    /// Reusable, heap allocated resources to drive the Wasm validation.
+    pub resources: T,
+    /// The core Wasm function index being validated.
+    pub index: u32,
+    /// The core Wasm type index of the function being validated,
+    /// defining the results and parameters to the function.
+    pub ty: u32,
+    /// The Wasm features enabled to validate the function.
+    pub features: WasmFeatures,
 }
 
 impl<T: WasmModuleResources> FuncToValidate<T> {
-    /// Creates a new function to validate which will have the specified
-    /// configuration parameters:
-    ///
-    /// * `index` - the core wasm function index being validated
-    /// * `ty` - the core wasm type index of the function being validated,
-    ///   defining the results and parameters to the function.
-    /// * `resources` - metadata and type information about the module that
-    ///   this function is validated within.
-    /// * `features` - enabled WebAssembly features.
-    pub fn new(index: u32, ty: u32, resources: T, features: &WasmFeatures) -> FuncToValidate<T> {
-        FuncToValidate {
-            resources,
-            index,
-            ty,
-            features: *features,
-        }
-    }
-
     /// Converts this [`FuncToValidate`] into a [`FuncValidator`] using the
     /// `allocs` provided.
     ///
@@ -310,8 +297,13 @@ mod tests {
 
     #[test]
     fn operand_stack_height() {
-        let mut v = FuncToValidate::new(0, 0, EmptyResources::default(), &Default::default())
-            .into_validator(Default::default());
+        let mut v = FuncToValidate {
+            index: 0,
+            ty: 0,
+            resources: EmptyResources::default(),
+            features: Default::default(),
+        }
+        .into_validator(Default::default());
 
         // Initially zero values on the stack.
         assert_eq!(v.operand_stack_height(), 0);


### PR DESCRIPTION
Partially closes https://github.com/bytecodealliance/wasm-tools/issues/1491.

I will implement the bit-field based `WasmFeatures` in another PR.