### PR TITLE
threads: add more `missing-features` tests

### DIFF
--- a/tests/local/missing-features/gc/shared-everything-threads-arrays.wast
+++ b/tests/local/missing-features/gc/shared-everything-threads-arrays.wast
@@ -1,0 +1,11 @@
+;; This relies on the GC proposal (plus reference types) to check that shared
+;; arrays are not allowed without the shared-everything-threads proposal.
+(assert_invalid
+  (module
+    (type $a (array i32))
+    (func (param $x (ref null $a)) (param $y i32) (result i32)
+      local.get $x
+      local.get $y
+      array.atomic.get seq_cst $a)
+  )
+  "shared-everything-threads support is not enabled")

--- a/tests/local/missing-features/gc/shared-everything-threads-structs.wast
+++ b/tests/local/missing-features/gc/shared-everything-threads-structs.wast
@@ -1,0 +1,10 @@
+;; This relies on the GC proposal (plus reference types) to check that shared
+;; structs are not allowed without the shared-everything-threads proposal.
+(assert_invalid
+  (module
+    (type $s (struct (field i32)))
+    (func (param $x (ref null $s)) (result i32)
+      local.get $x
+      struct.atomic.get seq_cst $s 0)
+  )
+  "shared-everything-threads support is not enabled")

--- a/tests/local/missing-features/reference-types/shared-everything-threads-types.wast
+++ b/tests/local/missing-features/reference-types/shared-everything-threads-types.wast
@@ -1,0 +1,8 @@
+;; This relies on the reference-types proposal to check that shared function
+;; parameters are not allowed without the shared-everything-threads proposal.
+(assert_invalid
+  (module
+    (func (param $f (ref null (shared func)))
+      drop)
+  )
+  "shared reference types require the shared-everything-threads proposal")

--- a/tests/local/missing-features/shared-everything-threads-arrays.wast
+++ b/tests/local/missing-features/shared-everything-threads-arrays.wast
@@ -3,6 +3,3 @@
     (type (shared (array i8)))
   )
   "shared composite types require the shared-everything-threads proposal")
-
-;; Any uses of `array.atomic.*` are first gated behind the GC feature, which the
-;; `missing-features` test cannot selectively enable.

--- a/tests/local/missing-features/shared-everything-threads-structs.wast
+++ b/tests/local/missing-features/shared-everything-threads-structs.wast
@@ -3,6 +3,3 @@
     (type (shared (struct)))
   )
   "shared composite types require the shared-everything-threads proposal")
-
-;; Any uses of `struct.atomic.*` are first gated behind the GC feature, which
-;; the `missing-features` test cannot selectively enable.

--- a/tests/local/missing-features/shared-everything-threads-types.wast
+++ b/tests/local/missing-features/shared-everything-threads-types.wast
@@ -3,6 +3,3 @@
     (type (shared (func)))
   )
   "shared composite types require the shared-everything-threads proposal")
-
-;; Other uses of `shared` types are first gated behind the reference types
-;; feature, which the `missing-features` test cannot selectively enable.

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -616,6 +616,7 @@ impl TestState {
                 "reference-types" => features.insert(WasmFeatures::REFERENCE_TYPES),
                 "gc" => {
                     features.insert(WasmFeatures::FUNCTION_REFERENCES);
+                    features.insert(WasmFeatures::REFERENCE_TYPES);
                     features.insert(WasmFeatures::GC);
                 }
                 "custom-page-sizes" => features.insert(WasmFeatures::CUSTOM_PAGE_SIZES),

--- a/tests/snapshots/local/missing-features/gc/shared-everything-threads-arrays.wast.json
+++ b/tests/snapshots/local/missing-features/gc/shared-everything-threads-arrays.wast.json
@@ -1,0 +1,12 @@
+{
+  "source_filename": "tests/local/missing-features/gc/shared-everything-threads-arrays.wast",
+  "commands": [
+    {
+      "type": "assert_invalid",
+      "line": 4,
+      "filename": "shared-everything-threads-arrays.0.wasm",
+      "text": "shared-everything-threads support is not enabled",
+      "module_type": "binary"
+    }
+  ]
+}

--- a/tests/snapshots/local/missing-features/gc/shared-everything-threads-structs.wast.json
+++ b/tests/snapshots/local/missing-features/gc/shared-everything-threads-structs.wast.json
@@ -1,0 +1,12 @@
+{
+  "source_filename": "tests/local/missing-features/gc/shared-everything-threads-structs.wast",
+  "commands": [
+    {
+      "type": "assert_invalid",
+      "line": 4,
+      "filename": "shared-everything-threads-structs.0.wasm",
+      "text": "shared-everything-threads support is not enabled",
+      "module_type": "binary"
+    }
+  ]
+}

--- a/tests/snapshots/local/missing-features/reference-types/shared-everything-threads-types.wast.json
+++ b/tests/snapshots/local/missing-features/reference-types/shared-everything-threads-types.wast.json
@@ -1,0 +1,12 @@
+{
+  "source_filename": "tests/local/missing-features/reference-types/shared-everything-threads-types.wast",
+  "commands": [
+    {
+      "type": "assert_invalid",
+      "line": 4,
+      "filename": "shared-everything-threads-types.0.wasm",
+      "text": "shared reference types require the shared-everything-threads proposal",
+      "module_type": "binary"
+    }
+  ]
+}


### PR DESCRIPTION
This change adopts the suggestion to use the "missing-features + X" functionality in `roundtrip.rs` to check more corner cases where shared-everything-threads must be enabled. It adds the reference-types proposal to the GC feature set to make this possible.