### PR TITLE
Remove a special cased error message in roundtrip tests

### DIFF
--- a/crates/wasmparser/src/parser.rs
+++ b/crates/wasmparser/src/parser.rs
@@ -715,6 +715,7 @@ impl Parser {
                         self.max_size -= u64::from(len);
                         self.offset += u64::from(len);
                         let mut parser = Parser::new(usize_to_u64(reader.original_position()));
+                        parser.features = self.features;
                         parser.max_size = u64::from(len);
 
                         Ok(match id {

--- a/crates/wasmparser/src/readers/core/globals.rs
+++ b/crates/wasmparser/src/readers/core/globals.rs
@@ -39,8 +39,18 @@ impl<'a> FromReader<'a> for GlobalType {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
         let content_type = reader.read()?;
         let flags = reader.read_u8()?;
-        if flags > 0b11 {
-            bail!(reader.original_position() - 1, "malformed global flags")
+        if reader.features().shared_everything_threads() {
+            if flags > 0b11 {
+                bail!(reader.original_position() - 1, "malformed global flags")
+            }
+        } else {
+            if flags > 0b1 {
+                bail!(
+                    reader.original_position() - 1,
+                    "malformed mutability -- or shared globals \
+                     require the shared-everything-threads proposal"
+                )
+            }
         }
         Ok(GlobalType {
             content_type,

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -455,7 +455,9 @@ impl Validator {
     pub fn validate_all(&mut self, bytes: &[u8]) -> Result<Types> {
         let mut functions_to_validate = Vec::new();
         let mut last_types = None;
-        for payload in Parser::new(0).parse_all(bytes) {
+        let mut parser = Parser::new(0);
+        parser.set_features(self.features);
+        for payload in parser.parse_all(bytes) {
             match self.payload(&payload?)? {
                 ValidPayload::Func(a, b) => {
                     functions_to_validate.push((a, b));

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -818,16 +818,6 @@ fn error_matches(error: &str, message: &str) -> bool {
         return error.starts_with("type mismatch");
     }
 
-    if message == "malformed mutability" {
-        // When parsing a global `shared` type (e.g., `global (mut shared i32)
-        // ...`), many spec tests expect a `malformed mutability` error.
-        // Previously, `0x2` was an invalid flag but it now means `shared`. We
-        // accept either (a) a new, more accurate error message or (b) a
-        // validation error instead.
-        return error.contains("malformed global flags")
-            || error.contains("require the shared-everything-threads proposal");
-    }
-
     if message == "table size must be at most 2^32-1" {
         return error.contains("invalid u32 number: constant out of range");
     }


### PR DESCRIPTION
Use the features on `BinaryReader` to dictate what the valid flags are for a global.