### PR TITLE
Don't generate multi-return functions in wit-smith

### DIFF
--- a/crates/wit-smith/src/generate.rs
+++ b/crates/wit-smith/src/generate.rs
@@ -847,9 +847,6 @@ impl<'a> InterfaceGenerator<'a> {
         self.gen_params(u, dst, method)?;
         if u.arbitrary()? {
             dst.push_str(" -> ");
-            self.gen_params(u, dst, false)?;
-        } else if u.arbitrary()? {
-            dst.push_str(" -> ");
             let mut fuel = self.config.max_type_size;
             self.gen_type(u, &mut fuel, dst)?;
         }


### PR DESCRIPTION
This fixes a fuzz issue from #1670 which wasn't fixed at the time and has been found on oss-fuzz.