### PR TITLE
Fix `no_std` build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -219,6 +219,8 @@ jobs:
       - run: cargo check --no-default-features -p wit-parser --features serde,decoding,wat
       - run: cargo check --no-default-features -p wasmparser
       - run: cargo check --no-default-features -p wasmparser --target x86_64-unknown-none
+      - run: cargo check --no-default-features -p wasmparser --target x86_64-unknown-none --features validate,serde
+      - run: cargo check --no-default-features -p wasmparser --target x86_64-unknown-none --features validate,serde,no-hash-maps
       - run: cargo check --no-default-features -p wasmparser --features std
       - run: cargo check --no-default-features -p wasmparser --features validate
       - run: cargo check --no-default-features -p wasmparser --features no-hash-maps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ log = "0.4.17"
 num_cpus = "1.13"
 rand = { version = "0.8.4", features = ["small_rng"] }
 rayon = "1.3"
-serde = "1.0.166"
+serde = { version = "1.0.166", default-features = false, features = ['alloc'] }
 serde_derive = "1.0.166"
 serde_json = { version = "1" }
 wasmtime = { version = "20.0.0", default-features = false, features = ['cranelift', 'component-model', 'runtime', 'gc'] }


### PR DESCRIPTION
This fixes a mistake in #1569 where it accidentally broke `no_std` support since the `std` feature of the `serde` crate was still enabled.