### PR TITLE
Fix newline separators between invalid `end` instructions

### DIFF
--- a/crates/wasmprinter/src/operator.rs
+++ b/crates/wasmprinter/src/operator.rs
@@ -71,8 +71,8 @@ impl<'printer, 'state, 'a, 'b> PrintOperator<'printer, 'state, 'a, 'b> {
     fn block_end(&mut self) -> Result<()> {
         if self.printer.nesting > self.nesting_start {
             self.printer.nesting -= 1;
-            self.separator()?;
         }
+        self.separator()?;
         Ok(())
     }
 

--- a/tests/cli/print-with-too-many-ends.wat
+++ b/tests/cli/print-with-too-many-ends.wat
@@ -1,0 +1,5 @@
+;; RUN: print %
+
+(module
+  (func end i32.const 0 drop end)
+)

--- a/tests/cli/print-with-too-many-ends.wat.stdout
+++ b/tests/cli/print-with-too-many-ends.wat.stdout
@@ -2,5 +2,8 @@
   (type (;0;) (func))
   (func (;0;) (type 0)
     end
+    i32.const 0
+    drop
+    end
   )
 )


### PR DESCRIPTION
This commit fixes a bug from a prior refactoring where when there were too many `end` instructions in a function, which is invalid, then printing would confusingly "fuse" instructions together by not printing a separator.