### PR TITLE
`wasmparser`: Raise imports and exports limit to 1,000,000

### DIFF
--- a/crates/wasmparser/src/limits.rs
+++ b/crates/wasmparser/src/limits.rs
@@ -20,7 +20,8 @@
 pub const MAX_WASM_TYPES: usize = 1_000_000;
 pub const MAX_WASM_SUPERTYPES: usize = 1;
 pub const MAX_WASM_FUNCTIONS: usize = 1_000_000;
-pub const MAX_WASM_EXPORTS: usize = 100_000;
+pub const MAX_WASM_IMPORTS: usize = 1_000_000;
+pub const MAX_WASM_EXPORTS: usize = 1_000_000;
 pub const MAX_WASM_GLOBALS: usize = 1_000_000;
 pub const MAX_WASM_ELEMENT_SEGMENTS: usize = 100_000;
 pub const MAX_WASM_DATA_SEGMENTS: usize = 100_000;

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -677,7 +677,17 @@ impl Validator {
             Order::Import,
             section,
             "import",
-            |_, _, _, _, _| Ok(()), // add_import will check limits
+            |state, _, _, count, offset| {
+                check_max(
+                    state.module.imports.len(),
+                    count,
+                    MAX_WASM_IMPORTS,
+                    "imports",
+                    offset,
+                )?;
+                state.module.assert_mut().imports.reserve(count as usize);
+                Ok(())
+            },
             |state, features, types, import, offset| {
                 state
                     .module


### PR DESCRIPTION
See https://github.com/WebAssembly/spec/pull/1766 and https://github.com/WebAssembly/design/issues/1520 for details.