### PR TITLE
Added serde support to wit-encoder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,9 +942,9 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "logos"
@@ -1302,6 +1302,9 @@ name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
@@ -2218,6 +2221,7 @@ dependencies = [
  "indoc",
  "pretty_assertions",
  "semver",
+ "serde",
 ]
 
 [[package]]

--- a/crates/wit-encoder/Cargo.toml
+++ b/crates/wit-encoder/Cargo.toml
@@ -10,9 +10,14 @@ version.workspace = true
 [lints]
 workspace = true
 
+[features]
+default = ["serde"]
+serde = ["dep:serde", "semver/serde"]
+
 [dependencies]
 semver = { workspace = true }
 pretty_assertions = { workspace = true }
+serde = { workspace = true, optional = true, features = ["derive"] }
 
 [dev-dependencies]
 indoc = { workspace = true }

--- a/crates/wit-encoder/src/docs.rs
+++ b/crates/wit-encoder/src/docs.rs
@@ -4,6 +4,8 @@ use crate::{Render, RenderOpts};
 
 /// Documentation
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub struct Docs {
     contents: String,
 }

--- a/crates/wit-encoder/src/enum_.rs
+++ b/crates/wit-encoder/src/enum_.rs
@@ -2,6 +2,8 @@ use crate::{Docs, Ident};
 
 /// A variant without a payload
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub struct Enum {
     pub(crate) cases: Vec<EnumCase>,
 }
