### PR TITLE
Implement a wasmparser -> wasm-encoder trait

### DIFF
--- a/crates/wasm-encoder/src/component/types.rs
+++ b/crates/wasm-encoder/src/component/types.rs
@@ -527,16 +527,6 @@ impl Encode for PrimitiveValType {
     }
 }
 
-#[cfg(feature = "wasmparser")]
-impl From<wasmparser::PrimitiveValType> for PrimitiveValType {
-    fn from(ty: wasmparser::PrimitiveValType) -> Self {
-        crate::reencode::utils::component_primitive_val_type(
-            &mut crate::reencode::RoundtripReencoder,
-            ty,
-        )
-    }
-}
-
 /// Represents a component value type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ComponentValType {

--- a/crates/wasm-encoder/src/component/types.rs
+++ b/crates/wasm-encoder/src/component/types.rs
@@ -530,21 +530,10 @@ impl Encode for PrimitiveValType {
 #[cfg(feature = "wasmparser")]
 impl From<wasmparser::PrimitiveValType> for PrimitiveValType {
     fn from(ty: wasmparser::PrimitiveValType) -> Self {
-        match ty {
-            wasmparser::PrimitiveValType::Bool => PrimitiveValType::Bool,
-            wasmparser::PrimitiveValType::S8 => PrimitiveValType::S8,
-            wasmparser::PrimitiveValType::U8 => PrimitiveValType::U8,
-            wasmparser::PrimitiveValType::S16 => PrimitiveValType::S16,
-            wasmparser::PrimitiveValType::U16 => PrimitiveValType::U16,
-            wasmparser::PrimitiveValType::S32 => PrimitiveValType::S32,
-            wasmparser::PrimitiveValType::U32 => PrimitiveValType::U32,
-            wasmparser::PrimitiveValType::S64 => PrimitiveValType::S64,
-            wasmparser::PrimitiveValType::U64 => PrimitiveValType::U64,
-            wasmparser::PrimitiveValType::F32 => PrimitiveValType::F32,
-            wasmparser::PrimitiveValType::F64 => PrimitiveValType::F64,
-            wasmparser::PrimitiveValType::Char => PrimitiveValType::Char,
-            wasmparser::PrimitiveValType::String => PrimitiveValType::String,
-        }
+        crate::reencode::utils::component_primitive_val_type(
+            &mut crate::reencode::RoundtripReencoder,
+            ty,
+        )
     }
 }
 

--- a/crates/wasm-encoder/src/core/code.rs
+++ b/crates/wasm-encoder/src/core/code.rs
@@ -433,10 +433,10 @@ impl Encode for BlockType {
 
 #[cfg(feature = "wasmparser")]
 impl TryFrom<wasmparser::BlockType> for BlockType {
-    type Error = ();
-    fn try_from(arg: wasmparser::BlockType) -> Result<BlockType, ()> {
+    type Error = crate::reencode::Error;
+
+    fn try_from(arg: wasmparser::BlockType) -> Result<BlockType, Self::Error> {
         crate::reencode::utils::block_type(&mut crate::reencode::RoundtripReencoder, arg)
-            .map_err(|_| ())
     }
 }
 
@@ -3398,11 +3398,10 @@ impl Encode for Instruction<'_> {
 
 #[cfg(feature = "wasmparser")]
 impl<'a> TryFrom<wasmparser::Operator<'a>> for Instruction<'a> {
-    type Error = ();
+    type Error = crate::reencode::Error;
 
-    fn try_from(arg: wasmparser::Operator<'a>) -> Result<Self, ()> {
+    fn try_from(arg: wasmparser::Operator<'a>) -> Result<Self, Self::Error> {
         crate::reencode::utils::instruction(&mut crate::reencode::RoundtripReencoder, arg)
-            .map_err(|_| ())
     }
 }
 

--- a/crates/wasm-encoder/src/core/custom.rs
+++ b/crates/wasm-encoder/src/core/custom.rs
@@ -47,10 +47,7 @@ impl Section for RawCustomSection<'_> {
 #[cfg(feature = "wasmparser")]
 impl<'a> From<wasmparser::CustomSectionReader<'a>> for CustomSection<'a> {
     fn from(section: wasmparser::CustomSectionReader<'a>) -> Self {
-        CustomSection {
-            data: section.data().into(),
-            name: section.name().into(),
-        }
+        crate::reencode::utils::custom_section(&mut crate::reencode::RoundtripReencoder, section)
     }
 }
 

--- a/crates/wasm-encoder/src/core/custom.rs
+++ b/crates/wasm-encoder/src/core/custom.rs
@@ -44,13 +44,6 @@ impl Section for RawCustomSection<'_> {
     }
 }
 
-#[cfg(feature = "wasmparser")]
-impl<'a> From<wasmparser::CustomSectionReader<'a>> for CustomSection<'a> {
-    fn from(section: wasmparser::CustomSectionReader<'a>) -> Self {
-        crate::reencode::utils::custom_section(&mut crate::reencode::RoundtripReencoder, section)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/wasm-encoder/src/core/data.rs
+++ b/crates/wasm-encoder/src/core/data.rs
@@ -158,30 +158,18 @@ impl DataSection {
     pub fn parse_section(
         &mut self,
         section: wasmparser::DataSectionReader<'_>,
-    ) -> Result<&mut Self, crate::ConstExprConversionError> {
-        for data in section {
-            self.parse(data?)?;
-        }
-        Ok(self)
+    ) -> crate::reencode::Result<&mut Self> {
+        crate::reencode::utils::parse_data_section(
+            &mut crate::reencode::RoundtripReencoder,
+            self,
+            section,
+        )
     }
 
     /// Parses a single [`wasmparser::Data`] and adds it to this section.
     #[cfg(feature = "wasmparser")]
-    pub fn parse(
-        &mut self,
-        data: wasmparser::Data<'_>,
-    ) -> Result<&mut Self, crate::ConstExprConversionError> {
-        match data.kind {
-            wasmparser::DataKind::Active {
-                memory_index,
-                offset_expr,
-            } => Ok(self.active(
-                memory_index,
-                &ConstExpr::try_from(offset_expr)?,
-                data.data.iter().copied(),
-            )),
-            wasmparser::DataKind::Passive => Ok(self.passive(data.data.iter().copied())),
-        }
+    pub fn parse(&mut self, data: wasmparser::Data<'_>) -> crate::reencode::Result<&mut Self> {
+        crate::reencode::utils::parse_data(&mut crate::reencode::RoundtripReencoder, self, data)
     }
 }
 

--- a/crates/wasm-encoder/src/core/data.rs
+++ b/crates/wasm-encoder/src/core/data.rs
@@ -151,26 +151,6 @@ impl DataSection {
         self.num_added += 1;
         self
     }
-
-    /// Parses the input `section` given from the `wasmparser` crate and adds
-    /// all the data to this section.
-    #[cfg(feature = "wasmparser")]
-    pub fn parse_section(
-        &mut self,
-        section: wasmparser::DataSectionReader<'_>,
-    ) -> crate::reencode::Result<&mut Self> {
-        crate::reencode::utils::parse_data_section(
-            &mut crate::reencode::RoundtripReencoder,
-            self,
-            section,
-        )
-    }
-
-    /// Parses a single [`wasmparser::Data`] and adds it to this section.
-    #[cfg(feature = "wasmparser")]
-    pub fn parse(&mut self, data: wasmparser::Data<'_>) -> crate::reencode::Result<&mut Self> {
-        crate::reencode::utils::parse_data(&mut crate::reencode::RoundtripReencoder, self, data)
-    }
 }
 
 impl Encode for DataSection {

--- a/crates/wasm-encoder/src/core/elements.rs
+++ b/crates/wasm-encoder/src/core/elements.rs
@@ -206,34 +206,6 @@ impl ElementSection {
         self.num_added += 1;
         self
     }
-
-    /// Parses the input `section` given from the `wasmparser` crate and adds
-    /// all the elements to this section.
-    #[cfg(feature = "wasmparser")]
-    pub fn parse_section(
-        &mut self,
-        section: wasmparser::ElementSectionReader<'_>,
-    ) -> crate::reencode::Result<&mut Self> {
-        crate::reencode::utils::parse_element_section(
-            &mut crate::reencode::RoundtripReencoder,
-            self,
-            section,
-        )
-    }
-
-    /// Parses the single [`wasmparser::Element`] provided and adds it to this
-    /// section.
-    #[cfg(feature = "wasmparser")]
-    pub fn parse(
-        &mut self,
-        element: wasmparser::Element<'_>,
-    ) -> crate::reencode::Result<&mut Self> {
-        crate::reencode::utils::parse_element(
-            &mut crate::reencode::RoundtripReencoder,
-            self,
-            element,
-        )
-    }
 }
 
 impl Encode for ElementSection {

--- a/crates/wasm-encoder/src/core/exports.rs
+++ b/crates/wasm-encoder/src/core/exports.rs
@@ -25,13 +25,6 @@ impl Encode for ExportKind {
     }
 }
 
-#[cfg(feature = "wasmparser")]
-impl From<wasmparser::ExternalKind> for ExportKind {
-    fn from(external_kind: wasmparser::ExternalKind) -> Self {
-        crate::reencode::utils::export_kind(&mut crate::reencode::RoundtripReencoder, external_kind)
-    }
-}
-
 /// An encoder for the export section of WebAssembly module.
 ///
 /// # Example
@@ -76,27 +69,6 @@ impl ExportSection {
         index.encode(&mut self.bytes);
         self.num_added += 1;
         self
-    }
-
-    /// Parses the input `section` given from the `wasmparser` crate and adds
-    /// all the exports to this section.
-    #[cfg(feature = "wasmparser")]
-    pub fn parse_section(
-        &mut self,
-        section: wasmparser::ExportSectionReader<'_>,
-    ) -> crate::reencode::Result<&mut Self> {
-        crate::reencode::utils::parse_export_section(
-            &mut crate::reencode::RoundtripReencoder,
-            self,
-            section,
-        )
-    }
-
-    /// Parses the single [`wasmparser::Export`] provided and adds it to this
-    /// section.
-    #[cfg(feature = "wasmparser")]
-    pub fn parse(&mut self, export: wasmparser::Export<'_>) -> &mut Self {
-        crate::reencode::utils::parse_export(&mut crate::reencode::RoundtripReencoder, self, export)
     }
 }
 

--- a/crates/wasm-encoder/src/core/exports.rs
+++ b/crates/wasm-encoder/src/core/exports.rs
@@ -28,13 +28,7 @@ impl Encode for ExportKind {
 #[cfg(feature = "wasmparser")]
 impl From<wasmparser::ExternalKind> for ExportKind {
     fn from(external_kind: wasmparser::ExternalKind) -> Self {
-        match external_kind {
-            wasmparser::ExternalKind::Func => ExportKind::Func,
-            wasmparser::ExternalKind::Table => ExportKind::Table,
-            wasmparser::ExternalKind::Memory => ExportKind::Memory,
-            wasmparser::ExternalKind::Global => ExportKind::Global,
-            wasmparser::ExternalKind::Tag => ExportKind::Tag,
-        }
+        crate::reencode::utils::export_kind(&mut crate::reencode::RoundtripReencoder, external_kind)
     }
 }
 
@@ -90,18 +84,19 @@ impl ExportSection {
     pub fn parse_section(
         &mut self,
         section: wasmparser::ExportSectionReader<'_>,
-    ) -> wasmparser::Result<&mut Self> {
-        for export in section {
-            self.parse(export?);
-        }
-        Ok(self)
+    ) -> crate::reencode::Result<&mut Self> {
+        crate::reencode::utils::parse_export_section(
+            &mut crate::reencode::RoundtripReencoder,
+            self,
+            section,
+        )
     }
 
     /// Parses the single [`wasmparser::Export`] provided and adds it to this
     /// section.
     #[cfg(feature = "wasmparser")]
     pub fn parse(&mut self, export: wasmparser::Export<'_>) -> &mut Self {
-        self.export(export.name, export.kind.into(), export.index)
+        crate::reencode::utils::parse_export(&mut crate::reencode::RoundtripReencoder, self, export)
     }
 }
 

--- a/crates/wasm-encoder/src/core/functions.rs
+++ b/crates/wasm-encoder/src/core/functions.rs
@@ -55,11 +55,12 @@ impl FunctionSection {
     pub fn parse_section(
         &mut self,
         section: wasmparser::FunctionSectionReader<'_>,
-    ) -> wasmparser::Result<&mut Self> {
-        for func in section {
-            self.function(func?);
-        }
-        Ok(self)
+    ) -> crate::reencode::Result<&mut Self> {
+        crate::reencode::utils::parse_function_section(
+            &mut crate::reencode::RoundtripReencoder,
+            self,
+            section,
+        )
     }
 }
 

--- a/crates/wasm-encoder/src/core/functions.rs
+++ b/crates/wasm-encoder/src/core/functions.rs
@@ -48,20 +48,6 @@ impl FunctionSection {
         self.num_added += 1;
         self
     }
-
-    /// Parses the input `section` given from the `wasmparser` crate and adds
-    /// all the functions to this section.
-    #[cfg(feature = "wasmparser")]
-    pub fn parse_section(
-        &mut self,
-        section: wasmparser::FunctionSectionReader<'_>,
-    ) -> crate::reencode::Result<&mut Self> {
-        crate::reencode::utils::parse_function_section(
-            &mut crate::reencode::RoundtripReencoder,
-            self,
-            section,
-        )
-    }
 }
 
 impl Encode for FunctionSection {

--- a/crates/wasm-encoder/src/core/globals.rs
+++ b/crates/wasm-encoder/src/core/globals.rs
@@ -122,9 +122,9 @@ impl Encode for GlobalType {
 
 #[cfg(feature = "wasmparser")]
 impl TryFrom<wasmparser::GlobalType> for GlobalType {
-    type Error = ();
+    type Error = crate::reencode::Error;
+
     fn try_from(global_ty: wasmparser::GlobalType) -> Result<Self, Self::Error> {
         crate::reencode::utils::global_type(&mut crate::reencode::RoundtripReencoder, global_ty)
-            .map_err(|_| ())
     }
 }

--- a/crates/wasm-encoder/src/core/globals.rs
+++ b/crates/wasm-encoder/src/core/globals.rs
@@ -60,27 +60,6 @@ impl GlobalSection {
         self.num_added += 1;
         self
     }
-
-    /// Parses the input `section` given from the `wasmparser` crate and adds
-    /// all the globals to this section.
-    #[cfg(feature = "wasmparser")]
-    pub fn parse_section(
-        &mut self,
-        section: wasmparser::GlobalSectionReader<'_>,
-    ) -> crate::reencode::Result<&mut Self> {
-        crate::reencode::utils::parse_global_section(
-            &mut crate::reencode::RoundtripReencoder,
-            self,
-            section,
-        )
-    }
-
-    /// Parses the single [`wasmparser::Global`] provided and adds it to this
-    /// section.
-    #[cfg(feature = "wasmparser")]
-    pub fn parse(&mut self, global: wasmparser::Global<'_>) -> crate::reencode::Result<&mut Self> {
-        crate::reencode::utils::parse_global(&mut crate::reencode::RoundtripReencoder, self, global)
-    }
 }
 
 impl Encode for GlobalSection {
@@ -117,14 +96,5 @@ impl Encode for GlobalType {
             flag |= 0b10;
         }
         sink.push(flag);
-    }
-}
-
-#[cfg(feature = "wasmparser")]
-impl TryFrom<wasmparser::GlobalType> for GlobalType {
-    type Error = crate::reencode::Error;
-
-    fn try_from(global_ty: wasmparser::GlobalType) -> Result<Self, Self::Error> {
-        crate::reencode::utils::global_type(&mut crate::reencode::RoundtripReencoder, global_ty)
     }
 }

--- a/crates/wasm-encoder/src/core/imports.rs
+++ b/crates/wasm-encoder/src/core/imports.rs
@@ -73,15 +73,6 @@ impl From<TagType> for EntityType {
     }
 }
 
-#[cfg(feature = "wasmparser")]
-impl TryFrom<wasmparser::TypeRef> for EntityType {
-    type Error = crate::reencode::Error;
-
-    fn try_from(type_ref: wasmparser::TypeRef) -> Result<Self, Self::Error> {
-        crate::reencode::utils::entity_type(&mut crate::reencode::RoundtripReencoder, type_ref)
-    }
-}
-
 /// An encoder for the import section of WebAssembly modules.
 ///
 /// # Example
@@ -136,27 +127,6 @@ impl ImportSection {
         ty.into().encode(&mut self.bytes);
         self.num_added += 1;
         self
-    }
-
-    /// Parses the input `section` given from the `wasmparser` crate and adds
-    /// all the imports to this section.
-    #[cfg(feature = "wasmparser")]
-    pub fn parse_section(
-        &mut self,
-        section: wasmparser::ImportSectionReader<'_>,
-    ) -> crate::reencode::Result<&mut Self> {
-        crate::reencode::utils::parse_import_section(
-            &mut crate::reencode::RoundtripReencoder,
-            self,
-            section,
-        )
-    }
-
-    /// Parses the single [`wasmparser::Import`] provided and adds it to this
-    /// section.
-    #[cfg(feature = "wasmparser")]
-    pub fn parse(&mut self, import: wasmparser::Import<'_>) -> crate::reencode::Result<&mut Self> {
-        crate::reencode::utils::parse_import(&mut crate::reencode::RoundtripReencoder, self, import)
     }
 }
 

--- a/crates/wasm-encoder/src/core/imports.rs
+++ b/crates/wasm-encoder/src/core/imports.rs
@@ -75,10 +75,10 @@ impl From<TagType> for EntityType {
 
 #[cfg(feature = "wasmparser")]
 impl TryFrom<wasmparser::TypeRef> for EntityType {
-    type Error = ();
+    type Error = crate::reencode::Error;
+
     fn try_from(type_ref: wasmparser::TypeRef) -> Result<Self, Self::Error> {
         crate::reencode::utils::entity_type(&mut crate::reencode::RoundtripReencoder, type_ref)
-            .map_err(|_| ())
     }
 }
 

--- a/crates/wasm-encoder/src/core/memories.rs
+++ b/crates/wasm-encoder/src/core/memories.rs
@@ -51,20 +51,6 @@ impl MemorySection {
         self.num_added += 1;
         self
     }
-
-    /// Parses the input `section` given from the `wasmparser` crate and adds
-    /// all the memories to this section.
-    #[cfg(feature = "wasmparser")]
-    pub fn parse_section(
-        &mut self,
-        section: wasmparser::MemorySectionReader<'_>,
-    ) -> crate::reencode::Result<&mut Self> {
-        crate::reencode::utils::parse_memory_section(
-            &mut crate::reencode::RoundtripReencoder,
-            self,
-            section,
-        )
-    }
 }
 
 impl Encode for MemorySection {
@@ -125,12 +111,5 @@ impl Encode for MemoryType {
         if let Some(p) = self.page_size_log2 {
             p.encode(sink);
         }
-    }
-}
-
-#[cfg(feature = "wasmparser")]
-impl From<wasmparser::MemoryType> for MemoryType {
-    fn from(memory_ty: wasmparser::MemoryType) -> Self {
-        crate::reencode::utils::memory_type(&mut crate::reencode::RoundtripReencoder, memory_ty)
     }
 }

--- a/crates/wasm-encoder/src/core/memories.rs
+++ b/crates/wasm-encoder/src/core/memories.rs
@@ -58,12 +58,12 @@ impl MemorySection {
     pub fn parse_section(
         &mut self,
         section: wasmparser::MemorySectionReader<'_>,
-    ) -> wasmparser::Result<&mut Self> {
-        for memory in section {
-            let memory = memory?;
-            self.memory(memory.into());
-        }
-        Ok(self)
+    ) -> crate::reencode::Result<&mut Self> {
+        crate::reencode::utils::parse_memory_section(
+            &mut crate::reencode::RoundtripReencoder,
+            self,
+            section,
+        )
     }
 }
 
@@ -131,12 +131,6 @@ impl Encode for MemoryType {
 #[cfg(feature = "wasmparser")]
 impl From<wasmparser::MemoryType> for MemoryType {
     fn from(memory_ty: wasmparser::MemoryType) -> Self {
-        MemoryType {
-            minimum: memory_ty.initial,
-            maximum: memory_ty.maximum,
-            memory64: memory_ty.memory64,
-            shared: memory_ty.shared,
-            page_size_log2: memory_ty.page_size_log2,
-        }
+        crate::reencode::utils::memory_type(&mut crate::reencode::RoundtripReencoder, memory_ty)
     }
 }

--- a/crates/wasm-encoder/src/core/tables.rs
+++ b/crates/wasm-encoder/src/core/tables.rs
@@ -62,26 +62,6 @@ impl TableSection {
         self.num_added += 1;
         self
     }
-
-    /// Parses the input `section` given from the `wasmparser` crate and adds
-    /// all the tables to this section.
-    #[cfg(feature = "wasmparser")]
-    pub fn parse_section(
-        &mut self,
-        section: wasmparser::TableSectionReader<'_>,
-    ) -> crate::reencode::Result<&mut Self> {
-        crate::reencode::utils::parse_table_section(
-            &mut crate::reencode::RoundtripReencoder,
-            self,
-            section,
-        )
-    }
-
-    /// Parses a single [`wasmparser::Table`] and adds it to this section.
-    #[cfg(feature = "wasmparser")]
-    pub fn parse(&mut self, table: wasmparser::Table<'_>) -> crate::reencode::Result<&mut Self> {
-        crate::reencode::utils::parse_table(&mut crate::reencode::RoundtripReencoder, self, table)
-    }
 }
 
 impl Encode for TableSection {
@@ -137,14 +117,5 @@ impl Encode for TableType {
         if let Some(max) = self.maximum {
             max.encode(sink);
         }
-    }
-}
-
-#[cfg(feature = "wasmparser")]
-impl TryFrom<wasmparser::TableType> for TableType {
-    type Error = crate::reencode::Error;
-
-    fn try_from(table_ty: wasmparser::TableType) -> Result<Self, Self::Error> {
-        crate::reencode::utils::table_type(&mut crate::reencode::RoundtripReencoder, table_ty)
     }
 }

