### PR TITLE
 Store a full WasmFeatures inside of BinaryReader 

### DIFF
--- a/crates/wasm-encoder/src/core/code.rs
+++ b/crates/wasm-encoder/src/core/code.rs
@@ -83,11 +83,13 @@ impl CodeSection {
     /// into a new code section encoder:
     ///
     /// ```
+    /// # use wasmparser::{BinaryReader, WasmFeatures, CodeSectionReader};
     /// //                  id, size, # entries, entry
     /// let code_section = [10, 6,    1,         4, 0, 65, 0, 11];
     ///
     /// // Parse the code section.
-    /// let reader = wasmparser::CodeSectionReader::new(&code_section, 0).unwrap();
+    /// let reader = BinaryReader::new(&code_section, 0, WasmFeatures::all());
+    /// let reader = CodeSectionReader::new(reader).unwrap();
     /// let body = reader.into_iter().next().unwrap().unwrap();
     /// let body_range = body.range();
     ///

--- a/crates/wasm-metadata/src/lib.rs
+++ b/crates/wasm-metadata/src/lib.rs
@@ -9,8 +9,8 @@ use std::mem;
 use std::ops::Range;
 use wasm_encoder::{ComponentSection as _, ComponentSectionId, Encode, Section};
 use wasmparser::{
-    ComponentNameSectionReader, KnownCustom, NameSectionReader, Parser, Payload::*,
-    ProducersSectionReader,
+    BinaryReader, ComponentNameSectionReader, KnownCustom, NameSectionReader, Parser, Payload::*,
+    ProducersSectionReader, WasmFeatures,
 };
 
 /// A representation of a WebAssembly producers section.
@@ -64,7 +64,8 @@ impl Producers {
     }
     /// Read the producers section from a Wasm binary.
     pub fn from_bytes(bytes: &[u8], offset: usize) -> Result<Self> {
-        let section = ProducersSectionReader::new(bytes, offset)?;
+        let reader = BinaryReader::new(bytes, offset, WasmFeatures::all());
+        let section = ProducersSectionReader::new(reader)?;
         let mut fields = IndexMap::new();
         for field in section.into_iter() {
             let field = field?;
@@ -603,7 +604,8 @@ impl<'a> ModuleNames<'a> {
     /// Read a name section from a WebAssembly binary. Records the module name, and all other
     /// contents of name section, for later serialization.
     pub fn from_bytes(bytes: &'a [u8], offset: usize) -> Result<ModuleNames<'a>> {
-        let section = NameSectionReader::new(bytes, offset);
+        let reader = BinaryReader::new(bytes, offset, WasmFeatures::all());
+        let section = NameSectionReader::new(reader);
         let mut s = Self::empty();
         for name in section.into_iter() {
             let name = name?;
@@ -688,7 +690,8 @@ impl<'a> ComponentNames<'a> {
     /// Read a component-name section from a WebAssembly binary. Records the component name, as
     /// well as all other component name fields for later serialization.
     pub fn from_bytes(bytes: &'a [u8], offset: usize) -> Result<ComponentNames<'a>> {
-        let section = ComponentNameSectionReader::new(bytes, offset);
+        let reader = BinaryReader::new(bytes, offset, WasmFeatures::all());
+        let section = ComponentNameSectionReader::new(reader);
         let mut s = Self::empty();
         for name in section.into_iter() {
             let name = name?;

--- a/crates/wasm-mutate/src/mutators/add_function.rs
+++ b/crates/wasm-mutate/src/mutators/add_function.rs
@@ -21,8 +21,8 @@ impl Mutator for AddFunctionMutator {
         // (Re)encode the function section and add this new entry.
         let mut func_sec_enc = wasm_encoder::FunctionSection::new();
         if let Some(func_sec_idx) = config.info().functions {
-            let raw_func_sec = config.info().raw_sections[func_sec_idx];
-            let reader = wasmparser::FunctionSectionReader::new(raw_func_sec.data, 0)?;
+            let reader = config.info().get_binary_reader(func_sec_idx);
+            let reader = wasmparser::FunctionSectionReader::new(reader)?;
             for x in reader {
                 func_sec_enc.function(x?);
             }
@@ -33,12 +33,11 @@ impl Mutator for AddFunctionMutator {
         // this function.
         let mut code_sec_enc = wasm_encoder::CodeSection::new();
         if let Some(code_sec_idx) = config.info().code {
-            let raw_code_sec = config.info().raw_sections[code_sec_idx];
-            let reader = wasmparser::CodeSectionReader::new(raw_code_sec.data, 0)?;
+            let reader = config.info().get_binary_reader(code_sec_idx);
+            let reader = wasmparser::CodeSectionReader::new(reader)?;
             for body in reader {
                 let body = body?;
-                let range = body.range();
-                code_sec_enc.raw(&raw_code_sec.data[range.start..range.end]);
+                code_sec_enc.raw(body.as_bytes());
             }
         }
         let func_ty = match &config.info().types_map[usize::try_from(ty_idx).unwrap()] {

--- a/crates/wasm-mutate/src/mutators/add_type.rs
+++ b/crates/wasm-mutate/src/mutators/add_type.rs
@@ -52,9 +52,10 @@ impl Mutator for AddTypeMutator {
         }
 
         let mut types = wasm_encoder::TypeSection::new();
-        if let Some(old_types) = config.info().get_type_section() {
+        if let Some(old_types) = config.info().types {
             // Copy the existing types section over into the encoder.
-            let reader = wasmparser::TypeSectionReader::new(old_types.data, 0)?;
+            let reader = config.info().get_binary_reader(old_types);
+            let reader = wasmparser::TypeSectionReader::new(reader)?;
             for ty in reader.into_iter_err_on_gc_types() {
                 let ty = ty?;
                 let params = ty

--- a/crates/wasm-mutate/src/mutators/custom.rs
+++ b/crates/wasm-mutate/src/mutators/custom.rs
@@ -28,9 +28,8 @@ impl Mutator for CustomSectionMutator {
         assert!(!custom_section_indices.is_empty());
 
         let custom_section_index = *custom_section_indices.choose(config.rng()).unwrap();
-        let old_custom_section = &config.info().raw_sections[custom_section_index];
-        let old_custom_section =
-            wasmparser::CustomSectionReader::new(old_custom_section.data, 0).unwrap();
+        let reader = config.info().get_binary_reader(custom_section_index);
+        let old_custom_section = wasmparser::CustomSectionReader::new(reader).unwrap();
 
         let name_string;
         let data_vec;

--- a/crates/wasm-mutate/src/mutators/function_body_unreachable.rs
+++ b/crates/wasm-mutate/src/mutators/function_body_unreachable.rs
@@ -19,8 +19,9 @@ impl Mutator for FunctionBodyUnreachable {
     ) -> Result<Box<dyn Iterator<Item = Result<Module>> + 'a>> {
         let mut codes = CodeSection::new();
 
-        let code_section = config.info().get_code_section();
-        let reader = CodeSectionReader::new(code_section.data, 0)?;
+        let code_section = config.info().code.unwrap();
+        let reader = config.info().get_binary_reader(code_section);
+        let reader = CodeSectionReader::new(reader)?;
 
         let count = reader.count();
         let function_to_mutate = config.rng().gen_range(0..count);
@@ -38,7 +39,7 @@ impl Mutator for FunctionBodyUnreachable {
 
                 codes.function(&f);
             } else {
-                codes.raw(&code_section.data[f.range().start..f.range().end]);
+                codes.raw(f.as_bytes());
             }
         }
 

--- a/crates/wasm-mutate/src/mutators/modify_const_exprs.rs
+++ b/crates/wasm-mutate/src/mutators/modify_const_exprs.rs
@@ -155,7 +155,8 @@ impl Mutator for ConstExpressionMutator {
                 let mutate_idx = config.rng().gen_range(0..num_total);
                 let section = config.info().globals.ok_or(skip_err)?;
                 let mut new_section = GlobalSection::new();
-                let reader = GlobalSectionReader::new(config.info().raw_sections[section].data, 0)?;
+                let reader = config.info().get_binary_reader(section);
+                let reader = GlobalSectionReader::new(reader)?;
                 let mut translator = InitTranslator {
                     config,
                     skip_inits: 0,
@@ -179,8 +180,8 @@ impl Mutator for ConstExpressionMutator {
                 let mutate_idx = config.rng().gen_range(0..num_total);
                 let section = config.info().elements.ok_or(skip_err)?;
                 let mut new_section = ElementSection::new();
-                let reader =
-                    ElementSectionReader::new(config.info().raw_sections[section].data, 0)?;
+                let reader = config.info().get_binary_reader(section);
+                let reader = ElementSectionReader::new(reader)?;
                 let mut translator = InitTranslator {
                     config,
                     skip_inits: 0,

--- a/crates/wasm-mutate/src/mutators/modify_data.rs
+++ b/crates/wasm-mutate/src/mutators/modify_data.rs
@@ -18,7 +18,9 @@ impl Mutator for ModifyDataMutator {
         config: &'a mut WasmMutate,
     ) -> Result<Box<dyn Iterator<Item = Result<Module>> + 'a>> {
         let mut new_section = DataSection::new();
-        let reader = DataSectionReader::new(config.info().get_data_section().data, 0)?;
+        let section_idx = config.info().data.unwrap();
+        let reader = config.info().get_binary_reader(section_idx);
+        let reader = DataSectionReader::new(reader)?;
 
         // Select an arbitrary data segment to modify.
         let data_to_modify = config.rng().gen_range(0..reader.count());

--- a/crates/wasm-mutate/src/mutators/remove_export.rs
+++ b/crates/wasm-mutate/src/mutators/remove_export.rs
@@ -16,7 +16,9 @@ impl Mutator for RemoveExportMutator {
         config: &'a mut WasmMutate,
     ) -> Result<Box<dyn Iterator<Item = Result<Module>> + 'a>> {
         let mut exports = ExportSection::new();
-        let reader = ExportSectionReader::new(config.info().get_exports_section().data, 0)?;
+        let exports_idx = config.info().exports.unwrap();
+        let reader = config.info().get_binary_reader(exports_idx);
+        let reader = ExportSectionReader::new(reader)?;
         let max_exports = u64::from(reader.count());
         let skip_at = config.rng().gen_range(0..max_exports);
 

--- a/crates/wasm-mutate/src/mutators/remove_section.rs
+++ b/crates/wasm-mutate/src/mutators/remove_section.rs
@@ -16,22 +16,23 @@ pub enum RemoveSection {
 
 fn is_empty_section(section: &wasm_encoder::RawSection) -> bool {
     use wasmparser::*;
+    let reader = BinaryReader::new(section.data, 0, WasmFeatures::all());
     crate::module::match_section_id! {
         match section.id;
         Custom => Ok(section.data.is_empty()),
-        Type => TypeSectionReader::new(section.data, 0).map(|r| r.count() == 0),
-        Import => ImportSectionReader::new(section.data, 0).map(|r| r.count() == 0),
-        Function => FunctionSectionReader::new(section.data, 0).map(|r| r.count() == 0),
-        Table => FunctionSectionReader::new(section.data, 0).map(|r| r.count() == 0),
-        Memory => MemorySectionReader::new(section.data, 0).map(|r| r.count() == 0),
-        Global => GlobalSectionReader::new(section.data, 0).map(|r| r.count() == 0),
-        Export => ExportSectionReader::new(section.data, 0).map(|r| r.count() == 0),
+        Type => TypeSectionReader::new(reader).map(|r| r.count() == 0),
+        Import => ImportSectionReader::new(reader).map(|r| r.count() == 0),
+        Function => FunctionSectionReader::new(reader).map(|r| r.count() == 0),
+        Table => FunctionSectionReader::new(reader).map(|r| r.count() == 0),
+        Memory => MemorySectionReader::new(reader).map(|r| r.count() == 0),
+        Global => GlobalSectionReader::new(reader).map(|r| r.count() == 0),
+        Export => ExportSectionReader::new(reader).map(|r| r.count() == 0),
         Start => Ok(section.data.is_empty()),
-        Element => ElementSectionReader::new(section.data, 0).map(|r| r.count() == 0),
-        Code => CodeSectionReader::new(section.data, 0).map(|r| r.count() == 0),
-        Data => DataSectionReader::new(section.data, 0).map(|r| r.count() == 0),
+        Element => ElementSectionReader::new(reader).map(|r| r.count() == 0),
+        Code => CodeSectionReader::new(reader).map(|r| r.count() == 0),
+        Data => DataSectionReader::new(reader).map(|r| r.count() == 0),
         DataCount => Ok(section.data.is_empty()),
-        Tag => TagSectionReader::new(section.data, 0).map(|r| r.count() == 0),
+        Tag => TagSectionReader::new(reader).map(|r| r.count() == 0),
         _ => Ok(section.data.is_empty()),
     }
     .unwrap_or(false)

--- a/crates/wasm-mutate/src/mutators/rename_export.rs
+++ b/crates/wasm-mutate/src/mutators/rename_export.rs
@@ -48,7 +48,9 @@ impl Mutator for RenameExportMutator {
         config: &'a mut WasmMutate,
     ) -> Result<Box<dyn Iterator<Item = Result<Module>> + 'a>> {
         let mut exports = ExportSection::new();
-        let reader = ExportSectionReader::new(config.info().get_exports_section().data, 0)?;
+        let exports_idx = config.info().exports.unwrap();
+        let reader = config.info().get_binary_reader(exports_idx);
+        let reader = ExportSectionReader::new(reader)?;
         let max_exports = u64::from(reader.count());
         let skip_at = config.rng().gen_range(0..max_exports);
 

--- a/crates/wasm-mutate/src/mutators/snip_function.rs
+++ b/crates/wasm-mutate/src/mutators/snip_function.rs
@@ -17,8 +17,9 @@ impl Mutator for SnipMutator {
         config: &'a mut WasmMutate,
     ) -> Result<Box<dyn Iterator<Item = Result<Module>> + 'a>> {
         let mut codes = CodeSection::new();
-        let code_section = config.info().get_code_section();
-        let reader = CodeSectionReader::new(code_section.data, 0)?;
+        let code_section = config.info().code.unwrap();
+        let reader = config.info().get_binary_reader(code_section);
+        let reader = CodeSectionReader::new(reader)?;
         let count = reader.count();
         let function_to_mutate = config.rng().gen_range(0..count);
         let ftype = config
@@ -31,7 +32,7 @@ impl Mutator for SnipMutator {
             let f = func?;
 
             if i as u32 != function_to_mutate {
-                codes.raw(&code_section.data[f.range().start..f.range().end]);
+                codes.raw(f.as_bytes());
                 continue;
             }
 

--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -481,8 +481,7 @@ pub fn code(t: &mut dyn Translator, body: FunctionBody<'_>, s: &mut CodeSection)
         .collect::<Result<Vec<_>>>()?;
     let mut func = Function::new(locals);
 
-    let mut reader = body.get_operators_reader()?;
-    reader.allow_memarg64(true);
+    let reader = body.get_operators_reader()?;
     for op in reader {
         let op = op?;
         func.instruction(&t.translate_op(&op)?);

--- a/crates/wasmparser/src/features.rs
+++ b/crates/wasmparser/src/features.rs
@@ -1,0 +1,156 @@
+use bitflags::bitflags;
+
+macro_rules! define_wasm_features {
+    (
+        $(#[$outer:meta])*
+        pub struct WasmFeatures: $repr:ty {
+            $(
+                $(#[$inner:ident $($args:tt)*])*
+                pub $field:ident: $const:ident($flag:expr) = $default:expr;
+            )*
+        }
+    ) => {
+        bitflags! {
+            $(#[$outer])*
+            pub struct WasmFeatures: $repr {
+                $(
+                    $(#[$inner $($args)*])*
+                    #[doc = "\nDefaults to `"]
+                    #[doc = stringify!($default)]
+                    #[doc = "`.\n"]
+                    const $const = $flag;
+                )*
+            }
+        }
+
+        impl Default for WasmFeatures {
+            #[inline]
+            fn default() -> Self {
+                let mut features = WasmFeatures::empty();
+                $(
+                    features.set(WasmFeatures::$const, $default);
+                )*
+                features
+            }
+        }
+
+        impl WasmFeatures {
+            /// Construct a bit-packed `WasmFeatures` from the inflated struct version.
+            #[inline]
+            pub fn from_inflated(inflated: WasmFeaturesInflated) -> Self {
+                let mut features = WasmFeatures::empty();
+                $(
+                    features.set(WasmFeatures::$const, inflated.$field);
+                )*
+                features
+            }
+
+            /// Inflate these bit-packed features into a struct with a field per
+            /// feature.
+            ///
+            /// Although the inflated struct takes up much more memory than the
+            /// bit-packed version, its fields can be exhaustively matched
+            /// upon. This makes it useful for temporarily checking against,
+            /// while keeping the bit-packed version as the method of storing
+            /// the features for longer periods of time.
+            #[inline]
+            pub fn inflate(&self) -> WasmFeaturesInflated {
+                WasmFeaturesInflated {
+                    $(
+                        $field: self.contains(WasmFeatures::$const),
+                    )*
+                }
+            }
+        }
+
+        /// Inflated version of [`WasmFeatures`][crate::WasmFeatures] that
+        /// allows for exhaustive matching on fields.
+        pub struct WasmFeaturesInflated {
+            $(
+                $(#[$inner $($args)*])*
+                #[doc = "\nDefaults to `"]
+                #[doc = stringify!($default)]
+                #[doc = "`.\n"]
+                pub $field: bool,
+            )*
+        }
+    };
+}
+
+define_wasm_features! {
+    /// Flags for features that are enabled for validation.
+    #[derive(Hash, Debug, Copy, Clone)]
+    pub struct WasmFeatures: u32 {
+        /// The WebAssembly `mutable-global` proposal.
+        pub mutable_global: MUTABLE_GLOBAL(1) = true;
+        /// The WebAssembly `saturating-float-to-int` proposal.
+        pub saturating_float_to_int: SATURATING_FLOAT_TO_INT(1 << 1) = true;
+        /// The WebAssembly `sign-extension-ops` proposal.
+        pub sign_extension: SIGN_EXTENSION(1 << 2) = true;
+        /// The WebAssembly reference types proposal.
+        pub reference_types: REFERENCE_TYPES(1 << 3) = true;
+        /// The WebAssembly multi-value proposal.
+        pub multi_value: MULTI_VALUE(1 << 4) = true;
+        /// The WebAssembly bulk memory operations proposal.
+        pub bulk_memory: BULK_MEMORY(1 << 5) = true;
+        /// The WebAssembly SIMD proposal.
+        pub simd: SIMD(1 << 6) = true;
+        /// The WebAssembly Relaxed SIMD proposal.
+        pub relaxed_simd: RELAXED_SIMD(1 << 7) = true;
+        /// The WebAssembly threads proposal.
+        pub threads: THREADS(1 << 8) = true;
+        /// The WebAssembly shared-everything-threads proposal; includes new
+        /// component model built-ins.
+        pub shared_everything_threads: SHARED_EVERYTHING_THREADS(1 << 9) = false;
+        /// The WebAssembly tail-call proposal.
+        pub tail_call: TAIL_CALL(1 << 10) = true;
+        /// Whether or not floating-point instructions are enabled.
+        ///
+        /// This is enabled by default can be used to disallow floating-point
+        /// operators and types.
+        ///
+        /// This does not correspond to a WebAssembly proposal but is instead
+        /// intended for embeddings which have stricter-than-usual requirements
+        /// about execution. Floats in WebAssembly can have different NaN patterns
+        /// across hosts which can lead to host-dependent execution which some
+        /// runtimes may not desire.
+        pub floats: FLOATS(1 << 11) = true;
+        /// The WebAssembly multi memory proposal.
+        pub multi_memory: MULTI_MEMORY(1 << 12) = true;
+        /// The WebAssembly exception handling proposal.
+        pub exceptions: EXCEPTIONS(1 << 13) = false;
+        /// The WebAssembly memory64 proposal.
+        pub memory64: MEMORY64(1 << 14) = false;
+        /// The WebAssembly extended_const proposal.
+        pub extended_const: EXTENDED_CONST(1 << 15) = true;
+        /// The WebAssembly component model proposal.
+        pub component_model: COMPONENT_MODEL(1 << 16) = true;
+        /// The WebAssembly typed function references proposal.
+        pub function_references: FUNCTION_REFERENCES(1 << 17) = false;
+        /// The WebAssembly memory control proposal.
+        pub memory_control: MEMORY_CONTROL(1 << 18) = false;
+        /// The WebAssembly gc proposal.
+        pub gc: GC(1 << 19) = false;
+        /// The WebAssembly [custom-page-sizes
+        /// proposal](https://github.com/WebAssembly/custom-page-sizes).
+        pub custom_page_sizes: CUSTOM_PAGE_SIZES(1 << 20) = false;
+        /// Support for the `value` type in the component model proposal.
+        pub component_model_values: COMPONENT_MODEL_VALUES(1 << 21) = false;
+        /// Support for the nested namespaces and projects in component model names.
+        pub component_model_nested_names: COMPONENT_MODEL_NESTED_NAMES(1 << 22) = false;
+    }
+}
+
+impl From<WasmFeaturesInflated> for WasmFeatures {
+    #[inline]
+    fn from(inflated: WasmFeaturesInflated) -> Self {
+        Self::from_inflated(inflated)
+    }
+}
+
+impl From<WasmFeatures> for WasmFeaturesInflated {
+    #[inline]
+    fn from(features: WasmFeatures) -> Self {
+        features.inflate()
+    }
+}

--- a/crates/wasmparser/src/features.rs
+++ b/crates/wasmparser/src/features.rs
@@ -57,10 +57,18 @@ macro_rules! define_wasm_features {
             pub fn inflate(&self) -> WasmFeaturesInflated {
                 WasmFeaturesInflated {
                     $(
-                        $field: self.contains(WasmFeatures::$const),
+                        $field: self.$field(),
                     )*
                 }
             }
+
+            $(
+                /// Returns whether this feature is enabled in this feature set.
+                #[inline]
+                pub fn $field(&self) -> bool {
+                    self.contains(WasmFeatures::$const)
+                }
+            )*
         }
 
         /// Inflated version of [`WasmFeatures`][crate::WasmFeatures] that

--- a/crates/wasmparser/src/lib.rs
+++ b/crates/wasmparser/src/lib.rs
@@ -784,10 +784,12 @@ macro_rules! bail {
 }
 
 pub use crate::binary_reader::{BinaryReader, BinaryReaderError, Result};
+pub use crate::features::*;
 pub use crate::parser::*;
 pub use crate::readers::*;
 
 mod binary_reader;
+mod features;
 mod limits;
 mod parser;
 mod readers;

--- a/crates/wasmparser/src/parser.rs
+++ b/crates/wasmparser/src/parser.rs
@@ -7,7 +7,7 @@ use crate::{
     ComponentStartFunction, ComponentTypeSectionReader, CustomSectionReader, DataSectionReader,
     ElementSectionReader, ExportSectionReader, FromReader, FunctionBody, FunctionSectionReader,
     GlobalSectionReader, ImportSectionReader, InstanceSectionReader, MemorySectionReader, Result,
-    SectionLimited, TableSectionReader, TagSectionReader, TypeSectionReader,
+    SectionLimited, TableSectionReader, TagSectionReader, TypeSectionReader, WasmFeatures,
 };
 use core::fmt;
 use core::iter;
@@ -52,6 +52,7 @@ pub struct Parser {
     offset: u64,
     max_size: u64,
     encoding: Encoding,
+    features: WasmFeatures,
 }
 
 #[derive(Debug, Clone)]
@@ -341,6 +342,7 @@ impl Parser {
             max_size: u64::MAX,
             // Assume the encoding is a module until we know otherwise
             encoding: Encoding::Module,
+            features: WasmFeatures::all(),
         }
     }
 
@@ -378,6 +380,25 @@ impl Parser {
             KIND_COMPONENT.to_le_bytes()[1],
         ];
         bytes.starts_with(&HEADER)
+    }
+
+    /// Returns the currently active set of wasm features that this parser is
+    /// using while parsing.
+    ///
+    /// The default set of features is [`WasmFeatures::all()`] for new parsers.
+    ///
+    /// For more information see [`BinaryReader::new`].
+    pub fn features(&self) -> WasmFeatures {
+        self.features
+    }
+
+    /// Sets the wasm features active while parsing to the `features` specified.
+    ///
+    /// The default set of features is [`WasmFeatures::all()`] for new parsers.
+    ///
+    /// For more information see [`BinaryReader::new`].
+    pub fn set_features(&mut self, features: WasmFeatures) {
+        self.features = features;
     }
 
     /// Attempts to parse a chunk of data.
@@ -534,7 +555,7 @@ impl Parser {
         // TODO: thread through `offset: u64` to `BinaryReader`, remove
         // the cast here.
         let starting_offset = self.offset as usize;
-        let mut reader = BinaryReader::new_with_offset(data, starting_offset);
+        let mut reader = BinaryReader::new(data, starting_offset, self.features);
         match self.parse_reader(&mut reader, eof) {
             Ok(payload) => {
                 // Be sure to update our offset with how far we got in the
@@ -803,7 +824,9 @@ impl Parser {
                 let body = delimited(reader, &mut len, |r| {
                     let size = r.read_var_u32()?;
                     let offset = r.original_position();
-                    Ok(FunctionBody::new(offset, r.read_bytes(size as usize)?))
+                    let reader =
+                        BinaryReader::new(r.read_bytes(size as usize)?, offset, self.features);
+                    Ok(FunctionBody::new(reader))
                 })?;
                 self.state = State::FunctionBody {
                     remaining: remaining - 1,
@@ -1014,15 +1037,16 @@ fn usize_to_u64(a: usize) -> u64 {
 fn section<'a, T>(
     reader: &mut BinaryReader<'a>,
     len: u32,
-    ctor: fn(&'a [u8], usize) -> Result<T>,
+    ctor: fn(BinaryReader<'a>) -> Result<T>,
     variant: fn(T) -> Payload<'a>,
 ) -> Result<Payload<'a>> {
     let offset = reader.original_position();
     let payload = reader.read_bytes(len as usize)?;
+    let reader = BinaryReader::new(payload, offset, reader.features());
     // clear the hint for "need this many more bytes" here because we already
     // read all the bytes, so it's not possible to read more bytes if this
     // fails.
-    let reader = ctor(payload, offset).map_err(clear_hint)?;
+    let reader = ctor(reader).map_err(clear_hint)?;
     Ok(variant(reader))
 }
 
@@ -1036,7 +1060,11 @@ where
     T: FromReader<'a>,
 {
     let range = reader.original_position()..reader.original_position() + len as usize;
-    let mut content = BinaryReader::new_with_offset(reader.read_bytes(len as usize)?, range.start);
+    let mut content = BinaryReader::new(
+        reader.read_bytes(len as usize)?,
+        range.start,
+        reader.features(),
+    );
     // We can't recover from "unexpected eof" here because our entire section is
     // already resident in memory, so clear the hint for how many more bytes are
     // expected.
@@ -1404,42 +1432,56 @@ mod tests {
             parser_after_header().parse(&[0, 2, 1], false),
             Ok(Chunk::NeedMoreData(1)),
         );
-        assert_matches!(
-            parser_after_header().parse(&[0, 1, 0], false),
-            Ok(Chunk::Parsed {
-                consumed: 3,
-                payload: Payload::CustomSection(CustomSectionReader {
-                    name: "",
-                    data_offset: 11,
-                    data: b"",
-                    range: Range { start: 10, end: 11 },
-                }),
-            }),
+        assert_custom(
+            parser_after_header().parse(&[0, 1, 0], false).unwrap(),
+            3,
+            "",
+            11,
+            b"",
+            Range { start: 10, end: 11 },
         );
-        assert_matches!(
-            parser_after_header().parse(&[0, 2, 1, b'a'], false),
-            Ok(Chunk::Parsed {
-                consumed: 4,
-                payload: Payload::CustomSection(CustomSectionReader {
-                    name: "a",
-                    data_offset: 12,
-                    data: b"",
-                    range: Range { start: 10, end: 12 },
-                }),
-            }),
+        assert_custom(
+            parser_after_header()
+                .parse(&[0, 2, 1, b'a'], false)
+                .unwrap(),
+            4,
+            "a",
+            12,
+            b"",
+            Range { start: 10, end: 12 },
         );
-        assert_matches!(
-            parser_after_header().parse(&[0, 2, 0, b'a'], false),
-            Ok(Chunk::Parsed {
-                consumed: 4,
-                payload: Payload::CustomSection(CustomSectionReader {
-                    name: "",
-                    data_offset: 11,
-                    data: b"a",
-                    range: Range { start: 10, end: 12 },
-                }),
-            }),
+        assert_custom(
+            parser_after_header()
+                .parse(&[0, 2, 0, b'a'], false)
+                .unwrap(),
+            4,
+            "",
+            11,
+            b"a",
+            Range { start: 10, end: 12 },
         );
+    }
+
+    fn assert_custom(
+        chunk: Chunk<'_>,
+        expected_consumed: usize,
+        expected_name: &str,
+        expected_data_offset: usize,
+        expected_data: &[u8],
+        expected_range: Range<usize>,
+    ) {
+        let (consumed, s) = match chunk {
+            Chunk::Parsed {
+                consumed,
+                payload: Payload::CustomSection(s),
+            } => (consumed, s),
+            _ => panic!("not a custom section payload"),
+        };
+        assert_eq!(consumed, expected_consumed);
+        assert_eq!(s.name(), expected_name);
+        assert_eq!(s.data_offset(), expected_data_offset);
+        assert_eq!(s.data(), expected_data);
+        assert_eq!(s.range(), expected_range);
     }
 
     #[test]

--- a/crates/wasmparser/src/readers.rs
+++ b/crates/wasmparser/src/readers.rs
@@ -83,8 +83,7 @@ impl<'a, T> SectionLimited<'a, T> {
     /// # Errors
     ///
     /// Returns an error if a 32-bit count couldn't be read from the `data`.
-    pub fn new(data: &'a [u8], offset: usize) -> Result<Self> {
-        let mut reader = BinaryReader::new_with_offset(data, offset);
+    pub fn new(mut reader: BinaryReader<'a>) -> Result<Self> {
         let count = reader.read_var_u32()?;
         Ok(SectionLimited {
             reader,
@@ -255,9 +254,9 @@ pub struct Subsections<'a, T> {
 impl<'a, T> Subsections<'a, T> {
     /// Creates a new reader for the specified section contents starting at
     /// `offset` within the original wasm file.
-    pub fn new(data: &'a [u8], offset: usize) -> Self {
+    pub fn new(reader: BinaryReader<'a>) -> Self {
         Subsections {
-            reader: BinaryReader::new_with_offset(data, offset),
+            reader,
             _marker: marker::PhantomData,
         }
     }

--- a/crates/wasmparser/src/readers/component/imports.rs
+++ b/crates/wasmparser/src/readers/component/imports.rs
@@ -98,9 +98,10 @@ impl<'a> FromReader<'a> for ComponentImport<'a> {
 /// # Examples
 ///
 /// ```
-/// use wasmparser::ComponentImportSectionReader;
+/// use wasmparser::{ComponentImportSectionReader, BinaryReader, WasmFeatures};
 /// let data: &[u8] = &[0x01, 0x00, 0x01, 0x41, 0x01, 0x66];
-/// let reader = ComponentImportSectionReader::new(data, 0).unwrap();
+/// let reader = BinaryReader::new(data, 0, WasmFeatures::all());
+/// let reader = ComponentImportSectionReader::new(reader).unwrap();
 /// for import in reader {
 ///     let import = import.expect("import");
 ///     println!("Import: {:?}", import);

--- a/crates/wasmparser/src/readers/component/instances.rs
+++ b/crates/wasmparser/src/readers/component/instances.rs
@@ -42,9 +42,10 @@ pub enum Instance<'a> {
 /// # Examples
 ///
 /// ```
-/// use wasmparser::InstanceSectionReader;
+/// use wasmparser::{InstanceSectionReader, BinaryReader, WasmFeatures};
 /// # let data: &[u8] = &[0x01, 0x00, 0x00, 0x01, 0x03, b'f', b'o', b'o', 0x12, 0x00];
-/// let mut reader = InstanceSectionReader::new(data, 0).unwrap();
+/// let reader = BinaryReader::new(data, 0, WasmFeatures::all());
+/// let mut reader = InstanceSectionReader::new(reader).unwrap();
 /// for inst in reader {
 ///     println!("Instance {:?}", inst.expect("instance"));
 /// }
@@ -119,9 +120,10 @@ pub enum ComponentInstance<'a> {
 /// # Examples
 ///
 /// ```
-/// use wasmparser::ComponentInstanceSectionReader;
+/// use wasmparser::{ComponentInstanceSectionReader, BinaryReader, WasmFeatures};
 /// # let data: &[u8] = &[0x01, 0x00, 0x00, 0x01, 0x03, b'f', b'o', b'o', 0x01, 0x00];
-/// let mut reader = ComponentInstanceSectionReader::new(data, 0).unwrap();
+/// let reader = BinaryReader::new(data, 0, WasmFeatures::all());
+/// let mut reader = ComponentInstanceSectionReader::new(reader).unwrap();
 /// for inst in reader {
 ///     println!("Instance {:?}", inst.expect("instance"));
 /// }

--- a/crates/wasmparser/src/readers/component/names.rs
+++ b/crates/wasmparser/src/readers/component/names.rs
@@ -87,10 +87,7 @@ impl<'a> Subsection<'a> for ComponentName<'a> {
                         });
                     }
                 };
-                ctor(NameMap::new(
-                    reader.remaining_buffer(),
-                    reader.original_position(),
-                )?)
+                ctor(NameMap::new(reader.shrink())?)
             }
             ty => ComponentName::Unknown {
                 ty,

--- a/crates/wasmparser/src/readers/component/types.rs
+++ b/crates/wasmparser/src/readers/component/types.rs
@@ -104,9 +104,10 @@ impl<'a> FromReader<'a> for ModuleTypeDeclaration<'a> {
 ///
 /// # Examples
 /// ```
-/// use wasmparser::CoreTypeSectionReader;
+/// use wasmparser::{CoreTypeSectionReader, BinaryReader, WasmFeatures};
 /// # let data: &[u8] = &[0x01, 0x60, 0x00, 0x00];
-/// let mut reader = CoreTypeSectionReader::new(data, 0).unwrap();
+/// let reader = BinaryReader::new(data, 0, WasmFeatures::all());
+/// let mut reader = CoreTypeSectionReader::new(reader).unwrap();
 /// for ty in reader {
 ///     println!("Type {:?}", ty.expect("type"));
 /// }
@@ -541,9 +542,10 @@ impl<'a> ComponentDefinedType<'a> {
 /// # Examples
 ///
 /// ```
-/// use wasmparser::ComponentTypeSectionReader;
+/// use wasmparser::{ComponentTypeSectionReader, BinaryReader, WasmFeatures};
 /// let data: &[u8] = &[0x01, 0x40, 0x01, 0x03, b'f', b'o', b'o', 0x73, 0x00, 0x73];
-/// let mut reader = ComponentTypeSectionReader::new(data, 0).unwrap();
+/// let reader = BinaryReader::new(data, 0, WasmFeatures::all());
+/// let mut reader = ComponentTypeSectionReader::new(reader).unwrap();
 /// for ty in reader {
 ///     println!("Type {:?}", ty.expect("type"));
 /// }

--- a/crates/wasmparser/src/readers/core/branch_hinting.rs
+++ b/crates/wasmparser/src/readers/core/branch_hinting.rs
@@ -27,7 +27,7 @@ impl<'a> FromReader<'a> for BranchHintFunction<'a> {
         })?;
         Ok(BranchHintFunction {
             func,
-            hints: SectionLimited::new(hints.remaining_buffer(), hints.original_position())?,
+            hints: SectionLimited::new(hints)?,
         })
     }
 }

--- a/crates/wasmparser/src/readers/core/code.rs
+++ b/crates/wasmparser/src/readers/core/code.rs
@@ -27,19 +27,8 @@ pub struct FunctionBody<'a> {
 
 impl<'a> FunctionBody<'a> {
     /// Constructs a new `FunctionBody` for the given data and offset.
-    pub fn new(offset: usize, data: &'a [u8]) -> Self {
-        Self {
-            reader: BinaryReader::new_with_offset(data, offset),
-        }
-    }
-
-    /// Whether or not to allow 64-bit memory arguments in the
-    /// function body.
-    ///
-    /// This is intended to be `true` when support for the memory64
-    /// WebAssembly proposal is also enabled.
-    pub fn allow_memarg64(&mut self, allow: bool) {
-        self.reader.allow_memarg64(allow);
+    pub fn new(reader: BinaryReader<'a>) -> Self {
+        Self { reader }
     }
 
     /// Gets a binary reader for this function body.
@@ -73,6 +62,13 @@ impl<'a> FunctionBody<'a> {
     /// Gets the range of the function body.
     pub fn range(&self) -> Range<usize> {
         self.reader.range()
+    }
+
+    /// Returns the body of this function as a list of bytes.
+    ///
+    /// Note that the returned bytes start with the function locals declaration.
+    pub fn as_bytes(&self) -> &'a [u8] {
+        self.reader.remaining_buffer()
     }
 }
 

--- a/crates/wasmparser/src/readers/core/coredumps.rs
+++ b/crates/wasmparser/src/readers/core/coredumps.rs
@@ -9,10 +9,10 @@ use crate::{BinaryReader, FromReader, Result};
 /// # Examples
 ///
 /// ```
-/// use wasmparser::{ BinaryReader, CoreDumpSection, FromReader, Result };
+/// use wasmparser::{BinaryReader, CoreDumpSection, FromReader, Result, WasmFeatures};
 /// let data: &[u8] = &[0x00, 0x09, 0x74, 0x65, 0x73, 0x74, 0x2e, 0x77, 0x61,
 ///      0x73, 0x6d];
-/// let mut reader = BinaryReader::new(data);
+/// let mut reader = BinaryReader::new(data, 0, WasmFeatures::all());
 /// let core = CoreDumpSection::new(reader).unwrap();
 /// assert!(core.name == "test.wasm")
 /// ```
@@ -46,9 +46,9 @@ impl<'a> CoreDumpSection<'a> {
 /// # Example
 ///
 /// ```
-/// use wasmparser::{ BinaryReader, CoreDumpModulesSection, FromReader, Result };
+/// use wasmparser::{BinaryReader, CoreDumpModulesSection, FromReader, Result, WasmFeatures};
 /// let data: &[u8] = &[0x01, 0x00, 0x04, 0x74, 0x65, 0x73, 0x74];
-/// let reader = BinaryReader::new(data);
+/// let reader = BinaryReader::new(data, 0, WasmFeatures::all());
 /// let modules_section = CoreDumpModulesSection::new(reader).unwrap();
 /// assert!(modules_section.modules[0] == "test")
 /// ```
@@ -151,10 +151,11 @@ impl<'a> FromReader<'a> for CoreDumpInstance {
 /// # Examples
 ///
 /// ```
+/// use wasmparser::{BinaryReader, CoreDumpStackSection, FromReader, WasmFeatures};
+///
 /// let data: &[u8] = &[0x00, 0x04, 0x6d, 0x61, 0x69, 0x6e, 0x01, 0x00, 0x04,
 ///     0x2a, 0x33, 0x01, 0x7f, 0x01, 0x01, 0x7f, 0x02];
-/// use wasmparser::{ BinaryReader, CoreDumpStackSection, FromReader };
-/// let reader = BinaryReader::new(data);
+/// let reader = BinaryReader::new(data, 0, WasmFeatures::all());
 /// let corestack = CoreDumpStackSection::new(reader).unwrap();
 /// assert!(corestack.name == "main");
 /// assert!(corestack.frames.len() == 1);

--- a/crates/wasmparser/src/readers/core/custom.rs
+++ b/crates/wasmparser/src/readers/core/custom.rs
@@ -84,12 +84,12 @@ impl<'a> CustomSectionReader<'a> {
                 Ok(s) => KnownCustom::CoreDumpStack(s),
                 Err(_) => KnownCustom::Unknown,
             },
-            "linking" => match crate::LinkingSectionReader::new(self.data, self.data_offset) {
+            "linking" => match crate::LinkingSectionReader::new(self.reader.shrink()) {
                 Ok(s) => KnownCustom::Linking(s),
                 Err(_) => KnownCustom::Unknown,
             },
             s if s.starts_with("reloc.") => {
-                match crate::RelocSectionReader::new(self.data, self.data_offset) {
+                match crate::RelocSectionReader::new(self.reader.shrink()) {
                     Ok(s) => KnownCustom::Reloc(s),
                     Err(_) => KnownCustom::Unknown,
                 }

--- a/crates/wasmparser/src/readers/core/custom.rs
+++ b/crates/wasmparser/src/readers/core/custom.rs
@@ -5,27 +5,15 @@ use core::ops::Range;
 /// A reader for custom sections of a WebAssembly module.
 #[derive(Clone)]
 pub struct CustomSectionReader<'a> {
-    // NB: these fields are public to the crate to make testing easier.
-    pub(crate) name: &'a str,
-    pub(crate) data_offset: usize,
-    pub(crate) data: &'a [u8],
-    pub(crate) range: Range<usize>,
+    name: &'a str,
+    reader: BinaryReader<'a>,
 }
 
 impl<'a> CustomSectionReader<'a> {
     /// Constructs a new `CustomSectionReader` for the given data and offset.
-    pub fn new(data: &'a [u8], offset: usize) -> Result<CustomSectionReader<'a>> {
-        let mut reader = BinaryReader::new_with_offset(data, offset);
+    pub fn new(mut reader: BinaryReader<'a>) -> Result<CustomSectionReader<'a>> {
         let name = reader.read_string()?;
-        let data_offset = reader.original_position();
-        let data = reader.remaining_buffer();
-        let range = reader.range();
-        Ok(CustomSectionReader {
-            name,
-            data_offset,
-            data,
-            range,
-        })
+        Ok(CustomSectionReader { name, reader })
     }
 
     /// The name of the custom section.
@@ -36,19 +24,19 @@ impl<'a> CustomSectionReader<'a> {
     /// The offset, relative to the start of the original module or component,
     /// that the `data` payload for this custom section starts at.
     pub fn data_offset(&self) -> usize {
-        self.data_offset
+        self.reader.original_position()
     }
 
     /// The actual contents of the custom section.
     pub fn data(&self) -> &'a [u8] {
-        self.data
+        self.reader.remaining_buffer()
     }
 
     /// The range of bytes that specify this whole custom section (including
     /// both the name of this custom section and its data) specified in
     /// offsets relative to the start of the byte stream.
     pub fn range(&self) -> Range<usize> {
-        self.range.clone()
+        self.reader.range()
     }
 
     /// Attempts to match and see if this custom section is statically known to
@@ -63,48 +51,36 @@ impl<'a> CustomSectionReader<'a> {
     /// created, then `KnownCustom::Unknown` is returned.
     pub fn as_known(&self) -> KnownCustom<'a> {
         match self.name() {
-            "name" => KnownCustom::Name(crate::NameSectionReader::new(self.data, self.data_offset)),
+            "name" => KnownCustom::Name(crate::NameSectionReader::new(self.reader.shrink())),
             "component-name" => KnownCustom::ComponentName(crate::ComponentNameSectionReader::new(
-                self.data,
-                self.data_offset,
+                self.reader.shrink(),
             )),
             "metadata.code.branch_hint" => {
-                match crate::BranchHintSectionReader::new(self.data, self.data_offset) {
+                match crate::BranchHintSectionReader::new(self.reader.shrink()) {
                     Ok(s) => KnownCustom::BranchHints(s),
                     Err(_) => KnownCustom::Unknown,
                 }
             }
-            "producers" => match crate::ProducersSectionReader::new(self.data, self.data_offset) {
+            "producers" => match crate::ProducersSectionReader::new(self.reader.shrink()) {
                 Ok(s) => KnownCustom::Producers(s),
                 Err(_) => KnownCustom::Unknown,
             },
-            "dylink.0" => KnownCustom::Dylink0(crate::Dylink0SectionReader::new(
-                self.data,
-                self.data_offset,
-            )),
-            "core" => match crate::CoreDumpSection::new(BinaryReader::new_with_offset(
-                self.data,
-                self.data_offset,
-            )) {
+            "dylink.0" => {
+                KnownCustom::Dylink0(crate::Dylink0SectionReader::new(self.reader.shrink()))
+            }
+            "core" => match crate::CoreDumpSection::new(self.reader.shrink()) {
                 Ok(s) => KnownCustom::CoreDump(s),
                 Err(_) => KnownCustom::Unknown,
             },
-            "coremodules" => match crate::CoreDumpModulesSection::new(
-                BinaryReader::new_with_offset(self.data, self.data_offset),
-            ) {
+            "coremodules" => match crate::CoreDumpModulesSection::new(self.reader.shrink()) {
                 Ok(s) => KnownCustom::CoreDumpModules(s),
                 Err(_) => KnownCustom::Unknown,
             },
-            "coreinstances" => match crate::CoreDumpInstancesSection::new(
-                BinaryReader::new_with_offset(self.data, self.data_offset),
-            ) {
+            "coreinstances" => match crate::CoreDumpInstancesSection::new(self.reader.shrink()) {
                 Ok(s) => KnownCustom::CoreDumpInstances(s),
                 Err(_) => KnownCustom::Unknown,
             },
-            "corestack" => match crate::CoreDumpStackSection::new(BinaryReader::new_with_offset(
-                self.data,
-                self.data_offset,
-            )) {
+            "corestack" => match crate::CoreDumpStackSection::new(self.reader.shrink()) {
                 Ok(s) => KnownCustom::CoreDumpStack(s),
                 Err(_) => KnownCustom::Unknown,
             },
@@ -144,9 +120,9 @@ impl<'a> fmt::Debug for CustomSectionReader<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CustomSectionReader")
             .field("name", &self.name)
-            .field("data_offset", &self.data_offset)
+            .field("data_offset", &self.data_offset())
             .field("data", &"...")
-            .field("range", &self.range)
+            .field("range", &self.range())
             .finish()
     }
 }

--- a/crates/wasmparser/src/readers/core/data.rs
+++ b/crates/wasmparser/src/readers/core/data.rs
@@ -28,7 +28,7 @@ pub struct Data<'a> {
 }
 
 /// The kind of data segment.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub enum DataKind<'a> {
     /// The data segment is passive.
     Passive,

--- a/crates/wasmparser/src/readers/core/elements.rs
+++ b/crates/wasmparser/src/readers/core/elements.rs
@@ -132,16 +132,10 @@ impl<'a> FromReader<'a> for Element<'a> {
             Ok(())
         })?;
         let items = if exprs {
-            ElementItems::Expressions(
-                ty.unwrap_or(RefType::FUNCREF),
-                SectionLimited::new(data.remaining_buffer(), data.original_position())?,
-            )
+            ElementItems::Expressions(ty.unwrap_or(RefType::FUNCREF), SectionLimited::new(data)?)
         } else {
             assert!(ty.is_none());
-            ElementItems::Functions(SectionLimited::new(
-                data.remaining_buffer(),
-                data.original_position(),
-            )?)
+            ElementItems::Functions(SectionLimited::new(data)?)
         };
 
         let elem_end = reader.original_position();

--- a/crates/wasmparser/src/readers/core/globals.rs
+++ b/crates/wasmparser/src/readers/core/globals.rs
@@ -16,7 +16,7 @@
 use crate::{BinaryReader, ConstExpr, FromReader, GlobalType, Result, SectionLimited};
 
 /// Represents a core WebAssembly global.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct Global<'a> {
     /// The global's type.
     pub ty: GlobalType,

--- a/crates/wasmparser/src/readers/core/linking.rs
+++ b/crates/wasmparser/src/readers/core/linking.rs
@@ -145,11 +145,18 @@ impl<'a> FromReader<'a> for Comdat<'a> {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
         let name = reader.read_string()?;
         let flags = reader.read_var_u32()?;
-        let symbols = SectionLimited::new(reader.remaining_buffer(), reader.original_position())?;
+        // FIXME(#188) ideally shouldn't need to skip here
+        let symbols = reader.skip(|reader| {
+            let count = reader.read_var_u32()?;
+            for _ in 0..count {
+                reader.read::<ComdatSymbol>()?;
+            }
+            Ok(())
+        })?;
         Ok(Self {
             name,
             flags,
-            symbols,
+            symbols: SectionLimited::new(symbols)?,
         })
     }
 }
@@ -380,10 +387,10 @@ impl<'a> Subsection<'a> for Linking<'a> {
         let data = reader.remaining_buffer();
         let offset = reader.original_position();
         Ok(match id {
-            5 => Self::SegmentInfo(SegmentMap::new(data, offset)?),
-            6 => Self::InitFuncs(InitFuncMap::new(data, offset)?),
-            7 => Self::ComdatInfo(ComdatMap::new(data, offset)?),
-            8 => Self::SymbolTable(SymbolInfoMap::new(data, offset)?),
+            5 => Self::SegmentInfo(SegmentMap::new(reader)?),
+            6 => Self::InitFuncs(InitFuncMap::new(reader)?),
+            7 => Self::ComdatInfo(ComdatMap::new(reader)?),
+            8 => Self::SymbolTable(SymbolInfoMap::new(reader)?),
             ty => Self::Unknown {
                 ty,
                 data,
@@ -396,9 +403,9 @@ impl<'a> Subsection<'a> for Linking<'a> {
 impl<'a> LinkingSectionReader<'a> {
     /// Creates a new reader for the linking section contents starting at
     /// `offset` within the original wasm file.
-    pub fn new(data: &'a [u8], offset: usize) -> Result<Self> {
-        let mut reader = BinaryReader::new_with_offset(data, offset);
+    pub fn new(mut reader: BinaryReader<'a>) -> Result<Self> {
         let range = reader.range();
+        let offset = reader.original_position();
 
         let version = reader.read_var_u32()?;
         if version != 2 {
@@ -408,7 +415,7 @@ impl<'a> LinkingSectionReader<'a> {
             ));
         }
 
-        let subsections = Subsections::new(reader.remaining_buffer(), reader.original_position());
+        let subsections = Subsections::new(reader);
         Ok(Self {
             version,
             subsections,

--- a/crates/wasmparser/src/readers/core/linking.rs
+++ b/crates/wasmparser/src/readers/core/linking.rs
@@ -415,7 +415,7 @@ impl<'a> LinkingSectionReader<'a> {
             ));
         }
 
-        let subsections = Subsections::new(reader);
+        let subsections = Subsections::new(reader.shrink());
         Ok(Self {
             version,
             subsections,

--- a/crates/wasmparser/src/readers/core/names.rs
+++ b/crates/wasmparser/src/readers/core/names.rs
@@ -68,7 +68,7 @@ impl<'a> FromReader<'a> for IndirectNaming<'a> {
 
         Ok(IndirectNaming {
             index,
-            names: NameMap::new(names.remaining_buffer(), names.original_position())?,
+            names: NameMap::new(names)?,
         })
     }
 }
@@ -138,17 +138,17 @@ impl<'a> Subsection<'a> for Name<'a> {
                     name_range: offset..reader.original_position(),
                 }
             }
-            1 => Name::Function(NameMap::new(data, offset)?),
-            2 => Name::Local(IndirectNameMap::new(data, offset)?),
-            3 => Name::Label(IndirectNameMap::new(data, offset)?),
-            4 => Name::Type(NameMap::new(data, offset)?),
-            5 => Name::Table(NameMap::new(data, offset)?),
-            6 => Name::Memory(NameMap::new(data, offset)?),
-            7 => Name::Global(NameMap::new(data, offset)?),
-            8 => Name::Element(NameMap::new(data, offset)?),
-            9 => Name::Data(NameMap::new(data, offset)?),
-            10 => Name::Field(IndirectNameMap::new(data, offset)?),
-            11 => Name::Tag(NameMap::new(data, offset)?),
+            1 => Name::Function(NameMap::new(reader)?),
+            2 => Name::Local(IndirectNameMap::new(reader)?),
+            3 => Name::Label(IndirectNameMap::new(reader)?),
+            4 => Name::Type(NameMap::new(reader)?),
+            5 => Name::Table(NameMap::new(reader)?),
+            6 => Name::Memory(NameMap::new(reader)?),
+            7 => Name::Global(NameMap::new(reader)?),
+            8 => Name::Element(NameMap::new(reader)?),
+            9 => Name::Data(NameMap::new(reader)?),
+            10 => Name::Field(IndirectNameMap::new(reader)?),
+            11 => Name::Tag(NameMap::new(reader)?),
             ty => Name::Unknown {
                 ty,
                 data,

--- a/crates/wasmparser/src/readers/core/operators.rs
+++ b/crates/wasmparser/src/readers/core/operators.rs
@@ -145,7 +145,7 @@ for_each_operator!(define_operator);
 /// A reader for a core WebAssembly function's operators.
 #[derive(Clone)]
 pub struct OperatorsReader<'a> {
-    pub(crate) reader: BinaryReader<'a>,
+    reader: BinaryReader<'a>,
 }
 
 impl<'a> OperatorsReader<'a> {
@@ -161,15 +161,6 @@ impl<'a> OperatorsReader<'a> {
     /// Gets the original position of the reader.
     pub fn original_position(&self) -> usize {
         self.reader.original_position()
-    }
-
-    /// Whether or not to allow 64-bit memory arguments in the
-    /// the operators being read.
-    ///
-    /// This is intended to be `true` when support for the memory64
-    /// WebAssembly proposal is also enabled.
-    pub fn allow_memarg64(&mut self, allow: bool) {
-        self.reader.allow_memarg64(allow);
     }
 
     /// Ensures the reader is at the end.
@@ -228,10 +219,11 @@ impl<'a> IntoIterator for OperatorsReader<'a> {
     ///
     /// # Examples
     /// ```
-    /// use wasmparser::{Operator, CodeSectionReader, Result};
+    /// # use wasmparser::{Operator, CodeSectionReader, Result, BinaryReader, WasmFeatures};
     /// # let data: &[u8] = &[
     /// #     0x01, 0x03, 0x00, 0x01, 0x0b];
-    /// let code_reader = CodeSectionReader::new(data, 0).unwrap();
+    /// let reader = BinaryReader::new(data, 0, WasmFeatures::all());
+    /// let code_reader = CodeSectionReader::new(reader).unwrap();
     /// for body in code_reader {
     ///     let body = body.expect("function body");
     ///     let mut op_reader = body.get_operators_reader().expect("op reader");
@@ -283,10 +275,11 @@ impl<'a> Iterator for OperatorsIteratorWithOffsets<'a> {
     ///
     /// # Examples
     /// ```
-    /// use wasmparser::{Operator, CodeSectionReader, Result};
+    /// use wasmparser::{Operator, CodeSectionReader, Result, BinaryReader, WasmFeatures};
     /// # let data: &[u8] = &[
     /// #     0x01, 0x03, 0x00, /* offset = 23 */ 0x01, 0x0b];
-    /// let code_reader = CodeSectionReader::new(data, 20).unwrap();
+    /// let reader = BinaryReader::new(data, 20, WasmFeatures::all());
+    /// let code_reader = CodeSectionReader::new(reader).unwrap();
     /// for body in code_reader {
     ///     let body = body.expect("function body");
     ///     let mut op_reader = body.get_operators_reader().expect("op reader");

--- a/crates/wasmparser/src/readers/core/producers.rs
+++ b/crates/wasmparser/src/readers/core/producers.rs
@@ -22,8 +22,9 @@ use crate::{BinaryReader, FromReader, Result, SectionLimited};
 /// ```
 /// # let data: &[u8] = &[0x01, 0x08, 0x6c, 0x61, 0x6e, 0x67, 0x75, 0x61, 0x67, 0x65,
 /// #     0x02, 0x03, 0x77, 0x61, 0x74, 0x01, 0x31, 0x01, 0x43, 0x03, 0x39, 0x2e, 0x30];
-/// use wasmparser::{ProducersSectionReader, ProducersFieldValue, Result};
-/// let reader = ProducersSectionReader::new(data, 0).expect("producers reader");
+/// # use wasmparser::{ProducersSectionReader, ProducersFieldValue, Result, BinaryReader, WasmFeatures};
+/// let reader = BinaryReader::new(data, 0, WasmFeatures::all());
+/// let reader = ProducersSectionReader::new(reader).expect("producers reader");
 /// let field = reader.into_iter().next().unwrap().expect("producers field");
 /// assert!(field.name == "language");
 /// let value = field.values.into_iter().collect::<Result<Vec<_>>>().expect("values");
@@ -60,7 +61,7 @@ impl<'a> FromReader<'a> for ProducersField<'a> {
         })?;
         Ok(ProducersField {
             name,
-            values: SectionLimited::new(values.remaining_buffer(), values.original_position())?,
+            values: SectionLimited::new(values)?,
         })
     }
 }

--- a/crates/wasmparser/src/readers/core/reloc.rs
+++ b/crates/wasmparser/src/readers/core/reloc.rs
@@ -22,7 +22,7 @@ impl<'a> RelocSectionReader<'a> {
         Ok(Self {
             section,
             range,
-            entries: SectionLimited::new(reader)?,
+            entries: SectionLimited::new(reader.shrink())?,
         })
     }
 

--- a/crates/wasmparser/src/readers/core/reloc.rs
+++ b/crates/wasmparser/src/readers/core/reloc.rs
@@ -16,14 +16,13 @@ pub struct RelocSectionReader<'a> {
 impl<'a> RelocSectionReader<'a> {
     /// Creates a new reader for a `reloc.*` section starting at
     /// `original_position` within the wasm file.
-    pub fn new(data: &'a [u8], original_position: usize) -> Result<Self> {
-        let mut reader = BinaryReader::new_with_offset(data, original_position);
+    pub fn new(mut reader: BinaryReader<'a>) -> Result<Self> {
         let range = reader.range().clone();
         let section = reader.read_var_u32()?;
         Ok(Self {
             section,
             range,
-            entries: SectionLimited::new(reader.remaining_buffer(), reader.original_position())?,
+            entries: SectionLimited::new(reader)?,
         })
     }
 

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -16,13 +16,13 @@
 use crate::prelude::*;
 use crate::{
     limits::*, BinaryReaderError, Encoding, FromReader, FunctionBody, HeapType, Parser, Payload,
-    RefType, Result, SectionLimited, ValType, WASM_COMPONENT_VERSION, WASM_MODULE_VERSION,
+    RefType, Result, SectionLimited, ValType, WasmFeatures, WASM_COMPONENT_VERSION,
+    WASM_MODULE_VERSION,
 };
 use ::core::mem;
 use ::core::ops::Range;
 use ::core::sync::atomic::{AtomicUsize, Ordering};
 use alloc::sync::Arc;
-use bitflags::bitflags;
 
 /// Test whether the given buffer contains a valid WebAssembly module or component,
 /// analogous to [`WebAssembly.validate`][js] in the JS API.
@@ -216,161 +216,6 @@ impl State {
 impl Default for State {
     fn default() -> Self {
         Self::Unparsed(None)
-    }
-}
-
-macro_rules! define_wasm_features {
-    (
-        $(#[$outer:meta])*
-        pub struct WasmFeatures: $repr:ty {
-            $(
-                $(#[$inner:ident $($args:tt)*])*
-                pub $field:ident: $const:ident($flag:expr) = $default:expr;
-            )*
-        }
-    ) => {
-        bitflags! {
-            $(#[$outer])*
-            pub struct WasmFeatures: $repr {
-                $(
-                    $(#[$inner $($args)*])*
-                    #[doc = "\nDefaults to `"]
-                    #[doc = stringify!($default)]
-                    #[doc = "`.\n"]
-                    const $const = $flag;
-                )*
-            }
-        }
-
-        impl Default for WasmFeatures {
-            #[inline]
-            fn default() -> Self {
-                let mut features = WasmFeatures::empty();
-                $(
-                    features.set(WasmFeatures::$const, $default);
-                )*
-                features
-            }
-        }
-
-        impl WasmFeatures {
-            /// Construct a bit-packed `WasmFeatures` from the inflated struct version.
-            #[inline]
-            pub fn from_inflated(inflated: WasmFeaturesInflated) -> Self {
-                let mut features = WasmFeatures::empty();
-                $(
-                    features.set(WasmFeatures::$const, inflated.$field);
-                )*
-                features
-            }
-
-            /// Inflate these bit-packed features into a struct with a field per
-            /// feature.
-            ///
-            /// Although the inflated struct takes up much more memory than the
-            /// bit-packed version, its fields can be exhaustively matched
-            /// upon. This makes it useful for temporarily checking against,
-            /// while keeping the bit-packed version as the method of storing
-            /// the features for longer periods of time.
-            #[inline]
-            pub fn inflate(&self) -> WasmFeaturesInflated {
-                WasmFeaturesInflated {
-                    $(
-                        $field: self.contains(WasmFeatures::$const),
-                    )*
-                }
-            }
-        }
-
-        /// Inflated version of [`WasmFeatures`][crate::WasmFeatures] that
-        /// allows for exhaustive matching on fields.
-        pub struct WasmFeaturesInflated {
-            $(
-                $(#[$inner $($args)*])*
-                #[doc = "\nDefaults to `"]
-                #[doc = stringify!($default)]
-                #[doc = "`.\n"]
-                pub $field: bool,
-            )*
-        }
-    };
-}
-
-define_wasm_features! {
-    /// Flags for features that are enabled for validation.
-    #[derive(Hash, Debug, Copy, Clone)]
-    pub struct WasmFeatures: u32 {
-        /// The WebAssembly `mutable-global` proposal.
-        pub mutable_global: MUTABLE_GLOBAL(1) = true;
-        /// The WebAssembly `saturating-float-to-int` proposal.
-        pub saturating_float_to_int: SATURATING_FLOAT_TO_INT(1 << 1) = true;
-        /// The WebAssembly `sign-extension-ops` proposal.
-        pub sign_extension: SIGN_EXTENSION(1 << 2) = true;
-        /// The WebAssembly reference types proposal.
-        pub reference_types: REFERENCE_TYPES(1 << 3) = true;
-        /// The WebAssembly multi-value proposal.
-        pub multi_value: MULTI_VALUE(1 << 4) = true;
-        /// The WebAssembly bulk memory operations proposal.
-        pub bulk_memory: BULK_MEMORY(1 << 5) = true;
-        /// The WebAssembly SIMD proposal.
-        pub simd: SIMD(1 << 6) = true;
-        /// The WebAssembly Relaxed SIMD proposal.
-        pub relaxed_simd: RELAXED_SIMD(1 << 7) = true;
-        /// The WebAssembly threads proposal.
-        pub threads: THREADS(1 << 8) = true;
-        /// The WebAssembly shared-everything-threads proposal; includes new
-        /// component model built-ins.
-        pub shared_everything_threads: SHARED_EVERYTHING_THREADS(1 << 9) = false;
-        /// The WebAssembly tail-call proposal.
-        pub tail_call: TAIL_CALL(1 << 10) = true;
-        /// Whether or not floating-point instructions are enabled.
-        ///
-        /// This is enabled by default can be used to disallow floating-point
-        /// operators and types.
-        ///
-        /// This does not correspond to a WebAssembly proposal but is instead
-        /// intended for embeddings which have stricter-than-usual requirements
-        /// about execution. Floats in WebAssembly can have different NaN patterns
-        /// across hosts which can lead to host-dependent execution which some
-        /// runtimes may not desire.
-        pub floats: FLOATS(1 << 11) = true;
-        /// The WebAssembly multi memory proposal.
-        pub multi_memory: MULTI_MEMORY(1 << 12) = true;
-        /// The WebAssembly exception handling proposal.
-        pub exceptions: EXCEPTIONS(1 << 13) = false;
-        /// The WebAssembly memory64 proposal.
-        pub memory64: MEMORY64(1 << 14) = false;
-        /// The WebAssembly extended_const proposal.
-        pub extended_const: EXTENDED_CONST(1 << 15) = true;
-        /// The WebAssembly component model proposal.
-        pub component_model: COMPONENT_MODEL(1 << 16) = true;
-        /// The WebAssembly typed function references proposal.
-        pub function_references: FUNCTION_REFERENCES(1 << 17) = false;
-        /// The WebAssembly memory control proposal.
-        pub memory_control: MEMORY_CONTROL(1 << 18) = false;
-        /// The WebAssembly gc proposal.
-        pub gc: GC(1 << 19) = false;
-        /// The WebAssembly [custom-page-sizes
-        /// proposal](https://github.com/WebAssembly/custom-page-sizes).
-        pub custom_page_sizes: CUSTOM_PAGE_SIZES(1 << 20) = false;
-        /// Support for the `value` type in the component model proposal.
-        pub component_model_values: COMPONENT_MODEL_VALUES(1 << 21) = false;
-        /// Support for the nested namespaces and projects in component model names.
-        pub component_model_nested_names: COMPONENT_MODEL_NESTED_NAMES(1 << 22) = false;
-    }
-}
-
-impl From<WasmFeaturesInflated> for WasmFeatures {
-    #[inline]
-    fn from(inflated: WasmFeaturesInflated) -> Self {
-        Self::from_inflated(inflated)
-    }
-}
-
-impl From<WasmFeatures> for WasmFeaturesInflated {
-    #[inline]
-    fn from(features: WasmFeatures) -> Self {
-        features.inflate()
     }
 }
 

--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -1191,7 +1191,7 @@ impl ComponentState {
         types: &mut TypeList,
         offset: usize,
     ) -> Result<()> {
-        if !features.contains(WasmFeatures::COMPONENT_MODEL_VALUES) {
+        if !features.component_model_values() {
             bail!(
                 offset,
                 "support for component model `value`s is not enabled"
@@ -2991,7 +2991,7 @@ impl ComponentState {
     }
 
     fn check_value_support(&self, features: &WasmFeatures, offset: usize) -> Result<()> {
-        if !features.contains(WasmFeatures::COMPONENT_MODEL_VALUES) {
+        if !features.component_model_values() {
             bail!(
                 offset,
                 "support for component model `value`s is not enabled"

--- a/crates/wasmparser/src/validator/core/canonical.rs
+++ b/crates/wasmparser/src/validator/core/canonical.rs
@@ -140,7 +140,7 @@ impl<'a> TypeCanonicalizer<'a> {
     }
 
     fn allow_gc(&self) -> bool {
-        self.features.map_or(true, |f| f.contains(WasmFeatures::GC))
+        self.features.map_or(true, |f| f.gc())
     }
 
     fn canonicalize_rec_group(&mut self, rec_group: &mut RecGroup) -> Result<()> {

--- a/crates/wasmparser/src/validator/func.rs
+++ b/crates/wasmparser/src/validator/func.rs
@@ -80,7 +80,7 @@ impl<T: WasmModuleResources> FuncValidator<T> {
     pub fn validate(&mut self, body: &FunctionBody<'_>) -> Result<()> {
         let mut reader = body.get_binary_reader();
         self.read_locals(&mut reader)?;
-        reader.allow_memarg64(self.validator.features.memory64());
+        reader.set_features(self.validator.features);
         while !reader.eof() {
             reader.visit_operator(&mut self.visitor(reader.original_position()))??;
         }

--- a/crates/wasmparser/src/validator/func.rs
+++ b/crates/wasmparser/src/validator/func.rs
@@ -80,7 +80,7 @@ impl<T: WasmModuleResources> FuncValidator<T> {
     pub fn validate(&mut self, body: &FunctionBody<'_>) -> Result<()> {
         let mut reader = body.get_binary_reader();
         self.read_locals(&mut reader)?;
-        reader.allow_memarg64(self.validator.features.contains(WasmFeatures::MEMORY64));
+        reader.allow_memarg64(self.validator.features.memory64());
         while !reader.eof() {
             reader.visit_operator(&mut self.visitor(reader.original_position()))??;
         }

--- a/crates/wasmparser/src/validator/names.rs
+++ b/crates/wasmparser/src/validator/names.rs
@@ -632,10 +632,7 @@ impl<'a> ComponentNameParser<'a> {
         self.expect_str(":")?;
         self.take_lowercase_kebab()?;
 
-        if self
-            .features
-            .contains(WasmFeatures::COMPONENT_MODEL_NESTED_NAMES)
-        {
+        if self.features.component_model_nested_names() {
             // Take the remaining package namespaces and name
             while self.next.starts_with(':') {
                 self.expect_str(":")?;
@@ -648,10 +645,7 @@ impl<'a> ComponentNameParser<'a> {
             self.expect_str("/")?;
             self.take_kebab()?;
 
-            if self
-                .features
-                .contains(WasmFeatures::COMPONENT_MODEL_NESTED_NAMES)
-            {
+            if self.features.component_model_nested_names() {
                 while self.next.starts_with('/') {
                     self.expect_str("/")?;
                     self.take_kebab()?;

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -749,7 +749,7 @@ where
     }
 
     fn check_floats_enabled(&self) -> Result<()> {
-        if !self.features.contains(WasmFeatures::FLOATS) {
+        if !self.features.floats() {
             bail!(self.offset, "floating-point instruction disallowed");
         }
         Ok(())
@@ -780,7 +780,7 @@ where
                 .resources
                 .check_value_type(t, &self.features, self.offset),
             BlockType::FuncType(idx) => {
-                if !self.features.contains(WasmFeatures::MULTI_VALUE) {
+                if !self.features.multi_value() {
                     bail!(
                         self.offset,
                         "blocks, loops, and ifs may only produce a resulttype \
@@ -1231,7 +1231,7 @@ macro_rules! validate_proposal {
 
     (validate self mvp) => {};
     (validate $self:ident $proposal:ident) => {
-        $self.check_enabled($self.0.features.contains(validate_proposal!(bitflags $proposal)), validate_proposal!(desc $proposal))?
+        $self.check_enabled($self.0.features.$proposal(), validate_proposal!(desc $proposal))?
     };
 
     (desc simd) => ("SIMD");
@@ -1247,20 +1247,6 @@ macro_rules! validate_proposal {
     (desc function_references) => ("function references");
     (desc memory_control) => ("memory control");
     (desc gc) => ("gc");
-
-    (bitflags sign_extension) => (WasmFeatures::SIGN_EXTENSION);
-    (bitflags saturating_float_to_int) => (WasmFeatures::SATURATING_FLOAT_TO_INT);
-    (bitflags bulk_memory) => (WasmFeatures::BULK_MEMORY);
-    (bitflags simd) => (WasmFeatures::SIMD);
-    (bitflags relaxed_simd) => (WasmFeatures::RELAXED_SIMD);
-    (bitflags exceptions) => (WasmFeatures::EXCEPTIONS);
-    (bitflags tail_call) => (WasmFeatures::TAIL_CALL);
-    (bitflags reference_types) => (WasmFeatures::REFERENCE_TYPES);
-    (bitflags function_references) => (WasmFeatures::FUNCTION_REFERENCES);
-    (bitflags threads) => (WasmFeatures::THREADS);
-    (bitflags shared_everything_threads) => (WasmFeatures::SHARED_EVERYTHING_THREADS);
-    (bitflags gc) => (WasmFeatures::GC);
-    (bitflags memory_control) => (WasmFeatures::MEMORY_CONTROL);
 }
 
 impl<'a, T> VisitOperator<'a> for WasmProposalValidator<'_, '_, T>
@@ -1548,7 +1534,7 @@ where
         table_index: u32,
         table_byte: u8,
     ) -> Self::Output {
-        if table_byte != 0 && !self.features.contains(WasmFeatures::REFERENCE_TYPES) {
+        if table_byte != 0 && !self.features.reference_types() {
             bail!(
                 self.offset,
                 "reference-types not enabled: zero byte expected"
@@ -1815,7 +1801,7 @@ where
         Ok(())
     }
     fn visit_memory_size(&mut self, mem: u32, mem_byte: u8) -> Self::Output {
-        if mem_byte != 0 && !self.features.contains(WasmFeatures::MULTI_MEMORY) {
+        if mem_byte != 0 && !self.features.multi_memory() {
             bail!(self.offset, "multi-memory not enabled: zero byte expected");
         }
         let index_ty = self.check_memory_index(mem)?;
@@ -1823,7 +1809,7 @@ where
         Ok(())
     }
     fn visit_memory_grow(&mut self, mem: u32, mem_byte: u8) -> Self::Output {
-        if mem_byte != 0 && !self.features.contains(WasmFeatures::MULTI_MEMORY) {
+        if mem_byte != 0 && !self.features.multi_memory() {
             bail!(self.offset, "multi-memory not enabled: zero byte expected");
         }
         let index_ty = self.check_memory_index(mem)?;

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -1280,7 +1280,6 @@ impl Printer {
         locals.finish(&mut self.result);
 
         let nesting_start = self.nesting;
-        body.allow_memarg64(true);
 
         let mut buf = String::new();
         let mut op_printer = operator::PrintOperator::new(self, state);

--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -315,7 +315,11 @@ impl<'a> Module<'a> {
                         self.funcs.push(Func {
                             // Specify a dummy definition to get filled in later
                             // when parsing the code section.
-                            def: Definition::Local(FunctionBody::new(0, &[])),
+                            def: Definition::Local(FunctionBody::new(BinaryReader::new(
+                                &[],
+                                0,
+                                WasmFeatures::all(),
+                            ))),
                             ty,
                         });
                     }

--- a/crates/wit-component/src/metadata.rs
+++ b/crates/wit-component/src/metadata.rs
@@ -50,7 +50,7 @@ use wasm_encoder::{
     ComponentBuilder, ComponentExportKind, ComponentType, ComponentTypeRef, CustomSection,
 };
 use wasm_metadata::Producers;
-use wasmparser::{BinaryReader, Encoding, Parser, Payload};
+use wasmparser::{BinaryReader, Encoding, Parser, Payload, WasmFeatures};
 use wit_parser::{Package, PackageName, Resolve, World, WorldId, WorldItem};
 
 const CURRENT_VERSION: u8 = 0x04;
@@ -249,7 +249,7 @@ impl Bindgen {
         let resolve;
         let encoding;
 
-        let mut reader = BinaryReader::new(data);
+        let mut reader = BinaryReader::new(data, 0, WasmFeatures::all());
         match reader.read_u8()? {
             // Historical 0x03 format where the support here will be deleted in
             // the future

--- a/fuzz/src/roundtrip.rs
+++ b/fuzz/src/roundtrip.rs
@@ -62,9 +62,10 @@ fn validate_name_section(wasm: &[u8]) -> wasmparser::Result<()> {
     use wasmparser::*;
     for payload in Parser::new(0).parse_all(wasm) {
         let reader = match payload? {
-            Payload::CustomSection(c) if c.name() == "name" => {
-                NameSectionReader::new(c.data(), c.data_offset())
-            }
+            Payload::CustomSection(c) => match c.as_known() {
+                KnownCustom::Name(name) => name,
+                _ => continue,
+            },
             _ => continue,
         };
         for section in reader {


### PR DESCRIPTION
Historically wasmparser has had a pretty clean split between validation
and parsing with the idea that the parser produces a bunch of stuff and
validation weeds it all out depending on activated features. Parsing has
historically not had access to the set of active features to have it
work the same no matter what. Over time, though, this has become quite
the burden.

The integration with the spec test repo in this repository tries to
make sure that any invalid wasm binary matches the same error message,
with a degree of flexibility. Not being able to take wasm features into
account when parsing makes this quite difficult. For example WebAssembly
binaries invalid before a feature is implemented might be valid after a
feature is implemented. They might also have an entirely different class
of error after a feature is implemented. Effectively WebAssembly does
not guarantee stability of the error message for invalid wasms as it
evolves, only that valid wasms all remain interpreted the same way.

Wasmparser has historically had a number of hacks around this. The
`roundtrip.rs` test suite has a very large function trying to match
error messages between wasmparser and the spec interpreter. Lots of
special cases happen here for wasmparser's feature-agnostic parser when
run against the spec test suite where each proposal has its own copy of
the spec interpreter, possibly with subtly different binary decoders.
Wasmparser additionally has hacks present in the public API such as
`BinaryReader::allow_memarg64` and the `table_byte` field of the
`CallIndirect` instruction. These have historically exclusively been
around to get the spec tests passing but otherwise serve no purpose.

Overall, there's been a lot of pain historically from not being able to
understand active wasm features when parsing wasm. It's quite easy to
write a code path along the lines of "if this feature is active parse
this way otherwise parse this way", but the features have never been
available to test this. Additionally `BinaryReader` instances were
created in quite a few locations throughout `wasmparser` which would
mean threading these around would be quite difficult. This commit
changes all of this.

This commit replaces the `allow_memarg64: bool` field of `BinaryReader`
with `features: WasmFeatures`. This means that all instances of
`BinaryReader` have access to all activated features and will be able to
parse differently when a feature is disabled or enabled. This should
make it much easier to pass the various stages of spec tests depending
on what happens to be merged into the spec interpreter.

To assist with threading this value around and to ensure it's accurate
the `new_with_offset` constructor of `BinaryReader` was removed and the
only remaining `new` constructor now requires that features must be
specified. Much of `wasmparser` has now additionally been refactored to
take a `BinaryReader` as a constructor rather than a slice-and-offset.
This centralizes the construction of `BinaryReader` and cuts down on
constant conversions in-and-out of a `BinaryReader`. For example much of
wasmparser now forwards along `BinaryReader` instances as-is. This is a
large-ish API change, too, for anyone constructing these manually
(shouldn't affect those exclusively using the validator).

The intention is that it's generally ok to pass `WasmFeatures::all()` to
the construction of a `BinaryReader`. For example the
`wasmparser::Parser` type defaults to having all features active. This
means that errors will be different (or not present) for newer wasm
features but they'll all still get filtered out by the validator. The
features in the `BinaryReader` are not intended to be a strict gating
procedure such that it's an exact wasm MVP parser, for example, instead
only being available as necessary for spec tests and other relevant edge
cases.