### PR TITLE
Add no-hash-maps tests to gated CI checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -269,6 +269,7 @@ jobs:
       - verify-publish
       - test_capi
       - test_extra_features
+      - test-no-hash-maps
     if: always()
 
     steps:


### PR DESCRIPTION
Forgot to flag this in #1521 so adding in a follow-up.