### PR TITLE
Enable json-from-wast tests for components

### DIFF
--- a/tests/local/component-model/adapt.wast
+++ b/tests/local/component-model/adapt.wast
@@ -245,12 +245,10 @@
 )
 
 (assert_invalid
-  (component
-    (core module $m
-      (func (export ""))
-    )
-    (core instance $i (instantiate $m))
-    (core func (canon lower (func $i "")))
+  (component quote
+    "(core module $m (func (export \"\")))"
+    "(core instance $i (instantiate $m))"
+    "(core func (canon lower (func $i \"\")))"
   )
   "unknown instance: failed to find name `$i`")
 
@@ -280,8 +278,8 @@
   "not a function type")
 
 (assert_invalid
-  (component
-    (import "a" (func $f))
-    (func (export "foo") (canon lift (core func $f)))
+  (component quote
+    "(import \"a\" (func $f))"
+    "(func (export \"foo\") (canon lift (core func $f)))"
   )
   "unknown core func: failed to find name `$f`")

--- a/tests/local/component-model/definedtypes.wast
+++ b/tests/local/component-model/definedtypes.wast
@@ -43,23 +43,23 @@
 )
 
 (assert_invalid
-  (component
-    (type $t (variant (case $x "x" string (refines $x))))
+  (component quote
+    "(type $t (variant (case $x \"x\" string (refines $x))))"
   )
   "variant case cannot refine itself"
 )
 
 (assert_invalid
-  (component
-    (type $t (variant (case "x" (refines $y)) (case $y "y" string)))
+  (component quote
+    "(type $t (variant (case \"x\" (refines $y)) (case $y \"y\" string)))"
   )
   "unknown variant case"
 )
 
 (assert_invalid
-  (component
-    (type $t string)
-    (type $v (variant (case "x" $t (refines $z))))
+  (component quote
+    "(type $t string)"
+    "(type $v (variant (case \"x\" $t (refines $z))))"
   )
   "unknown variant case"
 )
@@ -82,9 +82,9 @@
 )
 
 (assert_invalid
-  (component
-    (type $t string)
-    (type $v (variant (case $x "x" $t) (case $x "y" $t)))
+  (component quote
+    "(type $t string)"
+    "(type $v (variant (case $x \"x\" $t) (case $x \"y\" $t)))"
   )
   "duplicate variant case identifier"
 )

--- a/tests/local/component-model/export-introduces-alias.wast
+++ b/tests/local/component-model/export-introduces-alias.wast
@@ -27,11 +27,11 @@
 )
 
 (assert_invalid
-  (component
-    (type (instance
-      (type $t u8)
-      (export $t "t" (type (eq $t)))
-    ))
+  (component quote
+    "(type (instance"
+      "(type $t u8)"
+      "(export $t \"t\" (type (eq $t)))"
+    "))"
   )
   "duplicate type identifier")
 

--- a/tests/local/component-model/instance-type.wast
+++ b/tests/local/component-model/instance-type.wast
@@ -199,11 +199,10 @@
   "core type index 0 is not a module type")
 
 (assert_invalid
-  (component
-    (type $t (func))
-    (type (instance
-      (export "a" (core module (type $t)))
-    )))
+  (component quote
+    "(type $t (func))"
+    "(type (instance (export \"a\" (core module (type $t)))))"
+  )
   "unknown core type")
 
 (assert_invalid

--- a/tests/local/component-model/types.wast
+++ b/tests/local/component-model/types.wast
@@ -119,10 +119,8 @@
   "import name `a` conflicts with previous name `A`")
 
 (assert_invalid
-  (component $c
-    (core type $t (module
-      (alias outer $c $t (type))
-    ))
+  (component quote
+    "(component $c (core type $t (module (alias outer $c $t (type)))))"
   )
   "unknown core type")
 
@@ -142,10 +140,8 @@
 )
 
 (assert_invalid
-  (component $c
-    (type $t (component
-      (alias outer $c $t (type))
-    ))
+  (component quote
+    "(component $c (type $t (component (alias outer $c $t (type)))))"
   )
   "unknown type")
 
@@ -196,10 +192,8 @@
   "export name `FOO-bar-BAZ` conflicts with previous name `foo-BAR-baz`")
 
 (assert_invalid
-  (component $c
-    (type $t (instance
-      (alias outer $c $t (type))
-    ))
+  (component quote
+    "(component $c (type $t (instance (alias outer $c $t (type)))))"
   )
   "unknown type")
 

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -533,11 +533,6 @@ impl TestState {
     }
 
     fn test_json_from_wast(&self, path: &Path) -> Result<()> {
-        // component model tests aren't tested through json-from-wast at this time.
-        if path.iter().any(|p| p == "component-model") {
-            return Ok(());
-        }
-
         // This has an `assert_invalid` which should be `assert_malformed`, so
         // skip it.
         if path.ends_with("gc-subtypes-invalid.wast") {

--- a/tests/snapshots/local/component-model/a.wast.json
+++ b/tests/snapshots/local/component-model/a.wast.json
@@ -1,0 +1,10 @@
+{
+  "source_filename": "tests/local/component-model/a.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 4,
+      "filename": "a.0.wasm"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/adapt.wast.json
+++ b/tests/snapshots/local/component-model/adapt.wast.json
@@ -1,0 +1,134 @@
+{
+  "source_filename": "tests/local/component-model/adapt.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 1,
+      "filename": "adapt.0.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 75,
+      "filename": "adapt.1.wasm",
+      "text": "canonical encoding option `utf8` conflicts with option `utf16`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 82,
+      "filename": "adapt.2.wasm",
+      "text": "canonical encoding option `utf8` conflicts with option `latin1-utf16`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 89,
+      "filename": "adapt.3.wasm",
+      "text": "canonical encoding option `utf16` conflicts with option `latin1-utf16`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 96,
+      "filename": "adapt.4.wasm",
+      "text": "memory index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 103,
+      "filename": "adapt.5.wasm",
+      "text": "`memory` is specified more than once",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 112,
+      "filename": "adapt.6.wasm",
+      "text": "canonical option `memory` is required",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 122,
+      "filename": "adapt.7.wasm",
+      "text": "canonical option `realloc` is required",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 137,
+      "filename": "adapt.8.wasm",
+      "text": "canonical option `realloc` is specified more than once",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 155,
+      "filename": "adapt.9.wasm",
+      "text": "canonical option `realloc` uses a core function with an incorrect signature",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 172,
+      "filename": "adapt.10.wasm",
+      "text": "canonical option `post-return` uses a core function with an incorrect signature",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 191,
+      "filename": "adapt.11.wasm",
+      "text": "canonical option `post-return` is specified more than once",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 211,
+      "filename": "adapt.12.wasm",
+      "text": "canonical option `post-return` cannot be specified for lowerings",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 230,
+      "filename": "adapt.13.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 248,
+      "filename": "adapt.14.wat",
+      "text": "unknown instance: failed to find name `$i`",
+      "module_type": "text"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 256,
+      "filename": "adapt.15.wasm",
+      "text": "lowered parameter types `[]` do not match parameter types `[I32]`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 264,
+      "filename": "adapt.16.wasm",
+      "text": "lowered result types `[]` do not match result types `[I32]`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 272,
+      "filename": "adapt.17.wasm",
+      "text": "not a function type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 281,
+      "filename": "adapt.18.wat",
+      "text": "unknown core func: failed to find name `$f`",
+      "module_type": "text"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/alias.wast.json
+++ b/tests/snapshots/local/component-model/alias.wast.json
@@ -1,0 +1,179 @@
+{
+  "source_filename": "tests/local/component-model/alias.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 1,
+      "filename": "alias.0.wasm"
+    },
+    {
+      "type": "module",
+      "line": 9,
+      "filename": "alias.1.wasm"
+    },
+    {
+      "type": "module",
+      "line": 18,
+      "filename": "alias.2.wasm"
+    },
+    {
+      "type": "module",
+      "line": 30,
+      "filename": "alias.3.wasm"
+    },
+    {
+      "type": "module",
+      "line": 62,
+      "filename": "alias.4.wasm"
+    },
+    {
+      "type": "module",
+      "line": 73,
+      "filename": "alias.5.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 101,
+      "filename": "alias.6.wasm",
+      "text": "export `a` for instance 0 is not a module",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 108,
+      "filename": "alias.7.wasm",
+      "text": "export `a` for instance 0 is not a module",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 118,
+      "filename": "alias.8.wasm",
+      "text": "core instance 0 has no export named `a`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 126,
+      "filename": "alias.9.wasm",
+      "text": "core instance 0 has no export named `a`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 134,
+      "filename": "alias.10.wasm",
+      "text": "instance 0 has no export named `a`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 142,
+      "filename": "alias.11.wasm",
+      "text": "type mismatch",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 153,
+      "name": "PARENT",
+      "filename": "alias.12.wasm"
+    },
+    {
+      "type": "module",
+      "line": 165,
+      "filename": "alias.13.wasm"
+    },
+    {
+      "type": "module",
+      "line": 194,
+      "name": "a",
+      "filename": "alias.14.wasm"
+    },
+    {
+      "type": "module",
+      "line": 213,
+      "filename": "alias.15.wasm"
+    },
+    {
+      "type": "module",
+      "line": 218,
+      "filename": "alias.16.wasm"
+    },
+    {
+      "type": "module",
+      "line": 223,
+      "filename": "alias.17.wasm"
+    },
+    {
+      "type": "module",
+      "line": 228,
+      "name": "C",
+      "filename": "alias.18.wasm"
+    },
+    {
+      "type": "module",
+      "line": 239,
+      "name": "C",
+      "filename": "alias.19.wasm"
+    },
+    {
+      "type": "module",
+      "line": 245,
+      "name": "C",
+      "filename": "alias.20.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 252,
+      "filename": "alias.21.wasm",
+      "text": "invalid outer alias count of 100",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 256,
+      "filename": "alias.22.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 260,
+      "filename": "alias.23.wasm",
+      "text": "invalid outer alias count of 100",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 264,
+      "filename": "alias.24.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 268,
+      "filename": "alias.25.wasm",
+      "text": "invalid outer alias count of 100",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 272,
+      "filename": "alias.26.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 275,
+      "filename": "alias.27.wasm"
+    },
+    {
+      "type": "module",
+      "line": 283,
+      "filename": "alias.28.wasm"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/big.wast.json
+++ b/tests/snapshots/local/component-model/big.wast.json
@@ -1,0 +1,10 @@
+{
+  "source_filename": "tests/local/component-model/big.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 1,
+      "filename": "big.0.wasm"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/definedtypes.wast.json
+++ b/tests/snapshots/local/component-model/definedtypes.wast.json
@@ -1,0 +1,179 @@
+{
+  "source_filename": "tests/local/component-model/definedtypes.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 1,
+      "name": "C",
+      "filename": "definedtypes.0.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 46,
+      "filename": "definedtypes.1.wat",
+      "text": "variant case cannot refine itself",
+      "module_type": "text"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 53,
+      "filename": "definedtypes.2.wat",
+      "text": "unknown variant case",
+      "module_type": "text"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 60,
+      "filename": "definedtypes.3.wat",
+      "text": "unknown variant case",
+      "module_type": "text"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 69,
+      "filename": "definedtypes.4.wasm",
+      "text": "variant case can only refine a previously defined case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 77,
+      "filename": "definedtypes.5.wasm",
+      "text": "variant case can only refine a previously defined case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 85,
+      "filename": "definedtypes.6.wat",
+      "text": "duplicate variant case identifier",
+      "module_type": "text"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 93,
+      "filename": "definedtypes.7.wasm",
+      "text": "type index 0 is not a defined type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 100,
+      "filename": "definedtypes.8.wasm",
+      "text": "type index 0 is not a defined type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 107,
+      "filename": "definedtypes.9.wasm",
+      "text": "type index 0 is not a defined type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 114,
+      "filename": "definedtypes.10.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 117,
+      "filename": "definedtypes.11.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 120,
+      "filename": "definedtypes.12.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 123,
+      "filename": "definedtypes.13.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 126,
+      "filename": "definedtypes.14.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 129,
+      "filename": "definedtypes.15.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 133,
+      "filename": "definedtypes.16.wasm",
+      "text": "record field name `A-b-C-d` conflicts with previous field name `a-B-c-D`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 136,
+      "filename": "definedtypes.17.wasm",
+      "text": "variant case name `x` conflicts with previous case name `x`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 139,
+      "filename": "definedtypes.18.wasm",
+      "text": "flag name `X` conflicts with previous flag name `x`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 142,
+      "filename": "definedtypes.19.wasm",
+      "text": "enum tag name `X` conflicts with previous tag name `x`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 146,
+      "filename": "definedtypes.20.wasm",
+      "text": "name cannot be empty",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 149,
+      "filename": "definedtypes.21.wasm",
+      "text": "name cannot be empty",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 152,
+      "filename": "definedtypes.22.wasm",
+      "text": "name cannot be empty",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 155,
+      "filename": "definedtypes.23.wasm",
+      "text": "name cannot be empty",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 159,
+      "filename": "definedtypes.24.wasm",
+      "text": "variant type must have at least one case",
+      "module_type": "binary"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/empty.wast.json
+++ b/tests/snapshots/local/component-model/empty.wast.json
@@ -1,0 +1,10 @@
+{
+  "source_filename": "tests/local/component-model/empty.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 2,
+      "filename": "empty.0.wasm"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/example.wast.json
+++ b/tests/snapshots/local/component-model/example.wast.json
@@ -1,0 +1,10 @@
+{
+  "source_filename": "tests/local/component-model/example.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 3,
+      "filename": "example.0.wasm"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/export-ascription.wast.json
+++ b/tests/snapshots/local/component-model/export-ascription.wast.json
@@ -1,0 +1,29 @@
+{
+  "source_filename": "tests/local/component-model/export-ascription.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 1,
+      "filename": "export-ascription.0.wasm"
+    },
+    {
+      "type": "module",
+      "line": 7,
+      "filename": "export-ascription.1.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 14,
+      "filename": "export-ascription.2.wasm",
+      "text": "ascribed type of export is not compatible",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 22,
+      "filename": "export-ascription.3.wasm",
+      "text": "missing expected export `f`",
+      "module_type": "binary"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/export-introduces-alias.wast.json
+++ b/tests/snapshots/local/component-model/export-introduces-alias.wast.json
@@ -1,0 +1,32 @@
+{
+  "source_filename": "tests/local/component-model/export-introduces-alias.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 1,
+      "filename": "export-introduces-alias.0.wasm"
+    },
+    {
+      "type": "module",
+      "line": 8,
+      "filename": "export-introduces-alias.1.wasm"
+    },
+    {
+      "type": "module",
+      "line": 16,
+      "filename": "export-introduces-alias.2.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 30,
+      "filename": "export-introduces-alias.3.wat",
+      "text": "duplicate type identifier",
+      "module_type": "text"
+    },
+    {
+      "type": "module",
+      "line": 38,
+      "filename": "export-introduces-alias.4.wasm"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/export.wast.json
+++ b/tests/snapshots/local/component-model/export.wast.json
@@ -1,0 +1,97 @@
+{
+  "source_filename": "tests/local/component-model/export.wast",
+  "commands": [
+    {
+      "type": "assert_invalid",
+      "line": 2,
+      "filename": "export.0.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 6,
+      "filename": "export.1.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 10,
+      "filename": "export.2.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 14,
+      "filename": "export.3.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 18,
+      "filename": "export.4.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 21,
+      "filename": "export.5.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 36,
+      "filename": "export.6.wasm",
+      "text": "cannot be used more than once",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 44,
+      "filename": "export.7.wasm"
+    },
+    {
+      "type": "module",
+      "line": 50,
+      "filename": "export.8.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 57,
+      "filename": "export.9.wasm",
+      "text": "not a valid export name",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 60,
+      "filename": "export.10.wasm",
+      "text": "not a valid export name",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 63,
+      "filename": "export.11.wasm",
+      "text": "not a valid extern name",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 66,
+      "filename": "export.12.wasm",
+      "text": "not a valid export name",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 69,
+      "filename": "export.13.wasm",
+      "text": "not a valid export name",
+      "module_type": "binary"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/func.wast.json
+++ b/tests/snapshots/local/component-model/func.wast.json
@@ -1,0 +1,72 @@
+{
+  "source_filename": "tests/local/component-model/func.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 1,
+      "filename": "func.0.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 8,
+      "filename": "func.1.wasm",
+      "text": "multiple returns on a function is now a gated feature",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 13,
+      "filename": "func.2.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 22,
+      "filename": "func.3.wasm",
+      "text": "function parameter name `FOO` conflicts with previous parameter name `foo`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 30,
+      "filename": "func.4.wasm",
+      "text": "canonical option `memory` is required",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 44,
+      "filename": "func.5.wasm"
+    },
+    {
+      "type": "module",
+      "line": 53,
+      "filename": "func.6.wasm"
+    },
+    {
+      "type": "module",
+      "line": 65,
+      "filename": "func.7.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 82,
+      "filename": "func.8.wasm",
+      "text": "canonical option `realloc` is required",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 105,
+      "filename": "func.9.wasm",
+      "text": "canonical option `realloc` is required",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 117,
+      "filename": "func.10.wasm",
+      "text": "canonical option `realloc` is required",
+      "module_type": "binary"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/import-extended.wast.json
+++ b/tests/snapshots/local/component-model/import-extended.wast.json
@@ -1,0 +1,20 @@
+{
+  "source_filename": "tests/local/component-model/import-extended.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 4,
+      "filename": "import-extended.0.wasm"
+    },
+    {
+      "type": "module",
+      "line": 9,
+      "filename": "import-extended.1.wasm"
+    },
+    {
+      "type": "module",
+      "line": 20,
+      "filename": "import-extended.2.wasm"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/import.wast.json
+++ b/tests/snapshots/local/component-model/import.wast.json
@@ -1,0 +1,514 @@
+{
+  "source_filename": "tests/local/component-model/import.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 1,
+      "filename": "import.0.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 16,
+      "filename": "import.1.wasm",
+      "text": "type index 0 is not an instance type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 23,
+      "filename": "import.2.wasm",
+      "text": "core type index 0 is not a module type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 30,
+      "filename": "import.3.wasm",
+      "text": "type index 0 is not a function type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 38,
+      "filename": "import.4.wasm",
+      "text": "duplicate import name `:`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 46,
+      "filename": "import.5.wasm",
+      "text": "duplicate import name `:`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 54,
+      "filename": "import.6.wasm",
+      "text": "duplicate import name `:a`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 62,
+      "filename": "import.7.wasm",
+      "text": "duplicate import name `:a`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 71,
+      "filename": "import.8.wat",
+      "text": "import name `a` conflicts with previous name `a`",
+      "module_type": "text"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 78,
+      "filename": "import.9.wat",
+      "text": "import name `a` conflicts with previous name `a`",
+      "module_type": "text"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 87,
+      "filename": "import.10.wasm",
+      "text": "type index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 93,
+      "filename": "import.11.wasm",
+      "text": "type index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 101,
+      "filename": "import.12.wasm",
+      "text": "value index 0 was not used as part of an instantiation, start function, or export",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 106,
+      "filename": "import.13.wasm"
+    },
+    {
+      "type": "module",
+      "line": 111,
+      "filename": "import.14.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 125,
+      "filename": "import.15.wasm",
+      "text": "conflicts with previous name",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 132,
+      "filename": "import.16.wasm",
+      "text": "`` is not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 135,
+      "filename": "import.17.wasm",
+      "text": "`` is not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 138,
+      "filename": "import.18.wasm",
+      "text": "not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 141,
+      "filename": "import.19.wasm",
+      "text": "not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 144,
+      "filename": "import.20.wasm",
+      "text": "`wasi/http` is not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 147,
+      "filename": "import.21.wasm",
+      "text": "`TyPeS` is not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 150,
+      "filename": "import.22.wasm",
+      "text": "`WaSi` is not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 153,
+      "filename": "import.23.wasm",
+      "text": "`HtTp` is not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 156,
+      "filename": "import.24.wasm",
+      "text": "empty string",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 159,
+      "filename": "import.25.wasm",
+      "text": "unexpected character '.'",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 162,
+      "filename": "import.26.wasm",
+      "text": "unexpected end of input",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 165,
+      "filename": "import.27.wasm",
+      "text": "unexpected character 'a'",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 168,
+      "filename": "import.28.wasm",
+      "text": "unexpected character 'b'",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 171,
+      "filename": "import.29.wasm",
+      "text": "unexpected character 'x'",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 174,
+      "filename": "import.30.wasm",
+      "text": "empty identifier segment",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 177,
+      "filename": "import.31.wasm",
+      "text": "empty identifier segment",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 180,
+      "filename": "import.32.wasm",
+      "text": "expected `/` after package name",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 183,
+      "filename": "import.33.wasm",
+      "text": "trailing characters found: `/qux`",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 186,
+      "filename": "import.34.wasm"
+    },
+    {
+      "type": "module",
+      "line": 191,
+      "filename": "import.35.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 203,
+      "filename": "import.36.wasm",
+      "text": "expected `<` at ``",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 206,
+      "filename": "import.37.wasm",
+      "text": "`` is not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 209,
+      "filename": "import.38.wasm",
+      "text": "`` is not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 212,
+      "filename": "import.39.wasm",
+      "text": "`` is not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 215,
+      "filename": "import.40.wasm",
+      "text": "`` is not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 218,
+      "filename": "import.41.wasm",
+      "text": "`` is not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 221,
+      "filename": "import.42.wasm",
+      "text": "expected `{` at `>`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 224,
+      "filename": "import.43.wasm",
+      "text": "expected `>=` or `<` at start of version range",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 227,
+      "filename": "import.44.wasm",
+      "text": "`xyz` is not a valid semver",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 230,
+      "filename": "import.45.wasm",
+      "text": "`1.2.3 >=2.3.4` is not a valid semver",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 233,
+      "filename": "import.46.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 241,
+      "filename": "import.47.wasm",
+      "text": "expected `<` at ``",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 244,
+      "filename": "import.48.wasm",
+      "text": "`` is not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 247,
+      "filename": "import.49.wasm",
+      "text": "`` is not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 250,
+      "filename": "import.50.wasm",
+      "text": "`` is not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 253,
+      "filename": "import.51.wasm",
+      "text": "`` is not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 256,
+      "filename": "import.52.wasm",
+      "text": "`` is not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 259,
+      "filename": "import.53.wasm",
+      "text": "expected `>` at ``",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 262,
+      "filename": "import.54.wasm",
+      "text": "is not a valid semver",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 265,
+      "filename": "import.55.wasm",
+      "text": "expected `>` at ``",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 268,
+      "filename": "import.56.wasm",
+      "text": "expected `integrity=<`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 271,
+      "filename": "import.57.wasm",
+      "text": "trailing characters found: `x`",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 274,
+      "filename": "import.58.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 281,
+      "filename": "import.59.wasm",
+      "text": "expected `<` at ``",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 284,
+      "filename": "import.60.wasm",
+      "text": "failed to find `>`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 287,
+      "filename": "import.61.wasm",
+      "text": "url cannot contain `<`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 291,
+      "filename": "import.62.wasm",
+      "text": "not a valid extern name",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 299,
+      "filename": "import.63.wasm",
+      "text": "not a valid extern name",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 302,
+      "filename": "import.64.wasm",
+      "text": "not a valid extern name",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 305,
+      "filename": "import.65.wasm",
+      "text": "not a valid extern name",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 308,
+      "filename": "import.66.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 321,
+      "filename": "import.67.wasm",
+      "text": "integrity hash cannot be empty",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 324,
+      "filename": "import.68.wasm",
+      "text": "expected `-` after hash algorithm",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 327,
+      "filename": "import.69.wasm",
+      "text": "not valid base64",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 330,
+      "filename": "import.70.wasm",
+      "text": "not valid base64",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 333,
+      "filename": "import.71.wasm",
+      "text": "not valid base64",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 336,
+      "filename": "import.72.wasm",
+      "text": "not valid base64",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 339,
+      "filename": "import.73.wasm",
+      "text": "not valid base64",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 342,
+      "filename": "import.74.wasm",
+      "text": "unrecognized hash algorithm",
+      "module_type": "binary"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/imports-exports.wast.json
+++ b/tests/snapshots/local/component-model/imports-exports.wast.json
@@ -1,0 +1,10 @@
+{
+  "source_filename": "tests/local/component-model/imports-exports.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 3,
+      "filename": "imports-exports.0.wasm"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/inline-exports.wast.json
+++ b/tests/snapshots/local/component-model/inline-exports.wast.json
@@ -1,0 +1,17 @@
+{
+  "source_filename": "tests/local/component-model/inline-exports.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 1,
+      "filename": "inline-exports.0.wasm"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 6,
+      "filename": "inline-exports.1.wat",
+      "text": "unexpected token",
+      "module_type": "text"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/instance-type.wast.json
+++ b/tests/snapshots/local/component-model/instance-type.wast.json
@@ -1,0 +1,79 @@
+{
+  "source_filename": "tests/local/component-model/instance-type.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 2,
+      "filename": "instance-type.0.wasm"
+    },
+    {
+      "type": "module",
+      "line": 68,
+      "filename": "instance-type.1.wasm"
+    },
+    {
+      "type": "module",
+      "line": 73,
+      "filename": "instance-type.2.wasm"
+    },
+    {
+      "type": "module",
+      "line": 83,
+      "filename": "instance-type.3.wasm"
+    },
+    {
+      "type": "module",
+      "line": 107,
+      "filename": "instance-type.4.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 179,
+      "filename": "instance-type.5.wasm",
+      "text": "export name `a` conflicts with previous name `a`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 186,
+      "filename": "instance-type.6.wasm",
+      "text": "type index 0 is not an instance type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 194,
+      "filename": "instance-type.7.wasm",
+      "text": "core type index 0 is not a module type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 202,
+      "filename": "instance-type.8.wat",
+      "text": "unknown core type",
+      "module_type": "text"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 209,
+      "filename": "instance-type.9.wasm",
+      "text": "type index 0 is not a function type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 217,
+      "filename": "instance-type.10.wasm",
+      "text": "type index 0 is not a function type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 225,
+      "filename": "instance-type.11.wasm",
+      "text": "type index 0 is not a function type",
+      "module_type": "binary"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/instantiate.wast.json
+++ b/tests/snapshots/local/component-model/instantiate.wast.json
@@ -1,0 +1,628 @@
+{
+  "source_filename": "tests/local/component-model/instantiate.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 1,
+      "filename": "instantiate.0.wasm"
+    },
+    {
+      "type": "module",
+      "line": 6,
+      "filename": "instantiate.1.wasm"
+    },
+    {
+      "type": "module",
+      "line": 12,
+      "filename": "instantiate.2.wasm"
+    },
+    {
+      "type": "module",
+      "line": 18,
+      "filename": "instantiate.3.wasm"
+    },
+    {
+      "type": "module",
+      "line": 24,
+      "filename": "instantiate.4.wasm"
+    },
+    {
+      "type": "module",
+      "line": 30,
+      "filename": "instantiate.5.wasm"
+    },
+    {
+      "type": "module",
+      "line": 36,
+      "filename": "instantiate.6.wasm"
+    },
+    {
+      "type": "module",
+      "line": 53,
+      "filename": "instantiate.7.wasm"
+    },
+    {
+      "type": "module",
+      "line": 76,
+      "filename": "instantiate.8.wasm"
+    },
+    {
+      "type": "module",
+      "line": 83,
+      "filename": "instantiate.9.wasm"
+    },
+    {
+      "type": "module",
+      "line": 99,
+      "filename": "instantiate.10.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 136,
+      "filename": "instantiate.11.wasm",
+      "text": "unknown module",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 141,
+      "filename": "instantiate.12.wasm",
+      "text": "unknown component",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 146,
+      "filename": "instantiate.13.wasm",
+      "text": "unknown module",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 152,
+      "filename": "instantiate.14.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 158,
+      "filename": "instantiate.15.wasm",
+      "text": "missing module instantiation argument",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 164,
+      "filename": "instantiate.16.wasm",
+      "text": "missing import named `a`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 171,
+      "filename": "instantiate.17.wasm",
+      "text": "expected func, found component",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 181,
+      "filename": "instantiate.18.wasm",
+      "text": "expected 0 results, found 1",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 191,
+      "filename": "instantiate.19.wasm",
+      "text": "expected 0 parameters, found 1",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 201,
+      "filename": "instantiate.20.wasm",
+      "text": "type mismatch in import `::`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 215,
+      "filename": "instantiate.21.wasm",
+      "text": "missing expected import `::foobar`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 226,
+      "filename": "instantiate.22.wasm",
+      "text": "missing expected export `x`",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 236,
+      "filename": "instantiate.23.wasm"
+    },
+    {
+      "type": "module",
+      "line": 250,
+      "filename": "instantiate.24.wasm"
+    },
+    {
+      "type": "module",
+      "line": 262,
+      "filename": "instantiate.25.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 280,
+      "filename": "instantiate.26.wasm",
+      "text": "expected: [] -> []",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 288,
+      "filename": "instantiate.27.wasm",
+      "text": "expected: [] -> []",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 296,
+      "filename": "instantiate.28.wasm",
+      "text": "expected global type i32, found i64",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 304,
+      "filename": "instantiate.29.wasm",
+      "text": "expected table element type funcref, found externref",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 312,
+      "filename": "instantiate.30.wasm",
+      "text": "mismatch in table limits",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 320,
+      "filename": "instantiate.31.wasm",
+      "text": "mismatch in table limits",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 328,
+      "filename": "instantiate.32.wasm",
+      "text": "mismatch in table limits",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 336,
+      "filename": "instantiate.33.wasm",
+      "text": "mismatch in the shared flag for memories",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 344,
+      "filename": "instantiate.34.wasm",
+      "text": "mismatch in memory limits",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 352,
+      "filename": "instantiate.35.wasm",
+      "text": "type mismatch in export `g`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 362,
+      "filename": "instantiate.36.wasm",
+      "text": "unknown module",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 367,
+      "filename": "instantiate.37.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 386,
+      "filename": "instantiate.38.wasm",
+      "text": "function index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 390,
+      "filename": "instantiate.39.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 394,
+      "filename": "instantiate.40.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 398,
+      "filename": "instantiate.41.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 402,
+      "filename": "instantiate.42.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 406,
+      "filename": "instantiate.43.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 410,
+      "filename": "instantiate.44.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 414,
+      "filename": "instantiate.45.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 418,
+      "filename": "instantiate.46.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 422,
+      "filename": "instantiate.47.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 426,
+      "filename": "instantiate.48.wasm",
+      "text": "duplicate module instantiation argument named ``",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 438,
+      "filename": "instantiate.49.wasm",
+      "text": "duplicate module instantiation argument named ``",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 449,
+      "filename": "instantiate.50.wasm",
+      "text": "expected global, found func",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 460,
+      "filename": "instantiate.51.wasm",
+      "text": "instantiation argument `a` conflicts with previous argument `a`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 471,
+      "filename": "instantiate.52.wasm",
+      "text": "expected func, found component",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 480,
+      "filename": "instantiate.53.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 489,
+      "filename": "instantiate.54.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 498,
+      "filename": "instantiate.55.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 507,
+      "filename": "instantiate.56.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 516,
+      "filename": "instantiate.57.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 525,
+      "filename": "instantiate.58.wasm",
+      "text": "export name `a` conflicts with previous name `a`",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 534,
+      "filename": "instantiate.59.wasm"
+    },
+    {
+      "type": "module",
+      "line": 549,
+      "filename": "instantiate.60.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 566,
+      "filename": "instantiate.61.wasm",
+      "text": "export name `` already defined",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 577,
+      "filename": "instantiate.62.wasm",
+      "text": "no export named `a`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 585,
+      "filename": "instantiate.63.wasm",
+      "text": "index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 591,
+      "filename": "instantiate.64.wasm",
+      "text": "module instantiation argument `` does not export an item named `table`",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 623,
+      "filename": "instantiate.65.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 637,
+      "filename": "instantiate.66.wasm",
+      "text": "expected primitive `u32` found primitive `string`",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 661,
+      "filename": "instantiate.67.wasm"
+    },
+    {
+      "type": "module",
+      "line": 676,
+      "filename": "instantiate.68.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 690,
+      "filename": "instantiate.69.wasm",
+      "text": "expected parameter named `y`, found `x`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 700,
+      "filename": "instantiate.70.wasm",
+      "text": "type mismatch in function parameter `x`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 710,
+      "filename": "instantiate.71.wasm",
+      "text": "mismatched result names",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 720,
+      "filename": "instantiate.72.wasm",
+      "text": "type mismatch with result type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 731,
+      "filename": "instantiate.73.wasm",
+      "text": "type mismatch in instance export `a`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 742,
+      "filename": "instantiate.74.wasm",
+      "text": "expected primitive, found record",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 754,
+      "filename": "instantiate.75.wasm",
+      "text": "expected record, found u32",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 766,
+      "filename": "instantiate.76.wasm",
+      "text": "expected u32, found tuple",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 779,
+      "filename": "instantiate.77.wasm",
+      "text": "type mismatch in record field `x`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 792,
+      "filename": "instantiate.78.wasm",
+      "text": "expected 1 fields, found 2",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 804,
+      "filename": "instantiate.79.wasm",
+      "text": "expected field name `a`, found `b`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 816,
+      "filename": "instantiate.80.wasm",
+      "text": "expected 1 cases, found 2",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 828,
+      "filename": "instantiate.81.wasm",
+      "text": "expected case named `x`, found `y`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 840,
+      "filename": "instantiate.82.wasm",
+      "text": "expected case `x` to have a type, found none",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 852,
+      "filename": "instantiate.83.wasm",
+      "text": "expected case `x` to have no type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 864,
+      "filename": "instantiate.84.wasm",
+      "text": "type mismatch in variant case `x`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 876,
+      "filename": "instantiate.85.wasm",
+      "text": "expected 1 types, found 2",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 888,
+      "filename": "instantiate.86.wasm",
+      "text": "type mismatch in tuple field 0",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 900,
+      "filename": "instantiate.87.wasm",
+      "text": "mismatch in flags elements",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 912,
+      "filename": "instantiate.88.wasm",
+      "text": "mismatch in enum elements",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 924,
+      "filename": "instantiate.89.wasm",
+      "text": "type mismatch in ok variant",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 936,
+      "filename": "instantiate.90.wasm",
+      "text": "type mismatch in err variant",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 948,
+      "filename": "instantiate.91.wasm",
+      "text": "expected ok type to not be present",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 960,
+      "filename": "instantiate.92.wasm",
+      "text": "expected ok type, but found none",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 972,
+      "filename": "instantiate.93.wasm",
+      "text": "expected err type to not be present",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 984,
+      "filename": "instantiate.94.wasm",
+      "text": "expected err type, but found none",
+      "module_type": "binary"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/invalid.wast.json
+++ b/tests/snapshots/local/component-model/invalid.wast.json
@@ -1,0 +1,33 @@
+{
+  "source_filename": "tests/local/component-model/invalid.wast",
+  "commands": [
+    {
+      "type": "assert_invalid",
+      "line": 2,
+      "filename": "invalid.0.wasm",
+      "text": "type index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 11,
+      "filename": "invalid.1.wat",
+      "text": "unknown func",
+      "module_type": "text"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 17,
+      "filename": "invalid.2.wat",
+      "text": "outer count of `100` is too large",
+      "module_type": "text"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 23,
+      "filename": "invalid.3.wat",
+      "text": "outer component `nonexistent` not found",
+      "module_type": "text"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/link.wast.json
+++ b/tests/snapshots/local/component-model/link.wast.json
@@ -1,0 +1,10 @@
+{
+  "source_filename": "tests/local/component-model/link.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 3,
+      "filename": "link.0.wasm"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/lots-of-aliases.wast.json
+++ b/tests/snapshots/local/component-model/lots-of-aliases.wast.json
@@ -1,0 +1,10 @@
+{
+  "source_filename": "tests/local/component-model/lots-of-aliases.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 1,
+      "filename": "lots-of-aliases.0.wasm"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/lower.wast.json
+++ b/tests/snapshots/local/component-model/lower.wast.json
@@ -1,0 +1,19 @@
+{
+  "source_filename": "tests/local/component-model/lower.wast",
+  "commands": [
+    {
+      "type": "assert_invalid",
+      "line": 2,
+      "filename": "lower.0.wasm",
+      "text": "canonical option `memory` is required",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 10,
+      "filename": "lower.1.wasm",
+      "text": "canonical option `memory` is required",
+      "module_type": "binary"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/memory64.wast.json
+++ b/tests/snapshots/local/component-model/memory64.wast.json
@@ -1,0 +1,19 @@
+{
+  "source_filename": "tests/local/component-model/memory64.wast",
+  "commands": [
+    {
+      "type": "assert_invalid",
+      "line": 2,
+      "filename": "memory64.0.wasm",
+      "text": "mismatch in index type used for memories",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 13,
+      "filename": "memory64.1.wasm",
+      "text": "mismatch in index type used for memories",
+      "module_type": "binary"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/module-link.wast.json
+++ b/tests/snapshots/local/component-model/module-link.wast.json
@@ -1,0 +1,15 @@
+{
+  "source_filename": "tests/local/component-model/module-link.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 1,
+      "filename": "module-link.0.wasm"
+    },
+    {
+      "type": "module",
+      "line": 10,
+      "filename": "module-link.1.wasm"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/more-flags.wast.json
+++ b/tests/snapshots/local/component-model/more-flags.wast.json
@@ -1,0 +1,10 @@
+{
+  "source_filename": "tests/local/component-model/more-flags.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 1,
+      "filename": "more-flags.0.wasm"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/multiple-returns.wast.json
+++ b/tests/snapshots/local/component-model/multiple-returns.wast.json
@@ -1,0 +1,36 @@
+{
+  "source_filename": "tests/local/component-model/multiple-returns.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 1,
+      "filename": "multiple-returns.0.wasm"
+    },
+    {
+      "type": "module",
+      "line": 5,
+      "filename": "multiple-returns.1.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 15,
+      "filename": "multiple-returns.2.wasm",
+      "text": "component start function has a result count of 1 but the function type has a result count of 2",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 26,
+      "filename": "multiple-returns.3.wasm",
+      "text": "function result name cannot be empty",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 33,
+      "filename": "multiple-returns.4.wasm",
+      "text": "function result name `foo` conflicts with previous result name `FOO`",
+      "module_type": "binary"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/naming.wast.json
+++ b/tests/snapshots/local/component-model/naming.wast.json
@@ -1,0 +1,120 @@
+{
+  "source_filename": "tests/local/component-model/naming.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 1,
+      "filename": "naming.0.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 8,
+      "filename": "naming.1.wasm",
+      "text": "`1` is not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 16,
+      "filename": "naming.2.wasm",
+      "text": "instance 0 has no export named `Xml`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 24,
+      "filename": "naming.3.wasm",
+      "text": "flag name `a-1-c` is not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 31,
+      "filename": "naming.4.wasm",
+      "text": "enum tag name `NevEr` is not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 38,
+      "filename": "naming.5.wasm",
+      "text": "record field name `GoNnA` is not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 45,
+      "filename": "naming.6.wasm",
+      "text": "variant case name `GIVe` is not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 53,
+      "filename": "naming.7.wasm",
+      "text": "function parameter name `yOu` is not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 60,
+      "filename": "naming.8.wasm",
+      "text": "name `uP` is not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 67,
+      "filename": "naming.9.wasm",
+      "text": "`NevEr` is not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 74,
+      "filename": "naming.10.wasm",
+      "text": "`GonnA` is not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 81,
+      "filename": "naming.11.wasm",
+      "text": "`lET` is not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 88,
+      "filename": "naming.12.wasm",
+      "text": "`YoU` is not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 95,
+      "filename": "naming.13.wasm",
+      "text": "`DOWn` is not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 102,
+      "filename": "naming.14.wasm",
+      "text": "character `A` is not lowercase in package name/namespace",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 108,
+      "filename": "naming.15.wasm",
+      "text": "character `B` is not lowercase in package name/namespace",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 113,
+      "filename": "naming.16.wasm"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/nested-modules.wast.json
+++ b/tests/snapshots/local/component-model/nested-modules.wast.json
@@ -1,0 +1,27 @@
+{
+  "source_filename": "tests/local/component-model/nested-modules.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 1,
+      "filename": "nested-modules.0.wasm"
+    },
+    {
+      "type": "module",
+      "line": 21,
+      "filename": "nested-modules.1.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 28,
+      "filename": "nested-modules.2.wasm",
+      "text": "type mismatch",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 38,
+      "filename": "nested-modules.3.wasm"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/resources.wast.json
+++ b/tests/snapshots/local/component-model/resources.wast.json
@@ -1,0 +1,713 @@
+{
+  "source_filename": "tests/local/component-model/resources.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 1,
+      "filename": "resources.0.wasm"
+    },
+    {
+      "type": "module",
+      "line": 5,
+      "filename": "resources.1.wasm"
+    },
+    {
+      "type": "module",
+      "line": 13,
+      "filename": "resources.2.wasm"
+    },
+    {
+      "type": "module",
+      "line": 19,
+      "filename": "resources.3.wasm"
+    },
+    {
+      "type": "module",
+      "line": 28,
+      "filename": "resources.4.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 50,
+      "filename": "resources.5.wasm",
+      "text": "resources can only be represented by `i32`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 56,
+      "filename": "resources.6.wasm",
+      "text": "type index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 62,
+      "filename": "resources.7.wasm",
+      "text": "type index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 68,
+      "filename": "resources.8.wasm",
+      "text": "not a resource type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 75,
+      "filename": "resources.9.wasm",
+      "text": "not a resource type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 82,
+      "filename": "resources.10.wasm",
+      "text": "not a local resource",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 89,
+      "filename": "resources.11.wasm",
+      "text": "not a local resource",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 96,
+      "filename": "resources.12.wasm",
+      "text": "not a resource type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 103,
+      "filename": "resources.13.wasm",
+      "text": "type index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 109,
+      "filename": "resources.14.wasm",
+      "text": "not a resource type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 116,
+      "filename": "resources.15.wasm",
+      "text": "not a resource type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 123,
+      "filename": "resources.16.wasm",
+      "text": "wrong signature for a destructor",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 134,
+      "filename": "resources.17.wasm",
+      "text": "function index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 140,
+      "filename": "resources.18.wasm",
+      "text": "resource types are not the same",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 154,
+      "filename": "resources.19.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 163,
+      "filename": "resources.20.wasm",
+      "text": "resources can only be defined within a concrete component",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 171,
+      "filename": "resources.21.wasm",
+      "text": "resources can only be defined within a concrete component",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 178,
+      "filename": "resources.22.wasm"
+    },
+    {
+      "type": "module",
+      "line": 189,
+      "filename": "resources.23.wasm"
+    },
+    {
+      "type": "module",
+      "line": 199,
+      "name": "C",
+      "filename": "resources.24.wasm"
+    },
+    {
+      "type": "module",
+      "line": 218,
+      "filename": "resources.25.wasm"
+    },
+    {
+      "type": "module",
+      "line": 223,
+      "name": "C",
+      "filename": "resources.26.wasm"
+    },
+    {
+      "type": "module",
+      "line": 232,
+      "filename": "resources.27.wasm"
+    },
+    {
+      "type": "module",
+      "line": 249,
+      "filename": "resources.28.wasm"
+    },
+    {
+      "type": "module",
+      "line": 261,
+      "filename": "resources.29.wasm"
+    },
+    {
+      "type": "module",
+      "line": 274,
+      "filename": "resources.30.wasm"
+    },
+    {
+      "type": "module",
+      "line": 280,
+      "filename": "resources.31.wasm"
+    },
+    {
+      "type": "module",
+      "line": 287,
+      "filename": "resources.32.wasm"
+    },
+    {
+      "type": "module",
+      "line": 293,
+      "filename": "resources.33.wasm"
+    },
+    {
+      "type": "module",
+      "line": 300,
+      "name": "P",
+      "filename": "resources.34.wasm"
+    },
+    {
+      "type": "module",
+      "line": 317,
+      "filename": "resources.35.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 339,
+      "filename": "resources.36.wasm",
+      "text": "not a local resource",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 350,
+      "filename": "resources.37.wasm"
+    },
+    {
+      "type": "module",
+      "line": 360,
+      "filename": "resources.38.wasm"
+    },
+    {
+      "type": "module",
+      "line": 372,
+      "filename": "resources.39.wasm"
+    },
+    {
+      "type": "module",
+      "line": 388,
+      "filename": "resources.40.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 409,
+      "filename": "resources.41.wasm",
+      "text": "resource types are not the same",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 431,
+      "filename": "resources.42.wasm"
+    },
+    {
+      "type": "module",
+      "line": 457,
+      "filename": "resources.43.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 484,
+      "filename": "resources.44.wasm",
+      "text": "expected resource, found defined type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 494,
+      "filename": "resources.45.wasm",
+      "text": "expected defined type, found resource",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 505,
+      "filename": "resources.46.wasm",
+      "text": "resource types are not the same",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 519,
+      "filename": "resources.47.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 533,
+      "filename": "resources.48.wasm",
+      "text": "func not valid to be used as import",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 540,
+      "filename": "resources.49.wasm",
+      "text": "func not valid to be used as import",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 549,
+      "filename": "resources.50.wasm",
+      "text": "func not valid to be used as export",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 559,
+      "filename": "resources.51.wasm"
+    },
+    {
+      "type": "module",
+      "line": 569,
+      "filename": "resources.52.wasm"
+    },
+    {
+      "type": "module",
+      "line": 583,
+      "filename": "resources.53.wasm"
+    },
+    {
+      "type": "module",
+      "line": 601,
+      "filename": "resources.54.wasm"
+    },
+    {
+      "type": "module",
+      "line": 617,
+      "filename": "resources.55.wasm"
+    },
+    {
+      "type": "module",
+      "line": 649,
+      "filename": "resources.56.wasm"
+    },
+    {
+      "type": "module",
+      "line": 669,
+      "filename": "resources.57.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 693,
+      "filename": "resources.58.wasm",
+      "text": "resource types are not the same",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 713,
+      "filename": "resources.59.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 736,
+      "filename": "resources.60.wasm",
+      "text": "missing import named `x`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 744,
+      "filename": "resources.61.wasm",
+      "text": "missing import named `y`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 756,
+      "filename": "resources.62.wasm",
+      "text": "resource types are not the same",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 771,
+      "name": "A",
+      "filename": "resources.63.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 795,
+      "filename": "resources.64.wasm",
+      "text": "refers to resources not defined in the current component",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 801,
+      "filename": "resources.65.wasm",
+      "text": "refers to resources not defined in the current component",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 808,
+      "filename": "resources.66.wasm",
+      "text": "refers to resources not defined in the current component",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 815,
+      "filename": "resources.67.wasm",
+      "text": "refers to resources not defined in the current component",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 822,
+      "filename": "resources.68.wasm",
+      "text": "refers to resources not defined in the current component",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 830,
+      "filename": "resources.69.wasm",
+      "text": "expected component, found instance",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 846,
+      "filename": "resources.70.wasm",
+      "text": "type mismatch for import `y`",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 866,
+      "filename": "resources.71.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 890,
+      "filename": "resources.72.wasm",
+      "text": "failed to find `.` character",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 895,
+      "filename": "resources.73.wasm",
+      "text": "not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 898,
+      "filename": "resources.74.wasm",
+      "text": "should return one value",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 901,
+      "filename": "resources.75.wasm",
+      "text": "should return `(own $T)`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 904,
+      "filename": "resources.76.wasm",
+      "text": "import name `[constructor]a` is not valid",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 909,
+      "filename": "resources.77.wasm",
+      "text": "function does not match expected resource name `b`",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 913,
+      "filename": "resources.78.wasm"
+    },
+    {
+      "type": "module",
+      "line": 916,
+      "filename": "resources.79.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 922,
+      "filename": "resources.80.wasm",
+      "text": "failed to find `.` character",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 925,
+      "filename": "resources.81.wasm",
+      "text": "failed to find `.` character",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 928,
+      "filename": "resources.82.wasm",
+      "text": "not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 931,
+      "filename": "resources.83.wasm",
+      "text": "not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 934,
+      "filename": "resources.84.wasm",
+      "text": "not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 937,
+      "filename": "resources.85.wasm",
+      "text": "is not a func",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 940,
+      "filename": "resources.86.wasm",
+      "text": "should have at least one argument",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 943,
+      "filename": "resources.87.wasm",
+      "text": "should have a first argument called `self`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 946,
+      "filename": "resources.88.wasm",
+      "text": "should take a first argument of `(borrow $T)`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 949,
+      "filename": "resources.89.wasm",
+      "text": "does not match expected resource name",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 953,
+      "filename": "resources.90.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 959,
+      "filename": "resources.91.wasm",
+      "text": "failed to find `.` character",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 962,
+      "filename": "resources.92.wasm",
+      "text": "failed to find `.` character",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 965,
+      "filename": "resources.93.wasm",
+      "text": "not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 968,
+      "filename": "resources.94.wasm",
+      "text": "not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 971,
+      "filename": "resources.95.wasm",
+      "text": "not in kebab case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 974,
+      "filename": "resources.96.wasm",
+      "text": "is not a func",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 977,
+      "filename": "resources.97.wasm",
+      "text": "static resource name is not known in this context",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 980,
+      "filename": "resources.98.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 986,
+      "filename": "resources.99.wasm",
+      "text": "resource used in function does not have a name in this context",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 993,
+      "filename": "resources.100.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 1002,
+      "filename": "resources.101.wasm",
+      "text": "resource used in function does not have a name in this context",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 1013,
+      "filename": "resources.102.wasm",
+      "text": "function does not match expected resource name `b`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 1023,
+      "filename": "resources.103.wasm",
+      "text": "resource used in function does not have a name in this context",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 1035,
+      "filename": "resources.104.wasm"
+    },
+    {
+      "type": "module",
+      "line": 1043,
+      "filename": "resources.105.wasm"
+    },
+    {
+      "type": "module",
+      "line": 1049,
+      "filename": "resources.106.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 1084,
+      "filename": "resources.107.wasm",
+      "text": "resource types are not the same",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 1104,
+      "filename": "resources.108.wasm"
+    },
+    {
+      "type": "module",
+      "line": 1119,
+      "filename": "resources.109.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 1130,
+      "filename": "resources.110.wasm",
+      "text": "function result cannot contain a `borrow` type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 1136,
+      "filename": "resources.111.wasm",
+      "text": "function result cannot contain a `borrow` type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 1142,
+      "filename": "resources.112.wasm",
+      "text": "function result cannot contain a `borrow` type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 1148,
+      "filename": "resources.113.wasm",
+      "text": "function result cannot contain a `borrow` type",
+      "module_type": "binary"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/start.wast.json
+++ b/tests/snapshots/local/component-model/start.wast.json
@@ -1,0 +1,64 @@
+{
+  "source_filename": "tests/local/component-model/start.wast",
+  "commands": [
+    {
+      "type": "assert_invalid",
+      "line": 3,
+      "filename": "start.0.wasm",
+      "text": "start function requires 1 arguments",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 10,
+      "filename": "start.1.wasm",
+      "text": "start function requires 1 arguments",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 18,
+      "filename": "start.2.wasm",
+      "text": "cannot be used more than once",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 26,
+      "filename": "start.3.wasm",
+      "text": "type mismatch for component start function argument 1",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 34,
+      "filename": "start.4.wasm"
+    },
+    {
+      "type": "module",
+      "line": 41,
+      "filename": "start.5.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 48,
+      "filename": "start.6.wasm",
+      "text": "cannot have more than one start",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 56,
+      "filename": "start.7.wasm",
+      "text": "start function results size is out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 78,
+      "filename": "start.8.wasm",
+      "text": "unexpected content in the component start section",
+      "module_type": "binary"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/string.wast.json
+++ b/tests/snapshots/local/component-model/string.wast.json
@@ -1,0 +1,10 @@
+{
+  "source_filename": "tests/local/component-model/string.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 3,
+      "filename": "string.0.wasm"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/type-export-restrictions.wast.json
+++ b/tests/snapshots/local/component-model/type-export-restrictions.wast.json
@@ -1,0 +1,299 @@
+{
+  "source_filename": "tests/local/component-model/type-export-restrictions.wast",
+  "commands": [
+    {
+      "type": "assert_invalid",
+      "line": 4,
+      "filename": "type-export-restrictions.0.wasm",
+      "text": "type not valid to be used as export",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 12,
+      "filename": "type-export-restrictions.1.wasm",
+      "text": "type not valid to be used as export",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 20,
+      "filename": "type-export-restrictions.2.wasm",
+      "text": "type not valid to be used as export",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 28,
+      "filename": "type-export-restrictions.3.wasm",
+      "text": "type not valid to be used as export",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 36,
+      "filename": "type-export-restrictions.4.wasm",
+      "text": "type not valid to be used as export",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 44,
+      "filename": "type-export-restrictions.5.wasm",
+      "text": "type not valid to be used as export",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 54,
+      "filename": "type-export-restrictions.6.wasm",
+      "text": "type not valid to be used as export",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 62,
+      "filename": "type-export-restrictions.7.wasm",
+      "text": "type not valid to be used as export",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 70,
+      "filename": "type-export-restrictions.8.wasm",
+      "text": "type not valid to be used as export",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 78,
+      "filename": "type-export-restrictions.9.wasm",
+      "text": "type not valid to be used as export",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 86,
+      "filename": "type-export-restrictions.10.wasm",
+      "text": "type not valid to be used as export",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 94,
+      "filename": "type-export-restrictions.11.wasm"
+    },
+    {
+      "type": "module",
+      "line": 105,
+      "filename": "type-export-restrictions.12.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 114,
+      "filename": "type-export-restrictions.13.wasm",
+      "text": "type not valid to be used as import",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 120,
+      "filename": "type-export-restrictions.14.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 127,
+      "filename": "type-export-restrictions.15.wasm",
+      "text": "func not valid to be used as import",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 135,
+      "filename": "type-export-restrictions.16.wasm",
+      "text": "type not valid to be used as export",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 145,
+      "filename": "type-export-restrictions.17.wasm",
+      "text": "func not valid to be used as export",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 153,
+      "filename": "type-export-restrictions.18.wasm",
+      "text": "type not valid to be used as export",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 163,
+      "filename": "type-export-restrictions.19.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 172,
+      "filename": "type-export-restrictions.20.wasm",
+      "text": "instance not valid to be used as export",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 184,
+      "filename": "type-export-restrictions.21.wasm",
+      "text": "func not valid to be used as export",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 197,
+      "filename": "type-export-restrictions.22.wasm",
+      "text": "func not valid to be used as export",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 213,
+      "filename": "type-export-restrictions.23.wasm",
+      "text": "func not valid to be used as export",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 229,
+      "filename": "type-export-restrictions.24.wasm"
+    },
+    {
+      "type": "module",
+      "line": 242,
+      "filename": "type-export-restrictions.25.wasm"
+    },
+    {
+      "type": "module",
+      "line": 258,
+      "filename": "type-export-restrictions.26.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 271,
+      "filename": "type-export-restrictions.27.wasm",
+      "text": "func not valid to be used as import",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 279,
+      "filename": "type-export-restrictions.28.wasm"
+    },
+    {
+      "type": "module",
+      "line": 284,
+      "filename": "type-export-restrictions.29.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 294,
+      "filename": "type-export-restrictions.30.wasm",
+      "text": "func not valid to be used as import",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 303,
+      "filename": "type-export-restrictions.31.wasm",
+      "text": "func not valid to be used as export",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 315,
+      "filename": "type-export-restrictions.32.wasm"
+    },
+    {
+      "type": "module",
+      "line": 335,
+      "filename": "type-export-restrictions.33.wasm"
+    },
+    {
+      "type": "module",
+      "line": 339,
+      "filename": "type-export-restrictions.34.wasm"
+    },
+    {
+      "type": "module",
+      "line": 344,
+      "filename": "type-export-restrictions.35.wasm"
+    },
+    {
+      "type": "module",
+      "line": 348,
+      "filename": "type-export-restrictions.36.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 356,
+      "filename": "type-export-restrictions.37.wasm",
+      "text": "instance not valid to be used as export",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 378,
+      "filename": "type-export-restrictions.38.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 385,
+      "filename": "type-export-restrictions.39.wasm",
+      "text": "instance not valid to be used as import",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 396,
+      "name": "C",
+      "filename": "type-export-restrictions.40.wasm"
+    },
+    {
+      "type": "module",
+      "line": 412,
+      "filename": "type-export-restrictions.41.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 427,
+      "filename": "type-export-restrictions.42.wasm",
+      "text": "type not valid to be used as import",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 437,
+      "filename": "type-export-restrictions.43.wasm",
+      "text": "type not valid to be used as export",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 448,
+      "filename": "type-export-restrictions.44.wasm",
+      "text": "type not valid to be used as import",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 455,
+      "filename": "type-export-restrictions.45.wasm",
+      "text": "type not valid to be used as export",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 462,
+      "filename": "type-export-restrictions.46.wasm"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/types.wast.json
+++ b/tests/snapshots/local/component-model/types.wast.json
@@ -1,0 +1,288 @@
+{
+  "source_filename": "tests/local/component-model/types.wast",
+  "commands": [
+    {
+      "type": "assert_invalid",
+      "line": 2,
+      "filename": "types.0.wasm",
+      "text": "type index 0 is not a function type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 9,
+      "filename": "types.1.wasm",
+      "text": "core type index 0 is not a module type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 16,
+      "filename": "types.2.wasm",
+      "text": "type index 0 is not an instance type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 23,
+      "filename": "types.3.wasm",
+      "text": "type index 0 is not an instance type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 32,
+      "filename": "types.4.wasm",
+      "text": "core type index 0 is not a module type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 41,
+      "filename": "types.5.wasm",
+      "text": "type index 0 is not a function type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 50,
+      "filename": "types.6.wasm",
+      "text": "module index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 56,
+      "filename": "types.7.wasm",
+      "text": "instance index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 62,
+      "filename": "types.8.wasm",
+      "text": "type index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 70,
+      "filename": "types.9.wasm",
+      "text": "export name `a` already defined",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 79,
+      "filename": "types.10.wasm",
+      "text": "duplicate import name",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 88,
+      "filename": "types.11.wasm",
+      "text": "memory size must be at most",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 96,
+      "filename": "types.12.wasm",
+      "text": "type index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 104,
+      "filename": "types.13.wasm",
+      "text": "export name `A` conflicts with previous name `a`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 113,
+      "filename": "types.14.wasm",
+      "text": "import name `a` conflicts with previous name `A`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 122,
+      "filename": "types.15.wat",
+      "text": "unknown core type",
+      "module_type": "text"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 128,
+      "filename": "types.16.wasm",
+      "text": "type index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 135,
+      "name": "c",
+      "filename": "types.17.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 143,
+      "filename": "types.18.wat",
+      "text": "unknown type",
+      "module_type": "text"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 149,
+      "filename": "types.19.wasm",
+      "text": "type index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 157,
+      "filename": "types.20.wasm",
+      "text": "invalid outer alias count of 100",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 166,
+      "filename": "types.21.wasm",
+      "text": "name `` already defined",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 178,
+      "filename": "types.22.wasm",
+      "text": "type index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 186,
+      "filename": "types.23.wasm",
+      "text": "export name `FOO-bar-BAZ` conflicts with previous name `foo-BAR-baz`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 195,
+      "filename": "types.24.wat",
+      "text": "unknown type",
+      "module_type": "text"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 201,
+      "filename": "types.25.wasm",
+      "text": "type index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 209,
+      "filename": "types.26.wasm",
+      "text": "invalid outer alias count of 100",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 218,
+      "filename": "types.27.wasm",
+      "text": "name `` already defined",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 230,
+      "filename": "types.28.wasm",
+      "text": "function parameter name cannot be empty",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 235,
+      "filename": "types.29.wasm"
+    },
+    {
+      "type": "module",
+      "line": 239,
+      "name": "C",
+      "filename": "types.30.wasm"
+    },
+    {
+      "type": "module",
+      "line": 247,
+      "name": "C",
+      "filename": "types.31.wasm"
+    },
+    {
+      "type": "module",
+      "line": 257,
+      "name": "C",
+      "filename": "types.32.wasm"
+    },
+    {
+      "type": "module",
+      "line": 267,
+      "filename": "types.33.wasm"
+    },
+    {
+      "type": "module",
+      "line": 274,
+      "filename": "types.34.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 283,
+      "filename": "types.35.wasm",
+      "text": "variant type must have at least one case",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 289,
+      "filename": "types.36.wasm",
+      "text": "enum type must have at least one variant",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 295,
+      "filename": "types.37.wasm",
+      "text": "record type must have at least one field",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 301,
+      "filename": "types.38.wasm",
+      "text": "flags must have at least one entry",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 307,
+      "filename": "types.39.wasm",
+      "text": "tuple type must have at least one type",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 312,
+      "name": "c",
+      "filename": "types.40.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 322,
+      "filename": "types.41.wasm",
+      "text": "cannot have more than 32 flags",
+      "module_type": "binary"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/very-nested.wast.json
+++ b/tests/snapshots/local/component-model/very-nested.wast.json
@@ -1,0 +1,40 @@
+{
+  "source_filename": "tests/local/component-model/very-nested.wast",
+  "commands": [
+    {
+      "type": "assert_invalid",
+      "line": 2,
+      "filename": "very-nested.0.wasm",
+      "text": "conflicts with previous name",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 1568,
+      "filename": "very-nested.1.wasm",
+      "text": "effective type size exceeds the limit",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 1689,
+      "filename": "very-nested.2.wasm",
+      "text": "effective type size exceeds the limit",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 1779,
+      "filename": "very-nested.3.wasm",
+      "text": "effective type size exceeds the limit",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 1869,
+      "filename": "very-nested.4.wat",
+      "text": "nesting too deep",
+      "module_type": "text"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/virtualize.wast.json
+++ b/tests/snapshots/local/component-model/virtualize.wast.json
@@ -1,0 +1,10 @@
+{
+  "source_filename": "tests/local/component-model/virtualize.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 1,
+      "filename": "virtualize.0.wasm"
+    }
+  ]
+}

--- a/tests/snapshots/local/component-model/wrong-order.wast.json
+++ b/tests/snapshots/local/component-model/wrong-order.wast.json
@@ -1,0 +1,12 @@
+{
+  "source_filename": "tests/local/component-model/wrong-order.wast",
+  "commands": [
+    {
+      "type": "assert_invalid",
+      "line": 2,
+      "filename": "wrong-order.0.wasm",
+      "text": "section out of order",
+      "module_type": "binary"
+    }
+  ]
+}

--- a/tests/snapshots/local/missing-features/component-model/value-not-enabled.wast.json
+++ b/tests/snapshots/local/missing-features/component-model/value-not-enabled.wast.json
@@ -1,0 +1,54 @@
+{
+  "source_filename": "tests/local/missing-features/component-model/value-not-enabled.wast",
+  "commands": [
+    {
+      "type": "assert_invalid",
+      "line": 2,
+      "filename": "value-not-enabled.0.wasm",
+      "text": "support for component model `value`s is not enabled",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 9,
+      "filename": "value-not-enabled.1.wasm",
+      "text": "support for component model `value`s is not enabled",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 15,
+      "filename": "value-not-enabled.2.wasm",
+      "text": "support for component model `value`s is not enabled",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 21,
+      "filename": "value-not-enabled.3.wasm",
+      "text": "support for component model `value`s is not enabled",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 26,
+      "filename": "value-not-enabled.4.wasm",
+      "text": "support for component model `value`s is not enabled",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 32,
+      "filename": "value-not-enabled.5.wasm",
+      "text": "support for component model `value`s is not enabled",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 38,
+      "filename": "value-not-enabled.6.wasm",
+      "text": "support for component model `value`s is not enabled",
+      "module_type": "binary"
+    }
+  ]
+}


### PR DESCRIPTION
Then fix a number of mistakes in the tests where `component quote` should have been used instead of `component`.

Closes #1705