### PR TITLE
Update spec test suite submodule

### DIFF
--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -729,7 +729,10 @@ where
     fn check_memarg(&self, memarg: MemArg) -> Result<ValType> {
         let index_ty = self.check_memory_index(memarg.memory)?;
         if memarg.align > memarg.max_align {
-            bail!(self.offset, "alignment must not be larger than natural");
+            bail!(
+                self.offset,
+                "malformed memop flags: alignment must not be larger than natural"
+            );
         }
         if index_ty == ValType::I32 && memarg.offset > u64::from(u32::MAX) {
             bail!(self.offset, "offset out of range: must be <= 2**32");

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -116,9 +116,8 @@ fn find_tests() -> Vec<PathBuf> {
 /// Note that this is used to skip tests for all crates, not just one at a
 /// time. There's further filters applied while testing.
 fn skip_test(test: &Path, contents: &[u8]) -> bool {
-    // currently no tests are skipped
-    let _ = (test, contents);
-    false
+    let _ = contents;
+    test.iter().any(|p| p == "exception-handling") && test.iter().any(|p| p == "legacy")
 }
 
 fn skip_validation(_test: &Path) -> bool {

--- a/tests/snapshots/testsuite/align.wast.json
+++ b/tests/snapshots/testsuite/align.wast.json
@@ -1813,6 +1813,48 @@
           "value": "0"
         }
       ]
+    },
+    {
+      "type": "assert_invalid",
+      "line": 873,
+      "filename": "align.108.wasm",
+      "text": "alignment must not be larger than natural",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 892,
+      "filename": "align.109.wasm",
+      "text": "malformed memop flags",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 911,
+      "filename": "align.110.wasm",
+      "text": "malformed memop flags",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 930,
+      "filename": "align.111.wasm",
+      "text": "malformed memop flags",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 949,
+      "filename": "align.112.wasm",
+      "text": "malformed memop flags",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 968,
+      "filename": "align.113.wasm",
+      "text": "malformed memop flags",
+      "module_type": "binary"
     }
   ]
 }


### PR DESCRIPTION
Use the previous support for `WasmFeatures` in a parser to help guide which error messages are generated when reading various sections.