### PR TITLE
Fix allowing numerals in package names

### DIFF
--- a/crates/wasmparser/src/validator/names.rs
+++ b/crates/wasmparser/src/validator/names.rs
@@ -825,7 +825,10 @@ impl<'a> ComponentNameParser<'a> {
 
     fn take_lowercase_kebab(&mut self) -> Result<&'a KebabStr> {
         let kebab = self.take_kebab()?;
-        if let Some(c) = kebab.chars().find(|c| *c != '-' && !c.is_lowercase()) {
+        if let Some(c) = kebab
+            .chars()
+            .find(|c| c.is_alphabetic() && !c.is_lowercase())
+        {
             bail!(
                 self.offset,
                 "character `{c}` is not lowercase in package name/namespace"

--- a/tests/local/component-model/naming.wast
+++ b/tests/local/component-model/naming.wast
@@ -112,4 +112,5 @@
 )
 (component
   (instance (import "a:b/c"))
+  (instance (import "a1:b1/c"))
 )

--- a/tests/snapshots/local/component-model/naming.wast/16.print
+++ b/tests/snapshots/local/component-model/naming.wast/16.print
@@ -3,4 +3,8 @@
     (instance)
   )
   (import "a:b/c" (instance (;0;) (type 0)))
+  (type (;1;)
+    (instance)
+  )
+  (import "a1:b1/c" (instance (;1;) (type 1)))
 )


### PR DESCRIPTION
This fixes a mistake in #1505 where numerals were disallowed in package names.