--- a/crates/wasm-encoder/src/core/tables.rs
+++ b/crates/wasm-encoder/src/core/tables.rs
@@ -142,9 +142,9 @@ impl Encode for TableType {
 
 #[cfg(feature = "wasmparser")]
 impl TryFrom<wasmparser::TableType> for TableType {
-    type Error = ();
+    type Error = crate::reencode::Error;
+
     fn try_from(table_ty: wasmparser::TableType) -> Result<Self, Self::Error> {
         crate::reencode::utils::table_type(&mut crate::reencode::RoundtripReencoder, table_ty)
-            .map_err(|_| ())
     }
 }

--- a/crates/wasm-encoder/src/core/tags.rs
+++ b/crates/wasm-encoder/src/core/tags.rs
@@ -53,12 +53,12 @@ impl TagSection {
     pub fn parse_section(
         &mut self,
         section: wasmparser::TagSectionReader<'_>,
-    ) -> wasmparser::Result<&mut Self> {
-        for tag in section {
-            let tag = tag?;
-            self.tag(tag.into());
-        }
-        Ok(self)
+    ) -> crate::reencode::Result<&mut Self> {
+        crate::reencode::utils::parse_tag_section(
+            &mut crate::reencode::RoundtripReencoder,
+            self,
+            section,
+        )
     }
 }
 
@@ -85,9 +85,7 @@ pub enum TagKind {
 #[cfg(feature = "wasmparser")]
 impl From<wasmparser::TagKind> for TagKind {
     fn from(kind: wasmparser::TagKind) -> Self {
-        match kind {
-            wasmparser::TagKind::Exception => TagKind::Exception,
-        }
+        crate::reencode::utils::tag_kind(&mut crate::reencode::RoundtripReencoder, kind)
     }
 }
 
@@ -110,9 +108,6 @@ impl Encode for TagType {
 #[cfg(feature = "wasmparser")]
 impl From<wasmparser::TagType> for TagType {
     fn from(tag_ty: wasmparser::TagType) -> Self {
-        TagType {
-            kind: tag_ty.kind.into(),
-            func_type_idx: tag_ty.func_type_idx,
-        }
+        crate::reencode::utils::tag_type(&mut crate::reencode::RoundtripReencoder, tag_ty)
     }
 }

--- a/crates/wasm-encoder/src/core/tags.rs
+++ b/crates/wasm-encoder/src/core/tags.rs
@@ -46,20 +46,6 @@ impl TagSection {
         self.num_added += 1;
         self
     }
-
-    /// Parses the input `section` given from the `wasmparser` crate and adds
-    /// all the tags to this section.
-    #[cfg(feature = "wasmparser")]
-    pub fn parse_section(
-        &mut self,
-        section: wasmparser::TagSectionReader<'_>,
-    ) -> crate::reencode::Result<&mut Self> {
-        crate::reencode::utils::parse_tag_section(
-            &mut crate::reencode::RoundtripReencoder,
-            self,
-            section,
-        )
-    }
 }
 
 impl Encode for TagSection {
@@ -82,13 +68,6 @@ pub enum TagKind {
     Exception = 0x0,
 }
 
-#[cfg(feature = "wasmparser")]
-impl From<wasmparser::TagKind> for TagKind {
-    fn from(kind: wasmparser::TagKind) -> Self {
-        crate::reencode::utils::tag_kind(&mut crate::reencode::RoundtripReencoder, kind)
-    }
-}
-
 /// A tag's type.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TagType {
@@ -102,12 +81,5 @@ impl Encode for TagType {
     fn encode(&self, sink: &mut Vec<u8>) {
         sink.push(self.kind as u8);
         self.func_type_idx.encode(sink);
-    }
-}
-
-#[cfg(feature = "wasmparser")]
-impl From<wasmparser::TagType> for TagType {
-    fn from(tag_ty: wasmparser::TagType) -> Self {
-        crate::reencode::utils::tag_type(&mut crate::reencode::RoundtripReencoder, tag_ty)
     }
 }

--- a/crates/wasm-encoder/src/core/types.rs
+++ b/crates/wasm-encoder/src/core/types.rs
@@ -25,11 +25,10 @@ impl Encode for SubType {
 
 #[cfg(feature = "wasmparser")]
 impl TryFrom<wasmparser::SubType> for SubType {
-    type Error = ();
+    type Error = crate::reencode::Error;
 
     fn try_from(sub_ty: wasmparser::SubType) -> Result<Self, Self::Error> {
         crate::reencode::utils::sub_type(&mut crate::reencode::RoundtripReencoder, sub_ty)
-            .map_err(|_| ())
     }
 }
 
@@ -64,13 +63,13 @@ impl Encode for CompositeType {
 
 #[cfg(feature = "wasmparser")]
 impl TryFrom<wasmparser::CompositeType> for CompositeType {
-    type Error = ();
+    type Error = crate::reencode::Error;
+
     fn try_from(composite_ty: wasmparser::CompositeType) -> Result<Self, Self::Error> {
         crate::reencode::utils::composite_type(
             &mut crate::reencode::RoundtripReencoder,
             composite_ty,
         )
-        .map_err(|_| ())
     }
 }
 
@@ -85,10 +84,10 @@ pub struct FuncType {
 
 #[cfg(feature = "wasmparser")]
 impl TryFrom<wasmparser::FuncType> for FuncType {
-    type Error = ();
+    type Error = crate::reencode::Error;
+
     fn try_from(func_ty: wasmparser::FuncType) -> Result<Self, Self::Error> {
         crate::reencode::utils::func_type(&mut crate::reencode::RoundtripReencoder, func_ty)
-            .map_err(|_| ())
     }
 }
 
@@ -98,10 +97,10 @@ pub struct ArrayType(pub FieldType);
 
 #[cfg(feature = "wasmparser")]
 impl TryFrom<wasmparser::ArrayType> for ArrayType {
-    type Error = ();
+    type Error = crate::reencode::Error;
+
     fn try_from(array_ty: wasmparser::ArrayType) -> Result<Self, Self::Error> {
         crate::reencode::utils::array_type(&mut crate::reencode::RoundtripReencoder, array_ty)
-            .map_err(|_| ())
     }
 }
 
@@ -114,10 +113,10 @@ pub struct StructType {
 
 #[cfg(feature = "wasmparser")]
 impl TryFrom<wasmparser::StructType> for StructType {
-    type Error = ();
+    type Error = crate::reencode::Error;
+
     fn try_from(struct_ty: wasmparser::StructType) -> Result<Self, Self::Error> {
         crate::reencode::utils::struct_type(&mut crate::reencode::RoundtripReencoder, struct_ty)
-            .map_err(|_| ())
     }
 }
 
@@ -132,10 +131,10 @@ pub struct FieldType {
 
 #[cfg(feature = "wasmparser")]
 impl TryFrom<wasmparser::FieldType> for FieldType {
-    type Error = ();
+    type Error = crate::reencode::Error;
+
     fn try_from(field_ty: wasmparser::FieldType) -> Result<Self, Self::Error> {
         crate::reencode::utils::field_type(&mut crate::reencode::RoundtripReencoder, field_ty)
-            .map_err(|_| ())
     }
 }
 
@@ -152,10 +151,10 @@ pub enum StorageType {
 
 #[cfg(feature = "wasmparser")]
 impl TryFrom<wasmparser::StorageType> for StorageType {
-    type Error = ();
+    type Error = crate::reencode::Error;
+
     fn try_from(storage_ty: wasmparser::StorageType) -> Result<Self, Self::Error> {
         crate::reencode::utils::storage_type(&mut crate::reencode::RoundtripReencoder, storage_ty)
-            .map_err(|_| ())
     }
 }
 
@@ -199,10 +198,10 @@ pub enum ValType {
 
 #[cfg(feature = "wasmparser")]
 impl TryFrom<wasmparser::ValType> for ValType {
-    type Error = ();
+    type Error = crate::reencode::Error;
+
     fn try_from(val_ty: wasmparser::ValType) -> Result<Self, Self::Error> {
         crate::reencode::utils::val_type(&mut crate::reencode::RoundtripReencoder, val_ty)
-            .map_err(|_| ())
     }
 }
 
@@ -419,11 +418,10 @@ impl Encode for RefType {
 
 #[cfg(feature = "wasmparser")]
 impl TryFrom<wasmparser::RefType> for RefType {
-    type Error = ();
+    type Error = crate::reencode::Error;
 
     fn try_from(ref_type: wasmparser::RefType) -> Result<Self, Self::Error> {
         crate::reencode::utils::ref_type(&mut crate::reencode::RoundtripReencoder, ref_type)
-            .map_err(|_| ())
     }
 }
 
@@ -492,11 +490,10 @@ impl Encode for HeapType {
 
 #[cfg(feature = "wasmparser")]
 impl TryFrom<wasmparser::HeapType> for HeapType {
-    type Error = ();
+    type Error = crate::reencode::Error;
 
     fn try_from(heap_type: wasmparser::HeapType) -> Result<Self, Self::Error> {
         crate::reencode::utils::heap_type(&mut crate::reencode::RoundtripReencoder, heap_type)
-            .map_err(|_| ())
     }
 }
 

--- a/crates/wasm-encoder/src/core/types.rs
+++ b/crates/wasm-encoder/src/core/types.rs
@@ -530,6 +530,17 @@ impl TypeSection {
         self
     }
 
+    /// Define a function type in this type section.
+    pub fn func_type(&mut self, ty: &FuncType) -> &mut Self {
+        Self::encode_function(
+            &mut self.bytes,
+            ty.params().iter().cloned(),
+            ty.results().iter().cloned(),
+        );
+        self.num_added += 1;
+        self
+    }
+
     fn encode_function<P, R>(sink: &mut Vec<u8>, params: P, results: R)
     where
         P: IntoIterator<Item = ValType>,

--- a/crates/wasm-encoder/src/core/types.rs
+++ b/crates/wasm-encoder/src/core/types.rs
@@ -23,15 +23,6 @@ impl Encode for SubType {
     }
 }
 
-#[cfg(feature = "wasmparser")]
-impl TryFrom<wasmparser::SubType> for SubType {
-    type Error = crate::reencode::Error;
-
-    fn try_from(sub_ty: wasmparser::SubType) -> Result<Self, Self::Error> {
-        crate::reencode::utils::sub_type(&mut crate::reencode::RoundtripReencoder, sub_ty)
-    }
-}
-
 /// Represents a composite type in a WebAssembly module.
 #[derive(Debug, Clone)]
 pub enum CompositeType {
@@ -61,18 +52,6 @@ impl Encode for CompositeType {
     }
 }
 
-#[cfg(feature = "wasmparser")]
-impl TryFrom<wasmparser::CompositeType> for CompositeType {
-    type Error = crate::reencode::Error;
-
-    fn try_from(composite_ty: wasmparser::CompositeType) -> Result<Self, Self::Error> {
-        crate::reencode::utils::composite_type(
-            &mut crate::reencode::RoundtripReencoder,
-            composite_ty,
-        )
-    }
-}
-
 /// Represents a type of a function in a WebAssembly module.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct FuncType {
@@ -82,42 +61,15 @@ pub struct FuncType {
     len_params: usize,
 }
 
-#[cfg(feature = "wasmparser")]
-impl TryFrom<wasmparser::FuncType> for FuncType {
-    type Error = crate::reencode::Error;
-
-    fn try_from(func_ty: wasmparser::FuncType) -> Result<Self, Self::Error> {
-        crate::reencode::utils::func_type(&mut crate::reencode::RoundtripReencoder, func_ty)
-    }
-}
-
 /// Represents a type of an array in a WebAssembly module.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct ArrayType(pub FieldType);
-
-#[cfg(feature = "wasmparser")]
-impl TryFrom<wasmparser::ArrayType> for ArrayType {
-    type Error = crate::reencode::Error;
-
-    fn try_from(array_ty: wasmparser::ArrayType) -> Result<Self, Self::Error> {
-        crate::reencode::utils::array_type(&mut crate::reencode::RoundtripReencoder, array_ty)
-    }
-}
 
 /// Represents a type of a struct in a WebAssembly module.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct StructType {
     /// Struct fields.
     pub fields: Box<[FieldType]>,
-}
-
-#[cfg(feature = "wasmparser")]
-impl TryFrom<wasmparser::StructType> for StructType {
-    type Error = crate::reencode::Error;
-
-    fn try_from(struct_ty: wasmparser::StructType) -> Result<Self, Self::Error> {
-        crate::reencode::utils::struct_type(&mut crate::reencode::RoundtripReencoder, struct_ty)
-    }
 }
 
 /// Field type in composite types (structs, arrays).
@@ -129,15 +81,6 @@ pub struct FieldType {
     pub mutable: bool,
 }
 
-#[cfg(feature = "wasmparser")]
-impl TryFrom<wasmparser::FieldType> for FieldType {
-    type Error = crate::reencode::Error;
-
-    fn try_from(field_ty: wasmparser::FieldType) -> Result<Self, Self::Error> {
-        crate::reencode::utils::field_type(&mut crate::reencode::RoundtripReencoder, field_ty)
-    }
-}
-
 /// Storage type for composite type fields.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub enum StorageType {
@@ -147,15 +90,6 @@ pub enum StorageType {
     I16,
     /// A value type.
     Val(ValType),
-}
-
-#[cfg(feature = "wasmparser")]
-impl TryFrom<wasmparser::StorageType> for StorageType {
-    type Error = crate::reencode::Error;
-
-    fn try_from(storage_ty: wasmparser::StorageType) -> Result<Self, Self::Error> {
-        crate::reencode::utils::storage_type(&mut crate::reencode::RoundtripReencoder, storage_ty)
-    }
 }
 
 impl StorageType {
@@ -194,15 +128,6 @@ pub enum ValType {
     /// generalization here is due to the implementation of the
     /// function-references proposal.
     Ref(RefType),
-}
-
-#[cfg(feature = "wasmparser")]
-impl TryFrom<wasmparser::ValType> for ValType {
-    type Error = crate::reencode::Error;
-
-    fn try_from(val_ty: wasmparser::ValType) -> Result<Self, Self::Error> {
-        crate::reencode::utils::val_type(&mut crate::reencode::RoundtripReencoder, val_ty)
-    }
 }
 
 impl ValType {
@@ -416,15 +341,6 @@ impl Encode for RefType {
     }
 }
 
-#[cfg(feature = "wasmparser")]
-impl TryFrom<wasmparser::RefType> for RefType {
-    type Error = crate::reencode::Error;
-
-    fn try_from(ref_type: wasmparser::RefType) -> Result<Self, Self::Error> {
-        crate::reencode::utils::ref_type(&mut crate::reencode::RoundtripReencoder, ref_type)
-    }
-}
-
 impl From<RefType> for ValType {
     fn from(ty: RefType) -> ValType {
         ValType::Ref(ty)
@@ -485,15 +401,6 @@ impl Encode for HeapType {
             // as it's decoded as an s33
             HeapType::Concrete(i) => i64::from(*i).encode(sink),
         }
-    }
-}
-
-#[cfg(feature = "wasmparser")]
-impl TryFrom<wasmparser::HeapType> for HeapType {
-    type Error = crate::reencode::Error;
-
-    fn try_from(heap_type: wasmparser::HeapType) -> Result<Self, Self::Error> {
-        crate::reencode::utils::heap_type(&mut crate::reencode::RoundtripReencoder, heap_type)
     }
 }
 
@@ -569,13 +476,6 @@ impl Encode for AbstractHeapType {
             Exn => sink.push(0x69),
             NoExn => sink.push(0x74),
         }
-    }
-}
-
-#[cfg(feature = "wasmparser")]
-impl From<wasmparser::AbstractHeapType> for AbstractHeapType {
-    fn from(value: wasmparser::AbstractHeapType) -> Self {
-        crate::reencode::utils::abstract_heap_type(&mut crate::reencode::RoundtripReencoder, value)
     }
 }
 
@@ -707,30 +607,6 @@ impl TypeSection {
         types.for_each(|t| t.encode(&mut self.bytes));
         self.num_added += 1;
         self
-    }
-
-    /// Parses the input `section` given from the `wasmparser` crate and adds
-    /// all the types to this section.
-    #[cfg(feature = "wasmparser")]
-    pub fn parse_section(
-        &mut self,
-        section: wasmparser::TypeSectionReader<'_>,
-    ) -> crate::reencode::Result<&mut Self> {
-        crate::reencode::utils::parse_type_section(
-            &mut crate::reencode::RoundtripReencoder,
-            self,
-            section,
-        )
-    }
-
-    /// Parses a single [`wasmparser::RecGroup`] and adds it to this section.
-    #[cfg(feature = "wasmparser")]
-    pub fn parse(&mut self, rec_group: wasmparser::RecGroup) -> crate::reencode::Result<&mut Self> {
-        crate::reencode::utils::parse_recursive_type_group(
-            &mut crate::reencode::RoundtripReencoder,
-            self,
-            rec_group,
-        )
     }
 }
 

--- a/crates/wasm-encoder/src/lib.rs
+++ b/crates/wasm-encoder/src/lib.rs
@@ -74,6 +74,8 @@
 mod component;
 mod core;
 mod raw;
+#[cfg(feature = "wasmparser")]
+pub mod reencode;
 
 pub use self::component::*;
 pub use self::core::*;

--- a/crates/wasm-encoder/src/reencode.rs
+++ b/crates/wasm-encoder/src/reencode.rs
@@ -42,9 +42,9 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 pub trait WasmParserToWasmEncoder {
     fn core_module<'a, 'b>(
         &mut self,
-        module: &'a mut crate::Module,
+        module: &mut crate::Module,
         sections: impl Iterator<Item = Result<wasmparser::Payload<'b>, wasmparser::BinaryReaderError>>,
-    ) -> Result<&'a crate::Module> {
+    ) -> Result<()> {
         utils::core_module(self, module, sections)
     }
 
@@ -119,20 +119,20 @@ pub trait WasmParserToWasmEncoder {
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the types to the `types` section.
-    fn parse_type_section<'a>(
+    fn parse_type_section(
         &mut self,
-        types: &'a mut crate::TypeSection,
+        types: &mut crate::TypeSection,
         section: wasmparser::TypeSectionReader<'_>,
-    ) -> Result<&'a mut crate::TypeSection> {
+    ) -> Result<()> {
         utils::parse_type_section(self, types, section)
     }
 
     /// Parses a single [`wasmparser::RecGroup`] and adds it to the `types` section.
-    fn parse_recursive_type_group<'a>(
+    fn parse_recursive_type_group(
         &mut self,
-        types: &'a mut crate::TypeSection,
+        types: &mut crate::TypeSection,
         rec_group: wasmparser::RecGroup,
-    ) -> Result<&'a mut crate::TypeSection> {
+    ) -> Result<()> {
         utils::parse_recursive_type_group(self, types, rec_group)
     }
 
@@ -181,20 +181,20 @@ pub trait WasmParserToWasmEncoder {
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the tables to the `tables` section.
-    fn parse_table_section<'a>(
+    fn parse_table_section(
         &mut self,
-        tables: &'a mut crate::TableSection,
+        tables: &mut crate::TableSection,
         section: wasmparser::TableSectionReader<'_>,
-    ) -> Result<&'a mut crate::TableSection> {
+    ) -> Result<()> {
         utils::parse_table_section(self, tables, section)
     }
 
     /// Parses a single [`wasmparser::Table`] and adds it to the `tables` section.
-    fn parse_table<'a>(
+    fn parse_table(
         &mut self,
-        tables: &'a mut crate::TableSection,
+        tables: &mut crate::TableSection,
         table: wasmparser::Table<'_>,
-    ) -> Result<&'a mut crate::TableSection> {
+    ) -> Result<()> {
         utils::parse_table(self, tables, table)
     }
 
@@ -204,21 +204,21 @@ pub trait WasmParserToWasmEncoder {
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the tags to the `tags` section.
-    fn parse_tag_section<'a>(
+    fn parse_tag_section(
         &mut self,
-        tags: &'a mut crate::TagSection,
+        tags: &mut crate::TagSection,
         section: wasmparser::TagSectionReader<'_>,
-    ) -> Result<&'a mut crate::TagSection> {
+    ) -> Result<()> {
         utils::parse_tag_section(self, tags, section)
     }
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the exports to the `exports` section.
-    fn parse_export_section<'a>(
+    fn parse_export_section(
         &mut self,
-        exports: &'a mut crate::ExportSection,
+        exports: &mut crate::ExportSection,
         section: wasmparser::ExportSectionReader<'_>,
-    ) -> Result<&'a mut crate::ExportSection> {
+    ) -> Result<()> {
         utils::parse_export_section(self, exports, section)
     }
 
@@ -228,31 +228,27 @@ pub trait WasmParserToWasmEncoder {
 
     /// Parses the single [`wasmparser::Export`] provided and adds it to the
     /// `exports` section.
-    fn parse_export<'a>(
-        &mut self,
-        exports: &'a mut crate::ExportSection,
-        export: wasmparser::Export<'_>,
-    ) -> &'a mut crate::ExportSection {
+    fn parse_export(&mut self, exports: &mut crate::ExportSection, export: wasmparser::Export<'_>) {
         utils::parse_export(self, exports, export)
     }
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the globals to the `globals` section.
-    fn parse_global_section<'a>(
+    fn parse_global_section(
         &mut self,
-        globals: &'a mut crate::GlobalSection,
+        globals: &mut crate::GlobalSection,
         section: wasmparser::GlobalSectionReader<'_>,
-    ) -> Result<&'a mut crate::GlobalSection> {
+    ) -> Result<()> {
         utils::parse_global_section(self, globals, section)
     }
 
     /// Parses the single [`wasmparser::Global`] provided and adds it to the
     /// `globals` section.
-    fn parse_global<'a>(
+    fn parse_global(
         &mut self,
-        globals: &'a mut crate::GlobalSection,
+        globals: &mut crate::GlobalSection,
         global: wasmparser::Global<'_>,
-    ) -> Result<&'a mut crate::GlobalSection> {
+    ) -> Result<()> {
         utils::parse_global(self, globals, global)
     }
 
@@ -266,80 +262,80 @@ pub trait WasmParserToWasmEncoder {
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the imports to the `import` section.
-    fn parse_import_section<'a>(
+    fn parse_import_section(
         &mut self,
-        imports: &'a mut crate::ImportSection,
+        imports: &mut crate::ImportSection,
         section: wasmparser::ImportSectionReader<'_>,
-    ) -> Result<&'a mut crate::ImportSection> {
+    ) -> Result<()> {
         utils::parse_import_section(self, imports, section)
     }
 
     /// Parses the single [`wasmparser::Import`] provided and adds it to the
     /// `import` section.
-    fn parse_import<'a>(
+    fn parse_import(
         &mut self,
-        imports: &'a mut crate::ImportSection,
+        imports: &mut crate::ImportSection,
         import: wasmparser::Import<'_>,
-    ) -> Result<&'a mut crate::ImportSection> {
+    ) -> Result<()> {
         utils::parse_import(self, imports, import)
     }
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the memories to the `memories` section.
-    fn parse_memory_section<'a>(
+    fn parse_memory_section(
         &mut self,
-        memories: &'a mut crate::MemorySection,
+        memories: &mut crate::MemorySection,
         section: wasmparser::MemorySectionReader<'_>,
-    ) -> Result<&'a mut crate::MemorySection> {
+    ) -> Result<()> {
         utils::parse_memory_section(self, memories, section)
     }
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the functions to the `functions` section.
-    fn parse_function_section<'a>(
+    fn parse_function_section(
         &mut self,
-        functions: &'a mut crate::FunctionSection,
+        functions: &mut crate::FunctionSection,
         section: wasmparser::FunctionSectionReader<'_>,
-    ) -> Result<&'a mut crate::FunctionSection> {
+    ) -> Result<()> {
         utils::parse_function_section(self, functions, section)
     }
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the data to the `data` section.
-    fn parse_data_section<'a>(
+    fn parse_data_section(
         &mut self,
-        data: &'a mut crate::DataSection,
+        data: &mut crate::DataSection,
         section: wasmparser::DataSectionReader<'_>,
-    ) -> Result<&'a mut crate::DataSection> {
+    ) -> Result<()> {
         utils::parse_data_section(self, data, section)
     }
 
     /// Parses a single [`wasmparser::Data`] and adds it to the `data` section.
-    fn parse_data<'a>(
+    fn parse_data(
         &mut self,
-        data: &'a mut crate::DataSection,
+        data: &mut crate::DataSection,
         datum: wasmparser::Data<'_>,
-    ) -> Result<&'a mut crate::DataSection> {
+    ) -> Result<()> {
         utils::parse_data(self, data, datum)
     }
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the elements to the `element` section.
-    fn parse_element_section<'a>(
+    fn parse_element_section(
         &mut self,
-        elements: &'a mut crate::ElementSection,
+        elements: &mut crate::ElementSection,
         section: wasmparser::ElementSectionReader<'_>,
-    ) -> Result<&'a mut crate::ElementSection> {
+    ) -> Result<()> {
         utils::parse_element_section(self, elements, section)
     }
 
     /// Parses the single [`wasmparser::Element`] provided and adds it to the
     /// `element` section.
-    fn parse_element<'a>(
+    fn parse_element(
         &mut self,
-        elements: &'a mut crate::ElementSection,
+        elements: &mut crate::ElementSection,
         element: wasmparser::Element<'_>,
-    ) -> Result<&'a mut crate::ElementSection> {
+    ) -> Result<()> {
         utils::parse_element(self, elements, element)
     }
 
@@ -373,20 +369,20 @@ pub trait WasmParserToWasmEncoder {
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the code to the `code` section.
-    fn parse_code_section<'a>(
+    fn parse_code_section(
         &mut self,
-        code: &'a mut crate::CodeSection,
+        code: &mut crate::CodeSection,
         section: wasmparser::CodeSectionReader<'_>,
-    ) -> Result<&'a mut crate::CodeSection> {
+    ) -> Result<()> {
         utils::parse_code_section(self, code, section)
     }
 
     /// Parses a single [`wasmparser::FunctionBody`] and adds it to the `code` section.
-    fn parse_function_body<'a>(
+    fn parse_function_body(
         &mut self,
-        code: &'a mut crate::CodeSection,
+        code: &mut crate::CodeSection,
         func: wasmparser::FunctionBody<'_>,
-    ) -> Result<&'a mut crate::CodeSection> {
+    ) -> Result<()> {
         utils::parse_function_body(self, code, func)
     }
 
@@ -400,11 +396,11 @@ pub trait WasmParserToWasmEncoder {
     }
 
     /// Parses a single instruction from `reader` and adds it to `function`.
-    fn parse_instruction<'a>(
+    fn parse_instruction(
         &mut self,
-        function: &'a mut crate::Function,
+        function: &mut crate::Function,
         reader: &mut wasmparser::OperatorsReader<'_>,
-    ) -> Result<&'a mut crate::Function> {
+    ) -> Result<()> {
         utils::parse_instruction(self, function, reader)
     }
 }
