### PR TITLE
Add some more parallelism to CI jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,11 +85,33 @@ jobs:
     - name: Install Rust (rustup)
       run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
     - run: cargo test --locked --all
+
+  test_extra_features:
+    name: Test with extra Cargo features
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - run: rustup update stable --no-self-update && rustup default stable
     - run: cargo test --locked -p wasmparser --benches
     - run: cargo test --locked -p wasm-encoder --all-features
     - run: cargo test -p wasm-smith --features wasmparser
-    - run: cargo build --manifest-path crates/wast/Cargo.toml --no-default-features
-    - run: cargo build --manifest-path crates/wast/Cargo.toml --no-default-features --features wasm-module
+
+  test_capi:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+          - os: macos-latest
+          - os: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - run: rustup update stable --no-self-update && rustup default stable
     - run: cmake -S examples -B examples/build -DCMAKE_BUILD_TYPE=Release
     - run: cmake --build examples/build --config Release
 
@@ -191,6 +213,8 @@ jobs:
       - run: cargo check --no-default-features -p wasmparser --target x86_64-unknown-none
       - run: cargo check --no-default-features -p wasmparser --features std
       - run: cargo check --no-default-features -p wasmparser --features validate
+      - run: cargo check --no-default-features -p wast
+      - run: cargo check --no-default-features -p wast --features wasm-module
       - run: |
           if cargo tree -p wasm-smith --no-default-features -e no-dev | grep wasmparser; then
             echo wasm-smith without default features should not depend on wasmparser
@@ -231,6 +255,8 @@ jobs:
       - doc
       - build
       - verify-publish
+      - test_capi
+      - test_extra_features
     if: always()
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,7 +99,7 @@ jobs:
     - run: cargo test -p wasm-smith --features wasmparser
 
   test_capi:
-    name: Test
+    name: Test the C API
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
Split out some work from the main "test the workspace" CI job to avoid bottlenecking too much on that. Notably split the various extra builds/tests into their own jobs and move the C API build/run into its own job.