### PR TITLE
Downgrade `memoffset` dependency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,13 +84,6 @@ jobs:
         submodules: true
     - name: Install Rust (rustup)
       run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
-    - run: |
-        curl -LO https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-21/wasi-sdk-21.0-linux.tar.gz
-        tar xf wasi-sdk-21.0-linux.tar.gz
-        export WASI_SDK_PATH=$(pwd)/wasi-sdk-21.0
-        rustup target add wasm32-wasi
-        cd crates/wit-component/dl && bash check.sh
-      if: matrix.os == 'ubuntu-latest' && matrix.build == 'stable'
     - run: cargo test --locked --all
     - run: cargo test --locked -p wasmparser --benches
     - run: cargo test --locked -p wasm-encoder --all-features
@@ -99,6 +92,22 @@ jobs:
     - run: cargo build --manifest-path crates/wast/Cargo.toml --no-default-features --features wasm-module
     - run: cmake -S examples -B examples/build -DCMAKE_BUILD_TYPE=Release
     - run: cmake --build examples/build --config Release
+
+  testdl:
+    name: Test libdl.so
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - name: Install Rust (rustup)
+      run: rustup update 1.77.0 --no-self-update && rustup default 1.77.0
+    - run: |
+        curl -LO https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-21/wasi-sdk-21.0-linux.tar.gz
+        tar xf wasi-sdk-21.0-linux.tar.gz
+        export WASI_SDK_PATH=$(pwd)/wasi-sdk-21.0
+        rustup target add wasm32-wasi
+        cd crates/wit-component/dl && bash check.sh
 
   wasm:
     name: Test on WebAssembly
@@ -213,6 +222,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - test
+      - testdl
       - wasm
       - rustfmt
       - fuzz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,9 +923,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.9.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
 ]

--- a/crates/wit-component/dl/build.sh
+++ b/crates/wit-component/dl/build.sh
@@ -5,6 +5,8 @@
 #
 # Example: WASI_SDK_PATH=/opt/wasi-sdk bash build.sh ../libdl.so
 
+set -ex
+
 CARGO_PROFILE_RELEASE_LTO=true RUSTFLAGS="-C relocation-model=pic" cargo build --release --target=wasm32-wasi
 $WASI_SDK_PATH/bin/clang -shared -o $1 -Wl,--whole-archive ../../../target/wasm32-wasi/release/libdl.a -Wl,--no-whole-archive
 cargo run --manifest-path ../../../Cargo.toml -- strip $1 -o $1

--- a/crates/wit-component/dl/check.sh
+++ b/crates/wit-component/dl/check.sh
@@ -1,3 +1,5 @@
+set -ex
+
 bash ./build.sh ../../../target/wasm32-wasi/release/tmp.so
 if diff ../../../target/wasm32-wasi/release/tmp.so ../libdl.so; then
   exit 0


### PR DESCRIPTION
The 0.9.1 version doesn't build on OSS-Fuzz with the pinned version of a nightly that's being used.