### PR TITLE
threads: add `shared` tables

### DIFF
--- a/crates/wasm-encoder/src/core/elements.rs
+++ b/crates/wasm-encoder/src/core/elements.rs
@@ -18,6 +18,7 @@ use crate::{encode_section, ConstExpr, Encode, RefType, Section, SectionId};
 ///     minimum: 128,
 ///     maximum: None,
 ///     table64: false,
+///     shared: false,
 /// });
 ///
 /// let mut elements = ElementSection::new();

--- a/crates/wasm-encoder/src/core/tables.rs
+++ b/crates/wasm-encoder/src/core/tables.rs
@@ -15,6 +15,7 @@ use crate::{encode_section, ConstExpr, Encode, RefType, Section, SectionId, ValT
 ///     minimum: 128,
 ///     maximum: None,
 ///     table64: false,
+///     shared: false,
 /// });
 ///
 /// let mut module = Module::new();
@@ -87,6 +88,10 @@ pub struct TableType {
     pub minimum: u64,
     /// Maximum size, in elements, of this table
     pub maximum: Option<u64>,
+    /// Whether this table is shared or not.
+    ///
+    /// This is included the shared-everything-threads proposal.
+    pub shared: bool,
 }
 
 impl TableType {
@@ -105,6 +110,9 @@ impl Encode for TableType {
         let mut flags = 0;
         if self.maximum.is_some() {
             flags |= 0b001;
+        }
+        if self.shared {
+            flags |= 0b010;
         }
         if self.table64 {
             flags |= 0b100;

--- a/crates/wasm-encoder/src/reencode.rs
+++ b/crates/wasm-encoder/src/reencode.rs
@@ -1154,6 +1154,7 @@ pub mod utils {
             minimum: table_ty.initial,
             maximum: table_ty.maximum,
             table64: table_ty.table64,
+            shared: table_ty.shared,
         })
     }
 

--- a/crates/wasm-mutate/src/mutators/translate.rs
+++ b/crates/wasm-mutate/src/mutators/translate.rs
@@ -156,6 +156,7 @@ pub fn table_type(
         minimum: ty.initial,
         maximum: ty.maximum,
         table64: ty.table64,
+        shared: ty.shared,
     })
 }
 

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -2542,6 +2542,7 @@ pub(crate) fn arbitrary_table_type(
         minimum,
         maximum,
         table64,
+        shared: false, // TODO: handle shared
     })
 }
 

--- a/crates/wasmparser/src/readers/core/tables.rs
+++ b/crates/wasmparser/src/readers/core/tables.rs
@@ -68,10 +68,11 @@ impl<'a> FromReader<'a> for TableType {
         let element_type = reader.read()?;
         let pos = reader.original_position();
         let flags = reader.read_u8()?;
-        if (flags & !0b101) != 0 {
+        if (flags & !0b111) != 0 {
             bail!(pos, "invalid table resizable limits flags");
         }
         let has_max = (flags & 0b001) != 0;
+        let shared = (flags & 0b010) != 0;
         let table64 = (flags & 0b100) != 0;
         Ok(TableType {
             element_type,
@@ -88,6 +89,7 @@ impl<'a> FromReader<'a> for TableType {
             } else {
                 Some(reader.read_var_u32()?.into())
             },
+            shared,
         })
     }
 }

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -1700,6 +1700,10 @@ pub struct TableType {
     /// For 32-bit tables (when `table64` is `false`) this is guaranteed to
     /// be at most `u32::MAX` for valid types.
     pub maximum: Option<u64>,
+    /// Whether this table is shared or not.
+    ///
+    /// This is included the shared-everything-threads proposal.
+    pub shared: bool,
 }
 
 impl TableType {

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -1537,6 +1537,7 @@ mod tests {
                 maximum: None,
                 element_type: RefType::FUNCREF,
                 table64: false,
+                shared: false,
             }
         );
 

--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -2834,19 +2834,23 @@ impl TypeList {
     }
 
     /// Is `ty` shared?
