### PR TITLE
Add color by default to printing the text format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1735,6 +1735,7 @@ dependencies = [
  "diff",
  "rayon",
  "tempfile",
+ "termcolor",
  "wasmparser 0.209.1",
  "wast",
  "wat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ libtest-mimic = "0.7.0"
 bitflags = "2.5.0"
 hashbrown = { version = "0.14.3", default-features = false, features = ['ahash'] }
 ahash = { version = "0.8.11", default-features = false }
+termcolor = "1.2.0"
 
 wasm-compose = { version = "0.209.1", path = "crates/wasm-compose" }
 wasm-encoder = { version = "0.209.1", path = "crates/wasm-encoder" }
@@ -103,7 +104,7 @@ clap = { workspace = true }
 clap_complete = { workspace = true, optional = true }
 tempfile = "3.2.0"
 wat = { workspace = true }
-termcolor = "1.2.0"
+termcolor = { workspace = true }
 
 # Dependencies of `validate`
 wasmparser = { workspace = true, optional = true, features = ['validate'] }

--- a/crates/wasmprinter/Cargo.toml
+++ b/crates/wasmprinter/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 wasmparser = { workspace = true, features = ['std'] }
+termcolor = { workspace = true }
 
 [dev-dependencies]
 diff = "0.1"

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -2946,16 +2946,26 @@ macro_rules! print_float {
                 self.result.write_str("-")?;
             }
             if f.is_infinite() {
-                write!(self.result, "inf (;={};)", f)?;
+                self.result.start_literal()?;
+                self.result.write_str("inf ")?;
+                self.result.start_comment()?;
+                write!(self.result, "(;={f};)")?;
+                self.result.reset_color()?;
                 return Ok(());
             }
             if f.is_nan() {
                 let payload = bits & ((1 << mantissa_width) - 1);
+                self.result.start_literal()?;
                 if payload == 1 << (mantissa_width - 1) {
-                    write!(self.result, "nan (;={};)", f)?;
+                    self.result.write_str("nan ")?;
+                    self.result.start_comment()?;
+                    write!(self.result, "(;={f};)")?;
                 } else {
-                    write!(self.result, "nan:{:#x} (;={};)", payload, f)?;
+                    write!(self.result, "nan:{:#x} ", payload)?;
+                    self.result.start_comment()?;
+                    write!(self.result, "(;={f};)")?;
                 }
+                self.result.reset_color()?;
                 return Ok(());
             }
 
@@ -2977,6 +2987,7 @@ macro_rules! print_float {
             let mut exponent = (((bits << 1) as $sint) >> (mantissa_width + 1)).wrapping_sub(bias);
             exponent = (exponent << (int_width - exp_width)) >> (int_width - exp_width);
             let mut fraction = bits & ((1 << mantissa_width) - 1);
+            self.result.start_literal()?;
             self.result.write_str("0x")?;
             if bits == 0 {
                 self.result.write_str("0p+0")?;
@@ -3006,7 +3017,9 @@ macro_rules! print_float {
                 }
                 write!(self.result, "p{:+}", exponent)?;
             }
+            self.result.start_comment()?;
             write!(self.result, " (;={};)", f)?;
+            self.result.reset_color()?;
             Ok(())
         }
     };

