### PR TITLE
Add `Debug` derive to `FuncToValidate` and its uses

### DIFF
--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -510,6 +510,7 @@ impl ModuleState {
     }
 }
 
+#[derive(Debug)]
 pub(crate) struct Module {
     // This is set once the code section starts.
     // `WasmModuleResources` implementations use the snapshot to
@@ -1271,6 +1272,7 @@ impl WasmModuleResources for OperatorValidatorResources<'_> {
 
 /// The implementation of [`WasmModuleResources`] used by
 /// [`Validator`](crate::Validator).
+#[derive(Debug)]
 pub struct ValidatorResources(pub(crate) Arc<Module>);
 
 impl WasmModuleResources for ValidatorResources {

--- a/crates/wasmparser/src/validator/func.rs
+++ b/crates/wasmparser/src/validator/func.rs
@@ -9,6 +9,7 @@ use crate::{FunctionBody, Operator, WasmFeatures, WasmModuleResources};
 /// is created per-function in a WebAssembly module. This structure is suitable
 /// for sending to other threads while the original
 /// [`Validator`](crate::Validator) continues processing other functions.
+#[derive(Debug)]
 pub struct FuncToValidate<T> {
     /// Reusable, heap allocated resources to drive the Wasm validation.
     pub resources: T,

--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -2267,6 +2267,7 @@ where
 //
 // Only public because it shows up in a public trait's `doc(hidden)` method.
 #[doc(hidden)]
+#[derive(Debug)]
 pub struct SnapshotList<T> {
     // All previous snapshots, the "head" of the list that this type represents.
     // The first entry in this pair is the starting index for all elements
@@ -2286,6 +2287,7 @@ pub struct SnapshotList<T> {
     cur: Vec<T>,
 }
 
+#[derive(Debug)]
 struct Snapshot<T> {
     prior_types: usize,
     items: Vec<T>,
@@ -2394,7 +2396,7 @@ impl<T> Default for SnapshotList<T> {
 /// component model's {component, instance, defined, func} types are in the same
 /// index space). However, we store each of them in their own type-specific
 /// snapshot list and give each of them their own identifier type.
-#[derive(Default)]
+#[derive(Default, Debug)]
 // Only public because it shows up in a public trait's `doc(hidden)` method.
 #[doc(hidden)]
 pub struct TypeList {


### PR DESCRIPTION
Small PR to add `Debug` impl to `FuncToValidate`. I just noticed that it bothered me in Wasmi that this type was not covered.

What is the stance of putting `Debug` on all exported items just like in the standard library for the `wasmparser` crate?

Possible downsides are compile time regressions although I wasn't able to measure any significant compile time performance regressions on my local machine.