### PR TITLE
Calculate sizes, alignment and offsets for both wasm32 and wasm64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1572,7 +1572,7 @@ dependencies = [
  "wasmparser 0.215.0",
  "wasmprinter 0.215.0",
  "wat",
- "wit-component",
+ "wit-component 0.215.0",
 ]
 
 [[package]]
@@ -1586,12 +1586,38 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
+version = "0.214.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff694f02a8d7a50b6922b197ae03883fbf18cdb2ae9fbee7b6148456f5f44041"
+dependencies = [
+ "leb128",
+ "wasmparser 0.214.0",
+]
+
+[[package]]
+name = "wasm-encoder"
 version = "0.215.0"
 dependencies = [
  "anyhow",
  "leb128",
  "tempfile",
  "wasmparser 0.215.0",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.214.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "865c5bff5f7a3781b5f92ea4cfa99bb38267da097441cdb09080de1568ef3075"
+dependencies = [
+ "anyhow",
+ "indexmap 2.2.6",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "spdx",
+ "wasm-encoder 0.214.0",
+ "wasmparser 0.214.0",
 ]
 
 [[package]]
@@ -1710,7 +1736,7 @@ dependencies = [
  "termcolor",
  "wasm-compose",
  "wasm-encoder 0.215.0",
- "wasm-metadata",
+ "wasm-metadata 0.215.0",
  "wasm-mutate",
  "wasm-shrink",
  "wasm-smith",
@@ -1718,7 +1744,7 @@ dependencies = [
  "wasmprinter 0.215.0",
  "wast",
  "wat",
- "wit-component",
+ "wit-component 0.215.0",
  "wit-encoder",
  "wit-parser 0.215.0",
  "wit-smith",
@@ -1756,7 +1782,9 @@ dependencies = [
  "wasmtime",
  "wast",
  "wat",
- "wit-component",
+ "wit-component 0.214.0",
+ "wit-component 0.215.0",
+ "wit-parser 0.214.0",
  "wit-parser 0.215.0",
  "wit-smith",
 ]
@@ -1784,6 +1812,19 @@ dependencies = [
  "indexmap 2.2.6",
  "semver",
  "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.214.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5309c1090e3e84dad0d382f42064e9933fdaedb87e468cc239f0eabea73ddcb6"
+dependencies = [
+ "ahash",
+ "bitflags",
+ "hashbrown 0.14.5",
+ "indexmap 2.2.6",
+ "semver",
 ]
 
 [[package]]
@@ -2179,6 +2220,25 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
+version = "0.214.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd9fd46f0e783bf80f1ab7291f9d442fa5553ff0e96cdb71964bd8859b734b55"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.2.6",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.214.0",
+ "wasm-metadata 0.214.0",
+ "wasmparser 0.214.0",
+ "wit-parser 0.214.0",
+]
+
+[[package]]
+name = "wit-component"
 version = "0.215.0"
 dependencies = [
  "anyhow",
@@ -2193,7 +2253,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "wasm-encoder 0.215.0",
- "wasm-metadata",
+ "wasm-metadata 0.215.0",
  "wasmparser 0.215.0",
  "wasmprinter 0.215.0",
  "wasmtime",
@@ -2230,6 +2290,24 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.209.1",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.214.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "681d526d6ea42e28f9afe9eae2b50e0b0a627aef8822c75eb04078db84d03e57"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.2.6",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.214.0",
 ]
 
 [[package]]
@@ -2274,7 +2352,7 @@ dependencies = [
  "indexmap 2.2.6",
  "log",
  "semver",
- "wit-component",
+ "wit-component 0.215.0",
  "wit-parser 0.215.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1747,7 +1747,7 @@ dependencies = [
  "wit-component 0.215.0",
  "wit-encoder",
  "wit-parser 0.215.0",
- "wit-smith",
+ "wit-smith 0.215.0",
 ]
 
 [[package]]
@@ -1786,7 +1786,8 @@ dependencies = [
  "wit-component 0.215.0",
  "wit-parser 0.214.0",
  "wit-parser 0.215.0",
- "wit-smith",
+ "wit-smith 0.214.0",
+ "wit-smith 0.215.0",
 ]
 
 [[package]]
@@ -2341,6 +2342,20 @@ dependencies = [
  "log",
  "wasmprinter 0.215.0",
  "wit-parser 0.215.0",
+]
+
+[[package]]
+name = "wit-smith"
+version = "0.214.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cf816019a376a912cafb103677a8d28e3cba86b7671b754281e75f4909e129"
+dependencies = [
+ "arbitrary",
+ "indexmap 2.2.6",
+ "log",
+ "semver",
+ "wit-component 0.214.0",
+ "wit-parser 0.214.0",
 ]
 
 [[package]]

--- a/crates/wit-parser/src/sizealign.rs
+++ b/crates/wit-parser/src/sizealign.rs
@@ -18,6 +18,15 @@ impl Default for Alignment {
     }
 }
 
+impl std::fmt::Display for Alignment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Alignment::Pointer => f.write_str("ptr"),
+            Alignment::Bytes(b) => f.write_fmt(format_args!("{}", b.get())),
+        }
+    }
+}
+
 impl Ord for Alignment {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         match (self, other) {
@@ -81,6 +90,27 @@ impl From<Alignment> for ArchitectureSize {
                 bytes: 4,
                 add_for_64bit: 4,
             },
+        }
+    }
+}
+
+impl std::fmt::Display for ArchitectureSize {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.add_for_64bit != 0 {
+            if self.bytes > self.add_for_64bit {
+                // both
+                f.write_fmt(format_args!(
+                    "{}+{}*ptrsz",
+                    self.constant_bytes(),
+                    self.usize_to_add()
+                ))
+            } else {
+                // only pointer
+                f.write_fmt(format_args!("{}*ptrsz", self.usize_to_add()))
+            }
+        } else {
+            // only bytes
+            f.write_fmt(format_args!("{}", self.constant_bytes()))
         }
     }
 }

--- a/crates/wit-parser/src/sizealign.rs
+++ b/crates/wit-parser/src/sizealign.rs
@@ -95,6 +95,13 @@ impl ArchitectureSize {
         }
     }
 