--- a/crates/wasmprinter/src/operator.rs
+++ b/crates/wasmprinter/src/operator.rs
@@ -531,15 +531,11 @@ macro_rules! define_visit {
     );
     (payload $self:ident F32Const $val:ident) => (
         $self.push_str(" ")?;
-        $self.result().start_literal()?;
         $self.printer.print_f32($val.bits())?;
-        $self.result().reset_color()?;
     );
     (payload $self:ident F64Const $val:ident) => (
         $self.push_str(" ")?;
-        $self.result().start_literal()?;
         $self.printer.print_f64($val.bits())?;
-        $self.result().reset_color()?;
     );
     (payload $self:ident V128Const $val:ident) => (
         $self.printer.print_type_keyword(" i32x4")?;

--- a/crates/wasmprinter/src/print.rs
+++ b/crates/wasmprinter/src/print.rs
@@ -1,0 +1,190 @@
+use std::fmt;
+use std::io;
+use termcolor::{Color, ColorSpec};
+
+/// Trait used to print WebAssembly modules in this crate.
+///
+/// Instances of this trait are passed to
+/// [`Config::print`](super::Config::print). Instances of this trait are where
+/// the output of a WebAssembly binary goes.
+///
+/// Note that this trait has built-in adapters in the `wasmprinter` crate:
+///
+/// * For users of [`std::io::Write`] use [`PrintIoWrite`].
+/// * For users of [`std::fmt::Write`] use [`PrintFmtWrite`].
+pub trait Print {
+    /// Writes the given string `s` in its entirety.
+    ///
+    /// Returns an error for any I/O error.
+    fn write_str(&mut self, s: &str) -> io::Result<()>;
+
+    /// Indicates that a newline is being printed.
+    ///
+    /// This can be overridden to hook into the offset at which lines are
+    /// printed.
+    fn newline(&mut self) -> io::Result<()> {
+        self.write_str("\n")
+    }
+
+    /// Indicates that a new line in the output is starting at the
+    /// `binary_offset` provided.
+    ///
+    /// Not all new lines have a binary offset associated with them but this
+    /// method should be called for new lines in the output. This enables
+    /// correlating binary offsets to lines in the output.
+    fn start_line(&mut self, binary_offset: Option<usize>) {
+        let _ = binary_offset;
+    }
+
+    /// Enables usage of `write!` with this trait.
+    fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> io::Result<()> {
+        struct Adapter<'a, T: ?Sized + 'a> {
+            inner: &'a mut T,
+            error: io::Result<()>,
+        }
+
+        impl<T: Print + ?Sized> fmt::Write for Adapter<'_, T> {
+            fn write_str(&mut self, s: &str) -> fmt::Result {
+                match self.inner.write_str(s) {
+                    Ok(()) => Ok(()),
+                    Err(e) => {
+                        self.error = Err(e);
+                        Err(fmt::Error)
+                    }
+                }
+            }
+        }
+
+        let mut output = Adapter {
+            inner: self,
+            error: Ok(()),
+        };
+        match fmt::write(&mut output, args) {
+            Ok(()) => Ok(()),
+            Err(..) => output.error,
+        }
+    }
+
+    /// Helper to print a custom section, if needed.
+    ///
+    /// If this output has a custom means of printing a custom section then this
+    /// can be used to override the default. If `Ok(true)` is returned then the
+    /// section will be considered to be printed. Otherwise an `Ok(false)`
+    /// return value indicates that the default printing should happen.
+    fn print_custom_section(
+        &mut self,
+        name: &str,
+        binary_offset: usize,
+        data: &[u8],
+    ) -> io::Result<bool> {
+        let _ = (name, binary_offset, data);
+        Ok(false)
+    }
+
+    /// Sets the colors settings for literals (`"foo"`) to be printed.
+    fn start_literal(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    /// Sets the colors settings for a name (`$foo`) to be printed.
+    fn start_name(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    /// Sets the colors settings for a keyword (`(module ...)`) to be printed.
+    fn start_keyword(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    /// Sets the colors settings for a type (`(param i32)`) to be printed.
+    fn start_type(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    /// Sets the colors settings for a comment (`;; ...`) to be printed.
+    fn start_comment(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    /// Resets colors settings to the default.
+    fn reset_color(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// An adapter between the [`std::io::Write`] trait and [`Print`].
+pub struct PrintIoWrite<T>(pub T);
+
+impl<T> Print for PrintIoWrite<T>
+where
+    T: io::Write,
+{
+    fn write_str(&mut self, s: &str) -> io::Result<()> {
+        self.0.write_all(s.as_bytes())
+    }
+}
+
+/// An adapter between the [`std::fmt::Write`] trait and [`Print`].
+pub struct PrintFmtWrite<T>(pub T);
+
+impl<T> Print for PrintFmtWrite<T>
+where
+    T: fmt::Write,
+{
+    fn write_str(&mut self, s: &str) -> io::Result<()> {
+        match self.0.write_str(s) {
+            Ok(()) => Ok(()),
+            Err(fmt::Error) => Err(io::Error::new(
+                io::ErrorKind::Other,
+                "failed to write string",
+            )),
+        }
+    }
+}
+
+/// An adapter between the [`std::fmt::Write`] trait and [`termcolor::WriteColor`].
+pub struct PrintTermcolor<T>(pub T);
+
+impl<T> Print for PrintTermcolor<T>
+where
+    T: termcolor::WriteColor,
+{
+    fn write_str(&mut self, s: &str) -> io::Result<()> {
+        self.0.write_all(s.as_bytes())
+    }
+
+    fn start_name(&mut self) -> io::Result<()> {
+        self.0
+            .set_color(ColorSpec::new().set_fg(Some(Color::Magenta)))
+    }
+
+    fn start_literal(&mut self) -> io::Result<()> {
+        self.0.set_color(ColorSpec::new().set_fg(Some(Color::Red)))
+    }
+
+    fn start_keyword(&mut self) -> io::Result<()> {
+        self.0.set_color(
+            ColorSpec::new()
+                .set_fg(Some(Color::Yellow))
+                .set_bold(true)
+                .set_intense(true),
+        )
+    }
+
+    fn start_type(&mut self) -> io::Result<()> {
+        self.0.set_color(
+            ColorSpec::new()
+                .set_fg(Some(Color::Green))
+                .set_bold(true)
+                .set_intense(true),
+        )
+    }
+
+    fn start_comment(&mut self) -> io::Result<()> {
+        self.0.set_color(ColorSpec::new().set_fg(Some(Color::Cyan)))
+    }
+
+    fn reset_color(&mut self) -> io::Result<()> {
+        self.0.reset()
+    }
+}

--- a/crates/wasmprinter/tests/all.rs
+++ b/crates/wasmprinter/tests/all.rs
@@ -249,8 +249,7 @@ fn offsets_and_lines_smoke_test() {
     let bytes = wat::parse_str(MODULE).unwrap();
 
     let mut storage = String::new();
-    let printer = wasmprinter::Config::new();
-    let actual: Vec<_> = printer
+    let actual: Vec<_> = wasmprinter::Config::new()
         .offsets_and_lines(&bytes, &mut storage)
         .unwrap()
         .collect();

--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -162,10 +162,7 @@ impl NewOpts {
             .encode()
             .context("failed to encode a component from module")?;
 
-        self.io.output(Output::Wasm {
-            bytes: &bytes,
-            wat: self.wat,
-        })?;
+        self.io.output_wasm(&bytes, self.wat)?;
 
         Ok(())
     }
@@ -290,10 +287,7 @@ impl EmbedOpts {
             self.encoding.unwrap_or(StringEncoding::UTF8),
         )?;
 
-        self.io.output(Output::Wasm {
-            bytes: &wasm,
-            wat: self.wat,
-        })?;
+        self.io.output_wasm(&wasm, self.wat)?;
 
         Ok(())
     }
@@ -420,10 +414,7 @@ impl LinkOpts {
             .encode()
             .context("failed to encode a component from modules")?;
 
-        self.output.output(Output::Wasm {
-            bytes: &bytes,
-            wat: self.wat,
-        })?;
+        self.output.output_wasm(&self.general, &bytes, self.wat)?;
 
         Ok(())
     }
@@ -604,10 +595,7 @@ impl WitOpts {
             )
             .validate_all(&bytes)?;
         }
-        self.output.output(Output::Wasm {
-            bytes: &bytes,
-            wat: self.wat,
-        })?;
+        self.output.output_wasm(&self.general, &bytes, self.wat)?;
         Ok(())
     }
 
@@ -666,8 +654,14 @@ impl WitOpts {
                 }
             }
             None => {
-                let output = printer.print(resolve, &main)?;
-                self.output.output(Output::Wat(&output))?;
+                self.output.output(
+                    &self.general,
+                    Output::Wit {
+                        resolve: &resolve,
+                        ids: &main,
+                        printer,
+                    },
+                )?;
             }
         }
 
@@ -679,7 +673,7 @@ impl WitOpts {
 
         let resolve = decoded.resolve();
         let output = serde_json::to_string_pretty(&resolve)?;
-        self.output.output(Output::Json(&output))?;
+        self.output.output(&self.general, Output::Json(&output))?;
 
         Ok(())
     }

--- a/src/bin/wasm-tools/compose.rs
+++ b/src/bin/wasm-tools/compose.rs
@@ -61,10 +61,7 @@ impl Opts {
 
         let bytes = ComponentComposer::new(&self.component, &config).compose()?;
 
-        self.output.output(wasm_tools::Output::Wasm {
-            bytes: &bytes,
-            wat: self.wat,
-        })?;
+        self.output.output_wasm(&self.general, &bytes, self.wat)?;
 
         if config.skip_validation {
             log::debug!("output validation was skipped");

--- a/src/bin/wasm-tools/demangle.rs
+++ b/src/bin/wasm-tools/demangle.rs
@@ -54,10 +54,7 @@ impl Opts {
             }
         }
 
-        self.io.output(wasm_tools::Output::Wasm {
-            bytes: module.as_slice(),
-            wat: self.wat,
-        })?;
+        self.io.output_wasm(module.as_slice(), self.wat)?;
         Ok(())
     }
 

--- a/src/bin/wasm-tools/json_from_wast.rs
+++ b/src/bin/wasm-tools/json_from_wast.rs
@@ -112,7 +112,8 @@ impl Opts {
         } else {
             serde_json::to_string(&builder.ret)?
         };
-        self.output.output(wasm_tools::Output::Json(&json))?;
+        self.output
+            .output(&self.general, wasm_tools::Output::Json(&json))?;
         Ok(())
     }
 }

--- a/src/bin/wasm-tools/metadata.rs
+++ b/src/bin/wasm-tools/metadata.rs
@@ -78,10 +78,7 @@ impl AddOpts {
 
         let output = self.add_metadata.to_wasm(&input)?;
 
-        self.io.output(wasm_tools::Output::Wasm {
-            bytes: output.as_slice(),
-            wat: self.wat,
-        })?;
+        self.io.output_wasm(&output, self.wat)?;
         Ok(())
     }
 }

