### PR TITLE
Add `#[inline]` to forwarding methods of `wasmparser::collections` types

### DIFF
--- a/crates/wasmparser/src/collections/index_map.rs
+++ b/crates/wasmparser/src/collections/index_map.rs
@@ -22,6 +22,7 @@ pub struct IndexMap<K, V> {
 }
 
 impl<K, V> Default for IndexMap<K, V> {
+    #[inline]
     fn default() -> Self {
         Self {
             inner: detail::IndexMapImpl::default(),
@@ -31,21 +32,25 @@ impl<K, V> Default for IndexMap<K, V> {
 
 impl<K, V> IndexMap<K, V> {
     /// Clears the [`IndexMap`], removing all elements.
+    #[inline]
     pub fn clear(&mut self) {
         self.inner.clear()
     }
 
     /// Returns the number of elements in the [`IndexMap`].
+    #[inline]
     pub fn len(&self) -> usize {
         self.inner.len()
     }
 
     /// Returns `true` if the [`IndexMap`] contains no elements.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
 
     /// Returns an iterator that yields the items in the [`IndexMap`].
+    #[inline]
     pub fn iter(&self) -> Iter<'_, K, V> {
         Iter {
             inner: self.inner.iter(),
@@ -53,6 +58,7 @@ impl<K, V> IndexMap<K, V> {
     }
 
     /// Returns an iterator that yields the mutable items in the [`IndexMap`].
+    #[inline]
     pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
         IterMut {
             inner: self.inner.iter_mut(),
@@ -60,6 +66,7 @@ impl<K, V> IndexMap<K, V> {
     }
 
     /// Returns an iterator that yields the keys in the [`IndexMap`].
+    #[inline]
     pub fn keys(&self) -> Keys<'_, K, V> {
         Keys {
             inner: self.inner.keys(),
@@ -67,6 +74,7 @@ impl<K, V> IndexMap<K, V> {
     }
 
     /// Returns an iterator that yields the values in the [`IndexMap`].
+    #[inline]
     pub fn values(&self) -> Values<'_, K, V> {
         Values {
             inner: self.inner.values(),
@@ -74,6 +82,7 @@ impl<K, V> IndexMap<K, V> {
     }
 
     /// Returns a mutable iterator that yields the values in the [`IndexMap`].
+    #[inline]
     pub fn values_mut(&mut self) -> ValuesMut<'_, K, V> {
         ValuesMut {
             inner: self.inner.values_mut(),
@@ -81,11 +90,13 @@ impl<K, V> IndexMap<K, V> {
     }
 
     /// Returns the key-value entry at the given `index` if any.
+    #[inline]
     pub fn get_index(&self, index: usize) -> Option<(&K, &V)> {
         self.inner.get_index(index)
     }
 
     /// Returns the mutable key-value entry at the given `index` if any.
+    #[inline]
     pub fn get_index_mut(&mut self, index: usize) -> Option<(&K, &mut V)> {
         self.inner.get_index_mut(index)
     }
@@ -96,6 +107,7 @@ where
     K: Hash + Eq + Ord + Clone,
 {
     /// Reserves capacity for at least `additional` more elements to be inserted in the [`IndexMap`].
+    #[inline]
     pub fn reserve(&mut self, additional: usize) {
         #[cfg(not(feature = "no-hash-maps"))]
         self.inner.reserve(additional);
@@ -104,6 +116,7 @@ where
     }
 
     /// Returns true if `key` is contains in the [`IndexMap`].
+    #[inline]
     pub fn contains_key<Q: ?Sized>(&self, key: &Q) -> bool
     where
         K: Borrow<Q>,
@@ -113,6 +126,7 @@ where
     }
 
     /// Returns a reference to the value corresponding to the `key`.
+    #[inline]
     pub fn get<Q: ?Sized>(&self, key: &Q) -> Option<&V>
     where
         K: Borrow<Q>,
@@ -123,6 +137,7 @@ where
 
     /// Return references to the key-value pair stored for `key`,
     /// if it is present, else `None`.
+    #[inline]
     pub fn get_key_value<Q: ?Sized>(&self, key: &Q) -> Option<(&K, &V)>
     where
         K: Borrow<Q>,
@@ -137,6 +152,7 @@ where
     /// The supplied key may be any borrowed form of the map's key type,
     /// but the ordering on the borrowed form *must* match the ordering
     /// on the key type.
+    #[inline]
     pub fn get_full<Q: ?Sized>(&self, key: &Q) -> Option<(usize, &K, &V)>
     where
         K: Borrow<Q> + Ord,
@@ -146,6 +162,7 @@ where
     }
 
     /// Returns a mutable reference to the value corresponding to the key.
+    #[inline]
     pub fn get_mut<Q: ?Sized>(&mut self, key: &Q) -> Option<&mut V>
     where
         K: Borrow<Q>,
@@ -161,6 +178,7 @@ where
     /// If the map did have this key present, the value is updated, and the old
     /// value is returned. The key is not updated, though; this matters for
     /// types that can be `==` without being identical.
+    #[inline]
     pub fn insert(&mut self, key: K, value: V) -> Option<V> {
         self.inner.insert(key, value)
     }
@@ -174,6 +192,7 @@ where
     /// Return `None` if `key` is not in map.
     ///
     /// [`Vec::swap_remove`]: alloc::vec::Vec::swap_remove
+    #[inline]
     pub fn swap_remove<Q>(&mut self, key: &Q) -> Option<V>
     where
         K: Borrow<Q>,
@@ -191,6 +210,7 @@ where
     /// Return `None` if `key` is not in map.
     ///
     /// [`Vec::swap_remove`]: alloc::vec::Vec::swap_remove
+    #[inline]
     pub fn swap_remove_entry<Q>(&mut self, key: &Q) -> Option<(K, V)>
     where
         K: Borrow<Q>,
@@ -200,6 +220,7 @@ where
     }
 
     /// Gets the given key's corresponding entry in the [`IndexMap`] for in-place manipulation.
+    #[inline]
     pub fn entry(&mut self, key: K) -> Entry<'_, K, V> {
         match self.inner.entry(key) {
             detail::EntryImpl::Occupied(entry) => Entry::Occupied(OccupiedEntry { inner: entry }),
@@ -215,6 +236,7 @@ where
 {
     type Output = V;
 
+    #[inline]
     fn index(&self, key: &Q) -> &V {
         &self.inner[key]
     }
@@ -226,6 +248,7 @@ where
 {
     type Output = V;
 
+    #[inline]
     fn index(&self, key: usize) -> &V {
         &self.inner[key]
     }
@@ -235,6 +258,7 @@ impl<K, V> Extend<(K, V)> for IndexMap<K, V>
 where
     K: Eq + Hash + Ord + Clone,
 {
+    #[inline]
     fn extend<Iter: IntoIterator<Item = (K, V)>>(&mut self, iter: Iter) {
         self.inner.extend(iter)
     }
@@ -256,6 +280,7 @@ where
     K: Hash + Eq + Ord + Clone,
 {
     /// Returns a reference to this entry's key.
+    #[inline]
     pub fn key(&self) -> &K {
         match *self {
             Self::Occupied(ref entry) => entry.key(),
@@ -271,6 +296,7 @@ where
 {
     /// Ensures a value is in the entry by inserting the default value if empty,
     /// and returns a mutable reference to the value in the entry.
+    #[inline]
     pub fn or_default(self) -> &'a mut V {
         match self {
             Self::Occupied(entry) => entry.into_mut(),
@@ -292,27 +318,32 @@ where
     K: Ord + Clone,
 {
     /// Gets a reference to the key in the entry.
+    #[inline]
     pub fn key(&self) -> &K {
         self.inner.key()
     }
 
     /// Gets a reference to the value in the entry.
+    #[inline]
     pub fn get(&self) -> &V {
         self.inner.get()
     }
 
     /// Gets a mutable reference to the value in the entry.
+    #[inline]
     pub fn get_mut(&mut self) -> &mut V {
         self.inner.get_mut()
     }
 
     /// Sets the value of the entry with the [`OccupiedEntry`]'s key, and returns the entry's old value.
+    #[inline]
     pub fn insert(&mut self, value: V) -> V {
         self.inner.insert(value)
     }
 
     /// Converts the [`OccupiedEntry`] into a mutable reference to the value in the entry
     /// with a lifetime bound to the map itself.
+    #[inline]
     pub fn into_mut(self) -> &'a mut V {
         self.inner.into_mut()
     }
@@ -331,16 +362,19 @@ where
     K: Ord + Clone,
 {
     /// Gets a reference to the key in the entry.
+    #[inline]
     pub fn key(&self) -> &K {
         self.inner.key()
     }
 
     /// Take ownership of the key.
+    #[inline]
     pub fn into_key(self) -> K {
         self.inner.into_key()
     }
 
     /// Sets the value of the entry with the [`VacantEntry`]'s key, and returns a mutable reference to it.
+    #[inline]
     pub fn insert(self, value: V) -> &'a mut V
     where
         K: Hash,
@@ -353,6 +387,7 @@ impl<K, V> FromIterator<(K, V)> for IndexMap<K, V>
 where
     K: Hash + Ord + Eq + Clone,
 {
+    #[inline]
     fn from_iter<I>(iter: I) -> Self
     where
         I: IntoIterator<Item = (K, V)>,
@@ -367,6 +402,7 @@ impl<'a, K, V> IntoIterator for &'a IndexMap<K, V> {
     type Item = (&'a K, &'a V);
     type IntoIter = Iter<'a, K, V>;
 
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
@@ -381,16 +417,19 @@ pub struct Iter<'a, K, V> {
 impl<'a, K, V> Iterator for Iter<'a, K, V> {
     type Item = (&'a K, &'a V);
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
 }
 
 impl<'a, K, V> ExactSizeIterator for Iter<'a, K, V> {
+    #[inline]
     fn len(&self) -> usize {
         self.inner.len()
     }
@@ -402,6 +441,7 @@ impl<'a, K, V> IntoIterator for &'a mut IndexMap<K, V> {
     type Item = (&'a K, &'a mut V);
     type IntoIter = IterMut<'a, K, V>;
 
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
         self.iter_mut()
     }
@@ -416,16 +456,19 @@ pub struct IterMut<'a, K, V> {
 impl<'a, K, V> Iterator for IterMut<'a, K, V> {
     type Item = (&'a K, &'a mut V);
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
 }
 
 impl<'a, K, V> ExactSizeIterator for IterMut<'a, K, V> {
+    #[inline]
     fn len(&self) -> usize {
         self.inner.len()
     }
@@ -437,6 +480,7 @@ impl<K, V> IntoIterator for IndexMap<K, V> {
     type Item = (K, V);
     type IntoIter = IntoIter<K, V>;
 
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
         IntoIter {
             inner: self.inner.into_iter(),
@@ -453,16 +497,19 @@ pub struct IntoIter<K, V> {
 impl<'a, K, V> Iterator for IntoIter<K, V> {
     type Item = (K, V);
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
 }
 
 impl<'a, K, V> ExactSizeIterator for IntoIter<K, V> {
+    #[inline]
     fn len(&self) -> usize {
         self.inner.len()
     }
@@ -479,16 +526,19 @@ pub struct Keys<'a, K, V> {
 impl<'a, K, V> Iterator for Keys<'a, K, V> {
     type Item = &'a K;
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
 }
 
 impl<'a, K, V> ExactSizeIterator for Keys<'a, K, V> {
+    #[inline]
     fn len(&self) -> usize {
         self.inner.len()
     }
@@ -505,16 +555,19 @@ pub struct Values<'a, K, V> {
 impl<'a, K, V> Iterator for Values<'a, K, V> {
     type Item = &'a V;
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
 }
 
 impl<'a, K, V> ExactSizeIterator for Values<'a, K, V> {
+    #[inline]
     fn len(&self) -> usize {
         self.inner.len()
     }
@@ -531,16 +584,19 @@ pub struct ValuesMut<'a, K, V> {
 impl<'a, K, V> Iterator for ValuesMut<'a, K, V> {
     type Item = &'a mut V;
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
 }
 
 impl<'a, K, V> ExactSizeIterator for ValuesMut<'a, K, V> {
+    #[inline]
     fn len(&self) -> usize {
         self.inner.len()
     }

--- a/crates/wasmparser/src/collections/index_set.rs
+++ b/crates/wasmparser/src/collections/index_set.rs
@@ -15,6 +15,7 @@ pub struct IndexSet<T> {
 }
 
 impl<T> Default for IndexSet<T> {
+    #[inline]
     fn default() -> Self {
         Self {
             inner: IndexMap::default(),
@@ -24,21 +25,25 @@ impl<T> Default for IndexSet<T> {
 
 impl<T> IndexSet<T> {
     /// Clears the [`IndexSet`], removing all elements.
+    #[inline]
     pub fn clear(&mut self) {
         self.inner.clear()
     }
 
     /// Returns the number of elements in the [`IndexSet`].
+    #[inline]
     pub fn len(&self) -> usize {
         self.inner.len()
     }
 
     /// Returns `true` if the [`IndexSet`] contains no elements.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
 
     /// Returns an iterator that yields the items in the [`IndexSet`].
+    #[inline]
     pub fn iter(&self) -> Iter<'_, T> {
         Iter {
             inner: self.inner.iter(),
@@ -51,11 +56,13 @@ where
     T: Eq + Hash + Ord + Clone,
 {
     /// Reserves capacity for at least `additional` more elements to be inserted in the [`IndexSet`].
+    #[inline]
     pub fn reserve(&mut self, additional: usize) {
         self.inner.reserve(additional);
     }
 
     /// Returns true if the [`IndexSet`] contains an element equal to the `value`.
+    #[inline]
     pub fn contains<Q: ?Sized>(&self, value: &Q) -> bool
     where
         T: Borrow<Q>,
@@ -65,6 +72,7 @@ where
     }
 
     /// Returns a reference to the element in the [`IndexSet`], if any, that is equal to the `value`.
+    #[inline]
     pub fn get<Q: ?Sized>(&self, value: &Q) -> Option<&T>
     where
         T: Borrow<Q>,
@@ -79,6 +87,7 @@ where
     ///
     /// - Returns `true` if the set did not previously contain an equal value.
     /// - Returns `false` otherwise and the entry is not updated.
+    #[inline]
     pub fn insert(&mut self, value: T) -> bool {
         self.inner.insert(value, ()).is_none()
     }
@@ -94,6 +103,7 @@ where
     /// Computes in **O(1)** time (average).
     ///
     /// [`Vec::swap_remove`]: alloc::vec::Vec::swap_remove
+    #[inline]
     pub fn swap_remove<Q: ?Sized>(&mut self, value: &Q) -> bool
     where
         T: Borrow<Q>,
@@ -128,6 +138,7 @@ where
 
     /// Returns `true` if the [`IndexSet`] is a superset of another,
     /// i.e., `self` contains at least all the values in `other`.
+    #[inline]
     pub fn is_superset(&self, other: &Self) -> bool {
         other.is_subset(self)
     }
@@ -139,6 +150,7 @@ where
 {
     type Output = T;
 
+    #[inline]
     fn index(&self, index: usize) -> &T {
         let Some((value, _)) = self.inner.get_index(index) else {
             panic!("out of bounds index: {index}");
@@ -165,6 +177,7 @@ impl<'a, T> IntoIterator for &'a IndexSet<T> {
     type Item = &'a T;
     type IntoIter = Iter<'a, T>;
 
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
@@ -188,16 +201,19 @@ pub struct Iter<'a, T> {
 impl<'a, T> Iterator for Iter<'a, T> {
     type Item = &'a T;
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next().map(|(key, _value)| key)
     }
 }
 
 impl<'a, T> ExactSizeIterator for Iter<'a, T> {
+    #[inline]
     fn len(&self) -> usize {
         self.inner.len()
     }
@@ -209,6 +225,7 @@ impl<T> IntoIterator for IndexSet<T> {
     type Item = T;
     type IntoIter = IntoIter<T>;
 
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
         IntoIter {
             inner: self.inner.into_iter(),
@@ -225,16 +242,19 @@ pub struct IntoIter<T> {
 impl<T> Iterator for IntoIter<T> {
     type Item = T;
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next().map(|(key, _value)| key)
     }
 }
 
 impl<T> ExactSizeIterator for IntoIter<T> {
+    #[inline]
     fn len(&self) -> usize {
         self.inner.len()
     }

--- a/crates/wasmparser/src/collections/map.rs
+++ b/crates/wasmparser/src/collections/map.rs
@@ -52,6 +52,7 @@ pub struct Map<K, V> {
 }
 
 impl<K, V> Default for Map<K, V> {
+    #[inline]
     fn default() -> Self {
         Self {
             inner: detail::MapImpl::default(),
@@ -61,26 +62,31 @@ impl<K, V> Default for Map<K, V> {
 
 impl<K, V> Map<K, V> {
     /// Creates a new empty [`Map`].
+    #[inline]
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Clears the [`Map`], removing all elements.
+    #[inline]
     pub fn clear(&mut self) {
         self.inner.clear()
     }
 
     /// Returns the number of elements in the [`Map`].
+    #[inline]
     pub fn len(&self) -> usize {
         self.inner.len()
     }
 
     /// Returns `true` if the [`Map`] contains no elements.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
 
     /// Returns an iterator that yields the items in the [`Map`].
+    #[inline]
     pub fn iter(&self) -> Iter<'_, K, V> {
         Iter {
             inner: self.inner.iter(),
@@ -88,6 +94,7 @@ impl<K, V> Map<K, V> {
     }
 
     /// Returns a mutable iterator that yields the items in the [`Map`].
+    #[inline]
     pub fn iter_mut(&mut self) -> IterMut<'_, K, V> {
         IterMut {
             inner: self.inner.iter_mut(),
@@ -95,6 +102,7 @@ impl<K, V> Map<K, V> {
     }
 
     /// Returns an iterator that yields the keys in the [`Map`].
+    #[inline]
     pub fn keys(&self) -> Keys<'_, K, V> {
         Keys {
             inner: self.inner.keys(),
@@ -105,6 +113,7 @@ impl<K, V> Map<K, V> {
     ///
     /// The [`Map`] cannot be used after calling this.
     /// The iterator element type is `K`.
+    #[inline]
     pub fn into_keys(self) -> IntoKeys<K, V> {
         IntoKeys {
             inner: self.inner.into_keys(),
@@ -112,6 +121,7 @@ impl<K, V> Map<K, V> {
     }
 
     /// Returns an iterator that yields the values in the [`Map`].
+    #[inline]
     pub fn values(&self) -> Values<'_, K, V> {
         Values {
             inner: self.inner.values(),
@@ -122,6 +132,7 @@ impl<K, V> Map<K, V> {
     ///
     /// The [`Map`] cannot be used after calling this.
     /// The iterator element type is `V`.
+    #[inline]
     pub fn into_values(self) -> IntoValues<K, V> {
         IntoValues {
             inner: self.inner.into_values(),
@@ -129,6 +140,7 @@ impl<K, V> Map<K, V> {
     }
 
     /// Returns a mutable iterator that yields the values in the [`Map`].
+    #[inline]
     pub fn values_mut(&mut self) -> ValuesMut<'_, K, V> {
         ValuesMut {
             inner: self.inner.values_mut(),
@@ -141,6 +153,7 @@ where
     K: Hash + Eq + Ord,
 {
     /// Reserves capacity for at least `additional` more elements to be inserted in the [`Map`].
+    #[inline]
     pub fn reserve(&mut self, additional: usize) {
         #[cfg(not(feature = "no-hash-maps"))]
         self.inner.reserve(additional);
@@ -149,6 +162,7 @@ where
     }
 
     /// Returns true if `key` is contains in the [`Map`].
+    #[inline]
     pub fn contains_key<Q>(&self, key: &Q) -> bool
     where
         K: Borrow<Q>,
@@ -158,6 +172,7 @@ where
     }
 
     /// Returns a reference to the value corresponding to the `key`.
+    #[inline]
     pub fn get<Q>(&self, key: &Q) -> Option<&V>
     where
         K: Borrow<Q>,
@@ -170,6 +185,7 @@ where
     ///
     /// The supplied key may be any borrowed form of the map's key type, but the ordering
     /// on the borrowed form *must* match the ordering on the key type.
+    #[inline]
     pub fn get_key_value<Q>(&self, key: &Q) -> Option<(&K, &V)>
     where
         K: Borrow<Q>,
@@ -179,6 +195,7 @@ where
     }
 
     /// Returns a mutable reference to the value corresponding to the key.
+    #[inline]
     pub fn get_mut<Q>(&mut self, key: &Q) -> Option<&mut V>
     where
         K: Borrow<Q>,
@@ -194,11 +211,13 @@ where
     /// If the map did have this key present, the value is updated, and the old
     /// value is returned. The key is not updated, though; this matters for
     /// types that can be `==` without being identical.
+    #[inline]
     pub fn insert(&mut self, key: K, value: V) -> Option<V> {
         self.inner.insert(key, value)
     }
 
     /// Removes a key from the [`Map`], returning the value at the key if the key was previously in the map.
+    #[inline]
     pub fn remove<Q>(&mut self, key: &Q) -> Option<V>
     where
         K: Borrow<Q>,
@@ -212,6 +231,7 @@ where
     ///
     /// The key may be any borrowed form of the map's key type, but the ordering
     /// on the borrowed form *must* match the ordering on the key type.
+    #[inline]
     pub fn remove_entry<Q>(&mut self, key: &Q) -> Option<(K, V)>
     where
         K: Borrow<Q>,
@@ -221,6 +241,7 @@ where
     }
 
     /// Gets the given key's corresponding entry in the [`Map`] for in-place manipulation.
+    #[inline]
     pub fn entry(&mut self, key: K) -> Entry<'_, K, V> {
         match self.inner.entry(key) {
             detail::EntryImpl::Occupied(entry) => Entry::Occupied(OccupiedEntry { inner: entry }),
@@ -232,6 +253,7 @@ where
     ///
     /// In other words, remove all pairs `(k, v)` for which `f(&k, &mut v)` returns `false`.
     /// The elements are visited in ascending key order.
+    #[inline]
     pub fn retain<F>(&mut self, f: F)
     where
         F: FnMut(&K, &mut V) -> bool,
@@ -245,6 +267,7 @@ where
     K: Eq + Hash,
     V: Eq,
 {
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.inner == other.inner
     }
@@ -264,6 +287,7 @@ where
 {
     type Output = V;
 
+    #[inline]
     fn index(&self, key: &Q) -> &V {
         &self.inner[key]
     }
@@ -274,6 +298,7 @@ where
     K: Eq + Hash + Ord + Copy,
     V: Copy,
 {
+    #[inline]
     fn extend<Iter: IntoIterator<Item = (&'a K, &'a V)>>(&mut self, iter: Iter) {
         self.inner.extend(iter)
     }
@@ -283,6 +308,7 @@ impl<K, V> Extend<(K, V)> for Map<K, V>
 where
     K: Eq + Hash + Ord,
 {
+    #[inline]
     fn extend<Iter: IntoIterator<Item = (K, V)>>(&mut self, iter: Iter) {
         self.inner.extend(iter)
     }
@@ -305,6 +331,7 @@ where
 {
     /// Ensures a value is in the entry by inserting the default if empty, and returns
     /// a mutable reference to the value in the entry.
+    #[inline]
     pub fn or_insert(self, default: V) -> &'a mut V {
         match self {
             Self::Occupied(entry) => entry.into_mut(),
@@ -314,6 +341,7 @@ where
 
     /// Ensures a value is in the [`Entry`] by inserting the result of the default function if empty,
     /// and returns a mutable reference to the value in the entry.
+    #[inline]
     pub fn or_insert_with<F: FnOnce() -> V>(self, default: F) -> &'a mut V {
         match self {
             Self::Occupied(entry) => entry.into_mut(),
@@ -327,6 +355,7 @@ where
     ///
     /// The reference to the moved key is provided so that cloning or copying the key is
     /// unnecessary, unlike with `.or_insert_with(|| ... )`.
+    #[inline]
     pub fn or_insert_with_key<F: FnOnce(&K) -> V>(self, default: F) -> &'a mut V {
         match self {
             Self::Occupied(entry) => entry.into_mut(),
@@ -338,6 +367,7 @@ where
     }
 
     /// Returns a reference to this [`Entry`]'s key.
+    #[inline]
     pub fn key(&self) -> &K {
         match *self {
             Self::Occupied(ref entry) => entry.key(),
@@ -347,6 +377,7 @@ where
 
     /// Provides in-place mutable access to an occupied [`Entry`] before any
     /// potential inserts into the map.
+    #[inline]
     pub fn and_modify<F>(self, f: F) -> Self
     where
         F: FnOnce(&mut V),
@@ -368,6 +399,7 @@ where
 {
     /// Ensures a value is in the [`Entry`] by inserting the default value if empty,
     /// and returns a mutable reference to the value in the entry.
+    #[inline]
     pub fn or_default(self) -> &'a mut V {
         match self {
             Self::Occupied(entry) => entry.into_mut(),
@@ -399,37 +431,44 @@ where
     V: 'a,
 {
     /// Gets a reference to the key in the entry.
+    #[inline]
     pub fn key(&self) -> &K {
         self.inner.key()
     }
 
     /// Gets a reference to the value in the entry.
+    #[inline]
     pub fn get(&self) -> &V {
         self.inner.get()
     }
 
     /// Gets a mutable reference to the value in the entry.
+    #[inline]
     pub fn get_mut(&mut self) -> &mut V {
         self.inner.get_mut()
     }
 
     /// Sets the value of the entry with the [`OccupiedEntry`]'s key, and returns the entry's old value.
+    #[inline]
     pub fn insert(&mut self, value: V) -> V {
         self.inner.insert(value)
     }
 
     /// Converts the [`OccupiedEntry`] into a mutable reference to the value in the entry
     /// with a lifetime bound to the map itself.
+    #[inline]
     pub fn into_mut(self) -> &'a mut V {
         self.inner.into_mut()
     }
 
     /// Take ownership of the key and value from the [`Map`].
+    #[inline]
     pub fn remove_entry(self) -> (K, V) {
         self.inner.remove_entry()
     }
 
     /// Takes the value of the entry out of the [`Map`], and returns it.
+    #[inline]
     pub fn remove(self) -> V {
         self.inner.remove()
     }
@@ -458,16 +497,19 @@ where
     V: 'a,
 {
     /// Gets a reference to the key in the entry.
+    #[inline]
     pub fn key(&self) -> &K {
         self.inner.key()
     }
 
     /// Take ownership of the key.
+    #[inline]
     pub fn into_key(self) -> K {
         self.inner.into_key()
     }
 
     /// Sets the value of the entry with the [`VacantEntry`]'s key, and returns a mutable reference to it.
+    #[inline]
     pub fn insert(self, value: V) -> &'a mut V
     where
         K: Hash,
@@ -480,6 +522,7 @@ impl<K, V> FromIterator<(K, V)> for Map<K, V>
 where
     K: Hash + Eq + Ord,
 {
+    #[inline]
     fn from_iter<I>(iter: I) -> Self
     where
         I: IntoIterator<Item = (K, V)>,
@@ -494,6 +537,7 @@ impl<'a, K, V> IntoIterator for &'a Map<K, V> {
     type Item = (&'a K, &'a V);
     type IntoIter = Iter<'a, K, V>;
 
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
@@ -508,16 +552,19 @@ pub struct Iter<'a, K, V> {
 impl<'a, K: 'a, V: 'a> Iterator for Iter<'a, K, V> {
     type Item = (&'a K, &'a V);
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
 }
 
 impl<'a, K: 'a, V: 'a> ExactSizeIterator for Iter<'a, K, V> {
+    #[inline]
     fn len(&self) -> usize {
         self.inner.len()
     }
@@ -532,6 +579,7 @@ impl<'a, K: 'a, V: 'a> IntoIterator for &'a mut Map<K, V> {
     type Item = (&'a K, &'a mut V);
     type IntoIter = IterMut<'a, K, V>;
 
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
         self.iter_mut()
     }
@@ -546,16 +594,19 @@ pub struct IterMut<'a, K, V> {
 impl<'a, K: 'a, V: 'a> Iterator for IterMut<'a, K, V> {
     type Item = (&'a K, &'a mut V);
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
 }
 
 impl<'a, K: 'a, V: 'a> ExactSizeIterator for IterMut<'a, K, V> {
+    #[inline]
     fn len(&self) -> usize {
         self.inner.len()
     }
@@ -570,6 +621,7 @@ impl<K, V> IntoIterator for Map<K, V> {
     type Item = (K, V);
     type IntoIter = IntoIter<K, V>;
 
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
         IntoIter {
             inner: self.inner.into_iter(),
@@ -586,16 +638,19 @@ pub struct IntoIter<K, V> {
 impl<K, V> Iterator for IntoIter<K, V> {
     type Item = (K, V);
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
 }
 
 impl<K, V> ExactSizeIterator for IntoIter<K, V> {
+    #[inline]
     fn len(&self) -> usize {
         self.inner.len()
     }
@@ -612,16 +667,19 @@ pub struct Keys<'a, K, V> {
 impl<'a, K: 'a, V> Iterator for Keys<'a, K, V> {
     type Item = &'a K;
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
 }
 
 impl<'a, K: 'a, V> ExactSizeIterator for Keys<'a, K, V> {
+    #[inline]
     fn len(&self) -> usize {
         self.inner.len()
     }
@@ -638,16 +696,19 @@ pub struct Values<'a, K, V> {
 impl<'a, K, V: 'a> Iterator for Values<'a, K, V> {
     type Item = &'a V;
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
 }
 
 impl<'a, K, V: 'a> ExactSizeIterator for Values<'a, K, V> {
+    #[inline]
     fn len(&self) -> usize {
         self.inner.len()
     }
@@ -667,16 +728,19 @@ pub struct ValuesMut<'a, K, V> {
 impl<'a, K, V: 'a> Iterator for ValuesMut<'a, K, V> {
     type Item = &'a mut V;
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
 }
 
 impl<'a, K, V: 'a> ExactSizeIterator for ValuesMut<'a, K, V> {
+    #[inline]
     fn len(&self) -> usize {
         self.inner.len()
     }
@@ -696,16 +760,19 @@ pub struct IntoKeys<K, V> {
 impl<K, V> Iterator for IntoKeys<K, V> {
     type Item = K;
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
 }
 
 impl<K, V> ExactSizeIterator for IntoKeys<K, V> {
+    #[inline]
     fn len(&self) -> usize {
         self.inner.len()
     }
@@ -722,16 +789,19 @@ pub struct IntoValues<K, V> {
 impl<K, V> Iterator for IntoValues<K, V> {
     type Item = V;
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
 }
 
 impl<K, V> ExactSizeIterator for IntoValues<K, V> {
+    #[inline]
     fn len(&self) -> usize {
         self.inner.len()
     }

--- a/crates/wasmparser/src/collections/set.rs
+++ b/crates/wasmparser/src/collections/set.rs
@@ -49,6 +49,7 @@ pub struct Set<T> {
 }
 
 impl<T> Default for Set<T> {
+    #[inline]
     fn default() -> Self {
         Self {
             inner: detail::SetImpl::default(),
@@ -58,6 +59,7 @@ impl<T> Default for Set<T> {
 
 impl<T> Set<T> {
     /// Clears the [`Set`], removing all elements.
+    #[inline]
     pub fn clear(&mut self) {
         self.inner.clear()
     }
@@ -66,6 +68,7 @@ impl<T> Set<T> {
     ///
     /// In other words, remove all elements `e` for which `f(&e)` returns `false`.
     /// The elements are visited in unsorted (and unspecified) order.
+    #[inline]
     pub fn retain<F>(&mut self, f: F)
     where
         T: Ord,
@@ -75,16 +78,19 @@ impl<T> Set<T> {
     }
 
     /// Returns the number of elements in the [`Set`].
+    #[inline]
     pub fn len(&self) -> usize {
         self.inner.len()
     }
 
     /// Returns `true` if the [`Set`] contains no elements.
+    #[inline]
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
 
     /// Returns an iterator that yields the items in the [`Set`].
+    #[inline]
     pub fn iter(&self) -> Iter<'_, T> {
         Iter {
             inner: self.inner.iter(),
@@ -97,6 +103,7 @@ where
     T: Eq + Hash + Ord,
 {
     /// Reserves capacity for at least `additional` more elements to be inserted in the [`Set`].
+    #[inline]
     pub fn reserve(&mut self, additional: usize) {
         #[cfg(not(feature = "no-hash-maps"))]
         self.inner.reserve(additional);
@@ -105,6 +112,7 @@ where
     }
 
     /// Returns true if the [`Set`] contains an element equal to the `value`.
+    #[inline]
     pub fn contains<Q>(&self, value: &Q) -> bool
     where
         T: Borrow<Q>,
@@ -114,6 +122,7 @@ where
     }
 
     /// Returns a reference to the element in the [`Set`], if any, that is equal to the `value`.
+    #[inline]
     pub fn get<Q>(&self, value: &Q) -> Option<&T>
     where
         T: Borrow<Q>,
@@ -128,6 +137,7 @@ where
     ///
     /// - Returns `true` if the set did not previously contain an equal value.
     /// - Returns `false` otherwise and the entry is not updated.
+    #[inline]
     pub fn insert(&mut self, value: T) -> bool {
         self.inner.insert(value)
     }
@@ -135,6 +145,7 @@ where
     /// If the set contains an element equal to the value, removes it from the [`Set`] and drops it.
     ///
     /// Returns `true` if such an element was present, otherwise `false`.
+    #[inline]
     pub fn remove<Q>(&mut self, value: &Q) -> bool
     where
         T: Borrow<Q>,
@@ -149,6 +160,7 @@ where
     /// The value may be any borrowed form of the set's element type,
     /// but the ordering on the borrowed form *must* match the
     /// ordering on the element type.
+    #[inline]
     pub fn take<Q>(&mut self, value: &Q) -> Option<T>
     where
         T: Borrow<Q>,
@@ -159,30 +171,35 @@ where
 
     /// Adds a value to the [`Set`], replacing the existing value, if any, that is equal to the given
     /// one. Returns the replaced value.
+    #[inline]
     pub fn replace(&mut self, value: T) -> Option<T> {
         self.inner.replace(value)
     }
 
     /// Returns `true` if `self` has no elements in common with `other`.
     /// This is equivalent to checking for an empty intersection.
+    #[inline]
     pub fn is_disjoint(&self, other: &Self) -> bool {
         self.inner.is_disjoint(&other.inner)
     }
 
     /// Returns `true` if the [`Set`] is a subset of another,
     /// i.e., `other` contains at least all the values in `self`.
+    #[inline]
     pub fn is_subset(&self, other: &Self) -> bool {
         self.inner.is_subset(&other.inner)
     }
 
     /// Returns `true` if the [`Set`] is a superset of another,
     /// i.e., `self` contains at least all the values in `other`.
+    #[inline]
     pub fn is_superset(&self, other: &Self) -> bool {
         self.inner.is_superset(&other.inner)
     }
 
     /// Visits the values representing the difference,
     /// i.e., the values that are in `self` but not in `other`.
+    #[inline]
     pub fn difference<'a>(&'a self, other: &'a Self) -> Difference<'a, T> {
         Difference {
             inner: self.inner.difference(&other.inner),
@@ -191,6 +208,7 @@ where
 
     /// Visits the values representing the symmetric difference,
     /// i.e., the values that are in `self` or in `other` but not in both.
+    #[inline]
     pub fn symmetric_difference<'a>(&'a self, other: &'a Self) -> SymmetricDifference<'a, T> {
         SymmetricDifference {
             inner: self.inner.symmetric_difference(&other.inner),
@@ -205,6 +223,7 @@ where
     /// one or the other. This can be relevant if `T` contains fields which
     /// are not compared by its `Eq` implementation, and may hold different
     /// value between the two equal copies of `T` in the two sets.
+    #[inline]
     pub fn intersection<'a>(&'a self, other: &'a Self) -> Intersection<'a, T> {
         Intersection {
             inner: self.inner.intersection(&other.inner),
@@ -213,6 +232,7 @@ where
 
     /// Visits the values representing the union,
     /// i.e., all the values in `self` or `other`, without duplicates.
+    #[inline]
     pub fn union<'a>(&'a self, other: &'a Self) -> Union<'a, T> {
         Union {
             inner: self.inner.union(&other.inner),
@@ -224,6 +244,7 @@ impl<T> PartialEq for Set<T>
 where
     T: Eq + Hash,
 {
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.inner == other.inner
     }
@@ -235,6 +256,7 @@ impl<T> FromIterator<T> for Set<T>
 where
     T: Hash + Eq + Ord,
 {
+    #[inline]
     fn from_iter<I>(iter: I) -> Self
     where
         I: IntoIterator<Item = T>,
@@ -249,6 +271,7 @@ impl<'a, T> IntoIterator for &'a Set<T> {
     type Item = &'a T;
     type IntoIter = Iter<'a, T>;
 
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
     }
@@ -258,6 +281,7 @@ impl<'a, T> Extend<&'a T> for Set<T>
 where
     T: Hash + Eq + Ord + Copy + 'a,
 {
+    #[inline]
     fn extend<Iter: IntoIterator<Item = &'a T>>(&mut self, iter: Iter) {
         self.inner.extend(iter)
     }
@@ -267,6 +291,7 @@ impl<T> Extend<T> for Set<T>
 where
     T: Hash + Eq + Ord,
 {
+    #[inline]
     fn extend<Iter: IntoIterator<Item = T>>(&mut self, iter: Iter) {
         self.inner.extend(iter)
     }
@@ -278,6 +303,7 @@ where
 {
     type Output = Set<T>;
 
+    #[inline]
     fn bitand(self, rhs: Self) -> Set<T> {
         Set {
             inner: BitAnd::bitand(&self.inner, &rhs.inner),
@@ -291,6 +317,7 @@ where
 {
     type Output = Set<T>;
 
+    #[inline]
     fn bitor(self, rhs: Self) -> Set<T> {
         Set {
             inner: BitOr::bitor(&self.inner, &rhs.inner),
@@ -304,6 +331,7 @@ where
 {
     type Output = Set<T>;
 
+    #[inline]
     fn bitxor(self, rhs: Self) -> Set<T> {
         Set {
             inner: BitXor::bitxor(&self.inner, &rhs.inner),
@@ -317,6 +345,7 @@ where
 {
     type Output = Set<T>;
 
+    #[inline]
     fn sub(self, rhs: Self) -> Set<T> {
         Set {
             inner: Sub::sub(&self.inner, &rhs.inner),
@@ -333,16 +362,19 @@ pub struct Iter<'a, T> {
 impl<'a, T: 'a> Iterator for Iter<'a, T> {
     type Item = &'a T;
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
 }
 
 impl<'a, T: 'a> ExactSizeIterator for Iter<'a, T> {
+    #[inline]
     fn len(&self) -> usize {
         self.inner.len()
     }
@@ -354,6 +386,7 @@ impl<T> IntoIterator for Set<T> {
     type Item = T;
     type IntoIter = IntoIter<T>;
 
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
         IntoIter {
             inner: self.inner.into_iter(),
@@ -370,16 +403,19 @@ pub struct IntoIter<T> {
 impl<T> Iterator for IntoIter<T> {
     type Item = T;
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
 }
 
 impl<T> ExactSizeIterator for IntoIter<T> {
+    #[inline]
     fn len(&self) -> usize {
         self.inner.len()
     }
@@ -407,6 +443,7 @@ where
 }
 
 impl<T> Clone for Difference<'_, T> {
+    #[inline]
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
@@ -420,10 +457,12 @@ where
 {
     type Item = &'a T;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
@@ -456,6 +495,7 @@ where
 }
 
 impl<T> Clone for Intersection<'_, T> {
+    #[inline]
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
@@ -469,10 +509,12 @@ where
 {
     type Item = &'a T;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
@@ -505,6 +547,7 @@ where
 }
 
 impl<T> Clone for SymmetricDifference<'_, T> {
+    #[inline]
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
@@ -518,10 +561,12 @@ where
 {
     type Item = &'a T;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }
@@ -554,6 +599,7 @@ where
 }
 
 impl<T> Clone for Union<'_, T> {
+    #[inline]
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
@@ -567,10 +613,12 @@ where
 {
     type Item = &'a T;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.inner.next()
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.inner.size_hint()
     }


### PR DESCRIPTION
I applied `#[inline]` to all trivial methods of types in the `wasmparser::collections` submodule [as stated here](https://github.com/bytecodealliance/wasm-tools/pull/1521#issuecomment-2106164632).

I ran benchmarks on `main` and the PR and built `main` and PR after a `cargo clean` to observe the performance impact of the changes on both compilation and execution. The tl;dr is that compile times are the same, and I only see minor improvements on execution.

Build times:

- `main`: 16.08s user 0.46s system 343% cpu 4.822 total
- PR: 16.04s user 0.46s system 348% cpu 4.736 total

Benchmarks: (PR run after `main` run)

## Default Features

![image](https://github.com/bytecodealliance/wasm-tools/assets/8193155/a61af3cc-da31-4d0a-a1df-d2dbad6567ee)

## Features: `no-hash-maps`

![image](https://github.com/bytecodealliance/wasm-tools/assets/8193155/4dedec89-4577-4a0c-818f-c41de8944fe2)
