### PR TITLE
fuzz(no_traps): enable the custom-page-sizes proposal as necessary

### DIFF
--- a/fuzz/src/no_traps.rs
+++ b/fuzz/src/no_traps.rs
@@ -113,24 +113,7 @@ pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
 
 fn validate_module(config: wasm_smith::Config, wasm_bytes: &Vec<u8>) {
     // Validate the module or component and assert that it passes validation.
-    let mut validator = wasmparser::Validator::new_with_features({
-        let mut features = WasmFeatures::default();
-        features.remove(WasmFeatures::COMPONENT_MODEL);
-        features.set(WasmFeatures::MULTI_VALUE, config.multi_value_enabled);
-        features.set(WasmFeatures::MULTI_MEMORY, config.max_memories > 1);
-        features.insert(WasmFeatures::BULK_MEMORY);
-        features.insert(WasmFeatures::REFERENCE_TYPES);
-        features.set(WasmFeatures::SIMD, config.simd_enabled);
-        features.set(WasmFeatures::RELAXED_SIMD, config.relaxed_simd_enabled);
-        features.set(WasmFeatures::MEMORY64, config.memory64_enabled);
-        features.set(WasmFeatures::THREADS, config.threads_enabled);
-        features.set(WasmFeatures::EXCEPTIONS, config.exceptions_enabled);
-        features.set(
-            WasmFeatures::CUSTOM_PAGE_SIZES,
-            config.custom_page_sizes_enabled,
-        );
-        features
-    });
+    let mut validator = wasmparser::Validator::new_with_features(WasmFeatures::all());
     if let Err(e) = validator.validate_all(wasm_bytes) {
         panic!("Invalid module: {}", e);
     }

--- a/fuzz/src/no_traps.rs
+++ b/fuzz/src/no_traps.rs
@@ -24,7 +24,7 @@ pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
         config.memory64_enabled = false;
         Ok(())
     })?;
-    validate_module(config.clone(), &wasm_bytes);
+    validate_module(&wasm_bytes);
 
     // Tail calls aren't implemented in wasmtime, so don't try to run them
     // there.
@@ -111,7 +111,7 @@ pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
     Ok(())
 }
 
-fn validate_module(config: wasm_smith::Config, wasm_bytes: &Vec<u8>) {
+fn validate_module(wasm_bytes: &Vec<u8>) {
     // Validate the module or component and assert that it passes validation.
     let mut validator = wasmparser::Validator::new_with_features(WasmFeatures::all());
     if let Err(e) = validator.validate_all(wasm_bytes) {

--- a/fuzz/src/no_traps.rs
+++ b/fuzz/src/no_traps.rs
@@ -125,6 +125,10 @@ fn validate_module(config: wasm_smith::Config, wasm_bytes: &Vec<u8>) {
         features.set(WasmFeatures::MEMORY64, config.memory64_enabled);
         features.set(WasmFeatures::THREADS, config.threads_enabled);
         features.set(WasmFeatures::EXCEPTIONS, config.exceptions_enabled);
+        features.set(
+            WasmFeatures::CUSTOM_PAGE_SIZES,
+            config.custom_page_sizes_enabled,
+        );
         features
     });
     if let Err(e) = validator.validate_all(wasm_bytes) {


### PR DESCRIPTION
If the `wasm-smith` config enabled it, then we should enable it for validation.