--- a/src/bin/wasm-tools/mutate.rs
+++ b/src/bin/wasm-tools/mutate.rs
@@ -82,10 +82,7 @@ impl Opts {
             }
         };
 
-        self.io.output(wasm_tools::Output::Wasm {
-            bytes: &wasm,
-            wat: self.wat,
-        })?;
+        self.io.output_wasm(&wasm, self.wat)?;
 
         Ok(())
     }

--- a/src/bin/wasm-tools/parse.rs
+++ b/src/bin/wasm-tools/parse.rs
@@ -22,10 +22,7 @@ impl Opts {
 
     pub fn run(&self) -> Result<()> {
         let binary = self.io.parse_input_wasm()?;
-        self.io.output(wasm_tools::Output::Wasm {
-            bytes: &binary,
-            wat: self.wat,
-        })?;
+        self.io.output_wasm(&binary, self.wat)?;
         Ok(())
     }
 }

--- a/src/bin/wasm-tools/print.rs
+++ b/src/bin/wasm-tools/print.rs
@@ -34,13 +34,14 @@ impl Opts {
 
     pub fn run(&self) -> Result<()> {
         let wasm = self.io.parse_input_wasm()?;
-        let mut printer = wasmprinter::Config::new();
-        printer.print_offsets(self.print_offsets);
-        printer.print_skeleton(self.skeleton);
-        printer.name_unnamed(self.name_unnamed);
-        let mut wat = String::new();
-        printer.print(&wasm, &mut wat)?;
-        self.io.output(wasm_tools::Output::Wat(&wat))?;
-        Ok(())
+
+        let mut config = wasmprinter::Config::new();
+        config.print_offsets(self.print_offsets);
+        config.print_skeleton(self.skeleton);
+        config.name_unnamed(self.name_unnamed);
+        self.io.output(wasm_tools::Output::Wat {
+            wasm: &wasm,
+            config,
+        })
     }
 }

