### PR TITLE
Test `wasm_encoder::reencode` in roundtrip tests

### DIFF
--- a/crates/wast/src/core/binary.rs
+++ b/crates/wast/src/core/binary.rs
@@ -458,12 +458,9 @@ impl<'a> Encode for RefType<'a> {
             // nullable.
             RefType {
                 nullable: true,
-                heap: HeapType::Abstract { shared, ty },
+                heap: heap @ HeapType::Abstract { .. },
             } => {
-                if *shared {
-                    e.push(0x65);
-                }
-                ty.encode(e);
+                heap.encode(e);
             }
 
             // Generic 'ref null <heaptype>' encoding (i.e., long form).

--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -746,7 +746,7 @@ impl<'a> Module<'a> {
                     func.instruction(&Instruction::Call(lazy_stack_init_index));
                     let mut reader = body.get_operators_reader()?;
                     while !reader.eof() {
-                        map.parse_instruction(&mut func, &mut reader)?;
+                        func.instruction(&map.parse_instruction(&mut reader)?);
                     }
                     code.function(&func);
                 }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -30,6 +30,7 @@ use std::process::{Command, Stdio};
 use std::str;
 use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 use std::sync::Arc;
+use wasm_encoder::reencode::{Reencode, RoundtripReencoder};
 use wasmparser::*;
 use wast::core::{Module, ModuleKind};
 use wast::lexer::Lexer;
@@ -178,6 +179,16 @@ impl TestState {
             self.bump_ntests();
             self.binary_compare(&binary2, contents)
                 .context("failed to compare original `wat` with roundtrip `wat`")?;
+
+            if !wasmparser::Parser::is_component(contents) {
+                let mut reencode = Default::default();
+                RoundtripReencoder
+                    .parse_core_module(&mut reencode, wasmparser::Parser::new(0), contents)
+                    .context("failed to reencode module")?;
+
+                self.binary_compare(&reencode.finish(), contents)
+                    .context("failed to compare reencoded module with original encoding")?;
+            }
         }
 
         // Test that the `wasmprinter`-printed bytes have "pretty" whitespace

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -537,8 +537,9 @@ impl TestState {
         dump.stdin.take().unwrap().write_all(bytes)?;
         let mut stdout = String::new();
         dump.stdout.take().unwrap().read_to_string(&mut stdout)?;
-        if dump.wait()?.success() {
-            bail!("dump subcommand failed");
+        let status = dump.wait()?;
+        if !status.success() {
+            bail!("dump subcommand failed: {status}");
         }
         Ok(stdout)
     }


### PR DESCRIPTION
Run all binaries in the spec test suite and our own through the `wasm_encoder::reencode` process to make sure the final binary is byte-for-byte identical in applicable situations. This fixes a few discrepancies along the way with value type encodings (wasm-encoder was producing some slightly longer forms) and additionally improves support for constant expressions by being a bit more general in the reencoding process.