-    ///
-    /// This is complicated by reference types, since they may have concrete
-    /// heap types whose shared-ness must be checked by looking at the type they
-    /// point to.
     pub fn valtype_is_shared(&self, ty: ValType) -> bool {
         match ty {
             ValType::I32 | ValType::I64 | ValType::F32 | ValType::F64 | ValType::V128 => true,
-            ValType::Ref(rt) => match rt.heap_type() {
-                HeapType::Abstract { shared, .. } => shared,
-                HeapType::Concrete(index) => {
-                    self[index.as_core_type_id().unwrap()].composite_type.shared
-                }
-            },
+            ValType::Ref(rt) => self.reftype_is_shared(rt),
+        }
+    }
+
+    /// Is the reference type `ty` shared?
+    ///
+    /// This is complicated by concrete heap types whose shared-ness must be
+    /// checked by looking at the type they point to.
+    pub fn reftype_is_shared(&self, ty: RefType) -> bool {
+        match ty.heap_type() {
+            HeapType::Abstract { shared, .. } => shared,
+            HeapType::Concrete(index) => {
+                self[index.as_core_type_id().unwrap()].composite_type.shared
+            }
         }
     }
 

--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -1130,6 +1130,9 @@ impl Printer<'_, '_> {
             self.print_name(&state.core.table_names, state.core.tables)?;
             self.result.write_str(" ")?;
         }
+        if ty.shared {
+            self.print_type_keyword("shared ")?;
+        }
         if ty.table64 {
             self.print_type_keyword("i64 ")?;
         }

--- a/crates/wast/src/component/binary.rs
+++ b/crates/wast/src/component/binary.rs
@@ -648,6 +648,7 @@ impl From<core::TableType<'_>> for wasm_encoder::TableType {
             minimum: ty.limits.min,
             maximum: ty.limits.max,
             table64: ty.limits.is64,
+            shared: ty.shared,
         }
     }
 }

--- a/crates/wast/src/core/binary.rs
+++ b/crates/wast/src/core/binary.rs
@@ -560,6 +560,9 @@ impl<'a> Encode for TableType<'a> {
         if self.limits.max.is_some() {
             flags |= 1 << 0;
         }
+        if self.shared {
+            flags |= 1 << 1;
+        }
         if self.limits.is64 {
             flags |= 1 << 2;
         }

--- a/crates/wast/src/core/resolve/deinline_import_export.rs
+++ b/crates/wast/src/core/resolve/deinline_import_export.rs
@@ -103,11 +103,13 @@ pub fn run(fields: &mut Vec<ModuleField>) {
                             },
                         });
                     }
-                    // If data is defined inline insert an explicit `data` module
-                    // field here instead, switching this to a `Normal` memory.
+                    // If data is defined inline insert an explicit `data`
+                    // module field here instead, switching this to a `Normal`
+                    // memory.
                     TableKind::Inline {
                         payload,
                         elem,
+                        shared,
                         is64,
                     } => {
                         let is64 = *is64;
@@ -123,6 +125,7 @@ pub fn run(fields: &mut Vec<ModuleField>) {
                                     is64,
                                 },
                                 elem: *elem,
+                                shared: *shared,
                             },
                             init_expr: None,
                         };

--- a/crates/wast/src/core/table.rs
+++ b/crates/wast/src/core/table.rs
@@ -29,7 +29,7 @@ pub enum TableKind<'a> {
         ty: TableType<'a>,
     },
 
-    /// A typical memory definition which simply says the limits of the table
+    /// A typical memory definition which simply says the limits of the table.
     Normal {
         /// Table type.
         ty: TableType<'a>,
@@ -37,12 +37,14 @@ pub enum TableKind<'a> {
         init_expr: Option<Expression<'a>>,
     },
 
