### PR TITLE
Allow aliases to core wasm types outside of depth 1

### DIFF
--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -1503,13 +1503,6 @@ impl ComponentState {
                     state.add_export(name, ty, features, offset, true, types)?;
                 }
                 crate::ModuleTypeDeclaration::OuterAlias { kind, count, index } => {
-                    if count > 1 {
-                        return Err(BinaryReaderError::new(
-                            "outer type aliases in module type declarations are limited to a \
-                             maximum count of 1",
-                            offset,
-                        ));
-                    }
                     match kind {
                         crate::OuterAliasKind::Type => {
                             let ty = if count == 0 {

--- a/tests/local/component-model/types.wast
+++ b/tests/local/component-model/types.wast
@@ -134,14 +134,12 @@
   )
   "type index out of bounds")
 
-(assert_invalid
-  (component $c
-    (type $f (func))
-    (core type $t (module
-      (alias outer 100 0 (type))
-    ))
-  )
-  "outer type aliases in module type declarations are limited to a maximum count of 1")
+(component $c
+  (core type $f (func))
+  (core type $t (module
+    (alias outer $c $f (type))
+  ))
+)
 
 (assert_invalid
   (component $c
@@ -262,17 +260,14 @@
   )
 )
 
-(assert_invalid
-  (component $C
-    (core type $t (func))
-    (component $C2
-      (core type (module
-        (alias outer $C $t (type $a))
-        (import "" "" (func (type $a)))
-      ))
-    )
+(component $C
+  (core type $t (func))
+  (component $C2
+    (core type (module
+      (alias outer $C $t (type $a))
+      (import "" "" (func (type $a)))
+    ))
   )
-  "only the local or enclosing scope can be aliased"
 )
 
 (component
@@ -319,3 +314,12 @@
     (type (tuple))
   )
   "tuple type must have at least one type")
+
+(component $c
+  (core type $f (func))
+  (component $c2
+    (core type $t (module
+      (alias outer $c $f (type))
+    ))
+  )
+)

--- a/tests/snapshots/local/component-model/types.wast/17.print
+++ b/tests/snapshots/local/component-model/types.wast/17.print
@@ -1,0 +1,8 @@
+(component $c
+  (core type $f (;0;) (func))
+  (core type $t (;1;)
+    (module
+      (alias outer $c $f (type (;0;)))
+    )
+  )
+)

--- a/tests/snapshots/local/component-model/types.wast/32.print
+++ b/tests/snapshots/local/component-model/types.wast/32.print
@@ -1,0 +1,11 @@
+(component $C
+  (core type $t (;0;) (func))
+  (component $C2 (;0;)
+    (core type (;0;)
+      (module
+        (alias outer $C $t (type (;0;)))
+        (import "" "" (func (type 0)))
+      )
+    )
+  )
+)

--- a/tests/snapshots/local/component-model/types.wast/40.print
+++ b/tests/snapshots/local/component-model/types.wast/40.print
@@ -1,0 +1,10 @@
+(component $c
+  (core type $f (;0;) (func))
+  (component $c2 (;0;)
+    (core type $t (;0;)
+      (module
+        (alias outer $c $f (type (;0;)))
+      )
+    )
+  )
+)


### PR DESCRIPTION
This accompanies WebAssembly/component-model#350 and relaxes the previous constraint implemented in #640 to reflect the spec-at-the-time, which has since been relaxed.