### PR TITLE
Improve error message for missing delimiter at EOF

### DIFF
--- a/crates/wit-parser/src/ast.rs
+++ b/crates/wit-parser/src/ast.rs
@@ -1385,10 +1385,7 @@ fn err_expected(
             format!("expected {}, found {}", expected, token.describe()),
         ),
         None => Error::new(
-            Span {
-                start: u32::try_from(tokens.input().len()).unwrap(),
-                end: u32::try_from(tokens.input().len()).unwrap(),
-            },
+            tokens.eof_span(),
             format!("expected {}, found eof", expected),
         ),
     }

--- a/crates/wit-parser/src/ast/lex.rs
+++ b/crates/wit-parser/src/ast/lex.rs
@@ -162,10 +162,6 @@ impl<'a> Tokenizer<'a> {
         Ok(())
     }
 
-    pub fn input(&self) -> &'a str {
-        self.input
-    }
-
     pub fn get_span(&self, span: Span) -> &'a str {
         let start = usize::try_from(span.start - self.span_offset).unwrap();
         let end = usize::try_from(span.end - self.span_offset).unwrap();
@@ -394,6 +390,11 @@ impl<'a> Tokenizer<'a> {
             }
             _ => false,
         }
+    }
+
+    pub fn eof_span(&self) -> Span {
+        let end = self.span_offset + u32::try_from(self.input.len()).unwrap();
+        Span { start: end, end }
     }
 }
 

--- a/crates/wit-parser/tests/ui/parse-fail/multi-file-missing-delimiter.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/multi-file-missing-delimiter.wit.result
@@ -1,0 +1,9 @@
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/multi-file-missing-delimiter]
+
+Caused by:
+    0: failed to parse package: tests/ui/parse-fail/multi-file-missing-delimiter
+    1: expected `type`, `resource` or `func`, found eof
+            --> tests/ui/parse-fail/multi-file-missing-delimiter/observe.wit:6:1
+             |
+           6 | 
+             | ^

--- a/crates/wit-parser/tests/ui/parse-fail/multi-file-missing-delimiter.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/multi-file-missing-delimiter.wit.result
@@ -3,7 +3,7 @@ failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/mult
 Caused by:
     0: failed to parse package: tests/ui/parse-fail/multi-file-missing-delimiter
     1: expected `type`, `resource` or `func`, found eof
-            --> tests/ui/parse-fail/multi-file-missing-delimiter/observe.wit:6:1
+            --> tests/ui/parse-fail/multi-file-missing-delimiter/observe.wit:5:5
              |
-           6 | 
-             | ^
+           5 |   // NB: intentionally missing a delimiter at the end of the file
+             |     ^

--- a/crates/wit-parser/tests/ui/parse-fail/multi-file-missing-delimiter.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/multi-file-missing-delimiter.wit.result
@@ -3,7 +3,7 @@ failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/mult
 Caused by:
     0: failed to parse package: tests/ui/parse-fail/multi-file-missing-delimiter
     1: expected `type`, `resource` or `func`, found eof
-            --> tests/ui/parse-fail/multi-file-missing-delimiter/observe.wit:5:5
+            --> tests/ui/parse-fail/multi-file-missing-delimiter/observe.wit:6:1
              |
-           5 |   // NB: intentionally missing a delimiter at the end of the file
-             |     ^
+           6 | 
+             | ^

--- a/crates/wit-parser/tests/ui/parse-fail/multi-file-missing-delimiter/observe.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/multi-file-missing-delimiter/observe.wit
@@ -1,0 +1,5 @@
+interface observe {
+  record bar {
+    a : string,
+  }
+  // NB: intentionally missing a delimiter at the end of the file

--- a/crates/wit-parser/tests/ui/parse-fail/multi-file-missing-delimiter/world.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/multi-file-missing-delimiter/world.wit
@@ -1,0 +1,5 @@
+package qux:qaz@2.0.0;
+
+world platform {
+  import observe;
+}


### PR DESCRIPTION
Due to the way source maps worked the span would point to the wrong file if the marker was pointing at the end of a file. While this still isn't necessarily a perfect error message it should be a significant improvement over before by actually pointing to the incorrect file.

Closes #1583