### PR TITLE
Add predefined `WasmFeatures` sets for wasm 1.0/2.0

### DIFF
--- a/crates/wasmparser/src/features.rs
+++ b/crates/wasmparser/src/features.rs
@@ -160,6 +160,27 @@ define_wasm_features! {
     }
 }
 
+impl WasmFeatures {
+    /// Returns the feature set associated with the 1.0 version of the
+    /// WebAssembly specification or the "MVP" feature set.
+    pub fn wasm1() -> WasmFeatures {
+        WasmFeatures::FLOATS
+    }
+
+    /// Returns the feature set associated with the 2.0 version of the
+    /// WebAssembly specification.
+    pub fn wasm2() -> WasmFeatures {
+        WasmFeatures::wasm1()
+            | WasmFeatures::BULK_MEMORY
+            | WasmFeatures::REFERENCE_TYPES
+            | WasmFeatures::SIGN_EXTENSION
+            | WasmFeatures::MUTABLE_GLOBAL
+            | WasmFeatures::SATURATING_FLOAT_TO_INT
+            | WasmFeatures::MULTI_VALUE
+            | WasmFeatures::SIMD
+    }
+}
+
 impl From<WasmFeaturesInflated> for WasmFeatures {
     #[inline]
     fn from(inflated: WasmFeaturesInflated) -> Self {


### PR DESCRIPTION
This commit adds new `WasmFeatures::wasm{1,2}()` function which returns the set of features enabled for those versions of the WebAssembly specification. This is then reflected on the CLI with `--features wasm1` or `--features wasm2` or `--features mvp`.

This is intended to make it a bit easier to run the validator on the CLI for the MVP version of wasm without passing a long set of `-disable-this-feature` options.

This also updates the help text for `wasm-tools validate` to be a bit more readable.