### PR TITLE
Test `wasm-tools component wit` on core modules

### DIFF
--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -1922,6 +1922,7 @@ impl ComponentEncoder {
     /// core module.
     pub fn module(mut self, module: &[u8]) -> Result<Self> {
         let (wasm, metadata) = metadata::decode(module)?;
+        let wasm = wasm.as_deref().unwrap_or(module);
         let world = self
             .metadata
             .merge(metadata)
@@ -1931,7 +1932,7 @@ impl ComponentEncoder {
         self.module = if let Some(producers) = &self.metadata.producers {
             producers.add_to_wasm(&wasm)?
         } else {
-            wasm
+            wasm.to_vec()
         };
         Ok(self)
     }
@@ -1986,6 +1987,7 @@ impl ComponentEncoder {
         library_info: Option<LibraryInfo>,
     ) -> Result<Self> {
         let (wasm, metadata) = metadata::decode(bytes)?;
+        let wasm = wasm.as_deref().unwrap_or(bytes);
         // Merge the adapter's document into our own document to have one large
         // document, and then afterwards merge worlds as well.
         //
@@ -2041,7 +2043,7 @@ impl ComponentEncoder {
         self.adapters.insert(
             name.to_string(),
             Adapter {
-                wasm,
+                wasm: wasm.to_vec(),
                 metadata: metadata.metadata,
                 required_exports: exports,
                 library_info,

--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -574,7 +574,15 @@ impl WitOpts {
                 if wasmparser::Parser::is_component(&input) {
                     wit_component::decode(&input)
                 } else {
-                    let (_wasm, bindgen) = wit_component::metadata::decode(&input)?;
+                    let (wasm, bindgen) = wit_component::metadata::decode(&input)?;
+                    if wasm.is_none() {
+                        bail!(
+                            "input is a core wasm module with no `component-type*` \
+                             custom sections meaning that there is not WIT information; \
+                             is the information not embedded or is this supposed \
+                             to be a component?"
+                        )
+                    }
                     Ok(DecodedWasm::Component(bindgen.resolve, bindgen.world))
                 }
             }

--- a/tests/cli/component-wit-empty-core-module.wat
+++ b/tests/cli/component-wit-empty-core-module.wat
@@ -1,0 +1,3 @@
+;; FAIL: component wit %
+
+(module)

--- a/tests/cli/component-wit-empty-core-module.wat.stderr
+++ b/tests/cli/component-wit-empty-core-module.wat.stderr
@@ -1,0 +1,1 @@
+error: input is a core wasm module with no `component-type*` custom sections meaning that there is not WIT information; is the information not embedded or is this supposed to be a component?

--- a/tests/cli/component-wit-of-core-module.wit
+++ b/tests/cli/component-wit-of-core-module.wit
@@ -1,0 +1,8 @@
+// RUN: component embed --dummy % | component wit
+
+package a:b;
+
+world foo {
+  import x: func();
+  export y: func();
+}

--- a/tests/cli/component-wit-of-core-module.wit.stdout
+++ b/tests/cli/component-wit-of-core-module.wit.stdout
@@ -1,0 +1,14 @@
+package root:root;
+
+world root {
+  import x: func();
+
+  export y: func();
+}
+package a:b {
+  world foo {
+    import x: func();
+
+    export y: func();
+  }
+}


### PR DESCRIPTION
Also cause it to return an error if the input is a core wasm module with zero `component-type` custom sections.

Closes #1673