### PR TITLE
[wip] wit-encoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2482,6 +2482,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-encoder"
+version = "0.204.0"
+dependencies = [
+ "arbitrary",
+ "clap 4.5.2",
+ "indexmap 2.2.5",
+ "log",
+ "semver",
+ "wit-component",
+ "wit-parser 0.204.0",
+]
+
+[[package]]
 name = "wit-parser"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
   'crates/fuzz-stats',
   'crates/wasm-mutate-stats',
   'fuzz',
+  'crates/wit-encoder',
   'crates/wit-parser/fuzz',
   'crates/wit-component/dl',
 ]
@@ -52,7 +53,10 @@ rayon = "1.3"
 serde = "1.0.166"
 serde_derive = "1.0.166"
 serde_json = { version = "1" }
-wasmtime = { version = "12.0.0", default-features = false, features = ['cranelift', 'component-model'] }
+wasmtime = { version = "12.0.0", default-features = false, features = [
+  'cranelift',
+  'component-model',
+] }
 url = "2.0.0"
 pretty_assertions = "1.3.0"
 semver = "1.0.0"
@@ -96,7 +100,10 @@ arbitrary = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
-wasm-smith = { workspace = true, features = ["_internal_cli", "wasmparser"], optional = true }
+wasm-smith = { workspace = true, features = [
+  "_internal_cli",
+  "wasmparser",
+], optional = true }
 
 # Dependencies of `shrink`
 wasm-shrink = { workspace = true, features = ["clap"], optional = true }
@@ -116,8 +123,16 @@ rustc-demangle = { version = "0.1.21", optional = true }
 cpp_demangle = { version = "0.4.0", optional = true }
 
 # Dependencies of `component`
-wit-component = { workspace = true, optional = true, features = ['dummy-module', 'wat', 'semver-check'] }
-wit-parser = { workspace = true, optional = true, features = ['decoding', 'wat', 'serde'] }
+wit-component = { workspace = true, optional = true, features = [
+  'dummy-module',
+  'wat',
+  'semver-check',
+] }
+wit-parser = { workspace = true, optional = true, features = [
+  'decoding',
+  'wat',
+  'serde',
+] }
 wast = { workspace = true, optional = true }
 
 # Dependencies of `metadata`
@@ -175,7 +190,13 @@ default = [
 validate = ['dep:wasmparser', 'rayon']
 print = []
 parse = []
-smith = ['wasm-smith', 'arbitrary', 'dep:serde', 'dep:serde_derive', 'dep:serde_json']
+smith = [
+  'wasm-smith',
+  'arbitrary',
+  'dep:serde',
+  'dep:serde_derive',
+  'dep:serde_json',
+]
 shrink = ['wasm-shrink', 'is_executable']
 mutate = ['wasm-mutate']
 dump = ['dep:wasmparser']

--- a/crates/wit-encoder/Cargo.toml
+++ b/crates/wit-encoder/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+description = "A WIT encoder for Rust"
+documentation = "https://docs.rs/wit-encoder"
+edition.workspace = true
+license = "Apache-2.0 WITH LLVM-exception"
+name = "wit-encoder"
+repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wit-encoder"
+version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+arbitrary = { workspace = true, features = ["derive"] }
+wit-component = { workspace = true }
+wit-parser = { workspace = true }
+clap = { workspace = true, optional = true }
+indexmap = { workspace = true }
+log = { workspace = true }
+semver = { workspace = true }

--- a/crates/wit-encoder/src/docs.rs
+++ b/crates/wit-encoder/src/docs.rs
@@ -1,0 +1,5 @@
+/// Documentation
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Default)]
+pub struct Docs {
+    pub contents: Option<String>,
+}

--- a/crates/wit-encoder/src/enum_.rs
+++ b/crates/wit-encoder/src/enum_.rs
@@ -1,6 +1,6 @@
 // use std::fmt::Display;
 
-use crate::{Case, Docs, Type};
+use crate::Case;
 
 /// A variant without a payload
 #[derive(Debug, Clone, PartialEq, Default)]

