### PR TITLE
`wasmparser`: Enable the extended constant expressions proposal by default

### DIFF
--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -341,7 +341,7 @@ define_wasm_features! {
         /// The WebAssembly memory64 proposal.
         pub memory64: MEMORY64(1 << 14) = false;
         /// The WebAssembly extended_const proposal.
-        pub extended_const: EXTENDED_CONST(1 << 15) = false;
+        pub extended_const: EXTENDED_CONST(1 << 15) = true;
         /// The WebAssembly component model proposal.
         pub component_model: COMPONENT_MODEL(1 << 16) = true;
         /// The WebAssembly typed function references proposal.

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -651,6 +651,7 @@ fn error_matches(error: &str, message: &str) -> bool {
         || message == "malformed annotation id"
         || message == "alignment must be a power of two"
         || message == "i32 constant out of range"
+        || message == "constant expression required"
     {
         return error.contains("expected ")
             || error.contains("constant out of range")


### PR DESCRIPTION
It is phase 4, so let's enable it by default.