### PR TITLE
Refactor type checks when popping refs

### DIFF
--- a/tests/local/function-references/bad-call-ref-ty.wast
+++ b/tests/local/function-references/bad-call-ref-ty.wast
@@ -5,7 +5,7 @@
       (call_ref $t (local.get $f))
     )
   )
-  "funcref on stack does not match specified type")
+  "expected (ref null $type), found funcref")
 
 (assert_invalid
   (module

--- a/tests/local/gc/br-on-non-null.wast
+++ b/tests/local/gc/br-on-non-null.wast
@@ -1,0 +1,12 @@
+(assert_invalid
+  (module
+    (func
+      block $l (result anyref)
+        ref.null func
+        br_on_non_null $l
+        unreachable
+      end
+      drop
+    )
+  )
+  "expected anyref, found funcref")

--- a/tests/snapshots/local/function-references/bad-call-ref-ty.wast.json
+++ b/tests/snapshots/local/function-references/bad-call-ref-ty.wast.json
@@ -5,7 +5,7 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "bad-call-ref-ty.0.wasm",
-      "text": "funcref on stack does not match specified type",
+      "text": "expected (ref null $type), found funcref",
       "module_type": "binary"
     },
     {

--- a/tests/snapshots/local/gc/br-on-non-null.wast.json
+++ b/tests/snapshots/local/gc/br-on-non-null.wast.json
@@ -1,0 +1,12 @@
+{
+  "source_filename": "tests/local/gc/br-on-non-null.wast",
+  "commands": [
+    {
+      "type": "assert_invalid",
+      "line": 2,
+      "filename": "br-on-non-null.0.wasm",
+      "text": "expected anyref, found funcref",
+      "module_type": "binary"
+    }
+  ]
+}


### PR DESCRIPTION
This commit refactors users of `pop_ref` during validation to be able to pass in an expected type. This removes the need for a few manual `is_subtype` checks and helps centralize type-checking in one location.