### PR TITLE
Check `...BACKTRACE` variables gracefully before running tests

### DIFF
--- a/crates/wit-parser/tests/all.rs
+++ b/crates/wit-parser/tests/all.rs
@@ -33,11 +33,11 @@ fn main() {
     // for debugging purposes.
     if bless && wasm_debug_backtrace {
         eprintln!("Cannot set both the `BLESS=1` and `WASM_DEBUG_BACKTRACE=1` env variables simultaneously; blessing a new set of golden values and debugging broken tests should be separate operations.");
-        return
+        return;
     }
     if (rust_backtrace || rust_lib_backtrace) && !wasm_debug_backtrace {
         eprintln!("One of the `RUST_BACKTRACE`/`RUST_LIB_BACKTRACE` env variables is currently set to a truthy value; please either disable these (to allow `parse-fail` tests to run properly), or, if debugging, also set `WASM_DEBUG_BACKTRACE=1` to indicate that these tests failing with a detailed backtrace is the desired effect.");
-        return
+        return;
     }
 
     let mut trials = Vec::new();


### PR DESCRIPTION
This caught me a few times, especially since I had two terminals open, one with `export RUST_BACKTRACE=1` and one without. It took me longer than I'd like to admit to figure out why tests were passing in one and not the other!

If this is viewed as a desirable check to keep other contributors from tripping over this quirk, it may be useful to extract into its own `utils` crate, since the logic of dealing with the interaction of the `BLESS` and RUST_[LIB_]BACKTRACE` env variables occurs in a number of other internal crates' test suites as well.