### PR TITLE
Better handle stability attributes when merging WIT packages

### DIFF
--- a/crates/wit-component/tests/merge/success/from/deps/foo/shared.wit
+++ b/crates/wit-component/tests/merge/success/from/deps/foo/shared.wit
@@ -23,3 +23,20 @@ world shared-world {
 
   import d: interface {}
 }
+
+@since(version = 1.0.0)
+interface shared-version-on-from {}
+
+interface shared-version-on-into {}
+
+world shared-world-with-versions {
+  @since(version = 1.0.0)
+  import shared-version-on-from;
+  import shared-version-on-into;
+}
+
+world shared-world-with-versions-and-include {
+  import shared-version-on-from;
+  import shared-version-on-into;
+  include shared-world-with-versions;
+}

--- a/crates/wit-component/tests/merge/success/into/deps/foo/shared.wit
+++ b/crates/wit-component/tests/merge/success/into/deps/foo/shared.wit
@@ -21,3 +21,20 @@ world shared-world {
 
   import d: interface {}
 }
+
+interface shared-version-on-from {}
+
+@since(version = 1.0.0)
+interface shared-version-on-into {}
+
+world shared-world-with-versions {
+  import shared-version-on-from;
+  @since(version = 1.0.0)
+  import shared-version-on-into;
+}
+
+world shared-world-with-versions-and-include {
+  import shared-version-on-from;
+  import shared-version-on-into;
+  include shared-world-with-versions;
+}

--- a/crates/wit-component/tests/merge/success/merge/foo.wit
+++ b/crates/wit-component/tests/merge/success/merge/foo.wit
@@ -19,6 +19,14 @@ interface shared-items {
   type a = u32;
 }
 
+@since(version = 1.0.0)
+interface shared-version-on-from {
+}
+
+@since(version = 1.0.0)
+interface shared-version-on-into {
+}
+
 interface only-from {
   record r {
   }
@@ -44,4 +52,14 @@ world shared-world {
   type c = u32;
 
   export shared-items;
+}
+world shared-world-with-versions {
+  import shared-version-on-from;
+  @since(version = 1.0.0)
+  import shared-version-on-into;
+}
+world shared-world-with-versions-and-include {
+  import shared-version-on-from;
+  @since(version = 1.0.0)
+  import shared-version-on-into;
 }


### PR DESCRIPTION
This commit updates the logic when merging WIT packages together to better handle stability. This isn't perfect but it should suffice to fix the issue in #1666. The general idea is that stability is something that needs to be specifically handled during the merging process and it erroneously wasn't processed at all before. This commit fixes that and fixes a panic along the way. Stability is now inherited if possible but generates an error if two packages disagree.

Closes #1666