### PR TITLE
 Improve filtering for return_call_indirect with wasm-smith 

### DIFF
--- a/crates/wasm-smith/src/core/code_builder.rs
+++ b/crates/wasm-smith/src/core/code_builder.rs
@@ -2203,6 +2203,9 @@ fn return_call_ref(
 
 #[inline]
 fn return_call_indirect_valid(module: &Module, builder: &mut CodeBuilder) -> bool {
+    if !module.config.tail_call_enabled {
+        return false;
+    }
     call_indirect_valid_impl(module, builder, true)
 }
 


### PR DESCRIPTION
Add to the `call_indirect` filter that the selected function type must
have the exact same return signature as the function doing the call.

Closes https://github.com/bytecodealliance/wasm-tools/issues/1612