### PR TITLE
`wasmparser`: Fix validation of the `return_call` family of instructions

### DIFF
--- a/tests/local/function-references/return-call.wast
+++ b/tests/local/function-references/return-call.wast
@@ -1,0 +1,37 @@
+;; Test that various return calls must exactly match the callee's returns, not
+;; simply leave the operand stack in a state where a `call; return` would
+;; otherwise be valid, but with some dangling stack values. Those dangling stack
+;; values are valid for regular calls, but not for return calls.
+
+(assert_invalid
+  (module
+    (func $f (result i32 i32) unreachable)
+    (func (result i32)
+      return_call $f
+    )
+  )
+  "type mismatch: current function requires result type [i32] but callee returns [i32 i32]"
+)
+
+(assert_invalid
+  (module
+    (type $ty (func (result i32 i32)))
+    (import "env" "table" (table $table 0 funcref))
+    (func (param i32) (result i32)
+      local.get 0
+      return_call_indirect $table (type $ty)
+    )
+  )
+  "type mismatch: current function requires result type [i32] but callee returns [i32 i32]"
+)
+
+(assert_invalid
+  (module
+    (type $ty (func (result i32 i32)))
+    (func (param funcref) (result i32)
+      local.get 0
+      return_call_ref $ty
+    )
+  )
+  "type mismatch: current function requires result type [i32] but callee returns [i32 i32]"
+)

--- a/tests/snapshots/local/function-references/return-call.wast.json
+++ b/tests/snapshots/local/function-references/return-call.wast.json
@@ -1,0 +1,26 @@
+{
+  "source_filename": "tests/local/function-references/return-call.wast",
+  "commands": [
+    {
+      "type": "assert_invalid",
+      "line": 7,
+      "filename": "return-call.0.wasm",
+      "text": "type mismatch: current function requires result type [i32] but callee returns [i32 i32]",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 17,
+      "filename": "return-call.1.wasm",
+      "text": "type mismatch: current function requires result type [i32] but callee returns [i32 i32]",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 29,
+      "filename": "return-call.2.wasm",
+      "text": "type mismatch: current function requires result type [i32] but callee returns [i32 i32]",
+      "module_type": "binary"
+    }
+  ]
+}


### PR DESCRIPTION
We need to additionally check that the callee's results are an exact match of the caller's results. We were incorrectly allowing return calls that would push more values on the operand stack than would be returned. That is fine with a `call; return` sequence, where extra values on the stack are allowed to dangle, but not okay with a `return_call`. With a `return_call` it doesn't make sense because the callee might need a return pointer to put all its results into, but the caller can't supply one since its frame is going away, nor can the caller forward a return pointer that it received to the callee, since it might not return enough values to require a return pointer. This commit fixes the validation to match the spec and disallow `return_call`s that would leave dangling values on the operand stack.

cc https://github.com/bytecodealliance/wasmtime/issues/8704