### PR TITLE
Make fields of `BinaryReader` private

### DIFF
--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -103,8 +103,8 @@ impl BinaryReaderError {
 /// A binary reader of the WebAssembly structures and types.
 #[derive(Clone, Debug, Hash)]
 pub struct BinaryReader<'a> {
-    pub(crate) buffer: &'a [u8],
-    pub(crate) position: usize,
+    buffer: &'a [u8],
+    position: usize,
     original_offset: usize,
     allow_memarg64: bool,
 }

--- a/crates/wasmparser/src/readers/component/names.rs
+++ b/crates/wasmparser/src/readers/component/names.rs
@@ -53,7 +53,7 @@ impl<'a> Subsection<'a> for ComponentName<'a> {
                 }
                 ComponentName::Component {
                     name,
-                    name_range: offset..offset + reader.position,
+                    name_range: offset..reader.original_position(),
                 }
             }
             1 => {

--- a/crates/wasmparser/src/readers/component/types.rs
+++ b/crates/wasmparser/src/readers/component/types.rs
@@ -125,7 +125,7 @@ pub enum ComponentValType {
 impl<'a> FromReader<'a> for ComponentValType {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
         if let Some(ty) = PrimitiveValType::from_byte(reader.peek()?) {
-            reader.position += 1;
+            reader.read_u8()?;
             return Ok(ComponentValType::Primitive(ty));
         }
 
@@ -319,7 +319,7 @@ impl<'a> FromReader<'a> for ComponentTypeDeclaration<'a> {
         // variant of imports; check for imports here or delegate to
         // `InstanceTypeDeclaration` with the appropriate conversions.
         if reader.peek()? == 0x03 {
-            reader.position += 1;
+            reader.read_u8()?;
             return Ok(ComponentTypeDeclaration::Import(reader.read()?));
         }
 

--- a/crates/wasmparser/src/readers/core/names.rs
+++ b/crates/wasmparser/src/readers/core/names.rs
@@ -135,7 +135,7 @@ impl<'a> Subsection<'a> for Name<'a> {
                 }
                 Name::Module {
                     name,
-                    name_range: offset..offset + reader.position,
+                    name_range: offset..reader.original_position(),
                 }
             }
             1 => Name::Function(NameMap::new(data, offset)?),

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -1368,11 +1368,11 @@ impl<'a> FromReader<'a> for StorageType {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
         match reader.peek()? {
             0x78 => {
-                reader.position += 1;
+                reader.read_u8()?;
                 Ok(StorageType::I8)
             }
             0x77 => {
-                reader.position += 1;
+                reader.read_u8()?;
                 Ok(StorageType::I16)
             }
             _ => Ok(StorageType::Val(reader.read()?)),
@@ -1384,23 +1384,23 @@ impl<'a> FromReader<'a> for ValType {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
         match reader.peek()? {
             0x7F => {
-                reader.position += 1;
+                reader.read_u8()?;
                 Ok(ValType::I32)
             }
             0x7E => {
-                reader.position += 1;
+                reader.read_u8()?;
                 Ok(ValType::I64)
             }
             0x7D => {
-                reader.position += 1;
+                reader.read_u8()?;
                 Ok(ValType::F32)
             }
             0x7C => {
-                reader.position += 1;
+                reader.read_u8()?;
                 Ok(ValType::F64)
             }
             0x7B => {
-                reader.position += 1;
+                reader.read_u8()?;
                 Ok(ValType::V128)
             }
             0x70 | 0x6F | 0x64 | 0x63 | 0x6E | 0x71 | 0x72 | 0x73 | 0x74 | 0x6D | 0x6B | 0x6A
@@ -1440,51 +1440,51 @@ impl<'a> FromReader<'a> for HeapType {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
         match reader.peek()? {
             0x70 => {
-                reader.position += 1;
+                reader.read_u8()?;
                 Ok(HeapType::Func)
             }
             0x6F => {
-                reader.position += 1;
+                reader.read_u8()?;
                 Ok(HeapType::Extern)
             }
             0x6E => {
-                reader.position += 1;
+                reader.read_u8()?;
                 Ok(HeapType::Any)
             }
             0x71 => {
-                reader.position += 1;
+                reader.read_u8()?;
                 Ok(HeapType::None)
             }
             0x72 => {
-                reader.position += 1;
+                reader.read_u8()?;
                 Ok(HeapType::NoExtern)
             }
             0x73 => {
-                reader.position += 1;
+                reader.read_u8()?;
                 Ok(HeapType::NoFunc)
             }
             0x6D => {
-                reader.position += 1;
+                reader.read_u8()?;
                 Ok(HeapType::Eq)
             }
             0x6B => {
-                reader.position += 1;
+                reader.read_u8()?;
                 Ok(HeapType::Struct)
             }
             0x6A => {
-                reader.position += 1;
+                reader.read_u8()?;
                 Ok(HeapType::Array)
             }
             0x6C => {
-                reader.position += 1;
+                reader.read_u8()?;
                 Ok(HeapType::I31)
             }
             0x69 => {
-                reader.position += 1;
+                reader.read_u8()?;
                 Ok(HeapType::Exn)
             }
             0x74 => {
-                reader.position += 1;
+                reader.read_u8()?;
                 Ok(HeapType::NoExn)
             }
             _ => {


### PR DESCRIPTION
Don't allow arbitrary modifications/access throughout the crate to be sure arbitrate through the methods on this type. This is a pretty core type to the crate so it's best to not spread implementation details too much.