### PR TITLE
fix(wit-parser): improve checking for stable feature gates

### DIFF
--- a/crates/wit-component/tests/merge/success/from/a.wit
+++ b/crates/wit-component/tests/merge/success/from/a.wit
@@ -1,7 +1,7 @@
 package foo:%from;
 
 interface a {
-  use foo:foo/only-from.{r};
+  use foo:foo/only-from@1.0.0.{r};
 
   foo: func();
 }

--- a/crates/wit-component/tests/merge/success/from/deps/foo/shared.wit
+++ b/crates/wit-component/tests/merge/success/from/deps/foo/shared.wit
@@ -1,4 +1,4 @@
-package foo:foo;
+package foo:foo@1.0.0;
 
 interface shared-only-from {
   variant v {

--- a/crates/wit-component/tests/merge/success/into/b.wit
+++ b/crates/wit-component/tests/merge/success/into/b.wit
@@ -1,7 +1,7 @@
 package foo:into;
 
 interface b {
-  use foo:foo/only-into.{r};
+  use foo:foo/only-into@1.0.0.{r};
 
   foo: func();
 }

--- a/crates/wit-component/tests/merge/success/into/deps/foo/shared.wit
+++ b/crates/wit-component/tests/merge/success/into/deps/foo/shared.wit
@@ -1,4 +1,4 @@
-package foo:foo;
+package foo:foo@1.0.0;
 
 interface shared-only-into {
   variant v {

--- a/crates/wit-component/tests/merge/success/merge/foo.wit
+++ b/crates/wit-component/tests/merge/success/merge/foo.wit
@@ -1,4 +1,4 @@
-package foo:foo;
+package foo:foo@1.0.0;
 
 interface only-into {
   record r {

--- a/crates/wit-component/tests/merge/success/merge/from.wit
+++ b/crates/wit-component/tests/merge/success/merge/from.wit
@@ -1,7 +1,7 @@
 package foo:%from;
 
 interface a {
-  use foo:foo/only-from.{r};
+  use foo:foo/only-from@1.0.0.{r};
 
   foo: func();
 }

--- a/crates/wit-component/tests/merge/success/merge/into.wit
+++ b/crates/wit-component/tests/merge/success/merge/into.wit
@@ -1,7 +1,7 @@
 package foo:into;
 
 interface b {
-  use foo:foo/only-into.{r};
+  use foo:foo/only-into@1.0.0.{r};
 
   foo: func();
 }

--- a/tests/cli/since-on-future-package.wit
+++ b/tests/cli/since-on-future-package.wit
@@ -1,0 +1,18 @@
+// FAIL: component embed --dummy %
+
+package test:invalid@0.1.0;
+
+interface foo {
+  a: func(s: string) -> string;
+
+  @since(version = 0.1.1)
+  b: func(s: string) -> string;
+
+  @since(version = 0.1.1, feature = c-please)
+  c: func(s: string) -> string;
+}
+
+world test {
+  import foo;
+  export foo;
+}

--- a/tests/cli/since-on-future-package.wit.stderr
+++ b/tests/cli/since-on-future-package.wit.stderr
@@ -1,0 +1,4 @@
+error: failed to process feature gate for function [b] in package [test:invalid@0.1.0]
+
+Caused by:
+    0: feature gate cannot reference unreleased version 0.1.1 of package [test:invalid@0.1.0] (current version 0.1.0)

--- a/tests/cli/wit-stability-in-binary-format.wit
+++ b/tests/cli/wit-stability-in-binary-format.wit
@@ -1,6 +1,6 @@
 // RUN: component wit % --wasm | component wit
 
-package a:b;
+package a:b@1.0.0;
 
 @since(version = 1.0.0)
 interface foo {

--- a/tests/cli/wit-stability-in-binary-format.wit.stdout
+++ b/tests/cli/wit-stability-in-binary-format.wit.stdout
@@ -1,5 +1,5 @@
 /// RUN: component wit % --wasm | component wit
-package a:b;
+package a:b@1.0.0;
 
 @since(version = 1.0.0)
 interface foo {

--- a/tests/cli/wit-stability-inherited.wit
+++ b/tests/cli/wit-stability-inherited.wit
@@ -1,6 +1,6 @@
 // RUN: component wit %
 
-package a:b;
+package a:b@1.0.0;
 
 interface foo {
   type t = u32;

--- a/tests/cli/wit-stability-inherited.wit.stdout
+++ b/tests/cli/wit-stability-inherited.wit.stdout
@@ -1,5 +1,5 @@
 /// RUN: component wit %
-package a:b;
+package a:b@1.0.0;
 
 interface foo {
   type t = u32;


### PR DESCRIPTION
This commit introduces some extra checking (and panicking) for feature gates that are stable (i.e. `Stability::Stable`) AKA `@since` with a version and/or features specified.

There are two primary changes:
- Make referring to a *future* version of the package an error (for now)
- Ensure that if a feature is specified that it is checked before inclusion

In the past `Stability::Stable` feature gates were simply treated as `Unknown`, which hides the information necessary for downstream crates/consumers to use (and created the question around whether referring to future package versions is valid).

See also the [relevant Zulip discussion](https://bytecodealliance.zulipchat.com/#narrow/stream/223391-wasm/topic/Missing.20impl.20for.20.40since.20in.20.60Resolve.3A.3Ainclude_stability.28.29.60/near/452175637)