@@ -28,6 +30,8 @@ impl Enum {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub struct EnumCase {
     pub(crate) name: Ident,
     pub(crate) docs: Option<Docs>,

--- a/crates/wit-encoder/src/flags.rs
+++ b/crates/wit-encoder/src/flags.rs
@@ -1,6 +1,8 @@
 use crate::{ident::Ident, Docs};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub struct Flags {
     pub(crate) flags: Vec<Flag>,
 }
@@ -22,6 +24,8 @@ impl Flags {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub struct Flag {
     pub(crate) name: Ident,
     pub(crate) docs: Option<Docs>,

--- a/crates/wit-encoder/src/function.rs
+++ b/crates/wit-encoder/src/function.rs
@@ -3,6 +3,8 @@ use std::fmt::{self, Display};
 use crate::{ident::Ident, Docs, Type};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub struct Params {
     items: Vec<(Ident, Type)>,
 }
@@ -57,6 +59,8 @@ impl Params {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum Results {
     Named(Params),
     Anon(Type),
@@ -137,6 +141,8 @@ impl Results {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub struct StandaloneFunc {
     pub(crate) name: Ident,
     pub(crate) params: Params,

--- a/crates/wit-encoder/src/ident.rs
+++ b/crates/wit-encoder/src/ident.rs
@@ -1,6 +1,8 @@
 use std::{borrow::Cow, fmt};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub struct Ident(Cow<'static, str>);
 
 impl Ident {

--- a/crates/wit-encoder/src/include.rs
+++ b/crates/wit-encoder/src/include.rs
@@ -4,6 +4,8 @@ use crate::{Ident, Render};
 
 /// Enable the union of a world with another world
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub struct Include {
     use_path: Ident,
     include_names_list: Vec<(String, String)>,

--- a/crates/wit-encoder/src/interface.rs
+++ b/crates/wit-encoder/src/interface.rs
@@ -3,6 +3,8 @@ use std::fmt;
 use crate::{Docs, Ident, Render, RenderOpts, StandaloneFunc, TypeDef};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub struct Interface {
     /// Name of this interface.
     pub(crate) name: Ident,
@@ -49,6 +51,8 @@ impl Interface {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum InterfaceItem {
     TypeDef(TypeDef),
     Function(StandaloneFunc),

--- a/crates/wit-encoder/src/package.rs
+++ b/crates/wit-encoder/src/package.rs
@@ -10,6 +10,8 @@ use crate::{ident::Ident, Interface, Render, RenderOpts, World};
 /// have a unique identifier that affects generated components and uniquely
 /// identifiers this particular package.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub struct Package {
     /// A unique name corresponding to this package.
     name: PackageName,
@@ -73,6 +75,8 @@ impl fmt::Display for Package {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum PackageItem {
     Interface(Interface),
     World(World),
@@ -84,6 +88,8 @@ pub enum PackageItem {
 /// This is directly encoded as an "ID" in the binary component representation
 /// with an interfaced tacked on as well.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub struct PackageName {
     /// A namespace such as `wasi` in `wasi:foo/bar`
     namespace: String,

--- a/crates/wit-encoder/src/record.rs
+++ b/crates/wit-encoder/src/record.rs
@@ -1,6 +1,8 @@
 use crate::{ident::Ident, Docs, Type};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub struct Record {
     pub(crate) fields: Vec<Field>,
 }
@@ -22,6 +24,8 @@ impl Record {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub struct Field {
     pub(crate) name: Ident,
     pub(crate) ty: Type,

--- a/crates/wit-encoder/src/render.rs
+++ b/crates/wit-encoder/src/render.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub struct RenderOpts {
     /// width of each indent
     pub indent_width: usize,

--- a/crates/wit-encoder/src/resource.rs
+++ b/crates/wit-encoder/src/resource.rs
@@ -1,6 +1,8 @@
 use crate::{ident::Ident, Docs, Params, Results};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub struct Resource {
     pub funcs: Vec<ResourceFunc>,
 }
@@ -24,6 +26,8 @@ impl Resource {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub struct ResourceFunc {
     pub(crate) kind: ResourceFuncKind,
     pub(crate) params: Params,
@@ -31,6 +35,8 @@ pub struct ResourceFunc {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum ResourceFuncKind {
     Method(Ident, Results),
     Static(Ident, Results),

--- a/crates/wit-encoder/src/result.rs
+++ b/crates/wit-encoder/src/result.rs
@@ -3,6 +3,8 @@ use std::fmt::Display;
 use crate::Type;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub struct Result_ {
     ok: Option<Type>,
     err: Option<Type>,

--- a/crates/wit-encoder/src/tuple.rs
+++ b/crates/wit-encoder/src/tuple.rs
@@ -3,6 +3,8 @@ use std::fmt::Display;
 use crate::Type;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub struct Tuple {
     pub(crate) types: Vec<Type>,
 }

--- a/crates/wit-encoder/src/ty.rs
+++ b/crates/wit-encoder/src/ty.rs
@@ -6,6 +6,8 @@ use crate::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum Type {
     Bool,
     U8,
@@ -111,6 +113,8 @@ impl Display for Type {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub struct VariantCase {
     name: Ident,
     ty: Option<Type>,
@@ -168,6 +172,8 @@ where
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub struct TypeDef {
     name: Ident,
     kind: TypeDefKind,
@@ -265,6 +271,8 @@ impl TypeDef {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum TypeDefKind {
     Record(Record),
     Resource(Resource),

--- a/crates/wit-encoder/src/variant.rs
+++ b/crates/wit-encoder/src/variant.rs
@@ -1,6 +1,8 @@
 use crate::VariantCase;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub struct Variant {
     pub(crate) cases: Vec<VariantCase>,
 }

--- a/crates/wit-encoder/src/world.rs
+++ b/crates/wit-encoder/src/world.rs
@@ -3,6 +3,8 @@ use std::fmt;
 use crate::{ident::Ident, Docs, Include, Interface, Render, RenderOpts, StandaloneFunc};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub struct World {
     /// The WIT identifier name of this world.
     name: Ident,
@@ -152,6 +154,8 @@ impl Render for World {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub enum WorldItem {
     /// An imported inline interface
     InlineInterfaceImport(Interface),
@@ -200,6 +204,8 @@ impl WorldItem {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "kebab-case"))]
 pub struct WorldNamedInterface {
     /// Name of this interface.
     pub(crate) name: Ident,


### PR DESCRIPTION
This PR add serde support to wit-encoder.

Why is wit-parser's serde not enough?
- wit-parser only supports `Serialize` and not `Deserialize`. So we can't recreate it from json.
- wit-parser's representation includes a lot of references by id, and it's hard to keep track of that in a json file.