-    /// The elem segments of this table, starting from 0, explicitly listed
+    /// The elem segments of this table, starting from 0, explicitly listed.
     Inline {
         /// The element type of this table.
         elem: RefType<'a>,
-        /// Whether or not this will be creating a 64-bit table
+        /// Whether or not this will be creating a 64-bit table.
         is64: bool,
+        /// Whether this table is shared or not.
+        shared: bool,
         /// The element table entries to have, and the length of this list is
         /// the limits of the table as well.
         payload: ElemPayload<'a>,
@@ -58,13 +60,19 @@ impl<'a> Parse<'a> for Table<'a> {
 
         // Afterwards figure out which style this is, either:
         //
-        //  * `elemtype (elem ...)`
-        //  * `(import "a" "b") limits`
-        //  * `limits`
+        //  * inline: `elemtype (elem ...)`
+        //  * normal: `tabletype`
+        //  * import: `(import "a" "b") tabletype`
+        //
+        // Where `tabletype := shared? index_type limits reftype`
         let mut l = parser.lookahead1();
 
+        let is_shared = l.peek::<kw::shared>()?;
         let has_index_type = l.peek::<kw::i32>()? | l.peek::<kw::i64>()?;
-        let kind = if l.peek::<RefType>()? || (has_index_type && parser.peek2::<RefType>()?) {
+        let kind = if l.peek::<RefType>()?
+            || ((is_shared || has_index_type) && parser.peek2::<RefType>()?)
+        {
+            let shared = parser.parse::<Option<kw::shared>>()?.is_some();
             let is64 = if parser.parse::<Option<kw::i32>>()?.is_some() {
                 false
             } else {
@@ -82,9 +90,10 @@ impl<'a> Parse<'a> for Table<'a> {
             TableKind::Inline {
                 elem,
                 is64,
+                shared,
                 payload,
             }
-        } else if has_index_type || l.peek::<u64>()? {
+        } else if is_shared || has_index_type || l.peek::<u64>()? {
             TableKind::Normal {
                 ty: parser.parse()?,
                 init_expr: if !parser.is_empty() {

--- a/crates/wast/src/core/types.rs
+++ b/crates/wast/src/core/types.rs
@@ -587,18 +587,21 @@ impl<'a> Parse<'a> for Limits {
     }
 }
 
-/// Configuration for a table of a wasm mdoule
+/// Configuration for a table of a wasm module.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct TableType<'a> {
     /// Limits on the element sizes of this table
     pub limits: Limits,
     /// The type of element stored in this table
     pub elem: RefType<'a>,
+    /// Whether or not this is a shared table.
+    pub shared: bool,
 }
 
 impl<'a> Parse<'a> for TableType<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
         Ok(TableType {
+            shared: parser.parse::<Option<kw::shared>>()?.is_some(),
             limits: parser.parse()?,
             elem: parser.parse()?,
         })

--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -1269,6 +1269,7 @@ impl<'a> EncodingState<'a> {
             minimum: signatures.len() as u64,
             maximum: Some(signatures.len() as u64),
             table64: false,
+            shared: false,
         };
 
         tables.table(table_type);

--- a/crates/wit-component/src/linking.rs
+++ b/crates/wit-component/src/linking.rs
@@ -468,6 +468,7 @@ fn make_env_module<'a>(
             minimum: table_offset.into(),
             maximum: None,
             table64: false,
+            shared: false,
         });
         exports.export("__indirect_function_table", ExportKind::Table, 0);
         module.section(&tables);
@@ -560,6 +561,7 @@ fn make_init_module(
             minimum: 0,
             maximum: None,
             table64: false,
+            shared: false,
         },
     );
 

--- a/tests/cli/dump-llvm-object.wat.stdout
+++ b/tests/cli/dump-llvm-object.wat.stdout
@@ -47,7 +47,7 @@
        | 39 65 32 32
        | 65 30 65 45
        | 00 02      
-  0x98 | 03 65 6e 76 | import [table 0] Import { module: "env", name: "__indirect_function_table", ty: Table(TableType { element_type: funcref, table64: false, initial: 4, maximum: None }) }
+  0x98 | 03 65 6e 76 | import [table 0] Import { module: "env", name: "__indirect_function_table", ty: Table(TableType { element_type: funcref, table64: false, initial: 4, maximum: None, shared: false }) }
        | 19 5f 5f 69
        | 6e 64 69 72
        | 65 63 74 5f

--- a/tests/cli/dump/alias2.wat.stdout
+++ b/tests/cli/dump/alias2.wat.stdout
@@ -133,7 +133,7 @@
    0x161 | 00          | [func 0] type 0
    0x162 | 04 04       | table section
    0x164 | 01          | 1 count
-   0x165 | 70 00 01    | [table 0] Table { ty: TableType { element_type: funcref, table64: false, initial: 1, maximum: None }, init: RefNull }
+   0x165 | 70 00 01    | [table 0] Table { ty: TableType { element_type: funcref, table64: false, initial: 1, maximum: None, shared: false }, init: RefNull }
    0x168 | 05 03       | memory section
    0x16a | 01          | 1 count
    0x16b | 00 01       | [memory 0] MemoryType { memory64: false, shared: false, initial: 1, maximum: None, page_size_log2: None }
@@ -173,7 +173,7 @@
          | 00 01      
    0x1b6 | 00 01 33 03 | import [global 0] Import { module: "", name: "3", ty: Global(GlobalType { content_type: I32, mutable: false, shared: false }) }
          | 7f 00      
-   0x1bc | 00 01 34 01 | import [table 0] Import { module: "", name: "4", ty: Table(TableType { element_type: funcref, table64: false, initial: 1, maximum: None }) }
+   0x1bc | 00 01 34 01 | import [table 0] Import { module: "", name: "4", ty: Table(TableType { element_type: funcref, table64: false, initial: 1, maximum: None, shared: false }) }
          | 70 00 01   
    0x1c3 | 00 0a       | custom section
    0x1c5 | 04 6e 61 6d | name: "name"

--- a/tests/cli/dump/module-types.wat.stdout
+++ b/tests/cli/dump/module-types.wat.stdout
@@ -2,7 +2,7 @@
       | 0d 00 01 00
   0x8 | 03 23       | core type section
   0xa | 01          | 1 count
-  0xb | 50 05 01 60 | [core type 0] Module([Type(SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [], results: [] }), shared: false } }), Import(Import { module: "", name: "f", ty: Func(0) }), Import(Import { module: "", name: "g", ty: Global(GlobalType { content_type: I32, mutable: false, shared: false }) }), Import(Import { module: "", name: "t", ty: Table(TableType { element_type: funcref, table64: false, initial: 1, maximum: None }) }), Import(Import { module: "", name: "m", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None, page_size_log2: None }) })])
+  0xb | 50 05 01 60 | [core type 0] Module([Type(SubType { is_final: true, supertype_idx: None, composite_type: CompositeType { inner: Func(FuncType { params: [], results: [] }), shared: false } }), Import(Import { module: "", name: "f", ty: Func(0) }), Import(Import { module: "", name: "g", ty: Global(GlobalType { content_type: I32, mutable: false, shared: false }) }), Import(Import { module: "", name: "t", ty: Table(TableType { element_type: funcref, table64: false, initial: 1, maximum: None, shared: false }) }), Import(Import { module: "", name: "m", ty: Memory(MemoryType { memory64: false, shared: false, initial: 1, maximum: None, page_size_log2: None }) })])
       | 00 00 00 00
       | 01 66 00 00
       | 00 00 01 67

