### PR TITLE
fix: f32, f64 encoding for wit-encoder

### DIFF
--- a/crates/wit-encoder/src/ident.rs
+++ b/crates/wit-encoder/src/ident.rs
@@ -37,8 +37,8 @@ impl AsRef<str> for Ident {
 
 fn is_keyword(name: &str) -> bool {
     match name {
-        "u8" | "u16" | "u32" | "u64" | "s8" | "s16" | "s32" | "s64" | "float32" | "float64"
-        | "char" | "bool" | "string" | "tuple" | "list" | "option" | "result" | "use" | "type"
+        "u8" | "u16" | "u32" | "u64" | "s8" | "s16" | "s32" | "s64" | "f32" | "f64" | "char"
+        | "bool" | "string" | "tuple" | "list" | "option" | "result" | "use" | "type"
         | "resource" | "func" | "record" | "enum" | "flags" | "variant" | "static"
         | "interface" | "world" | "import" | "export" | "package" | "own" | "borrow" => true,
         _ => false,

--- a/crates/wit-encoder/src/ident.rs
+++ b/crates/wit-encoder/src/ident.rs
@@ -5,12 +5,7 @@ pub struct Ident(Cow<'static, str>);
 
 impl Ident {
     pub fn new(s: impl Into<Cow<'static, str>>) -> Self {
-        let s: Cow<'static, str> = s.into();
-        if is_keyword(&s) {
-            Self(Cow::Owned(format!("%{}", s)))
-        } else {
-            Self(s)
-        }
+        Self(s.into())
     }
 }
 
@@ -25,6 +20,9 @@ where
 
 impl fmt::Display for Ident {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if is_keyword(&self.0) {
+            write!(f, "%")?;
+        }
         self.0.fmt(f)
     }
 }

--- a/crates/wit-encoder/tests/type_defs.rs
+++ b/crates/wit-encoder/tests/type_defs.rs
@@ -211,6 +211,8 @@ fn types() {
         interface.type_def(TypeDef::type_("foo", Type::named("bar")));
         interface.type_def(TypeDef::type_("bar", Type::U32));
 
+        interface.type_def(TypeDef::type_("f64", Type::F64));
+
         interface.type_def(TypeDef::resource("t50", Vec::<ResourceFunc>::new()));
         interface.type_def(TypeDef::resource(
             "t51",

--- a/crates/wit-encoder/tests/type_defs.rs
+++ b/crates/wit-encoder/tests/type_defs.rs
@@ -103,6 +103,7 @@ const PACKAGE: &str = indoc::indoc! {"
       type t46 = t44;
       type foo = bar;
       type bar = u32;
+      type %f64 = f64;
       resource t50 {
       }
       resource t51 {


### PR DESCRIPTION
Fixes `f32` and `f64` handling in wit-encoder treating them as proper keywords.

In the process, also moves the escaping process into the rendering itself, as opposed to mutating the internal representation.