### PR TITLE
Switch from centos 7 to almalinux 8 for binary-compatible-builds

### DIFF
--- a/ci/docker/x86_64-linux/Dockerfile
+++ b/ci/docker/x86_64-linux/Dockerfile
@@ -1,5 +1,5 @@
-FROM centos:7
+FROM almalinux:8
 
-RUN yum install -y git gcc
+RUN dnf install -y git gcc
 
 ENV PATH=$PATH:/rust/bin


### PR DESCRIPTION
As centos 7 has hit EOL, switch our binary-compatible-builds container to using almalinux 8.
