### PR TITLE
Support `include` statements in `wasm-parser`

### DIFF
--- a/crates/wit-encoder/src/include.rs
+++ b/crates/wit-encoder/src/include.rs
@@ -6,7 +6,7 @@ use crate::{Ident, Render};
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Include {
     use_path: Ident,
-    include_names_list: Vec<String>,
+    include_names_list: Vec<(String, String)>,
 }
 
 impl Include {
@@ -16,11 +16,29 @@ impl Include {
             include_names_list: vec![],
         }
     }
+
+    pub fn with(&mut self, id: &str, alias: &str) {
+        self.include_names_list
+            .push((id.to_string(), alias.to_string()));
+    }
 }
 
 impl Render for Include {
     fn render(&self, f: &mut fmt::Formatter<'_>, opts: &crate::RenderOpts) -> fmt::Result {
-        write!(f, "{}include {};\n", opts.spaces(), self.use_path)?;
+        match self.include_names_list.len() {
+            0 => write!(f, "{}include {};\n", opts.spaces(), self.use_path)?,
+            len => {
+                write!(f, "{}include {} with {{ ", opts.spaces(), self.use_path)?;
+                for (i, (id, alias)) in self.include_names_list.iter().enumerate() {
+                    if i == len - 1 {
+                        write!(f, "{id} as {alias}")?;
+                    } else {
+                        write!(f, "{id} as {alias}, ")?;
+                    }
+                }
+                write!(f, " }};\n")?;
+            }
+        }
         Ok(())
     }
 }

--- a/crates/wit-encoder/src/world.rs
+++ b/crates/wit-encoder/src/world.rs
@@ -52,8 +52,8 @@ impl World {
     pub fn function_export(&mut self, value: StandaloneFunc) {
         self.item(WorldItem::function_export(value));
     }
-    pub fn include(&mut self, value: impl Into<Ident>) {
-        self.item(WorldItem::include(value));
+    pub fn include(&mut self, include: Include) {
+        self.item(WorldItem::Include(include));
     }
 
     /// Set the documentation

--- a/crates/wit-encoder/tests/include-aliases.rs
+++ b/crates/wit-encoder/tests/include-aliases.rs
@@ -1,0 +1,68 @@
+use pretty_assertions::assert_eq;
+use wit_encoder::{Include, Package, PackageName, StandaloneFunc, World};
+
+const PACKAGE: &str = indoc::indoc! {"
+    package foo:foo;
+
+    world foo {
+      import a: func();
+    }
+
+    world bar {
+      import a: func();
+      import b: func();
+    }
+
+    world baz {
+      import a: func();
+      import b: func();
+      import c: func();
+    }
+
+    world quux {
+      include foo with { a as b };
+      include bar with { a as b, b as c };
+      include baz with { a as b, b as c, c as d };
+    }
+"};
+
+#[test]
+fn concrete_types() {
+    let mut package = Package::new(PackageName::new("foo", "foo", None));
+
+    let mut world = World::new("foo");
+    world.function_import(StandaloneFunc::new("a"));
+    package.world(world);
+
+    let mut world = World::new("bar");
+    world.function_import(StandaloneFunc::new("a"));
+    world.function_import(StandaloneFunc::new("b"));
+    package.world(world);
+
+    let mut world = World::new("baz");
+    world.function_import(StandaloneFunc::new("a"));
+    world.function_import(StandaloneFunc::new("b"));
+    world.function_import(StandaloneFunc::new("c"));
+    package.world(world);
+
+    let mut world = World::new("quux");
+
+    let mut include = Include::new("foo");
+    include.with("a", "b");
+    world.include(include);
+
+    let mut include = Include::new("bar");
+    include.with("a", "b");
+    include.with("b", "c");
+    world.include(include);
+
+    let mut include = Include::new("baz");
+    include.with("a", "b");
+    include.with("b", "c");
+    include.with("c", "d");
+    world.include(include);
+
+    package.world(world);
+
+    assert_eq!(package.to_string(), PACKAGE);
+}

--- a/crates/wit-encoder/tests/include-reps.rs
+++ b/crates/wit-encoder/tests/include-reps.rs
@@ -1,5 +1,5 @@
 use pretty_assertions::assert_eq;
-use wit_encoder::{Interface, Package, PackageName, World};
+use wit_encoder::{Include, Interface, Package, PackageName, World};
 
 const PACKAGE: &str = indoc::indoc! {"
     package foo:foo;
@@ -33,9 +33,9 @@ fn concrete_types() {
     package.world(world);
 
     let mut world = World::new("foo");
-    world.include("bar");
-    world.include("bar");
-    world.include("bar");
+    world.include(Include::new("bar"));
+    world.include(Include::new("bar"));
+    world.include(Include::new("bar"));
     package.world(world);
 
     assert_eq!(package.to_string(), PACKAGE);

--- a/crates/wit-encoder/tests/kebab-name-include-with.rs
+++ b/crates/wit-encoder/tests/kebab-name-include-with.rs
@@ -1,0 +1,41 @@
+use pretty_assertions::assert_eq;
+use wit_encoder::{Include, Package, PackageName, StandaloneFunc, World};
+
+const PACKAGE: &str = indoc::indoc! {"
+    package foo:foo;
+
+    world foo {
+      import a: func();
+    }
+
+    world bar {
+      import a: func();
+    }
+
+    world baz {
+      include bar;
+      include foo with { a as b };
+    }
+"};
+
+#[test]
+fn concrete_types() {
+    let mut package = Package::new(PackageName::new("foo", "foo", None));
+
+    let mut world = World::new("foo");
+    world.function_import(StandaloneFunc::new("a"));
+    package.world(world);
+
+    let mut world = World::new("bar");
+    world.function_import(StandaloneFunc::new("a"));
+    package.world(world);
+
+    let mut world = World::new("baz");
+    world.include(Include::new("bar"));
+    let mut include = Include::new("foo");
+    include.with("a", "b");
+    world.include(include);
+    package.world(world);
+
+    assert_eq!(package.to_string(), PACKAGE);
+}


### PR DESCRIPTION
We already had basic support for `include`, but this tests it and fixes it. Thanks!