--- a/src/bin/wasm-tools/smith.rs
+++ b/src/bin/wasm-tools/smith.rs
@@ -122,10 +122,8 @@ impl Opts {
         }
         let wasm_bytes = module.to_bytes();
 
-        self.output.output(wasm_tools::Output::Wasm {
-            bytes: &wasm_bytes,
-            wat: self.wat,
-        })?;
+        self.output
+            .output_wasm(&self.general, &wasm_bytes, self.wat)?;
         Ok(())
     }
 }

--- a/src/bin/wasm-tools/strip.rs
+++ b/src/bin/wasm-tools/strip.rs
@@ -106,10 +106,7 @@ impl Opts {
             }
         }
 
-        self.io.output(wasm_tools::Output::Wasm {
-            bytes: &output,
-            wat: self.wat,
-        })?;
+        self.io.output_wasm(&output, self.wat)?;
         Ok(())
     }
 }

--- a/src/bin/wasm-tools/wit_smith.rs
+++ b/src/bin/wasm-tools/wit_smith.rs
@@ -72,10 +72,8 @@ impl Opts {
         };
         let wasm_bytes = wit_smith::smith(&config, &mut u)?;
 
-        self.output.output(wasm_tools::Output::Wasm {
-            bytes: &wasm_bytes,
-            wat: self.wat,
-        })?;
+        self.output
+            .output_wasm(&self.general, &wasm_bytes, self.wat)?;
         Ok(())
     }
 }


