### PR TITLE
Fix naming non-locals with `--name-unnamed`

### DIFF
--- a/tests/cli/print-unnamed.wat
+++ b/tests/cli/print-unnamed.wat
@@ -31,4 +31,11 @@
       )
     )
   )
+
+  (func $foo
+    unreachable
+    block (param i32 f32) (result i32 f32)
+      unreachable
+    end
+  )
 )

--- a/tests/cli/print-unnamed.wat.stdout
+++ b/tests/cli/print-unnamed.wat.stdout
@@ -1,5 +1,6 @@
 (module
   (type $#type0 (;0;) (func))
+  (type $#type1 (;1;) (func (param i32 f32) (result i32 f32)))
   (func $#func0 (;0;) (type $#type0)
     block $a
       block $#label1
@@ -24,6 +25,12 @@
           br_table $a 1 2 3
         end
       end
+    end
+  )
+  (func $foo (;1;) (type $#type0)
+    unreachable
+    block $#label0 (type $#type1) (param i32 f32) (result i32 f32)
+      unreachable
     end
   )
 )


### PR DESCRIPTION
This commit fixes an issue where the `--name-unnamed` argument to `wasm-tools print` would erroneously assign names to block params where names were not allowed.

Closes #1684