### PR TITLE
Rewrite `Resolve::merge_worlds`

### DIFF
--- a/tests/cli/world-merging-add-imports.wit
+++ b/tests/cli/world-merging-add-imports.wit
@@ -1,0 +1,17 @@
+// RUN: component embed --dummy --world into % | component embed --world %from % | component wit
+
+package a:b;
+
+world into {
+}
+
+interface b {
+  type t = u32;
+}
+
+world %from {
+  import a: interface {}
+  import b;
+  use b.{t};
+  import c: func() -> t;
+}

--- a/tests/cli/world-merging-add-imports.wit.stdout
+++ b/tests/cli/world-merging-add-imports.wit.stdout
@@ -1,0 +1,26 @@
+package root:root {
+  world root {
+    import a: interface {
+    }
+    import a:b/b;
+    import c: func() -> t;
+    use a:b/b.{t};
+  }
+}
+
+
+package a:b {
+  interface b {
+    type t = u32;
+  }
+
+  world into {
+  }
+  world %from {
+    import a: interface {
+    }
+    import b;
+    import c: func() -> t;
+    use b.{t};
+  }
+}

--- a/tests/cli/world-merging-export-conflict.wit
+++ b/tests/cli/world-merging-export-conflict.wit
@@ -1,0 +1,11 @@
+// FAIL: component embed --dummy --world into % | component embed --world %from % | component wit
+
+package a:b;
+
+world into {
+  export a: interface {}
+}
+
+world %from {
+  export a: func();
+}

--- a/tests/cli/world-merging-export-conflict.wit.stderr
+++ b/tests/cli/world-merging-export-conflict.wit.stderr
@@ -1,0 +1,6 @@
+error: updating metadata for section component-type
+
+Caused by:
+    0: failed to merge worlds from two documents
+    1: failed to merge world export a
+    2: different kinds of items

--- a/tests/cli/world-merging-export-semantic-change.wit
+++ b/tests/cli/world-merging-export-semantic-change.wit
@@ -1,0 +1,24 @@
+// FAIL: component embed --dummy --world into % | component embed --world %from % | component wit
+
+package a:b;
+
+interface i1 {
+  type t = u32;
+}
+interface i2 {
+  use i1.{t};
+}
+
+world into {
+  export i2;
+}
+
+// This world cannot be merged into `into` because it would change the meaning
+// of `into`. Previously in `into` i2's export of `i2` would refer to the
+// implicit import of `i1`, but here the export of `i2` refers to the export of
+// `i1`.
+world %from {
+  export i1;
+  export i2;
+}
+

--- a/tests/cli/world-merging-export-semantic-change.wit.stderr
+++ b/tests/cli/world-merging-export-semantic-change.wit.stderr
@@ -1,0 +1,6 @@
+error: updating metadata for section component-type
+
+Caused by:
+    0: failed to merge worlds from two documents
+    1: failed to add export `a:b/i1`
+    2: export `a:b/i2` has a type `t` which could change meaning if this world export were added

--- a/tests/cli/world-merging-import-conflict.wit
+++ b/tests/cli/world-merging-import-conflict.wit
@@ -1,0 +1,11 @@
+// FAIL: component embed --dummy --world into % | component embed --world %from % | component wit
+
+package a:b;
+
+world into {
+  import a: interface {}
+}
+
+world %from {
+  import a: func();
+}

--- a/tests/cli/world-merging-import-conflict.wit.stderr
+++ b/tests/cli/world-merging-import-conflict.wit.stderr
@@ -1,0 +1,6 @@
+error: updating metadata for section component-type
+
+Caused by:
+    0: failed to merge worlds from two documents
+    1: failed to merge world import a
+    2: different kinds of items

--- a/tests/cli/world-merging-same-imports.wit
+++ b/tests/cli/world-merging-same-imports.wit
@@ -1,0 +1,21 @@
+// RUN: component embed --dummy --world into % | component embed --world %from % | component wit
+
+package a:b;
+
+interface b {
+  type t = u32;
+}
+
+world into {
+  import a: interface {}
+  import b;
+  import c: func();
+  use b.{t};
+}
+
+world %from {
+  import a: interface {}
+  import b;
+  import c: func();
+  use b.{t};
+}

--- a/tests/cli/world-merging-same-imports.wit.stdout
+++ b/tests/cli/world-merging-same-imports.wit.stdout
@@ -1,0 +1,31 @@
+package root:root {
+  world root {
+    import a: interface {
+    }
+    import a:b/b;
+    import c: func();
+    use a:b/b.{t};
+  }
+}
+
+
+package a:b {
+  interface b {
+    type t = u32;
+  }
+
+  world into {
+    import a: interface {
+    }
+    import b;
+    import c: func();
+    use b.{t};
+  }
+  world %from {
+    import a: interface {
+    }
+    import b;
+    import c: func();
+    use b.{t};
+  }
+}

--- a/tests/cli/world-merging.wit
+++ b/tests/cli/world-merging.wit
@@ -1,0 +1,22 @@
+// RUN: component embed --dummy --world foo % | component embed --world foo % | component wit
+
+// This test embeds this world twice and then ensures that merging the two
+// worlds together works (it's the same definition anyway).
+
+package a:b;
+
+interface x {
+  type t = u32;
+}
+
+world foo {
+  import x;
+  export x;
+
+  use x.{t};
+
+  import a: func() -> t;
+
+  export x: interface {}
+  export y: func();
+}

--- a/tests/cli/world-merging.wit.stdout
+++ b/tests/cli/world-merging.wit.stdout
@@ -1,0 +1,30 @@
+package root:root {
+  world root {
+    import a:b/x;
+    import a: func() -> t;
+    use a:b/x.{t};
+
+    export y: func();
+    export a:b/x;
+    export x: interface {
+    }
+  }
+}
+
+
+package a:b {
+  interface x {
+    type t = u32;
+  }
+
+  world foo {
+    import x;
+    import a: func() -> t;
+    use x.{t};
+
+    export y: func();
+    export x;
+    export x: interface {
+    }
+  }
+}


### PR DESCRIPTION
This commit updates and rewrites the `Resolve::merge_worlds` helper which is one of the workhorses of `wit-bindgen` and `wit-component`. The previous implementation is largely thrown out and replaced with:

* Any new import can always be added.
* Any preexisting import must "match" the one being added. This is done by updating `MergeMap` with some more functionality (but not everything) and handling all kinds of imports.
* Any preexisting export must "match" in the same way as imports.
* New exports can only be added if the meaning of previous exports don't change. This means that if a new export is a transitive dependency of an existing export then it can't be added.

This fixes a number of issues with the previous implementation which was written during a different time with a different structure of WIT.

Closes #1685