### PR TITLE
Add manifest metadata for `cargo binstall`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,21 @@ readme = "README.md"
 exclude = ['tests/wabt', 'tests/testsuite', 'tests/snapshots', 'ci']
 rust-version.workspace = true
 
+[package.metadata.binstall]
+pkg-url = "{repo}/releases/download/v{version}/{name}-{version}-{target-arch}-{target-family}{archive-suffix}"
+bin-dir = "{name}-{version}-{target-arch}-{target-family}/{bin}{binary-ext}"
+pkg-fmt = "tgz"
+[package.metadata.binstall.overrides.x86_64-apple-darwin]
+pkg-url = "{repo}/releases/download/v{version}/{name}-{version}-{target-arch}-macos{archive-suffix}"
+bin-dir = "{name}-{version}-{target-arch}-macos/{bin}{binary-ext}"
+[package.metadata.binstall.overrides.aarch64-apple-darwin]
+pkg-url = "{repo}/releases/download/v{version}/{name}-{version}-{target-arch}-macos{archive-suffix}"
+bin-dir = "{name}-{version}-{target-arch}-macos/{bin}{binary-ext}"
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-fmt = "zip"
+[package.metadata.binstall.overrides.x86_64-pc-windows-gnu]
+pkg-fmt = "zip"
+
 [lints]
 workspace = true
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@
 [Precompiled artifacts built on CI][artifacts] are available for download for
 each release.
 
-If you'd prefer to build from source then first [install Rust for your
+[artifacts]: https://github.com/bytecodealliance/wasm-tools/releases
+
+To build from source first [install Rust for your
 platform](https://www.rust-lang.org/tools/install) and then use the included
 Cargo package manager to install:
 
@@ -21,7 +23,13 @@ Cargo package manager to install:
 $ cargo install wasm-tools
 ```
 
-[artifacts]: https://github.com/bytecodealliance/wasm-tools/releases
+Alternatively if you use [`cargo
+binstall`](https://github.com/cargo-bins/cargo-binstall) then that can be used
+to install [the precompiled artifacts][artifacts] instead:
+
+```
+$ cargo binstall wasm-tools
+```
 
 Installation can be confirmed with:
 


### PR DESCRIPTION
I've seen this recommended a number of times for installing precompiled binaries and this enables `cargo binstall` to pull from the precompiled artifacts produced on CI rather than needing a third-party source.