--- a/crates/wit-encoder/src/enum_.rs
+++ b/crates/wit-encoder/src/enum_.rs
@@ -1,0 +1,15 @@
+// use std::fmt::Display;
+
+use crate::{Case, Docs, Type};
+
+/// A variant without a payload
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Enum {
+    pub cases: Vec<Case>,
+}
+
+// impl Display for Enum {
+//     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+//         todo!()
+//     }
+// }

--- a/crates/wit-encoder/src/flags.rs
+++ b/crates/wit-encoder/src/flags.rs
@@ -1,0 +1,32 @@
+use crate::Docs;
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+pub struct Flags {
+    pub flags: Vec<Flag>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+pub struct Flag {
+    pub name: String,
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Docs::is_empty"))]
+    pub docs: Docs,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum FlagsRepr {
+    U8,
+    U16,
+    U32(usize),
+}
+
+impl FlagsRepr {
+    pub fn count(&self) -> usize {
+        match self {
+            FlagsRepr::U8 => 1,
+            FlagsRepr::U16 => 1,
+            FlagsRepr::U32(n) => *n,
+        }
+    }
+}

--- a/crates/wit-encoder/src/function.rs
+++ b/crates/wit-encoder/src/function.rs
@@ -1,0 +1,84 @@
+use crate::{Docs, Type};
+
+pub type Params = Vec<(String, Type)>;
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", serde(untagged))]
+pub enum Results {
+    #[cfg_attr(feature = "serde", serde(serialize_with = "serialize_params"))]
+    Named(Params),
+    #[cfg_attr(feature = "serde", serde(serialize_with = "serialize_anon_result"))]
+    Anon(Type),
+}
+
+pub enum ResultsTypeIter<'a> {
+    Named(std::slice::Iter<'a, (String, Type)>),
+    Anon(std::iter::Once<&'a Type>),
+}
+
+impl<'a> Iterator for ResultsTypeIter<'a> {
+    type Item = &'a Type;
+
+    fn next(&mut self) -> Option<&'a Type> {
+        match self {
+            ResultsTypeIter::Named(ps) => ps.next().map(|p| &p.1),
+            ResultsTypeIter::Anon(ty) => ty.next(),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            ResultsTypeIter::Named(ps) => ps.size_hint(),
+            ResultsTypeIter::Anon(ty) => ty.size_hint(),
+        }
+    }
+}
+
+impl<'a> ExactSizeIterator for ResultsTypeIter<'a> {}
+
+impl Results {
+    // For the common case of an empty results list.
+    pub fn empty() -> Results {
+        Results::Named(Vec::new())
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            Results::Named(params) => params.len(),
+            Results::Anon(_) => 1,
+        }
+    }
+
+    pub fn iter_types(&self) -> ResultsTypeIter {
+        match self {
+            Results::Named(ps) => ResultsTypeIter::Named(ps.iter()),
+            Results::Anon(ty) => ResultsTypeIter::Anon(std::iter::once(ty)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+pub struct Function {
+    pub name: String,
+    pub kind: FunctionKind,
+    #[cfg_attr(feature = "serde", serde(serialize_with = "serialize_params"))]
+    pub params: Params,
+    pub results: Results,
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Docs::is_empty"))]
+    pub docs: Docs,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
+pub enum FunctionKind {
+    Freestanding,
+    #[cfg_attr(feature = "serde", serde(serialize_with = "serialize_id"))]
+    Method,
+    #[cfg_attr(feature = "serde", serde(serialize_with = "serialize_id"))]
+    Static,
+    #[cfg_attr(feature = "serde", serde(serialize_with = "serialize_id"))]
+    Constructor,
+}

--- a/crates/wit-encoder/src/handle.rs
+++ b/crates/wit-encoder/src/handle.rs
@@ -1,0 +1,11 @@
+use crate::Type;
+
+#[derive(Debug, PartialEq, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
+pub enum Handle {
+    #[cfg_attr(feature = "serde", serde(serialize_with = "serialize_id"))]
+    Own(Type),
+    #[cfg_attr(feature = "serde", serde(serialize_with = "serialize_id"))]
+    Borrow(Type),
+}

--- a/crates/wit-encoder/src/interface.rs
+++ b/crates/wit-encoder/src/interface.rs
@@ -1,0 +1,27 @@
+use crate::{Docs, Function, Resource, Type};
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+pub struct Interface {
+    /// Optionally listed name of this interface.
+    ///
+    /// This is `None` for inline interfaces in worlds.
+    pub name: Option<String>,
+
+    /// Exported types from this interface.
+    ///
+    /// Export names are listed within the types themselves. Note that the
+    /// export name here matches the name listed in the `TypeDef`.
+    #[cfg_attr(feature = "serde", serde(serialize_with = "serialize_id_map"))]
+    pub types: Vec<Type>,
+
+    /// Exported functions from this interface.
+    pub functions: Vec<Function>,
+
+    /// Exported resources from this interface.
+    pub resources: Vec<Resource>,
+
+    /// Documentation associated with this interface.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Docs::is_empty"))]
+    pub docs: Docs,
+}

--- a/crates/wit-encoder/src/lib.rs
+++ b/crates/wit-encoder/src/lib.rs
@@ -5,4 +5,32 @@
 //!
 //! The main builder is [`Resolve`].
 
+mod docs;
+mod enum_;
+mod flags;
+mod function;
+mod handle;
+mod interface;
 mod package;
+mod record;
+mod resource;
+mod result;
+mod tuple;
+mod ty;
+mod variant;
+mod world;
+
+pub use docs::*;
+pub use enum_::*;
+pub use flags::*;
+pub use function::*;
+pub use handle::*;
+pub use interface::*;
+pub use package::*;
+pub use record::*;
+pub use resource::*;
+pub use result::*;
+pub use tuple::*;
+pub use ty::*;
+pub use variant::*;
+pub use world::*;

--- a/crates/wit-encoder/src/lib.rs
+++ b/crates/wit-encoder/src/lib.rs
@@ -1,0 +1,8 @@
+//! A WIT encoder for Rust.
+//!
+//! This crate is modeled after the `wasm-encoder` crate but is used to encode
+//! WIT documents instead of WebAssembly modules.
+//!
+//! The main builder is [`Resolve`].
+
+mod package;

--- a/crates/wit-encoder/src/package.rs
+++ b/crates/wit-encoder/src/package.rs
@@ -1,0 +1,12 @@
+#[derive(Clone)]
+pub struct Package {
+    pub name: PackageName,
+    pub sources: SourceMap,
+}
+
+#[derive(Clone)]
+pub struct PackageName {
+    pub namespace: String,
+    pub name: String,
+    pub version: Option<Version>,
+}

--- a/crates/wit-encoder/src/package.rs
+++ b/crates/wit-encoder/src/package.rs
@@ -1,12 +1,76 @@
-#[derive(Clone)]
+use std::fmt;
+
+use semver::Version;
+
+use crate::{Docs, Interface, World};
+
+/// A WIT package.
+///
+/// A package is a collection of interfaces and worlds. Packages additionally
+/// have a unique identifier that affects generated components and uniquely
+/// identifiers this particular package.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct Package {
+    /// A unique name corresponding to this package.
     pub name: PackageName,
-    pub sources: SourceMap,
+
+    /// Documentation associated with this package.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Docs::is_empty"))]
+    pub docs: Docs,
+
+    /// All interfaces contained in this packaged, keyed by the interface's
+    /// name.
+    #[cfg_attr(feature = "serde", serde(serialize_with = "serialize_id_map"))]
+    pub interfaces: Vec<Interface>,
+
+    /// All worlds contained in this package, keyed by the world's name.
+    #[cfg_attr(feature = "serde", serde(serialize_with = "serialize_id_map"))]
+    pub worlds: Vec<World>,
 }
 
-#[derive(Clone)]
+/// A structure used to keep track of the name of a package, containing optional
+/// information such as a namespace and version information.
+///
+/// This is directly encoded as an "ID" in the binary component representation
+/// with an interfaced tacked on as well.
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", serde(into = "String"))]
 pub struct PackageName {
+    /// A namespace such as `wasi` in `wasi:foo/bar`
     pub namespace: String,
+    /// The kebab-name of this package, which is always specified.
     pub name: String,
+    /// Optional major/minor version information.
     pub version: Option<Version>,
+}
+
+impl From<PackageName> for String {
+    fn from(name: PackageName) -> String {
+        name.to_string()
+    }
+}
+
+impl PackageName {
+    /// Returns the ID that this package name would assign the `interface` name
+    /// specified.
+    pub fn interface_id(&self, interface: &str) -> String {
+        let mut s = String::new();
+        s.push_str(&format!("{}:{}/{interface}", self.namespace, self.name));
+        if let Some(version) = &self.version {
+            s.push_str(&format!("@{version}"));
+        }
+        s
+    }
+}
+
+impl fmt::Display for PackageName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{}", self.namespace, self.name)?;
+        if let Some(version) = &self.version {
+            write!(f, "@{version}")?;
+        }
+        Ok(())
+    }
 }

--- a/crates/wit-encoder/src/package.rs
+++ b/crates/wit-encoder/src/package.rs
@@ -13,20 +13,47 @@ use crate::{Docs, Interface, World};
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct Package {
     /// A unique name corresponding to this package.
-    pub name: PackageName,
+    name: PackageName,
 
     /// Documentation associated with this package.
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Docs::is_empty"))]
-    pub docs: Docs,
+    docs: Docs,
 
     /// All interfaces contained in this packaged, keyed by the interface's
     /// name.
     #[cfg_attr(feature = "serde", serde(serialize_with = "serialize_id_map"))]
-    pub interfaces: Vec<Interface>,
+    interfaces: Vec<Interface>,
 
     /// All worlds contained in this package, keyed by the world's name.
     #[cfg_attr(feature = "serde", serde(serialize_with = "serialize_id_map"))]
-    pub worlds: Vec<World>,
+    worlds: Vec<World>,
+}
+
+impl Package {
+    /// Create a new instance of `Package`.
+    pub fn new(name: PackageName) -> Self {
+        Self {
+            name,
+            docs: Docs::default(),
+            interfaces: vec![],
+            worlds: vec![],
+        }
+    }
+
+    /// Set the documentation
+    pub fn docs(&mut self, docs: Docs) {
+        self.docs = docs;
+    }
+
+    /// Add an `Interface` to the package
+    pub fn interface(&mut self, interface: Interface) {
+        self.interfaces.push(interface)
+    }
+
+    /// Add a `World` to the package
+    pub fn world(&mut self, world: World) {
+        self.worlds.push(world)
+    }
 }
 
 /// A structure used to keep track of the name of a package, containing optional
@@ -39,29 +66,27 @@ pub struct Package {
 #[cfg_attr(feature = "serde", serde(into = "String"))]
 pub struct PackageName {
     /// A namespace such as `wasi` in `wasi:foo/bar`
-    pub namespace: String,
+    namespace: String,
     /// The kebab-name of this package, which is always specified.
-    pub name: String,
+    name: String,
     /// Optional major/minor version information.
-    pub version: Option<Version>,
+    version: Option<Version>,
+}
+
+impl PackageName {
+    /// Create a new instance of `PackageName`
+    pub fn new(namespace: String, name: String, version: Option<Version>) -> Self {
+        Self {
+            namespace,
+            name,
+            version,
+        }
+    }
 }
 
 impl From<PackageName> for String {
     fn from(name: PackageName) -> String {
         name.to_string()
-    }
-}
-
-impl PackageName {
-    /// Returns the ID that this package name would assign the `interface` name
-    /// specified.
-    pub fn interface_id(&self, interface: &str) -> String {
-        let mut s = String::new();
-        s.push_str(&format!("{}:{}/{interface}", self.namespace, self.name));
-        if let Some(version) = &self.version {
-            s.push_str(&format!("@{version}"));
-        }
-        s
     }
 }
 

--- a/crates/wit-encoder/src/record.rs
+++ b/crates/wit-encoder/src/record.rs
@@ -1,0 +1,17 @@
+use crate::{Docs, Type};
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+pub struct Record {
+    pub fields: Vec<Field>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+pub struct Field {
+    pub name: String,
+    #[cfg_attr(feature = "serde", serde(rename = "type"))]
+    pub ty: Type,
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Docs::is_empty"))]
+    pub docs: Docs,
+}

--- a/crates/wit-encoder/src/resource.rs
+++ b/crates/wit-encoder/src/resource.rs
@@ -1,0 +1,17 @@
+use wit_parser::{FunctionKind, Params};
+
+use crate::Function;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Resource {
+    Item(String),
+    ItemList(String, Vec<ResourceMethod>),
+    Method(ResourceMethod),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ResourceMethod {
+    Function(Function),
+    Static(String, FunctionKind),
+    Constructor(Params),
+}

--- a/crates/wit-encoder/src/result.rs
+++ b/crates/wit-encoder/src/result.rs
@@ -1,0 +1,8 @@
+use crate::Type;
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+pub struct Result_ {
+    pub ok: Option<Type>,
+    pub err: Option<Type>,
+}

--- a/crates/wit-encoder/src/tuple.rs
+++ b/crates/wit-encoder/src/tuple.rs
@@ -1,0 +1,7 @@
+use crate::Type;
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+pub struct Tuple {
+    pub types: Vec<Type>,
+}

--- a/crates/wit-encoder/src/ty.rs
+++ b/crates/wit-encoder/src/ty.rs
@@ -1,0 +1,84 @@
+use crate::{Docs, Enum, Flags, Handle, Record, Result_, Tuple, Variant};
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum Type {
+    Bool,
+    U8,
+    U16,
+    U32,
+    U64,
+    S8,
+    S16,
+    S32,
+    S64,
+    F32,
+    F64,
+    Char,
+    String,
+    TypeDef(Box<TypeDef>),
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum Int {
+    U8,
+    U16,
+    U32,
+    U64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+pub struct Case {
+    pub name: String,
+    #[cfg_attr(feature = "serde", serde(rename = "type"))]
+    pub ty: Option<Type>,
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Docs::is_empty"))]
+    pub docs: Docs,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+pub struct TypeDef {
+    pub name: Option<String>,
+    pub kind: TypeDefKind,
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Docs::is_empty"))]
+    pub docs: Docs,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
+pub enum TypeDefKind {
+    Record(Record),
+    Resource,
+    Handle(Handle),
+    Flags(Flags),
+    Tuple(Tuple),
+    Variant(Variant),
+    Enum(Enum),
+    Option(Type),
+    Result(Result_),
+    List(Type),
+    Type(Type),
+}
+
+impl TypeDefKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TypeDefKind::Record(_) => "record",
+            TypeDefKind::Resource => "resource",
+            TypeDefKind::Handle(handle) => match handle {
+                Handle::Own(_) => "own",
+                Handle::Borrow(_) => "borrow",
+            },
+            TypeDefKind::Flags(_) => "flags",
+            TypeDefKind::Tuple(_) => "tuple",
+            TypeDefKind::Variant(_) => "variant",
+            TypeDefKind::Enum(_) => "enum",
+            TypeDefKind::Option(_) => "option",
+            TypeDefKind::Result(_) => "result",
+            TypeDefKind::List(_) => "list",
+            TypeDefKind::Type(_) => "type",
+        }
+    }
+}

--- a/crates/wit-encoder/src/variant.rs
+++ b/crates/wit-encoder/src/variant.rs
@@ -1,0 +1,7 @@
+use crate::Case;
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+pub struct Variant {
+    pub cases: Vec<Case>,
+}

--- a/crates/wit-encoder/src/world.rs
+++ b/crates/wit-encoder/src/world.rs
@@ -15,14 +15,6 @@ pub struct World {
     /// Documentation associated with this world declaration.
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Docs::is_empty"))]
     pub docs: Docs,
-
-    /// All the included worlds from this world. Empty if this is fully resolved
-    #[cfg_attr(feature = "serde", serde(skip))]
-    pub includes: Vec<WorldKey>,
-
-    /// All the included worlds names. Empty if this is fully resolved
-    #[cfg_attr(feature = "serde", serde(skip))]
-    pub include_names: Vec<Vec<IncludeName>>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/wit-encoder/src/world.rs
+++ b/crates/wit-encoder/src/world.rs
@@ -1,0 +1,77 @@
+use crate::{Docs, Function, Interface, Type};
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+pub struct World {
+    /// The WIT identifier name of this world.
+    pub name: String,
+
+    /// All imported items into this interface, both worlds and functions.
+    pub imports: Vec<(WorldKey, WorldItem)>,
+
+    /// All exported items from this interface, both worlds and functions.
+    pub exports: Vec<(WorldKey, WorldItem)>,
+
+    /// Documentation associated with this world declaration.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Docs::is_empty"))]
+    pub docs: Docs,
+
+    /// All the included worlds from this world. Empty if this is fully resolved
+    #[cfg_attr(feature = "serde", serde(skip))]
+    pub includes: Vec<WorldKey>,
+
+    /// All the included worlds names. Empty if this is fully resolved
+    #[cfg_attr(feature = "serde", serde(skip))]
+    pub include_names: Vec<Vec<IncludeName>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct IncludeName {
+    /// The name of the item
+    pub name: String,
+
+    /// The name to be replaced with
+    pub as_: String,
+}
+
+/// The key to the import/export maps of a world. Either a kebab-name or a
+/// unique interface.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", serde(into = "String"))]
+pub enum WorldKey {
+    /// A kebab-name.
+    Name(String),
+    /// An interface which is assigned no kebab-name.
+    Interface(String),
+}
+
+impl WorldKey {
+    /// Asserts that this is `WorldKey::Name` and returns the name.
+    #[track_caller]
+    pub fn unwrap_name(self) -> String {
+        match self {
+            WorldKey::Name(name) => name,
+            WorldKey::Interface(_) => panic!("expected a name, found interface"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
+pub enum WorldItem {
+    /// An interface is being imported or exported from a world, indicating that
+    /// it's a namespace of functions.
+    #[cfg_attr(feature = "serde", serde(serialize_with = "serialize_id"))]
+    Interface(Interface),
+
+    /// A function is being directly imported or exported from this world.
+    Function(Function),
+
+    /// A type is being exported from this world.
+    ///
+    /// Note that types are never imported into worlds at this time.
+    #[cfg_attr(feature = "serde", serde(serialize_with = "serialize_id"))]
+    Type(Type),
+}

--- a/crates/wit-encoder/tests/smoke.rs
+++ b/crates/wit-encoder/tests/smoke.rs
@@ -1,0 +1,24 @@
+const PACKAGE: &str = "package foo:functions;
+
+interface functions {
+  f1: func();
+  f2: func(a: u32);
+  f3: func(a: u32,);
+  f4: func() -> u32;
+  f6: func() -> tuple<u32, u32>;
+  f7: func(a: f32, b: f32) -> tuple<u32, u32>;
+  f8: func(a: option<u32>) -> result<u32, f32>;
+  f9: func() -> (u: u32, f: f32);
+  f10: func() -> (u: u32);
+  f11: func() -> ();
+}
+";
+
+#[test]
+fn smoke() {
+    let name = wit_encoder::PackageName::new("foo".into(), "functions".into(), None);
+    let mut package = wit_encoder::Package::new(name);
+
+    let mut interface = wit_encoder::Interface::new();
+    package.interface(interface);
+}


### PR DESCRIPTION
I started work on a new `wit-encoder` crate a few weeks ago. I haven't found time to finish this work up, but @MendyBerger mentioned he might have time to progress some of this work - so I'm putting this up as a draft PR. Part as a reference, part so he can maybe push this forward.

Definitely not intended to be merged (yet?). Probably doesn't need to stay open for too long either. I just wanted to make sure to put this up so folks could take a look at it in a place that's easy to reference.

To share the stat of this work: I'd just started implementing the actual backing impls of the various types. To make sure I got this right I was in the progress of porting the parser tests and making sure we're able to generate those programs correctly using `wit-encoder`. To handle indentation I was thinking of implementing something similar to the [`html::Render`](https://docs.rs/html/latest/html/trait.Render.html) trait.

Anyway; despite not being done yet I hope it's okay to share this here. Perhaps someone can run with it, or if not I'll find time to pick it up once my current workload lifts. Thanks!