### PR TITLE
wast: Fix offsets computation for branch-hinting proposal.

### DIFF
--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -1254,7 +1254,6 @@ impl Printer {
         let mut first = true;
         let mut local_idx = 0;
         let mut locals = NamedLocalPrinter::new("local");
-        let func_start = body.original_position();
         for _ in 0..body.read_var_u32()? {
             let offset = body.original_position();
             let cnt = body.read_var_u32()?;
@@ -1279,6 +1278,7 @@ impl Printer {
         }
         locals.finish(&mut self.result);
 
+        let func_start = body.original_position();
         let nesting_start = self.nesting;
         body.allow_memarg64(true);
 

--- a/crates/wast/src/core/binary.rs
+++ b/crates/wast/src/core/binary.rs
@@ -712,7 +712,8 @@ impl Func<'_> {
         // encodes its length first then the body.
         let mut tmp = Vec::new();
         locals.encode(&mut tmp);
-        let branch_hints = expr.encode(&mut tmp, 0);
+        let offset = tmp.len();
+        let branch_hints = expr.encode(&mut tmp, offset);
         tmp.encode(e);
 
         branch_hints


### PR DESCRIPTION
The branch hinting proposal uses offsets from the "function body". In a previous patch, I implemented this offset as starting from the beginning of the function body (before locals).

Offsets were actually supposed to be relative to the start of the locals vector, see: 
https://github.com/WebAssembly/branch-hinting/pull/26