@@ -421,7 +417,7 @@ pub mod utils {
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
         module: &'a mut crate::Module,
         sections: impl Iterator<Item = Result<wasmparser::Payload<'b>, wasmparser::BinaryReaderError>>,
-    ) -> Result<&'a crate::Module> {
+    ) -> Result<()> {
         fn module_section_flush_codes(
             module: &mut crate::Module,
             section: &impl crate::Section,
@@ -541,7 +537,7 @@ pub mod utils {
             module.section(&codes);
         }
 
-        Ok(module)
+        Ok(())
     }
 
     pub fn component_primitive_val_type(
@@ -715,23 +711,23 @@ pub mod utils {
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the types to the `types` section.
-    pub fn parse_type_section<'a>(
+    pub fn parse_type_section(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
-        types: &'a mut crate::TypeSection,
+        types: &mut crate::TypeSection,
         section: wasmparser::TypeSectionReader<'_>,
-    ) -> Result<&'a mut crate::TypeSection> {
+    ) -> Result<()> {
         for rec_group in section {
             reencoder.parse_recursive_type_group(types, rec_group.map_err(Error::ParseError)?)?;
         }
-        Ok(types)
+        Ok(())
     }
 
     /// Parses a single [`wasmparser::RecGroup`] and adds it to the `types` section.
-    pub fn parse_recursive_type_group<'a>(
+    pub fn parse_recursive_type_group(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
-        types: &'a mut crate::TypeSection,
+        types: &mut crate::TypeSection,
         rec_group: wasmparser::RecGroup,
-    ) -> Result<&'a mut crate::TypeSection> {
+    ) -> Result<()> {
         if rec_group.is_explicit_rec_group() {
             let subtypes = rec_group
                 .into_types()
@@ -742,7 +738,7 @@ pub mod utils {
             let ty = rec_group.into_types().next().unwrap();
             types.subtype(&reencoder.sub_type(ty)?);
         }
-        Ok(types)
+        Ok(())
     }
 
     pub fn sub_type(
@@ -878,23 +874,23 @@ pub mod utils {
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the tables to the `tables` section.
-    pub fn parse_table_section<'a>(
+    pub fn parse_table_section(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
-        tables: &'a mut crate::TableSection,
+        tables: &mut crate::TableSection,
         section: wasmparser::TableSectionReader<'_>,
-    ) -> Result<&'a mut crate::TableSection> {
+    ) -> Result<()> {
         for table in section {
             reencoder.parse_table(tables, table.map_err(Error::ParseError)?)?;
         }
-        Ok(tables)
+        Ok(())
     }
 
     /// Parses a single [`wasmparser::Table`] and adds it to the `tables` section.
-    pub fn parse_table<'a>(
+    pub fn parse_table(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
-        tables: &'a mut crate::TableSection,
+        tables: &mut crate::TableSection,
         table: wasmparser::Table<'_>,
-    ) -> Result<&'a mut crate::TableSection> {
+    ) -> Result<()> {
         let ty = reencoder.table_type(table.ty)?;
         match table.init {
             wasmparser::TableInit::RefNull => {
@@ -904,7 +900,7 @@ pub mod utils {
                 tables.table_with_init(ty, &reencoder.const_expr(e)?);
             }
         }
-        Ok(tables)
+        Ok(())
     }
 
     pub fn table_type(
@@ -921,29 +917,29 @@ pub mod utils {
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the tags to the `tags` section.
-    pub fn parse_tag_section<'a>(
+    pub fn parse_tag_section(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
-        tags: &'a mut crate::TagSection,
+        tags: &mut crate::TagSection,
         section: wasmparser::TagSectionReader<'_>,
-    ) -> Result<&'a mut crate::TagSection> {
+    ) -> Result<()> {
         for tag in section {
             let tag = tag.map_err(Error::ParseError)?;
             tags.tag(reencoder.tag_type(tag));
         }
-        Ok(tags)
+        Ok(())
     }
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the exports to the `exports` section.
-    pub fn parse_export_section<'a>(
+    pub fn parse_export_section(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
-        exports: &'a mut crate::ExportSection,
+        exports: &mut crate::ExportSection,
         section: wasmparser::ExportSectionReader<'_>,
-    ) -> Result<&'a mut crate::ExportSection> {
+    ) -> Result<()> {
         for export in section {
             reencoder.parse_export(exports, export.map_err(Error::ParseError)?);
         }
-        Ok(exports)
+        Ok(())
     }
 
     pub fn export_index(
@@ -955,43 +951,43 @@ pub mod utils {
 
     /// Parses the single [`wasmparser::Export`] provided and adds it to the
     /// `exports` section.
-    pub fn parse_export<'a>(
+    pub fn parse_export(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
-        exports: &'a mut crate::ExportSection,
+        exports: &mut crate::ExportSection,
         export: wasmparser::Export<'_>,
-    ) -> &'a mut crate::ExportSection {
+    ) {
         exports.export(
             export.name,
             reencoder.export_kind(export.kind),
             reencoder.export_index(export.index),
-        )
+        );
     }
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the globals to the `globals` section.
-    pub fn parse_global_section<'a>(
+    pub fn parse_global_section(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
-        globals: &'a mut crate::GlobalSection,
+        globals: &mut crate::GlobalSection,
         section: wasmparser::GlobalSectionReader<'_>,
-    ) -> Result<&'a mut crate::GlobalSection> {
+    ) -> Result<()> {
         for global in section {
             reencoder.parse_global(globals, global.map_err(Error::ParseError)?)?;
         }
-        Ok(globals)
+        Ok(())
     }
 
     /// Parses the single [`wasmparser::Global`] provided and adds it to the
     /// `globals` section.
-    pub fn parse_global<'a>(
+    pub fn parse_global(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
-        globals: &'a mut crate::GlobalSection,
+        globals: &mut crate::GlobalSection,
         global: wasmparser::Global<'_>,
-    ) -> Result<&'a mut crate::GlobalSection> {
+    ) -> Result<()> {
         globals.global(
             reencoder.global_type(global.ty)?,
             &reencoder.const_expr(global.init_expr)?,
         );
-        Ok(globals)
+        Ok(())
     }
 
     pub fn global_type(
@@ -1020,111 +1016,112 @@ pub mod utils {
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the imports to the `import` section.
-    pub fn parse_import_section<'a>(
+    pub fn parse_import_section(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
-        imports: &'a mut crate::ImportSection,
+        imports: &mut crate::ImportSection,
         section: wasmparser::ImportSectionReader<'_>,
-    ) -> Result<&'a mut crate::ImportSection> {
+    ) -> Result<()> {
         for import in section {
             reencoder.parse_import(imports, import.map_err(Error::ParseError)?)?;
         }
-        Ok(imports)
+        Ok(())
     }
 
     /// Parses the single [`wasmparser::Import`] provided and adds it to the
     /// `import` section.
-    pub fn parse_import<'a>(
+    pub fn parse_import(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
-        imports: &'a mut crate::ImportSection,
+        imports: &mut crate::ImportSection,
         import: wasmparser::Import<'_>,
-    ) -> Result<&'a mut crate::ImportSection> {
+    ) -> Result<()> {
         imports.import(
             import.module,
             import.name,
             reencoder.entity_type(import.ty)?,
         );
-        Ok(imports)
+        Ok(())
     }
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the memories to the `memories` section.
-    pub fn parse_memory_section<'a>(
+    pub fn parse_memory_section(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
-        memories: &'a mut crate::MemorySection,
+        memories: &mut crate::MemorySection,
         section: wasmparser::MemorySectionReader<'_>,
-    ) -> Result<&'a mut crate::MemorySection> {
+    ) -> Result<()> {
         for memory in section {
             let memory = memory.map_err(Error::ParseError)?;
             memories.memory(reencoder.memory_type(memory));
         }
-        Ok(memories)
+        Ok(())
     }
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the functions to the `functions` section.
-    pub fn parse_function_section<'a>(
+    pub fn parse_function_section(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
-        functions: &'a mut crate::FunctionSection,
+        functions: &mut crate::FunctionSection,
         section: wasmparser::FunctionSectionReader<'_>,
-    ) -> Result<&'a mut crate::FunctionSection> {
+    ) -> Result<()> {
         for func in section {
             functions.function(reencoder.type_index(func.map_err(Error::ParseError)?));
         }
-        Ok(functions)
+        Ok(())
     }
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the data to the `data` section.
-    pub fn parse_data_section<'a>(
+    pub fn parse_data_section(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
-        data: &'a mut crate::DataSection,
+        data: &mut crate::DataSection,
         section: wasmparser::DataSectionReader<'_>,
-    ) -> Result<&'a mut crate::DataSection> {
+    ) -> Result<()> {
         for datum in section {
             reencoder.parse_data(data, datum.map_err(Error::ParseError)?)?;
         }
-        Ok(data)
+        Ok(())
     }
 
     /// Parses a single [`wasmparser::Data`] and adds it to the `data` section.
-    pub fn parse_data<'a>(
+    pub fn parse_data(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
-        data: &'a mut crate::DataSection,
+        data: &mut crate::DataSection,
         datum: wasmparser::Data<'_>,
-    ) -> Result<&'a mut crate::DataSection> {
+    ) -> Result<()> {
         match datum.kind {
             wasmparser::DataKind::Active {
                 memory_index,
                 offset_expr,
-            } => Ok(data.active(
+            } => data.active(
                 reencoder.memory_index(memory_index),
                 &reencoder.const_expr(offset_expr)?,
                 datum.data.iter().copied(),
-            )),
-            wasmparser::DataKind::Passive => Ok(data.passive(datum.data.iter().copied())),
-        }
+            ),
+            wasmparser::DataKind::Passive => data.passive(datum.data.iter().copied()),
+        };
+        Ok(())
     }
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the elements to the `element` section.
-    pub fn parse_element_section<'a>(
+    pub fn parse_element_section(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
-        elements: &'a mut crate::ElementSection,
+        elements: &mut crate::ElementSection,
         section: wasmparser::ElementSectionReader<'_>,
-    ) -> Result<&'a mut crate::ElementSection> {
+    ) -> Result<()> {
         for element in section {
             reencoder.parse_element(elements, element.map_err(Error::ParseError)?)?;
         }
-        Ok(elements)
+        Ok(())
     }
 
     /// Parses the single [`wasmparser::Element`] provided and adds it to the
     /// `element` section.
-    pub fn parse_element<'a>(
+    pub fn parse_element(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
-        elements: &'a mut crate::ElementSection,
+        elements: &mut crate::ElementSection,
         element: wasmparser::Element<'_>,
-    ) -> Result<&'a mut crate::ElementSection> {
+    ) -> Result<()> {
         let mut funcs;
         let mut exprs;
         let elems = match element.items {
@@ -1147,14 +1144,15 @@ pub mod utils {
             wasmparser::ElementKind::Active {
                 table_index,
                 offset_expr,
-            } => Ok(elements.active(
+            } => elements.active(
                 table_index.map(|t| reencoder.table_index(t)),
                 &reencoder.const_expr(offset_expr)?,
                 elems,
-            )),
-            wasmparser::ElementKind::Passive => Ok(elements.passive(elems)),
-            wasmparser::ElementKind::Declared => Ok(elements.declared(elems)),
-        }
+            ),
+            wasmparser::ElementKind::Passive => elements.passive(elems),
+            wasmparser::ElementKind::Declared => elements.declared(elems),
+        };
+        Ok(())
     }
 
     pub fn table_index(
@@ -1329,29 +1327,30 @@ pub mod utils {
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the code to the `code` section.
-    pub fn parse_code_section<'a>(
+    pub fn parse_code_section(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
-        code: &'a mut crate::CodeSection,
+        code: &mut crate::CodeSection,
         section: wasmparser::CodeSectionReader<'_>,
-    ) -> Result<&'a mut crate::CodeSection> {
+    ) -> Result<()> {
         for func in section {
             reencoder.parse_function_body(code, func.map_err(Error::ParseError)?)?;
         }
-        Ok(code)
+        Ok(())
     }
 
     /// Parses a single [`wasmparser::FunctionBody`] and adds it to the `code` section.
-    pub fn parse_function_body<'a>(
+    pub fn parse_function_body(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
-        code: &'a mut crate::CodeSection,
+        code: &mut crate::CodeSection,
         func: wasmparser::FunctionBody<'_>,
-    ) -> Result<&'a mut crate::CodeSection> {
+    ) -> Result<()> {
         let mut f = reencoder.new_function_with_parsed_locals(&func)?;
         let mut reader = func.get_operators_reader().map_err(Error::ParseError)?;
         while !reader.eof() {
             reencoder.parse_instruction(&mut f, &mut reader)?;
         }
-        Ok(code.function(&f))
+        code.function(&f);
+        Ok(())
     }
 
     /// Create a new [`crate::Function`] by parsing the locals declarations from the
@@ -1369,15 +1368,13 @@ pub mod utils {
     }
 
     /// Parses a single instruction from `reader` and adds it to `function`.
-    pub fn parse_instruction<'a>(
+    pub fn parse_instruction(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
-        function: &'a mut crate::Function,
+        function: &mut crate::Function,
         reader: &mut wasmparser::OperatorsReader<'_>,
-    ) -> Result<&'a mut crate::Function> {
-        Ok(
-            function
-                .instruction(&reencoder.instruction(reader.read().map_err(Error::ParseError)?)?),
-        )
+    ) -> Result<()> {
+        function.instruction(&reencoder.instruction(reader.read().map_err(Error::ParseError)?)?);
+        Ok(())
     }
 }
 

