### PR TITLE
More internal refactorings of `wasmprinter` to print to an I/O source

### DIFF
--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -434,8 +434,7 @@ impl Printer {
                     let msg = format!("failed to parse custom section `{}`: {err}", c.name());
                     for line in msg.lines() {
                         self.newline(c.data_offset())?;
-                        self.result.push_str(";; ");
-                        self.result.push_str(line);
+                        write!(self.result, ";; {line}")?;
                     }
                     self.newline(c.range().end)?;
                     self.print_raw_custom_section(state, c)?;
@@ -610,8 +609,7 @@ impl Printer {
     }
 
     fn start_group(&mut self, name: &str) -> Result<()> {
-        write!(self.result, "(")?;
-        self.result.push_str(name);
+        write!(self.result, "({name}")?;
         self.nesting += 1;
         self.group_lines.push(self.line);
         Ok(())
@@ -891,7 +889,7 @@ impl Printer {
         }
         params.finish(&mut self.result);
         if !ty.results().is_empty() {
-            self.result.push_str(" (result");
+            write!(self.result, " (result")?;
             for result in ty.results().iter() {
                 write!(self.result, " ")?;
                 self.print_valtype(state, *result)?;
@@ -916,11 +914,11 @@ impl Printer {
             }
         }
         if ty.mutable {
-            self.result.push_str("(mut ");
+            write!(self.result, "(mut ")?;
         }
         self.print_storage_type(state, ty.element_type)?;
         if ty.mutable {
-            self.result.push_str(")");
+            write!(self.result, ")")?;
         }
         Ok(0)
     }
@@ -931,7 +929,7 @@ impl Printer {
 
     fn print_struct_type(&mut self, state: &State, ty: &StructType, ty_idx: u32) -> Result<u32> {
         for (field_index, field) in ty.fields.iter().enumerate() {
-            self.result.push_str(" (field");
+            write!(self.result, " (field")?;
             self.print_field_type(state, field, Some((ty_idx, field_index as u32)))?;
             write!(self.result, ")")?;
         }
@@ -941,7 +939,7 @@ impl Printer {
     fn print_sub_type(&mut self, state: &State, ty: &SubType) -> Result<u32> {
         write!(self.result, " ")?;
         if ty.is_final {
-            self.result.push_str("final ");
+            write!(self.result, "final ")?;
         }
         if let Some(idx) = ty.supertype_idx {
             self.print_idx(&state.core.type_names, idx.as_module_index().unwrap())?;
@@ -952,8 +950,8 @@ impl Printer {
 
     fn print_storage_type(&mut self, state: &State, ty: StorageType) -> Result<()> {
         match ty {
-            StorageType::I8 => self.result.push_str("i8"),
-            StorageType::I16 => self.result.push_str("i16"),
+            StorageType::I8 => write!(self.result, "i8")?,
+            StorageType::I16 => write!(self.result, "i16")?,
             StorageType::Val(val_type) => self.print_valtype(state, val_type)?,
         }
         Ok(())
@@ -961,11 +959,11 @@ impl Printer {
 
     fn print_valtype(&mut self, state: &State, ty: ValType) -> Result<()> {
         match ty {
-            ValType::I32 => self.result.push_str("i32"),
-            ValType::I64 => self.result.push_str("i64"),
-            ValType::F32 => self.result.push_str("f32"),
-            ValType::F64 => self.result.push_str("f64"),
-            ValType::V128 => self.result.push_str("v128"),
+            ValType::I32 => write!(self.result, "i32")?,
+            ValType::I64 => write!(self.result, "i64")?,
+            ValType::F32 => write!(self.result, "f32")?,
+            ValType::F64 => write!(self.result, "f64")?,
+            ValType::V128 => write!(self.result, "v128")?,
             ValType::Ref(rt) => self.print_reftype(state, rt)?,
         }
         Ok(())
@@ -974,46 +972,46 @@ impl Printer {
     fn print_reftype(&mut self, state: &State, ty: RefType) -> Result<()> {
         if ty.is_nullable() {
             match ty.as_non_null() {
-                RefType::FUNC => self.result.push_str("funcref"),
-                RefType::EXTERN => self.result.push_str("externref"),
-                RefType::I31 => self.result.push_str("i31ref"),
-                RefType::ANY => self.result.push_str("anyref"),
-                RefType::NONE => self.result.push_str("nullref"),
-                RefType::NOEXTERN => self.result.push_str("nullexternref"),
-                RefType::NOFUNC => self.result.push_str("nullfuncref"),
-                RefType::EQ => self.result.push_str("eqref"),
-                RefType::STRUCT => self.result.push_str("structref"),
-                RefType::ARRAY => self.result.push_str("arrayref"),
-                RefType::EXN => self.result.push_str("exnref"),
-                RefType::NOEXN => self.result.push_str("nullexnref"),
+                RefType::FUNC => write!(self.result, "funcref")?,
+                RefType::EXTERN => write!(self.result, "externref")?,
+                RefType::I31 => write!(self.result, "i31ref")?,
+                RefType::ANY => write!(self.result, "anyref")?,
+                RefType::NONE => write!(self.result, "nullref")?,
+                RefType::NOEXTERN => write!(self.result, "nullexternref")?,
+                RefType::NOFUNC => write!(self.result, "nullfuncref")?,
+                RefType::EQ => write!(self.result, "eqref")?,
+                RefType::STRUCT => write!(self.result, "structref")?,
+                RefType::ARRAY => write!(self.result, "arrayref")?,
+                RefType::EXN => write!(self.result, "exnref")?,
+                RefType::NOEXN => write!(self.result, "nullexnref")?,
                 _ => {
-                    self.result.push_str("(ref null ");
+                    write!(self.result, "(ref null ")?;
                     self.print_heaptype(state, ty.heap_type())?;
-                    self.result.push_str(")");
+                    write!(self.result, ")")?;
                 }
             }
         } else {
-            self.result.push_str("(ref ");
+            write!(self.result, "(ref ")?;
             self.print_heaptype(state, ty.heap_type())?;
-            self.result.push_str(")");
+            write!(self.result, ")")?;
         }
         Ok(())
     }
 
     fn print_heaptype(&mut self, state: &State, ty: HeapType) -> Result<()> {
         match ty {
-            HeapType::Func => self.result.push_str("func"),
-            HeapType::Extern => self.result.push_str("extern"),
-            HeapType::Any => self.result.push_str("any"),
-            HeapType::None => self.result.push_str("none"),
-            HeapType::NoExtern => self.result.push_str("noextern"),
-            HeapType::NoFunc => self.result.push_str("nofunc"),
-            HeapType::Eq => self.result.push_str("eq"),
-            HeapType::Struct => self.result.push_str("struct"),
-            HeapType::Array => self.result.push_str("array"),
-            HeapType::I31 => self.result.push_str("i31"),
-            HeapType::Exn => self.result.push_str("exn"),
-            HeapType::NoExn => self.result.push_str("noexn"),
+            HeapType::Func => write!(self.result, "func")?,
+            HeapType::Extern => write!(self.result, "extern")?,
+            HeapType::Any => write!(self.result, "any")?,
+            HeapType::None => write!(self.result, "none")?,
+            HeapType::NoExtern => write!(self.result, "noextern")?,
+            HeapType::NoFunc => write!(self.result, "nofunc")?,
+            HeapType::Eq => write!(self.result, "eq")?,
+            HeapType::Struct => write!(self.result, "struct")?,
+            HeapType::Array => write!(self.result, "array")?,
+            HeapType::I31 => write!(self.result, "i31")?,
+            HeapType::Exn => write!(self.result, "exn")?,
+            HeapType::NoExn => write!(self.result, "noexn")?,
             HeapType::Concrete(i) => {
                 self.print_idx(&state.core.type_names, i.as_module_index().unwrap())?;
             }
@@ -1074,7 +1072,7 @@ impl Printer {
             write!(self.result, " ")?;
         }
         if ty.table64 {
-            self.result.push_str("i64 ");
+            write!(self.result, "i64 ")?;
         }
         self.print_limits(ty.initial, ty.maximum)?;
         write!(self.result, " ")?;
@@ -1089,11 +1087,11 @@ impl Printer {
             write!(self.result, " ")?;
         }
         if ty.memory64 {
-            self.result.push_str("i64 ");
+            write!(self.result, "i64 ")?;
         }
         self.print_limits(ty.initial, ty.maximum)?;
         if ty.shared {
-            self.result.push_str(" shared");
+            write!(self.result, " shared")?;
         }
         if let Some(p) = ty.page_size_log2 {
             let p = 1_u64
@@ -1134,10 +1132,10 @@ impl Printer {
         if ty.shared || ty.mutable {
             write!(self.result, "(")?;
             if ty.shared {
-                self.result.push_str("shared ");
+                write!(self.result, "shared ")?;
             }
             if ty.mutable {
-                self.result.push_str("mut ");
+                write!(self.result, "mut ")?;
             }
             self.print_valtype(state, ty.content_type)?;
             write!(self.result, ")")?;
@@ -1155,7 +1153,7 @@ impl Printer {
             match &table.init {
                 TableInit::RefNull => {}
                 TableInit::Expr(expr) => {
-                    self.result.push_str(" ");
+                    write!(self.result, " ")?;
                     self.print_const_expr(state, expr)?;
                 }
             }
@@ -1233,7 +1231,7 @@ impl Printer {
             };
 
             if self.print_skeleton {
-                self.result.push_str(" ...");
+                write!(self.result, " ...")?;
             } else {
                 self.print_func_body(state, func_idx, params, &mut body, &hints)?;
             }
@@ -1335,7 +1333,7 @@ impl Printer {
         if self.print_offsets {
             match offset {
                 Some(offset) => write!(self.result, "(;@{offset:<6x};)").unwrap(),
-                None => self.result.push_str("           "),
+                None => write!(self.result, "           ")?,
             }
         }
         self.line += 1;
@@ -1344,7 +1342,7 @@ impl Printer {
         // reasonable to avoid generating hundreds of megabytes of whitespace
         // for small-ish modules that have deep-ish nesting.
         for _ in 0..self.nesting.min(MAX_NESTING_TO_PRINT) {
-            self.result.push_str("  ");
+            write!(self.result, "  ")?;
         }
         Ok(())
     }
@@ -1371,19 +1369,19 @@ impl Printer {
         write!(self.result, "(")?;
         match kind {
             ExternalKind::Func => {
-                self.result.push_str("func ");
+                write!(self.result, "func ")?;
                 self.print_idx(&state.core.func_names, index)?;
             }
             ExternalKind::Table => {
-                self.result.push_str("table ");
+                write!(self.result, "table ")?;
                 self.print_idx(&state.core.table_names, index)?;
             }
             ExternalKind::Global => {
-                self.result.push_str("global ");
+                write!(self.result, "global ")?;
                 self.print_idx(&state.core.global_names, index)?;
             }
             ExternalKind::Memory => {
-                self.result.push_str("memory ");
+                write!(self.result, "memory ")?;
                 self.print_idx(&state.core.memory_names, index)?;
             }
             ExternalKind::Tag => write!(self.result, "tag {}", index)?,
@@ -1393,14 +1391,14 @@ impl Printer {
     }
 
     fn print_core_type_ref(&mut self, state: &State, idx: u32) -> Result<()> {
-        self.result.push_str("(type ");
+        write!(self.result, "(type ")?;
         self.print_idx(&state.core.type_names, idx)?;
         write!(self.result, ")")?;
         Ok(())
     }
 
     fn print_component_type_ref(&mut self, state: &State, idx: u32) -> Result<()> {
-        self.result.push_str("(type ");
+        write!(self.result, "(type ")?;
         self.print_idx(&state.component.type_names, idx)?;
         write!(self.result, ")")?;
         Ok(())
@@ -1482,7 +1480,7 @@ impl Printer {
                 } => {
                     let table_index = table_index.unwrap_or(0);
                     if table_index != 0 {
-                        self.result.push_str(" (table ");
+                        write!(self.result, " (table ")?;
                         self.print_idx(&state.core.table_names, table_index)?;
                         write!(self.result, ")")?;
                     }
@@ -1493,11 +1491,11 @@ impl Printer {
             write!(self.result, " ")?;
 
             if self.print_skeleton {
-                self.result.push_str("...");
+                write!(self.result, "...")?;
             } else {
                 match elem.items {
                     ElementItems::Functions(reader) => {
-                        self.result.push_str("func");
+                        write!(self.result, "func")?;
                         for idx in reader {
                             write!(self.result, " ")?;
                             self.print_idx(&state.core.func_names, idx?)?
@@ -1531,16 +1529,16 @@ impl Printer {
                     offset_expr,
                 } => {
                     if *memory_index != 0 {
-                        self.result.push_str("(memory ");
+                        write!(self.result, "(memory ")?;
                         self.print_idx(&state.core.memory_names, *memory_index)?;
-                        self.result.push_str(") ");
+                        write!(self.result, ") ")?;
                     }
                     self.print_const_expr_sugar(state, offset_expr, "offset")?;
                     write!(self.result, " ")?;
                 }
             }
             if self.print_skeleton {
-                self.result.push_str("...");
+                write!(self.result, "...")?;
             } else {
                 self.print_bytes(data.data)?;
             }
@@ -1589,22 +1587,23 @@ impl Printer {
         Ok(())
     }
 
-    fn print_primitive_val_type(&mut self, ty: &PrimitiveValType) {
+    fn print_primitive_val_type(&mut self, ty: &PrimitiveValType) -> Result<()> {
         match ty {
-            PrimitiveValType::Bool => self.result.push_str("bool"),
-            PrimitiveValType::S8 => self.result.push_str("s8"),
-            PrimitiveValType::U8 => self.result.push_str("u8"),
-            PrimitiveValType::S16 => self.result.push_str("s16"),
-            PrimitiveValType::U16 => self.result.push_str("u16"),
-            PrimitiveValType::S32 => self.result.push_str("s32"),
-            PrimitiveValType::U32 => self.result.push_str("u32"),
-            PrimitiveValType::S64 => self.result.push_str("s64"),
-            PrimitiveValType::U64 => self.result.push_str("u64"),
-            PrimitiveValType::F32 => self.result.push_str("f32"),
-            PrimitiveValType::F64 => self.result.push_str("f64"),
-            PrimitiveValType::Char => self.result.push_str("char"),
-            PrimitiveValType::String => self.result.push_str("string"),
+            PrimitiveValType::Bool => write!(self.result, "bool")?,
+            PrimitiveValType::S8 => write!(self.result, "s8")?,
+            PrimitiveValType::U8 => write!(self.result, "u8")?,
+            PrimitiveValType::S16 => write!(self.result, "s16")?,
+            PrimitiveValType::U16 => write!(self.result, "u16")?,
+            PrimitiveValType::S32 => write!(self.result, "s32")?,
+            PrimitiveValType::U32 => write!(self.result, "u32")?,
+            PrimitiveValType::S64 => write!(self.result, "s64")?,
+            PrimitiveValType::U64 => write!(self.result, "u64")?,
+            PrimitiveValType::F32 => write!(self.result, "f32")?,
+            PrimitiveValType::F64 => write!(self.result, "f64")?,
+            PrimitiveValType::Char => write!(self.result, "char")?,
+            PrimitiveValType::String => write!(self.result, "string")?,
         }
+        Ok(())
     }
 
     fn print_record_type(
@@ -1711,7 +1710,7 @@ impl Printer {
 
     fn print_defined_type(&mut self, state: &State, ty: &ComponentDefinedType) -> Result<()> {
         match ty {
-            ComponentDefinedType::Primitive(ty) => self.print_primitive_val_type(ty),
+            ComponentDefinedType::Primitive(ty) => self.print_primitive_val_type(ty)?,
             ComponentDefinedType::Record(fields) => self.print_record_type(state, fields)?,
             ComponentDefinedType::Variant(cases) => self.print_variant_type(state, cases)?,
             ComponentDefinedType::List(ty) => self.print_list_type(state, ty)?,
@@ -1737,10 +1736,8 @@ impl Printer {
 
     fn print_component_val_type(&mut self, state: &State, ty: &ComponentValType) -> Result<()> {
         match ty {
-            ComponentValType::Primitive(ty) => self.print_primitive_val_type(ty),
-            ComponentValType::Type(idx) => {
-                self.print_idx(&state.component.type_names, *idx)?;
-            }
+            ComponentValType::Primitive(ty) => self.print_primitive_val_type(ty)?,
+            ComponentValType::Type(idx) => self.print_idx(&state.component.type_names, *idx)?,
         }
 
         Ok(())
@@ -1944,15 +1941,15 @@ impl Printer {
                 self.print_instance_type(states, decls.into_vec())?;
             }
             ComponentType::Resource { rep, dtor } => {
-                self.result.push_str(" ");
+                write!(self.result, " ")?;
                 self.start_group("resource")?;
-                self.result.push_str(" (rep ");
+                write!(self.result, " (rep ")?;
                 self.print_valtype(states.last().unwrap(), rep)?;
-                self.result.push_str(")");
+                write!(self.result, ")")?;
                 if let Some(dtor) = dtor {
-                    self.result.push_str(" (dtor (func ");
+                    write!(self.result, " (dtor (func ")?;
                     self.print_idx(&states.last().unwrap().core.func_names, dtor)?;
-                    self.result.push_str("))");
+                    write!(self.result, "))")?;
                 }
                 self.end_group()?;
             }
@@ -2041,15 +2038,13 @@ impl Printer {
                     state.component.values += 1;
                 }
                 match ty {
-                    ComponentValType::Primitive(ty) => self.print_primitive_val_type(ty),
-                    ComponentValType::Type(idx) => {
-                        self.print_component_type_ref(state, *idx)?;
-                    }
+                    ComponentValType::Primitive(ty) => self.print_primitive_val_type(ty)?,
+                    ComponentValType::Type(idx) => self.print_component_type_ref(state, *idx)?,
                 }
                 self.end_group()?;
             }
             ComponentTypeRef::Type(bounds) => {
-                self.result.push_str("(type ");
+                write!(self.result, "(type ")?;
                 if index {
                     self.print_name(&state.component.type_names, state.component.types)?;
                     write!(self.result, " ")?;
@@ -2057,12 +2052,12 @@ impl Printer {
                 }
                 match bounds {
                     TypeBounds::Eq(idx) => {
-                        self.result.push_str("(eq ");
+                        write!(self.result, "(eq ")?;
                         self.print_idx(&state.component.type_names, *idx)?;
                         write!(self.result, ")")?;
                     }
                     TypeBounds::SubResource => {
-                        self.result.push_str("(sub resource)");
+                        write!(self.result, "(sub resource)")?;
                     }
                 };
                 write!(self.result, ")")?;
@@ -2223,10 +2218,10 @@ impl Printer {
         for option in options {
             write!(self.result, " ")?;
             match option {
-                CanonicalOption::UTF8 => self.result.push_str("string-encoding=utf8"),
-                CanonicalOption::UTF16 => self.result.push_str("string-encoding=utf16"),
+                CanonicalOption::UTF8 => write!(self.result, "string-encoding=utf8")?,
+                CanonicalOption::UTF16 => write!(self.result, "string-encoding=utf16")?,
                 CanonicalOption::CompactUTF16 => {
-                    self.result.push_str("string-encoding=latin1+utf16")
+                    write!(self.result, "string-encoding=latin1+utf16")?
                 }
                 CanonicalOption::Memory(idx) => {
                     self.start_group("memory ")?;
@@ -2547,7 +2542,7 @@ impl Printer {
                 if let Some(name) = outer.name.as_ref() {
                     name.write(&mut self.result);
                 } else {
-                    self.result.push_str(count.to_string().as_str());
+                    write!(self.result, "{count}")?;
                 }
                 write!(self.result, " ")?;
                 match kind {
@@ -2674,11 +2669,9 @@ impl Printer {
         self.start_group("@custom ")?;
         self.print_str(section.name())?;
         if let Some(place) = state.custom_section_place {
-            self.result.push_str(" (");
-            self.result.push_str(place);
-            self.result.push_str(")");
+            write!(self.result, " ({place})")?;
         }
-        self.result.push_str(" ");
+        write!(self.result, " ")?;
         self.print_bytes(section.data())?;
         self.end_group()?;
         Ok(())
@@ -2692,9 +2685,9 @@ impl Printer {
                 let (offset, value) = value?;
                 self.newline(offset)?;
                 self.start_group(field.name)?;
-                self.result.push_str(" ");
+                write!(self.result, " ")?;
                 self.print_str(value.name)?;
-                self.result.push_str(" ");
+                write!(self.result, " ")?;
                 self.print_str(value.version)?;
                 self.end_group()?;
             }
@@ -2736,7 +2729,7 @@ impl Printer {
                     self.newline(start)?;
                     self.start_group("needed")?;
                     for s in needed {
-                        self.result.push_str(" ");
+                        write!(self.result, " ")?;
                         self.print_str(s)?;
                     }
                     self.end_group()?;
@@ -2755,7 +2748,7 @@ impl Printer {
                         self.newline(start)?;
                         self.start_group("import-info ")?;
                         self.print_str(info.module)?;
-                        self.result.push_str(" ");
+                        write!(self.result, " ")?;
                         self.print_str(info.field)?;
                         self.print_dylink0_flags(info.flags)?;
                         self.end_group()?;
@@ -2775,7 +2768,7 @@ impl Printer {
             ($($name:ident = $text:tt)*) => ({$(
                 if flags.contains(SymbolFlags::$name) {
                     flags.remove(SymbolFlags::$name);
-                    self.result.push_str(concat!(" ", $text));
+                    write!(self.result, concat!(" ", $text))?;
                 }
             )*})
         }
@@ -2940,9 +2933,9 @@ macro_rules! print_float {
             let mut exponent = (((bits << 1) as $sint) >> (mantissa_width + 1)).wrapping_sub(bias);
             exponent = (exponent << (int_width - exp_width)) >> (int_width - exp_width);
             let mut fraction = bits & ((1 << mantissa_width) - 1);
-            self.result.push_str("0x");
+            write!(self.result, "0x")?;
             if bits == 0 {
-                self.result.push_str("0p+0");
+                write!(self.result, "0p+0")?;
             } else {
                 write!(self.result, "1")?;
                 if fraction > 0 {

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -367,7 +367,7 @@ impl Printer {
 
                             if states.len() > 1 {
                                 let parent = &states[states.len() - 2];
-                                self.result.push(' ');
+                                write!(self.result, " ")?;
                                 self.print_name(&parent.core.module_names, parent.core.modules)?;
                             }
                         }
@@ -377,7 +377,7 @@ impl Printer {
 
                             if states.len() > 1 {
                                 let parent = &states[states.len() - 2];
-                                self.result.push(' ');
+                                write!(self.result, " ")?;
                                 self.print_name(
                                     &parent.component.component_names,
                                     parent.component.components,
@@ -398,7 +398,7 @@ impl Printer {
 
                     if len == 1 {
                         if let Some(name) = state.name.as_ref() {
-                            self.result.push(' ');
+                            write!(self.result, " ")?;
                             name.write(&mut self.result);
                         }
                     }
@@ -588,7 +588,7 @@ impl Printer {
                     } else {
                         self.newline(offset)?;
                         if self.print_offsets {
-                            self.result.push('\n');
+                            write!(self.result, "\n")?;
                         }
                         break;
                     }
@@ -610,7 +610,7 @@ impl Printer {
     }
 
     fn start_group(&mut self, name: &str) -> Result<()> {
-        self.result.push('(');
+        write!(self.result, "(")?;
         self.result.push_str(name);
         self.nesting += 1;
         self.group_lines.push(self.line);
@@ -624,7 +624,7 @@ impl Printer {
                 self.newline_unknown_pos()?;
             }
         }
-        self.result.push(')');
+        write!(self.result, ")")?;
         Ok(())
     }
 
@@ -737,7 +737,7 @@ impl Printer {
                         unreachable!("Wasm GC types cannot appear in components yet")
                     }
                 };
-                self.result.push(' ');
+                write!(self.result, " ")?;
                 self.start_group("func")?;
                 self.print_func_type(states.last().unwrap(), &ty, None)?;
                 self.end_group()?;
@@ -777,7 +777,7 @@ impl Printer {
         self.start_group("type ")?;
         let ty_idx = state.core.types.len() as u32;
         self.print_name(&state.core.type_names, ty_idx)?;
-        self.result.push(' ');
+        write!(self.result, " ")?;
         self.print_sub(state, &ty, ty_idx)?;
         self.end_group()?; // `type`
         state.core.types.push(Some(ty));
@@ -877,7 +877,7 @@ impl Printer {
         names_for: Option<u32>,
     ) -> Result<u32> {
         if !ty.params().is_empty() {
-            self.result.push(' ');
+            write!(self.result, " ")?;
         }
 
         let mut params = NamedLocalPrinter::new("param");
@@ -893,10 +893,10 @@ impl Printer {
         if !ty.results().is_empty() {
             self.result.push_str(" (result");
             for result in ty.results().iter() {
-                self.result.push(' ');
+                write!(self.result, " ")?;
                 self.print_valtype(state, *result)?;
             }
-            self.result.push(')');
+            write!(self.result, ")")?;
         }
         Ok(ty.params().len() as u32)
     }
@@ -907,7 +907,7 @@ impl Printer {
         ty: &FieldType,
         ty_field_idx: Option<(u32, u32)>,
     ) -> Result<u32> {
-        self.result.push(' ');
+        write!(self.result, " ")?;
         if let Some(idxs @ (_, field_idx)) = ty_field_idx {
             match state.core.field_names.index_to_name.get(&idxs) {
                 Some(name) => write!(self.result, "${} ", name.identifier())?,
@@ -933,19 +933,19 @@ impl Printer {
         for (field_index, field) in ty.fields.iter().enumerate() {
             self.result.push_str(" (field");
             self.print_field_type(state, field, Some((ty_idx, field_index as u32)))?;
-            self.result.push(')');
+            write!(self.result, ")")?;
         }
         Ok(0)
     }
 
     fn print_sub_type(&mut self, state: &State, ty: &SubType) -> Result<u32> {
-        self.result.push(' ');
+        write!(self.result, " ")?;
         if ty.is_final {
             self.result.push_str("final ");
         }
         if let Some(idx) = ty.supertype_idx {
             self.print_idx(&state.core.type_names, idx.as_module_index().unwrap())?;
-            self.result.push(' ');
+            write!(self.result, " ")?;
         }
         Ok(0)
     }
@@ -1040,9 +1040,9 @@ impl Printer {
     fn print_import(&mut self, state: &State, import: &Import<'_>, index: bool) -> Result<()> {
         self.start_group("import ")?;
         self.print_str(import.module)?;
-        self.result.push(' ');
+        write!(self.result, " ")?;
         self.print_str(import.name)?;
-        self.result.push(' ');
+        write!(self.result, " ")?;
         self.print_import_ty(state, &import.ty, index)?;
         self.end_group()?;
         Ok(())
@@ -1054,7 +1054,7 @@ impl Printer {
                 self.start_group("func ")?;
                 if index {
                     self.print_name(&state.core.func_names, state.core.funcs)?;
-                    self.result.push(' ');
+                    write!(self.result, " ")?;
                 }
                 self.print_core_type_ref(state, *f)?;
             }
@@ -1071,13 +1071,13 @@ impl Printer {
         self.start_group("table ")?;
         if index {
             self.print_name(&state.core.table_names, state.core.tables)?;
-            self.result.push(' ');
+            write!(self.result, " ")?;
         }
         if ty.table64 {
             self.result.push_str("i64 ");
         }
         self.print_limits(ty.initial, ty.maximum)?;
-        self.result.push(' ');
+        write!(self.result, " ")?;
         self.print_reftype(state, ty.element_type)?;
         Ok(())
     }
@@ -1086,7 +1086,7 @@ impl Printer {
         self.start_group("memory ")?;
         if index {
             self.print_name(&state.core.memory_names, state.core.memories)?;
-            self.result.push(' ');
+            write!(self.result, " ")?;
         }
         if ty.memory64 {
             self.result.push_str("i64 ");
@@ -1108,7 +1108,7 @@ impl Printer {
         self.start_group("tag ")?;
         if index {
             self.print_name(&state.core.tag_names, state.core.tags)?;
-            self.result.push(' ');
+            write!(self.result, " ")?;
         }
         self.print_core_functype_idx(state, ty.func_type_idx, None)?;
         Ok(())
@@ -1129,10 +1129,10 @@ impl Printer {
         self.start_group("global ")?;
         if index {
             self.print_name(&state.core.global_names, state.core.globals)?;
-            self.result.push(' ');
+            write!(self.result, " ")?;
         }
         if ty.shared || ty.mutable {
-            self.result.push('(');
+            write!(self.result, "(")?;
             if ty.shared {
                 self.result.push_str("shared ");
             }
@@ -1140,7 +1140,7 @@ impl Printer {
                 self.result.push_str("mut ");
             }
             self.print_valtype(state, ty.content_type)?;
-            self.result.push(')');
+            write!(self.result, ")")?;
         } else {
             self.print_valtype(state, ty.content_type)?;
         }
@@ -1192,7 +1192,7 @@ impl Printer {
             let (offset, global) = global?;
             self.newline(offset)?;
             self.print_global_type(state, &global.ty, true)?;
-            self.result.push(' ');
+            write!(self.result, " ")?;
             self.print_const_expr(state, &global.init_expr)?;
             self.end_group()?;
             state.core.globals += 1;
@@ -1217,7 +1217,7 @@ impl Printer {
             self.start_group("func ")?;
             let func_idx = state.core.funcs;
             self.print_name(&state.core.func_names, func_idx)?;
-            self.result.push(' ');
+            write!(self.result, " ")?;
             let params = self
                 .print_core_functype_idx(state, ty, Some(func_idx))?
                 .unwrap_or(0);
@@ -1327,7 +1327,7 @@ impl Printer {
     }
 
     fn print_newline(&mut self, offset: Option<usize>) -> Result<()> {
-        self.result.push('\n');
+        write!(self.result, "\n")?;
 
         self.lines.push(self.result.len());
         self.line_offsets.push(offset);
@@ -1361,14 +1361,14 @@ impl Printer {
     fn print_export(&mut self, state: &State, export: &Export) -> Result<()> {
         self.start_group("export ")?;
         self.print_str(export.name)?;
-        self.result.push(' ');
+        write!(self.result, " ")?;
         self.print_external_kind(state, export.kind, export.index)?;
         self.end_group()?; // export
         Ok(())
     }
 
     fn print_external_kind(&mut self, state: &State, kind: ExternalKind, index: u32) -> Result<()> {
-        self.result.push('(');
+        write!(self.result, "(")?;
         match kind {
             ExternalKind::Func => {
                 self.result.push_str("func ");
@@ -1388,21 +1388,21 @@ impl Printer {
             }
             ExternalKind::Tag => write!(self.result, "tag {}", index)?,
         }
-        self.result.push(')');
+        write!(self.result, ")")?;
         Ok(())
     }
 
     fn print_core_type_ref(&mut self, state: &State, idx: u32) -> Result<()> {
         self.result.push_str("(type ");
         self.print_idx(&state.core.type_names, idx)?;
-        self.result.push(')');
+        write!(self.result, ")")?;
         Ok(())
     }
 
     fn print_component_type_ref(&mut self, state: &State, idx: u32) -> Result<()> {
         self.result.push_str("(type ");
         self.print_idx(&state.component.type_names, idx)?;
-        self.result.push(')');
+        write!(self.result, ")")?;
         Ok(())
     }
 
@@ -1456,7 +1456,7 @@ impl Printer {
         match names.get(&cur_idx) {
             Some(name) => {
                 name.write(&mut self.result);
-                self.result.push(' ');
+                write!(self.result, " ")?;
             }
             None if self.name_unnamed => {
                 write!(self.result, "$#{desc}{cur_idx} ")?;
@@ -1484,13 +1484,13 @@ impl Printer {
                     if table_index != 0 {
                         self.result.push_str(" (table ");
                         self.print_idx(&state.core.table_names, table_index)?;
-                        self.result.push(')');
+                        write!(self.result, ")")?;
                     }
-                    self.result.push(' ');
+                    write!(self.result, " ")?;
                     self.print_const_expr_sugar(state, offset_expr, "offset")?;
                 }
             }
-            self.result.push(' ');
+            write!(self.result, " ")?;
 
             if self.print_skeleton {
                 self.result.push_str("...");
@@ -1499,14 +1499,14 @@ impl Printer {
                     ElementItems::Functions(reader) => {
                         self.result.push_str("func");
                         for idx in reader {
-                            self.result.push(' ');
+                            write!(self.result, " ")?;
                             self.print_idx(&state.core.func_names, idx?)?
                         }
                     }
                     ElementItems::Expressions(ty, reader) => {
                         self.print_reftype(state, ty)?;
                         for expr in reader {
-                            self.result.push(' ');
+                            write!(self.result, " ")?;
                             self.print_const_expr_sugar(state, &expr?, "item")?
                         }
                     }
@@ -1523,7 +1523,7 @@ impl Printer {
             self.newline(offset)?;
             self.start_group("data ")?;
             self.print_name(&state.core.data_names, i as u32)?;
-            self.result.push(' ');
+            write!(self.result, " ")?;
             match &data.kind {
                 DataKind::Passive => {}
                 DataKind::Active {
@@ -1536,7 +1536,7 @@ impl Printer {
                         self.result.push_str(") ");
                     }
                     self.print_const_expr_sugar(state, offset_expr, "offset")?;
-                    self.result.push(' ');
+                    write!(self.result, " ")?;
                 }
             }
             if self.print_skeleton {
@@ -1614,10 +1614,10 @@ impl Printer {
     ) -> Result<()> {
         self.start_group("record")?;
         for (name, ty) in fields.iter() {
-            self.result.push(' ');
+            write!(self.result, " ")?;
             self.start_group("field ")?;
             self.print_str(name)?;
-            self.result.push(' ');
+            write!(self.result, " ")?;
             self.print_component_val_type(state, ty)?;
             self.end_group()?
         }
@@ -1628,17 +1628,17 @@ impl Printer {
     fn print_variant_type(&mut self, state: &State, cases: &[VariantCase]) -> Result<()> {
         self.start_group("variant")?;
         for case in cases {
-            self.result.push(' ');
+            write!(self.result, " ")?;
             self.start_group("case ")?;
             self.print_str(case.name)?;
 
             if let Some(ty) = case.ty {
-                self.result.push(' ');
+                write!(self.result, " ")?;
                 self.print_component_val_type(state, &ty)?;
             }
 
             if let Some(refines) = case.refines {
-                self.result.push(' ');
+                write!(self.result, " ")?;
                 self.start_group("refines ")?;
                 write!(&mut self.result, "{}", refines)?;
                 self.end_group()?;
@@ -1660,7 +1660,7 @@ impl Printer {
     fn print_tuple_type(&mut self, state: &State, tys: &[ComponentValType]) -> Result<()> {
         self.start_group("tuple")?;
         for ty in tys {
-            self.result.push(' ');
+            write!(self.result, " ")?;
             self.print_component_val_type(state, ty)?;
         }
         self.end_group()?;
@@ -1670,7 +1670,7 @@ impl Printer {
     fn print_flag_or_enum_type(&mut self, ty: &str, names: &[&str]) -> Result<()> {
         self.start_group(ty)?;
         for name in names {
-            self.result.push(' ');
+            write!(self.result, " ")?;
             self.print_str(name)?;
         }
         self.end_group()?;
@@ -1693,12 +1693,12 @@ impl Printer {
         self.start_group("result")?;
 
         if let Some(ok) = ok {
-            self.result.push(' ');
+            write!(self.result, " ")?;
             self.print_component_val_type(state, &ok)?;
         }
 
         if let Some(err) = err {
-            self.result.push(' ');
+            write!(self.result, " ")?;
             self.start_group("error ")?;
             self.print_component_val_type(state, &err)?;
             self.end_group()?;
@@ -1766,7 +1766,7 @@ impl Printer {
                 ModuleTypeDeclaration::Export { name, ty } => {
                     self.start_group("export ")?;
                     self.print_str(name)?;
-                    self.result.push(' ');
+                    write!(self.result, " ")?;
                     self.print_import_ty(states.last_mut().unwrap(), &ty, false)?;
                     self.end_group()?;
                 }
@@ -1799,9 +1799,9 @@ impl Printer {
                 ComponentTypeDeclaration::Export { name, ty } => {
                     self.start_group("export ")?;
                     self.print_component_kind_name(states.last_mut().unwrap(), ty.kind())?;
-                    self.result.push(' ');
+                    write!(self.result, " ")?;
                     self.print_str(name.0)?;
-                    self.result.push(' ');
+                    write!(self.result, " ")?;
                     self.print_component_import_ty(states.last_mut().unwrap(), &ty, false)?;
                     self.end_group()?;
                 }
@@ -1834,9 +1834,9 @@ impl Printer {
                 InstanceTypeDeclaration::Export { name, ty } => {
                     self.start_group("export ")?;
                     self.print_component_kind_name(states.last_mut().unwrap(), ty.kind())?;
-                    self.result.push(' ');
+                    write!(self.result, " ")?;
                     self.print_str(name.0)?;
-                    self.result.push(' ');
+                    write!(self.result, " ")?;
                     self.print_component_import_ty(states.last_mut().unwrap(), &ty, false)?;
                     self.end_group()?;
                 }
@@ -1871,11 +1871,11 @@ impl Printer {
         } else {
             self.result.push_str(count.to_string().as_str());
         }
-        self.result.push(' ');
+        write!(self.result, " ")?;
         match kind {
             OuterAliasKind::Type => {
                 self.print_idx(&outer.core.type_names, index)?;
-                self.result.push(' ');
+                write!(self.result, " ")?;
                 self.start_group("type ")?;
                 self.print_name(&state.core.type_names, state.core.types.len() as u32)?;
             }
@@ -1894,20 +1894,20 @@ impl Printer {
     fn print_component_func_type(&mut self, state: &State, ty: &ComponentFuncType) -> Result<()> {
         self.start_group("func")?;
         for (name, ty) in ty.params.iter() {
-            self.result.push(' ');
+            write!(self.result, " ")?;
             self.start_group("param ")?;
             self.print_str(name)?;
-            self.result.push(' ');
+            write!(self.result, " ")?;
             self.print_component_val_type(state, ty)?;
             self.end_group()?
         }
 
         for (name, ty) in ty.results.iter() {
-            self.result.push(' ');
+            write!(self.result, " ")?;
             self.start_group("result ")?;
             if let Some(name) = name {
                 self.print_str(name)?;
-                self.result.push(' ');
+                write!(self.result, " ")?;
             }
             self.print_component_val_type(state, ty)?;
             self.end_group()?
@@ -1930,11 +1930,11 @@ impl Printer {
         }
         match ty {
             ComponentType::Defined(ty) => {
-                self.result.push(' ');
+                write!(self.result, " ")?;
                 self.print_defined_type(states.last_mut().unwrap(), &ty)?;
             }
             ComponentType::Func(ty) => {
-                self.result.push(' ');
+                write!(self.result, " ")?;
                 self.print_component_func_type(states.last_mut().unwrap(), &ty)?;
             }
             ComponentType::Component(decls) => {
@@ -2000,7 +2000,7 @@ impl Printer {
     ) -> Result<()> {
         self.start_group("import ")?;
         self.print_str(import.name.0)?;
-        self.result.push(' ');
+        write!(self.result, " ")?;
         self.print_component_import_ty(state, &import.ty, index)?;
         self.end_group()?;
         Ok(())
@@ -2017,7 +2017,7 @@ impl Printer {
                 self.start_group("core module ")?;
                 if index {
                     self.print_name(&state.core.module_names, state.core.modules as u32)?;
-                    self.result.push(' ');
+                    write!(self.result, " ")?;
                     state.core.modules += 1;
                 }
                 self.print_component_type_ref(state, *idx)?;
@@ -2027,7 +2027,7 @@ impl Printer {
                 self.start_group("func ")?;
                 if index {
                     self.print_name(&state.component.func_names, state.component.funcs)?;
-                    self.result.push(' ');
+                    write!(self.result, " ")?;
                     state.component.funcs += 1;
                 }
                 self.print_component_type_ref(state, *idx)?;
@@ -2037,7 +2037,7 @@ impl Printer {
                 self.start_group("value ")?;
                 if index {
                     self.print_name(&state.component.value_names, state.component.values)?;
-                    self.result.push(' ');
+                    write!(self.result, " ")?;
                     state.component.values += 1;
                 }
                 match ty {
@@ -2052,26 +2052,26 @@ impl Printer {
                 self.result.push_str("(type ");
                 if index {
                     self.print_name(&state.component.type_names, state.component.types)?;
-                    self.result.push(' ');
+                    write!(self.result, " ")?;
                     state.component.types += 1;
                 }
                 match bounds {
                     TypeBounds::Eq(idx) => {
                         self.result.push_str("(eq ");
                         self.print_idx(&state.component.type_names, *idx)?;
-                        self.result.push(')');
+                        write!(self.result, ")")?;
                     }
                     TypeBounds::SubResource => {
                         self.result.push_str("(sub resource)");
                     }
                 };
-                self.result.push(')');
+                write!(self.result, ")")?;
             }
             ComponentTypeRef::Instance(idx) => {
                 self.start_group("instance ")?;
                 if index {
                     self.print_name(&state.component.instance_names, state.component.instances)?;
-                    self.result.push(' ');
+                    write!(self.result, " ")?;
                     state.component.instances += 1;
                 }
                 self.print_component_type_ref(state, *idx)?;
@@ -2081,7 +2081,7 @@ impl Printer {
                 self.start_group("component ")?;
                 if index {
                     self.print_name(&state.component.component_names, state.component.components)?;
-                    self.result.push(' ');
+                    write!(self.result, " ")?;
                     state.component.components += 1;
                 }
                 self.print_component_type_ref(state, *idx)?;
@@ -2113,13 +2113,13 @@ impl Printer {
         self.start_group("export ")?;
         if named {
             self.print_component_kind_name(state, export.kind)?;
-            self.result.push(' ');
+            write!(self.result, " ")?;
         }
         self.print_str(export.name.0)?;
-        self.result.push(' ');
+        write!(self.result, " ")?;
         self.print_component_external_kind(state, export.kind, export.index)?;
         if let Some(ty) = &export.ty {
-            self.result.push(' ');
+            write!(self.result, " ")?;
             self.print_component_import_ty(state, &ty, false)?;
         }
         self.end_group()?;
@@ -2221,7 +2221,7 @@ impl Printer {
         options: &[CanonicalOption],
     ) -> Result<()> {
         for option in options {
-            self.result.push(' ');
+            write!(self.result, " ")?;
             match option {
                 CanonicalOption::UTF8 => self.result.push_str("string-encoding=utf8"),
                 CanonicalOption::UTF16 => self.result.push_str("string-encoding=utf16"),
@@ -2264,11 +2264,11 @@ impl Printer {
                 } => {
                     self.start_group("func ")?;
                     self.print_name(&state.component.func_names, state.component.funcs)?;
-                    self.result.push(' ');
+                    write!(self.result, " ")?;
                     self.start_group("type ")?;
                     self.print_idx(&state.component.type_names, type_index)?;
                     self.end_group()?;
-                    self.result.push(' ');
+                    write!(self.result, " ")?;
                     self.start_group("canon lift ")?;
                     self.start_group("core func ")?;
                     self.print_idx(&state.core.func_names, core_func_index)?;
@@ -2284,7 +2284,7 @@ impl Printer {
                 } => {
                     self.start_group("core func ")?;
                     self.print_name(&state.core.func_names, state.core.funcs)?;
-                    self.result.push(' ');
+                    write!(self.result, " ")?;
                     self.start_group("canon lower ")?;
                     self.start_group("func ")?;
                     self.print_idx(&state.component.func_names, func_index)?;
@@ -2297,7 +2297,7 @@ impl Printer {
                 CanonicalFunction::ResourceNew { resource } => {
                     self.start_group("core func ")?;
                     self.print_name(&state.core.func_names, state.core.funcs)?;
-                    self.result.push(' ');
+                    write!(self.result, " ")?;
                     self.start_group("canon resource.new ")?;
                     self.print_idx(&state.component.type_names, resource)?;
                     self.end_group()?;
@@ -2307,7 +2307,7 @@ impl Printer {
                 CanonicalFunction::ResourceDrop { resource } => {
                     self.start_group("core func ")?;
                     self.print_name(&state.core.func_names, state.core.funcs)?;
-                    self.result.push(' ');
+                    write!(self.result, " ")?;
                     self.start_group("canon resource.drop ")?;
                     self.print_idx(&state.component.type_names, resource)?;
                     self.end_group()?;
@@ -2317,7 +2317,7 @@ impl Printer {
                 CanonicalFunction::ResourceRep { resource } => {
                     self.start_group("core func ")?;
                     self.print_name(&state.core.func_names, state.core.funcs)?;
-                    self.result.push(' ');
+                    write!(self.result, " ")?;
                     self.start_group("canon resource.rep ")?;
                     self.print_idx(&state.component.type_names, resource)?;
                     self.end_group()?;
@@ -2338,7 +2338,7 @@ impl Printer {
             self.print_name(&state.core.instance_names, state.core.instances)?;
             match instance {
                 Instance::Instantiate { module_index, args } => {
-                    self.result.push(' ');
+                    write!(self.result, " ")?;
                     self.start_group("instantiate ")?;
                     self.print_idx(&state.core.module_names, module_index)?;
                     for arg in args.iter() {
@@ -2377,7 +2377,7 @@ impl Printer {
                     component_index,
                     args,
                 } => {
-                    self.result.push(' ');
+                    write!(self.result, " ")?;
                     self.start_group("instantiate ")?;
                     self.print_idx(&state.component.component_names, component_index)?;
                     for arg in args.iter() {
@@ -2401,7 +2401,7 @@ impl Printer {
     fn print_instantiation_arg(&mut self, state: &State, arg: &InstantiationArg) -> Result<()> {
         self.start_group("with ")?;
         self.print_str(arg.name)?;
-        self.result.push(' ');
+        write!(self.result, " ")?;
         match arg.kind {
             InstantiationArgKind::Instance => {
                 self.start_group("instance ")?;
@@ -2420,7 +2420,7 @@ impl Printer {
     ) -> Result<()> {
         self.start_group("with ")?;
         self.print_str(arg.name)?;
-        self.result.push(' ');
+        write!(self.result, " ")?;
         self.print_component_external_kind(state, arg.kind, arg.index)?;
         self.end_group()?;
         Ok(())
@@ -2437,14 +2437,14 @@ impl Printer {
         self.print_idx(&state.component.func_names, start.func_index)?;
 
         for arg in start.arguments.iter() {
-            self.result.push(' ');
+            write!(self.result, " ")?;
             self.start_group("value ")?;
             self.print_idx(&state.component.value_names, *arg)?;
             self.end_group()?;
         }
 
         for _ in 0..start.results {
-            self.result.push(' ');
+            write!(self.result, " ")?;
             self.start_group("result ")?;
             self.start_group("value ")?;
             self.print_name(&state.component.value_names, state.component.values)?;
@@ -2485,9 +2485,9 @@ impl Printer {
                 let state = states.last_mut().unwrap();
                 self.start_group("alias export ")?;
                 self.print_idx(&state.component.instance_names, instance_index)?;
-                self.result.push(' ');
+                write!(self.result, " ")?;
                 self.print_str(name)?;
-                self.result.push(' ');
+                write!(self.result, " ")?;
                 self.start_component_external_kind_group(kind)?;
                 self.print_component_kind_name(state, kind)?;
                 self.end_group()?;
@@ -2502,9 +2502,9 @@ impl Printer {
                 let state = states.last_mut().unwrap();
                 self.start_group("alias core export ")?;
                 self.print_idx(&state.core.instance_names, instance_index)?;
-                self.result.push(' ');
+                write!(self.result, " ")?;
                 self.print_str(name)?;
-                self.result.push(' ');
+                write!(self.result, " ")?;
                 match kind {
                     ExternalKind::Func => {
                         self.start_group("core func ")?;
@@ -2549,29 +2549,29 @@ impl Printer {
                 } else {
                     self.result.push_str(count.to_string().as_str());
                 }
-                self.result.push(' ');
+                write!(self.result, " ")?;
                 match kind {
                     ComponentOuterAliasKind::CoreModule => {
                         self.print_idx(&outer.core.module_names, index)?;
-                        self.result.push(' ');
+                        write!(self.result, " ")?;
                         self.start_group("core module ")?;
                         self.print_name(&state.core.module_names, state.core.modules)?;
                     }
                     ComponentOuterAliasKind::CoreType => {
                         self.print_idx(&outer.core.type_names, index)?;
-                        self.result.push(' ');
+                        write!(self.result, " ")?;
                         self.start_group("core type ")?;
                         self.print_name(&state.core.type_names, state.core.types.len() as u32)?;
                     }
                     ComponentOuterAliasKind::Type => {
                         self.print_idx(&outer.component.type_names, index)?;
-                        self.result.push(' ');
+                        write!(self.result, " ")?;
                         self.start_group("type ")?;
                         self.print_name(&state.component.type_names, state.component.types)?;
                     }
                     ComponentOuterAliasKind::Component => {
                         self.print_idx(&outer.component.component_names, index)?;
-                        self.result.push(' ');
+                        write!(self.result, " ")?;
                         self.start_group("component ")?;
                         self.print_name(
                             &state.component.component_names,
@@ -2596,45 +2596,37 @@ impl Printer {
 
     fn print_str(&mut self, name: &str) -> Result<()> {
         let mut bytes = [0; 4];
-        self.result.push('"');
+        write!(self.result, "\"")?;
         for c in name.chars() {
             let v = c as u32;
             if (0x20..0x7f).contains(&v) && c != '"' && c != '\\' && v < 0xff {
-                self.result.push(c);
+                write!(self.result, "{c}")?;
             } else {
                 for byte in c.encode_utf8(&mut bytes).as_bytes() {
-                    self.hex_byte(*byte);
+                    self.hex_byte(*byte)?;
                 }
             }
         }
-        self.result.push('"');
+        write!(self.result, "\"")?;
         Ok(())
     }
 
     fn print_bytes(&mut self, bytes: &[u8]) -> Result<()> {
-        self.result.push('"');
+        write!(self.result, "\"")?;
         for byte in bytes {
             if *byte >= 0x20 && *byte < 0x7f && *byte != b'"' && *byte != b'\\' {
-                self.result.push(*byte as char);
+                write!(self.result, "{}", *byte as char)?;
             } else {
-                self.hex_byte(*byte);
+                self.hex_byte(*byte)?;
             }
         }
-        self.result.push('"');
+        write!(self.result, "\"")?;
         Ok(())
     }
 
-    fn hex_byte(&mut self, byte: u8) {
-        fn to_hex(b: u8) -> char {
-            if b < 10 {
-                (b'0' + b) as char
-            } else {
-                (b'a' + b - 10) as char
-            }
-        }
-        self.result.push('\\');
-        self.result.push(to_hex((byte >> 4) & 0xf));
-        self.result.push(to_hex(byte & 0xf));
+    fn hex_byte(&mut self, byte: u8) -> Result<()> {
+        write!(self.result, "\\{byte:02x}")?;
+        Ok(())
     }
 
     fn print_custom_section(
@@ -2914,7 +2906,7 @@ macro_rules! print_float {
             let f = $float::from_bits(bits);
             if bits >> (int_width - 1) != 0 {
                 bits ^= 1 << (int_width - 1);
-                self.result.push('-');
+                write!(self.result, "-")?;
             }
             if f.is_infinite() {
                 write!(self.result, "inf (;={};)", f)?;
@@ -2952,7 +2944,7 @@ macro_rules! print_float {
             if bits == 0 {
                 self.result.push_str("0p+0");
             } else {
-                self.result.push('1');
+                write!(self.result, "1")?;
                 if fraction > 0 {
                     fraction <<= (int_width - mantissa_width);
 
@@ -2969,7 +2961,7 @@ macro_rules! print_float {
                         exponent -= leading as $sint;
                     }
 
-                    self.result.push('.');
+                    write!(self.result, ".")?;
                     while fraction > 0 {
                         write!(self.result, "{:x}", fraction >> (int_width - 4))?;
                         fraction <<= 4;

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -396,7 +396,7 @@ impl Printer<'_> {
 
                             if states.len() > 1 {
                                 let parent = &states[states.len() - 2];
-                                write!(self.result, " ")?;
+                                self.result.write_str(" ")?;
                                 self.print_name(&parent.core.module_names, parent.core.modules)?;
                             }
                         }
@@ -406,7 +406,7 @@ impl Printer<'_> {
 
                             if states.len() > 1 {
                                 let parent = &states[states.len() - 2];
-                                write!(self.result, " ")?;
+                                self.result.write_str(" ")?;
                                 self.print_name(
                                     &parent.component.component_names,
                                     parent.component.components,
@@ -427,7 +427,7 @@ impl Printer<'_> {
 
                     if len == 1 {
                         if let Some(name) = state.name.as_ref() {
-                            write!(self.result, " ")?;
+                            self.result.write_str(" ")?;
                             name.write(&mut self.result);
                         }
                     }
@@ -621,7 +621,7 @@ impl Printer<'_> {
                     } else {
                         self.newline(offset)?;
                         if self.config.print_offsets {
-                            write!(self.result, "\n")?;
+                            self.result.write_str("\n")?;
                         }
                         break;
                     }
@@ -656,7 +656,7 @@ impl Printer<'_> {
                 self.newline_unknown_pos()?;
             }
         }
-        write!(self.result, ")")?;
+        self.result.write_str(")")?;
         Ok(())
     }
 
@@ -769,7 +769,7 @@ impl Printer<'_> {
                         unreachable!("Wasm GC types cannot appear in components yet")
                     }
                 };
-                write!(self.result, " ")?;
+                self.result.write_str(" ")?;
                 self.start_group("func")?;
                 self.print_func_type(states.last().unwrap(), &ty, None)?;
                 self.end_group()?;
@@ -809,7 +809,7 @@ impl Printer<'_> {
         self.start_group("type ")?;
         let ty_idx = state.core.types.len() as u32;
         self.print_name(&state.core.type_names, ty_idx)?;
-        write!(self.result, " ")?;
+        self.result.write_str(" ")?;
         self.print_sub(state, &ty, ty_idx)?;
         self.end_group()?; // `type`
         state.core.types.push(Some(ty));
@@ -909,7 +909,7 @@ impl Printer<'_> {
         names_for: Option<u32>,
     ) -> Result<u32> {
         if !ty.params().is_empty() {
-            write!(self.result, " ")?;
+            self.result.write_str(" ")?;
         }
 
         let mut params = NamedLocalPrinter::new("param");
@@ -923,10 +923,10 @@ impl Printer<'_> {
         }
         params.finish(self)?;
         if !ty.results().is_empty() {
-            write!(self.result, " ")?;
+            self.result.write_str(" ")?;
             self.start_group("result")?;
             for result in ty.results().iter() {
-                write!(self.result, " ")?;
+                self.result.write_str(" ")?;
                 self.print_valtype(state, *result)?;
             }
             self.end_group()?;
@@ -940,7 +940,7 @@ impl Printer<'_> {
         ty: &FieldType,
         ty_field_idx: Option<(u32, u32)>,
     ) -> Result<u32> {
-        write!(self.result, " ")?;
+        self.result.write_str(" ")?;
         if let Some(idxs @ (_, field_idx)) = ty_field_idx {
             match state.core.field_names.index_to_name.get(&idxs) {
                 Some(name) => write!(self.result, "${} ", name.identifier())?,
@@ -949,11 +949,11 @@ impl Printer<'_> {
             }
         }
         if ty.mutable {
-            write!(self.result, "(mut ")?;
+            self.result.write_str("(mut ")?;
         }
         self.print_storage_type(state, ty.element_type)?;
         if ty.mutable {
-            write!(self.result, ")")?;
+            self.result.write_str(")")?;
         }
         Ok(0)
     }
@@ -964,29 +964,29 @@ impl Printer<'_> {
 
     fn print_struct_type(&mut self, state: &State, ty: &StructType, ty_idx: u32) -> Result<u32> {
         for (field_index, field) in ty.fields.iter().enumerate() {
-            write!(self.result, " (field")?;
+            self.result.write_str(" (field")?;
             self.print_field_type(state, field, Some((ty_idx, field_index as u32)))?;
-            write!(self.result, ")")?;
+            self.result.write_str(")")?;
         }
         Ok(0)
     }
 
     fn print_sub_type(&mut self, state: &State, ty: &SubType) -> Result<u32> {
-        write!(self.result, " ")?;
+        self.result.write_str(" ")?;
         if ty.is_final {
-            write!(self.result, "final ")?;
+            self.result.write_str("final ")?;
         }
         if let Some(idx) = ty.supertype_idx {
             self.print_idx(&state.core.type_names, idx.as_module_index().unwrap())?;
-            write!(self.result, " ")?;
+            self.result.write_str(" ")?;
         }
         Ok(0)
     }
 
     fn print_storage_type(&mut self, state: &State, ty: StorageType) -> Result<()> {
         match ty {
-            StorageType::I8 => write!(self.result, "i8")?,
-            StorageType::I16 => write!(self.result, "i16")?,
+            StorageType::I8 => self.result.write_str("i8")?,
+            StorageType::I16 => self.result.write_str("i16")?,
             StorageType::Val(val_type) => self.print_valtype(state, val_type)?,
         }
         Ok(())
@@ -994,11 +994,11 @@ impl Printer<'_> {
 
     fn print_valtype(&mut self, state: &State, ty: ValType) -> Result<()> {
         match ty {
-            ValType::I32 => write!(self.result, "i32")?,
-            ValType::I64 => write!(self.result, "i64")?,
-            ValType::F32 => write!(self.result, "f32")?,
-            ValType::F64 => write!(self.result, "f64")?,
-            ValType::V128 => write!(self.result, "v128")?,
+            ValType::I32 => self.result.write_str("i32")?,
+            ValType::I64 => self.result.write_str("i64")?,
+            ValType::F32 => self.result.write_str("f32")?,
+            ValType::F64 => self.result.write_str("f64")?,
+            ValType::V128 => self.result.write_str("v128")?,
             ValType::Ref(rt) => self.print_reftype(state, rt)?,
         }
         Ok(())
@@ -1007,21 +1007,21 @@ impl Printer<'_> {
     fn print_reftype(&mut self, state: &State, ty: RefType) -> Result<()> {
         if ty.is_nullable() {
             match ty.as_non_null() {
-                RefType::FUNC => write!(self.result, "funcref")?,
-                RefType::EXTERN => write!(self.result, "externref")?,
-                RefType::I31 => write!(self.result, "i31ref")?,
-                RefType::ANY => write!(self.result, "anyref")?,
-                RefType::NONE => write!(self.result, "nullref")?,
-                RefType::NOEXTERN => write!(self.result, "nullexternref")?,
-                RefType::NOFUNC => write!(self.result, "nullfuncref")?,
-                RefType::EQ => write!(self.result, "eqref")?,
-                RefType::STRUCT => write!(self.result, "structref")?,
-                RefType::ARRAY => write!(self.result, "arrayref")?,
-                RefType::EXN => write!(self.result, "exnref")?,
-                RefType::NOEXN => write!(self.result, "nullexnref")?,
+                RefType::FUNC => self.result.write_str("funcref")?,
+                RefType::EXTERN => self.result.write_str("externref")?,
+                RefType::I31 => self.result.write_str("i31ref")?,
+                RefType::ANY => self.result.write_str("anyref")?,
+                RefType::NONE => self.result.write_str("nullref")?,
+                RefType::NOEXTERN => self.result.write_str("nullexternref")?,
+                RefType::NOFUNC => self.result.write_str("nullfuncref")?,
+                RefType::EQ => self.result.write_str("eqref")?,
+                RefType::STRUCT => self.result.write_str("structref")?,
+                RefType::ARRAY => self.result.write_str("arrayref")?,
+                RefType::EXN => self.result.write_str("exnref")?,
+                RefType::NOEXN => self.result.write_str("nullexnref")?,
                 _ => {
                     self.start_group("ref")?;
-                    write!(self.result, " null ")?;
+                    self.result.write_str(" null ")?;
                     self.print_heaptype(state, ty.heap_type())?;
                     self.end_group()?;
                 }
@@ -1036,18 +1036,18 @@ impl Printer<'_> {
 
     fn print_heaptype(&mut self, state: &State, ty: HeapType) -> Result<()> {
         match ty {
-            HeapType::Func => write!(self.result, "func")?,
-            HeapType::Extern => write!(self.result, "extern")?,
-            HeapType::Any => write!(self.result, "any")?,
-            HeapType::None => write!(self.result, "none")?,
-            HeapType::NoExtern => write!(self.result, "noextern")?,
-            HeapType::NoFunc => write!(self.result, "nofunc")?,
-            HeapType::Eq => write!(self.result, "eq")?,
-            HeapType::Struct => write!(self.result, "struct")?,
-            HeapType::Array => write!(self.result, "array")?,
-            HeapType::I31 => write!(self.result, "i31")?,
-            HeapType::Exn => write!(self.result, "exn")?,
-            HeapType::NoExn => write!(self.result, "noexn")?,
+            HeapType::Func => self.result.write_str("func")?,
+            HeapType::Extern => self.result.write_str("extern")?,
+            HeapType::Any => self.result.write_str("any")?,
+            HeapType::None => self.result.write_str("none")?,
+            HeapType::NoExtern => self.result.write_str("noextern")?,
+            HeapType::NoFunc => self.result.write_str("nofunc")?,
+            HeapType::Eq => self.result.write_str("eq")?,
+            HeapType::Struct => self.result.write_str("struct")?,
+            HeapType::Array => self.result.write_str("array")?,
+            HeapType::I31 => self.result.write_str("i31")?,
+            HeapType::Exn => self.result.write_str("exn")?,
+            HeapType::NoExn => self.result.write_str("noexn")?,
             HeapType::Concrete(i) => {
                 self.print_idx(&state.core.type_names, i.as_module_index().unwrap())?;
             }
@@ -1074,9 +1074,9 @@ impl Printer<'_> {
     fn print_import(&mut self, state: &State, import: &Import<'_>, index: bool) -> Result<()> {
         self.start_group("import ")?;
         self.print_str(import.module)?;
-        write!(self.result, " ")?;
+        self.result.write_str(" ")?;
         self.print_str(import.name)?;
-        write!(self.result, " ")?;
+        self.result.write_str(" ")?;
         self.print_import_ty(state, &import.ty, index)?;
         self.end_group()?;
         Ok(())
@@ -1088,7 +1088,7 @@ impl Printer<'_> {
                 self.start_group("func ")?;
                 if index {
                     self.print_name(&state.core.func_names, state.core.funcs)?;
-                    write!(self.result, " ")?;
+                    self.result.write_str(" ")?;
                 }
                 self.print_core_type_ref(state, *f)?;
             }
@@ -1105,13 +1105,13 @@ impl Printer<'_> {
         self.start_group("table ")?;
         if index {
             self.print_name(&state.core.table_names, state.core.tables)?;
-            write!(self.result, " ")?;
+            self.result.write_str(" ")?;
         }
         if ty.table64 {
-            write!(self.result, "i64 ")?;
+            self.result.write_str("i64 ")?;
         }
         self.print_limits(ty.initial, ty.maximum)?;
-        write!(self.result, " ")?;
+        self.result.write_str(" ")?;
         self.print_reftype(state, ty.element_type)?;
         Ok(())
     }
@@ -1120,14 +1120,14 @@ impl Printer<'_> {
         self.start_group("memory ")?;
         if index {
             self.print_name(&state.core.memory_names, state.core.memories)?;
-            write!(self.result, " ")?;
+            self.result.write_str(" ")?;
         }
         if ty.memory64 {
-            write!(self.result, "i64 ")?;
+            self.result.write_str("i64 ")?;
         }
         self.print_limits(ty.initial, ty.maximum)?;
         if ty.shared {
-            write!(self.result, " shared")?;
+            self.result.write_str(" shared")?;
         }
         if let Some(p) = ty.page_size_log2 {
             let p = 1_u64
@@ -1142,7 +1142,7 @@ impl Printer<'_> {
         self.start_group("tag ")?;
         if index {
             self.print_name(&state.core.tag_names, state.core.tags)?;
-            write!(self.result, " ")?;
+            self.result.write_str(" ")?;
         }
         self.print_core_functype_idx(state, ty.func_type_idx, None)?;
         Ok(())
@@ -1163,18 +1163,18 @@ impl Printer<'_> {
         self.start_group("global ")?;
         if index {
             self.print_name(&state.core.global_names, state.core.globals)?;
-            write!(self.result, " ")?;
+            self.result.write_str(" ")?;
         }
         if ty.shared || ty.mutable {
-            write!(self.result, "(")?;
+            self.result.write_str("(")?;
             if ty.shared {
-                write!(self.result, "shared ")?;
+                self.result.write_str("shared ")?;
             }
             if ty.mutable {
-                write!(self.result, "mut ")?;
+                self.result.write_str("mut ")?;
             }
             self.print_valtype(state, ty.content_type)?;
-            write!(self.result, ")")?;
+            self.result.write_str(")")?;
         } else {
             self.print_valtype(state, ty.content_type)?;
         }
@@ -1189,7 +1189,7 @@ impl Printer<'_> {
             match &table.init {
                 TableInit::RefNull => {}
                 TableInit::Expr(expr) => {
-                    write!(self.result, " ")?;
+                    self.result.write_str(" ")?;
                     self.print_const_expr(state, expr)?;
                 }
             }
@@ -1226,7 +1226,7 @@ impl Printer<'_> {
             let (offset, global) = global?;
             self.newline(offset)?;
             self.print_global_type(state, &global.ty, true)?;
-            write!(self.result, " ")?;
+            self.result.write_str(" ")?;
             self.print_const_expr(state, &global.init_expr)?;
             self.end_group()?;
             state.core.globals += 1;
@@ -1251,7 +1251,7 @@ impl Printer<'_> {
             self.start_group("func ")?;
             let func_idx = state.core.funcs;
             self.print_name(&state.core.func_names, func_idx)?;
-            write!(self.result, " ")?;
+            self.result.write_str(" ")?;
             let params = self
                 .print_core_functype_idx(state, ty, Some(func_idx))?
                 .unwrap_or(0);
@@ -1267,7 +1267,7 @@ impl Printer<'_> {
             };
 
             if self.config.print_skeleton {
-                write!(self.result, " ...")?;
+                self.result.write_str(" ...")?;
             } else {
                 self.print_func_body(state, func_idx, params, &mut body, &hints)?;
             }
@@ -1360,7 +1360,7 @@ impl Printer<'_> {
     }
 
     fn print_newline(&mut self, offset: Option<usize>) -> Result<()> {
-        write!(self.result, "\n")?;
+        self.result.write_str("\n")?;
 
         self.lines.push(self.result.len());
         self.line_offsets.push(offset);
@@ -1368,7 +1368,7 @@ impl Printer<'_> {
         if self.config.print_offsets {
             match offset {
                 Some(offset) => write!(self.result, "(;@{offset:<6x};)")?,
-                None => write!(self.result, "           ")?,
+                None => self.result.write_str("           ")?,
             }
         }
         self.line += 1;
@@ -1377,7 +1377,7 @@ impl Printer<'_> {
         // reasonable to avoid generating hundreds of megabytes of whitespace
         // for small-ish modules that have deep-ish nesting.
         for _ in 0..self.nesting.min(MAX_NESTING_TO_PRINT) {
-            write!(self.result, "  ")?;
+            self.result.write_str("  ")?;
         }
         Ok(())
     }
@@ -1394,7 +1394,7 @@ impl Printer<'_> {
     fn print_export(&mut self, state: &State, export: &Export) -> Result<()> {
         self.start_group("export ")?;
         self.print_str(export.name)?;
-        write!(self.result, " ")?;
+        self.result.write_str(" ")?;
         self.print_external_kind(state, export.kind, export.index)?;
         self.end_group()?; // export
         Ok(())
@@ -1491,7 +1491,7 @@ impl Printer<'_> {
         match names.get(&cur_idx) {
             Some(name) => {
                 name.write(&mut self.result);
-                write!(self.result, " ")?;
+                self.result.write_str(" ")?;
             }
             None if self.config.name_unnamed => {
                 write!(self.result, "$#{desc}{cur_idx} ")?;
@@ -1510,38 +1510,38 @@ impl Printer<'_> {
             self.print_name(&state.core.element_names, i as u32)?;
             match &mut elem.kind {
                 ElementKind::Passive => {}
-                ElementKind::Declared => write!(self.result, " declare")?,
+                ElementKind::Declared => self.result.write_str(" declare")?,
                 ElementKind::Active {
                     table_index,
                     offset_expr,
                 } => {
                     let table_index = table_index.unwrap_or(0);
                     if table_index != 0 {
-                        write!(self.result, " (table ")?;
+                        self.result.write_str(" (table ")?;
                         self.print_idx(&state.core.table_names, table_index)?;
-                        write!(self.result, ")")?;
+                        self.result.write_str(")")?;
                     }
-                    write!(self.result, " ")?;
+                    self.result.write_str(" ")?;
                     self.print_const_expr_sugar(state, offset_expr, "offset")?;
                 }
             }
-            write!(self.result, " ")?;
+            self.result.write_str(" ")?;
 
             if self.config.print_skeleton {
-                write!(self.result, "...")?;
+                self.result.write_str("...")?;
             } else {
                 match elem.items {
                     ElementItems::Functions(reader) => {
-                        write!(self.result, "func")?;
+                        self.result.write_str("func")?;
                         for idx in reader {
-                            write!(self.result, " ")?;
+                            self.result.write_str(" ")?;
                             self.print_idx(&state.core.func_names, idx?)?
                         }
                     }
                     ElementItems::Expressions(ty, reader) => {
                         self.print_reftype(state, ty)?;
                         for expr in reader {
-                            write!(self.result, " ")?;
+                            self.result.write_str(" ")?;
                             self.print_const_expr_sugar(state, &expr?, "item")?
                         }
                     }
@@ -1558,7 +1558,7 @@ impl Printer<'_> {
             self.newline(offset)?;
             self.start_group("data ")?;
             self.print_name(&state.core.data_names, i as u32)?;
-            write!(self.result, " ")?;
+            self.result.write_str(" ")?;
             match &data.kind {
                 DataKind::Passive => {}
                 DataKind::Active {
@@ -1566,16 +1566,16 @@ impl Printer<'_> {
                     offset_expr,
                 } => {
                     if *memory_index != 0 {
-                        write!(self.result, "(memory ")?;
+                        self.result.write_str("(memory ")?;
                         self.print_idx(&state.core.memory_names, *memory_index)?;
-                        write!(self.result, ") ")?;
+                        self.result.write_str(") ")?;
                     }
                     self.print_const_expr_sugar(state, offset_expr, "offset")?;
-                    write!(self.result, " ")?;
+                    self.result.write_str(" ")?;
                 }
             }
             if self.config.print_skeleton {
-                write!(self.result, "...")?;
+                self.result.write_str("...")?;
             } else {
                 self.print_bytes(data.data)?;
             }
@@ -1626,19 +1626,19 @@ impl Printer<'_> {
 
     fn print_primitive_val_type(&mut self, ty: &PrimitiveValType) -> Result<()> {
         match ty {
-            PrimitiveValType::Bool => write!(self.result, "bool")?,
-            PrimitiveValType::S8 => write!(self.result, "s8")?,
-            PrimitiveValType::U8 => write!(self.result, "u8")?,
-            PrimitiveValType::S16 => write!(self.result, "s16")?,
-            PrimitiveValType::U16 => write!(self.result, "u16")?,
-            PrimitiveValType::S32 => write!(self.result, "s32")?,
-            PrimitiveValType::U32 => write!(self.result, "u32")?,
-            PrimitiveValType::S64 => write!(self.result, "s64")?,
-            PrimitiveValType::U64 => write!(self.result, "u64")?,
-            PrimitiveValType::F32 => write!(self.result, "f32")?,
-            PrimitiveValType::F64 => write!(self.result, "f64")?,
-            PrimitiveValType::Char => write!(self.result, "char")?,
-            PrimitiveValType::String => write!(self.result, "string")?,
+            PrimitiveValType::Bool => self.result.write_str("bool")?,
+            PrimitiveValType::S8 => self.result.write_str("s8")?,
+            PrimitiveValType::U8 => self.result.write_str("u8")?,
+            PrimitiveValType::S16 => self.result.write_str("s16")?,
+            PrimitiveValType::U16 => self.result.write_str("u16")?,
+            PrimitiveValType::S32 => self.result.write_str("s32")?,
+            PrimitiveValType::U32 => self.result.write_str("u32")?,
+            PrimitiveValType::S64 => self.result.write_str("s64")?,
+            PrimitiveValType::U64 => self.result.write_str("u64")?,
+            PrimitiveValType::F32 => self.result.write_str("f32")?,
+            PrimitiveValType::F64 => self.result.write_str("f64")?,
+            PrimitiveValType::Char => self.result.write_str("char")?,
+            PrimitiveValType::String => self.result.write_str("string")?,
         }
         Ok(())
     }
@@ -1650,10 +1650,10 @@ impl Printer<'_> {
     ) -> Result<()> {
         self.start_group("record")?;
         for (name, ty) in fields.iter() {
-            write!(self.result, " ")?;
+            self.result.write_str(" ")?;
             self.start_group("field ")?;
             self.print_str(name)?;
-            write!(self.result, " ")?;
+            self.result.write_str(" ")?;
             self.print_component_val_type(state, ty)?;
             self.end_group()?;
         }
@@ -1664,17 +1664,17 @@ impl Printer<'_> {
     fn print_variant_type(&mut self, state: &State, cases: &[VariantCase]) -> Result<()> {
         self.start_group("variant")?;
         for case in cases {
-            write!(self.result, " ")?;
+            self.result.write_str(" ")?;
             self.start_group("case ")?;
             self.print_str(case.name)?;
 
             if let Some(ty) = case.ty {
-                write!(self.result, " ")?;
+                self.result.write_str(" ")?;
                 self.print_component_val_type(state, &ty)?;
             }
 
             if let Some(refines) = case.refines {
-                write!(self.result, " ")?;
+                self.result.write_str(" ")?;
                 self.start_group("refines ")?;
                 write!(&mut self.result, "{}", refines)?;
                 self.end_group()?;
@@ -1696,7 +1696,7 @@ impl Printer<'_> {
     fn print_tuple_type(&mut self, state: &State, tys: &[ComponentValType]) -> Result<()> {
         self.start_group("tuple")?;
         for ty in tys {
-            write!(self.result, " ")?;
+            self.result.write_str(" ")?;
             self.print_component_val_type(state, ty)?;
         }
         self.end_group()?;
@@ -1706,7 +1706,7 @@ impl Printer<'_> {
     fn print_flag_or_enum_type(&mut self, ty: &str, names: &[&str]) -> Result<()> {
         self.start_group(ty)?;
         for name in names {
-            write!(self.result, " ")?;
+            self.result.write_str(" ")?;
             self.print_str(name)?;
         }
         self.end_group()?;
@@ -1729,12 +1729,12 @@ impl Printer<'_> {
         self.start_group("result")?;
 
         if let Some(ok) = ok {
-            write!(self.result, " ")?;
+            self.result.write_str(" ")?;
             self.print_component_val_type(state, &ok)?;
         }
 
         if let Some(err) = err {
-            write!(self.result, " ")?;
+            self.result.write_str(" ")?;
             self.start_group("error ")?;
             self.print_component_val_type(state, &err)?;
             self.end_group()?;
@@ -1798,7 +1798,7 @@ impl Printer<'_> {
                 ModuleTypeDeclaration::Export { name, ty } => {
                     self.start_group("export ")?;
                     self.print_str(name)?;
-                    write!(self.result, " ")?;
+                    self.result.write_str(" ")?;
                     self.print_import_ty(states.last_mut().unwrap(), &ty, false)?;
                     self.end_group()?;
                 }
@@ -1831,9 +1831,9 @@ impl Printer<'_> {
                 ComponentTypeDeclaration::Export { name, ty } => {
                     self.start_group("export ")?;
                     self.print_component_kind_name(states.last_mut().unwrap(), ty.kind())?;
-                    write!(self.result, " ")?;
+                    self.result.write_str(" ")?;
                     self.print_str(name.0)?;
-                    write!(self.result, " ")?;
+                    self.result.write_str(" ")?;
                     self.print_component_import_ty(states.last_mut().unwrap(), &ty, false)?;
                     self.end_group()?;
                 }
@@ -1866,9 +1866,9 @@ impl Printer<'_> {
                 InstanceTypeDeclaration::Export { name, ty } => {
                     self.start_group("export ")?;
                     self.print_component_kind_name(states.last_mut().unwrap(), ty.kind())?;
-                    write!(self.result, " ")?;
+                    self.result.write_str(" ")?;
                     self.print_str(name.0)?;
-                    write!(self.result, " ")?;
+                    self.result.write_str(" ")?;
                     self.print_component_import_ty(states.last_mut().unwrap(), &ty, false)?;
                     self.end_group()?;
                 }
@@ -1903,11 +1903,11 @@ impl Printer<'_> {
         } else {
             write!(self.result, "{count}")?;
         }
-        write!(self.result, " ")?;
+        self.result.write_str(" ")?;
         match kind {
             OuterAliasKind::Type => {
                 self.print_idx(&outer.core.type_names, index)?;
-                write!(self.result, " ")?;
+                self.result.write_str(" ")?;
                 self.start_group("type ")?;
                 self.print_name(&state.core.type_names, state.core.types.len() as u32)?;
             }
@@ -1926,20 +1926,20 @@ impl Printer<'_> {
     fn print_component_func_type(&mut self, state: &State, ty: &ComponentFuncType) -> Result<()> {
         self.start_group("func")?;
         for (name, ty) in ty.params.iter() {
-            write!(self.result, " ")?;
+            self.result.write_str(" ")?;
             self.start_group("param ")?;
             self.print_str(name)?;
-            write!(self.result, " ")?;
+            self.result.write_str(" ")?;
             self.print_component_val_type(state, ty)?;
             self.end_group()?;
         }
 
         for (name, ty) in ty.results.iter() {
-            write!(self.result, " ")?;
+            self.result.write_str(" ")?;
             self.start_group("result ")?;
             if let Some(name) = name {
                 self.print_str(name)?;
-                write!(self.result, " ")?;
+                self.result.write_str(" ")?;
             }
             self.print_component_val_type(state, ty)?;
             self.end_group()?;
@@ -1962,11 +1962,11 @@ impl Printer<'_> {
         }
         match ty {
             ComponentType::Defined(ty) => {
-                write!(self.result, " ")?;
+                self.result.write_str(" ")?;
                 self.print_defined_type(states.last_mut().unwrap(), &ty)?;
             }
             ComponentType::Func(ty) => {
-                write!(self.result, " ")?;
+                self.result.write_str(" ")?;
                 self.print_component_func_type(states.last_mut().unwrap(), &ty)?;
             }
             ComponentType::Component(decls) => {
@@ -1976,15 +1976,15 @@ impl Printer<'_> {
                 self.print_instance_type(states, decls.into_vec())?;
             }
             ComponentType::Resource { rep, dtor } => {
-                write!(self.result, " ")?;
+                self.result.write_str(" ")?;
                 self.start_group("resource")?;
-                write!(self.result, " (rep ")?;
+                self.result.write_str(" (rep ")?;
                 self.print_valtype(states.last().unwrap(), rep)?;
-                write!(self.result, ")")?;
+                self.result.write_str(")")?;
                 if let Some(dtor) = dtor {
-                    write!(self.result, " (dtor (func ")?;
+                    self.result.write_str(" (dtor (func ")?;
                     self.print_idx(&states.last().unwrap().core.func_names, dtor)?;
-                    write!(self.result, "))")?;
+                    self.result.write_str("))")?;
                 }
                 self.end_group()?;
             }
@@ -2032,7 +2032,7 @@ impl Printer<'_> {
     ) -> Result<()> {
         self.start_group("import ")?;
         self.print_str(import.name.0)?;
-        write!(self.result, " ")?;
+        self.result.write_str(" ")?;
         self.print_component_import_ty(state, &import.ty, index)?;
         self.end_group()?;
         Ok(())
@@ -2049,7 +2049,7 @@ impl Printer<'_> {
                 self.start_group("core module ")?;
                 if index {
                     self.print_name(&state.core.module_names, state.core.modules as u32)?;
-                    write!(self.result, " ")?;
+                    self.result.write_str(" ")?;
                     state.core.modules += 1;
                 }
                 self.print_component_type_ref(state, *idx)?;
@@ -2059,7 +2059,7 @@ impl Printer<'_> {
                 self.start_group("func ")?;
                 if index {
                     self.print_name(&state.component.func_names, state.component.funcs)?;
-                    write!(self.result, " ")?;
+                    self.result.write_str(" ")?;
                     state.component.funcs += 1;
                 }
                 self.print_component_type_ref(state, *idx)?;
@@ -2069,7 +2069,7 @@ impl Printer<'_> {
                 self.start_group("value ")?;
                 if index {
                     self.print_name(&state.component.value_names, state.component.values)?;
-                    write!(self.result, " ")?;
+                    self.result.write_str(" ")?;
                     state.component.values += 1;
                 }
                 match ty {
@@ -2079,29 +2079,29 @@ impl Printer<'_> {
                 self.end_group()?;
             }
             ComponentTypeRef::Type(bounds) => {
-                write!(self.result, "(type ")?;
+                self.result.write_str("(type ")?;
                 if index {
                     self.print_name(&state.component.type_names, state.component.types)?;
-                    write!(self.result, " ")?;
+                    self.result.write_str(" ")?;
                     state.component.types += 1;
                 }
                 match bounds {
                     TypeBounds::Eq(idx) => {
-                        write!(self.result, "(eq ")?;
+                        self.result.write_str("(eq ")?;
                         self.print_idx(&state.component.type_names, *idx)?;
-                        write!(self.result, ")")?;
+                        self.result.write_str(")")?;
                     }
                     TypeBounds::SubResource => {
-                        write!(self.result, "(sub resource)")?;
+                        self.result.write_str("(sub resource)")?;
                     }
                 };
-                write!(self.result, ")")?;
+                self.result.write_str(")")?;
             }
             ComponentTypeRef::Instance(idx) => {
                 self.start_group("instance ")?;
                 if index {
                     self.print_name(&state.component.instance_names, state.component.instances)?;
-                    write!(self.result, " ")?;
+                    self.result.write_str(" ")?;
                     state.component.instances += 1;
                 }
                 self.print_component_type_ref(state, *idx)?;
@@ -2111,7 +2111,7 @@ impl Printer<'_> {
                 self.start_group("component ")?;
                 if index {
                     self.print_name(&state.component.component_names, state.component.components)?;
-                    write!(self.result, " ")?;
+                    self.result.write_str(" ")?;
                     state.component.components += 1;
                 }
                 self.print_component_type_ref(state, *idx)?;
@@ -2143,13 +2143,13 @@ impl Printer<'_> {
         self.start_group("export ")?;
         if named {
             self.print_component_kind_name(state, export.kind)?;
-            write!(self.result, " ")?;
+            self.result.write_str(" ")?;
         }
         self.print_str(export.name.0)?;
-        write!(self.result, " ")?;
+        self.result.write_str(" ")?;
         self.print_component_external_kind(state, export.kind, export.index)?;
         if let Some(ty) = &export.ty {
-            write!(self.result, " ")?;
+            self.result.write_str(" ")?;
             self.print_component_import_ty(state, &ty, false)?;
         }
         self.end_group()?;
@@ -2251,12 +2251,12 @@ impl Printer<'_> {
         options: &[CanonicalOption],
     ) -> Result<()> {
         for option in options {
-            write!(self.result, " ")?;
+            self.result.write_str(" ")?;
             match option {
-                CanonicalOption::UTF8 => write!(self.result, "string-encoding=utf8")?,
-                CanonicalOption::UTF16 => write!(self.result, "string-encoding=utf16")?,
+                CanonicalOption::UTF8 => self.result.write_str("string-encoding=utf8")?,
+                CanonicalOption::UTF16 => self.result.write_str("string-encoding=utf16")?,
                 CanonicalOption::CompactUTF16 => {
-                    write!(self.result, "string-encoding=latin1+utf16")?
+                    self.result.write_str("string-encoding=latin1+utf16")?
                 }
                 CanonicalOption::Memory(idx) => {
                     self.start_group("memory ")?;
@@ -2294,11 +2294,11 @@ impl Printer<'_> {
                 } => {
                     self.start_group("func ")?;
                     self.print_name(&state.component.func_names, state.component.funcs)?;
-                    write!(self.result, " ")?;
+                    self.result.write_str(" ")?;
                     self.start_group("type ")?;
                     self.print_idx(&state.component.type_names, type_index)?;
                     self.end_group()?;
-                    write!(self.result, " ")?;
+                    self.result.write_str(" ")?;
                     self.start_group("canon lift ")?;
                     self.start_group("core func ")?;
                     self.print_idx(&state.core.func_names, core_func_index)?;
@@ -2314,7 +2314,7 @@ impl Printer<'_> {
                 } => {
                     self.start_group("core func ")?;
                     self.print_name(&state.core.func_names, state.core.funcs)?;
-                    write!(self.result, " ")?;
+                    self.result.write_str(" ")?;
                     self.start_group("canon lower ")?;
                     self.start_group("func ")?;
                     self.print_idx(&state.component.func_names, func_index)?;
@@ -2327,7 +2327,7 @@ impl Printer<'_> {
                 CanonicalFunction::ResourceNew { resource } => {
                     self.start_group("core func ")?;
                     self.print_name(&state.core.func_names, state.core.funcs)?;
-                    write!(self.result, " ")?;
+                    self.result.write_str(" ")?;
                     self.start_group("canon resource.new ")?;
                     self.print_idx(&state.component.type_names, resource)?;
                     self.end_group()?;
@@ -2337,7 +2337,7 @@ impl Printer<'_> {
                 CanonicalFunction::ResourceDrop { resource } => {
                     self.start_group("core func ")?;
                     self.print_name(&state.core.func_names, state.core.funcs)?;
-                    write!(self.result, " ")?;
+                    self.result.write_str(" ")?;
                     self.start_group("canon resource.drop ")?;
                     self.print_idx(&state.component.type_names, resource)?;
                     self.end_group()?;
@@ -2347,7 +2347,7 @@ impl Printer<'_> {
                 CanonicalFunction::ResourceRep { resource } => {
                     self.start_group("core func ")?;
                     self.print_name(&state.core.func_names, state.core.funcs)?;
-                    write!(self.result, " ")?;
+                    self.result.write_str(" ")?;
                     self.start_group("canon resource.rep ")?;
                     self.print_idx(&state.component.type_names, resource)?;
                     self.end_group()?;
@@ -2368,7 +2368,7 @@ impl Printer<'_> {
             self.print_name(&state.core.instance_names, state.core.instances)?;
             match instance {
                 Instance::Instantiate { module_index, args } => {
-                    write!(self.result, " ")?;
+                    self.result.write_str(" ")?;
                     self.start_group("instantiate ")?;
                     self.print_idx(&state.core.module_names, module_index)?;
                     for arg in args.iter() {
@@ -2407,7 +2407,7 @@ impl Printer<'_> {
                     component_index,
                     args,
                 } => {
-                    write!(self.result, " ")?;
+                    self.result.write_str(" ")?;
                     self.start_group("instantiate ")?;
                     self.print_idx(&state.component.component_names, component_index)?;
                     for arg in args.iter() {
@@ -2431,7 +2431,7 @@ impl Printer<'_> {
     fn print_instantiation_arg(&mut self, state: &State, arg: &InstantiationArg) -> Result<()> {
         self.start_group("with ")?;
         self.print_str(arg.name)?;
-        write!(self.result, " ")?;
+        self.result.write_str(" ")?;
         match arg.kind {
             InstantiationArgKind::Instance => {
                 self.start_group("instance ")?;
@@ -2450,7 +2450,7 @@ impl Printer<'_> {
     ) -> Result<()> {
         self.start_group("with ")?;
         self.print_str(arg.name)?;
-        write!(self.result, " ")?;
+        self.result.write_str(" ")?;
         self.print_component_external_kind(state, arg.kind, arg.index)?;
         self.end_group()?;
         Ok(())
@@ -2467,14 +2467,14 @@ impl Printer<'_> {
         self.print_idx(&state.component.func_names, start.func_index)?;
 
         for arg in start.arguments.iter() {
-            write!(self.result, " ")?;
+            self.result.write_str(" ")?;
             self.start_group("value ")?;
             self.print_idx(&state.component.value_names, *arg)?;
             self.end_group()?;
         }
 
         for _ in 0..start.results {
-            write!(self.result, " ")?;
+            self.result.write_str(" ")?;
             self.start_group("result ")?;
             self.start_group("value ")?;
             self.print_name(&state.component.value_names, state.component.values)?;
@@ -2515,9 +2515,9 @@ impl Printer<'_> {
                 let state = states.last_mut().unwrap();
                 self.start_group("alias export ")?;
                 self.print_idx(&state.component.instance_names, instance_index)?;
-                write!(self.result, " ")?;
+                self.result.write_str(" ")?;
                 self.print_str(name)?;
-                write!(self.result, " ")?;
+                self.result.write_str(" ")?;
                 self.start_component_external_kind_group(kind)?;
                 self.print_component_kind_name(state, kind)?;
                 self.end_group()?;
@@ -2532,9 +2532,9 @@ impl Printer<'_> {
                 let state = states.last_mut().unwrap();
                 self.start_group("alias core export ")?;
                 self.print_idx(&state.core.instance_names, instance_index)?;
-                write!(self.result, " ")?;
+                self.result.write_str(" ")?;
                 self.print_str(name)?;
-                write!(self.result, " ")?;
+                self.result.write_str(" ")?;
                 match kind {
                     ExternalKind::Func => {
                         self.start_group("core func ")?;
@@ -2579,29 +2579,29 @@ impl Printer<'_> {
                 } else {
                     write!(self.result, "{count}")?;
                 }
-                write!(self.result, " ")?;
+                self.result.write_str(" ")?;
                 match kind {
                     ComponentOuterAliasKind::CoreModule => {
                         self.print_idx(&outer.core.module_names, index)?;
-                        write!(self.result, " ")?;
+                        self.result.write_str(" ")?;
                         self.start_group("core module ")?;
                         self.print_name(&state.core.module_names, state.core.modules)?;
                     }
                     ComponentOuterAliasKind::CoreType => {
                         self.print_idx(&outer.core.type_names, index)?;
-                        write!(self.result, " ")?;
+                        self.result.write_str(" ")?;
                         self.start_group("core type ")?;
                         self.print_name(&state.core.type_names, state.core.types.len() as u32)?;
                     }
                     ComponentOuterAliasKind::Type => {
                         self.print_idx(&outer.component.type_names, index)?;
-                        write!(self.result, " ")?;
+                        self.result.write_str(" ")?;
                         self.start_group("type ")?;
                         self.print_name(&state.component.type_names, state.component.types)?;
                     }
                     ComponentOuterAliasKind::Component => {
                         self.print_idx(&outer.component.component_names, index)?;
-                        write!(self.result, " ")?;
+                        self.result.write_str(" ")?;
                         self.start_group("component ")?;
                         self.print_name(
                             &state.component.component_names,
@@ -2626,7 +2626,7 @@ impl Printer<'_> {
 
     fn print_str(&mut self, name: &str) -> Result<()> {
         let mut bytes = [0; 4];
-        write!(self.result, "\"")?;
+        self.result.write_str("\"")?;
         for c in name.chars() {
             let v = c as u32;
             if (0x20..0x7f).contains(&v) && c != '"' && c != '\\' && v < 0xff {
@@ -2637,12 +2637,12 @@ impl Printer<'_> {
                 }
             }
         }
-        write!(self.result, "\"")?;
+        self.result.write_str("\"")?;
         Ok(())
     }
 
     fn print_bytes(&mut self, bytes: &[u8]) -> Result<()> {
-        write!(self.result, "\"")?;
+        self.result.write_str("\"")?;
         for byte in bytes {
             if *byte >= 0x20 && *byte < 0x7f && *byte != b'"' && *byte != b'\\' {
                 write!(self.result, "{}", *byte as char)?;
@@ -2650,7 +2650,7 @@ impl Printer<'_> {
                 self.hex_byte(*byte)?;
             }
         }
-        write!(self.result, "\"")?;
+        self.result.write_str("\"")?;
         Ok(())
     }
 
@@ -2706,7 +2706,7 @@ impl Printer<'_> {
         if let Some(place) = state.custom_section_place {
             write!(self.result, " ({place})")?;
         }
-        write!(self.result, " ")?;
+        self.result.write_str(" ")?;
         self.print_bytes(section.data())?;
         self.end_group()?;
         Ok(())
@@ -2720,9 +2720,9 @@ impl Printer<'_> {
                 let (offset, value) = value?;
                 self.newline(offset)?;
                 self.start_group(field.name)?;
-                write!(self.result, " ")?;
+                self.result.write_str(" ")?;
                 self.print_str(value.name)?;
-                write!(self.result, " ")?;
+                self.result.write_str(" ")?;
                 self.print_str(value.version)?;
                 self.end_group()?;
             }
@@ -2764,7 +2764,7 @@ impl Printer<'_> {
                     self.newline(start)?;
                     self.start_group("needed")?;
                     for s in needed {
-                        write!(self.result, " ")?;
+                        self.result.write_str(" ")?;
                         self.print_str(s)?;
                     }
                     self.end_group()?;
@@ -2783,7 +2783,7 @@ impl Printer<'_> {
                         self.newline(start)?;
                         self.start_group("import-info ")?;
                         self.print_str(info.module)?;
-                        write!(self.result, " ")?;
+                        self.result.write_str(" ")?;
                         self.print_str(info.field)?;
                         self.print_dylink0_flags(info.flags)?;
                         self.end_group()?;
@@ -2882,14 +2882,14 @@ impl NamedLocalPrinter {
         if self.first {
             self.first = false;
         } else {
-            write!(dst.result, " ")?;
+            dst.result.write_str(" ")?;
         }
 
         // Next we either need a separator if we're already in a group or we
         // need to open a group for our new local.
         if !self.in_group {
             dst.start_group(self.group_name)?;
-            write!(dst.result, " ")?;
+            dst.result.write_str(" ")?;
             self.in_group = true;
         }
 
@@ -2897,7 +2897,7 @@ impl NamedLocalPrinter {
         match name {
             Some(name) => {
                 name.write(&mut dst.result);
-                write!(dst.result, " ")?;
+                dst.result.write_str(" ")?;
                 self.end_group_after_local = true;
             }
             None if dst.config.name_unnamed => {
@@ -2942,7 +2942,7 @@ macro_rules! print_float {
             let f = $float::from_bits(bits);
             if bits >> (int_width - 1) != 0 {
                 bits ^= 1 << (int_width - 1);
-                write!(self.result, "-")?;
+                self.result.write_str("-")?;
             }
             if f.is_infinite() {
                 write!(self.result, "inf (;={};)", f)?;
@@ -2976,11 +2976,11 @@ macro_rules! print_float {
             let mut exponent = (((bits << 1) as $sint) >> (mantissa_width + 1)).wrapping_sub(bias);
             exponent = (exponent << (int_width - exp_width)) >> (int_width - exp_width);
             let mut fraction = bits & ((1 << mantissa_width) - 1);
-            write!(self.result, "0x")?;
+            self.result.write_str("0x")?;
             if bits == 0 {
-                write!(self.result, "0p+0")?;
+                self.result.write_str("0p+0")?;
             } else {
-                write!(self.result, "1")?;
+                self.result.write_str("1")?;
                 if fraction > 0 {
                     fraction <<= (int_width - mantissa_width);
 
@@ -2997,7 +2997,7 @@ macro_rules! print_float {
                         exponent -= leading as $sint;
                     }
 
-                    write!(self.result, ".")?;
+                    self.result.write_str(".")?;
                     while fraction > 0 {
                         write!(self.result, "{:x}", fraction >> (int_width - 4))?;
                         fraction <<= 4;

--- a/crates/wasmprinter/src/operator.rs
+++ b/crates/wasmprinter/src/operator.rs
@@ -35,8 +35,9 @@ impl<'a, 'b> PrintOperator<'a, 'b> {
         }
     }
 
-    fn push_str(&mut self, s: &str) {
+    fn push_str(&mut self, s: &str) -> Result<()> {
         self.printer.result.push_str(s);
+        Ok(())
     }
 
     fn result(&mut self) -> &mut String {
@@ -102,13 +103,13 @@ impl<'a, 'b> PrintOperator<'a, 'b> {
         match ty {
             BlockType::Empty => {}
             BlockType::Type(t) => {
-                self.push_str(" ");
+                self.push_str(" ")?;
                 self.printer.start_group("result ")?;
                 self.printer.print_valtype(self.state, t)?;
                 self.printer.end_group()?;
             }
             BlockType::FuncType(idx) => {
-                self.push_str(" ");
+                self.push_str(" ")?;
                 self.printer
                     .print_core_functype_idx(self.state, idx, None)?;
             }
@@ -119,7 +120,7 @@ impl<'a, 'b> PrintOperator<'a, 'b> {
     fn maybe_blockty_label_comment(&mut self, has_name: bool) -> Result<()> {
         if !has_name {
             let depth = self.cur_depth();
-            self.push_str(" ");
+            self.push_str(" ")?;
             write!(self.result(), ";; label = @{}", depth)?;
         }
 
@@ -132,13 +133,13 @@ impl<'a, 'b> PrintOperator<'a, 'b> {
     }
 
     fn tag_index(&mut self, index: u32) -> Result<()> {
-        self.push_str(" ");
+        self.push_str(" ")?;
         self.printer.print_idx(&self.state.core.tag_names, index)?;
         Ok(())
     }
 
     fn relative_depth(&mut self, depth: u32) -> Result<()> {
-        self.push_str(" ");
+        self.push_str(" ")?;
         match self.cur_depth().checked_sub(depth) {
             // If this relative depth is in-range relative to the current depth,
             // then try to print a name for this label. Label names are tracked
@@ -219,23 +220,23 @@ impl<'a, 'b> PrintOperator<'a, 'b> {
     }
 
     fn function_index(&mut self, idx: u32) -> Result<()> {
-        self.push_str(" ");
+        self.push_str(" ")?;
         self.printer.print_idx(&self.state.core.func_names, idx)
     }
 
     fn local_index(&mut self, idx: u32) -> Result<()> {
-        self.push_str(" ");
+        self.push_str(" ")?;
         self.printer
             .print_local_idx(self.state, self.state.core.funcs, idx)
     }
 
     fn global_index(&mut self, idx: u32) -> Result<()> {
-        self.push_str(" ");
+        self.push_str(" ")?;
         self.printer.print_idx(&self.state.core.global_names, idx)
     }
 
     fn table_index(&mut self, idx: u32) -> Result<()> {
-        self.push_str(" ");
+        self.push_str(" ")?;
         self.printer.print_idx(&self.state.core.table_names, idx)
     }
 
@@ -244,27 +245,27 @@ impl<'a, 'b> PrintOperator<'a, 'b> {
     }
 
     fn memory_index(&mut self, idx: u32) -> Result<()> {
-        self.push_str(" ");
+        self.push_str(" ")?;
         self.printer.print_idx(&self.state.core.memory_names, idx)
     }
 
     fn type_index(&mut self, idx: u32) -> Result<()> {
-        self.push_str(" ");
+        self.push_str(" ")?;
         self.printer.print_core_type_ref(self.state, idx)
     }
 
     fn array_type_index(&mut self, idx: u32) -> Result<()> {
-        self.push_str(" ");
+        self.push_str(" ")?;
         self.printer.print_idx(&self.state.core.type_names, idx)
     }
 
     fn array_type_index_dst(&mut self, idx: u32) -> Result<()> {
-        self.push_str(" ");
+        self.push_str(" ")?;
         self.printer.print_idx(&self.state.core.type_names, idx)
     }
 
     fn array_type_index_src(&mut self, idx: u32) -> Result<()> {
-        self.push_str(" ");
+        self.push_str(" ")?;
         self.printer.print_idx(&self.state.core.type_names, idx)
     }
 
@@ -274,37 +275,37 @@ impl<'a, 'b> PrintOperator<'a, 'b> {
     }
 
     fn struct_type_index(&mut self, idx: u32) -> Result<()> {
-        self.push_str(" ");
+        self.push_str(" ")?;
         self.printer.print_idx(&self.state.core.type_names, idx)
     }
 
     fn from_ref_type(&mut self, ref_ty: RefType) -> Result<()> {
-        self.push_str(" ");
+        self.push_str(" ")?;
         self.printer.print_reftype(self.state, ref_ty)
     }
 
     fn to_ref_type(&mut self, ref_ty: RefType) -> Result<()> {
-        self.push_str(" ");
+        self.push_str(" ")?;
         self.printer.print_reftype(self.state, ref_ty)
     }
 
     fn data_index(&mut self, idx: u32) -> Result<()> {
-        self.push_str(" ");
+        self.push_str(" ")?;
         self.printer.print_idx(&self.state.core.data_names, idx)
     }
 
     fn array_data_index(&mut self, idx: u32) -> Result<()> {
-        self.push_str(" ");
+        self.push_str(" ")?;
         self.printer.print_idx(&self.state.core.data_names, idx)
     }
 
     fn elem_index(&mut self, idx: u32) -> Result<()> {
-        self.push_str(" ");
+        self.push_str(" ")?;
         self.printer.print_idx(&self.state.core.element_names, idx)
     }
 
     fn array_elem_index(&mut self, idx: u32) -> Result<()> {
-        self.push_str(" ");
+        self.push_str(" ")?;
         self.printer.print_idx(&self.state.core.element_names, idx)
     }
 
@@ -401,7 +402,7 @@ macro_rules! define_visit {
     ($(@$proposal:ident $op:ident $({ $($arg:ident: $argty:ty),* })? => $visit:ident )*) => ($(
         fn $visit(&mut self $( , $($arg: $argty),* )?) -> Self::Output {
             define_visit!(before_op self $op);
-            self.push_str(define_visit!(name $op));
+            self.push_str(define_visit!(name $op))?;
             $(
                 define_visit!(payload self $op $($arg)*);
             )?
@@ -450,21 +451,21 @@ macro_rules! define_visit {
         $self.type_index($ty)?;
     );
     (payload $self:ident CallRef $ty:ident) => (
-        $self.push_str(" ");
+        $self.push_str(" ")?;
         $self.printer.print_idx(&$self.state.core.type_names, $ty)?;
     );
     (payload $self:ident ReturnCallRef $ty:ident) => (
-        $self.push_str(" ");
+        $self.push_str(" ")?;
         $self.printer.print_idx(&$self.state.core.type_names, $ty)?;
     );
     (payload $self:ident TypedSelect $ty:ident) => (
-        $self.push_str(" ");
+        $self.push_str(" ")?;
         $self.printer.start_group("result ")?;
         $self.printer.print_valtype($self.state, $ty)?;
         $self.printer.end_group()?;
     );
     (payload $self:ident RefNull $hty:ident) => (
-        $self.push_str(" ");
+        $self.push_str(" ")?;
         $self.printer.print_heaptype($self.state, $hty)?;
     );
     (payload $self:ident TableInit $segment:ident $table:ident) => (
@@ -514,15 +515,15 @@ macro_rules! define_visit {
     (payload $self:ident I32Const $val:ident) => (write!($self.result(), " {}", $val)?);
     (payload $self:ident I64Const $val:ident) => (write!($self.result(), " {}", $val)?);
     (payload $self:ident F32Const $val:ident) => (
-        $self.push_str(" ");
+        $self.push_str(" ")?;
         $self.printer.print_f32($val.bits())?;
     );
     (payload $self:ident F64Const $val:ident) => (
-        $self.push_str(" ");
+        $self.push_str(" ")?;
         $self.printer.print_f64($val.bits())?;
     );
     (payload $self:ident V128Const $val:ident) => (
-        $self.push_str(" i32x4");
+        $self.push_str(" i32x4")?;
         for chunk in $val.bytes().chunks(4) {
             write!(
                 $self.result(),
@@ -535,47 +536,47 @@ macro_rules! define_visit {
         }
     );
     (payload $self:ident RefTestNonNull $hty:ident) => (
-        $self.push_str(" ");
+        $self.push_str(" ")?;
         let rty = RefType::new(false, $hty)
             .ok_or_else(|| anyhow!("implementation limit: type index too large"))?;
         $self.printer.print_reftype($self.state, rty)?;
     );
     (payload $self:ident RefTestNullable $hty:ident) => (
-        $self.push_str(" ");
+        $self.push_str(" ")?;
         let rty = RefType::new(true, $hty)
             .ok_or_else(|| anyhow!("implementation limit: type index too large"))?;
         $self.printer.print_reftype($self.state, rty)?;
     );
     (payload $self:ident RefCastNonNull $hty:ident) => (
-        $self.push_str(" ");
+        $self.push_str(" ")?;
         let rty = RefType::new(false, $hty)
             .ok_or_else(|| anyhow!("implementation limit: type index too large"))?;
         $self.printer.print_reftype($self.state, rty)?;
     );
     (payload $self:ident RefCastNullable $hty:ident) => (
-        $self.push_str(" ");
+        $self.push_str(" ")?;
         let rty = RefType::new(true, $hty)
             .ok_or_else(|| anyhow!("implementation limit: type index too large"))?;
         $self.printer.print_reftype($self.state, rty)?;
     );
     (payload $self:ident StructGet $ty:ident $field:ident) => (
         $self.struct_type_index($ty)?;
-        $self.push_str(" ");
+        $self.push_str(" ")?;
         $self.printer.print_field_idx($self.state, $ty, $field)?;
     );
     (payload $self:ident StructGetS $ty:ident $field:ident) => (
         $self.struct_type_index($ty)?;
-        $self.push_str(" ");
+        $self.push_str(" ")?;
         $self.printer.print_field_idx($self.state, $ty, $field)?;
     );
     (payload $self:ident StructGetU $ty:ident $field:ident) => (
         $self.struct_type_index($ty)?;
-        $self.push_str(" ");
+        $self.push_str(" ")?;
         $self.printer.print_field_idx($self.state, $ty, $field)?;
     );
     (payload $self:ident StructSet $ty:ident $field:ident) => (
         $self.struct_type_index($ty)?;
-        $self.push_str(" ");
+        $self.push_str(" ")?;
         $self.printer.print_field_idx($self.state, $ty, $field)?;
     );
     (payload $self:ident $op:ident $($arg:ident)*) => (

--- a/crates/wasmprinter/src/operator.rs
+++ b/crates/wasmprinter/src/operator.rs
@@ -360,7 +360,7 @@ impl<'cfg, 'a, 'b> PrintOperator<'cfg, 'a, 'b> {
         let try_table_label = self.label_indices.pop().unwrap();
 
         for catch in table.catches {
-            write!(self.result(), " ")?;
+            self.result().write_str(" ")?;
             match catch {
                 Catch::One { tag, label } => {
                     self.printer.start_group("catch")?;

--- a/crates/wasmprinter/src/operator.rs
+++ b/crates/wasmprinter/src/operator.rs
@@ -358,7 +358,7 @@ impl<'a, 'b> PrintOperator<'a, 'b> {
         let try_table_label = self.label_indices.pop().unwrap();
 
         for catch in table.catches {
-            self.result().push(' ');
+            write!(self.result(), " ")?;
             match catch {
                 Catch::One { tag, label } => {
                     self.printer.start_group("catch")?;

--- a/crates/wasmprinter/src/operator.rs
+++ b/crates/wasmprinter/src/operator.rs
@@ -102,9 +102,10 @@ impl<'a, 'b> PrintOperator<'a, 'b> {
         match ty {
             BlockType::Empty => {}
             BlockType::Type(t) => {
-                self.push_str(" (result ");
+                self.push_str(" ");
+                self.printer.start_group("result ")?;
                 self.printer.print_valtype(self.state, t)?;
-                self.push_str(")");
+                self.printer.end_group()?;
             }
             BlockType::FuncType(idx) => {
                 self.push_str(" ");
@@ -457,9 +458,10 @@ macro_rules! define_visit {
         $self.printer.print_idx(&$self.state.core.type_names, $ty)?;
     );
     (payload $self:ident TypedSelect $ty:ident) => (
-        $self.push_str(" (result ");
+        $self.push_str(" ");
+        $self.printer.start_group("result ")?;
         $self.printer.print_valtype($self.state, $ty)?;
-        $self.push_str(")")
+        $self.printer.end_group()?;
     );
     (payload $self:ident RefNull $hty:ident) => (
         $self.push_str(" ");

--- a/crates/wasmprinter/src/operator.rs
+++ b/crates/wasmprinter/src/operator.rs
@@ -360,26 +360,26 @@ impl<'a, 'b> PrintOperator<'a, 'b> {
             self.result().push(' ');
             match catch {
                 Catch::One { tag, label } => {
-                    self.printer.start_group("catch");
+                    self.printer.start_group("catch")?;
                     self.tag_index(tag)?;
                     self.relative_depth(label)?;
-                    self.printer.end_group();
+                    self.printer.end_group()?;
                 }
                 Catch::OneRef { tag, label } => {
-                    self.printer.start_group("catch_ref");
+                    self.printer.start_group("catch_ref")?;
                     self.tag_index(tag)?;
                     self.relative_depth(label)?;
-                    self.printer.end_group();
+                    self.printer.end_group()?;
                 }
                 Catch::All { label } => {
-                    self.printer.start_group("catch_all");
+                    self.printer.start_group("catch_all")?;
                     self.relative_depth(label)?;
-                    self.printer.end_group();
+                    self.printer.end_group()?;
                 }
                 Catch::AllRef { label } => {
-                    self.printer.start_group("catch_all_ref");
+                    self.printer.start_group("catch_all_ref")?;
                     self.relative_depth(label)?;
-                    self.printer.end_group();
+                    self.printer.end_group()?;
                 }
             }
         }

--- a/crates/wasmprinter/tests/all.rs
+++ b/crates/wasmprinter/tests/all.rs
@@ -248,8 +248,12 @@ fn offsets_and_lines_smoke_test() {
     "#;
     let bytes = wat::parse_str(MODULE).unwrap();
 
-    let mut printer = wasmprinter::Printer::new();
-    let actual: Vec<_> = printer.offsets_and_lines(&bytes).unwrap().collect();
+    let mut storage = String::new();
+    let printer = wasmprinter::Config::new();
+    let actual: Vec<_> = printer
+        .offsets_and_lines(&bytes, &mut storage)
+        .unwrap()
+        .collect();
 
     #[rustfmt::skip]
     let expected = vec![

--- a/src/bin/wasm-tools/print.rs
+++ b/src/bin/wasm-tools/print.rs
@@ -34,11 +34,12 @@ impl Opts {
 
     pub fn run(&self) -> Result<()> {
         let wasm = self.io.parse_input_wasm()?;
-        let mut printer = wasmprinter::Printer::new();
+        let mut printer = wasmprinter::Config::new();
         printer.print_offsets(self.print_offsets);
         printer.print_skeleton(self.skeleton);
         printer.name_unnamed(self.name_unnamed);
-        let wat = printer.print(&wasm)?;
+        let mut wat = String::new();
+        printer.print(&wasm, &mut wat)?;
         self.io.output(wasm_tools::Output::Wat(&wat))?;
         Ok(())
     }

--- a/tests/snapshots/local/producers.wast/5.print
+++ b/tests/snapshots/local/producers.wast/5.print
@@ -1,6 +1,5 @@
 (module
-    ;; failed to parse custom section `producers`: unexpected end-of-file (at offset 0x15)
-    
-    (@custom "producers" (before first) "\01")
-  )
+  (@producers)
+  ;; failed to parse custom section `producers`: unexpected end-of-file (at offset 0x15)
   
+)

--- a/tests/snapshots/local/producers.wast/6.print
+++ b/tests/snapshots/local/producers.wast/6.print
@@ -1,7 +1,6 @@
 (module
-    ;; failed to parse custom section `producers`: invalid producers field name: `a
-    ;; a` (at offset 0x15)
-    
-    (@custom "producers" (before first) "\01\03a\0aa\01\01a\01a")
-  )
+  (@producers)
+  ;; failed to parse custom section `producers`: invalid producers field name: `a
+  ;; a` (at offset 0x15)
   
+)


### PR DESCRIPTION
This PR is a series of commits where the intention is that each commit individually is a bite-sized chunk which moves `wasmprinter` towards being able to print directly to an I/O source instead of unconditionally to a `String`. The eventual end goal is to avoid the need to buffer the entire output of the printing and additionally plumb through colors from `termcolor` to be able to print a "pretty" module as opposed to the bland monochrome modules that are printed today. The CLI has all the necessary hooks and such to print colors, but so far they aren't plumbed to many locations.

This PR alone does not enable colors, it's just intended to make the next and final PR to add colors much smaller. As a whole this PR may be a bit messy but each commit should individually pass tests and showcase which refactorings were necessary to get towards this goal.