### PR TITLE
[wit-parser] select default world among multiple packages

### DIFF
--- a/crates/wit-parser/src/resolve.rs
+++ b/crates/wit-parser/src/resolve.rs
@@ -1016,32 +1016,29 @@ impl Resolve {
             None => match packages {
                 [] => bail!("no packages were specified nor is a world specified"),
                 [..] => {
-                    let mut world = None;
-                    for id in packages {
-                        let pkg = &self.packages[*id];
-                        match pkg.worlds.len() {
-                            0 => bail!("no worlds found in package `{}`", pkg.name),
-                            1 => {if world.is_none() {
-                                world = Some(*pkg.worlds.values().next().unwrap());
-                            } else {
-                                bail!(
-                                    "the supplied WIT source files describe multiple packages \
-                                     containing at least one world; \
-                                     please provide a fully-qualified world-specifier to select \
-                                     a world amongst these packages"
-                                );
-                            }}
-                            _ => bail!(
-                                "multiple worlds found in package `{}`, one must be explicitly chosen:{}",
-                                pkg.name,
-                                pkg.worlds.keys().map(|name| format!("\n  {name}")).collect::<String>()
-                            ),
-                        }
-                    }
-                    if let Some(world) = world {
-                        return Ok(world);
-                    } else {
-                        bail!("none of the specified packages contain a world");
+                    let worlds = packages
+                        .iter()
+                        .flat_map(|pkg| {
+                            self.packages[*pkg]
+                                .worlds
+                                .values()
+                                .map(|world| (*pkg, *world))
+                        })
+                        .collect::<Vec<_>>();
+
+                    match &worlds[..] {
+                        [] => bail!("none of the specified packages contain a world"),
+                        [(_, world)] => return Ok(*world),
+                        _ => bail!(
+                            "multiple worlds found; one must be explicitly chosen:{}",
+                            worlds
+                                .iter()
+                                .map(|(pkg, world)| format!(
+                                    "\n  {}/{}",
+                                    self.packages[*pkg].name, self.worlds[*world].name
+                                ))
+                                .collect::<String>()
+                        ),
                     }
                 }
             },

--- a/tests/cli/multiple-packages-multiple-worlds-in-package.wit
+++ b/tests/cli/multiple-packages-multiple-worlds-in-package.wit
@@ -1,0 +1,24 @@
+// FAIL: component embed --dummy --wat %
+
+package test:foo1 {
+  interface bar {
+    baz: func(s: string) -> string;
+  }
+}
+
+package test:foo2 {
+  interface bar {
+    baz: func(s: string) -> string;
+  }
+}
+
+package test:hola {
+  world hello {
+    import test:foo1/bar;
+    export test:foo2/bar;
+  }
+  world some-other-world {
+    import test:foo1/bar;
+    export test:foo2/bar;
+  }
+}

--- a/tests/cli/multiple-packages-multiple-worlds-in-package.wit.stderr
+++ b/tests/cli/multiple-packages-multiple-worlds-in-package.wit.stderr
@@ -1,0 +1,3 @@
+error: multiple worlds found; one must be explicitly chosen:
+  test:hola/hello
+  test:hola/some-other-world

--- a/tests/cli/multiple-packages-multiple-worlds.wit
+++ b/tests/cli/multiple-packages-multiple-worlds.wit
@@ -1,0 +1,24 @@
+// FAIL: component embed --dummy --wat %
+
+package test:foo1 {
+  interface bar {
+    baz: func(s: string) -> string;
+  }
+}
+
+package test:foo2 {
+  interface bar {
+    baz: func(s: string) -> string;
+  }
+  world some-other-world {
+    import test:foo1/bar;
+    export bar;
+  }
+}
+
+package test:hola {
+  world hello {
+    import test:foo1/bar;
+    export test:foo2/bar;
+  }
+}

--- a/tests/cli/multiple-packages-multiple-worlds.wit.stderr
+++ b/tests/cli/multiple-packages-multiple-worlds.wit.stderr
@@ -1,0 +1,3 @@
+error: multiple worlds found; one must be explicitly chosen:
+  test:foo2/some-other-world
+  test:hola/hello

--- a/tests/cli/multiple-packages-one-world.wit
+++ b/tests/cli/multiple-packages-one-world.wit
@@ -1,0 +1,20 @@
+// RUN: component embed --dummy --wat %
+
+package test:foo1 {
+  interface bar {
+    baz: func(s: string) -> string;
+  }
+}
+
+package test:foo2 {
+  interface bar {
+    baz: func(s: string) -> string;
+  }
+}
+
+package test:hola {
+  world hello {
+    import test:foo1/bar;
+    export test:foo2/bar;    
+  }
+}

--- a/tests/cli/multiple-packages-one-world.wit.stdout
+++ b/tests/cli/multiple-packages-one-world.wit.stdout
@@ -1,0 +1,17 @@
+(module
+  (type (;0;) (func (param i32 i32 i32)))
+  (type (;1;) (func (param i32 i32) (result i32)))
+  (type (;2;) (func (param i32 i32 i32 i32) (result i32)))
+  (import "test:foo1/bar" "baz" (func (;0;) (type 0)))
+  (func (;1;) (type 1) (param i32 i32) (result i32)
+    unreachable
+  )
+  (func (;2;) (type 2) (param i32 i32 i32 i32) (result i32)
+    unreachable
+  )
+  (memory (;0;) 0)
+  (export "test:foo2/bar#baz" (func 1))
+  (export "memory" (memory 0))
+  (export "cabi_realloc" (func 2))
+  (@custom "component-type" (after code) "/00asm/0d/00/01/00/00/19/16wit-component-encoding/04/00/07d/01A/02/01A/04/01B/02/01@/01/01ss/00s/04/00/03baz/01/00/03/01/0dtest:foo1/bar/05/00/01B/02/01@/01/01ss/00s/04/00/03baz/01/00/04/01/0dtest:foo2/bar/05/01/04/01/0ftest:hola/hello/04/00/0b/0b/01/00/05hello/03/00/00/00//09producers/01/0cprocessed-by/01/0dwit-component/070.213.0")
+)


### PR DESCRIPTION
Previously, `Resolve::select_world` would return an error if multiple packages were provided and no world was specified.  Now, we return `Ok` in this case as long as exactly one package has exactly one world.