--- a/crates/wasm-encoder/src/reencode.rs
+++ b/crates/wasm-encoder/src/reencode.rs
@@ -1,0 +1,1308 @@
+#![allow(missing_docs)] // FIXME
+
+#[derive(Debug)]
+pub enum Error {
+    /// There was a type reference that was canonicalized and no longer
+    /// references an index into a module's types space, so we cannot encode it
+    /// into a Wasm binary again.
+    CanonicalizedHeapTypeReference,
+    /// The const expression is invalid: not actually constant or something like
+    /// that.
+    InvalidConstExpr,
+    /// There was an error when parsing.
+    ParseError(wasmparser::BinaryReaderError),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::ParseError(_e) => {
+                write!(fmt, "There was an error when parsing")
+            }
+            Self::InvalidConstExpr => write!(fmt, "The const expression was invalid"),
+            Self::CanonicalizedHeapTypeReference => write!(
+                fmt,
+                "There was a canonicalized heap type reference without type index information"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::ParseError(e) => Some(e),
+            Self::InvalidConstExpr | Self::CanonicalizedHeapTypeReference => None,
+        }
+    }
+}
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+pub trait WasmParserToWasmEncoder {
+    fn core_module<'a, 'b>(
+        &mut self,
+        module: &'a mut crate::Module,
+        sections: impl Iterator<Item = Result<wasmparser::Payload<'b>, wasmparser::BinaryReaderError>>,
+    ) -> Result<&'a crate::Module> {
+        utils::core_module(self, module, sections)
+    }
+
+    fn component_primitive_val_type(
+        &mut self,
+        ty: wasmparser::PrimitiveValType,
+    ) -> crate::component::PrimitiveValType {
+        utils::component_primitive_val_type(self, ty)
+    }
+
+    fn memory_index(&mut self, memory: u32) -> u32 {
+        utils::memory_index(self, memory)
+    }
+
+    fn mem_arg(&mut self, arg: wasmparser::MemArg) -> crate::MemArg {
+        utils::mem_arg(self, arg)
+    }
+
+    fn ordering(&mut self, arg: wasmparser::Ordering) -> crate::Ordering {
+        utils::ordering(self, arg)
+    }
+
+    fn function_index(&mut self, func: u32) -> u32 {
+        utils::function_index(self, func)
+    }
+
+    fn tag_index(&mut self, tag: u32) -> u32 {
+        utils::tag_index(self, tag)
+    }
+
+    fn label_index(&mut self, label: u32) -> u32 {
+        utils::label_index(self, label)
+    }
+
+    fn catch(&mut self, arg: wasmparser::Catch) -> crate::Catch {
+        utils::catch(self, arg)
+    }
+
+    fn custom_section<'a>(
+        &mut self,
+        section: wasmparser::CustomSectionReader<'a>,
+    ) -> crate::CustomSection<'a> {
+        utils::custom_section(self, section)
+    }
+
+    fn export_kind(&mut self, external_kind: wasmparser::ExternalKind) -> crate::ExportKind {
+        utils::export_kind(self, external_kind)
+    }
+
+    fn memory_type(&mut self, memory_ty: wasmparser::MemoryType) -> crate::MemoryType {
+        utils::memory_type(self, memory_ty)
+    }
+
+    fn tag_kind(&mut self, kind: wasmparser::TagKind) -> crate::TagKind {
+        utils::tag_kind(self, kind)
+    }
+
+    fn type_index(&mut self, ty: u32) -> u32 {
+        utils::type_index(self, ty)
+    }
+
+    fn tag_type(&mut self, tag_ty: wasmparser::TagType) -> crate::TagType {
+        utils::tag_type(self, tag_ty)
+    }
+
+    fn abstract_heap_type(
+        &mut self,
+        value: wasmparser::AbstractHeapType,
+    ) -> crate::AbstractHeapType {
+        utils::abstract_heap_type(self, value)
+    }
+
+    fn parse_type_section<'a>(
+        &mut self,
+        types: &'a mut crate::TypeSection,
+        section: wasmparser::TypeSectionReader<'_>,
+    ) -> Result<&'a mut crate::TypeSection> {
+        utils::parse_type_section(self, types, section)
+    }
+
+    fn parse_recursive_type_group<'a>(
+        &mut self,
+        types: &'a mut crate::TypeSection,
+        rec_group: wasmparser::RecGroup,
+    ) -> Result<&'a mut crate::TypeSection> {
+        utils::parse_recursive_type_group(self, types, rec_group)
+    }
+
+    fn sub_type(&mut self, sub_ty: wasmparser::SubType) -> Result<crate::SubType> {
+        utils::sub_type(self, sub_ty)
+    }
+
+    fn composite_type(
+        &mut self,
+        composite_ty: wasmparser::CompositeType,
+    ) -> Result<crate::CompositeType> {
+        utils::composite_type(self, composite_ty)
+    }
+
+    fn func_type(&mut self, func_ty: wasmparser::FuncType) -> Result<crate::FuncType> {
+        utils::func_type(self, func_ty)
+    }
+
+    fn array_type(&mut self, array_ty: wasmparser::ArrayType) -> Result<crate::ArrayType> {
+        utils::array_type(self, array_ty)
+    }
+
+    fn struct_type(&mut self, struct_ty: wasmparser::StructType) -> Result<crate::StructType> {
+        utils::struct_type(self, struct_ty)
+    }
+
+    fn field_type(&mut self, field_ty: wasmparser::FieldType) -> Result<crate::FieldType> {
+        utils::field_type(self, field_ty)
+    }
+
+    fn storage_type(&mut self, storage_ty: wasmparser::StorageType) -> Result<crate::StorageType> {
+        utils::storage_type(self, storage_ty)
+    }
+
+    fn val_type(&mut self, val_ty: wasmparser::ValType) -> Result<crate::ValType> {
+        utils::val_type(self, val_ty)
+    }
+
+    fn ref_type(&mut self, ref_type: wasmparser::RefType) -> Result<crate::RefType> {
+        utils::ref_type(self, ref_type)
+    }
+
+    fn heap_type(&mut self, heap_type: wasmparser::HeapType) -> Result<crate::HeapType> {
+        utils::heap_type(self, heap_type)
+    }
+
+    fn parse_table_section<'a>(
+        &mut self,
+        tables: &'a mut crate::TableSection,
+        section: wasmparser::TableSectionReader<'_>,
+    ) -> Result<&'a mut crate::TableSection> {
+        utils::parse_table_section(self, tables, section)
+    }
+
+    fn parse_table<'a>(
+        &mut self,
+        tables: &'a mut crate::TableSection,
+        table: wasmparser::Table<'_>,
+    ) -> Result<&'a mut crate::TableSection> {
+        utils::parse_table(self, tables, table)
+    }
+
+    fn table_type(&mut self, table_ty: wasmparser::TableType) -> Result<crate::TableType> {
+        utils::table_type(self, table_ty)
+    }
+
+    fn parse_tag_section<'a>(
+        &mut self,
+        tags: &'a mut crate::TagSection,
+        section: wasmparser::TagSectionReader<'_>,
+    ) -> Result<&'a mut crate::TagSection> {
+        utils::parse_tag_section(self, tags, section)
+    }
+
+    fn parse_export_section<'a>(
+        &mut self,
+        exports: &'a mut crate::ExportSection,
+        section: wasmparser::ExportSectionReader<'_>,
+    ) -> Result<&'a mut crate::ExportSection> {
+        utils::parse_export_section(self, exports, section)
+    }
+
+    fn export_index(&mut self, export: u32) -> u32 {
+        utils::export_index(self, export)
+    }
+
+    fn parse_export<'a>(
+        &mut self,
+        exports: &'a mut crate::ExportSection,
+        export: wasmparser::Export<'_>,
+    ) -> &'a mut crate::ExportSection {
+        utils::parse_export(self, exports, export)
+    }
+
+    fn parse_global_section<'a>(
+        &mut self,
+        globals: &'a mut crate::GlobalSection,
+        section: wasmparser::GlobalSectionReader<'_>,
+    ) -> Result<&'a mut crate::GlobalSection> {
+        utils::parse_global_section(self, globals, section)
+    }
+
+    fn parse_global<'a>(
+        &mut self,
+        globals: &'a mut crate::GlobalSection,
+        global: wasmparser::Global<'_>,
+    ) -> Result<&'a mut crate::GlobalSection> {
+        utils::parse_global(self, globals, global)
+    }
+
+    fn global_type(&mut self, global_ty: wasmparser::GlobalType) -> Result<crate::GlobalType> {
+        utils::global_type(self, global_ty)
+    }
+
+    fn entity_type(&mut self, type_ref: wasmparser::TypeRef) -> Result<crate::EntityType> {
+        utils::entity_type(self, type_ref)
+    }
+
+    fn parse_import_section<'a>(
+        &mut self,
+        imports: &'a mut crate::ImportSection,
+        section: wasmparser::ImportSectionReader<'_>,
+    ) -> Result<&'a mut crate::ImportSection> {
+        utils::parse_import_section(self, imports, section)
+    }
+
+    fn parse_import<'a>(
+        &mut self,
+        imports: &'a mut crate::ImportSection,
+        import: wasmparser::Import<'_>,
+    ) -> Result<&'a mut crate::ImportSection> {
+        utils::parse_import(self, imports, import)
+    }
+
+    fn parse_memory_section<'a>(
+        &mut self,
+        memories: &'a mut crate::MemorySection,
+        section: wasmparser::MemorySectionReader<'_>,
+    ) -> Result<&'a mut crate::MemorySection> {
+        utils::parse_memory_section(self, memories, section)
+    }
+
+    fn parse_function_section<'a>(
+        &mut self,
+        functions: &'a mut crate::FunctionSection,
+        section: wasmparser::FunctionSectionReader<'_>,
+    ) -> Result<&'a mut crate::FunctionSection> {
+        utils::parse_function_section(self, functions, section)
+    }
+
+    fn parse_data_section<'a>(
+        &mut self,
+        data: &'a mut crate::DataSection,
+        section: wasmparser::DataSectionReader<'_>,
+    ) -> Result<&'a mut crate::DataSection> {
+        utils::parse_data_section(self, data, section)
+    }
+
+    fn parse_data<'a>(
+        &mut self,
+        data: &'a mut crate::DataSection,
+        datum: wasmparser::Data<'_>,
+    ) -> Result<&'a mut crate::DataSection> {
+        utils::parse_data(self, data, datum)
+    }
+
+    fn parse_element_section<'a>(
+        &mut self,
+        elements: &'a mut crate::ElementSection,
+        section: wasmparser::ElementSectionReader<'_>,
+    ) -> Result<&'a mut crate::ElementSection> {
+        utils::parse_element_section(self, elements, section)
+    }
+
+    fn parse_element<'a>(
+        &mut self,
+        elements: &'a mut crate::ElementSection,
+        element: wasmparser::Element<'_>,
+    ) -> Result<&'a mut crate::ElementSection> {
+        utils::parse_element(self, elements, element)
+    }
+
+    fn table_index(&mut self, table: u32) -> u32 {
+        utils::table_index(self, table)
+    }
+
+    fn global_index(&mut self, global: u32) -> u32 {
+        utils::global_index(self, global)
+    }
+
+    fn data_index(&mut self, data: u32) -> u32 {
+        utils::data_index(self, data)
+    }
+
+    fn element_index(&mut self, element: u32) -> u32 {
+        utils::element_index(self, element)
+    }
+
+    fn const_expr(&mut self, const_expr: wasmparser::ConstExpr) -> Result<crate::ConstExpr> {
+        utils::const_expr(self, const_expr)
+    }
+
+    fn block_type(&mut self, arg: wasmparser::BlockType) -> Result<crate::BlockType> {
+        utils::block_type(self, arg)
+    }
+
+    fn instruction<'a>(&mut self, arg: wasmparser::Operator<'a>) -> Result<crate::Instruction<'a>> {
+        utils::instruction(self, arg)
+    }
+
+    fn parse_code_section<'a>(
+        &mut self,
+        code: &'a mut crate::CodeSection,
+        section: wasmparser::CodeSectionReader<'_>,
+    ) -> Result<&'a mut crate::CodeSection> {
+        utils::parse_code_section(self, code, section)
+    }
+
+    fn parse_function_body<'a>(
+        &mut self,
+        code: &'a mut crate::CodeSection,
+        func: wasmparser::FunctionBody<'_>,
+    ) -> Result<&'a mut crate::CodeSection> {
+        utils::parse_function_body(self, code, func)
+    }
+
+    fn new_function_with_parsed_locals(
+        &mut self,
+        func: &wasmparser::FunctionBody<'_>,
+    ) -> Result<crate::Function> {
+        utils::new_function_with_parsed_locals(self, func)
+    }
+
+    fn parse_instruction<'a>(
+        &mut self,
+        function: &'a mut crate::Function,
+        reader: &mut wasmparser::OperatorsReader<'_>,
+    ) -> Result<&'a mut crate::Function> {
+        utils::parse_instruction(self, function, reader)
+    }
+}
+
+#[derive(Debug)]
+pub struct RoundtripReencoder;
+
+impl WasmParserToWasmEncoder for RoundtripReencoder {}
+
+pub mod utils {
+    use super::{Error, Result, WasmParserToWasmEncoder};
+
+    pub fn core_module<'a, 'b>(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        module: &'a mut crate::Module,
+        sections: impl Iterator<Item = Result<wasmparser::Payload<'b>, wasmparser::BinaryReaderError>>,
+    ) -> Result<&'a crate::Module> {
+        fn module_section_flush_codes(
+            module: &mut crate::Module,
+            section: &impl crate::Section,
+            codes: &mut Option<crate::CodeSection>,
+        ) {
+            if let Some(codes) = codes.take() {
+                module.section(&codes);
+            }
+
+            module.section(section);
+        }
+
+        let mut codes = None;
+
+        for section in sections {
+            let section = section.map_err(Error::ParseError)?;
+
+            match section {
+                wasmparser::Payload::Version { .. } => (),
+                wasmparser::Payload::TypeSection(section) => {
+                    let mut types = crate::TypeSection::new();
+                    reencoder.parse_type_section(&mut types, section)?;
+                    module_section_flush_codes(module, &types, &mut codes);
+                }
+                wasmparser::Payload::ImportSection(section) => {
+                    let mut imports = crate::ImportSection::new();
+                    reencoder.parse_import_section(&mut imports, section)?;
+                    module_section_flush_codes(module, &imports, &mut codes);
+                }
+                wasmparser::Payload::FunctionSection(section) => {
+                    let mut functions = crate::FunctionSection::new();
+                    reencoder.parse_function_section(&mut functions, section)?;
+                    module_section_flush_codes(module, &functions, &mut codes);
+                }
+                wasmparser::Payload::TableSection(section) => {
+                    let mut tables = crate::TableSection::new();
+                    reencoder.parse_table_section(&mut tables, section)?;
+                    module_section_flush_codes(module, &tables, &mut codes);
+                }
+                wasmparser::Payload::MemorySection(section) => {
+                    let mut memories = crate::MemorySection::new();
+                    reencoder.parse_memory_section(&mut memories, section)?;
+                    module_section_flush_codes(module, &memories, &mut codes);
+                }
+                wasmparser::Payload::TagSection(section) => {
+                    let mut tags = crate::TagSection::new();
+                    reencoder.parse_tag_section(&mut tags, section)?;
+                    module_section_flush_codes(module, &tags, &mut codes);
+                }
+                wasmparser::Payload::GlobalSection(section) => {
+                    let mut globals = crate::GlobalSection::new();
+                    reencoder.parse_global_section(&mut globals, section)?;
+                    module_section_flush_codes(module, &globals, &mut codes);
+                }
+                wasmparser::Payload::ExportSection(section) => {
+                    let mut exports = crate::ExportSection::new();
+                    reencoder.parse_export_section(&mut exports, section)?;
+                    module_section_flush_codes(module, &exports, &mut codes);
+                }
+                wasmparser::Payload::StartSection { func, .. } => {
+                    module_section_flush_codes(
+                        module,
+                        &crate::StartSection {
+                            function_index: reencoder.function_index(func),
+                        },
+                        &mut codes,
+                    );
+                }
+                wasmparser::Payload::ElementSection(section) => {
+                    let mut elements = crate::ElementSection::new();
+                    reencoder.parse_element_section(&mut elements, section)?;
+                    module_section_flush_codes(module, &elements, &mut codes);
+                }
+                wasmparser::Payload::DataCountSection { .. } => (),
+                wasmparser::Payload::DataSection(section) => {
+                    let mut data = crate::DataSection::new();
+                    reencoder.parse_data_section(&mut data, section)?;
+                    module_section_flush_codes(module, &data, &mut codes);
+                }
+                wasmparser::Payload::CodeSectionStart { .. } => {
+                    if let Some(codes) = codes.replace(crate::CodeSection::new()) {
+                        module.section(&codes);
+                    }
+                }
+                wasmparser::Payload::CodeSectionEntry(section) => {
+                    let codes = codes.get_or_insert_with(crate::CodeSection::new);
+                    reencoder.parse_function_body(codes, section)?;
+                }
+                wasmparser::Payload::ModuleSection { .. }
+                | wasmparser::Payload::InstanceSection(_)
+                | wasmparser::Payload::CoreTypeSection(_)
+                | wasmparser::Payload::ComponentSection { .. }
+                | wasmparser::Payload::ComponentInstanceSection(_)
+                | wasmparser::Payload::ComponentAliasSection(_)
+                | wasmparser::Payload::ComponentTypeSection(_)
+                | wasmparser::Payload::ComponentCanonicalSection(_)
+                | wasmparser::Payload::ComponentStartSection { .. }
+                | wasmparser::Payload::ComponentImportSection(_)
+                | wasmparser::Payload::ComponentExportSection(_) => {
+                    unreachable!("wasm component model section is not allowed in core wasm module")
+                }
+                wasmparser::Payload::CustomSection(section) => {
+                    module_section_flush_codes(
+                        module,
+                        &reencoder.custom_section(section),
+                        &mut codes,
+                    );
+                }
+                wasmparser::Payload::UnknownSection { id, .. } => {
+                    unreachable!("unknown wasm section with id {id}")
+                }
+                wasmparser::Payload::End(_) => (),
+            }
+        }
+
+        if let Some(codes) = codes {
+            module.section(&codes);
+        }
+
+        Ok(module)
+    }
+
+    pub fn component_primitive_val_type(
+        _reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        ty: wasmparser::PrimitiveValType,
+    ) -> crate::component::PrimitiveValType {
+        match ty {
+            wasmparser::PrimitiveValType::Bool => crate::component::PrimitiveValType::Bool,
+            wasmparser::PrimitiveValType::S8 => crate::component::PrimitiveValType::S8,
+            wasmparser::PrimitiveValType::U8 => crate::component::PrimitiveValType::U8,
+            wasmparser::PrimitiveValType::S16 => crate::component::PrimitiveValType::S16,
+            wasmparser::PrimitiveValType::U16 => crate::component::PrimitiveValType::U16,
+            wasmparser::PrimitiveValType::S32 => crate::component::PrimitiveValType::S32,
+            wasmparser::PrimitiveValType::U32 => crate::component::PrimitiveValType::U32,
+            wasmparser::PrimitiveValType::S64 => crate::component::PrimitiveValType::S64,
+            wasmparser::PrimitiveValType::U64 => crate::component::PrimitiveValType::U64,
+            wasmparser::PrimitiveValType::F32 => crate::component::PrimitiveValType::F32,
+            wasmparser::PrimitiveValType::F64 => crate::component::PrimitiveValType::F64,
+            wasmparser::PrimitiveValType::Char => crate::component::PrimitiveValType::Char,
+            wasmparser::PrimitiveValType::String => crate::component::PrimitiveValType::String,
+        }
+    }
+
+    pub fn memory_index(
+        _reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        memory: u32,
+    ) -> u32 {
+        memory
+    }
+
+    pub fn mem_arg(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        arg: wasmparser::MemArg,
+    ) -> crate::MemArg {
+        crate::MemArg {
+            offset: arg.offset,
+            align: arg.align.into(),
+            memory_index: reencoder.memory_index(arg.memory),
+        }
+    }
+
+    pub fn ordering(
+        _reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        arg: wasmparser::Ordering,
+    ) -> crate::Ordering {
+        match arg {
+            wasmparser::Ordering::SeqCst => crate::Ordering::SeqCst,
+            wasmparser::Ordering::AcqRel => crate::Ordering::AcqRel,
+        }
+    }
+
+    pub fn function_index(
+        _reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        func: u32,
+    ) -> u32 {
+        func
+    }
+
+    pub fn tag_index(_reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder), tag: u32) -> u32 {
+        tag
+    }
+
+    pub fn label_index(
+        _reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        label: u32,
+    ) -> u32 {
+        label
+    }
+
+    pub fn catch(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        arg: wasmparser::Catch,
+    ) -> crate::Catch {
+        match arg {
+            wasmparser::Catch::One { tag, label } => crate::Catch::One {
+                tag: reencoder.tag_index(tag),
+                label: reencoder.label_index(label),
+            },
+            wasmparser::Catch::OneRef { tag, label } => crate::Catch::OneRef {
+                tag: reencoder.tag_index(tag),
+                label: reencoder.label_index(label),
+            },
+            wasmparser::Catch::All { label } => crate::Catch::All {
+                label: reencoder.label_index(label),
+            },
+            wasmparser::Catch::AllRef { label } => crate::Catch::AllRef {
+                label: reencoder.label_index(label),
+            },
+        }
+    }
+
+    pub fn custom_section<'a>(
+        _reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        section: wasmparser::CustomSectionReader<'a>,
+    ) -> crate::CustomSection<'a> {
+        crate::CustomSection {
+            data: section.data().into(),
+            name: section.name().into(),
+        }
+    }
+
+    pub fn export_kind(
+        _reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        external_kind: wasmparser::ExternalKind,
+    ) -> crate::ExportKind {
+        match external_kind {
+            wasmparser::ExternalKind::Func => crate::ExportKind::Func,
+            wasmparser::ExternalKind::Table => crate::ExportKind::Table,
+            wasmparser::ExternalKind::Memory => crate::ExportKind::Memory,
+            wasmparser::ExternalKind::Global => crate::ExportKind::Global,
+            wasmparser::ExternalKind::Tag => crate::ExportKind::Tag,
+        }
+    }
+
+    pub fn memory_type(
+        _reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        memory_ty: wasmparser::MemoryType,
+    ) -> crate::MemoryType {
+        crate::MemoryType {
+            minimum: memory_ty.initial,
+            maximum: memory_ty.maximum,
+            memory64: memory_ty.memory64,
+            shared: memory_ty.shared,
+            page_size_log2: memory_ty.page_size_log2,
+        }
+    }
+
+    pub fn tag_kind(
+        _reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        kind: wasmparser::TagKind,
+    ) -> crate::TagKind {
+        match kind {
+            wasmparser::TagKind::Exception => crate::TagKind::Exception,
+        }
+    }
+
+    pub fn type_index(_reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder), ty: u32) -> u32 {
+        ty
+    }
+
+    pub fn tag_type(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        tag_ty: wasmparser::TagType,
+    ) -> crate::TagType {
+        crate::TagType {
+            kind: reencoder.tag_kind(tag_ty.kind),
+            func_type_idx: reencoder.type_index(tag_ty.func_type_idx),
+        }
+    }
+
+    pub fn abstract_heap_type(
+        _reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        value: wasmparser::AbstractHeapType,
+    ) -> crate::AbstractHeapType {
+        use wasmparser::AbstractHeapType::*;
+        match value {
+            Func => crate::AbstractHeapType::Func,
+            Extern => crate::AbstractHeapType::Extern,
+            Any => crate::AbstractHeapType::Any,
+            None => crate::AbstractHeapType::None,
+            NoExtern => crate::AbstractHeapType::NoExtern,
+            NoFunc => crate::AbstractHeapType::NoFunc,
+            Eq => crate::AbstractHeapType::Eq,
+            Struct => crate::AbstractHeapType::Struct,
+            Array => crate::AbstractHeapType::Array,
+            I31 => crate::AbstractHeapType::I31,
+            Exn => crate::AbstractHeapType::Exn,
+            NoExn => crate::AbstractHeapType::NoExn,
+        }
+    }
+
+    pub fn parse_type_section<'a>(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        types: &'a mut crate::TypeSection,
+        section: wasmparser::TypeSectionReader<'_>,
+    ) -> Result<&'a mut crate::TypeSection> {
+        for rec_group in section {
+            reencoder.parse_recursive_type_group(types, rec_group.map_err(Error::ParseError)?)?;
+        }
+        Ok(types)
+    }
+
+    pub fn parse_recursive_type_group<'a>(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        types: &'a mut crate::TypeSection,
+        rec_group: wasmparser::RecGroup,
+    ) -> Result<&'a mut crate::TypeSection> {
+        if rec_group.is_explicit_rec_group() {
+            let subtypes = rec_group
+                .into_types()
+                .map(|t| reencoder.sub_type(t))
+                .collect::<Result<Vec<_>, _>>()?;
+            types.rec(subtypes);
+        } else {
+            let ty = rec_group.into_types().next().unwrap();
+            types.subtype(&reencoder.sub_type(ty)?);
+        }
+        Ok(types)
+    }
+
+    pub fn sub_type(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        sub_ty: wasmparser::SubType,
+    ) -> Result<crate::SubType> {
+        Ok(crate::SubType {
+            is_final: sub_ty.is_final,
+            supertype_idx: sub_ty
+                .supertype_idx
+                .map(|i| {
+                    i.as_module_index()
+                        .map(|ty| reencoder.type_index(ty))
+                        .ok_or(Error::CanonicalizedHeapTypeReference)
+                })
+                .transpose()?,
+            composite_type: reencoder.composite_type(sub_ty.composite_type)?,
+        })
+    }
+
+    pub fn composite_type(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        composite_ty: wasmparser::CompositeType,
+    ) -> Result<crate::CompositeType> {
+        Ok(match composite_ty {
+            wasmparser::CompositeType::Func(f) => {
+                crate::CompositeType::Func(reencoder.func_type(f)?)
+            }
+            wasmparser::CompositeType::Array(a) => {
+                crate::CompositeType::Array(reencoder.array_type(a)?)
+            }
+            wasmparser::CompositeType::Struct(s) => {
+                crate::CompositeType::Struct(reencoder.struct_type(s)?)
+            }
+        })
+    }
+
+    pub fn func_type(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        func_ty: wasmparser::FuncType,
+    ) -> Result<crate::FuncType> {
+        let mut buf = Vec::with_capacity(func_ty.params().len() + func_ty.results().len());
+        for ty in func_ty.params().iter().chain(func_ty.results()).copied() {
+            buf.push(reencoder.val_type(ty)?);
+        }
+        Ok(crate::FuncType::from_parts(
+            buf.into(),
+            func_ty.params().len(),
+        ))
+    }
+
+    pub fn array_type(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        array_ty: wasmparser::ArrayType,
+    ) -> Result<crate::ArrayType> {
+        Ok(crate::ArrayType(reencoder.field_type(array_ty.0)?))
+    }
+
+    pub fn struct_type(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        struct_ty: wasmparser::StructType,
+    ) -> Result<crate::StructType> {
+        Ok(crate::StructType {
+            fields: struct_ty
+                .fields
+                .iter()
+                .map(|field_ty| reencoder.field_type(field_ty.clone()))
+                .collect::<Result<_, _>>()?,
+        })
+    }
+
+    pub fn field_type(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        field_ty: wasmparser::FieldType,
+    ) -> Result<crate::FieldType> {
+        Ok(crate::FieldType {
+            element_type: reencoder.storage_type(field_ty.element_type)?,
+            mutable: field_ty.mutable,
+        })
+    }
+
+    pub fn storage_type(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        storage_ty: wasmparser::StorageType,
+    ) -> Result<crate::StorageType> {
+        Ok(match storage_ty {
+            wasmparser::StorageType::I8 => crate::StorageType::I8,
+            wasmparser::StorageType::I16 => crate::StorageType::I16,
+            wasmparser::StorageType::Val(v) => crate::StorageType::Val(reencoder.val_type(v)?),
+        })
+    }
+
+    pub fn val_type(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        val_ty: wasmparser::ValType,
+    ) -> Result<crate::ValType> {
+        Ok(match val_ty {
+            wasmparser::ValType::I32 => crate::ValType::I32,
+            wasmparser::ValType::I64 => crate::ValType::I64,
+            wasmparser::ValType::F32 => crate::ValType::F32,
+            wasmparser::ValType::F64 => crate::ValType::F64,
+            wasmparser::ValType::V128 => crate::ValType::V128,
+            wasmparser::ValType::Ref(r) => crate::ValType::Ref(reencoder.ref_type(r)?),
+        })
+    }
+
+    pub fn ref_type(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        ref_type: wasmparser::RefType,
+    ) -> Result<crate::RefType> {
+        Ok(crate::RefType {
+            nullable: ref_type.is_nullable(),
+            heap_type: reencoder.heap_type(ref_type.heap_type())?,
+        })
+    }
+
+    pub fn heap_type(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        heap_type: wasmparser::HeapType,
+    ) -> Result<crate::HeapType> {
+        Ok(match heap_type {
+            wasmparser::HeapType::Concrete(i) => crate::HeapType::Concrete(
+                i.as_module_index()
+                    .map(|ty| reencoder.type_index(ty))
+                    .ok_or(Error::CanonicalizedHeapTypeReference)?,
+            ),
+            wasmparser::HeapType::Abstract { shared, ty } => crate::HeapType::Abstract {
+                shared,
+                ty: reencoder.abstract_heap_type(ty),
+            },
+        })
+    }
+
+    pub fn parse_table_section<'a>(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        tables: &'a mut crate::TableSection,
+        section: wasmparser::TableSectionReader<'_>,
+    ) -> Result<&'a mut crate::TableSection> {
+        for table in section {
+            reencoder.parse_table(tables, table.map_err(Error::ParseError)?)?;
+        }
+        Ok(tables)
+    }
+
+    pub fn parse_table<'a>(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        tables: &'a mut crate::TableSection,
+        table: wasmparser::Table<'_>,
+    ) -> Result<&'a mut crate::TableSection> {
+        let ty = reencoder.table_type(table.ty)?;
+        match table.init {
+            wasmparser::TableInit::RefNull => {
+                tables.table(ty);
+            }
+            wasmparser::TableInit::Expr(e) => {
+                tables.table_with_init(ty, &reencoder.const_expr(e)?);
+            }
+        }
+        Ok(tables)
+    }
+
+    pub fn table_type(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        table_ty: wasmparser::TableType,
+    ) -> Result<crate::TableType> {
+        Ok(crate::TableType {
+            element_type: reencoder.ref_type(table_ty.element_type)?,
+            minimum: table_ty.initial,
+            maximum: table_ty.maximum,
+            table64: table_ty.table64,
+        })
+    }
+
+    pub fn parse_tag_section<'a>(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        tags: &'a mut crate::TagSection,
+        section: wasmparser::TagSectionReader<'_>,
+    ) -> Result<&'a mut crate::TagSection> {
+        for tag in section {
+            let tag = tag.map_err(Error::ParseError)?;
+            tags.tag(reencoder.tag_type(tag));
+        }
+        Ok(tags)
+    }
+
+    pub fn parse_export_section<'a>(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        exports: &'a mut crate::ExportSection,
+        section: wasmparser::ExportSectionReader<'_>,
+    ) -> Result<&'a mut crate::ExportSection> {
+        for export in section {
+            reencoder.parse_export(exports, export.map_err(Error::ParseError)?);
+        }
+        Ok(exports)
+    }
+
+    pub fn export_index(
+        _reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        export: u32,
+    ) -> u32 {
+        export
+    }
+
+    pub fn parse_export<'a>(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        exports: &'a mut crate::ExportSection,
+        export: wasmparser::Export<'_>,
+    ) -> &'a mut crate::ExportSection {
+        exports.export(
+            export.name,
+            reencoder.export_kind(export.kind),
+            reencoder.export_index(export.index),
+        )
+    }
+
+    pub fn parse_global_section<'a>(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        globals: &'a mut crate::GlobalSection,
+        section: wasmparser::GlobalSectionReader<'_>,
+    ) -> Result<&'a mut crate::GlobalSection> {
+        for global in section {
+            reencoder.parse_global(globals, global.map_err(Error::ParseError)?)?;
+        }
+        Ok(globals)
+    }
+
+    pub fn parse_global<'a>(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        globals: &'a mut crate::GlobalSection,
+        global: wasmparser::Global<'_>,
+    ) -> Result<&'a mut crate::GlobalSection> {
+        globals.global(
+            reencoder.global_type(global.ty)?,
+            &reencoder.const_expr(global.init_expr)?,
+        );
+        Ok(globals)
+    }
+
+    pub fn global_type(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        global_ty: wasmparser::GlobalType,
+    ) -> Result<crate::GlobalType> {
+        Ok(crate::GlobalType {
+            val_type: reencoder.val_type(global_ty.content_type)?,
+            mutable: global_ty.mutable,
+            shared: global_ty.shared,
+        })
+    }
+
+    pub fn entity_type(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        type_ref: wasmparser::TypeRef,
+    ) -> Result<crate::EntityType> {
+        Ok(match type_ref {
+            wasmparser::TypeRef::Func(i) => crate::EntityType::Function(reencoder.type_index(i)),
+            wasmparser::TypeRef::Table(t) => crate::EntityType::Table(reencoder.table_type(t)?),
+            wasmparser::TypeRef::Memory(m) => crate::EntityType::Memory(reencoder.memory_type(m)),
+            wasmparser::TypeRef::Global(g) => crate::EntityType::Global(reencoder.global_type(g)?),
+            wasmparser::TypeRef::Tag(t) => crate::EntityType::Tag(reencoder.tag_type(t)),
+        })
+    }
+
+    pub fn parse_import_section<'a>(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        imports: &'a mut crate::ImportSection,
+        section: wasmparser::ImportSectionReader<'_>,
+    ) -> Result<&'a mut crate::ImportSection> {
+        for import in section {
+            reencoder.parse_import(imports, import.map_err(Error::ParseError)?)?;
+        }
+        Ok(imports)
+    }
+
+    pub fn parse_import<'a>(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        imports: &'a mut crate::ImportSection,
+        import: wasmparser::Import<'_>,
+    ) -> Result<&'a mut crate::ImportSection> {
+        imports.import(
+            import.module,
+            import.name,
+            reencoder.entity_type(import.ty)?,
+        );
+        Ok(imports)
+    }
+
+    pub fn parse_memory_section<'a>(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        memories: &'a mut crate::MemorySection,
+        section: wasmparser::MemorySectionReader<'_>,
+    ) -> Result<&'a mut crate::MemorySection> {
+        for memory in section {
+            let memory = memory.map_err(Error::ParseError)?;
+            memories.memory(reencoder.memory_type(memory));
+        }
+        Ok(memories)
+    }
+
+    pub fn parse_function_section<'a>(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        functions: &'a mut crate::FunctionSection,
+        section: wasmparser::FunctionSectionReader<'_>,
+    ) -> Result<&'a mut crate::FunctionSection> {
+        for func in section {
+            functions.function(reencoder.type_index(func.map_err(Error::ParseError)?));
+        }
+        Ok(functions)
+    }
+
+    pub fn parse_data_section<'a>(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        data: &'a mut crate::DataSection,
+        section: wasmparser::DataSectionReader<'_>,
+    ) -> Result<&'a mut crate::DataSection> {
+        for datum in section {
+            reencoder.parse_data(data, datum.map_err(Error::ParseError)?)?;
+        }
+        Ok(data)
+    }
+
+    pub fn parse_data<'a>(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        data: &'a mut crate::DataSection,
+        datum: wasmparser::Data<'_>,
+    ) -> Result<&'a mut crate::DataSection> {
+        match datum.kind {
+            wasmparser::DataKind::Active {
+                memory_index,
+                offset_expr,
+            } => Ok(data.active(
+                reencoder.memory_index(memory_index),
+                &reencoder.const_expr(offset_expr)?,
+                datum.data.iter().copied(),
+            )),
+            wasmparser::DataKind::Passive => Ok(data.passive(datum.data.iter().copied())),
+        }
+    }
+
+    pub fn parse_element_section<'a>(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        elements: &'a mut crate::ElementSection,
+        section: wasmparser::ElementSectionReader<'_>,
+    ) -> Result<&'a mut crate::ElementSection> {
+        for element in section {
+            reencoder.parse_element(elements, element.map_err(Error::ParseError)?)?;
+        }
+        Ok(elements)
+    }
+
+    pub fn parse_element<'a>(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        elements: &'a mut crate::ElementSection,
+        element: wasmparser::Element<'_>,
+    ) -> Result<&'a mut crate::ElementSection> {
+        let mut funcs;
+        let mut exprs;
+        let elems = match element.items {
+            wasmparser::ElementItems::Functions(f) => {
+                funcs = Vec::new();
+                for func in f {
+                    funcs.push(reencoder.function_index(func.map_err(Error::ParseError)?));
+                }
+                crate::Elements::Functions(&funcs)
+            }
+            wasmparser::ElementItems::Expressions(ty, e) => {
+                exprs = Vec::new();
+                for expr in e {
+                    exprs.push(reencoder.const_expr(expr.map_err(Error::ParseError)?)?);
+                }
+                crate::Elements::Expressions(reencoder.ref_type(ty)?, &exprs)
+            }
+        };
+        match element.kind {
+            wasmparser::ElementKind::Active {
+                table_index,
+                offset_expr,
+            } => Ok(elements.active(
+                table_index.map(|t| reencoder.table_index(t)),
+                &reencoder.const_expr(offset_expr)?,
+                elems,
+            )),
+            wasmparser::ElementKind::Passive => Ok(elements.passive(elems)),
+            wasmparser::ElementKind::Declared => Ok(elements.declared(elems)),
+        }
+    }
+
+    pub fn table_index(
+        _reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        table: u32,
+    ) -> u32 {
+        table
+    }
+
+    pub fn global_index(
+        _reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        global: u32,
+    ) -> u32 {
+        global
+    }
+
+    pub fn data_index(_reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder), data: u32) -> u32 {
+        data
+    }
+
+    pub fn element_index(
+        _reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        element: u32,
+    ) -> u32 {
+        element
+    }
+
+    pub fn const_expr(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        const_expr: wasmparser::ConstExpr,
+    ) -> Result<crate::ConstExpr> {
+        let mut ops = const_expr.get_operators_reader().into_iter();
+
+        let result = match ops.next() {
+            Some(Ok(wasmparser::Operator::I32Const { value })) => {
+                crate::ConstExpr::i32_const(value)
+            }
+            Some(Ok(wasmparser::Operator::I64Const { value })) => {
+                crate::ConstExpr::i64_const(value)
+            }
+            Some(Ok(wasmparser::Operator::F32Const { value })) => {
+                crate::ConstExpr::f32_const(f32::from_bits(value.bits()))
+            }
+            Some(Ok(wasmparser::Operator::F64Const { value })) => {
+                crate::ConstExpr::f64_const(f64::from_bits(value.bits()))
+            }
+            Some(Ok(wasmparser::Operator::V128Const { value })) => {
+                crate::ConstExpr::v128_const(i128::from_le_bytes(*value.bytes()))
+            }
+            Some(Ok(wasmparser::Operator::RefNull { hty })) => {
+                crate::ConstExpr::ref_null(reencoder.heap_type(hty)?)
+            }
+            Some(Ok(wasmparser::Operator::RefFunc { function_index })) => {
+                crate::ConstExpr::ref_func(reencoder.function_index(function_index))
+            }
+            Some(Ok(wasmparser::Operator::GlobalGet { global_index })) => {
+                crate::ConstExpr::global_get(reencoder.global_index(global_index))
+            }
+
+            // TODO: support the extended-const proposal.
+            Some(Ok(_op)) => return Err(Error::InvalidConstExpr),
+
+            Some(Err(e)) => return Err(Error::ParseError(e)),
+            None => return Err(Error::InvalidConstExpr),
+        };
+
+        match (ops.next(), ops.next()) {
+            (Some(Ok(wasmparser::Operator::End)), None) => Ok(result),
+            _ => Err(Error::InvalidConstExpr),
+        }
+    }
+
+    pub fn block_type(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        arg: wasmparser::BlockType,
+    ) -> Result<crate::BlockType> {
+        match arg {
+            wasmparser::BlockType::Empty => Ok(crate::BlockType::Empty),
+            wasmparser::BlockType::FuncType(n) => {
+                Ok(crate::BlockType::FunctionType(reencoder.type_index(n)))
+            }
+            wasmparser::BlockType::Type(t) => Ok(crate::BlockType::Result(reencoder.val_type(t)?)),
+        }
+    }
+
+    pub fn instruction<'a>(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        arg: wasmparser::Operator<'a>,
+    ) -> Result<crate::Instruction<'a>> {
+        use crate::Instruction;
+
+        macro_rules! translate {
+            ($( @$proposal:ident $op:ident $({ $($arg:ident: $argty:ty),* })? => $visit:ident)*) => {
+                Ok(match arg {
+                    $(
+                        wasmparser::Operator::$op $({ $($arg),* })? => {
+                            $(
+                                $(let $arg = translate!(map $arg $arg);)*
+                            )?
+                            translate!(build $op $($($arg)*)?)
+                        }
+                    )*
+                })
+            };
+
+            // This case is used to map, based on the name of the field, from the
+            // wasmparser payload type to the wasm-encoder payload type through
+            // `Translator` as applicable.
+            (map $arg:ident tag_index) => (reencoder.tag_index($arg));
+            (map $arg:ident function_index) => (reencoder.function_index($arg));
+            (map $arg:ident table) => (reencoder.table_index($arg));
+            (map $arg:ident table_index) => (reencoder.table_index($arg));
+            (map $arg:ident dst_table) => (reencoder.table_index($arg));
+            (map $arg:ident src_table) => (reencoder.table_index($arg));
+            (map $arg:ident type_index) => (reencoder.type_index($arg));
+            (map $arg:ident array_type_index) => (reencoder.type_index($arg));
+            (map $arg:ident array_type_index_dst) => (reencoder.type_index($arg));
+            (map $arg:ident array_type_index_src) => (reencoder.type_index($arg));
+            (map $arg:ident struct_type_index) => (reencoder.type_index($arg));
+            (map $arg:ident global_index) => (reencoder.global_index($arg));
+            (map $arg:ident mem) => (reencoder.memory_index($arg));
+            (map $arg:ident src_mem) => (reencoder.memory_index($arg));
+            (map $arg:ident dst_mem) => (reencoder.memory_index($arg));
+            (map $arg:ident data_index) => (reencoder.data_index($arg));
+            (map $arg:ident elem_index) => (reencoder.element_index($arg));
+            (map $arg:ident array_data_index) => (reencoder.data_index($arg));
+            (map $arg:ident array_elem_index) => (reencoder.element_index($arg));
+            (map $arg:ident blockty) => (reencoder.block_type($arg)?);
+            (map $arg:ident relative_depth) => ($arg);
+            (map $arg:ident targets) => ((
+                $arg
+                    .targets()
+                    .collect::<Result<Vec<_>, wasmparser::BinaryReaderError>>().map_err(Error::ParseError)?
+                    .into(),
+                $arg.default(),
+            ));
+            (map $arg:ident flags) => (());
+            (map $arg:ident ty) => (reencoder.val_type($arg)?);
+            (map $arg:ident hty) => (reencoder.heap_type($arg)?);
+            (map $arg:ident from_ref_type) => (reencoder.ref_type($arg)?);
+            (map $arg:ident to_ref_type) => (reencoder.ref_type($arg)?);
+            (map $arg:ident memarg) => (reencoder.mem_arg($arg));
+            (map $arg:ident ordering) => (reencoder.ordering($arg));
+            (map $arg:ident local_index) => ($arg);
+            (map $arg:ident value) => ($arg);
+            (map $arg:ident lane) => ($arg);
+            (map $arg:ident lanes) => ($arg);
+            (map $arg:ident array_size) => ($arg);
+            (map $arg:ident field_index) => ($arg);
+            (map $arg:ident try_table) => ($arg);
+
+            // This case takes the arguments of a wasmparser instruction and creates
+            // a wasm-encoder instruction. There are a few special cases for where
+            // the structure of a wasmparser instruction differs from that of
+            // wasm-encoder.
+            (build $op:ident) => (Instruction::$op);
+            (build BrTable $arg:ident) => (Instruction::BrTable($arg.0, $arg.1));
+            (build I32Const $arg:ident) => (Instruction::I32Const($arg));
+            (build I64Const $arg:ident) => (Instruction::I64Const($arg));
+            (build F32Const $arg:ident) => (Instruction::F32Const(f32::from_bits($arg.bits())));
+            (build F64Const $arg:ident) => (Instruction::F64Const(f64::from_bits($arg.bits())));
+            (build V128Const $arg:ident) => (Instruction::V128Const($arg.i128()));
+            (build TryTable $table:ident) => (Instruction::TryTable(reencoder.block_type($table.ty)?, {
+                $table.catches.into_iter().map(|c| reencoder.catch(c)).collect::<Vec<_>>().into()
+            }));
+            (build $op:ident $arg:ident) => (Instruction::$op($arg));
+            (build $op:ident $($arg:ident)*) => (Instruction::$op { $($arg),* });
+        }
+
+        wasmparser::for_each_operator!(translate)
+    }
+
+    pub fn parse_code_section<'a>(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        code: &'a mut crate::CodeSection,
+        section: wasmparser::CodeSectionReader<'_>,
+    ) -> Result<&'a mut crate::CodeSection> {
+        for func in section {
+            reencoder.parse_function_body(code, func.map_err(Error::ParseError)?)?;
+        }
+        Ok(code)
+    }
+
+    pub fn parse_function_body<'a>(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        code: &'a mut crate::CodeSection,
+        func: wasmparser::FunctionBody<'_>,
+    ) -> Result<&'a mut crate::CodeSection> {
+        let mut f = reencoder.new_function_with_parsed_locals(&func)?;
+        let mut reader = func.get_operators_reader().map_err(Error::ParseError)?;
+        while !reader.eof() {
+            reencoder.parse_instruction(&mut f, &mut reader)?;
+        }
+        Ok(code.function(&f))
+    }
+
+    pub fn new_function_with_parsed_locals(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        func: &wasmparser::FunctionBody<'_>,
+    ) -> Result<crate::Function> {
+        let mut locals = Vec::new();
+        for pair in func.get_locals_reader().map_err(Error::ParseError)? {
+            let (cnt, ty) = pair.map_err(Error::ParseError)?;
+            locals.push((cnt, reencoder.val_type(ty)?));
+        }
+        Ok(crate::Function::new(locals))
+    }
+
+    pub fn parse_instruction<'a>(
+        reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
+        function: &'a mut crate::Function,
+        reader: &mut wasmparser::OperatorsReader<'_>,
+    ) -> Result<&'a mut crate::Function> {
+        Ok(
+            function
+                .instruction(&reencoder.instruction(reader.read().map_err(Error::ParseError)?)?),
+        )
+    }
+}

