### PR TITLE
Fix creating components with only static methods on resources

### DIFF
--- a/crates/wit-component/tests/components/import-only-resource-static-function/component.wat
+++ b/crates/wit-component/tests/components/import-only-resource-static-function/component.wat
@@ -1,0 +1,30 @@
+(component
+  (type (;0;)
+    (instance
+      (export (;0;) "a" (type (sub resource)))
+      (type (;1;) (func))
+      (export (;0;) "[static]a.f" (func (type 1)))
+    )
+  )
+  (import "foo:bar/x" (instance (;0;) (type 0)))
+  (core module (;0;)
+    (type (;0;) (func))
+    (import "foo:bar/x" "[static]a.f" (func (;0;) (type 0)))
+    (@producers
+      (processed-by "wit-component" "$CARGO_PKG_VERSION")
+      (processed-by "my-fake-bindgen" "123.45")
+    )
+  )
+  (alias export 0 "[static]a.f" (func (;0;)))
+  (core func (;0;) (canon lower (func 0)))
+  (core instance (;0;)
+    (export "[static]a.f" (func 0))
+  )
+  (core instance (;1;) (instantiate 0
+      (with "foo:bar/x" (instance 0))
+    )
+  )
+  (@producers
+    (processed-by "wit-component" "$CARGO_PKG_VERSION")
+  )
+)

--- a/crates/wit-component/tests/components/import-only-resource-static-function/component.wit.print
+++ b/crates/wit-component/tests/components/import-only-resource-static-function/component.wit.print
@@ -1,0 +1,5 @@
+package root:component;
+
+world root {
+  import foo:bar/x;
+}

--- a/crates/wit-component/tests/components/import-only-resource-static-function/module.wat
+++ b/crates/wit-component/tests/components/import-only-resource-static-function/module.wat
@@ -1,0 +1,3 @@
+(module
+  (import "foo:bar/x" "[static]a.f" (func))
+)

--- a/crates/wit-component/tests/components/import-only-resource-static-function/module.wit
+++ b/crates/wit-component/tests/components/import-only-resource-static-function/module.wit
@@ -1,0 +1,11 @@
+package foo:bar;
+
+interface x {
+  resource a {
+    f: static func();
+  }
+}
+
+world module {
+  import x;
+}

--- a/crates/wit-parser/src/live.rs
+++ b/crates/wit-parser/src/live.rs
@@ -1,4 +1,6 @@
-use crate::{Function, InterfaceId, Resolve, Type, TypeDefKind, TypeId, WorldId, WorldItem};
+use crate::{
+    Function, FunctionKind, InterfaceId, Resolve, Type, TypeDefKind, TypeId, WorldId, WorldItem,
+};
 use indexmap::IndexSet;
 
 #[derive(Default)]
@@ -41,6 +43,19 @@ impl LiveTypes {
     }
 
     pub fn add_func(&mut self, resolve: &Resolve, func: &Function) {
+        match func.kind {
+            // This resource is live as it's attached to a static method but
+            // it's not guaranteed to be present in either params or results, so
+            // be sure to attach it here.
+            FunctionKind::Static(id) => self.add_type_id(resolve, id),
+
+            // The resource these are attached to is in the params/results, so
+            // no need to re-add it here.
+            FunctionKind::Method(_) | FunctionKind::Constructor(_) => {}
+
+            FunctionKind::Freestanding => {}
+        }
+
         for (_, ty) in func.params.iter() {
             self.add_type(resolve, ty);
         }


### PR DESCRIPTION
Previously the resource itself wasn't imported which meant that the `[static]` function did not pass validation. This commit updates the liveness of these functions to include the resource that the static function is attached to which ensures that the type is emitted during component construction.

Closes #1529