### PR TITLE
Add deprecation warnings to wasm-compose and wasm-tools compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ that can be use programmatically as well:
 | `wasm-tools objdump` |   | Print debugging information about section headers |
 | `wasm-tools strip` |   | Remove custom sections from a WebAssembly file |
 | `wasm-tools demangle` |   | Demangle Rust and C++ symbol names in the `name` section |
-| `wasm-tools compose` | [wasm-compose] | Compose wasm components together |
+| `wasm-tools compose` | [wasm-compose] | Compose wasm components together (*deprecated*) |
 | `wasm-tools component new` | [wit-component] | Create a component from a core wasm binary |
 | `wasm-tools component wit` |  | Extract a `*.wit` interface from a component |
 | `wasm-tools component embed` |  | Embed a `component-type` custom section in a core wasm binary |

--- a/crates/wasm-compose/README.md
+++ b/crates/wasm-compose/README.md
@@ -16,6 +16,8 @@
 
 ## Overview
 
+**IMPORTANT**:  `wasm-compose` has been been deprecated in favor of [`wac`](https://github.com/bytecodealliance/wac).
+
 `wasm-compose` is a library for composing [WebAssembly components](https://github.com/webassembly/component-model)
 from other WebAssembly components.
 

--- a/src/bin/wasm-tools/compose.rs
+++ b/src/bin/wasm-tools/compose.rs
@@ -53,6 +53,9 @@ impl Opts {
     }
 
     pub fn run(self) -> Result<()> {
+        eprintln!("WARNING: `wasm-tools compose` has been deprecated.");
+        eprintln!("");
+        eprintln!("Please use `wac` instead. You can find more information about `wac` at https://github.com/bytecodealliance/wac.");
         let config = self.create_config()?;
         log::debug!("configuration:\n{:#?}", config);
 


### PR DESCRIPTION
Start of #1555.

This is the bare minimum deprecation. Let me know if more detail would be appropriate, and I can add it. 