### PR TITLE
chore(wit-component): enable all features for docsrs

### DIFF
--- a/crates/wit-component/Cargo.toml
+++ b/crates/wit-component/Cargo.toml
@@ -16,6 +16,9 @@ rust-version.workspace = true
 [lints]
 workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+
 [dependencies]
 wasmparser = { workspace = true }
 wasm-encoder = { workspace = true, features = ["wasmparser"] }

--- a/crates/wit-component/src/lib.rs
+++ b/crates/wit-component/src/lib.rs
@@ -1,6 +1,7 @@
 //! The WebAssembly component tooling.
 
 #![deny(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use std::str::FromStr;
 use std::{borrow::Cow, fmt::Display};


### PR DESCRIPTION
This commit enables all features for docsrs generation so that `wit-component` docs will contain information (e.g. for the `dummy` feature).