### PR TITLE
added from floating point to ieee trait

### DIFF
--- a/crates/wasmparser/src/readers/core/operators.rs
+++ b/crates/wasmparser/src/readers/core/operators.rs
@@ -90,7 +90,9 @@ impl Ieee32 {
 
 impl From<f32> for Ieee32 {
     fn from(value: f32) -> Self {
-        Ieee32 { 0: u32::from(value) }
+        Ieee32 {
+            0: u32::from_le_bytes(value.to_le_bytes()),
+        }
     }
 }
 
@@ -116,7 +118,9 @@ impl Ieee64 {
 
 impl From<f64> for Ieee64 {
     fn from(value: f64) -> Self {
-        Ieee64 { 0: u64::from(value) }
+        Ieee64 {
+            0: u64::from_le_bytes(value.to_le_bytes()),
+        }
     }
 }
 

--- a/crates/wasmparser/src/readers/core/operators.rs
+++ b/crates/wasmparser/src/readers/core/operators.rs
@@ -88,6 +88,12 @@ impl Ieee32 {
     }
 }
 
+impl From<f32> for Ieee32 {
+    fn from(value: f32) -> Self {
+        Ieee32 { 0: u32::from(value) }
+    }
+}
+
 impl From<Ieee32> for f32 {
     fn from(bits: Ieee32) -> f32 {
         f32::from_bits(bits.bits())
@@ -105,6 +111,12 @@ impl Ieee64 {
     /// Gets the underlying bits of the 64-bit float.
     pub fn bits(self) -> u64 {
         self.0
+    }
+}
+
+impl From<f64> for Ieee64 {
+    fn from(value: f64) -> Self {
+        Ieee64 { 0: u64::from(value) }
     }
 }
 


### PR DESCRIPTION
I see that in `wasmparser`, you can convert from `Ieee32` to `f32` using the `From` trait. And in `wasm_encoder`, you can encode `f32`.
I have a use case where I'm maintaining an Intermediate Representation between the parser and encoder in `wasmparser` types and specifically need to create `wasmparser::Operator`. This trait enables me to convert floating point numbers to `wasmparser::Operator` floating point constants.