--- a/crates/wasm-encoder/src/reencode.rs
+++ b/crates/wasm-encoder/src/reencode.rs
@@ -3,8 +3,12 @@
 //! The [`RoundtripReencoder`] allows encoding identical wasm to the parsed
 //! input.
 
+use std::convert::Infallible;
+
 #[allow(missing_docs)] // FIXME
 pub trait Reencode {
+    type Error;
+
     fn data_index(&mut self, data: u32) -> u32 {
         utils::data_index(self, data)
     }
@@ -44,11 +48,17 @@ pub trait Reencode {
         utils::abstract_heap_type(self, value)
     }
 
-    fn array_type(&mut self, array_ty: wasmparser::ArrayType) -> Result<crate::ArrayType> {
+    fn array_type(
+        &mut self,
+        array_ty: wasmparser::ArrayType,
+    ) -> Result<crate::ArrayType, Error<Self::Error>> {
         utils::array_type(self, array_ty)
     }
 
-    fn block_type(&mut self, arg: wasmparser::BlockType) -> Result<crate::BlockType> {
+    fn block_type(
+        &mut self,
+        arg: wasmparser::BlockType,
+    ) -> Result<crate::BlockType, Error<Self::Error>> {
         utils::block_type(self, arg)
     }
 
@@ -59,7 +69,10 @@ pub trait Reencode {
         utils::component_primitive_val_type(self, ty)
     }
 
-    fn const_expr(&mut self, const_expr: wasmparser::ConstExpr) -> Result<crate::ConstExpr> {
+    fn const_expr(
+        &mut self,
+        const_expr: wasmparser::ConstExpr,
+    ) -> Result<crate::ConstExpr, Error<Self::Error>> {
         utils::const_expr(self, const_expr)
     }
 
@@ -70,11 +83,14 @@ pub trait Reencode {
     fn composite_type(
         &mut self,
         composite_ty: wasmparser::CompositeType,
-    ) -> Result<crate::CompositeType> {
+    ) -> Result<crate::CompositeType, Error<Self::Error>> {
         utils::composite_type(self, composite_ty)
     }
 
-    fn entity_type(&mut self, type_ref: wasmparser::TypeRef) -> Result<crate::EntityType> {
+    fn entity_type(
+        &mut self,
+        type_ref: wasmparser::TypeRef,
+    ) -> Result<crate::EntityType, Error<Self::Error>> {
         utils::entity_type(self, type_ref)
     }
 
@@ -82,23 +98,38 @@ pub trait Reencode {
         utils::export_kind(self, external_kind)
     }
 
-    fn field_type(&mut self, field_ty: wasmparser::FieldType) -> Result<crate::FieldType> {
+    fn field_type(
+        &mut self,
+        field_ty: wasmparser::FieldType,
+    ) -> Result<crate::FieldType, Error<Self::Error>> {
         utils::field_type(self, field_ty)
     }
 
-    fn func_type(&mut self, func_ty: wasmparser::FuncType) -> Result<crate::FuncType> {
+    fn func_type(
+        &mut self,
+        func_ty: wasmparser::FuncType,
+    ) -> Result<crate::FuncType, Error<Self::Error>> {
         utils::func_type(self, func_ty)
     }
 
-    fn global_type(&mut self, global_ty: wasmparser::GlobalType) -> Result<crate::GlobalType> {
+    fn global_type(
+        &mut self,
+        global_ty: wasmparser::GlobalType,
+    ) -> Result<crate::GlobalType, Error<Self::Error>> {
         utils::global_type(self, global_ty)
     }
 
-    fn heap_type(&mut self, heap_type: wasmparser::HeapType) -> Result<crate::HeapType> {
+    fn heap_type(
+        &mut self,
+        heap_type: wasmparser::HeapType,
+    ) -> Result<crate::HeapType, Error<Self::Error>> {
         utils::heap_type(self, heap_type)
     }
 
-    fn instruction<'a>(&mut self, arg: wasmparser::Operator<'a>) -> Result<crate::Instruction<'a>> {
+    fn instruction<'a>(
+        &mut self,
+        arg: wasmparser::Operator<'a>,
+    ) -> Result<crate::Instruction<'a>, Error<Self::Error>> {
         utils::instruction(self, arg)
     }
 
@@ -114,23 +145,38 @@ pub trait Reencode {
         utils::ordering(self, arg)
     }
 
-    fn ref_type(&mut self, ref_type: wasmparser::RefType) -> Result<crate::RefType> {
+    fn ref_type(
+        &mut self,
+        ref_type: wasmparser::RefType,
+    ) -> Result<crate::RefType, Error<Self::Error>> {
         utils::ref_type(self, ref_type)
     }
 
-    fn storage_type(&mut self, storage_ty: wasmparser::StorageType) -> Result<crate::StorageType> {
+    fn storage_type(
+        &mut self,
+        storage_ty: wasmparser::StorageType,
+    ) -> Result<crate::StorageType, Error<Self::Error>> {
         utils::storage_type(self, storage_ty)
     }
 
-    fn struct_type(&mut self, struct_ty: wasmparser::StructType) -> Result<crate::StructType> {
+    fn struct_type(
+        &mut self,
+        struct_ty: wasmparser::StructType,
+    ) -> Result<crate::StructType, Error<Self::Error>> {
         utils::struct_type(self, struct_ty)
     }
 
-    fn sub_type(&mut self, sub_ty: wasmparser::SubType) -> Result<crate::SubType> {
+    fn sub_type(
+        &mut self,
+        sub_ty: wasmparser::SubType,
+    ) -> Result<crate::SubType, Error<Self::Error>> {
         utils::sub_type(self, sub_ty)
     }
 
-    fn table_type(&mut self, table_ty: wasmparser::TableType) -> Result<crate::TableType> {
+    fn table_type(
+        &mut self,
+        table_ty: wasmparser::TableType,
+    ) -> Result<crate::TableType, Error<Self::Error>> {
         utils::table_type(self, table_ty)
     }
 
@@ -142,7 +188,10 @@ pub trait Reencode {
         utils::tag_type(self, tag_ty)
     }
 
-    fn val_type(&mut self, val_ty: wasmparser::ValType) -> Result<crate::ValType> {
+    fn val_type(
+        &mut self,
+        val_ty: wasmparser::ValType,
+    ) -> Result<crate::ValType, Error<Self::Error>> {
         utils::val_type(self, val_ty)
     }
 
@@ -159,7 +208,7 @@ pub trait Reencode {
         &mut self,
         code: &mut crate::CodeSection,
         section: wasmparser::CodeSectionReader<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<Self::Error>> {
         utils::parse_code_section(self, code, section)
     }
 
@@ -168,7 +217,7 @@ pub trait Reencode {
         &mut self,
         code: &mut crate::CodeSection,
         func: wasmparser::FunctionBody<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<Self::Error>> {
         utils::parse_function_body(self, code, func)
     }
 
@@ -177,7 +226,7 @@ pub trait Reencode {
     fn new_function_with_parsed_locals(
         &mut self,
         func: &wasmparser::FunctionBody<'_>,
-    ) -> Result<crate::Function> {
+    ) -> Result<crate::Function, Error<Self::Error>> {
         utils::new_function_with_parsed_locals(self, func)
     }
 
@@ -186,7 +235,7 @@ pub trait Reencode {
         &mut self,
         function: &mut crate::Function,
         reader: &mut wasmparser::OperatorsReader<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<Self::Error>> {
         utils::parse_instruction(self, function, reader)
     }
 
@@ -196,7 +245,7 @@ pub trait Reencode {
         &mut self,
         data: &mut crate::DataSection,
         section: wasmparser::DataSectionReader<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<Self::Error>> {
         utils::parse_data_section(self, data, section)
     }
 
@@ -205,7 +254,7 @@ pub trait Reencode {
         &mut self,
         data: &mut crate::DataSection,
         datum: wasmparser::Data<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<Self::Error>> {
         utils::parse_data(self, data, datum)
     }
 
@@ -215,7 +264,7 @@ pub trait Reencode {
         &mut self,
         elements: &mut crate::ElementSection,
         section: wasmparser::ElementSectionReader<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<Self::Error>> {
         utils::parse_element_section(self, elements, section)
     }
 
@@ -225,7 +274,7 @@ pub trait Reencode {
         &mut self,
         elements: &mut crate::ElementSection,
         element: wasmparser::Element<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<Self::Error>> {
         utils::parse_element(self, elements, element)
     }
 
@@ -235,7 +284,7 @@ pub trait Reencode {
         &mut self,
         exports: &mut crate::ExportSection,
         section: wasmparser::ExportSectionReader<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<Self::Error>> {
         utils::parse_export_section(self, exports, section)
     }
 
@@ -251,7 +300,7 @@ pub trait Reencode {
         &mut self,
         functions: &mut crate::FunctionSection,
         section: wasmparser::FunctionSectionReader<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<Self::Error>> {
         utils::parse_function_section(self, functions, section)
     }
 
@@ -261,7 +310,7 @@ pub trait Reencode {
         &mut self,
         globals: &mut crate::GlobalSection,
         section: wasmparser::GlobalSectionReader<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<Self::Error>> {
         utils::parse_global_section(self, globals, section)
     }
 
@@ -271,7 +320,7 @@ pub trait Reencode {
         &mut self,
         globals: &mut crate::GlobalSection,
         global: wasmparser::Global<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<Self::Error>> {
         utils::parse_global(self, globals, global)
     }
 
@@ -281,7 +330,7 @@ pub trait Reencode {
         &mut self,
         imports: &mut crate::ImportSection,
         section: wasmparser::ImportSectionReader<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<Self::Error>> {
         utils::parse_import_section(self, imports, section)
     }
 
@@ -291,7 +340,7 @@ pub trait Reencode {
         &mut self,
         imports: &mut crate::ImportSection,
         import: wasmparser::Import<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<Self::Error>> {
         utils::parse_import(self, imports, import)
     }
 
@@ -301,7 +350,7 @@ pub trait Reencode {
         &mut self,
         memories: &mut crate::MemorySection,
         section: wasmparser::MemorySectionReader<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<Self::Error>> {
         utils::parse_memory_section(self, memories, section)
     }
 
@@ -311,7 +360,7 @@ pub trait Reencode {
         &mut self,
         tables: &mut crate::TableSection,
         section: wasmparser::TableSectionReader<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<Self::Error>> {
         utils::parse_table_section(self, tables, section)
     }
 
@@ -320,7 +369,7 @@ pub trait Reencode {
         &mut self,
         tables: &mut crate::TableSection,
         table: wasmparser::Table<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<Self::Error>> {
         utils::parse_table(self, tables, table)
     }
 
@@ -330,7 +379,7 @@ pub trait Reencode {
         &mut self,
         tags: &mut crate::TagSection,
         section: wasmparser::TagSectionReader<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<Self::Error>> {
         utils::parse_tag_section(self, tags, section)
     }
 
@@ -340,7 +389,7 @@ pub trait Reencode {
         &mut self,
         types: &mut crate::TypeSection,
         section: wasmparser::TypeSectionReader<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<Self::Error>> {
         utils::parse_type_section(self, types, section)
     }
 
@@ -349,7 +398,7 @@ pub trait Reencode {
         &mut self,
         types: &mut crate::TypeSection,
         rec_group: wasmparser::RecGroup,
-    ) -> Result<()> {
+    ) -> Result<(), Error<Self::Error>> {
         utils::parse_recursive_type_group(self, types, rec_group)
     }
 
@@ -358,7 +407,7 @@ pub trait Reencode {
         module: &mut crate::Module,
         id: u8,
         contents: &[u8],
-    ) -> Result<()> {
+    ) -> Result<(), Error<Self::Error>> {
         utils::parse_unknown_section(self, module, id, contents)
     }
 
@@ -367,17 +416,14 @@ pub trait Reencode {
         module: &mut crate::Module,
         parser: wasmparser::Parser,
         data: &[u8],
-    ) -> Result<()> {
+    ) -> Result<(), Error<Self::Error>> {
         utils::parse_core_module(self, module, parser, data)
     }
 }
 
-/// A result when re-encoding from `wasmparser` to `wasm-encoder`.
-pub type Result<T, E = Error> = std::result::Result<T, E>;
-
 /// An error when re-encoding from `wasmparser` to `wasm-encoder`.
 #[derive(Debug)]
-pub enum Error {
+pub enum Error<E = Infallible> {
     /// There was a type reference that was canonicalized and no longer
     /// references an index into a module's types space, so we cannot encode it
     /// into a Wasm binary again.
@@ -389,20 +435,23 @@ pub enum Error {
     UnexpectedNonCoreModuleSection,
     /// There was an error when parsing.
     ParseError(wasmparser::BinaryReaderError),
+    /// There was a user-defined error when re-encoding.
+    UserError(E),
 }
 
-impl From<wasmparser::BinaryReaderError> for Error {
+impl<E> From<wasmparser::BinaryReaderError> for Error<E> {
     fn from(err: wasmparser::BinaryReaderError) -> Self {
         Self::ParseError(err)
     }
 }
 
-impl std::fmt::Display for Error {
+impl<E: std::fmt::Display> std::fmt::Display for Error<E> {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Self::ParseError(_e) => {
                 write!(fmt, "There was an error when parsing")
             }
+            Self::UserError(e) => write!(fmt, "{e}"),
             Self::InvalidConstExpr => write!(fmt, "The const expression was invalid"),
             Self::UnexpectedNonCoreModuleSection => write!(
                 fmt,
@@ -416,10 +465,11 @@ impl std::fmt::Display for Error {
     }
 }
 
-impl std::error::Error for Error {
+impl<E: 'static + std::error::Error> std::error::Error for Error<E> {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::ParseError(e) => Some(e),
+            Self::UserError(e) => Some(e),
             Self::InvalidConstExpr
             | Self::CanonicalizedHeapTypeReference
             | Self::UnexpectedNonCoreModuleSection => None,
@@ -432,18 +482,20 @@ impl std::error::Error for Error {
 #[derive(Debug)]
 pub struct RoundtripReencoder;
 
-impl Reencode for RoundtripReencoder {}
+impl Reencode for RoundtripReencoder {
+    type Error = Infallible;
+}
 
 #[allow(missing_docs)] // FIXME
 pub mod utils {
-    use super::{Error, Reencode, Result};
+    use super::{Error, Reencode};
 
-    pub fn parse_core_module(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn parse_core_module<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         module: &mut crate::Module,
         parser: wasmparser::Parser,
         data: &[u8],
-    ) -> Result<()> {
+    ) -> Result<(), Error<T::Error>> {
         let mut sections = parser.parse_all(data);
         let mut next_section = sections.next();
 
@@ -571,8 +623,8 @@ pub mod utils {
         Ok(())
     }
 
-    pub fn component_primitive_val_type(
-        _reencoder: &mut (impl ?Sized + Reencode),
+    pub fn component_primitive_val_type<T: ?Sized + Reencode>(
+        _reencoder: &mut T,
         ty: wasmparser::PrimitiveValType,
     ) -> crate::component::PrimitiveValType {
         match ty {
@@ -592,12 +644,12 @@ pub mod utils {
         }
     }
 
-    pub fn memory_index(_reencoder: &mut (impl ?Sized + Reencode), memory: u32) -> u32 {
+    pub fn memory_index<T: ?Sized + Reencode>(_reencoder: &mut T, memory: u32) -> u32 {
         memory
     }
 
-    pub fn mem_arg(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn mem_arg<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         arg: wasmparser::MemArg,
     ) -> crate::MemArg {
         crate::MemArg {
@@ -607,8 +659,8 @@ pub mod utils {
         }
     }
 
-    pub fn ordering(
-        _reencoder: &mut (impl ?Sized + Reencode),
+    pub fn ordering<T: ?Sized + Reencode>(
+        _reencoder: &mut T,
         arg: wasmparser::Ordering,
     ) -> crate::Ordering {
         match arg {
@@ -617,15 +669,15 @@ pub mod utils {
         }
     }
 
-    pub fn function_index(_reencoder: &mut (impl ?Sized + Reencode), func: u32) -> u32 {
+    pub fn function_index<T: ?Sized + Reencode>(_reencoder: &mut T, func: u32) -> u32 {
         func
     }
 
-    pub fn tag_index(_reencoder: &mut (impl ?Sized + Reencode), tag: u32) -> u32 {
+    pub fn tag_index<T: ?Sized + Reencode>(_reencoder: &mut T, tag: u32) -> u32 {
         tag
     }
 
-    pub fn catch(reencoder: &mut (impl ?Sized + Reencode), arg: wasmparser::Catch) -> crate::Catch {
+    pub fn catch<T: ?Sized + Reencode>(reencoder: &mut T, arg: wasmparser::Catch) -> crate::Catch {
         match arg {
             wasmparser::Catch::One { tag, label } => crate::Catch::One {
                 tag: reencoder.tag_index(tag),
@@ -640,8 +692,8 @@ pub mod utils {
         }
     }
 
-    pub fn custom_section<'a>(
-        _reencoder: &mut (impl ?Sized + Reencode),
+    pub fn custom_section<'a, T: ?Sized + Reencode>(
+        _reencoder: &mut T,
         section: wasmparser::CustomSectionReader<'a>,
     ) -> crate::CustomSection<'a> {
         crate::CustomSection {
@@ -650,8 +702,8 @@ pub mod utils {
         }
     }
 
-    pub fn export_kind(
-        _reencoder: &mut (impl ?Sized + Reencode),
+    pub fn export_kind<T: ?Sized + Reencode>(
+        _reencoder: &mut T,
         external_kind: wasmparser::ExternalKind,
     ) -> crate::ExportKind {
         match external_kind {
@@ -663,8 +715,8 @@ pub mod utils {
         }
     }
 
-    pub fn memory_type(
-        _reencoder: &mut (impl ?Sized + Reencode),
+    pub fn memory_type<T: ?Sized + Reencode>(
+        _reencoder: &mut T,
         memory_ty: wasmparser::MemoryType,
     ) -> crate::MemoryType {
         crate::MemoryType {
@@ -676,8 +728,8 @@ pub mod utils {
         }
     }
 
-    pub fn tag_kind(
-        _reencoder: &mut (impl ?Sized + Reencode),
+    pub fn tag_kind<T: ?Sized + Reencode>(
+        _reencoder: &mut T,
         kind: wasmparser::TagKind,
     ) -> crate::TagKind {
         match kind {
@@ -685,12 +737,12 @@ pub mod utils {
         }
     }
 
-    pub fn type_index(_reencoder: &mut (impl ?Sized + Reencode), ty: u32) -> u32 {
+    pub fn type_index<T: ?Sized + Reencode>(_reencoder: &mut T, ty: u32) -> u32 {
         ty
     }
 
-    pub fn tag_type(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn tag_type<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         tag_ty: wasmparser::TagType,
     ) -> crate::TagType {
         crate::TagType {
@@ -699,8 +751,8 @@ pub mod utils {
         }
     }
 
-    pub fn abstract_heap_type(
-        _reencoder: &mut (impl ?Sized + Reencode),
+    pub fn abstract_heap_type<T: ?Sized + Reencode>(
+        _reencoder: &mut T,
         value: wasmparser::AbstractHeapType,
     ) -> crate::AbstractHeapType {
         use wasmparser::AbstractHeapType::*;
@@ -722,11 +774,11 @@ pub mod utils {
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the types to the `types` section.
-    pub fn parse_type_section(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn parse_type_section<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         types: &mut crate::TypeSection,
         section: wasmparser::TypeSectionReader<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<T::Error>> {
         for rec_group in section {
             reencoder.parse_recursive_type_group(types, rec_group?)?;
         }
@@ -734,11 +786,11 @@ pub mod utils {
     }
 
     /// Parses a single [`wasmparser::RecGroup`] and adds it to the `types` section.
-    pub fn parse_recursive_type_group(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn parse_recursive_type_group<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         types: &mut crate::TypeSection,
         rec_group: wasmparser::RecGroup,
-    ) -> Result<()> {
+    ) -> Result<(), Error<T::Error>> {
         if rec_group.is_explicit_rec_group() {
             let subtypes = rec_group
                 .into_types()
@@ -752,10 +804,10 @@ pub mod utils {
         Ok(())
     }
 
-    pub fn sub_type(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn sub_type<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         sub_ty: wasmparser::SubType,
-    ) -> Result<crate::SubType> {
+    ) -> Result<crate::SubType, Error<T::Error>> {
         Ok(crate::SubType {
             is_final: sub_ty.is_final,
             supertype_idx: sub_ty
@@ -770,10 +822,10 @@ pub mod utils {
         })
     }
 
-    pub fn composite_type(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn composite_type<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         composite_ty: wasmparser::CompositeType,
-    ) -> Result<crate::CompositeType> {
+    ) -> Result<crate::CompositeType, Error<T::Error>> {
         Ok(match composite_ty {
             wasmparser::CompositeType::Func(f) => {
                 crate::CompositeType::Func(reencoder.func_type(f)?)
@@ -787,10 +839,10 @@ pub mod utils {
         })
     }
 
-    pub fn func_type(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn func_type<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         func_ty: wasmparser::FuncType,
-    ) -> Result<crate::FuncType> {
+    ) -> Result<crate::FuncType, Error<T::Error>> {
         let mut buf = Vec::with_capacity(func_ty.params().len() + func_ty.results().len());
         for ty in func_ty.params().iter().chain(func_ty.results()).copied() {
             buf.push(reencoder.val_type(ty)?);
@@ -801,17 +853,17 @@ pub mod utils {
         ))
     }
 
-    pub fn array_type(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn array_type<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         array_ty: wasmparser::ArrayType,
-    ) -> Result<crate::ArrayType> {
+    ) -> Result<crate::ArrayType, Error<T::Error>> {
         Ok(crate::ArrayType(reencoder.field_type(array_ty.0)?))
     }
 
-    pub fn struct_type(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn struct_type<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         struct_ty: wasmparser::StructType,
-    ) -> Result<crate::StructType> {
+    ) -> Result<crate::StructType, Error<T::Error>> {
         Ok(crate::StructType {
             fields: struct_ty
                 .fields
@@ -821,20 +873,20 @@ pub mod utils {
         })
     }
 
-    pub fn field_type(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn field_type<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         field_ty: wasmparser::FieldType,
-    ) -> Result<crate::FieldType> {
+    ) -> Result<crate::FieldType, Error<T::Error>> {
         Ok(crate::FieldType {
             element_type: reencoder.storage_type(field_ty.element_type)?,
             mutable: field_ty.mutable,
         })
     }
 
-    pub fn storage_type(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn storage_type<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         storage_ty: wasmparser::StorageType,
-    ) -> Result<crate::StorageType> {
+    ) -> Result<crate::StorageType, Error<T::Error>> {
         Ok(match storage_ty {
             wasmparser::StorageType::I8 => crate::StorageType::I8,
             wasmparser::StorageType::I16 => crate::StorageType::I16,
@@ -842,10 +894,10 @@ pub mod utils {
         })
     }
 
-    pub fn val_type(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn val_type<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         val_ty: wasmparser::ValType,
-    ) -> Result<crate::ValType> {
+    ) -> Result<crate::ValType, Error<T::Error>> {
         Ok(match val_ty {
             wasmparser::ValType::I32 => crate::ValType::I32,
             wasmparser::ValType::I64 => crate::ValType::I64,
@@ -856,20 +908,20 @@ pub mod utils {
         })
     }
 
-    pub fn ref_type(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn ref_type<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         ref_type: wasmparser::RefType,
-    ) -> Result<crate::RefType> {
+    ) -> Result<crate::RefType, Error<T::Error>> {
         Ok(crate::RefType {
             nullable: ref_type.is_nullable(),
             heap_type: reencoder.heap_type(ref_type.heap_type())?,
         })
     }
 
-    pub fn heap_type(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn heap_type<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         heap_type: wasmparser::HeapType,
-    ) -> Result<crate::HeapType> {
+    ) -> Result<crate::HeapType, Error<T::Error>> {
         Ok(match heap_type {
             wasmparser::HeapType::Concrete(i) => crate::HeapType::Concrete(
                 i.as_module_index()
@@ -885,11 +937,11 @@ pub mod utils {
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the tables to the `tables` section.
-    pub fn parse_table_section(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn parse_table_section<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         tables: &mut crate::TableSection,
         section: wasmparser::TableSectionReader<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<T::Error>> {
         for table in section {
             reencoder.parse_table(tables, table?)?;
         }
@@ -897,11 +949,11 @@ pub mod utils {
     }
 
     /// Parses a single [`wasmparser::Table`] and adds it to the `tables` section.
-    pub fn parse_table(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn parse_table<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         tables: &mut crate::TableSection,
         table: wasmparser::Table<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<T::Error>> {
         let ty = reencoder.table_type(table.ty)?;
         match table.init {
             wasmparser::TableInit::RefNull => {
@@ -914,10 +966,10 @@ pub mod utils {
         Ok(())
     }
 
-    pub fn table_type(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn table_type<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         table_ty: wasmparser::TableType,
-    ) -> Result<crate::TableType> {
+    ) -> Result<crate::TableType, Error<T::Error>> {
         Ok(crate::TableType {
             element_type: reencoder.ref_type(table_ty.element_type)?,
             minimum: table_ty.initial,
@@ -928,11 +980,11 @@ pub mod utils {
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the tags to the `tags` section.
-    pub fn parse_tag_section(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn parse_tag_section<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         tags: &mut crate::TagSection,
         section: wasmparser::TagSectionReader<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<T::Error>> {
         for tag in section {
             let tag = tag?;
             tags.tag(reencoder.tag_type(tag));
@@ -942,11 +994,11 @@ pub mod utils {
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the exports to the `exports` section.
-    pub fn parse_export_section(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn parse_export_section<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         exports: &mut crate::ExportSection,
         section: wasmparser::ExportSectionReader<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<T::Error>> {
         for export in section {
             reencoder.parse_export(exports, export?);
         }
@@ -955,8 +1007,8 @@ pub mod utils {
 
     /// Parses the single [`wasmparser::Export`] provided and adds it to the
     /// `exports` section.
-    pub fn parse_export(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn parse_export<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         exports: &mut crate::ExportSection,
         export: wasmparser::Export<'_>,
     ) {
@@ -975,11 +1027,11 @@ pub mod utils {
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the globals to the `globals` section.
-    pub fn parse_global_section(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn parse_global_section<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         globals: &mut crate::GlobalSection,
         section: wasmparser::GlobalSectionReader<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<T::Error>> {
         for global in section {
             reencoder.parse_global(globals, global?)?;
         }
@@ -988,11 +1040,11 @@ pub mod utils {
 
     /// Parses the single [`wasmparser::Global`] provided and adds it to the
     /// `globals` section.
-    pub fn parse_global(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn parse_global<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         globals: &mut crate::GlobalSection,
         global: wasmparser::Global<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<T::Error>> {
         globals.global(
             reencoder.global_type(global.ty)?,
             &reencoder.const_expr(global.init_expr)?,
@@ -1000,10 +1052,10 @@ pub mod utils {
         Ok(())
     }
 
-    pub fn global_type(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn global_type<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         global_ty: wasmparser::GlobalType,
-    ) -> Result<crate::GlobalType> {
+    ) -> Result<crate::GlobalType, Error<T::Error>> {
         Ok(crate::GlobalType {
             val_type: reencoder.val_type(global_ty.content_type)?,
             mutable: global_ty.mutable,
@@ -1011,10 +1063,10 @@ pub mod utils {
         })
     }
 
-    pub fn entity_type(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn entity_type<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         type_ref: wasmparser::TypeRef,
-    ) -> Result<crate::EntityType> {
+    ) -> Result<crate::EntityType, Error<T::Error>> {
         Ok(match type_ref {
             wasmparser::TypeRef::Func(i) => crate::EntityType::Function(reencoder.type_index(i)),
             wasmparser::TypeRef::Table(t) => crate::EntityType::Table(reencoder.table_type(t)?),
@@ -1026,11 +1078,11 @@ pub mod utils {
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the imports to the `import` section.
-    pub fn parse_import_section(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn parse_import_section<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         imports: &mut crate::ImportSection,
         section: wasmparser::ImportSectionReader<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<T::Error>> {
         for import in section {
             reencoder.parse_import(imports, import?)?;
         }
@@ -1039,11 +1091,11 @@ pub mod utils {
 
     /// Parses the single [`wasmparser::Import`] provided and adds it to the
     /// `import` section.
-    pub fn parse_import(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn parse_import<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         imports: &mut crate::ImportSection,
         import: wasmparser::Import<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<T::Error>> {
         imports.import(
             import.module,
             import.name,
@@ -1054,11 +1106,11 @@ pub mod utils {
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the memories to the `memories` section.
-    pub fn parse_memory_section(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn parse_memory_section<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         memories: &mut crate::MemorySection,
         section: wasmparser::MemorySectionReader<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<T::Error>> {
         for memory in section {
             let memory = memory?;
             memories.memory(reencoder.memory_type(memory));
@@ -1068,11 +1120,11 @@ pub mod utils {
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the functions to the `functions` section.
-    pub fn parse_function_section(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn parse_function_section<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         functions: &mut crate::FunctionSection,
         section: wasmparser::FunctionSectionReader<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<T::Error>> {
         for func in section {
             functions.function(reencoder.type_index(func?));
         }
@@ -1081,11 +1133,11 @@ pub mod utils {
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the data to the `data` section.
-    pub fn parse_data_section(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn parse_data_section<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         data: &mut crate::DataSection,
         section: wasmparser::DataSectionReader<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<T::Error>> {
         for datum in section {
             reencoder.parse_data(data, datum?)?;
         }
@@ -1093,11 +1145,11 @@ pub mod utils {
     }
 
     /// Parses a single [`wasmparser::Data`] and adds it to the `data` section.
-    pub fn parse_data(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn parse_data<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         data: &mut crate::DataSection,
         datum: wasmparser::Data<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<T::Error>> {
         match datum.kind {
             wasmparser::DataKind::Active {
                 memory_index,
@@ -1114,11 +1166,11 @@ pub mod utils {
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the elements to the `element` section.
-    pub fn parse_element_section(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn parse_element_section<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         elements: &mut crate::ElementSection,
         section: wasmparser::ElementSectionReader<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<T::Error>> {
         for element in section {
             reencoder.parse_element(elements, element?)?;
         }
@@ -1127,11 +1179,11 @@ pub mod utils {
 
     /// Parses the single [`wasmparser::Element`] provided and adds it to the
     /// `element` section.
-    pub fn parse_element(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn parse_element<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         elements: &mut crate::ElementSection,
         element: wasmparser::Element<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<T::Error>> {
         let mut funcs;
         let mut exprs;
         let elems = match element.items {
@@ -1165,26 +1217,26 @@ pub mod utils {
         Ok(())
     }
 
-    pub fn table_index(_reencoder: &mut (impl ?Sized + Reencode), table: u32) -> u32 {
+    pub fn table_index<T: ?Sized + Reencode>(_reencoder: &mut T, table: u32) -> u32 {
         table
     }
 
-    pub fn global_index(_reencoder: &mut (impl ?Sized + Reencode), global: u32) -> u32 {
+    pub fn global_index<T: ?Sized + Reencode>(_reencoder: &mut T, global: u32) -> u32 {
         global
     }
 
-    pub fn data_index(_reencoder: &mut (impl ?Sized + Reencode), data: u32) -> u32 {
+    pub fn data_index<T: ?Sized + Reencode>(_reencoder: &mut T, data: u32) -> u32 {
         data
     }
 
-    pub fn element_index(_reencoder: &mut (impl ?Sized + Reencode), element: u32) -> u32 {
+    pub fn element_index<T: ?Sized + Reencode>(_reencoder: &mut T, element: u32) -> u32 {
         element
     }
 
-    pub fn const_expr(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn const_expr<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         const_expr: wasmparser::ConstExpr,
-    ) -> Result<crate::ConstExpr> {
+    ) -> Result<crate::ConstExpr, Error<T::Error>> {
         let mut ops = const_expr.get_operators_reader().into_iter();
 
         let result = match ops.next() {
@@ -1226,10 +1278,10 @@ pub mod utils {
         }
     }
 
-    pub fn block_type(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn block_type<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         arg: wasmparser::BlockType,
-    ) -> Result<crate::BlockType> {
+    ) -> Result<crate::BlockType, Error<T::Error>> {
         match arg {
             wasmparser::BlockType::Empty => Ok(crate::BlockType::Empty),
             wasmparser::BlockType::FuncType(n) => {
@@ -1239,10 +1291,10 @@ pub mod utils {
         }
     }
 
-    pub fn instruction<'a>(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn instruction<'a, T: ?Sized + Reencode>(
+        reencoder: &mut T,
         arg: wasmparser::Operator<'a>,
-    ) -> Result<crate::Instruction<'a>> {
+    ) -> Result<crate::Instruction<'a>, Error<T::Error>> {
         use crate::Instruction;
 
         macro_rules! translate {
@@ -1327,11 +1379,11 @@ pub mod utils {
 
     /// Parses the input `section` given from the `wasmparser` crate and adds
     /// all the code to the `code` section.
-    pub fn parse_code_section(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn parse_code_section<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         code: &mut crate::CodeSection,
         section: wasmparser::CodeSectionReader<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<T::Error>> {
         for func in section {
             reencoder.parse_function_body(code, func?)?;
         }
@@ -1339,11 +1391,11 @@ pub mod utils {
     }
 
     /// Parses a single [`wasmparser::FunctionBody`] and adds it to the `code` section.
-    pub fn parse_function_body(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn parse_function_body<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         code: &mut crate::CodeSection,
         func: wasmparser::FunctionBody<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<T::Error>> {
         let mut f = reencoder.new_function_with_parsed_locals(&func)?;
         let mut reader = func.get_operators_reader()?;
         while !reader.eof() {
@@ -1355,10 +1407,10 @@ pub mod utils {
 
     /// Create a new [`crate::Function`] by parsing the locals declarations from the
     /// provided [`wasmparser::FunctionBody`].
-    pub fn new_function_with_parsed_locals(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn new_function_with_parsed_locals<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         func: &wasmparser::FunctionBody<'_>,
-    ) -> Result<crate::Function> {
+    ) -> Result<crate::Function, Error<T::Error>> {
         let mut locals = Vec::new();
         for pair in func.get_locals_reader()? {
             let (cnt, ty) = pair?;
@@ -1368,21 +1420,21 @@ pub mod utils {
     }
 
     /// Parses a single instruction from `reader` and adds it to `function`.
-    pub fn parse_instruction(
-        reencoder: &mut (impl ?Sized + Reencode),
+    pub fn parse_instruction<T: ?Sized + Reencode>(
+        reencoder: &mut T,
         function: &mut crate::Function,
         reader: &mut wasmparser::OperatorsReader<'_>,
-    ) -> Result<()> {
+    ) -> Result<(), Error<T::Error>> {
         function.instruction(&reencoder.instruction(reader.read()?)?);
         Ok(())
     }
 
-    pub fn parse_unknown_section(
-        _reencoder: &mut (impl ?Sized + Reencode),
+    pub fn parse_unknown_section<T: ?Sized + Reencode>(
+        _reencoder: &mut T,
         module: &mut crate::Module,
         id: u8,
         contents: &[u8],
-    ) -> Result<()> {
+    ) -> Result<(), Error<T::Error>> {
         module.section(&crate::RawSection { id, data: contents });
         Ok(())
     }

--- a/crates/wasm-encoder/src/reencode.rs
+++ b/crates/wasm-encoder/src/reencode.rs
@@ -3,6 +3,396 @@
 //! The [`RoundtripReencoder`] allows encoding identical wasm to the parsed
 //! input.
 
+#[allow(missing_docs)] // FIXME
+pub trait Reencode {
+    fn export_index(&mut self, export: u32) -> u32 {
+        utils::export_index(self, export)
+    }
+
+    fn data_index(&mut self, data: u32) -> u32 {
+        utils::data_index(self, data)
+    }
+
+    fn element_index(&mut self, element: u32) -> u32 {
+        utils::element_index(self, element)
+    }
+
+    fn function_index(&mut self, func: u32) -> u32 {
+        utils::function_index(self, func)
+    }
+
+    fn global_index(&mut self, global: u32) -> u32 {
+        utils::global_index(self, global)
+    }
+
+    fn label_index(&mut self, label: u32) -> u32 {
+        utils::label_index(self, label)
+    }
+
+    fn memory_index(&mut self, memory: u32) -> u32 {
+        utils::memory_index(self, memory)
+    }
+
+    fn table_index(&mut self, table: u32) -> u32 {
+        utils::table_index(self, table)
+    }
+
+    fn tag_index(&mut self, tag: u32) -> u32 {
+        utils::tag_index(self, tag)
+    }
+
+    fn type_index(&mut self, ty: u32) -> u32 {
+        utils::type_index(self, ty)
+    }
+
+    fn abstract_heap_type(
+        &mut self,
+        value: wasmparser::AbstractHeapType,
+    ) -> crate::AbstractHeapType {
+        utils::abstract_heap_type(self, value)
+    }
+
+    fn array_type(&mut self, array_ty: wasmparser::ArrayType) -> Result<crate::ArrayType> {
+        utils::array_type(self, array_ty)
+    }
+
+    fn block_type(&mut self, arg: wasmparser::BlockType) -> Result<crate::BlockType> {
+        utils::block_type(self, arg)
+    }
+
+    fn component_primitive_val_type(
+        &mut self,
+        ty: wasmparser::PrimitiveValType,
+    ) -> crate::component::PrimitiveValType {
+        utils::component_primitive_val_type(self, ty)
+    }
+
+    fn const_expr(&mut self, const_expr: wasmparser::ConstExpr) -> Result<crate::ConstExpr> {
+        utils::const_expr(self, const_expr)
+    }
+
+    fn catch(&mut self, arg: wasmparser::Catch) -> crate::Catch {
+        utils::catch(self, arg)
+    }
+
+    fn composite_type(
+        &mut self,
+        composite_ty: wasmparser::CompositeType,
+    ) -> Result<crate::CompositeType> {
+        utils::composite_type(self, composite_ty)
+    }
+
+    fn entity_type(&mut self, type_ref: wasmparser::TypeRef) -> Result<crate::EntityType> {
+        utils::entity_type(self, type_ref)
+    }
+
+    fn export_kind(&mut self, external_kind: wasmparser::ExternalKind) -> crate::ExportKind {
+        utils::export_kind(self, external_kind)
+    }
+
+    fn field_type(&mut self, field_ty: wasmparser::FieldType) -> Result<crate::FieldType> {
+        utils::field_type(self, field_ty)
+    }
+
+    fn func_type(&mut self, func_ty: wasmparser::FuncType) -> Result<crate::FuncType> {
+        utils::func_type(self, func_ty)
+    }
+
+    fn global_type(&mut self, global_ty: wasmparser::GlobalType) -> Result<crate::GlobalType> {
+        utils::global_type(self, global_ty)
+    }
+
+    fn heap_type(&mut self, heap_type: wasmparser::HeapType) -> Result<crate::HeapType> {
+        utils::heap_type(self, heap_type)
+    }
+
+    fn instruction<'a>(&mut self, arg: wasmparser::Operator<'a>) -> Result<crate::Instruction<'a>> {
+        utils::instruction(self, arg)
+    }
+
+    fn memory_type(&mut self, memory_ty: wasmparser::MemoryType) -> crate::MemoryType {
+        utils::memory_type(self, memory_ty)
+    }
+
+    fn mem_arg(&mut self, arg: wasmparser::MemArg) -> crate::MemArg {
+        utils::mem_arg(self, arg)
+    }
+
+    fn ordering(&mut self, arg: wasmparser::Ordering) -> crate::Ordering {
+        utils::ordering(self, arg)
+    }
+
+    fn ref_type(&mut self, ref_type: wasmparser::RefType) -> Result<crate::RefType> {
+        utils::ref_type(self, ref_type)
+    }
+
+    fn storage_type(&mut self, storage_ty: wasmparser::StorageType) -> Result<crate::StorageType> {
+        utils::storage_type(self, storage_ty)
+    }
+
+    fn struct_type(&mut self, struct_ty: wasmparser::StructType) -> Result<crate::StructType> {
+        utils::struct_type(self, struct_ty)
+    }
+
+    fn sub_type(&mut self, sub_ty: wasmparser::SubType) -> Result<crate::SubType> {
+        utils::sub_type(self, sub_ty)
+    }
+
+    fn table_type(&mut self, table_ty: wasmparser::TableType) -> Result<crate::TableType> {
+        utils::table_type(self, table_ty)
+    }
+
+    fn tag_kind(&mut self, kind: wasmparser::TagKind) -> crate::TagKind {
+        utils::tag_kind(self, kind)
+    }
+
+    fn tag_type(&mut self, tag_ty: wasmparser::TagType) -> crate::TagType {
+        utils::tag_type(self, tag_ty)
+    }
+
+    fn val_type(&mut self, val_ty: wasmparser::ValType) -> Result<crate::ValType> {
+        utils::val_type(self, val_ty)
+    }
+
+    fn custom_section<'a>(
+        &mut self,
+        section: wasmparser::CustomSectionReader<'a>,
+    ) -> crate::CustomSection<'a> {
+        utils::custom_section(self, section)
+    }
+
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the code to the `code` section.
+    fn parse_code_section(
+        &mut self,
+        code: &mut crate::CodeSection,
+        section: wasmparser::CodeSectionReader<'_>,
+    ) -> Result<()> {
+        utils::parse_code_section(self, code, section)
+    }
+
+    /// Parses a single [`wasmparser::FunctionBody`] and adds it to the `code` section.
+    fn parse_function_body(
+        &mut self,
+        code: &mut crate::CodeSection,
+        func: wasmparser::FunctionBody<'_>,
+    ) -> Result<()> {
+        utils::parse_function_body(self, code, func)
+    }
+
+    /// Create a new [`crate::Function`] by parsing the locals declarations from the
+    /// provided [`wasmparser::FunctionBody`].
+    fn new_function_with_parsed_locals(
+        &mut self,
+        func: &wasmparser::FunctionBody<'_>,
+    ) -> Result<crate::Function> {
+        utils::new_function_with_parsed_locals(self, func)
+    }
+
+    /// Parses a single instruction from `reader` and adds it to `function`.
+    fn parse_instruction(
+        &mut self,
+        function: &mut crate::Function,
+        reader: &mut wasmparser::OperatorsReader<'_>,
+    ) -> Result<()> {
+        utils::parse_instruction(self, function, reader)
+    }
+
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the data to the `data` section.
+    fn parse_data_section(
+        &mut self,
+        data: &mut crate::DataSection,
+        section: wasmparser::DataSectionReader<'_>,
+    ) -> Result<()> {
+        utils::parse_data_section(self, data, section)
+    }
+
+    /// Parses a single [`wasmparser::Data`] and adds it to the `data` section.
+    fn parse_data(
+        &mut self,
+        data: &mut crate::DataSection,
+        datum: wasmparser::Data<'_>,
+    ) -> Result<()> {
+        utils::parse_data(self, data, datum)
+    }
+
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the elements to the `element` section.
+    fn parse_element_section(
+        &mut self,
+        elements: &mut crate::ElementSection,
+        section: wasmparser::ElementSectionReader<'_>,
+    ) -> Result<()> {
+        utils::parse_element_section(self, elements, section)
+    }
+
+    /// Parses the single [`wasmparser::Element`] provided and adds it to the
+    /// `element` section.
+    fn parse_element(
+        &mut self,
+        elements: &mut crate::ElementSection,
+        element: wasmparser::Element<'_>,
+    ) -> Result<()> {
+        utils::parse_element(self, elements, element)
+    }
+
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the exports to the `exports` section.
+    fn parse_export_section(
+        &mut self,
+        exports: &mut crate::ExportSection,
+        section: wasmparser::ExportSectionReader<'_>,
+    ) -> Result<()> {
+        utils::parse_export_section(self, exports, section)
+    }
+
+    /// Parses the single [`wasmparser::Export`] provided and adds it to the
+    /// `exports` section.
+    fn parse_export(&mut self, exports: &mut crate::ExportSection, export: wasmparser::Export<'_>) {
+        utils::parse_export(self, exports, export)
+    }
+
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the functions to the `functions` section.
+    fn parse_function_section(
+        &mut self,
+        functions: &mut crate::FunctionSection,
+        section: wasmparser::FunctionSectionReader<'_>,
+    ) -> Result<()> {
+        utils::parse_function_section(self, functions, section)
+    }
+
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the globals to the `globals` section.
+    fn parse_global_section(
+        &mut self,
+        globals: &mut crate::GlobalSection,
+        section: wasmparser::GlobalSectionReader<'_>,
+    ) -> Result<()> {
+        utils::parse_global_section(self, globals, section)
+    }
+
+    /// Parses the single [`wasmparser::Global`] provided and adds it to the
+    /// `globals` section.
+    fn parse_global(
+        &mut self,
+        globals: &mut crate::GlobalSection,
+        global: wasmparser::Global<'_>,
+    ) -> Result<()> {
+        utils::parse_global(self, globals, global)
+    }
+
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the imports to the `import` section.
+    fn parse_import_section(
+        &mut self,
+        imports: &mut crate::ImportSection,
+        section: wasmparser::ImportSectionReader<'_>,
+    ) -> Result<()> {
+        utils::parse_import_section(self, imports, section)
+    }
+
+    /// Parses the single [`wasmparser::Import`] provided and adds it to the
+    /// `import` section.
+    fn parse_import(
+        &mut self,
+        imports: &mut crate::ImportSection,
+        import: wasmparser::Import<'_>,
+    ) -> Result<()> {
+        utils::parse_import(self, imports, import)
+    }
+
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the memories to the `memories` section.
+    fn parse_memory_section(
+        &mut self,
+        memories: &mut crate::MemorySection,
+        section: wasmparser::MemorySectionReader<'_>,
+    ) -> Result<()> {
+        utils::parse_memory_section(self, memories, section)
+    }
+
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the tables to the `tables` section.
+    fn parse_table_section(
+        &mut self,
+        tables: &mut crate::TableSection,
+        section: wasmparser::TableSectionReader<'_>,
+    ) -> Result<()> {
+        utils::parse_table_section(self, tables, section)
+    }
+
+    /// Parses a single [`wasmparser::Table`] and adds it to the `tables` section.
+    fn parse_table(
+        &mut self,
+        tables: &mut crate::TableSection,
+        table: wasmparser::Table<'_>,
+    ) -> Result<()> {
+        utils::parse_table(self, tables, table)
+    }
+
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the tags to the `tags` section.
+    fn parse_tag_section(
+        &mut self,
+        tags: &mut crate::TagSection,
+        section: wasmparser::TagSectionReader<'_>,
+    ) -> Result<()> {
+        utils::parse_tag_section(self, tags, section)
+    }
+
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the types to the `types` section.
+    fn parse_type_section(
+        &mut self,
+        types: &mut crate::TypeSection,
+        section: wasmparser::TypeSectionReader<'_>,
+    ) -> Result<()> {
+        utils::parse_type_section(self, types, section)
+    }
+
+    /// Parses a single [`wasmparser::RecGroup`] and adds it to the `types` section.
+    fn parse_recursive_type_group(
+        &mut self,
+        types: &mut crate::TypeSection,
+        rec_group: wasmparser::RecGroup,
+    ) -> Result<()> {
+        utils::parse_recursive_type_group(self, types, rec_group)
+    }
+
+    fn parse_unknown_section(
+        &mut self,
+        module: &mut crate::Module,
+        id: u8,
+        contents: &[u8],
+    ) -> Result<()> {
+        utils::parse_unknown_section(self, module, id, contents)
+    }
+
+    fn parse_core_module<'a, 'b>(
+        &mut self,
+        module: &'a mut crate::Module,
+        parser: wasmparser::Parser,
+        data: &[u8],
+    ) -> Result<()> {
+        utils::parse_core_module(self, module, parser, data)
+    }
+
+    fn parse_core_section(
+        &mut self,
+        module: &mut crate::Module,
+        parser: &mut wasmparser::Parser,
+        data: &[u8],
+        eof: bool,
+    ) -> Result<Chunk> {
+        utils::parse_core_section(self, module, parser, data, eof)
+    }
+}
+
+/// A result when re-encoding from `wasmparser` to `wasm-encoder`.
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
 /// An error when re-encoding from `wasmparser` to `wasm-encoder`.
 #[derive(Debug)]
 pub enum Error {
@@ -55,403 +445,6 @@ impl std::error::Error for Error {
     }
 }
 
-/// A result when re-encoding from `wasmparser` to `wasm-encoder`.
-pub type Result<T, E = Error> = std::result::Result<T, E>;
-
-#[allow(missing_docs)] // FIXME
-pub trait Reencode {
-    fn parse_core_section(
-        &mut self,
-        module: &mut crate::Module,
-        parser: &mut wasmparser::Parser,
-        data: &[u8],
-        eof: bool,
-    ) -> Result<Chunk> {
-        utils::parse_core_section(self, module, parser, data, eof)
-    }
-
-    fn parse_core_module<'a, 'b>(
-        &mut self,
-        module: &'a mut crate::Module,
-        parser: wasmparser::Parser,
-        data: &[u8],
-    ) -> Result<()> {
-        utils::parse_core_module(self, module, parser, data)
-    }
-
-    fn component_primitive_val_type(
-        &mut self,
-        ty: wasmparser::PrimitiveValType,
-    ) -> crate::component::PrimitiveValType {
-        utils::component_primitive_val_type(self, ty)
-    }
-
-    fn memory_index(&mut self, memory: u32) -> u32 {
-        utils::memory_index(self, memory)
-    }
-
-    fn mem_arg(&mut self, arg: wasmparser::MemArg) -> crate::MemArg {
-        utils::mem_arg(self, arg)
-    }
-
-    fn ordering(&mut self, arg: wasmparser::Ordering) -> crate::Ordering {
-        utils::ordering(self, arg)
-    }
-
-    fn function_index(&mut self, func: u32) -> u32 {
-        utils::function_index(self, func)
-    }
-
-    fn tag_index(&mut self, tag: u32) -> u32 {
-        utils::tag_index(self, tag)
-    }
-
-    fn label_index(&mut self, label: u32) -> u32 {
-        utils::label_index(self, label)
-    }
-
-    fn catch(&mut self, arg: wasmparser::Catch) -> crate::Catch {
-        utils::catch(self, arg)
-    }
-
-    fn custom_section<'a>(
-        &mut self,
-        section: wasmparser::CustomSectionReader<'a>,
-    ) -> crate::CustomSection<'a> {
-        utils::custom_section(self, section)
-    }
-
-    fn export_kind(&mut self, external_kind: wasmparser::ExternalKind) -> crate::ExportKind {
-        utils::export_kind(self, external_kind)
-    }
-
-    fn memory_type(&mut self, memory_ty: wasmparser::MemoryType) -> crate::MemoryType {
-        utils::memory_type(self, memory_ty)
-    }
-
-    fn tag_kind(&mut self, kind: wasmparser::TagKind) -> crate::TagKind {
-        utils::tag_kind(self, kind)
-    }
-
-    fn type_index(&mut self, ty: u32) -> u32 {
-        utils::type_index(self, ty)
-    }
-
-    fn tag_type(&mut self, tag_ty: wasmparser::TagType) -> crate::TagType {
-        utils::tag_type(self, tag_ty)
-    }
-
-    fn abstract_heap_type(
-        &mut self,
-        value: wasmparser::AbstractHeapType,
-    ) -> crate::AbstractHeapType {
-        utils::abstract_heap_type(self, value)
-    }
-
-    /// Parses the input `section` given from the `wasmparser` crate and adds
-    /// all the types to the `types` section.
-    fn parse_type_section(
-        &mut self,
-        types: &mut crate::TypeSection,
-        section: wasmparser::TypeSectionReader<'_>,
-    ) -> Result<()> {
-        utils::parse_type_section(self, types, section)
-    }
-
-    /// Parses a single [`wasmparser::RecGroup`] and adds it to the `types` section.
-    fn parse_recursive_type_group(
-        &mut self,
-        types: &mut crate::TypeSection,
-        rec_group: wasmparser::RecGroup,
-    ) -> Result<()> {
-        utils::parse_recursive_type_group(self, types, rec_group)
-    }
-
-    fn sub_type(&mut self, sub_ty: wasmparser::SubType) -> Result<crate::SubType> {
-        utils::sub_type(self, sub_ty)
-    }
-
-    fn composite_type(
-        &mut self,
-        composite_ty: wasmparser::CompositeType,
-    ) -> Result<crate::CompositeType> {
-        utils::composite_type(self, composite_ty)
-    }
-
-    fn func_type(&mut self, func_ty: wasmparser::FuncType) -> Result<crate::FuncType> {
-        utils::func_type(self, func_ty)
-    }
-
-    fn array_type(&mut self, array_ty: wasmparser::ArrayType) -> Result<crate::ArrayType> {
-        utils::array_type(self, array_ty)
-    }
-
-    fn struct_type(&mut self, struct_ty: wasmparser::StructType) -> Result<crate::StructType> {
-        utils::struct_type(self, struct_ty)
-    }
-
-    fn field_type(&mut self, field_ty: wasmparser::FieldType) -> Result<crate::FieldType> {
-        utils::field_type(self, field_ty)
-    }
-
-    fn storage_type(&mut self, storage_ty: wasmparser::StorageType) -> Result<crate::StorageType> {
-        utils::storage_type(self, storage_ty)
-    }
-
-    fn val_type(&mut self, val_ty: wasmparser::ValType) -> Result<crate::ValType> {
-        utils::val_type(self, val_ty)
-    }
-
-    fn ref_type(&mut self, ref_type: wasmparser::RefType) -> Result<crate::RefType> {
-        utils::ref_type(self, ref_type)
-    }
-
-    fn heap_type(&mut self, heap_type: wasmparser::HeapType) -> Result<crate::HeapType> {
-        utils::heap_type(self, heap_type)
-    }
-
-    /// Parses the input `section` given from the `wasmparser` crate and adds
-    /// all the tables to the `tables` section.
-    fn parse_table_section(
-        &mut self,
-        tables: &mut crate::TableSection,
-        section: wasmparser::TableSectionReader<'_>,
-    ) -> Result<()> {
-        utils::parse_table_section(self, tables, section)
-    }
-
-    /// Parses a single [`wasmparser::Table`] and adds it to the `tables` section.
-    fn parse_table(
-        &mut self,
-        tables: &mut crate::TableSection,
-        table: wasmparser::Table<'_>,
-    ) -> Result<()> {
-        utils::parse_table(self, tables, table)
-    }
-
-    fn table_type(&mut self, table_ty: wasmparser::TableType) -> Result<crate::TableType> {
-        utils::table_type(self, table_ty)
-    }
-
-    /// Parses the input `section` given from the `wasmparser` crate and adds
-    /// all the tags to the `tags` section.
-    fn parse_tag_section(
-        &mut self,
-        tags: &mut crate::TagSection,
-        section: wasmparser::TagSectionReader<'_>,
-    ) -> Result<()> {
-        utils::parse_tag_section(self, tags, section)
-    }
-
-    /// Parses the input `section` given from the `wasmparser` crate and adds
-    /// all the exports to the `exports` section.
-    fn parse_export_section(
-        &mut self,
-        exports: &mut crate::ExportSection,
-        section: wasmparser::ExportSectionReader<'_>,
-    ) -> Result<()> {
-        utils::parse_export_section(self, exports, section)
-    }
-
-    fn export_index(&mut self, export: u32) -> u32 {
-        utils::export_index(self, export)
-    }
-
-    /// Parses the single [`wasmparser::Export`] provided and adds it to the
-    /// `exports` section.
-    fn parse_export(&mut self, exports: &mut crate::ExportSection, export: wasmparser::Export<'_>) {
-        utils::parse_export(self, exports, export)
-    }
-
-    /// Parses the input `section` given from the `wasmparser` crate and adds
-    /// all the globals to the `globals` section.
-    fn parse_global_section(
-        &mut self,
-        globals: &mut crate::GlobalSection,
-        section: wasmparser::GlobalSectionReader<'_>,
-    ) -> Result<()> {
-        utils::parse_global_section(self, globals, section)
-    }
-
-    /// Parses the single [`wasmparser::Global`] provided and adds it to the
-    /// `globals` section.
-    fn parse_global(
-        &mut self,
-        globals: &mut crate::GlobalSection,
-        global: wasmparser::Global<'_>,
-    ) -> Result<()> {
-        utils::parse_global(self, globals, global)
-    }
-
-    fn global_type(&mut self, global_ty: wasmparser::GlobalType) -> Result<crate::GlobalType> {
-        utils::global_type(self, global_ty)
-    }
-
-    fn entity_type(&mut self, type_ref: wasmparser::TypeRef) -> Result<crate::EntityType> {
-        utils::entity_type(self, type_ref)
-    }
-
-    /// Parses the input `section` given from the `wasmparser` crate and adds
-    /// all the imports to the `import` section.
-    fn parse_import_section(
-        &mut self,
-        imports: &mut crate::ImportSection,
-        section: wasmparser::ImportSectionReader<'_>,
-    ) -> Result<()> {
-        utils::parse_import_section(self, imports, section)
-    }
-
-    /// Parses the single [`wasmparser::Import`] provided and adds it to the
-    /// `import` section.
-    fn parse_import(
-        &mut self,
-        imports: &mut crate::ImportSection,
-        import: wasmparser::Import<'_>,
-    ) -> Result<()> {
-        utils::parse_import(self, imports, import)
-    }
-
-    /// Parses the input `section` given from the `wasmparser` crate and adds
-    /// all the memories to the `memories` section.
-    fn parse_memory_section(
-        &mut self,
-        memories: &mut crate::MemorySection,
-        section: wasmparser::MemorySectionReader<'_>,
-    ) -> Result<()> {
-        utils::parse_memory_section(self, memories, section)
-    }
-
-    /// Parses the input `section` given from the `wasmparser` crate and adds
-    /// all the functions to the `functions` section.
-    fn parse_function_section(
-        &mut self,
-        functions: &mut crate::FunctionSection,
-        section: wasmparser::FunctionSectionReader<'_>,
-    ) -> Result<()> {
-        utils::parse_function_section(self, functions, section)
-    }
-
-    /// Parses the input `section` given from the `wasmparser` crate and adds
-    /// all the data to the `data` section.
-    fn parse_data_section(
-        &mut self,
-        data: &mut crate::DataSection,
-        section: wasmparser::DataSectionReader<'_>,
-    ) -> Result<()> {
-        utils::parse_data_section(self, data, section)
-    }
-
-    /// Parses a single [`wasmparser::Data`] and adds it to the `data` section.
-    fn parse_data(
-        &mut self,
-        data: &mut crate::DataSection,
-        datum: wasmparser::Data<'_>,
-    ) -> Result<()> {
-        utils::parse_data(self, data, datum)
-    }
-
-    /// Parses the input `section` given from the `wasmparser` crate and adds
-    /// all the elements to the `element` section.
-    fn parse_element_section(
-        &mut self,
-        elements: &mut crate::ElementSection,
-        section: wasmparser::ElementSectionReader<'_>,
-    ) -> Result<()> {
-        utils::parse_element_section(self, elements, section)
-    }
-
-    /// Parses the single [`wasmparser::Element`] provided and adds it to the
-    /// `element` section.
-    fn parse_element(
-        &mut self,
-        elements: &mut crate::ElementSection,
-        element: wasmparser::Element<'_>,
-    ) -> Result<()> {
-        utils::parse_element(self, elements, element)
-    }
-
-    fn table_index(&mut self, table: u32) -> u32 {
-        utils::table_index(self, table)
-    }
-
-    fn global_index(&mut self, global: u32) -> u32 {
-        utils::global_index(self, global)
-    }
-
-    fn data_index(&mut self, data: u32) -> u32 {
-        utils::data_index(self, data)
-    }
-
-    fn element_index(&mut self, element: u32) -> u32 {
-        utils::element_index(self, element)
-    }
-
-    fn const_expr(&mut self, const_expr: wasmparser::ConstExpr) -> Result<crate::ConstExpr> {
-        utils::const_expr(self, const_expr)
-    }
-
-    fn block_type(&mut self, arg: wasmparser::BlockType) -> Result<crate::BlockType> {
-        utils::block_type(self, arg)
-    }
-
-    fn instruction<'a>(&mut self, arg: wasmparser::Operator<'a>) -> Result<crate::Instruction<'a>> {
-        utils::instruction(self, arg)
-    }
-
-    /// Parses the input `section` given from the `wasmparser` crate and adds
-    /// all the code to the `code` section.
-    fn parse_code_section(
-        &mut self,
-        code: &mut crate::CodeSection,
-        section: wasmparser::CodeSectionReader<'_>,
-    ) -> Result<()> {
-        utils::parse_code_section(self, code, section)
-    }
-
-    /// Parses a single [`wasmparser::FunctionBody`] and adds it to the `code` section.
-    fn parse_function_body(
-        &mut self,
-        code: &mut crate::CodeSection,
-        func: wasmparser::FunctionBody<'_>,
-    ) -> Result<()> {
-        utils::parse_function_body(self, code, func)
-    }
-
-    /// Create a new [`crate::Function`] by parsing the locals declarations from the
-    /// provided [`wasmparser::FunctionBody`].
-    fn new_function_with_parsed_locals(
-        &mut self,
-        func: &wasmparser::FunctionBody<'_>,
-    ) -> Result<crate::Function> {
-        utils::new_function_with_parsed_locals(self, func)
-    }
-
-    /// Parses a single instruction from `reader` and adds it to `function`.
-    fn parse_instruction(
-        &mut self,
-        function: &mut crate::Function,
-        reader: &mut wasmparser::OperatorsReader<'_>,
-    ) -> Result<()> {
-        utils::parse_instruction(self, function, reader)
-    }
-
-    fn parse_unknown_section(
-        &mut self,
-        module: &mut crate::Module,
-        id: u8,
-        contents: &[u8],
-    ) -> Result<()> {
-        utils::parse_unknown_section(self, module, id, contents)
-    }
-}
-
-/// Reencodes `wasmparser` into `wasm-encoder` so that the encoded wasm is
-/// identical to the input and can be parsed and encoded again.
-#[derive(Debug)]
-pub struct RoundtripReencoder;
-
-impl Reencode for RoundtripReencoder {}
-
 /// A successful return payload from [`Reencode::parse_core_module_section`].
 ///
 /// On success one of two possible values can be returned, either that more data
@@ -471,6 +464,13 @@ pub enum Chunk {
         consumed: usize,
     },
 }
+
+/// Reencodes `wasmparser` into `wasm-encoder` so that the encoded wasm is
+/// identical to the input and can be parsed and encoded again.
+#[derive(Debug)]
+pub struct RoundtripReencoder;
+
+impl Reencode for RoundtripReencoder {}
 
 #[allow(missing_docs)] // FIXME
 pub mod utils {

--- a/crates/wasm-encoder/src/reencode.rs
+++ b/crates/wasm-encoder/src/reencode.rs
@@ -1,5 +1,9 @@
-#![allow(missing_docs)] // FIXME
+//! Conversions from `wasmparser` to `wasm-encoder` to [`Reencode`] parsed wasm.
+//!
+//! The [`RoundtripReencoder`] allows encoding identical wasm to the parsed
+//! input.
 
+/// An error when re-encoding from `wasmparser` to `wasm-encoder`.
 #[derive(Debug)]
 pub enum Error {
     /// There was a type reference that was canonicalized and no longer
@@ -51,8 +55,10 @@ impl std::error::Error for Error {
     }
 }
 
+/// A result when re-encoding from `wasmparser` to `wasm-encoder`.
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
+#[allow(missing_docs)] // FIXME
 pub trait Reencode {
     fn parse_core_section(
         &mut self,
@@ -439,6 +445,8 @@ pub trait Reencode {
     }
 }
 
+/// Reencodes `wasmparser` into `wasm-encoder` so that the encoded wasm is
+/// identical to the input and can be parsed and encoded again.
 #[derive(Debug)]
 pub struct RoundtripReencoder;
 
@@ -464,6 +472,7 @@ pub enum Chunk {
     },
 }
 
+#[allow(missing_docs)] // FIXME
 pub mod utils {
     use super::{Chunk, Error, Reencode, Result};
 

--- a/crates/wasm-encoder/src/reencode.rs
+++ b/crates/wasm-encoder/src/reencode.rs
@@ -117,6 +117,8 @@ pub trait WasmParserToWasmEncoder {
         utils::abstract_heap_type(self, value)
     }
 
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the types to the `types` section.
     fn parse_type_section<'a>(
         &mut self,
         types: &'a mut crate::TypeSection,
@@ -125,6 +127,7 @@ pub trait WasmParserToWasmEncoder {
         utils::parse_type_section(self, types, section)
     }
 
+    /// Parses a single [`wasmparser::RecGroup`] and adds it to the `types` section.
     fn parse_recursive_type_group<'a>(
         &mut self,
         types: &'a mut crate::TypeSection,
@@ -176,6 +179,8 @@ pub trait WasmParserToWasmEncoder {
         utils::heap_type(self, heap_type)
     }
 
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the tables to the `tables` section.
     fn parse_table_section<'a>(
         &mut self,
         tables: &'a mut crate::TableSection,
@@ -184,6 +189,7 @@ pub trait WasmParserToWasmEncoder {
         utils::parse_table_section(self, tables, section)
     }
 
+    /// Parses a single [`wasmparser::Table`] and adds it to the `tables` section.
     fn parse_table<'a>(
         &mut self,
         tables: &'a mut crate::TableSection,
@@ -196,6 +202,8 @@ pub trait WasmParserToWasmEncoder {
         utils::table_type(self, table_ty)
     }
 
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the tags to the `tags` section.
     fn parse_tag_section<'a>(
         &mut self,
         tags: &'a mut crate::TagSection,
@@ -204,6 +212,8 @@ pub trait WasmParserToWasmEncoder {
         utils::parse_tag_section(self, tags, section)
     }
 
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the exports to the `exports` section.
     fn parse_export_section<'a>(
         &mut self,
         exports: &'a mut crate::ExportSection,
@@ -216,6 +226,8 @@ pub trait WasmParserToWasmEncoder {
         utils::export_index(self, export)
     }
 
+    /// Parses the single [`wasmparser::Export`] provided and adds it to the
+    /// `exports` section.
     fn parse_export<'a>(
         &mut self,
         exports: &'a mut crate::ExportSection,
@@ -224,6 +236,8 @@ pub trait WasmParserToWasmEncoder {
         utils::parse_export(self, exports, export)
     }
 
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the globals to the `globals` section.
     fn parse_global_section<'a>(
         &mut self,
         globals: &'a mut crate::GlobalSection,
@@ -232,6 +246,8 @@ pub trait WasmParserToWasmEncoder {
         utils::parse_global_section(self, globals, section)
     }
 
+    /// Parses the single [`wasmparser::Global`] provided and adds it to the
+    /// `globals` section.
     fn parse_global<'a>(
         &mut self,
         globals: &'a mut crate::GlobalSection,
@@ -248,6 +264,8 @@ pub trait WasmParserToWasmEncoder {
         utils::entity_type(self, type_ref)
     }
 
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the imports to the `import` section.
     fn parse_import_section<'a>(
         &mut self,
         imports: &'a mut crate::ImportSection,
@@ -256,6 +274,8 @@ pub trait WasmParserToWasmEncoder {
         utils::parse_import_section(self, imports, section)
     }
 
+    /// Parses the single [`wasmparser::Import`] provided and adds it to the
+    /// `import` section.
     fn parse_import<'a>(
         &mut self,
         imports: &'a mut crate::ImportSection,
@@ -264,6 +284,8 @@ pub trait WasmParserToWasmEncoder {
         utils::parse_import(self, imports, import)
     }
 
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the memories to the `memories` section.
     fn parse_memory_section<'a>(
         &mut self,
         memories: &'a mut crate::MemorySection,
@@ -272,6 +294,8 @@ pub trait WasmParserToWasmEncoder {
         utils::parse_memory_section(self, memories, section)
     }
 
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the functions to the `functions` section.
     fn parse_function_section<'a>(
         &mut self,
         functions: &'a mut crate::FunctionSection,
@@ -280,6 +304,8 @@ pub trait WasmParserToWasmEncoder {
         utils::parse_function_section(self, functions, section)
     }
 
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the data to the `data` section.
     fn parse_data_section<'a>(
         &mut self,
         data: &'a mut crate::DataSection,
@@ -288,6 +314,7 @@ pub trait WasmParserToWasmEncoder {
         utils::parse_data_section(self, data, section)
     }
 
+    /// Parses a single [`wasmparser::Data`] and adds it to the `data` section.
     fn parse_data<'a>(
         &mut self,
         data: &'a mut crate::DataSection,
@@ -296,6 +323,8 @@ pub trait WasmParserToWasmEncoder {
         utils::parse_data(self, data, datum)
     }
 
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the elements to the `element` section.
     fn parse_element_section<'a>(
         &mut self,
         elements: &'a mut crate::ElementSection,
@@ -304,6 +333,8 @@ pub trait WasmParserToWasmEncoder {
         utils::parse_element_section(self, elements, section)
     }
 
+    /// Parses the single [`wasmparser::Element`] provided and adds it to the
+    /// `element` section.
     fn parse_element<'a>(
         &mut self,
         elements: &'a mut crate::ElementSection,
@@ -340,6 +371,8 @@ pub trait WasmParserToWasmEncoder {
         utils::instruction(self, arg)
     }
 
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the code to the `code` section.
     fn parse_code_section<'a>(
         &mut self,
         code: &'a mut crate::CodeSection,
@@ -348,6 +381,7 @@ pub trait WasmParserToWasmEncoder {
         utils::parse_code_section(self, code, section)
     }
 
+    /// Parses a single [`wasmparser::FunctionBody`] and adds it to the `code` section.
     fn parse_function_body<'a>(
         &mut self,
         code: &'a mut crate::CodeSection,
@@ -356,6 +390,8 @@ pub trait WasmParserToWasmEncoder {
         utils::parse_function_body(self, code, func)
     }
 
+    /// Create a new [`crate::Function`] by parsing the locals declarations from the
+    /// provided [`wasmparser::FunctionBody`].
     fn new_function_with_parsed_locals(
         &mut self,
         func: &wasmparser::FunctionBody<'_>,
@@ -363,6 +399,7 @@ pub trait WasmParserToWasmEncoder {
         utils::new_function_with_parsed_locals(self, func)
     }
 
+    /// Parses a single instruction from `reader` and adds it to `function`.
     fn parse_instruction<'a>(
         &mut self,
         function: &'a mut crate::Function,
@@ -676,6 +713,8 @@ pub mod utils {
         }
     }
 
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the types to the `types` section.
     pub fn parse_type_section<'a>(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
         types: &'a mut crate::TypeSection,
@@ -687,6 +726,7 @@ pub mod utils {
         Ok(types)
     }
 
+    /// Parses a single [`wasmparser::RecGroup`] and adds it to the `types` section.
     pub fn parse_recursive_type_group<'a>(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
         types: &'a mut crate::TypeSection,
@@ -836,6 +876,8 @@ pub mod utils {
         })
     }
 
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the tables to the `tables` section.
     pub fn parse_table_section<'a>(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
         tables: &'a mut crate::TableSection,
@@ -847,6 +889,7 @@ pub mod utils {
         Ok(tables)
     }
 
+    /// Parses a single [`wasmparser::Table`] and adds it to the `tables` section.
     pub fn parse_table<'a>(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
         tables: &'a mut crate::TableSection,
@@ -876,6 +919,8 @@ pub mod utils {
         })
     }
 
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the tags to the `tags` section.
     pub fn parse_tag_section<'a>(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
         tags: &'a mut crate::TagSection,
@@ -888,6 +933,8 @@ pub mod utils {
         Ok(tags)
     }
 
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the exports to the `exports` section.
     pub fn parse_export_section<'a>(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
         exports: &'a mut crate::ExportSection,
@@ -906,6 +953,8 @@ pub mod utils {
         export
     }
 
+    /// Parses the single [`wasmparser::Export`] provided and adds it to the
+    /// `exports` section.
     pub fn parse_export<'a>(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
         exports: &'a mut crate::ExportSection,
@@ -918,6 +967,8 @@ pub mod utils {
         )
     }
 
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the globals to the `globals` section.
     pub fn parse_global_section<'a>(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
         globals: &'a mut crate::GlobalSection,
@@ -929,6 +980,8 @@ pub mod utils {
         Ok(globals)
     }
 
+    /// Parses the single [`wasmparser::Global`] provided and adds it to the
+    /// `globals` section.
     pub fn parse_global<'a>(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
         globals: &'a mut crate::GlobalSection,
@@ -965,6 +1018,8 @@ pub mod utils {
         })
     }
 
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the imports to the `import` section.
     pub fn parse_import_section<'a>(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
         imports: &'a mut crate::ImportSection,
@@ -976,6 +1031,8 @@ pub mod utils {
         Ok(imports)
     }
 
+    /// Parses the single [`wasmparser::Import`] provided and adds it to the
+    /// `import` section.
     pub fn parse_import<'a>(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
         imports: &'a mut crate::ImportSection,
@@ -989,6 +1046,8 @@ pub mod utils {
         Ok(imports)
     }
 
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the memories to the `memories` section.
     pub fn parse_memory_section<'a>(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
         memories: &'a mut crate::MemorySection,
@@ -1001,6 +1060,8 @@ pub mod utils {
         Ok(memories)
     }
 
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the functions to the `functions` section.
     pub fn parse_function_section<'a>(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
         functions: &'a mut crate::FunctionSection,
@@ -1012,6 +1073,8 @@ pub mod utils {
         Ok(functions)
     }
 
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the data to the `data` section.
     pub fn parse_data_section<'a>(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
         data: &'a mut crate::DataSection,
@@ -1023,6 +1086,7 @@ pub mod utils {
         Ok(data)
     }
 
+    /// Parses a single [`wasmparser::Data`] and adds it to the `data` section.
     pub fn parse_data<'a>(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
         data: &'a mut crate::DataSection,
@@ -1041,6 +1105,8 @@ pub mod utils {
         }
     }
 
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the elements to the `element` section.
     pub fn parse_element_section<'a>(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
         elements: &'a mut crate::ElementSection,
@@ -1052,6 +1118,8 @@ pub mod utils {
         Ok(elements)
     }
 
+    /// Parses the single [`wasmparser::Element`] provided and adds it to the
+    /// `element` section.
     pub fn parse_element<'a>(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
         elements: &'a mut crate::ElementSection,
@@ -1259,6 +1327,8 @@ pub mod utils {
         wasmparser::for_each_operator!(translate)
     }
 
+    /// Parses the input `section` given from the `wasmparser` crate and adds
+    /// all the code to the `code` section.
     pub fn parse_code_section<'a>(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
         code: &'a mut crate::CodeSection,
@@ -1270,6 +1340,7 @@ pub mod utils {
         Ok(code)
     }
 
+    /// Parses a single [`wasmparser::FunctionBody`] and adds it to the `code` section.
     pub fn parse_function_body<'a>(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
         code: &'a mut crate::CodeSection,
@@ -1283,6 +1354,8 @@ pub mod utils {
         Ok(code.function(&f))
     }
 
+    /// Create a new [`crate::Function`] by parsing the locals declarations from the
+    /// provided [`wasmparser::FunctionBody`].
     pub fn new_function_with_parsed_locals(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
         func: &wasmparser::FunctionBody<'_>,
@@ -1295,6 +1368,7 @@ pub mod utils {
         Ok(crate::Function::new(locals))
     }
 
+    /// Parses a single instruction from `reader` and adds it to `function`.
     pub fn parse_instruction<'a>(
         reencoder: &mut (impl ?Sized + WasmParserToWasmEncoder),
         function: &'a mut crate::Function,
@@ -1304,5 +1378,193 @@ pub mod utils {
             function
                 .instruction(&reencoder.instruction(reader.read().map_err(Error::ParseError)?)?),
         )
+    }
+}
+
+impl From<wasmparser::PrimitiveValType> for crate::PrimitiveValType {
+    fn from(ty: wasmparser::PrimitiveValType) -> Self {
+        RoundtripReencoder.component_primitive_val_type(ty)
+    }
+}
+
+impl From<wasmparser::MemArg> for crate::MemArg {
+    fn from(arg: wasmparser::MemArg) -> Self {
+        RoundtripReencoder.mem_arg(arg)
+    }
+}
+
+impl From<wasmparser::Ordering> for crate::Ordering {
+    fn from(arg: wasmparser::Ordering) -> Self {
+        RoundtripReencoder.ordering(arg)
+    }
+}
+
+impl TryFrom<wasmparser::BlockType> for crate::BlockType {
+    type Error = Error;
+
+    fn try_from(arg: wasmparser::BlockType) -> Result<Self, Self::Error> {
+        RoundtripReencoder.block_type(arg)
+    }
+}
+
+impl<'a> TryFrom<wasmparser::Operator<'a>> for crate::Instruction<'a> {
+    type Error = Error;
+
+    fn try_from(arg: wasmparser::Operator<'a>) -> Result<Self, Self::Error> {
+        RoundtripReencoder.instruction(arg)
+    }
+}
+
+impl From<wasmparser::Catch> for crate::Catch {
+    fn from(arg: wasmparser::Catch) -> Self {
+        RoundtripReencoder.catch(arg)
+    }
+}
+
+impl<'a> TryFrom<wasmparser::ConstExpr<'a>> for crate::ConstExpr {
+    type Error = Error;
+
+    fn try_from(const_expr: wasmparser::ConstExpr) -> Result<Self, Self::Error> {
+        RoundtripReencoder.const_expr(const_expr)
+    }
+}
+
+impl<'a> From<wasmparser::CustomSectionReader<'a>> for crate::CustomSection<'a> {
+    fn from(section: wasmparser::CustomSectionReader<'a>) -> Self {
+        RoundtripReencoder.custom_section(section)
+    }
+}
+
+impl From<wasmparser::ExternalKind> for crate::ExportKind {
+    fn from(external_kind: wasmparser::ExternalKind) -> Self {
+        RoundtripReencoder.export_kind(external_kind)
+    }
+}
+
+impl TryFrom<wasmparser::GlobalType> for crate::GlobalType {
+    type Error = Error;
+
+    fn try_from(global_ty: wasmparser::GlobalType) -> Result<Self, Self::Error> {
+        RoundtripReencoder.global_type(global_ty)
+    }
+}
+
+impl TryFrom<wasmparser::TypeRef> for crate::EntityType {
+    type Error = Error;
+
+    fn try_from(type_ref: wasmparser::TypeRef) -> Result<Self, Self::Error> {
+        RoundtripReencoder.entity_type(type_ref)
+    }
+}
+
+impl From<wasmparser::MemoryType> for crate::MemoryType {
+    fn from(memory_ty: wasmparser::MemoryType) -> Self {
+        RoundtripReencoder.memory_type(memory_ty)
+    }
+}
+
+impl TryFrom<wasmparser::TableType> for crate::TableType {
+    type Error = Error;
+
+    fn try_from(table_ty: wasmparser::TableType) -> Result<Self, Self::Error> {
+        RoundtripReencoder.table_type(table_ty)
+    }
+}
+
+impl From<wasmparser::TagKind> for crate::TagKind {
+    fn from(kind: wasmparser::TagKind) -> Self {
+        RoundtripReencoder.tag_kind(kind)
+    }
+}
+
+impl From<wasmparser::TagType> for crate::TagType {
+    fn from(tag_ty: wasmparser::TagType) -> Self {
+        RoundtripReencoder.tag_type(tag_ty)
+    }
+}
+
+impl TryFrom<wasmparser::SubType> for crate::SubType {
+    type Error = Error;
+
+    fn try_from(sub_ty: wasmparser::SubType) -> Result<Self, Self::Error> {
+        RoundtripReencoder.sub_type(sub_ty)
+    }
+}
+
+impl TryFrom<wasmparser::CompositeType> for crate::CompositeType {
+    type Error = Error;
+
+    fn try_from(composite_ty: wasmparser::CompositeType) -> Result<Self, Self::Error> {
+        RoundtripReencoder.composite_type(composite_ty)
+    }
+}
+
+impl TryFrom<wasmparser::FuncType> for crate::FuncType {
+    type Error = Error;
+
+    fn try_from(func_ty: wasmparser::FuncType) -> Result<Self, Self::Error> {
+        RoundtripReencoder.func_type(func_ty)
+    }
+}
+
+impl TryFrom<wasmparser::ArrayType> for crate::ArrayType {
+    type Error = Error;
+
+    fn try_from(array_ty: wasmparser::ArrayType) -> Result<Self, Self::Error> {
+        RoundtripReencoder.array_type(array_ty)
+    }
+}
+
+impl TryFrom<wasmparser::StructType> for crate::StructType {
+    type Error = Error;
+
+    fn try_from(struct_ty: wasmparser::StructType) -> Result<Self, Self::Error> {
+        RoundtripReencoder.struct_type(struct_ty)
+    }
+}
+
+impl TryFrom<wasmparser::FieldType> for crate::FieldType {
+    type Error = Error;
+
+    fn try_from(field_ty: wasmparser::FieldType) -> Result<Self, Self::Error> {
+        RoundtripReencoder.field_type(field_ty)
+    }
+}
+
+impl TryFrom<wasmparser::StorageType> for crate::StorageType {
+    type Error = Error;
+
+    fn try_from(storage_ty: wasmparser::StorageType) -> Result<Self, Self::Error> {
+        RoundtripReencoder.storage_type(storage_ty)
+    }
+}
+
+impl TryFrom<wasmparser::ValType> for crate::ValType {
+    type Error = Error;
+
+    fn try_from(val_ty: wasmparser::ValType) -> Result<Self, Self::Error> {
+        RoundtripReencoder.val_type(val_ty)
+    }
+}
+
+impl TryFrom<wasmparser::RefType> for crate::RefType {
+    type Error = Error;
+
+    fn try_from(ref_type: wasmparser::RefType) -> Result<Self, Self::Error> {
+        RoundtripReencoder.ref_type(ref_type)
+    }
+}
+
+impl TryFrom<wasmparser::HeapType> for crate::HeapType {
+    type Error = Error;
+
+    fn try_from(heap_type: wasmparser::HeapType) -> Result<Self, Self::Error> {
+        crate::reencode::utils::heap_type(&mut crate::reencode::RoundtripReencoder, heap_type)
+    }
+}
+
+impl From<wasmparser::AbstractHeapType> for crate::AbstractHeapType {
+    fn from(value: wasmparser::AbstractHeapType) -> Self {
+        RoundtripReencoder.abstract_heap_type(value)
     }
 }

--- a/crates/wasm-encoder/src/reencode.rs
+++ b/crates/wasm-encoder/src/reencode.rs
@@ -497,7 +497,13 @@ pub mod utils {
                     reencoder.parse_element_section(&mut elements, section)?;
                     module_section_flush_codes(module, &elements, &mut codes);
                 }
-                wasmparser::Payload::DataCountSection { .. } => (),
+                wasmparser::Payload::DataCountSection { count, .. } => {
+                    module_section_flush_codes(
+                        module,
+                        &crate::DataCountSection { count },
+                        &mut codes,
+                    );
+                }
                 wasmparser::Payload::DataSection(section) => {
                     let mut data = crate::DataSection::new();
                     reencoder.parse_data_section(&mut data, section)?;

--- a/crates/wasmparser/src/parser.rs
+++ b/crates/wasmparser/src/parser.rs
@@ -71,7 +71,7 @@ enum State {
 pub enum Chunk<'a> {
     /// This can be returned at any time and indicates that more data is needed
     /// to proceed with parsing. Zero bytes were consumed from the input to
-    /// [`Parser::parse`]. The `usize` value here is a hint as to how many more
+    /// [`Parser::parse`]. The `u64` value here is a hint as to how many more
     /// bytes are needed to continue parsing.
     NeedMoreData(u64),
 

--- a/crates/wasmparser/src/readers/core/tables.rs
+++ b/crates/wasmparser/src/readers/core/tables.rs
@@ -20,7 +20,7 @@ pub type TableSectionReader<'a> = SectionLimited<'a, Table<'a>>;
 
 /// Type information about a table defined in the table section of a WebAssembly
 /// module.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Table<'a> {
     /// The type of this table, including its element type and its limits.
     pub ty: TableType,
@@ -29,7 +29,7 @@ pub struct Table<'a> {
 }
 
 /// Different modes of initializing a table.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum TableInit<'a> {
     /// The table is initialized to all null elements.
     RefNull,

--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -4,6 +4,7 @@ use indexmap::{IndexMap, IndexSet};
 use std::{
     borrow::Cow,
     collections::{HashMap, HashSet},
+    convert::Infallible,
     mem,
     ops::Deref,
 };
@@ -1054,6 +1055,8 @@ struct Encoder {
 }
 
 impl Reencode for Encoder {
+    type Error = Infallible;
+
     fn type_index(&mut self, i: u32) -> u32 {
         self.types.remap(i)
     }

--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -7,6 +7,7 @@ use std::{
     mem,
     ops::Deref,
 };
+use wasm_encoder::reencode::Reencode;
 use wasm_encoder::{Encode, EntityType, Instruction, RawCustomSection};
 use wasmparser::*;
 
@@ -552,10 +553,8 @@ impl<'a> Module<'a> {
         for (i, ty) in self.live_types() {
             map.types.push(i);
 
-            types.function(
-                ty.params().iter().map(|t| map.valty(*t)),
-                ty.results().iter().map(|t| map.valty(*t)),
-            );
+            let ty = map.func_type(ty.clone())?;
+            types.func_type(&ty);
 
             // Keep track of the "empty type" to see if we can reuse an
             // existing one or one needs to be injected if a `start`
@@ -568,7 +567,7 @@ impl<'a> Module<'a> {
         let mut num_memories = 0;
         for (i, mem) in self.live_memories() {
             map.memories.push(i);
-            let ty = mem.ty.into();
+            let ty = map.memory_type(mem.ty);
             match &mem.def {
                 Definition::Import(m, n) => {
                     imports.import(m, n, ty);
@@ -582,12 +581,7 @@ impl<'a> Module<'a> {
 
         for (i, table) in self.live_tables() {
             map.tables.push(i);
-            let ty = wasm_encoder::TableType {
-                minimum: table.ty.initial,
-                maximum: table.ty.maximum,
-                element_type: map.refty(table.ty.element_type),
-                table64: table.ty.table64,
-            };
+            let ty = map.table_type(table.ty.clone())?;
             match &table.def {
                 Definition::Import(m, n) => {
                     imports.import(m, n, ty);
@@ -600,19 +594,14 @@ impl<'a> Module<'a> {
 
         for (i, global) in self.live_globals() {
             map.globals.push(i);
-            let ty = wasm_encoder::GlobalType {
-                val_type: map.valty(global.ty.content_type),
-                mutable: global.ty.mutable,
-                shared: global.ty.shared,
-            };
+            let ty = map.global_type(global.ty.clone())?;
             match &global.def {
                 Definition::Import(m, n) => {
                     imports.import(m, n, ty);
                 }
                 Definition::Local(init) => {
-                    let mut bytes = map.operators(init.get_binary_reader())?;
-                    assert_eq!(bytes.pop(), Some(0xb));
-                    globals.global(ty, &wasm_encoder::ConstExpr::raw(bytes));
+                    let init = &map.const_expr(init.clone())?;
+                    globals.global(ty, &init);
                 }
             }
         }
@@ -743,26 +732,27 @@ impl<'a> Module<'a> {
             .collect::<HashSet<_>>();
 
         for (i, func) in self.live_funcs() {
-            let mut body = match &func.def {
+            let body = match &func.def {
                 Definition::Import(..) => continue,
-                Definition::Local(body) => body.get_binary_reader(),
+                Definition::Local(body) => body,
             };
-            let mut locals = Vec::new();
-            for _ in 0..body.read_var_u32()? {
-                let cnt = body.read_var_u32()?;
-                let ty = body.read()?;
-                locals.push((cnt, map.valty(ty)));
+
+            match (lazy_stack_init_index, exported_funcs.contains(&i)) {
+                // Prepend an `allocate_stack` call to all exports if we're
+                // lazily allocating the stack.
+                (Some(lazy_stack_init_index), true) => {
+                    let mut func = map.new_function_with_parsed_locals(&body)?;
+                    func.instruction(&Instruction::Call(lazy_stack_init_index));
+                    let mut reader = body.get_operators_reader()?;
+                    while !reader.eof() {
+                        map.parse_instruction(&mut func, &mut reader)?;
+                    }
+                    code.function(&func);
+                }
+                _ => {
+                    map.parse_function_body(&mut code, body.clone())?;
+                }
             }
-            // Prepend an `allocate_stack` call to all exports if we're lazily allocating the stack.
-            if let (Some(lazy_stack_init_index), true) =
-                (lazy_stack_init_index, exported_funcs.contains(&i))
-            {
-                Instruction::Call(lazy_stack_init_index).encode(&mut map.buf);
-            }
-            let bytes = map.operators(body)?;
-            let mut func = wasm_encoder::Function::new(locals);
-            func.raw(bytes);
-            code.function(&func);
         }
 
         if lazy_stack_init_index.is_some() {
@@ -1061,176 +1051,24 @@ struct Encoder {
     memories: Remap,
     globals: Remap,
     tables: Remap,
-    buf: Vec<u8>,
 }
 
-impl Encoder {
-    fn operators(&mut self, mut reader: BinaryReader<'_>) -> Result<Vec<u8>> {
-        while !reader.eof() {
-            reader.visit_operator(self)?;
-        }
-        Ok(mem::take(&mut self.buf))
+impl Reencode for Encoder {
+    fn type_index(&mut self, i: u32) -> u32 {
+        self.types.remap(i)
     }
-
-    fn memarg(&self, ty: MemArg) -> wasm_encoder::MemArg {
-        wasm_encoder::MemArg {
-            offset: ty.offset,
-            align: ty.align.into(),
-            memory_index: self.memories.remap(ty.memory),
-        }
+    fn function_index(&mut self, i: u32) -> u32 {
+        self.funcs.remap(i)
     }
-
-    fn ordering(&self, ord: Ordering) -> wasm_encoder::Ordering {
-        match ord {
-            Ordering::AcqRel => wasm_encoder::Ordering::AcqRel,
-            Ordering::SeqCst => wasm_encoder::Ordering::SeqCst,
-        }
+    fn memory_index(&mut self, i: u32) -> u32 {
+        self.memories.remap(i)
     }
-
-    fn blockty(&self, ty: BlockType) -> wasm_encoder::BlockType {
-        match ty {
-            BlockType::Empty => wasm_encoder::BlockType::Empty,
-            BlockType::Type(ty) => wasm_encoder::BlockType::Result(self.valty(ty)),
-            BlockType::FuncType(ty) => wasm_encoder::BlockType::FunctionType(self.types.remap(ty)),
-        }
+    fn global_index(&mut self, i: u32) -> u32 {
+        self.globals.remap(i)
     }
-
-    fn valty(&self, ty: wasmparser::ValType) -> wasm_encoder::ValType {
-        match ty {
-            wasmparser::ValType::I32 => wasm_encoder::ValType::I32,
-            wasmparser::ValType::I64 => wasm_encoder::ValType::I64,
-            wasmparser::ValType::F32 => wasm_encoder::ValType::F32,
-            wasmparser::ValType::F64 => wasm_encoder::ValType::F64,
-            wasmparser::ValType::V128 => wasm_encoder::ValType::V128,
-            wasmparser::ValType::Ref(rt) => wasm_encoder::ValType::Ref(self.refty(rt)),
-        }
+    fn table_index(&mut self, i: u32) -> u32 {
+        self.tables.remap(i)
     }
-
-    fn refty(&self, rt: wasmparser::RefType) -> wasm_encoder::RefType {
-        wasm_encoder::RefType {
-            nullable: rt.is_nullable(),
-            heap_type: self.heapty(rt.heap_type()),
-        }
-    }
-
-    fn heapty(&self, ht: wasmparser::HeapType) -> wasm_encoder::HeapType {
-        match ht {
-            HeapType::Concrete(idx) => {
-                wasm_encoder::HeapType::Concrete(self.types.remap(idx.as_module_index().unwrap()))
-            }
-            HeapType::Abstract { shared, ty } => {
-                let ty = ty.into();
-                wasm_encoder::HeapType::Abstract { shared, ty }
-            }
-        }
-    }
-}
-
-// This is a helper macro to translate all `wasmparser` instructions to
-// `wasm-encoder` instructions without having to list out every single
-// instruction itself.
-//
-// The general goal of this macro is to have O(unique instruction payload)
-// number of cases while also simultaneously adapting between the styles of
-// wasmparser and wasm-encoder.
-macro_rules! define_encode {
-    ($(@$p:ident $op:ident $({ $($arg:ident: $argty:ty),* })? => $visit:ident)*) => {
-        $(
-            fn $visit(&mut self $(, $($arg: $argty),*)?)  {
-                #[allow(unused_imports)]
-                use wasm_encoder::Instruction::*;
-                $(
-                    $(
-                        let $arg = define_encode!(map self $arg $arg);
-                    )*
-                )?
-                let insn = define_encode!(mk $op $($($arg)*)?);
-                insn.encode(&mut self.buf);
-            }
-        )*
-    };
-
-    // No-payload instructions are named the same in wasmparser as they are in
-    // wasm-encoder
-    (mk $op:ident) => ($op);
-
-    // Instructions which need "special care" to map from wasmparser to
-    // wasm-encoder
-    (mk BrTable $arg:ident) => ({
-        BrTable($arg.0, $arg.1)
-    });
-    (mk TryTable $try_table:ident) => ({
-        let _ = $try_table;
-        unimplemented_try_table()
-    });
-    (mk I32Const $v:ident) => (I32Const($v));
-    (mk I64Const $v:ident) => (I64Const($v));
-    (mk F32Const $v:ident) => (F32Const(f32::from_bits($v.bits())));
-    (mk F64Const $v:ident) => (F64Const(f64::from_bits($v.bits())));
-    (mk V128Const $v:ident) => (V128Const($v.i128()));
-
-    // Catch-all for the translation of one payload argument which is typically
-    // represented as a tuple-enum in wasm-encoder.
-    (mk $op:ident $arg:ident) => ($op($arg));
-
-    // Catch-all of everything else where the wasmparser fields are simply
-    // translated to wasm-encoder fields.
-    (mk $op:ident $($arg:ident)*) => ($op { $($arg),* });
-
-    // Individual cases of mapping one argument type to another, similar to the
-    // `define_visit` macro above.
-    (map $self:ident $arg:ident memarg) => {$self.memarg($arg)};
-    (map $self:ident $arg:ident ordering) => {$self.ordering($arg)};
-    (map $self:ident $arg:ident blockty) => {$self.blockty($arg)};
-    (map $self:ident $arg:ident hty) => {$self.heapty($arg)};
-    (map $self:ident $arg:ident from_ref_type) => {$self.refty($arg)};
-    (map $self:ident $arg:ident to_ref_type) => {$self.refty($arg)};
-    (map $self:ident $arg:ident tag_index) => {$arg};
-    (map $self:ident $arg:ident relative_depth) => {$arg};
-    (map $self:ident $arg:ident function_index) => {$self.funcs.remap($arg)};
-    (map $self:ident $arg:ident global_index) => {$self.globals.remap($arg)};
-    (map $self:ident $arg:ident mem) => {$self.memories.remap($arg)};
-    (map $self:ident $arg:ident src_mem) => {$self.memories.remap($arg)};
-    (map $self:ident $arg:ident dst_mem) => {$self.memories.remap($arg)};
-    (map $self:ident $arg:ident table) => {$self.tables.remap($arg)};
-    (map $self:ident $arg:ident table_index) => {$self.tables.remap($arg)};
-    (map $self:ident $arg:ident src_table) => {$self.tables.remap($arg)};
-    (map $self:ident $arg:ident dst_table) => {$self.tables.remap($arg)};
-    (map $self:ident $arg:ident type_index) => {$self.types.remap($arg)};
-    (map $self:ident $arg:ident array_type_index) => {$self.types.remap($arg)};
-    (map $self:ident $arg:ident array_type_index_dst) => {$self.types.remap($arg)};
-    (map $self:ident $arg:ident array_type_index_src) => {$self.types.remap($arg)};
-    (map $self:ident $arg:ident struct_type_index) => {$self.types.remap($arg)};
-    (map $self:ident $arg:ident ty) => {$self.valty($arg)};
-    (map $self:ident $arg:ident local_index) => {$arg};
-    (map $self:ident $arg:ident lane) => {$arg};
-    (map $self:ident $arg:ident lanes) => {$arg};
-    (map $self:ident $arg:ident elem_index) => {$arg};
-    (map $self:ident $arg:ident data_index) => {$arg};
-    (map $self:ident $arg:ident array_elem_index) => {$arg};
-    (map $self:ident $arg:ident array_data_index) => {$arg};
-    (map $self:ident $arg:ident table_byte) => {$arg};
-    (map $self:ident $arg:ident mem_byte) => {$arg};
-    (map $self:ident $arg:ident value) => {$arg};
-    (map $self:ident $arg:ident array_size) => {$arg};
-    (map $self:ident $arg:ident field_index) => {$arg};
-    (map $self:ident $arg:ident from_type_nullable) => {$arg};
-    (map $self:ident $arg:ident to_type_nullable) => {$arg};
-    (map $self:ident $arg:ident try_table) => {$arg};
-    (map $self:ident $arg:ident targets) => ((
-        $arg.targets().map(|i| i.unwrap()).collect::<Vec<_>>().into(),
-        $arg.default(),
-    ));
-}
-
-fn unimplemented_try_table() -> wasm_encoder::Instruction<'static> {
-    unimplemented!()
-}
-
-impl<'a> VisitOperator<'a> for Encoder {
-    type Output = ();
-
-    wasmparser::for_each_operator!(define_encode);
 }
 
 // Minimal definition of a bit vector necessary for the liveness calculations

--- a/fuzz/fuzz_targets/run.rs
+++ b/fuzz/fuzz_targets/run.rs
@@ -79,4 +79,5 @@ run_fuzzers! {
     print: unstructured,
     roundtrip: string,
     text_parser: string,
+    reencode: unstructured,
 }

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -7,6 +7,7 @@ pub mod incremental_parse;
 pub mod mutate;
 pub mod no_traps;
 pub mod print;
+pub mod reencode;
 pub mod roundtrip;
 pub mod roundtrip_wit;
 pub mod text_parser;

--- a/fuzz/src/reencode.rs
+++ b/fuzz/src/reencode.rs
@@ -1,0 +1,16 @@
+use arbitrary::{Result, Unstructured};
+use wasm_encoder::reencode::{Reencode, RoundtripReencoder};
+
+pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
+    let (module1, _) = super::generate_valid_module(u, |_, _| Ok(()))?;
+
+    let mut module2 = Default::default();
+    RoundtripReencoder
+        .parse_core_module(&mut module2, wasmparser::Parser::new(0), &module1)
+        .unwrap();
+
+    let module2 = module2.finish();
+    assert_eq!(module1, module2);
+
+    Ok(())
+}


### PR DESCRIPTION
Progress towards #1588, follow-up to #1627 

Thanks to @alexcrichton for coming up with the design!

This PR provides a new module, `reencoder`, which contains the `WasmParserToWasmEncoder` trait with utility functions to convert between `wasmparser` and `wasm-encoder` types. Every default implementation is also provided as a free function in the `reencoder::utils` module. In this PR, only types that are needed to re-encode core WASM modules are included, but future PRs could extend this.

This PR also does not yet replace similar functionality in other wasm-tools crates, e.g. the `wasm_mutate::mutators::translate::Translator` trait, which could in follow-up PRs be cleaned up to use this general-purpose re-encoder infrastructure instead.

Utility conversion functions added in #1627 are now implemented in terms of the `RoundtripReencoder` all-default implementation of the `WasmParserToWasmEncoder`. While most interfaces stay the same (and #1627 has not been published yet), some methods now return `Result`s.

## Unresolved questions and TODOs

- [x] How should user errors be handled? At the moment, many trait methods cannot error, and the others can only return pre-defined errors. We could add an extra variant to the `reencoder::Error` enum and make every method fallible if that's preferable.
- [x] Should the utility methods be monomorphised or use dynamic dispatch?
- [ ] Add documentation (I'd appreciate some help with this)