### PR TITLE
threads: fix `ref.i31_shared` encoding

### DIFF
--- a/crates/wasm-encoder/src/core/code.rs
+++ b/crates/wasm-encoder/src/core/code.rs
@@ -3693,7 +3693,7 @@ impl Encode for Instruction<'_> {
             }
             Instruction::RefI31Shared => {
                 sink.push(0xFE);
-                sink.push(0x1F);
+                sink.push(0x72);
             }
         }
     }

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -4534,7 +4534,9 @@ where
     }
     fn visit_ref_i31_shared(&mut self) -> Self::Output {
         self.pop_operand(Some(ValType::I32))?;
-        self.push_operand(ValType::Ref(RefType::I31)) // TODO: handle shared--is this correct?
+        self.push_operand(ValType::Ref(
+            RefType::I31.shared().expect("i31 is abstract"),
+        ))
     }
     fn visit_i31_get_s(&mut self) -> Self::Output {
         self.pop_operand(Some(ValType::Ref(RefType::I31REF)))?;

--- a/tests/local/shared-everything-threads/i31.wast
+++ b/tests/local/shared-everything-threads/i31.wast
@@ -1,0 +1,5 @@
+(module
+    (func (result (ref null (shared i31)))
+        (ref.i31_shared (i32.const 0))
+    )
+)

--- a/tests/snapshots/local/shared-everything-threads/i31.wast.json
+++ b/tests/snapshots/local/shared-everything-threads/i31.wast.json
@@ -1,0 +1,10 @@
+{
+  "source_filename": "tests/local/shared-everything-threads/i31.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 1,
+      "filename": "i31.0.wasm"
+    }
+  ]
+}

--- a/tests/snapshots/local/shared-everything-threads/i31.wast/0.print
+++ b/tests/snapshots/local/shared-everything-threads/i31.wast/0.print
@@ -1,0 +1,7 @@
+(module
+  (type (;0;) (func (result (ref null (shared i31)))))
+  (func (;0;) (type 0) (result (ref null (shared i31)))
+    i32.const 0
+    ref.i31_shared
+  )
+)


### PR DESCRIPTION
In the initial implementation, this encoding was incorrectly emitted as `0xFE 0x1F`, clobbering the encoding for `i64.atomic.rmw.add` (probably a copy-paste error). This change updates `wasm-encoder` to use the correct `0xFE 0x72` encoding.