### PR TITLE
add links to playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ with wasm modules and component. Many subcommands also come with Rust crates
 that can be use programmatically as well:
 
 | CLI | Rust Crate | Playground | Description |
-|------|------|------------|
+|------|------|--------|------------|
 | `wasm-tools validate` | [wasmparser] |  | Validate a WebAssembly file |
 | `wasm-tools parse` | [wat] and [wast] | [parse](https://bytecodealliance.github.io/wasm-tools/parse) | Translate the WebAssembly text format to binary |
 | `wasm-tools print` | [wasmprinter] | [print](https://bytecodealliance.github.io/wasm-tools/print) | Translate the WebAssembly binary format to text |

--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@
 
 # Installation
 
-[`wasm-tools parse`](https://bytecodealliance.github.io/wasm-tools/parse) and [`wasm-tools print`](https://bytecodealliance.github.io/wasm-tools/print) can be used from the web.
-
 [Precompiled artifacts built on CI][artifacts] are available for download for
 each release.
 
@@ -132,27 +130,27 @@ The `wasm-tools` binary internally contains a number of subcommands for working
 with wasm modules and component. Many subcommands also come with Rust crates
 that can be use programmatically as well:
 
-| CLI | Rust Crate | Description |
+| CLI | Rust Crate | Playground | Description |
 |------|------|------------|
-| `wasm-tools validate` | [wasmparser] | Validate a WebAssembly file |
-| `wasm-tools parse` | [wat] and [wast] | Translate the WebAssembly text format to binary |
-| `wasm-tools print` | [wasmprinter] | Translate the WebAssembly binary format to text |
-| `wasm-tools smith` | [wasm-smith] | Generate a valid WebAssembly module from an input seed |
-| `wasm-tools mutate` | [wasm-mutate] | Mutate an input wasm file into a new valid wasm file |
-| `wasm-tools shrink` | [wasm-shrink] | Shrink a wasm file while preserving a predicate |
-| `wasm-tools dump` |   | Print debugging information about the binary format |
-| `wasm-tools objdump` |   | Print debugging information about section headers |
-| `wasm-tools strip` |   | Remove custom sections from a WebAssembly file |
-| `wasm-tools demangle` |   | Demangle Rust and C++ symbol names in the `name` section |
-| `wasm-tools compose` | [wasm-compose] | Compose wasm components together (*deprecated*) |
-| `wasm-tools component new` | [wit-component] | Create a component from a core wasm binary |
-| `wasm-tools component wit` |  | Extract a `*.wit` interface from a component |
-| `wasm-tools component embed` |  | Embed a `component-type` custom section in a core wasm binary |
-| `wasm-tools metadata show` |  [wasm-metadata] | Show name and producer metadata in a component or module |
-| `wasm-tools metadata add` |  | Add name or producer metadata to a component or module |
-| `wasm-tools addr2line` |  | Translate wasm offsets to filename/line numbers with DWARF |
-| `wasm-tools completion` |  | Generate shell completion scripts for `wasm-tools` |
-| `wasm-tools json-from-wast` |  | Convert a `*.wast` file into JSON commands |
+| `wasm-tools validate` | [wasmparser] |  | Validate a WebAssembly file |
+| `wasm-tools parse` | [wat] and [wast] | [parse](https://bytecodealliance.github.io/wasm-tools/parse) | Translate the WebAssembly text format to binary |
+| `wasm-tools print` | [wasmprinter] | [print](https://bytecodealliance.github.io/wasm-tools/print) | Translate the WebAssembly binary format to text |
+| `wasm-tools smith` | [wasm-smith] |  | Generate a valid WebAssembly module from an input seed |
+| `wasm-tools mutate` | [wasm-mutate] |  | Mutate an input wasm file into a new valid wasm file |
+| `wasm-tools shrink` | [wasm-shrink] |  | Shrink a wasm file while preserving a predicate |
+| `wasm-tools dump` |   |  | Print debugging information about the binary format |
+| `wasm-tools objdump` |   |  | Print debugging information about section headers |
+| `wasm-tools strip` |   |  | Remove custom sections from a WebAssembly file |
+| `wasm-tools demangle` |   |  | Demangle Rust and C++ symbol names in the `name` section |
+| `wasm-tools compose` | [wasm-compose] |  | Compose wasm components together (*deprecated*) |
+| `wasm-tools component new` | [wit-component] |  | Create a component from a core wasm binary |
+| `wasm-tools component wit` |  |  | Extract a `*.wit` interface from a component |
+| `wasm-tools component embed` |  |  | Embed a `component-type` custom section in a core wasm binary |
+| `wasm-tools metadata show` |  [wasm-metadata] |  | Show name and producer metadata in a component or module |
+| `wasm-tools metadata add` |  |  | Add name or producer metadata to a component or module |
+| `wasm-tools addr2line` |  |  | Translate wasm offsets to filename/line numbers with DWARF |
+| `wasm-tools completion` |  |  | Generate shell completion scripts for `wasm-tools` |
+| `wasm-tools json-from-wast` |  |  | Convert a `*.wast` file into JSON commands |
 
 [wasmparser]: https://crates.io/crates/wasmparser
 [wat]: https://crates.io/crates/wat

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 # Installation
 
+[`wasm-tools parse`](https://bytecodealliance.github.io/wasm-tools/parse) and [`wasm-tools print`](https://bytecodealliance.github.io/wasm-tools/print) can be used from the web.
+
 [Precompiled artifacts built on CI][artifacts] are available for download for
 each release.
 

--- a/playground/README.md
+++ b/playground/README.md
@@ -1,6 +1,6 @@
 # Playground
 
-This is a simple online playground for `wasm-tools parse`, available at https://bytecodealliance.github.io/wasm-tools/.
+This is a simple online playground for `wasm-tools parse` and `print`, available at https://bytecodealliance.github.io/wasm-tools/parse / https://bytecodealliance.github.io/wasm-tools/print respectively.
 
 ## Building
 


### PR DESCRIPTION
These could definitely be improved but are sufficient to be useful, I think, and I'm probably not going to have time to make them fancier in the near future. That said if there's any more improvements you'd like to see, or if playground for any other subcommands would be valuable, let me know. `component wit` seems like it might be worth having a playground for?

I wasn't sure what the best place for these links would be, but `Installation` seems like a reasonable option.