### PR TITLE
Update build of x64 macos binary

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
           os: ubuntu-latest
         - build: x86_64-macos
           os: macos-latest
+          target: x86_64-apple-darwin
         - build: aarch64-macos
           os: macos-latest
           target: aarch64-apple-darwin


### PR DESCRIPTION
Looks like `macos-latest` is changing to arm64 so we can't rely on it implicitly building x86_64-apple-darwin, so explicitly build it instead.