### PR TITLE
Add `PartialEq` impls for `Index{Map,Set}` types

### DIFF
--- a/crates/wasmparser/src/collections/index_map.rs
+++ b/crates/wasmparser/src/collections/index_map.rs
@@ -633,3 +633,24 @@ where
         })
     }
 }
+
+impl<K, V> PartialEq for IndexMap<K, V>
+where
+    K: PartialEq + Hash + Ord,
+    V: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+
+    fn ne(&self, other: &Self) -> bool {
+        self.inner != other.inner
+    }
+}
+
+impl<K, V> Eq for IndexMap<K, V>
+where
+    K: Eq + Hash + Ord,
+    V: Eq,
+{
+}

--- a/crates/wasmparser/src/collections/index_set.rs
+++ b/crates/wasmparser/src/collections/index_set.rs
@@ -289,3 +289,18 @@ where
         })
     }
 }
+
+impl<T> PartialEq for IndexSet<T>
+where
+    T: PartialEq + Hash + Ord,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+
+    fn ne(&self, other: &Self) -> bool {
+        self.inner != other.inner
+    }
+}
+
+impl<T> Eq for IndexSet<T> where T: Eq + Hash + Ord {}


### PR DESCRIPTION
Currently required in Wasmtime so add then back in with the trivial implementations.