### PR TITLE
Fix a spuriously-printed DWARF warning

### DIFF
--- a/src/addr2line.rs
+++ b/src/addr2line.rs
@@ -103,10 +103,8 @@ impl<'a> Addr2lineModules<'a> {
         let text_relative_addr = if code_section_relative {
             addr
         } else {
-            match module.code_start {
-                Some(start) => addr
-                    .checked_sub(start)
-                    .context("address is before the beginning of the text section")?,
+            match module.code_start.and_then(|start| addr.checked_sub(start)) {
+                Some(rel) => rel,
                 None => return Ok(None),
             }
         };

--- a/tests/cli/invalid-before-code.wat
+++ b/tests/cli/invalid-before-code.wat
@@ -1,0 +1,6 @@
+;; FAIL: validate %
+
+(module
+  (type (func (param (ref 100))))
+  (func)
+)

--- a/tests/cli/invalid-before-code.wat.stderr
+++ b/tests/cli/invalid-before-code.wat.stderr
@@ -1,0 +1,1 @@
+error: unknown type 100: type index out of bounds (at offset 0xb)


### PR DESCRIPTION
If an error was found before the code section a DWARF-related warning was printed but that's not relevant and is false information, so squash the warning.