### PR TITLE
`wasmparser`: Add validator identifiers and a `reset` method

### DIFF
--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -104,13 +104,6 @@ impl Default for ValidatorId {
     }
 }
 
-impl From<ValidatorId> for usize {
-    #[inline]
-    fn from(id: ValidatorId) -> Self {
-        id.0
-    }
-}
-
 /// Validator for a WebAssembly binary module or component.
 ///
 /// This structure encapsulates state necessary to validate a WebAssembly


### PR DESCRIPTION
Lets users reuse validators (and their typing contexts) across different Wasm modules. The IDs are for helping them assert they are using the correct context with their `CoreTypeId`s and all that.