### PR TITLE
Add .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ publish
 *.wat
 test.config
 
+.vscode/


### PR DESCRIPTION
A nicety that allows VSCode-based developers to set custom settings and launch configurations for this project at their leisure.