--- a/tests/cli/dump/simple.wat.stdout
+++ b/tests/cli/dump/simple.wat.stdout
@@ -17,7 +17,7 @@
  0x20 | 01          | [func 3] type 1
  0x21 | 04 04       | table section
  0x23 | 01          | 1 count
- 0x24 | 70 00 01    | [table 0] Table { ty: TableType { element_type: funcref, table64: false, initial: 1, maximum: None }, init: RefNull }
+ 0x24 | 70 00 01    | [table 0] Table { ty: TableType { element_type: funcref, table64: false, initial: 1, maximum: None, shared: false }, init: RefNull }
  0x27 | 05 03       | memory section
  0x29 | 01          | 1 count
  0x2a | 00 01       | [memory 0] MemoryType { memory64: false, shared: false, initial: 1, maximum: None, page_size_log2: None }

--- a/tests/local/missing-features/tables.wast
+++ b/tests/local/missing-features/tables.wast
@@ -1,0 +1,5 @@
+(assert_invalid
+  (module
+    (table shared 1 funcref)
+  )
+  "shared tables require the shared-everything-threads proposal")

--- a/tests/local/shared-everything-threads/global.wast
+++ b/tests/local/shared-everything-threads/global.wast
@@ -1,4 +1,4 @@
-;; Check shared attribute.
+;; Check the `shared` attribute on globals.
 
 (module
   ;; Imported.

--- a/tests/local/shared-everything-threads/table.wast
+++ b/tests/local/shared-everything-threads/table.wast
@@ -35,3 +35,9 @@
 (assert_invalid
   (module (table (import "spectest" "table_ref") shared 0 funcref))
   "shared tables must have a shared element type")
+
+(assert_invalid
+  (module
+    (type $t (func))
+    (table shared 0 (ref $t)))
+  "shared tables must have a shared element type")

--- a/tests/local/shared-everything-threads/table.wast
+++ b/tests/local/shared-everything-threads/table.wast
@@ -1,0 +1,37 @@
+;; Check the `shared` attribute on tables.
+
+(module
+  ;; Imported.
+  (table (import "spectest" "table_ref") shared 1 (ref null (shared func)))
+  (table (import "spectest" "table_ref_with_max") shared 1 1 (ref null (shared func)))
+
+  ;; Normal.
+  (table shared 1 (ref null (shared func)))
+  (table shared 1 1 (ref null (shared func)))
+
+  ;; Inlined.
+  (table shared (ref null (shared func)) (elem (ref.null (shared func))))
+)
+
+;; Note that shared elements can live within an unshared table.
+(module
+  (table (import "spectest" "table_ref") 1 (ref null (shared func)))
+)
+
+(assert_malformed
+  (module quote "(table 1 shared funcref)")
+  "unexpected token")
+
+(assert_malformed
+  (module quote "(table 1 funcref shared)")
+  "unexpected token")
+
+;; The proposal creates too much ambiguity to allow this syntax: the parser
+;; would need to lookahead multiple tokens.
+(assert_malformed
+  (module quote "(table shared i64 (ref null (shared func)) (elem (ref.null (shared func))))")
+  "unexpected token")
+
+(assert_invalid
+  (module (table (import "spectest" "table_ref") shared 0 funcref))
+  "shared tables must have a shared element type")

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -717,6 +717,7 @@ fn error_matches(error: &str, message: &str) -> bool {
         // wasmparser implements more features than the default spec
         // interpreter, so these error looks different.
         return error.contains("threads must be enabled for shared memories")
+            || error.contains("shared tables require the shared-everything-threads proposal")
             || error.contains("invalid table resizable limits flags")
             // honestly this feels like the spec interpreter is just weird
             || error.contains("unexpected end-of-file")

--- a/tests/snapshots/local/missing-features/tables.wast.json
+++ b/tests/snapshots/local/missing-features/tables.wast.json
@@ -1,0 +1,12 @@
+{
+  "source_filename": "tests/local/missing-features/tables.wast",
+  "commands": [
+    {
+      "type": "assert_invalid",
+      "line": 2,
+      "filename": "tables.0.wasm",
+      "text": "shared tables require the shared-everything-threads proposal",
+      "module_type": "binary"
+    }
+  ]
+}

--- a/tests/snapshots/local/shared-everything-threads/table.wast.json
+++ b/tests/snapshots/local/shared-everything-threads/table.wast.json
@@ -1,0 +1,43 @@
+{
+  "source_filename": "tests/local/shared-everything-threads/table.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 3,
+      "filename": "table.0.wasm"
+    },
+    {
+      "type": "module",
+      "line": 17,
+      "filename": "table.1.wasm"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 22,
+      "filename": "table.2.wat",
+      "text": "unexpected token",
+      "module_type": "text"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 26,
+      "filename": "table.3.wat",
+      "text": "unexpected token",
+      "module_type": "text"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 32,
+      "filename": "table.4.wat",
+      "text": "unexpected token",
+      "module_type": "text"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 36,
+      "filename": "table.5.wasm",
+      "text": "shared tables must have a shared element type",
+      "module_type": "binary"
+    }
+  ]
+}

