### PR TITLE
Gate WebAssembly validation behind a new 'validate' feature

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -190,6 +190,7 @@ jobs:
       - run: cargo check --no-default-features -p wasmparser
       - run: cargo check --no-default-features -p wasmparser --target x86_64-unknown-none
       - run: cargo check --no-default-features -p wasmparser --features std
+      - run: cargo check --no-default-features -p wasmparser --features validate
       - run: |
           if cargo tree -p wasm-smith --no-default-features -e no-dev | grep wasmparser; then
             echo wasm-smith without default features should not depend on wasmparser

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ wasm-metadata = { version = "0.206.0", path = "crates/wasm-metadata" }
 wasm-mutate = { version = "0.206.0", path = "crates/wasm-mutate" }
 wasm-shrink = { version = "0.206.0", path = "crates/wasm-shrink" }
 wasm-smith = { version = "0.206.0", path = "crates/wasm-smith" }
-wasmparser = { version = "0.206.0", path = "crates/wasmparser" }
+wasmparser = { version = "0.206.0", path = "crates/wasmparser", default-features = false, features = ['std'] }
 wasmprinter = { version = "0.206.0", path = "crates/wasmprinter" }
 wast = { version = "206.0.0", path = "crates/wast" }
 wat = { version = "1.206.0", path = "crates/wat" }
@@ -87,7 +87,7 @@ wat = { workspace = true }
 termcolor = "1.2.0"
 
 # Dependencies of `validate`
-wasmparser = { workspace = true, optional = true }
+wasmparser = { workspace = true, optional = true, features = ['validate'] }
 rayon = { workspace = true, optional = true }
 
 # Dependencies of `print`

--- a/crates/wasm-compose/Cargo.toml
+++ b/crates/wasm-compose/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 [dependencies]
 wat = { workspace = true }
 wasm-encoder = { workspace = true, features = ['wasmparser'] }
-wasmparser = { workspace = true }
+wasmparser = { workspace = true, features = ['validate'] }
 indexmap = { workspace = true, features = ["serde"] }
 anyhow = { workspace = true }
 serde = { workspace = true }

--- a/crates/wasm-shrink/Cargo.toml
+++ b/crates/wasm-shrink/Cargo.toml
@@ -20,7 +20,7 @@ log = { workspace = true }
 rand = { workspace = true }
 clap = { workspace = true, optional = true }
 wasm-mutate = { workspace = true }
-wasmparser = { workspace = true }
+wasmparser = { workspace = true, features = ['validate'] }
 
 [dev-dependencies]
 env_logger = { workspace = true }

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -28,7 +28,7 @@ leb128 = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 wasm-encoder = { workspace = true }
-wasmparser = { workspace = true, optional = true }
+wasmparser = { workspace = true, optional = true, features = ['validate'] }
 wat = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -17,10 +17,10 @@ workspace = true
 
 [dependencies]
 bitflags = "2.4.1"
