### PR TITLE
wasm-wave: add license to cargo.toml

### DIFF
--- a/crates/wasm-wave/Cargo.toml
+++ b/crates/wasm-wave/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wasm-wave"
 version.workspace = true
 edition.workspace = true
+license = "Apache-2.0 WITH LLVM-exception"
 rust-version.workspace = true
 authors = ["lann.martin@fermyon.com"]
 description = "WebAssembly Value Encoding"


### PR DESCRIPTION
The crates.io publish of wasm-wave failed due to this missing field: https://github.com/bytecodealliance/wasm-tools/actions/runs/9573228545/job/26394219245. With this filled in, `cargo publish --dry-run` passes. 

I will make a patch release and publish again once @lann makes the [wasmtime-publish group](https://crates.io/teams/github:bytecodealliance:wasmtime-publish) an owner of the crate.  Update: this is done!