--- a/tests/snapshots/local/shared-everything-threads/table.wast.json
+++ b/tests/snapshots/local/shared-everything-threads/table.wast.json
@@ -38,6 +38,13 @@
       "filename": "table.5.wasm",
       "text": "shared tables must have a shared element type",
       "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 40,
+      "filename": "table.6.wasm",
+      "text": "shared tables must have a shared element type",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/shared-everything-threads/table.wast/0.print
+++ b/tests/snapshots/local/shared-everything-threads/table.wast/0.print
@@ -1,0 +1,8 @@
+(module
+  (import "spectest" "table_ref" (table (;0;) shared 1 (ref null (shared func))))
+  (import "spectest" "table_ref_with_max" (table (;1;) shared 1 1 (ref null (shared func))))
+  (table (;2;) shared 1 (ref null (shared func)))
+  (table (;3;) shared 1 1 (ref null (shared func)))
+  (table (;4;) shared 1 1 (ref null (shared func)))
+  (elem (;0;) (table 4) (i32.const 0) (ref null (shared func)) (ref.null (shared func)))
+)

--- a/tests/snapshots/local/shared-everything-threads/table.wast/1.print
+++ b/tests/snapshots/local/shared-everything-threads/table.wast/1.print
@@ -1,0 +1,3 @@
+(module
+  (import "spectest" "table_ref" (table (;0;) 1 (ref null (shared func))))
+)


### PR DESCRIPTION
This change spreads `shared` attributes on to tables. As with #1480, this does not yet turn on fuzzing for `shared` things so the only checking is via the in-progress test suite in `tests/local/shared-everything-threads`.

Implementing this raises an issue with the spec: the addition of `shared` in the text format means that inline table expressions (e.g.,
`(table <type> (elem ...))`) are difficult to parse: the parser would potentially have to look past two tokens now, `shared` and `i32|i64` to see if a type appears that indicates we should be parsing an inline format. There are multiple options for what to do here; I opened an issue to figure this out at the spec level first ([https://github.com/bytecodealliance/wasm-tools/pull/71]).

[proposal]: https://github.com/WebAssembly/shared-everything-threads
[https://github.com/bytecodealliance/wasm-tools/pull/71]: https://github.com/WebAssembly/shared-everything-threads/issues/71