### PR TITLE
Implement `@deprecated` in WIT

### DIFF
--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -903,7 +903,11 @@ impl WitPrinter {
     fn print_stability(&mut self, stability: &Stability) {
         match stability {
             Stability::Unknown => {}
-            Stability::Stable { since, feature } => {
+            Stability::Stable {
+                since,
+                feature,
+                deprecated,
+            } => {
                 self.output.push_str("@since(version = ");
                 self.output.push_str(&since.to_string());
                 if let Some(feature) = feature {
@@ -911,11 +915,24 @@ impl WitPrinter {
                     self.output.push_str(feature);
                 }
                 self.output.push_str(")\n");
+                if let Some(version) = deprecated {
+                    self.output.push_str("@deprecated(version = ");
+                    self.output.push_str(&version.to_string());
+                    self.output.push_str(")\n");
+                }
             }
-            Stability::Unstable { feature } => {
+            Stability::Unstable {
+                feature,
+                deprecated,
+            } => {
                 self.output.push_str("@unstable(feature = ");
                 self.output.push_str(feature);
                 self.output.push_str(")\n");
+                if let Some(version) = deprecated {
+                    self.output.push_str("@deprecated(version = ");
+                    self.output.push_str(&version.to_string());
+                    self.output.push_str(")\n");
+                }
             }
         }
     }

--- a/crates/wit-parser/src/ast.rs
+++ b/crates/wit-parser/src/ast.rs
@@ -1504,6 +1504,10 @@ enum Attribute<'a> {
         span: Span,
         feature: Id<'a>,
     },
+    Deprecated {
+        span: Span,
+        version: Version,
+    },
 }
 
 impl<'a> Attribute<'a> {
@@ -1513,18 +1517,18 @@ impl<'a> Attribute<'a> {
             let id = parse_id(tokens)?;
             let attr = match id.name {
                 "since" => {
-                    tokens.eat(Token::LeftParen)?;
+                    tokens.expect(Token::LeftParen)?;
                     eat_id(tokens, "version")?;
-                    tokens.eat(Token::Equals)?;
+                    tokens.expect(Token::Equals)?;
                     let (_span, version) = parse_version(tokens)?;
                     let feature = if tokens.eat(Token::Comma)? {
                         eat_id(tokens, "feature")?;
-                        tokens.eat(Token::Equals)?;
+                        tokens.expect(Token::Equals)?;
                         Some(parse_id(tokens)?)
                     } else {
                         None
                     };
-                    tokens.eat(Token::RightParen)?;
+                    tokens.expect(Token::RightParen)?;
                     Attribute::Since {
                         span: id.span,
                         version,
@@ -1532,14 +1536,25 @@ impl<'a> Attribute<'a> {
                     }
                 }
                 "unstable" => {
-                    tokens.eat(Token::LeftParen)?;
+                    tokens.expect(Token::LeftParen)?;
                     eat_id(tokens, "feature")?;
-                    tokens.eat(Token::Equals)?;
+                    tokens.expect(Token::Equals)?;
                     let feature = parse_id(tokens)?;
-                    tokens.eat(Token::RightParen)?;
+                    tokens.expect(Token::RightParen)?;
                     Attribute::Unstable {
                         span: id.span,
                         feature,
+                    }
+                }
+                "deprecated" => {
+                    tokens.expect(Token::LeftParen)?;
+                    eat_id(tokens, "version")?;
+                    tokens.expect(Token::Equals)?;
+                    let (_span, version) = parse_version(tokens)?;
+                    tokens.expect(Token::RightParen)?;
+                    Attribute::Deprecated {
+                        span: id.span,
+                        version,
                     }
                 }
                 other => {
@@ -1553,7 +1568,9 @@ impl<'a> Attribute<'a> {
 
     fn span(&self) -> Span {
         match self {
-            Attribute::Since { span, .. } | Attribute::Unstable { span, .. } => *span,
+            Attribute::Since { span, .. }
+            | Attribute::Unstable { span, .. }
+            | Attribute::Deprecated { span, .. } => *span,
         }
     }
 }

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -845,13 +845,35 @@ pub enum Stability {
         since: Version,
         #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
         feature: Option<String>,
+        #[cfg_attr(
+            feature = "serde",
+            serde(
+                skip_serializing_if = "Option::is_none",
+                default,
+                serialize_with = "serialize_optional_version",
+                deserialize_with = "deserialize_optional_version"
+            )
+        )]
+        deprecated: Option<Version>,
     },
 
     /// `@unstable(feature = foo)`
     ///
     /// This item is explicitly tagged `@unstable`. A feature name is listed and
     /// this item is excluded by default in `Resolve` unless explicitly enabled.
-    Unstable { feature: String },
+    Unstable {
+        feature: String,
+        #[cfg_attr(
+            feature = "serde",
+            serde(
+                skip_serializing_if = "Option::is_none",
+                default,
+                serialize_with = "serialize_optional_version",
+                deserialize_with = "deserialize_optional_version"
+            )
+        )]
+        deprecated: Option<Version>,
+    },
 
     /// This item does not have either `@since` or `@unstable`.
     Unknown,

--- a/crates/wit-parser/src/resolve.rs
+++ b/crates/wit-parser/src/resolve.rs
@@ -1332,7 +1332,9 @@ impl Resolve {
     fn include_stability(&self, stability: &Stability) -> bool {
         match stability {
             Stability::Stable { .. } | Stability::Unknown => true,
-            Stability::Unstable { feature } => self.features.contains(feature) || self.all_features,
+            Stability::Unstable { feature, .. } => {
+                self.features.contains(feature) || self.all_features
+            }
         }
     }
 }

--- a/crates/wit-parser/src/serde_.rs
+++ b/crates/wit-parser/src/serde_.rs
@@ -122,3 +122,26 @@ where
     let version: String = String::deserialize(deserializer)?;
     version.parse().map_err(|e| D::Error::custom(e))
 }
+
+pub fn serialize_optional_version<S>(
+    version: &Option<Version>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    version
+        .as_ref()
+        .map(|s| s.to_string())
+        .serialize(serializer)
+}
+
+pub fn deserialize_optional_version<'de, D>(deserializer: D) -> Result<Option<Version>, D::Error>
+where
+    D: serde::de::Deserializer<'de>,
+{
+    match <Option<String>>::deserialize(deserializer)? {
+        Some(version) => Ok(Some(version.parse().map_err(|e| D::Error::custom(e))?)),
+        None => Ok(None),
+    }
+}

--- a/crates/wit-parser/tests/ui/parse-fail/bad-deprecated1.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-deprecated1.wit
@@ -1,0 +1,4 @@
+package a:b;
+
+@deprecated
+interface foo {}

--- a/crates/wit-parser/tests/ui/parse-fail/bad-deprecated1.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-deprecated1.wit.result
@@ -1,0 +1,5 @@
+expected '(', found keyword `interface`
+     --> tests/ui/parse-fail/bad-deprecated1.wit:4:1
+      |
+    4 | interface foo {}
+      | ^

--- a/crates/wit-parser/tests/ui/parse-fail/bad-deprecated2.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-deprecated2.wit
@@ -1,0 +1,4 @@
+package a:b;
+
+@deprecated()
+interface foo {}

--- a/crates/wit-parser/tests/ui/parse-fail/bad-deprecated2.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-deprecated2.wit.result
@@ -1,0 +1,5 @@
+expected an identifier or string, found ')'
+     --> tests/ui/parse-fail/bad-deprecated2.wit:3:13
+      |
+    3 | @deprecated()
+      |             ^

--- a/crates/wit-parser/tests/ui/parse-fail/bad-deprecated3.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-deprecated3.wit
@@ -1,0 +1,4 @@
+package a:b;
+
+@deprecated(since = 1.2.3)
+interface foo {}

--- a/crates/wit-parser/tests/ui/parse-fail/bad-deprecated3.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-deprecated3.wit.result
@@ -1,0 +1,5 @@
+expected `version`, found `since`
+     --> tests/ui/parse-fail/bad-deprecated3.wit:3:13
+      |
+    3 | @deprecated(since = 1.2.3)
+      |             ^----

--- a/crates/wit-parser/tests/ui/parse-fail/bad-deprecated4.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-deprecated4.wit
@@ -1,0 +1,5 @@
+package a:b;
+
+@deprecated(since = 1.2.3)
+@deprecated(since = 1.2.3)
+interface foo {}

--- a/crates/wit-parser/tests/ui/parse-fail/bad-deprecated4.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-deprecated4.wit.result
@@ -1,0 +1,5 @@
+expected `version`, found `since`
+     --> tests/ui/parse-fail/bad-deprecated4.wit:3:13
+      |
+    3 | @deprecated(since = 1.2.3)
+      |             ^----

--- a/crates/wit-parser/tests/ui/parse-fail/bad-since1.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-since1.wit.result
@@ -1,5 +1,5 @@
-expected an identifier or string, found keyword `interface`
+expected '(', found keyword `interface`
      --> tests/ui/parse-fail/bad-since1.wit:4:1
       |
     4 | interface foo1 {}
-      | ^--------
+      | ^

--- a/crates/wit-parser/tests/ui/since-and-unstable.wit
+++ b/crates/wit-parser/tests/ui/since-and-unstable.wit
@@ -87,3 +87,21 @@ world in-a-world {
     constructor();
   }
 }
+
+interface deprecated1 {
+  @since(version = 1.0.0)
+  @deprecated(version = 1.0.1)
+  type t1 = u32;
+
+  @deprecated(version = 1.0.1)
+  @since(version = 1.0.0)
+  type t2 = u32;
+
+  @unstable(feature = foo)
+  @deprecated(version = 1.0.1)
+  type t3 = u32;
+
+  @deprecated(version = 1.0.1)
+  @unstable(feature = foo)
+  type t4 = u32;
+}

--- a/crates/wit-parser/tests/ui/since-and-unstable.wit.json
+++ b/crates/wit-parser/tests/ui/since-and-unstable.wit.json
@@ -27,7 +27,7 @@
       "imports": {
         "y": {
           "interface": {
-            "id": 5,
+            "id": 6,
             "stability": {
               "stable": {
                 "since": "1.0.0"
@@ -46,25 +46,25 @@
           }
         },
         "t1": {
-          "type": 9
-        },
-        "t2": {
-          "type": 10
-        },
-        "t3": {
           "type": 11
         },
-        "t4": {
+        "t2": {
           "type": 12
         },
-        "t5": {
+        "t3": {
           "type": 13
         },
-        "t6": {
+        "t4": {
           "type": 14
         },
-        "t7": {
+        "t5": {
           "type": 15
+        },
+        "t6": {
+          "type": 16
+        },
+        "t7": {
+          "type": 17
         },
         "x": {
           "function": {
@@ -83,12 +83,12 @@
           "function": {
             "name": "[constructor]t7",
             "kind": {
-              "constructor": 15
+              "constructor": 17
             },
             "params": [],
             "results": [
               {
-                "type": 17
+                "type": 19
               }
             ],
             "stability": {
@@ -115,7 +115,7 @@
         },
         "y": {
           "interface": {
-            "id": 6,
+            "id": 7,
             "stability": {
               "stable": {
                 "since": "1.0.0"
@@ -205,7 +205,7 @@
           "params": [],
           "results": [
             {
-              "type": 16
+              "type": 18
             }
           ],
           "stability": {
@@ -251,6 +251,15 @@
     {
       "name": "z",
       "types": {},
+      "functions": {},
+      "package": 0
+    },
+    {
+      "name": "deprecated1",
+      "types": {
+        "t1": 9,
+        "t2": 10
+      },
       "functions": {},
       "package": 0
     },
@@ -427,6 +436,36 @@
     {
       "name": "t1",
       "kind": {
+        "type": "u32"
+      },
+      "owner": {
+        "interface": 5
+      },
+      "stability": {
+        "stable": {
+          "since": "1.0.0",
+          "deprecated": "1.0.1"
+        }
+      }
+    },
+    {
+      "name": "t2",
+      "kind": {
+        "type": "u32"
+      },
+      "owner": {
+        "interface": 5
+      },
+      "stability": {
+        "stable": {
+          "since": "1.0.0",
+          "deprecated": "1.0.1"
+        }
+      }
+    },
+    {
+      "name": "t1",
+      "kind": {
         "record": {
           "fields": [
             {
@@ -557,7 +596,7 @@
       "name": null,
       "kind": {
         "handle": {
-          "own": 15
+          "own": 17
         }
       },
       "owner": null
@@ -571,7 +610,8 @@
         "foo2": 1,
         "foo3": 2,
         "in-an-interface": 3,
-        "z": 4
+        "z": 4,
+        "deprecated1": 5
       },
       "worlds": {
         "w1": 0,

--- a/tests/cli/wit-stability-in-binary-format.wit
+++ b/tests/cli/wit-stability-in-binary-format.wit
@@ -15,6 +15,10 @@ interface foo {
     @since(version = 1.0.0)
     constructor();
   }
+
+  @since(version = 1.0.0)
+  @deprecated(version = 1.0.1)
+  type t2 = u32;
 }
 
 @since(version = 1.0.0)

--- a/tests/cli/wit-stability-in-binary-format.wit.stdout
+++ b/tests/cli/wit-stability-in-binary-format.wit.stdout
@@ -13,6 +13,10 @@ interface foo {
   }
 
   @since(version = 1.0.0)
+  @deprecated(version = 1.0.1)
+  type t2 = u32;
+
+  @since(version = 1.0.0)
   f: func();
 }
 


### PR DESCRIPTION
This is intended to correspond with WebAssembly/component-model#377.

Closes #1683