### PR DESCRIPTION
This commit builds on #1593 to provide colorized output of `wasm-tools print`, or any other subcommand that prints the text format, by default. Color settings are controlled on the CLI with `--color` and are automatically disabled in various situations such as outputting to a file or when an output pipe is used.

Internally `wasmprinter` has grown a new trait, `Print`, through which all output goes through. There are adapters for this trait for `std::fmt::Write`, `std::io::Write`, and `termcolor::WriteColor`. Custom trait implementations are also possible if necessary.

While here I've additionally moved custom custom section printing to the trait itself instead of being part of the printer configuration as it felt more appropriate as a per-sink configuration.

I'll note that I am by no means an artist and my sense of taste and color are probably objectively "not good". My hope is to add some basics here which lays the groundwork for someone more artistic than I to improve this in the future. Some sample screenshots of what this looks like are:

<img width="579" alt="Screenshot 2024-06-07 at 5 05 42 PM" src="https://github.com/bytecodealliance/wasm-tools/assets/64996/f14df508-eb0e-4eed-85bd-1ffd533a9074">

<img width="375" alt="Screenshot 2024-06-07 at 5 06 44 PM" src="https://github.com/bytecodealliance/wasm-tools/assets/64996/0d42c615-e2da-4d86-8fb8-ccde199788aa">

<img width="354" alt="Screenshot 2024-06-07 at 5 06 54 PM" src="https://github.com/bytecodealliance/wasm-tools/assets/64996/b4f9aaaa-59b7-46b9-abaf-47d6a79daf6e">


<img width="624" alt="Screenshot 2024-06-07 at 5 10 25 PM" src="https://github.com/bytecodealliance/wasm-tools/assets/64996/bc954b05-4368-42d5-b639-c73e3e317b87">