+    pub fn add_bytes(&self, b: usize) -> Self {
+        Self {
+            bytes: self.bytes + b,
+            add_for_64bit: self.add_for_64bit,
+        }
+    }
+
     /// The effective offset/size is
     /// `constant_bytes() + std::sizeof::<usize> * usize_to_add()`
     pub fn constant_bytes(&self) -> usize {

--- a/crates/wit-parser/src/sizealign.rs
+++ b/crates/wit-parser/src/sizealign.rs
@@ -70,6 +70,21 @@ impl AddAssign<ArchitectureSize> for ArchitectureSize {
     }
 }
 
+impl From<Alignment> for ArchitectureSize {
+    fn from(align: Alignment) -> Self {
+        match align {
+            Alignment::Bytes(bytes) => ArchitectureSize {
+                bytes: bytes.get(),
+                add_for_64bit: 0,
+            },
+            Alignment::Pointer => ArchitectureSize {
+                bytes: 4,
+                add_for_64bit: 4,
+            },
+        }
+    }
+}
+
 impl ArchitectureSize {
     fn max(&self, other: &Self) -> Self {
         let new_bytes = self.bytes.max(other.bytes);
@@ -105,21 +120,9 @@ pub struct ElementInfo {
 
 impl From<Alignment> for ElementInfo {
     fn from(align: Alignment) -> Self {
-        match align {
-            Alignment::Bytes(bytes) => ElementInfo {
-                size: ArchitectureSize {
-                    bytes: bytes.get(),
-                    add_for_64bit: 0,
-                },
-                align,
-            },
-            Alignment::Pointer => ElementInfo {
-                size: ArchitectureSize {
-                    bytes: 4,
-                    add_for_64bit: 4,
-                },
-                align,
-            },
+        ElementInfo {
+            size: align.into(),
+            align,
         }
     }
 }

--- a/crates/wit-parser/src/sizealign.rs
+++ b/crates/wit-parser/src/sizealign.rs
@@ -106,22 +106,7 @@ impl From<Alignment> for ArchitectureSize {
 
 impl std::fmt::Display for ArchitectureSize {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.add_for_64bit != 0 {
-            if self.bytes > self.add_for_64bit {
-                // both
-                f.write_fmt(format_args!(
-                    "{}+{}*ptrsz",
-                    self.constant_bytes(),
-                    self.usize_to_add()
-                ))
-            } else {
-                // only pointer
-                f.write_fmt(format_args!("{}*ptrsz", self.usize_to_add()))
-            }
-        } else {
-            // only bytes
-            f.write_fmt(format_args!("{}", self.constant_bytes()))
-        }
+        f.write_str(&self.format("ptrsz"))
     }
 }
 
@@ -161,6 +146,25 @@ impl ArchitectureSize {
     /// prefer this over >0
     pub fn is_empty(&self) -> bool {
         self.bytes == 0
+    }
+
+    pub fn format(&self, ptrsize_expr: &str) -> String {
+        if self.add_for_64bit != 0 {
+            if self.bytes > self.add_for_64bit {
+                // both
+                format!(
+                    "({}+{}*{ptrsize_expr})",
+                    self.constant_bytes(),
+                    self.usize_to_add()
+                )
+            } else {
+                // only pointer
+                format!("({}*{ptrsize_expr})", self.usize_to_add())
+            }
+        } else {
+            // only bytes
+            format!("{}", self.constant_bytes())
+        }
     }
 }
 

--- a/crates/wit-parser/src/sizealign.rs
+++ b/crates/wit-parser/src/sizealign.rs
@@ -33,16 +33,16 @@ impl Ord for Alignment {
             (Alignment::Pointer, Alignment::Pointer) => std::cmp::Ordering::Equal,
             (Alignment::Pointer, Alignment::Bytes(b)) => {
                 if b.get() > 4 {
-                    std::cmp::Ordering::Greater
-                } else {
                     std::cmp::Ordering::Less
+                } else {
+                    std::cmp::Ordering::Greater
                 }
             }
             (Alignment::Bytes(b), Alignment::Pointer) => {
                 if b.get() > 4 {
-                    std::cmp::Ordering::Less
-                } else {
                     std::cmp::Ordering::Greater
+                } else {
+                    std::cmp::Ordering::Less
                 }
             }
             (Alignment::Bytes(a), Alignment::Bytes(b)) => a.cmp(b),
@@ -238,11 +238,11 @@ impl SizeAlign {
             TypeDefKind::Option(t) => self.variant(Int::U8, [Some(t)]),
             TypeDefKind::Result(r) => self.variant(Int::U8, [r.ok.as_ref(), r.err.as_ref()]),
             // A resource is represented as an index.
-            TypeDefKind::Handle(_) => int_size_align(Int::U32),
             // A future is represented as an index.
-            TypeDefKind::Future(_) => int_size_align(Int::U32),
             // A stream is represented as an index.
-            TypeDefKind::Stream(_) => int_size_align(Int::U32),
+            TypeDefKind::Handle(_) | TypeDefKind::Future(_) | TypeDefKind::Stream(_) => {
+                int_size_align(Int::U32)
+            }
             // This shouldn't be used for anything since raw resources aren't part of the ABI -- just handles to
             // them.
             TypeDefKind::Resource => ElementInfo::new(

--- a/crates/wit-parser/src/sizealign.rs
+++ b/crates/wit-parser/src/sizealign.rs
@@ -1,6 +1,6 @@
 use std::{
     num::{NonZero, NonZeroUsize},
-    ops::Add,
+    ops::{Add, AddAssign},
 };
 
 use crate::{FlagsRepr, Int, Resolve, Type, TypeDef, TypeDefKind};
@@ -60,6 +60,13 @@ impl Add<ArchitectureSize> for ArchitectureSize {
             bytes: self.bytes + rhs.bytes,
             add_for_64bit: self.add_for_64bit + rhs.add_for_64bit,
         }
+    }
+}
+
+impl AddAssign<ArchitectureSize> for ArchitectureSize {
+    fn add_assign(&mut self, rhs: ArchitectureSize) {
+        self.bytes += rhs.bytes;
+        self.add_for_64bit += rhs.add_for_64bit;
     }
 }
 
@@ -305,7 +312,7 @@ pub(crate) fn align_to(val: usize, align: usize) -> usize {
     (val + align - 1) & !(align - 1)
 }
 
-fn align_to_arch(val: ArchitectureSize, align: Alignment) -> ArchitectureSize {
+pub fn align_to_arch(val: ArchitectureSize, align: Alignment) -> ArchitectureSize {
     match align {
         Alignment::Pointer => {
             let new_bytes = align_to(val.bytes, 4);

--- a/crates/wit-parser/src/sizealign.rs
+++ b/crates/wit-parser/src/sizealign.rs
@@ -168,7 +168,7 @@ impl ArchitectureSize {
 
     /// prefer this over >0
     pub fn is_empty(&self) -> bool {
-        self.bytes == 0
+        self.bytes == 0 && self.pointers == 0
     }
 
     // create a suitable expression in bytes from a pointer size argument

--- a/crates/wit-parser/src/sizealign.rs
+++ b/crates/wit-parser/src/sizealign.rs
@@ -247,7 +247,7 @@ impl SizeAlign64 {
             // This shouldn't be used for anything since raw resources aren't part of the ABI -- just handles to
             // them.
             TypeDefKind::Resource => ElementInfo::new(
-                ArchitectureSize::new(usize::MAX, usize::MAX),
+                ArchitectureSize::new(usize::MAX, 0),
                 Alignment::Bytes(NonZeroUsize::new(usize::MAX).unwrap()),
             ),
             TypeDefKind::Unknown => unreachable!(),
@@ -506,5 +506,22 @@ mod test {
             ArchitectureSize::new(12, 0).max(&ArchitectureSize::new(8, 8)),
             ArchitectureSize::new(12, 4)
         );
+
+        {
+            // keep it identical to the old behavior
+            let obj = SizeAlign64::default();
+            let elem = obj.calculate(&TypeDef {
+                name: None,
+                kind: TypeDefKind::Resource,
+                owner: crate::TypeOwner::None,
+                docs: Default::default(),
+                stability: Default::default(),
+            });
+            assert_eq!(elem.size, ArchitectureSize::new(usize::MAX, 0));
+            assert_eq!(
+                elem.align,
+                Alignment::Bytes(NonZeroUsize::new(usize::MAX).unwrap())
+            );
+        }
     }
 }

--- a/crates/wit-parser/src/sizealign.rs
+++ b/crates/wit-parser/src/sizealign.rs
@@ -210,13 +210,6 @@ impl SizeAlign64 {
     //     Default::default()
     // }
 
-    pub fn new_symmetric() -> Self {
-        Self {
-            map: Vec::new(),
-            symmetric: true,
-        }
-    }
-
     pub fn fill(&mut self, resolve: &Resolve) {
         self.map = Vec::new();
         for (_, ty) in resolve.types.iter() {

--- a/crates/wit-parser/src/sizealign.rs
+++ b/crates/wit-parser/src/sizealign.rs
@@ -1,24 +1,130 @@
+use std::{
+    num::{NonZero, NonZeroUsize},
+    ops::Add,
+};
+
 use crate::{FlagsRepr, Int, Resolve, Type, TypeDef, TypeDefKind};
 
+/// Architecture specific alignment
+#[derive(Eq, PartialEq, PartialOrd, Clone, Copy, Debug)]
+pub enum Alignment {
+    Pointer,
+    Bytes(NonZeroUsize),
+}
+
+impl Default for Alignment {
+    fn default() -> Self {
+        Alignment::Bytes(NonZero::new(1).unwrap())
+    }
+}
+
+impl Ord for Alignment {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        match (self, other) {
+            (Alignment::Pointer, Alignment::Pointer) => std::cmp::Ordering::Equal,
+            (Alignment::Pointer, Alignment::Bytes(b)) => {
+                if b.get() > 4 {
+                    std::cmp::Ordering::Greater
+                } else {
+                    std::cmp::Ordering::Less
+                }
+            }
+            (Alignment::Bytes(b), Alignment::Pointer) => {
+                if b.get() > 4 {
+                    std::cmp::Ordering::Less
+                } else {
+                    std::cmp::Ordering::Greater
+                }
+            }
+            (Alignment::Bytes(a), Alignment::Bytes(b)) => a.cmp(b),
+        }
+    }
+}
+
+/// Architecture specific measurement of position,
+/// the combined amount in bytes is
+/// `bytes + if 4 < std::sizeof::<usize> { add_for_64bit } else { 0 }`
+#[derive(Default, Clone, Copy, Eq, PartialEq, Debug)]
+pub struct ArchitectureSize {
+    /// exact value for 32-bit pointers
+    pub bytes: usize,
+    /// amount of bytes to add for 64-bit architecture
+    pub add_for_64bit: usize,
+}
+
+impl Add<ArchitectureSize> for ArchitectureSize {
+    type Output = ArchitectureSize;
+
+    fn add(self, rhs: ArchitectureSize) -> Self::Output {
+        ArchitectureSize {
+            bytes: self.bytes + rhs.bytes,
+            add_for_64bit: self.add_for_64bit + rhs.add_for_64bit,
+        }
+    }
+}
+
+impl ArchitectureSize {
+    fn max(&self, other: &Self) -> Self {
+        let new_bytes = self.bytes.max(other.bytes);
+        Self {
+            bytes: new_bytes,
+            add_for_64bit: (self.bytes + self.add_for_64bit).max(other.bytes + other.add_for_64bit)
+                - new_bytes,
+        }
+    }
+
+    /// The effective offset/size is
+    /// `constant_bytes() + std::sizeof::<usize> * usize_to_add()`
+    pub fn constant_bytes(&self) -> usize {
+        self.bytes - self.add_for_64bit
+    }
+
+    pub fn usize_to_add(&self) -> usize {
+        self.add_for_64bit / 4
+    }
+
+    /// Shortcut for compatibility with previous versions
+    pub fn size_wasm32(&self) -> usize {
+        self.bytes
+    }
+}
+
+/// Information per structure element
 #[derive(Default)]
-pub enum AddressSize {
-    #[default]
-    Wasm32,
-    Wasm64,
+pub struct ElementInfo {
+    pub size: ArchitectureSize,
+    pub align: Alignment,
+}
+
+impl From<Alignment> for ElementInfo {
+    fn from(align: Alignment) -> Self {
+        match align {
+            Alignment::Bytes(bytes) => ElementInfo {
+                size: ArchitectureSize {
+                    bytes: bytes.get(),
+                    add_for_64bit: 0,
+                },
+                align,
+            },
+            Alignment::Pointer => ElementInfo {
+                size: ArchitectureSize {
+                    bytes: 4,
+                    add_for_64bit: 4,
+                },
+                align,
+            },
+        }
+    }
 }
 
 #[derive(Default)]
 pub struct SizeAlign {
-    map: Vec<(usize, usize)>,
-    wasm_type: AddressSize,
+    map: Vec<ElementInfo>,
 }
 
 impl SizeAlign {
-    pub fn new(wasm_type: AddressSize) -> Self {
-        Self {
-            map: Vec::new(),
-            wasm_type,
-        }
+    pub fn new() -> Self {
+        Self { map: Vec::new() }
     }
 
     pub fn fill(&mut self, resolve: &Resolve) {
@@ -29,83 +135,97 @@ impl SizeAlign {
         }
     }
 
-    fn calculate(&self, ty: &TypeDef) -> (usize, usize) {
+    fn calculate(&self, ty: &TypeDef) -> ElementInfo {
         match &ty.kind {
-            TypeDefKind::Type(t) => (self.size(t), self.align(t)),
-            TypeDefKind::List(_) => {
-                if matches!(self.wasm_type, AddressSize::Wasm64) {
-                    (16, 8)
-                } else {
-                    (8, 4)
-                }
-            }
+            TypeDefKind::Type(t) => ElementInfo {
+                size: self.size(t),
+                align: self.align(t),
+            },
+            TypeDefKind::List(_) => ElementInfo {
+                size: ArchitectureSize {
+                    bytes: 8,
+                    add_for_64bit: 8,
+                },
+                align: Alignment::Pointer,
+            },
             TypeDefKind::Record(r) => self.record(r.fields.iter().map(|f| &f.ty)),
             TypeDefKind::Tuple(t) => self.record(t.types.iter()),
             TypeDefKind::Flags(f) => match f.repr() {
-                FlagsRepr::U8 => (1, 1),
-                FlagsRepr::U16 => (2, 2),
-                FlagsRepr::U32(n) => (n * 4, 4),
+                FlagsRepr::U8 => int_size_align(Int::U8),
+                FlagsRepr::U16 => int_size_align(Int::U16),
+                FlagsRepr::U32(n) => ElementInfo {
+                    size: ArchitectureSize {
+                        bytes: n * 4,
+                        add_for_64bit: 0,
+                    },
+                    align: Alignment::Bytes(NonZero::new(4).unwrap()),
+                },
             },
             TypeDefKind::Variant(v) => self.variant(v.tag(), v.cases.iter().map(|c| c.ty.as_ref())),
             TypeDefKind::Enum(e) => self.variant(e.tag(), []),
             TypeDefKind::Option(t) => self.variant(Int::U8, [Some(t)]),
             TypeDefKind::Result(r) => self.variant(Int::U8, [r.ok.as_ref(), r.err.as_ref()]),
             // A resource is represented as an index.
-            TypeDefKind::Handle(_) => (4, 4),
+            TypeDefKind::Handle(_) => int_size_align(Int::U32),
             // A future is represented as an index.
-            TypeDefKind::Future(_) => (4, 4),
+            TypeDefKind::Future(_) => int_size_align(Int::U32),
             // A stream is represented as an index.
-            TypeDefKind::Stream(_) => (4, 4),
+            TypeDefKind::Stream(_) => int_size_align(Int::U32),
             // This shouldn't be used for anything since raw resources aren't part of the ABI -- just handles to
             // them.
-            TypeDefKind::Resource => (usize::MAX, usize::MAX),
+            TypeDefKind::Resource => unreachable!(),
             TypeDefKind::Unknown => unreachable!(),
         }
     }
 
-    pub fn size(&self, ty: &Type) -> usize {
+    pub fn size(&self, ty: &Type) -> ArchitectureSize {
         match ty {
-            Type::Bool | Type::U8 | Type::S8 => 1,
-            Type::U16 | Type::S16 => 2,
-            Type::U32 | Type::S32 | Type::F32 | Type::Char => 4,
-            Type::U64 | Type::S64 | Type::F64 => 8,
-            Type::String => {
-                if matches!(self.wasm_type, AddressSize::Wasm64) {
-                    16
-                } else {
-                    8
-                }
-            }
-            Type::Id(id) => self.map[id.index()].0,
+            Type::Bool | Type::U8 | Type::S8 => ArchitectureSize {
+                bytes: 1,
+                add_for_64bit: 0,
+            },
+            Type::U16 | Type::S16 => ArchitectureSize {
+                bytes: 2,
+                add_for_64bit: 0,
+            },
+            Type::U32 | Type::S32 | Type::F32 | Type::Char => ArchitectureSize {
+                bytes: 4,
+                add_for_64bit: 0,
+            },
+            Type::U64 | Type::S64 | Type::F64 => ArchitectureSize {
+                bytes: 8,
+                add_for_64bit: 0,
+            },
+            Type::String => ArchitectureSize {
+                bytes: 8,
+                add_for_64bit: 8,
+            },
+            Type::Id(id) => self.map[id.index()].size,
         }
     }
 
-    pub fn align(&self, ty: &Type) -> usize {
+    pub fn align(&self, ty: &Type) -> Alignment {
         match ty {
-            Type::Bool | Type::U8 | Type::S8 => 1,
-            Type::U16 | Type::S16 => 2,
-            Type::U32 | Type::S32 | Type::F32 | Type::Char => 4,
-            Type::U64 | Type::S64 | Type::F64 => 8,
-            Type::String => {
-                if matches!(self.wasm_type, AddressSize::Wasm64) {
-                    8
-                } else {
-                    4
-                }
+            Type::Bool | Type::U8 | Type::S8 => Alignment::Bytes(NonZero::new(1).unwrap()),
+            Type::U16 | Type::S16 => Alignment::Bytes(NonZero::new(2).unwrap()),
+            Type::U32 | Type::S32 | Type::F32 | Type::Char => {
+                Alignment::Bytes(NonZero::new(4).unwrap())
             }
-            Type::Id(id) => self.map[id.index()].1,
+            Type::U64 | Type::S64 | Type::F64 => Alignment::Bytes(NonZero::new(8).unwrap()),
+            Type::String => Alignment::Pointer,
+            Type::Id(id) => self.map[id.index()].align,
         }
     }
 
     pub fn field_offsets<'a>(
         &self,
         types: impl IntoIterator<Item = &'a Type>,
-    ) -> Vec<(usize, &'a Type)> {
-        let mut cur = 0;
+    ) -> Vec<(ArchitectureSize, &'a Type)> {
+        let mut cur = ArchitectureSize::default();
         types
             .into_iter()
             .map(|ty| {
-                let ret = align_to(cur, self.align(ty));
+                let ret = align_to_arch(cur, self.align(ty));
                 cur = ret + self.size(ty);
                 (ret, ty)
             })
@@ -116,30 +236,33 @@ impl SizeAlign {
         &self,
         tag: Int,
         cases: impl IntoIterator<Item = Option<&'a Type>>,
-    ) -> usize {
-        let mut max_align = 1;
+    ) -> ArchitectureSize {
+        let mut max_align = Alignment::default();
         for ty in cases {
             if let Some(ty) = ty {
                 max_align = max_align.max(self.align(ty));
             }
         }
-        let tag_size = int_size_align(tag).0;
-        align_to(tag_size, max_align)
+        let tag_size = int_size_align(tag).size;
+        align_to_arch(tag_size, max_align)
     }
 
-    pub fn record<'a>(&self, types: impl Iterator<Item = &'a Type>) -> (usize, usize) {
-        let mut size = 0;
-        let mut align = 1;
+    pub fn record<'a>(&self, types: impl Iterator<Item = &'a Type>) -> ElementInfo {
+        let mut size = ArchitectureSize::default();
+        let mut align = Alignment::default();
         for ty in types {
             let field_size = self.size(ty);
             let field_align = self.align(ty);
-            size = align_to(size, field_align) + field_size;
+            size = align_to_arch(size, field_align) + field_size;
             align = align.max(field_align);
         }
-        (align_to(size, align), align)
+        ElementInfo {
+            size: align_to_arch(size, align),
+            align,
+        }
     }
 
-    pub fn params<'a>(&self, types: impl IntoIterator<Item = &'a Type>) -> (usize, usize) {
+    pub fn params<'a>(&self, types: impl IntoIterator<Item = &'a Type>) -> ElementInfo {
         self.record(types.into_iter())
     }
 
@@ -147,33 +270,201 @@ impl SizeAlign {
         &self,
         tag: Int,
         types: impl IntoIterator<Item = Option<&'a Type>>,
-    ) -> (usize, usize) {
-        let (discrim_size, discrim_align) = int_size_align(tag);
-        let mut case_size = 0;
-        let mut case_align = 1;
+    ) -> ElementInfo {
+        let ElementInfo {
+            size: discrim_size,
+            align: discrim_align,
+        } = int_size_align(tag);
+        let mut case_size = ArchitectureSize::default();
+        let mut case_align = Alignment::default();
         for ty in types {
             if let Some(ty) = ty {
-                case_size = case_size.max(self.size(ty));
+                case_size = case_size.max(&self.size(ty));
                 case_align = case_align.max(self.align(ty));
             }
         }
         let align = discrim_align.max(case_align);
-        (
-            align_to(align_to(discrim_size, case_align) + case_size, align),
+        ElementInfo {
+            size: align_to_arch(align_to_arch(discrim_size, case_align) + case_size, align),
             align,
-        )
+        }
     }
 }
 
-fn int_size_align(i: Int) -> (usize, usize) {
+fn int_size_align(i: Int) -> ElementInfo {
     match i {
-        Int::U8 => (1, 1),
-        Int::U16 => (2, 2),
-        Int::U32 => (4, 4),
-        Int::U64 => (8, 8),
+        Int::U8 => Alignment::Bytes(NonZero::new(1).unwrap()),
+        Int::U16 => Alignment::Bytes(NonZero::new(2).unwrap()),
+        Int::U32 => Alignment::Bytes(NonZero::new(4).unwrap()),
+        Int::U64 => Alignment::Bytes(NonZero::new(8).unwrap()),
     }
+    .into()
 }
 
 pub(crate) fn align_to(val: usize, align: usize) -> usize {
     (val + align - 1) & !(align - 1)
+}
+
+fn align_to_arch(val: ArchitectureSize, align: Alignment) -> ArchitectureSize {
+    match align {
+        Alignment::Pointer => {
+            let new_bytes = align_to(val.bytes, 4);
+            let unaligned64 = new_bytes + val.add_for_64bit;
+            ArchitectureSize {
+                bytes: new_bytes,
+                add_for_64bit:
+                    // increase if necessary for 64bit alignment
+                    val.add_for_64bit
+                    + if unaligned64 != align_to(unaligned64, 8) {
+                        4
+                    } else {
+                        0
+                    },
+            }
+        }
+        Alignment::Bytes(align_bytes) => {
+            let new_bytes = align_to(val.bytes, align_bytes.get());
+            ArchitectureSize {
+                bytes: new_bytes,
+                add_for_64bit: align_to(val.bytes + val.add_for_64bit, align_bytes.get())
+                    - new_bytes,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn align() {
+        // u8 + ptr
+        assert_eq!(
+            align_to_arch(
+                ArchitectureSize {
+                    bytes: 1,
+                    add_for_64bit: 0
+                },
+                Alignment::Pointer
+            ),
+            ArchitectureSize {
+                bytes: 4,
+                add_for_64bit: 4
+            }
+        );
+        // u8 + u64
+        assert_eq!(
+            align_to_arch(
+                ArchitectureSize {
+                    bytes: 1,
+                    add_for_64bit: 0
+                },
+                Alignment::Bytes(NonZero::new(8).unwrap())
+            ),
+            ArchitectureSize {
+                bytes: 8,
+                add_for_64bit: 0
+            }
+        );
+        // u8 + u32
+        assert_eq!(
+            align_to_arch(
+                ArchitectureSize {
+                    bytes: 1,
+                    add_for_64bit: 0
+                },
+                Alignment::Bytes(NonZero::new(4).unwrap())
+            ),
+            ArchitectureSize {
+                bytes: 4,
+                add_for_64bit: 0
+            }
+        );
+        // ptr + u64
+        assert_eq!(
+            align_to_arch(
+                ArchitectureSize {
+                    bytes: 4,
+                    add_for_64bit: 4
+                },
+                Alignment::Bytes(NonZero::new(8).unwrap())
+            ),
+            ArchitectureSize {
+                bytes: 8,
+                add_for_64bit: 0
+            }
+        );
+        // u32 + ptr
+        assert_eq!(
+            align_to_arch(
+                ArchitectureSize {
+                    bytes: 4,
+                    add_for_64bit: 0
+                },
+                Alignment::Pointer
+            ),
+            ArchitectureSize {
+                bytes: 4,
+                add_for_64bit: 4
+            }
+        );
+        // u32, ptr + u64
+        assert_eq!(
+            align_to_arch(
+                ArchitectureSize {
+                    bytes: 8,
+                    add_for_64bit: 8
+                },
+                Alignment::Bytes(NonZero::new(8).unwrap())
+            ),
+            ArchitectureSize {
+                bytes: 8,
+                add_for_64bit: 8
+            }
+        );
+        // ptr, u8 + u64
+        assert_eq!(
+            align_to_arch(
+                ArchitectureSize {
+                    bytes: 5,
+                    add_for_64bit: 4
+                },
+                Alignment::Bytes(NonZero::new(8).unwrap())
+            ),
+            ArchitectureSize {
+                bytes: 8,
+                add_for_64bit: 8
+            }
+        );
+        // ptr, u8 + ptr
+        assert_eq!(
+            align_to_arch(
+                ArchitectureSize {
+                    bytes: 5,
+                    add_for_64bit: 4
+                },
+                Alignment::Pointer
+            ),
+            ArchitectureSize {
+                bytes: 8,
+                add_for_64bit: 8
+            }
+        );
+
+        assert_eq!(
+            ArchitectureSize {
+                bytes: 12,
+                add_for_64bit: 0
+            }
+            .max(&ArchitectureSize {
+                bytes: 8,
+                add_for_64bit: 8
+            }),
+            ArchitectureSize {
+                bytes: 12,
+                add_for_64bit: 4
+            }
+        );
+    }
 }

--- a/crates/wit-parser/src/sizealign.rs
+++ b/crates/wit-parser/src/sizealign.rs
@@ -1,5 +1,5 @@
 use std::{
-    num::{NonZero, NonZeroUsize},
+    num::NonZeroUsize,
     ops::{Add, AddAssign},
 };
 
@@ -14,7 +14,7 @@ pub enum Alignment {
 
 impl Default for Alignment {
     fn default() -> Self {
-        Alignment::Bytes(NonZero::new(1).unwrap())
+        Alignment::Bytes(NonZeroUsize::new(1).unwrap())
     }
 }
 
@@ -231,7 +231,7 @@ impl SizeAlign64 {
                 FlagsRepr::U16 => int_size_align(Int::U16),
                 FlagsRepr::U32(n) => ElementInfo::new(
                     ArchitectureSize::new(n * 4, 0),
-                    Alignment::Bytes(NonZero::new(4).unwrap()),
+                    Alignment::Bytes(NonZeroUsize::new(4).unwrap()),
                 ),
             },
             TypeDefKind::Variant(v) => self.variant(v.tag(), v.cases.iter().map(|c| c.ty.as_ref())),
@@ -248,7 +248,7 @@ impl SizeAlign64 {
             // them.
             TypeDefKind::Resource => ElementInfo::new(
                 ArchitectureSize::new(usize::MAX, usize::MAX),
-                Alignment::Bytes(NonZero::new(usize::MAX).unwrap()),
+                Alignment::Bytes(NonZeroUsize::new(usize::MAX).unwrap()),
             ),
             TypeDefKind::Unknown => unreachable!(),
         }
@@ -267,12 +267,12 @@ impl SizeAlign64 {
 
     pub fn align(&self, ty: &Type) -> Alignment {
         match ty {
-            Type::Bool | Type::U8 | Type::S8 => Alignment::Bytes(NonZero::new(1).unwrap()),
-            Type::U16 | Type::S16 => Alignment::Bytes(NonZero::new(2).unwrap()),
+            Type::Bool | Type::U8 | Type::S8 => Alignment::Bytes(NonZeroUsize::new(1).unwrap()),
+            Type::U16 | Type::S16 => Alignment::Bytes(NonZeroUsize::new(2).unwrap()),
             Type::U32 | Type::S32 | Type::F32 | Type::Char => {
-                Alignment::Bytes(NonZero::new(4).unwrap())
+                Alignment::Bytes(NonZeroUsize::new(4).unwrap())
             }
-            Type::U64 | Type::S64 | Type::F64 => Alignment::Bytes(NonZero::new(8).unwrap()),
+            Type::U64 | Type::S64 | Type::F64 => Alignment::Bytes(NonZeroUsize::new(8).unwrap()),
             Type::String => Alignment::Pointer,
             Type::Id(id) => self.map[id.index()].align,
         }
@@ -351,10 +351,10 @@ impl SizeAlign64 {
 
 fn int_size_align(i: Int) -> ElementInfo {
     match i {
-        Int::U8 => Alignment::Bytes(NonZero::new(1).unwrap()),
-        Int::U16 => Alignment::Bytes(NonZero::new(2).unwrap()),
-        Int::U32 => Alignment::Bytes(NonZero::new(4).unwrap()),
-        Int::U64 => Alignment::Bytes(NonZero::new(8).unwrap()),
+        Int::U8 => Alignment::Bytes(NonZeroUsize::new(1).unwrap()),
+        Int::U16 => Alignment::Bytes(NonZeroUsize::new(2).unwrap()),
+        Int::U32 => Alignment::Bytes(NonZeroUsize::new(4).unwrap()),
+        Int::U64 => Alignment::Bytes(NonZeroUsize::new(8).unwrap()),
     }
     .into()
 }
@@ -455,7 +455,7 @@ mod test {
         assert_eq!(
             align_to_arch(
                 ArchitectureSize::new(1, 0),
-                Alignment::Bytes(NonZero::new(8).unwrap())
+                Alignment::Bytes(NonZeroUsize::new(8).unwrap())
             ),
             ArchitectureSize::new(8, 0)
         );
@@ -463,7 +463,7 @@ mod test {
         assert_eq!(
             align_to_arch(
                 ArchitectureSize::new(1, 0),
-                Alignment::Bytes(NonZero::new(4).unwrap())
+                Alignment::Bytes(NonZeroUsize::new(4).unwrap())
             ),
             ArchitectureSize::new(4, 0)
         );
@@ -471,7 +471,7 @@ mod test {
         assert_eq!(
             align_to_arch(
                 ArchitectureSize::new(4, 4),
-                Alignment::Bytes(NonZero::new(8).unwrap())
+                Alignment::Bytes(NonZeroUsize::new(8).unwrap())
             ),
             ArchitectureSize::new(8, 0)
         );
@@ -484,7 +484,7 @@ mod test {
         assert_eq!(
             align_to_arch(
                 ArchitectureSize::new(8, 8),
-                Alignment::Bytes(NonZero::new(8).unwrap())
+                Alignment::Bytes(NonZeroUsize::new(8).unwrap())
             ),
             ArchitectureSize::new(8, 8)
         );
@@ -492,7 +492,7 @@ mod test {
         assert_eq!(
             align_to_arch(
                 ArchitectureSize::new(5, 4),
-                Alignment::Bytes(NonZero::new(8).unwrap())
+                Alignment::Bytes(NonZeroUsize::new(8).unwrap())
             ),
             ArchitectureSize::new(8, 8)
         );

--- a/crates/wit-parser/src/sizealign.rs
+++ b/crates/wit-parser/src/sizealign.rs
@@ -8,7 +8,9 @@ use crate::{FlagsRepr, Int, Resolve, Type, TypeDef, TypeDefKind};
 /// Architecture specific alignment
 #[derive(Eq, PartialEq, PartialOrd, Clone, Copy, Debug)]
 pub enum Alignment {
+    /// This represents 4 byte alignment on 32bit and 8 byte alignment on 64bit architectures
     Pointer,
+    /// This alignment is architecture independent (derived from integer or float types)
     Bytes(NonZeroUsize),
 }
 
@@ -28,6 +30,9 @@ impl std::fmt::Display for Alignment {
 }
 
 impl Ord for Alignment {
+    /// Needed for determining the max alignment of an object from its parts.
+    /// The ordering is: Bytes(1) < Bytes(2) < Bytes(4) < Pointer < Bytes(8)
+    /// as a Pointer is either four or eight byte aligned, depending on the architecture
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         match (self, other) {
             (Alignment::Pointer, Alignment::Pointer) => std::cmp::Ordering::Equal,

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -37,6 +37,10 @@ version = '0.214.0'
 package = 'wit-component'
 version = '0.214.0'
 
+[dependencies.wit-smith-old]
+package = 'wit-smith'
+version = '0.214.0'
+
 [lib]
 test = false
 doctest = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -29,6 +29,14 @@ wit-smith = { path = "../crates/wit-smith" }
 wit-component = { path = "../crates/wit-component", features = ['dummy-module'] }
 wasm-encoder = { path = "../crates/wasm-encoder" }
 
+[dependencies.wit-parser-old]
+package = 'wit-parser'
+version = '0.214.0'
+
+[dependencies.wit-component-old]
+package = 'wit-component'
+version = '0.214.0'
+
 [lib]
 test = false
 doctest = false

--- a/fuzz/fuzz_targets/run.rs
+++ b/fuzz/fuzz_targets/run.rs
@@ -80,4 +80,5 @@ run_fuzzers! {
     roundtrip: string,
     text_parser: string,
     reencode: unstructured,
+    wit64: unstructured,
 }

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -13,6 +13,7 @@ pub mod roundtrip_wit;
 pub mod text_parser;
 pub mod validate;
 pub mod validate_valid_module;
+pub mod wit64;
 
 pub fn generate_valid_module(
     u: &mut Unstructured,

--- a/fuzz/src/wit64.rs
+++ b/fuzz/src/wit64.rs
@@ -34,16 +34,10 @@ pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
         assert!(a32 <= a64);
 
         assert_eq!(a32, aalt.align_wasm32());
-        assert_eq!(
-            a64,
-            match aalt {
-                wit_parser_new::Alignment::Bytes(b) => b.get(),
-                wit_parser_new::Alignment::Pointer => 8,
-            }
-        );
+        assert_eq!(a64, aalt.align_wasm64());
 
         assert_eq!(s32, salt.size_wasm32());
-        assert_eq!(s64, salt.bytes + salt.add_for_64bit);
+        assert_eq!(s64, salt.size_wasm64());
 
         match (t1, t2) {
             (wit_parser_old::Type::Id(id1), wit_parser_new::Type::Id(id2)) => {
@@ -63,7 +57,7 @@ pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
                             .zip(offsetsalt.iter())
                         {
                             assert_eq!(fd32.0, fdalt.0.size_wasm32());
-                            assert_eq!(fd64.0, fdalt.0.bytes + fdalt.0.add_for_64bit);
+                            assert_eq!(fd64.0, fdalt.0.size_wasm64());
                         }
                     }
                     (
@@ -79,7 +73,7 @@ pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
                             .zip(offsetsalt.iter())
                         {
                             assert_eq!(fd32.0, fdalt.0.size_wasm32());
-                            assert_eq!(fd64.0, fdalt.0.bytes + fdalt.0.add_for_64bit);
+                            assert_eq!(fd64.0, fdalt.0.size_wasm64());
                         }
                     }
                     (
@@ -93,7 +87,7 @@ pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
                         let offsetalt =
                             alt.payload_offset(v2.tag(), v2.cases.iter().map(|f| f.ty.as_ref()));
                         assert_eq!(offset32, offsetalt.size_wasm32());
-                        assert_eq!(offset64, offsetalt.bytes + offsetalt.add_for_64bit);
+                        assert_eq!(offset64, offsetalt.size_wasm64());
                     }
                     _ => (),
                 }

--- a/fuzz/src/wit64.rs
+++ b/fuzz/src/wit64.rs
@@ -1,0 +1,112 @@
+use arbitrary::{Result, Unstructured};
+use std::path::Path;
+use wit_parser as wit_parser_new;
+use wit_component as wit_component_new;
+
+pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
+    let wasm = u.arbitrary().and_then(|config| {
+        log::debug!("config: {config:#?}");
+        wit_smith::smith(&config, u)
+    })?;
+    write_file("doc.wasm", &wasm);
+    let r1 = wit_component_old::decode(&wasm).unwrap();
+    let r1 = r1.resolve();
+    let r2 = wit_component_new::decode(&wasm).unwrap();
+    let r2 = r2.resolve();
+
+    let mut sa32 = wit_parser_old::SizeAlign::new(wit_parser_old::AddressSize::Wasm32);
+    let mut sa64 = wit_parser_old::SizeAlign::new(wit_parser_old::AddressSize::Wasm64);
+
+    sa32.fill(r1);
+    sa64.fill(r1);
+
+    let mut alt = wit_parser_new::SizeAlign::default();
+    alt.fill(r2);
+
+    for ((t1, _), (t2, _)) in r1.types.iter().zip(r2.types.iter()) {
+        let t1 = &wit_parser_old::Type::Id(t1);
+        let t2 = &wit_parser_new::Type::Id(t2);
+        let (s32, a32) = (sa32.size(t1), sa32.align(t1));
+        let (s64, a64) = (sa64.size(t1), sa64.align(t1));
+        let (salt, aalt) = (alt.size(t2), alt.align(t2));
+
+        assert!(s32 <= s64);
+        assert!(a32 <= a64);
+
+        assert_eq!(a32, aalt.align_wasm32());
+        assert_eq!(
+            a64,
+            match aalt {
+                wit_parser_new::Alignment::Bytes(b) => b.get(),
+                wit_parser_new::Alignment::Pointer => 8,
+            }
+        );
+
+        assert_eq!(s32, salt.size_wasm32());
+        assert_eq!(s64, salt.bytes + salt.add_for_64bit);
+
+        match (t1, t2) {
+            (wit_parser_old::Type::Id(id1), wit_parser_new::Type::Id(id2)) => {
+                let tp1 = &r1.types[*id1];
+                let tp2 = &r2.types[*id2];
+                match (&tp1.kind, &tp2.kind) {
+                    (wit_parser_old::TypeDefKind::Record(r1), wit_parser_new::TypeDefKind::Record(r2)) => {
+                        let offsets32 = sa32.field_offsets(r1.fields.iter().map(|f| &f.ty));
+                        let offsets64 = sa64.field_offsets(r1.fields.iter().map(|f| &f.ty));
+                        let offsetsalt = alt.field_offsets(r2.fields.iter().map(|f| &f.ty));
+                        for ((fd32, fd64), fdalt) in offsets32
+                            .iter()
+                            .zip(offsets64.iter())
+                            .zip(offsetsalt.iter())
+                        {
+                            assert_eq!(fd32.0, fdalt.0.size_wasm32());
+                            assert_eq!(fd64.0, fdalt.0.bytes + fdalt.0.add_for_64bit);
+                        }
+                    }
+                    (wit_parser_old::TypeDefKind::Tuple(t1), wit_parser_new::TypeDefKind::Tuple(t2)) => {
+                        let offsets32 = sa32.field_offsets(t1.types.iter());
+                        let offsets64 = sa64.field_offsets(t1.types.iter());
+                        let offsetsalt = alt.field_offsets(t2.types.iter());
+                        for ((fd32, fd64), fdalt) in offsets32
+                            .iter()
+                            .zip(offsets64.iter())
+                            .zip(offsetsalt.iter())
+                        {
+                            assert_eq!(fd32.0, fdalt.0.size_wasm32());
+                            assert_eq!(fd64.0, fdalt.0.bytes + fdalt.0.add_for_64bit);
+                        }
+                    }
+                    (
+                        wit_parser_old::TypeDefKind::Variant(v1),
+                        wit_parser_new::TypeDefKind::Variant(v2),
+                    ) => {
+                        let offset32 = sa32.payload_offset(v1.tag(), v1.cases.iter().map(|f| f.ty.as_ref()));
+                        let offset64 = sa64.payload_offset(v1.tag(), v1.cases.iter().map(|f| f.ty.as_ref()));
+                        let offsetalt = alt.payload_offset(v2.tag(), v2.cases.iter().map(|f| f.ty.as_ref()));
+                        assert_eq!(offset32, offsetalt.size_wasm32());
+                        assert_eq!(offset64, offsetalt.bytes + offsetalt.add_for_64bit);
+                    }
+                    _ => (),
+                }
+            }
+            _ => (),
+        }
+    }
+
+    Ok(())
+}
+
+fn write_file(path: &str, contents: impl AsRef<[u8]>) {
+    if !log::log_enabled!(log::Level::Debug) {
+        return;
+    }
+    log::debug!("writing file {path}");
+    let contents = contents.as_ref();
+    let path = Path::new(path);
+    std::fs::write(path, contents).unwrap();
+    if path.extension().and_then(|s| s.to_str()) == Some("wasm") {
+        let path = path.with_extension("wat");
+        log::debug!("writing file {}", path.display());
+        std::fs::write(path, wasmprinter::print_bytes(&contents).unwrap()).unwrap();
+    }
+}


### PR DESCRIPTION
This enables wit-bindgen to emit code like `let l2 = *ptr0.add(core::mem::size_of::<*const u8>()).cast::<usize>();` which automatically calculates the right offset of 4 for wasm32 and 8 for wasm64 e.g. for string or list lowering.

The more complex cases combine fixed byte offsets and pointer sized offsets.

~~This also adds a compatibility layer which falls back to 32bit for the classical `SizeAlign` usage.~~