-indexmap = { workspace = true }
-semver = { workspace = true }
-hashbrown = { workspace = true }
-ahash = { workspace = true }
+indexmap = { workspace = true, optional = true }
+semver = { workspace = true, optional = true }
+hashbrown = { workspace = true, optional = true }
+ahash = { workspace = true, optional = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
@@ -38,5 +38,19 @@ name = "benchmark"
 harness = false
 
 [features]
-default = ['std']
+default = ['std', 'validate']
+
+# A feature which enables implementations of `std::error::Error` as appropriate
+# along with other convenience APIs. This additionally uses the standard
+# library's source of randomness for seeding hash maps.
 std = ['indexmap/std']
+
+# A feature that enables validating WebAssembly files. This is enabled by
+# default but not required if you're only parsing a file, for example, as
+# opposed to validating all of its contents.
+validate = [
+  'dep:indexmap',
+  'dep:semver',
+  'dep:hashbrown',
+  'dep:ahash',
+]

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -93,6 +93,7 @@ impl BinaryReaderError {
         self.inner.offset
     }
 
+    #[cfg(feature = "validate")]
     pub(crate) fn add_context(&mut self, mut context: String) {
         context.push_str("\n");
         self.inner.message.insert_str(0, &context);

--- a/crates/wasmparser/src/lib.rs
+++ b/crates/wasmparser/src/lib.rs
@@ -28,6 +28,7 @@
 
 #![deny(missing_docs)]
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 extern crate alloc;
 #[cfg(feature = "std")]
@@ -47,6 +48,7 @@ mod prelude {
     pub use alloc::vec;
     pub use alloc::vec::Vec;
 
+    #[cfg(feature = "validate")]
     pub use crate::map::{HashMap, HashSet, IndexMap, IndexSet};
 }
 
@@ -783,14 +785,20 @@ macro_rules! bail {
 pub use crate::binary_reader::{BinaryReader, BinaryReaderError, Result};
 pub use crate::parser::*;
 pub use crate::readers::*;
-pub use crate::resources::*;
-pub use crate::validator::*;
 
 mod binary_reader;
 mod limits;
 mod parser;
 mod readers;
-mod resources;
-mod validator;
 
+#[cfg(feature = "validate")]
+mod resources;
+#[cfg(feature = "validate")]
+mod validator;
+#[cfg(feature = "validate")]
+pub use crate::resources::*;
+#[cfg(feature = "validate")]
+pub use crate::validator::*;
+
+#[cfg(feature = "validate")]
 pub mod map;

--- a/crates/wasmparser/src/limits.rs
+++ b/crates/wasmparser/src/limits.rs
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+#![cfg_attr(not(feature = "validate"), allow(dead_code))]
+
 // The following limits are imposed by wasmparser on WebAssembly modules.
 // The limits are agreed upon with other engines for consistency.
 pub const MAX_WASM_TYPES: usize = 1_000_000;

--- a/crates/wasmparser/src/readers/component/types.rs
+++ b/crates/wasmparser/src/readers/component/types.rs
@@ -194,6 +194,7 @@ impl PrimitiveValType {
         })
     }
 
+    #[cfg(feature = "validate")]
     pub(crate) fn contains_ptr(&self) -> bool {
         matches!(self, Self::String)
     }

--- a/crates/wasmparser/src/readers/core/reloc.rs
+++ b/crates/wasmparser/src/readers/core/reloc.rs
@@ -5,7 +5,7 @@ use core::ops::Range;
 pub type RelocationEntryReader<'a> = SectionLimited<'a, RelocationEntry>;
 
 /// Reader for reloc.* sections as defined by
-/// https://github.com/WebAssembly/tool-conventions/blob/main/Linking.md#relocation-sections.
+/// <https://github.com/WebAssembly/tool-conventions/blob/main/Linking.md#relocation-sections>.
 #[derive(Debug, Clone)]
 pub struct RelocSectionReader<'a> {
     section: u32,
@@ -69,9 +69,9 @@ back_to_enum! {
 
     /// Relocation entry type. Each entry type corresponds to one of the
     /// `R_WASM_*` constants defined at
-    /// https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/BinaryFormat/WasmRelocs.def
+    /// <https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/BinaryFormat/WasmRelocs.def>
     /// and
-    /// https://github.com/WebAssembly/tool-conventions/blob/main/Linking.md#relocation-sections.
+    /// <https://github.com/WebAssembly/tool-conventions/blob/main/Linking.md#relocation-sections>.
     #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
     #[repr(u8)]
     pub enum RelocationType {
@@ -170,7 +170,7 @@ back_to_enum! {
         /// immediate argument in the table.* instructions. (in LLVM 12.0)
         TableNumberLeb = 20,
 
-        /// An offset from the __tls_base symbol encoded as a 5-byte [varint32].
+        /// An offset from the __tls_base symbol encoded as a 5-byte varint32.
         /// Used for PIC case to avoid absolute relocation. (in LLVM 12.0)
         MemoryAddrTlsSleb = 21,
 
@@ -192,7 +192,7 @@ back_to_enum! {
         MemoryAddrTlsSleb64 = 25,
 
         /// A function index encoded as a uint32. Used in custom sections for
-        /// function annotations (__attribute__((annotate(<name>))) (in LLVM
+        /// function annotations (`__attribute__((annotate(<name>)))`) (in LLVM
         /// 17.0)
         FunctionIndexI32 = 26,
     }
@@ -224,7 +224,7 @@ pub enum RelocAddendKind {
 }
 
 /// Single relocation entry within a `reloc.*` section, as defined at
-/// https://github.com/WebAssembly/tool-conventions/blob/main/Linking.md#relocation-sections.
+/// <https://github.com/WebAssembly/tool-conventions/blob/main/Linking.md#relocation-sections>.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub struct RelocationEntry {
     /// Relocation entry type.

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -18,12 +18,15 @@ use crate::limits::{
     MAX_WASM_SUPERTYPES, MAX_WASM_TYPES,
 };
 use crate::prelude::*;
+#[cfg(feature = "validate")]
 use crate::types::CoreTypeId;
 use crate::{BinaryReader, BinaryReaderError, FromReader, Result, SectionLimited};
-use core::fmt::{self, Debug, Write};
+use core::fmt::{self, Debug};
 use core::hash::{Hash, Hasher};
 
+#[cfg(feature = "validate")]
 mod matches;
+#[cfg(feature = "validate")]
 pub(crate) use self::matches::{Matches, WithRecGroup};
 
 /// A packed representation of a type index.
@@ -83,6 +86,7 @@ impl PackedIndex {
 
     const MODULE_KIND: u32 = 0b00 << 20;
     const REC_GROUP_KIND: u32 = 0b01 << 20;
+    #[cfg(feature = "validate")]
     const ID_KIND: u32 = 0b10 << 20;
 
     #[inline]
@@ -136,6 +140,7 @@ impl PackedIndex {
 
     /// Construct a `PackedIndex` from the given `CoreTypeId`.
     #[inline]
+    #[cfg(feature = "validate")]
     pub fn from_id(id: CoreTypeId) -> Option<Self> {
         let index = u32::try_from(crate::types::TypeIdentifier::index(&id)).unwrap();
         if PackedIndex::can_represent_index(index) {
@@ -147,6 +152,7 @@ impl PackedIndex {
 
     /// Is this index in canonical form?
     #[inline]
+    #[cfg(feature = "validate")]
     pub fn is_canonical(&self) -> bool {
         match self.kind() {
             Self::REC_GROUP_KIND | Self::ID_KIND => true,
@@ -162,6 +168,7 @@ impl PackedIndex {
         match self.kind() {
             Self::MODULE_KIND => UnpackedIndex::Module(self.index()),
             Self::REC_GROUP_KIND => UnpackedIndex::RecGroup(self.index()),
+            #[cfg(feature = "validate")]
             Self::ID_KIND => UnpackedIndex::Id(
                 <CoreTypeId as crate::types::TypeIdentifier>::from_index(self.index()),
             ),
@@ -191,6 +198,7 @@ impl PackedIndex {
 
     /// Get the underlying `CoreTypeId`, if any.
     #[inline]
+    #[cfg(feature = "validate")]
     pub fn as_core_type_id(&self) -> Option<CoreTypeId> {
         if self.kind() == Self::ID_KIND {
             Some(<CoreTypeId as crate::types::TypeIdentifier>::from_index(
@@ -210,6 +218,7 @@ impl fmt::Debug for PackedIndex {
                 match self.kind() {
                     Self::MODULE_KIND => &"module",
                     Self::REC_GROUP_KIND => &"recgroup",
+                    #[cfg(feature = "validate")]
                     Self::ID_KIND => &"id",
                     _ => unreachable!(),
                 },
@@ -237,6 +246,7 @@ pub enum UnpackedIndex {
     RecGroup(u32),
 
     /// A type identifier.
+    #[cfg(feature = "validate")]
     Id(CoreTypeId),
 }
 
@@ -248,12 +258,14 @@ impl UnpackedIndex {
         match self {
             UnpackedIndex::Module(i) => PackedIndex::from_module_index(*i),
             UnpackedIndex::RecGroup(i) => PackedIndex::from_rec_group_index(*i),
+            #[cfg(feature = "validate")]
             UnpackedIndex::Id(id) => PackedIndex::from_id(*id),
         }
     }
 
     /// Is this index in canonical form?
     #[inline]
+    #[cfg(feature = "validate")]
     pub fn is_canonical(&self) -> bool {
         matches!(self, UnpackedIndex::RecGroup(_) | UnpackedIndex::Id(_))
     }
@@ -280,6 +292,7 @@ impl UnpackedIndex {
 
     /// Get the underlying `CoreTypeId`, if any.
     #[inline]
+    #[cfg(feature = "validate")]
     pub fn as_core_type_id(&self) -> Option<CoreTypeId> {
         if let Self::Id(id) = *self {
             Some(id)
@@ -294,6 +307,7 @@ impl fmt::Display for UnpackedIndex {
         match self {
             UnpackedIndex::Module(i) => write!(f, "(module {i})"),
             UnpackedIndex::RecGroup(i) => write!(f, "(recgroup {i})"),
+            #[cfg(feature = "validate")]
             UnpackedIndex::Id(id) => write!(f, "(id {})", crate::types::TypeIdentifier::index(id)),
         }
     }
@@ -343,6 +357,7 @@ impl RecGroup {
 
     /// Return a mutable borrow of the list of subtypes in this
     /// recursive type group.
+    #[cfg(feature = "validate")]
     pub(crate) fn types_mut(&mut self) -> impl ExactSizeIterator<Item = &mut SubType> + '_ {
         let types = match &mut self.inner {
             RecGroupInner::Implicit(ty) => core::slice::from_mut(ty),
@@ -465,6 +480,7 @@ impl SubType {
     }
 
     /// Maps any `UnpackedIndex` via the specified closure.
+    #[cfg(feature = "validate")]
     pub(crate) fn remap_indices(
         &mut self,
         f: &mut dyn FnMut(&mut PackedIndex) -> Result<()>,
@@ -597,6 +613,7 @@ impl FuncType {
     /// Returns an exclusive slice to the parameter types of the
     /// [`FuncType`].
     #[inline]
+    #[cfg(feature = "validate")]
     pub(crate) fn params_mut(&mut self) -> &mut [ValType] {
         &mut self.params_results[..self.len_params]
     }
@@ -610,11 +627,15 @@ impl FuncType {
     /// Returns an exclusive slice to the result types of the
     /// [`FuncType`].
     #[inline]
+    #[cfg(feature = "validate")]
     pub(crate) fn results_mut(&mut self) -> &mut [ValType] {
         &mut self.params_results[self.len_params..]
     }
 
+    #[cfg(feature = "validate")]
     pub(crate) fn desc(&self) -> String {
+        use core::fmt::Write;
+
         let mut s = String::new();
         s.push_str("[");
         for (i, param) in self.params().iter().enumerate() {
@@ -650,6 +671,7 @@ pub struct FieldType {
 
 impl FieldType {
     /// Maps any `UnpackedIndex` via the specified closure.
+    #[cfg(feature = "validate")]
     pub(crate) fn remap_indices(
         &mut self,
         f: &mut dyn FnMut(&mut PackedIndex) -> Result<()>,
@@ -791,6 +813,7 @@ impl ValType {
     }
 
     /// Maps any `UnpackedIndex` via the specified closure.
+    #[cfg(feature = "validate")]
     pub(crate) fn remap_indices(
         &mut self,
         map: &mut dyn FnMut(&mut PackedIndex) -> Result<()>,
@@ -1208,6 +1231,7 @@ impl RefType {
 
     // Note that this is similar to `Display for RefType` except that it has
     // the indexes stubbed out.
+    #[cfg(feature = "validate")]
     pub(crate) fn wat(&self) -> &'static str {
         match (self.is_nullable(), self.heap_type()) {
             (true, HeapType::Func) => "funcref",

--- a/crates/wit-parser/Cargo.toml
+++ b/crates/wit-parser/Cargo.toml
@@ -24,7 +24,7 @@ log = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
-wasmparser = { workspace = true, optional = true, features = ['std'] }
+wasmparser = { workspace = true, optional = true, features = ['validate'] }
 serde_json = { workspace = true, optional = true }
 wat = { workspace = true, optional = true }
 


### PR DESCRIPTION
This commit moves all of the validation logic of `wasmparser` behind a new Cargo features named `validate`. This cuts down the dependency tree for users who only need to parse wasm files. For example `wasmprinter` doesn't need to validate, it only needs to parse.

Closes #1528