### PR TITLE
Improve the output of `wasm-tools component wit`

### DIFF
--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -51,8 +51,13 @@ impl WitPrinter {
     }
 
     /// Print a set of one or more WIT packages into a string.
-    pub fn print(&mut self, resolve: &Resolve, pkg_ids: &[PackageId]) -> Result<String> {
-        let has_multiple_packages = pkg_ids.len() > 1;
+    pub fn print(
+        &mut self,
+        resolve: &Resolve,
+        pkg_ids: &[PackageId],
+        force_print_package_in_curlies: bool,
+    ) -> Result<String> {
+        let print_package_in_curlies = force_print_package_in_curlies || pkg_ids.len() > 1;
         for (i, pkg_id) in pkg_ids.into_iter().enumerate() {
             if i > 0 {
                 self.output.push_str("\n\n");
@@ -68,9 +73,8 @@ impl WitPrinter {
                 self.output.push_str(&format!("@{version}"));
             }
 
-            if has_multiple_packages {
-                self.output.push_str("{");
-                self.output.indent += 1
+            if print_package_in_curlies {
+                self.output.push_str(" {\n");
             } else {
                 self.print_semicolon();
                 self.output.push_str("\n\n");
@@ -96,9 +100,8 @@ impl WitPrinter {
                 writeln!(&mut self.output, "}}")?;
             }
 
-            if has_multiple_packages {
-                self.output.push_str("}");
-                self.output.indent -= 1
+            if print_package_in_curlies {
+                self.output.push_str("}\n");
             }
         }
 

--- a/crates/wit-component/tests/components.rs
+++ b/crates/wit-component/tests/components.rs
@@ -171,7 +171,7 @@ fn run_test(path: &Path) -> Result<()> {
                 }
             };
         let wit = WitPrinter::default()
-            .print(&resolve, &[pkg])
+            .print(&resolve, &[pkg], false)
             .context("failed to print WIT")?;
         assert_output(&wit, &component_wit_path)?;
 

--- a/crates/wit-component/tests/interfaces.rs
+++ b/crates/wit-component/tests/interfaces.rs
@@ -96,7 +96,7 @@ fn run_test(path: &Path, is_dir: bool) -> Result<()> {
 }
 
 fn assert_print(resolve: &Resolve, pkg_ids: &[PackageId], path: &Path, is_dir: bool) -> Result<()> {
-    let output = WitPrinter::default().print(resolve, &pkg_ids)?;
+    let output = WitPrinter::default().print(resolve, &pkg_ids, false)?;
     for pkg_id in pkg_ids {
         let pkg = &resolve.packages[*pkg_id];
         let expected = if is_dir {

--- a/crates/wit-component/tests/merge.rs
+++ b/crates/wit-component/tests/merge.rs
@@ -46,7 +46,7 @@ fn merging() -> Result<()> {
                         .join("merge")
                         .join(&pkg.name.name)
                         .with_extension("wit");
-                    let output = WitPrinter::default().print(&into, &[id])?;
+                    let output = WitPrinter::default().print(&into, &[id], false)?;
                     assert_output(&expected, &output)?;
                 }
             }

--- a/fuzz/src/roundtrip_wit.rs
+++ b/fuzz/src/roundtrip_wit.rs
@@ -86,7 +86,7 @@ fn roundtrip_through_printing(file: &str, resolve: &Resolve, wasm: &[u8]) {
     for (id, pkg) in resolve.packages.iter() {
         let mut map = SourceMap::new();
         let pkg_name = &pkg.name;
-        let doc = WitPrinter::default().print(resolve, &[id]).unwrap();
+        let doc = WitPrinter::default().print(resolve, &[id], false).unwrap();
         write_file(&format!("{file}-{pkg_name}.wit"), &doc);
         map.push(format!("{pkg_name}.wit").as_ref(), doc);
         let unresolved = map.parse().unwrap();

--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -523,9 +523,7 @@ impl WitOpts {
         // This interprets all of the output options and performs such a task.
         if self.json {
             self.emit_json(&decoded)?;
-            return Ok(());
-        }
-        if self.wasm || self.wat {
+        } else if self.wasm || self.wat {
             self.emit_wasm(&decoded)?;
         } else {
             self.emit_wit(&decoded)?;
@@ -618,7 +616,6 @@ impl WitOpts {
         assert!(!self.wasm && !self.wat);
 
         let resolve = decoded.resolve();
-        let main = decoded.packages();
 
         let mut printer = WitPrinter::default();
         printer.emit_docs(!self.no_docs);
@@ -641,28 +638,31 @@ impl WitOpts {
                     *cnt += 1;
                 }
 
+                let main = decoded.packages();
                 for (id, pkg) in resolve.packages.iter() {
-                    let output = printer.print(resolve, &[id])?;
-                    let out_dir = if main.contains(&id) {
+                    let is_main = main.contains(&id);
+                    let output = printer.print(resolve, &[id], is_main)?;
+                    let out_dir = if is_main {
                         dir.clone()
                     } else {
-                        let dir = dir.join("deps");
-                        let packages_with_same_name = &names[&pkg.name.name];
-                        if packages_with_same_name.len() == 1 {
-                            dir.join(&pkg.name.name)
+                        dir.join("deps")
+                    };
+                    let packages_with_same_name = &names[&pkg.name.name];
+                    let stem = if packages_with_same_name.len() == 1 {
+                        pkg.name.name.clone()
+                    } else {
+                        let packages_with_same_namespace =
+                            packages_with_same_name[&pkg.name.namespace];
+                        if packages_with_same_namespace == 1 {
+                            format!("{}:{}", pkg.name.namespace, pkg.name.name)
                         } else {
-                            let packages_with_same_namespace =
-                                packages_with_same_name[&pkg.name.namespace];
-                            if packages_with_same_namespace == 1 {
-                                dir.join(format!("{}:{}", pkg.name.namespace, pkg.name.name))
-                            } else {
-                                dir.join(pkg.name.to_string())
-                            }
+                            pkg.name.to_string()
                         }
                     };
                     std::fs::create_dir_all(&out_dir)
                         .with_context(|| format!("failed to create directory: {out_dir:?}"))?;
-                    let path = out_dir.join("main.wit");
+                    let filename = format!("{stem}.wit");
+                    let path = out_dir.join(&filename);
                     std::fs::write(&path, &output)
                         .with_context(|| format!("failed to write file: {path:?}"))?;
                     println!("Writing: {}", path.display());

--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -672,8 +672,7 @@ impl WitOpts {
                 self.output.output(
                     &self.general,
                     Output::Wit {
-                        resolve: &resolve,
-                        ids: &main,
+                        wit: &decoded,
                         printer,
                     },
                 )?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,7 +238,7 @@ impl OutputArg {
                 ids,
                 mut printer,
             } => {
-                let output = printer.print(resolve, ids)?;
+                let output = printer.print(resolve, ids, false)?;
                 self.output_str(&output)
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,8 +143,7 @@ pub struct OutputArg {
 pub enum Output<'a> {
     #[cfg(feature = "component")]
     Wit {
-        resolve: &'a wit_parser::Resolve,
-        ids: &'a [wit_parser::PackageId],
+        wit: &'a wit_component::DecodedWasm,
         printer: wit_component::WitPrinter,
     },
     Wasm(&'a [u8]),
@@ -233,12 +232,14 @@ impl OutputArg {
             }
             Output::Json(s) => self.output_str(s),
             #[cfg(feature = "component")]
-            Output::Wit {
-                resolve,
-                ids,
-                mut printer,
-            } => {
-                let output = printer.print(resolve, ids, false)?;
+            Output::Wit { wit, mut printer } => {
+                let resolve = wit.resolve();
+                let ids = resolve
+                    .packages
+                    .iter()
+                    .map(|(id, _)| id)
+                    .collect::<Vec<_>>();
+                let output = printer.print(resolve, &ids, false)?;
                 self.output_str(&output)
             }
         }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -153,7 +153,12 @@ fn execute(cmd: &mut Command, stdin: Option<&[u8]>, should_fail: bool) -> Result
 
 fn assert_output(bless: bool, output: &[u8], path: &Path, tempdir: &TempDir) -> Result<()> {
     let tempdir = tempdir.path().to_str().unwrap();
-    let output = String::from_utf8_lossy(output).replace(tempdir, "%tmpdir");
+    // sanitize the output to be consistent across platforms and handle per-test
+    // differences such as `%tmpdir`.
+    let output = String::from_utf8_lossy(output)
+        .replace(tempdir, "%tmpdir")
+        .replace("\\", "/");
+
     if bless {
         if output.is_empty() {
             drop(std::fs::remove_file(path));

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -32,6 +32,7 @@ use std::env;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output, Stdio};
+use tempfile::TempDir;
 
 fn main() {
     let mut tests = Vec::new();
@@ -76,6 +77,7 @@ fn run_test(test: &Path, bless: bool) -> Result<()> {
 
     let mut cmd = wasm_tools_exe();
     let mut stdin = None;
+    let tempdir = TempDir::new()?;
     for arg in line.split_whitespace() {
         if arg == "|" {
             let output = execute(&mut cmd, stdin.as_deref(), false)?;
@@ -83,6 +85,8 @@ fn run_test(test: &Path, bless: bool) -> Result<()> {
             cmd = wasm_tools_exe();
         } else if arg == "%" {
             cmd.arg(test);
+        } else if arg == "%tmpdir" {
+            cmd.arg(tempdir.path());
         } else {
             cmd.arg(arg);
         }
@@ -94,12 +98,14 @@ fn run_test(test: &Path, bless: bool) -> Result<()> {
         bless,
         &output.stdout,
         &test.with_extension(&format!("{extension}.stdout")),
+        &tempdir,
     )
     .context("failed to check stdout expectation (auto-update with BLESS=1)")?;
     assert_output(
         bless,
         &output.stderr,
         &test.with_extension(&format!("{extension}.stderr")),
+        &tempdir,
     )
     .context("failed to check stderr expectation (auto-update with BLESS=1)")?;
     Ok(())
@@ -145,7 +151,9 @@ fn execute(cmd: &mut Command, stdin: Option<&[u8]>, should_fail: bool) -> Result
     Ok(output)
 }
 
-fn assert_output(bless: bool, output: &[u8], path: &Path) -> Result<()> {
+fn assert_output(bless: bool, output: &[u8], path: &Path, tempdir: &TempDir) -> Result<()> {
+    let tempdir = tempdir.path().to_str().unwrap();
+    let output = String::from_utf8_lossy(output).replace(tempdir, "%tmpdir");
     if bless {
         if output.is_empty() {
             drop(std::fs::remove_file(path));
@@ -162,7 +170,6 @@ fn assert_output(bless: bool, output: &[u8], path: &Path) -> Result<()> {
             Ok(())
         }
     } else {
-        let output = std::str::from_utf8(output)?;
         let contents = std::fs::read_to_string(path)
             .with_context(|| format!("failed to read {path:?}"))?
             .replace("\r\n", "\n");

--- a/tests/cli/print-core-wasm-wit-multiple-packages.wit.stdout
+++ b/tests/cli/print-core-wasm-wit-multiple-packages.wit.stdout
@@ -1,5 +1,16 @@
-package root:root;
+package root:root {
+  world root {
+    import bar:bar/my-interface;
+  }
+}
 
-world root {
-  import bar:bar/my-interface;
+
+package bar:bar {
+  interface my-interface {
+    foo: func();
+  }
+
+  world my-world {
+    import my-interface;
+  }
 }

--- a/tests/cli/print-core-wasm-wit.wit.stdout
+++ b/tests/cli/print-core-wasm-wit.wit.stdout
@@ -1,5 +1,16 @@
-package root:root;
+package root:root {
+  world root {
+    import foo:foo/my-interface;
+  }
+}
 
-world root {
-  import foo:foo/my-interface;
+
+package foo:foo {
+  interface my-interface {
+    foo: func();
+  }
+
+  world my-world {
+    import my-interface;
+  }
 }

--- a/tests/cli/wit-directory-output-in-deps-folder.wit
+++ b/tests/cli/wit-directory-output-in-deps-folder.wit
@@ -1,0 +1,14 @@
+// RUN: component embed --dummy % --world a:b/c | component wit --out-dir %tmpdir
+
+package a:b {
+  interface foo {}
+
+  world c {
+    import foo;
+    import a:c/foo;
+  }
+}
+
+package a:c {
+  interface foo {}
+}

--- a/tests/cli/wit-directory-output-in-deps-folder.wit.stdout
+++ b/tests/cli/wit-directory-output-in-deps-folder.wit.stdout
@@ -1,0 +1,3 @@
+Writing: %tmpdir/root.wit
+Writing: %tmpdir/deps/b.wit
+Writing: %tmpdir/deps/c.wit

--- a/tests/cli/wit-directory-output-valid.wit
+++ b/tests/cli/wit-directory-output-valid.wit
@@ -1,0 +1,14 @@
+// RUN: component wit % --out-dir %tmpdir | component wit %tmpdir
+
+package a:b {
+  interface foo {}
+
+  world c {
+    import foo;
+    import a:c/foo;
+  }
+}
+
+package a:c {
+  interface foo {}
+}

--- a/tests/cli/wit-directory-output-valid.wit.stdout
+++ b/tests/cli/wit-directory-output-valid.wit.stdout
@@ -1,0 +1,16 @@
+package a:c {
+  interface foo {
+  }
+
+}
+
+
+package a:b {
+  interface foo {
+  }
+
+  world c {
+    import foo;
+    import a:c/foo;
+  }
+}

--- a/tests/cli/wit-directory-output.wit
+++ b/tests/cli/wit-directory-output.wit
@@ -1,0 +1,14 @@
+// RUN: component wit % --out-dir %tmpdir
+
+package a:b {
+  interface foo {}
+
+  world c {
+    import foo;
+    import a:c/foo;
+  }
+}
+
+package a:c {
+  interface foo {}
+}

--- a/tests/cli/wit-directory-output.wit.stdout
+++ b/tests/cli/wit-directory-output.wit.stdout
@@ -1,0 +1,2 @@
+Writing: %tmpdir/c.wit
+Writing: %tmpdir/b.wit


### PR DESCRIPTION
This commit implements a few minor improvements I've been wanting to make this this subcommand, notably changing the default output to use the multi-package form if needed to print everything in a component instead of just the "top"