### PR TITLE
Support optimizing feature checks at compile time

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -229,6 +229,8 @@ jobs:
       - run: cargo check --no-default-features -p wasmparser --target x86_64-unknown-none --features validate,serde,no-hash-maps
       - run: cargo check --no-default-features -p wasmparser --features std
       - run: cargo check --no-default-features -p wasmparser --features validate
+      - run: cargo check --no-default-features -p wasmparser --features features
+      - run: cargo check --no-default-features -p wasmparser --features features,validate
       - run: cargo check --no-default-features -p wasmparser --features no-hash-maps
       - run: cargo check --no-default-features -p wasmparser --features serde
       - run: cargo check --no-default-features -p wasmparser --features serde,no-hash-maps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ wat = { workspace = true, features = ['dwarf'] }
 termcolor = { workspace = true }
 
 # Dependencies of `validate`
-wasmparser = { workspace = true, optional = true, features = ['validate'] }
+wasmparser = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
 bitflags = { workspace = true, optional = true }
 
@@ -211,7 +211,15 @@ default = [
 ]
 
 # Each subcommand is gated behind a feature and lists the dependencies it needs
-validate = ['dep:wasmparser', 'rayon', 'dep:addr2line', 'dep:gimli', 'dep:bitflags']
+validate = [
+  'dep:wasmparser',
+  'rayon',
+  'dep:addr2line',
+  'dep:gimli',
+  'dep:bitflags',
+  'wasmparser/validate',
+  'wasmparser/features',
+]
 print = []
 parse = []
 smith = ['wasm-smith', 'arbitrary', 'dep:serde', 'dep:serde_derive', 'dep:serde_json']

--- a/crates/wasm-compose/src/graph.rs
+++ b/crates/wasm-compose/src/graph.rs
@@ -17,7 +17,7 @@ use wasmparser::{
         ResourceId, SubtypeCx, Types, TypesRef,
     },
     Chunk, ComponentExternalKind, ComponentTypeRef, Encoding, Parser, Payload, ValidPayload,
-    Validator, WasmFeatures,
+    Validator,
 };
 
 pub(crate) fn type_desc(item: ComponentEntityType) -> &'static str {
@@ -98,8 +98,7 @@ impl<'a> Component<'a> {
     fn parse(name: String, path: Option<PathBuf>, bytes: Cow<'a, [u8]>) -> Result<Self> {
         let mut parser = Parser::new(0);
         let mut parsers = Vec::new();
-        let mut validator =
-            Validator::new_with_features(WasmFeatures::default() | WasmFeatures::COMPONENT_MODEL);
+        let mut validator = Validator::new();
         let mut imports = IndexMap::new();
         let mut exports = IndexMap::new();
 
@@ -990,7 +989,7 @@ impl<'a> CompositionGraph<'a> {
         let bytes = CompositionGraphEncoder::new(options, self).encode()?;
 
         if options.validate {
-            Validator::new_with_features(WasmFeatures::default() | WasmFeatures::COMPONENT_MODEL)
+            Validator::new()
                 .validate_all(&bytes)
                 .context("failed to validate encoded graph bytes")?;
         }

--- a/crates/wasm-encoder/src/core/code.rs
+++ b/crates/wasm-encoder/src/core/code.rs
@@ -83,12 +83,12 @@ impl CodeSection {
     /// into a new code section encoder:
     ///
     /// ```
-    /// # use wasmparser::{BinaryReader, WasmFeatures, CodeSectionReader};
+    /// # use wasmparser::{BinaryReader, CodeSectionReader};
     /// //                  id, size, # entries, entry
     /// let code_section = [10, 6,    1,         4, 0, 65, 0, 11];
     ///
     /// // Parse the code section.
-    /// let reader = BinaryReader::new(&code_section, 0, WasmFeatures::all());
+    /// let reader = BinaryReader::new(&code_section, 0);
     /// let reader = CodeSectionReader::new(reader).unwrap();
     /// let body = reader.into_iter().next().unwrap().unwrap();
     /// let body_range = body.range();

--- a/crates/wasm-metadata/src/lib.rs
+++ b/crates/wasm-metadata/src/lib.rs
@@ -10,7 +10,7 @@ use std::ops::Range;
 use wasm_encoder::{ComponentSection as _, ComponentSectionId, Encode, Section};
 use wasmparser::{
     BinaryReader, ComponentNameSectionReader, KnownCustom, NameSectionReader, Parser, Payload::*,
-    ProducersSectionReader, WasmFeatures,
+    ProducersSectionReader,
 };
 
 /// A representation of a WebAssembly producers section.
@@ -64,7 +64,7 @@ impl Producers {
     }
     /// Read the producers section from a Wasm binary.
     pub fn from_bytes(bytes: &[u8], offset: usize) -> Result<Self> {
-        let reader = BinaryReader::new(bytes, offset, WasmFeatures::all());
+        let reader = BinaryReader::new(bytes, offset);
         let section = ProducersSectionReader::new(reader)?;
         let mut fields = IndexMap::new();
         for field in section.into_iter() {
@@ -604,7 +604,7 @@ impl<'a> ModuleNames<'a> {
     /// Read a name section from a WebAssembly binary. Records the module name, and all other
     /// contents of name section, for later serialization.
     pub fn from_bytes(bytes: &'a [u8], offset: usize) -> Result<ModuleNames<'a>> {
-        let reader = BinaryReader::new(bytes, offset, WasmFeatures::all());
+        let reader = BinaryReader::new(bytes, offset);
         let section = NameSectionReader::new(reader);
         let mut s = Self::empty();
         for name in section.into_iter() {
@@ -690,7 +690,7 @@ impl<'a> ComponentNames<'a> {
     /// Read a component-name section from a WebAssembly binary. Records the component name, as
     /// well as all other component name fields for later serialization.
     pub fn from_bytes(bytes: &'a [u8], offset: usize) -> Result<ComponentNames<'a>> {
-        let reader = BinaryReader::new(bytes, offset, WasmFeatures::all());
+        let reader = BinaryReader::new(bytes, offset);
         let section = ComponentNameSectionReader::new(reader);
         let mut s = Self::empty();
         for name in section.into_iter() {

--- a/crates/wasm-mutate/src/info.rs
+++ b/crates/wasm-mutate/src/info.rs
@@ -5,7 +5,7 @@ use crate::{
 use std::collections::HashSet;
 use std::ops::Range;
 use wasm_encoder::{RawSection, SectionId};
-use wasmparser::{BinaryReader, Chunk, Parser, Payload, WasmFeatures};
+use wasmparser::{BinaryReader, Chunk, Parser, Payload};
 
 /// Provides module information for future usage during mutation
 /// an instance of ModuleInfo could be user to determine which mutation could be applied
@@ -220,7 +220,7 @@ impl<'a> ModuleInfo<'a> {
     pub fn has_nonempty_code(&self) -> bool {
         if let Some(section) = self.code {
             let section_data = self.raw_sections[section].data;
-            let reader = BinaryReader::new(section_data, 0, WasmFeatures::all());
+            let reader = BinaryReader::new(section_data, 0);
             wasmparser::CodeSectionReader::new(reader)
                 .map(|r| r.count() != 0)
                 .unwrap_or(false)
@@ -253,7 +253,7 @@ impl<'a> ModuleInfo<'a> {
     }
 
     pub fn get_binary_reader(&self, i: usize) -> wasmparser::BinaryReader<'a> {
-        BinaryReader::new(self.raw_sections[i].data, 0, WasmFeatures::all())
+        BinaryReader::new(self.raw_sections[i].data, 0)
     }
 
     pub fn has_exports(&self) -> bool {

--- a/crates/wasm-mutate/src/mutators/remove_section.rs
+++ b/crates/wasm-mutate/src/mutators/remove_section.rs
@@ -16,7 +16,7 @@ pub enum RemoveSection {
 
 fn is_empty_section(section: &wasm_encoder::RawSection) -> bool {
     use wasmparser::*;
-    let reader = BinaryReader::new(section.data, 0, WasmFeatures::all());
+    let reader = BinaryReader::new(section.data, 0);
     crate::module::match_section_id! {
         match section.id;
         Custom => Ok(section.data.is_empty()),

--- a/crates/wasm-shrink/Cargo.toml
+++ b/crates/wasm-shrink/Cargo.toml
@@ -21,7 +21,7 @@ log = { workspace = true }
 rand = { workspace = true }
 clap = { workspace = true, optional = true }
 wasm-mutate = { workspace = true }
-wasmparser = { workspace = true, features = ['validate'] }
+wasmparser = { workspace = true, features = ['validate', 'features'] }
 
 [dev-dependencies]
 env_logger = { workspace = true }

--- a/crates/wasm-shrink/src/lib.rs
+++ b/crates/wasm-shrink/src/lib.rs
@@ -3,10 +3,9 @@
 //!
 //! See the [`WasmShrink`] type for details.
 
-use std::collections::HashSet;
-
 use anyhow::{Context, Result};
 use rand::{rngs::SmallRng, Rng, SeedableRng};
+use std::collections::HashSet;
 use wasm_mutate::WasmMutate;
 use wasmparser::WasmFeatures;
 
@@ -217,25 +216,7 @@ impl ShrinkRun {
     }
 
     fn validate_wasm(&self, wasm: &[u8]) -> Result<()> {
-        let mut validator = wasmparser::Validator::new_with_features(
-            WasmFeatures::REFERENCE_TYPES
-                | WasmFeatures::MULTI_VALUE
-                | WasmFeatures::BULK_MEMORY
-                | WasmFeatures::SIMD
-                | WasmFeatures::THREADS
-                | WasmFeatures::TAIL_CALL
-                | WasmFeatures::MULTI_MEMORY
-                | WasmFeatures::EXCEPTIONS
-                | WasmFeatures::MEMORY64
-                | WasmFeatures::RELAXED_SIMD
-                | WasmFeatures::EXTENDED_CONST
-                | WasmFeatures::MUTABLE_GLOBAL
-                | WasmFeatures::SATURATING_FLOAT_TO_INT
-                | WasmFeatures::SIGN_EXTENSION
-                | WasmFeatures::FLOATS
-                | WasmFeatures::MEMORY_CONTROL,
-        );
-
+        let mut validator = wasmparser::Validator::new_with_features(WasmFeatures::all());
         validator.validate_all(wasm)?;
         Ok(())
     }

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -35,7 +35,7 @@ wat = { workspace = true, optional = true }
 [dev-dependencies]
 criterion = { workspace = true }
 rand = { workspace = true }
-wasmparser = { workspace = true, features = ["validate"] }
+wasmparser = { workspace = true, features = ["validate", "features"] }
 wasmprinter = { path = "../wasmprinter" }
 wat = { path = "../wat" }
 

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -43,7 +43,7 @@ name = "benchmark"
 harness = false
 
 [features]
-default = ['std', 'validate', 'serde']
+default = ['std', 'validate', 'serde', 'features']
 
 # A feature which enables implementations of `std::error::Error` as appropriate
 # along with other convenience APIs. This additionally uses the standard
@@ -56,6 +56,7 @@ std = ['indexmap/std']
 # to properly initialize hashmap based data structures for resilience against
 # malious actors that control their inputs.
 no-hash-maps = []
+
 # A feature that enables validating WebAssembly files. This is enabled by
 # default but not required if you're only parsing a file, for example, as
 # opposed to validating all of its contents.
@@ -69,3 +70,11 @@ validate = [
 # Enable Serialize/Deserialize implementations for types in
 # `wasmparser::collections`
 serde = ['dep:serde', 'indexmap/serde', 'hashbrown/serde']
+
+# A feature that enables the guts of the `WasmFeatures` type in this crate.
+#
+# This feature is enabled by default. When disabled this crate does not support
+# runtime configuration of WebAssembly features. Instead the set of WebAssembly
+# features/proposals support are fixed at compile time to `wasmparser`'s default
+# set of supported features.
+features = []

--- a/crates/wasmparser/src/features.rs
+++ b/crates/wasmparser/src/features.rs
@@ -131,7 +131,7 @@ define_wasm_features! {
     /// [`BinaryReader::set_features`](crate::BinaryReader::set_features) can be
     /// used.
     ///
-    /// This crate additionally has a compile-time Cargo features called
+    /// This crate additionally has a compile-time Cargo feature called
     /// `features` which can be used to enable/disable most of this type at
     /// compile time. This crate feature is turned on by default and enables
     /// this bitflags-representation of this structure. When the `features`

--- a/crates/wasmparser/src/features.rs
+++ b/crates/wasmparser/src/features.rs
@@ -1,5 +1,3 @@
-use bitflags::bitflags;
-
 macro_rules! define_wasm_features {
     (
         $(#[$outer:meta])*
@@ -10,7 +8,8 @@ macro_rules! define_wasm_features {
             )*
         }
     ) => {
-        bitflags! {
+        #[cfg(feature = "features")]
+        bitflags::bitflags! {
             $(#[$outer])*
             pub struct WasmFeatures: $repr {
                 $(
@@ -23,6 +22,17 @@ macro_rules! define_wasm_features {
             }
         }
 
+        /// Enabled WebAssembly proposals and features.
+        ///
+        /// This is the disabled zero-size version of this structure because the
+        /// `features` feature was disabled at compile time of this crate.
+        #[cfg(not(feature = "features"))]
+        #[derive(Clone, Debug, Default, Hash, Copy)]
+        pub struct WasmFeatures {
+            _priv: (),
+        }
+
+        #[cfg(feature = "features")]
         impl Default for WasmFeatures {
             #[inline]
             fn default() -> Self {
@@ -37,6 +47,7 @@ macro_rules! define_wasm_features {
         impl WasmFeatures {
             /// Construct a bit-packed `WasmFeatures` from the inflated struct version.
             #[inline]
+            #[cfg(feature = "features")]
             pub fn from_inflated(inflated: WasmFeaturesInflated) -> Self {
                 let mut features = WasmFeatures::empty();
                 $(
@@ -54,6 +65,7 @@ macro_rules! define_wasm_features {
             /// while keeping the bit-packed version as the method of storing
             /// the features for longer periods of time.
             #[inline]
+            #[cfg(feature = "features")]
             pub fn inflate(&self) -> WasmFeaturesInflated {
                 WasmFeaturesInflated {
                     $(
@@ -66,13 +78,17 @@ macro_rules! define_wasm_features {
                 /// Returns whether this feature is enabled in this feature set.
                 #[inline]
                 pub fn $field(&self) -> bool {
-                    self.contains(WasmFeatures::$const)
+                    #[cfg(feature = "features")]
+                    { self.contains(WasmFeatures::$const) }
+                    #[cfg(not(feature = "features"))]
+                    { $default }
                 }
             )*
         }
 
         /// Inflated version of [`WasmFeatures`][crate::WasmFeatures] that
         /// allows for exhaustive matching on fields.
+        #[cfg(feature = "features")]
         pub struct WasmFeaturesInflated {
             $(
                 $(#[$inner $($args)*])*
@@ -82,11 +98,46 @@ macro_rules! define_wasm_features {
                 pub $field: bool,
             )*
         }
+
+        macro_rules! foreach_wasm_feature {
+            ($f:ident) => {
+                $($f!($field = $default);)*
+            }
+        }
+        pub(crate) use foreach_wasm_feature;
     };
 }
 
 define_wasm_features! {
     /// Flags for features that are enabled for validation.
+    ///
+    /// This type controls the set of WebAssembly proposals and features that
+    /// are active during validation and parsing of WebAssembly binaries. This
+    /// is used in conjunction with
+    /// [`Validator::new_with_features`](crate::Validator::new_with_features)
+    /// for example.
+    ///
+    /// The [`Default`] implementation for this structure returns the set of
+    /// supported WebAssembly proposals this crate implements. All features are
+    /// required to be in Phase 4 or above in the WebAssembly standardization
+    /// process.
+    ///
+    /// Enabled/disabled features can affect both parsing and validation at this
+    /// time. When decoding a WebAssembly binary it's generally recommended if
+    /// possible to enable all features, as is the default with
+    /// [`BinaryReader::new`](crate::BinaryReader::new). If strict conformance
+    /// with historical versions of the specification are required then
+    /// [`BinaryReader::new_features`](crate::BinaryReader::new_features) or
+    /// [`BinaryReader::set_features`](crate::BinaryReader::set_features) can be
+    /// used.
+    ///
+    /// This crate additionally has a compile-time Cargo features called
+    /// `features` which can be used to enable/disable most of this type at
+    /// compile time. This crate feature is turned on by default and enables
+    /// this bitflags-representation of this structure. When the `features`
+    /// feature is disabled then this is a zero-sized structure and no longer
+    /// has any associated constants. When `features` are disabled all values
+    /// for proposals are fixed at compile time to their defaults.
     #[derive(Hash, Debug, Copy, Clone, Eq, PartialEq)]
     pub struct WasmFeatures: u32 {
         /// The WebAssembly `mutable-global` proposal.
@@ -155,7 +206,7 @@ define_wasm_features! {
         /// # Note
         ///
         /// Support this feature as long as all leading browsers also support it
-        /// https://github.com/WebAssembly/exception-handling/blob/main/proposals/exception-handling/legacy/Exceptions.md
+        /// <https://github.com/WebAssembly/exception-handling/blob/main/proposals/exception-handling/legacy/Exceptions.md>
         pub legacy_exceptions: LEGACY_EXCEPTIONS(1 << 25) = false;
     }
 }
@@ -163,12 +214,14 @@ define_wasm_features! {
 impl WasmFeatures {
     /// Returns the feature set associated with the 1.0 version of the
     /// WebAssembly specification or the "MVP" feature set.
+    #[cfg(feature = "features")]
     pub fn wasm1() -> WasmFeatures {
         WasmFeatures::FLOATS
     }
 
     /// Returns the feature set associated with the 2.0 version of the
     /// WebAssembly specification.
+    #[cfg(feature = "features")]
     pub fn wasm2() -> WasmFeatures {
         WasmFeatures::wasm1()
             | WasmFeatures::BULK_MEMORY
@@ -181,6 +234,7 @@ impl WasmFeatures {
     }
 }
 
+#[cfg(feature = "features")]
 impl From<WasmFeaturesInflated> for WasmFeatures {
     #[inline]
     fn from(inflated: WasmFeaturesInflated) -> Self {
@@ -188,6 +242,7 @@ impl From<WasmFeaturesInflated> for WasmFeatures {
     }
 }
 
+#[cfg(feature = "features")]
 impl From<WasmFeatures> for WasmFeaturesInflated {
     #[inline]
     fn from(features: WasmFeatures) -> Self {

--- a/crates/wasmparser/src/readers.rs
+++ b/crates/wasmparser/src/readers.rs
@@ -277,7 +277,7 @@ impl<'a, T> Subsections<'a, T> {
         T: Subsection<'a>,
     {
         let subsection_id = self.reader.read_u7()?;
-        let reader = self.reader.read_reader("unexpected end of section")?;
+        let reader = self.reader.read_reader()?;
         T::from_reader(subsection_id, reader)
     }
 }

--- a/crates/wasmparser/src/readers/component/imports.rs
+++ b/crates/wasmparser/src/readers/component/imports.rs
@@ -98,9 +98,9 @@ impl<'a> FromReader<'a> for ComponentImport<'a> {
 /// # Examples
 ///
 /// ```
-/// use wasmparser::{ComponentImportSectionReader, BinaryReader, WasmFeatures};
+/// use wasmparser::{ComponentImportSectionReader, BinaryReader};
 /// let data: &[u8] = &[0x01, 0x00, 0x01, 0x41, 0x01, 0x66];
-/// let reader = BinaryReader::new(data, 0, WasmFeatures::all());
+/// let reader = BinaryReader::new(data, 0);
 /// let reader = ComponentImportSectionReader::new(reader).unwrap();
 /// for import in reader {
 ///     let import = import.expect("import");

--- a/crates/wasmparser/src/readers/component/instances.rs
+++ b/crates/wasmparser/src/readers/component/instances.rs
@@ -42,9 +42,9 @@ pub enum Instance<'a> {
 /// # Examples
 ///
 /// ```
-/// use wasmparser::{InstanceSectionReader, BinaryReader, WasmFeatures};
+/// use wasmparser::{InstanceSectionReader, BinaryReader};
 /// # let data: &[u8] = &[0x01, 0x00, 0x00, 0x01, 0x03, b'f', b'o', b'o', 0x12, 0x00];
-/// let reader = BinaryReader::new(data, 0, WasmFeatures::all());
+/// let reader = BinaryReader::new(data, 0);
 /// let mut reader = InstanceSectionReader::new(reader).unwrap();
 /// for inst in reader {
 ///     println!("Instance {:?}", inst.expect("instance"));
@@ -120,9 +120,9 @@ pub enum ComponentInstance<'a> {
 /// # Examples
 ///
 /// ```
-/// use wasmparser::{ComponentInstanceSectionReader, BinaryReader, WasmFeatures};
+/// use wasmparser::{ComponentInstanceSectionReader, BinaryReader};
 /// # let data: &[u8] = &[0x01, 0x00, 0x00, 0x01, 0x03, b'f', b'o', b'o', 0x01, 0x00];
-/// let reader = BinaryReader::new(data, 0, WasmFeatures::all());
+/// let reader = BinaryReader::new(data, 0);
 /// let mut reader = ComponentInstanceSectionReader::new(reader).unwrap();
 /// for inst in reader {
 ///     println!("Instance {:?}", inst.expect("instance"));

--- a/crates/wasmparser/src/readers/component/types.rs
+++ b/crates/wasmparser/src/readers/component/types.rs
@@ -104,9 +104,9 @@ impl<'a> FromReader<'a> for ModuleTypeDeclaration<'a> {
 ///
 /// # Examples
 /// ```
-/// use wasmparser::{CoreTypeSectionReader, BinaryReader, WasmFeatures};
+/// use wasmparser::{CoreTypeSectionReader, BinaryReader};
 /// # let data: &[u8] = &[0x01, 0x60, 0x00, 0x00];
-/// let reader = BinaryReader::new(data, 0, WasmFeatures::all());
+/// let reader = BinaryReader::new(data, 0);
 /// let mut reader = CoreTypeSectionReader::new(reader).unwrap();
 /// for ty in reader {
 ///     println!("Type {:?}", ty.expect("type"));
@@ -542,9 +542,9 @@ impl<'a> ComponentDefinedType<'a> {
 /// # Examples
 ///
 /// ```
-/// use wasmparser::{ComponentTypeSectionReader, BinaryReader, WasmFeatures};
+/// use wasmparser::{ComponentTypeSectionReader, BinaryReader};
 /// let data: &[u8] = &[0x01, 0x40, 0x01, 0x03, b'f', b'o', b'o', 0x73, 0x00, 0x73];
-/// let reader = BinaryReader::new(data, 0, WasmFeatures::all());
+/// let reader = BinaryReader::new(data, 0);
 /// let mut reader = ComponentTypeSectionReader::new(reader).unwrap();
 /// for ty in reader {
 ///     println!("Type {:?}", ty.expect("type"));

--- a/crates/wasmparser/src/readers/core/code.rs
+++ b/crates/wasmparser/src/readers/core/code.rs
@@ -74,7 +74,7 @@ impl<'a> FunctionBody<'a> {
 
 impl<'a> FromReader<'a> for FunctionBody<'a> {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
-        let reader = reader.read_reader("function body extends past end of the code section")?;
+        let reader = reader.read_reader()?;
         Ok(FunctionBody { reader })
     }
 }

--- a/crates/wasmparser/src/readers/core/coredumps.rs
+++ b/crates/wasmparser/src/readers/core/coredumps.rs
@@ -9,10 +9,10 @@ use crate::{BinaryReader, FromReader, Result};
 /// # Examples
 ///
 /// ```
-/// use wasmparser::{BinaryReader, CoreDumpSection, FromReader, Result, WasmFeatures};
+/// use wasmparser::{BinaryReader, CoreDumpSection, FromReader, Result};
 /// let data: &[u8] = &[0x00, 0x09, 0x74, 0x65, 0x73, 0x74, 0x2e, 0x77, 0x61,
 ///      0x73, 0x6d];
-/// let mut reader = BinaryReader::new(data, 0, WasmFeatures::all());
+/// let mut reader = BinaryReader::new(data, 0);
 /// let core = CoreDumpSection::new(reader).unwrap();
 /// assert!(core.name == "test.wasm")
 /// ```
@@ -46,9 +46,9 @@ impl<'a> CoreDumpSection<'a> {
 /// # Example
 ///
 /// ```
-/// use wasmparser::{BinaryReader, CoreDumpModulesSection, FromReader, Result, WasmFeatures};
+/// use wasmparser::{BinaryReader, CoreDumpModulesSection, FromReader, Result};
 /// let data: &[u8] = &[0x01, 0x00, 0x04, 0x74, 0x65, 0x73, 0x74];
-/// let reader = BinaryReader::new(data, 0, WasmFeatures::all());
+/// let reader = BinaryReader::new(data, 0);
 /// let modules_section = CoreDumpModulesSection::new(reader).unwrap();
 /// assert!(modules_section.modules[0] == "test")
 /// ```
@@ -151,11 +151,11 @@ impl<'a> FromReader<'a> for CoreDumpInstance {
 /// # Examples
 ///
 /// ```
-/// use wasmparser::{BinaryReader, CoreDumpStackSection, FromReader, WasmFeatures};
+/// use wasmparser::{BinaryReader, CoreDumpStackSection, FromReader};
 ///
 /// let data: &[u8] = &[0x00, 0x04, 0x6d, 0x61, 0x69, 0x6e, 0x01, 0x00, 0x04,
 ///     0x2a, 0x33, 0x01, 0x7f, 0x01, 0x01, 0x7f, 0x02];
-/// let reader = BinaryReader::new(data, 0, WasmFeatures::all());
+/// let reader = BinaryReader::new(data, 0);
 /// let corestack = CoreDumpStackSection::new(reader).unwrap();
 /// assert!(corestack.name == "main");
 /// assert!(corestack.frames.len() == 1);

--- a/crates/wasmparser/src/readers/core/data.rs
+++ b/crates/wasmparser/src/readers/core/data.rs
@@ -84,9 +84,7 @@ impl<'a> FromReader<'a> for Data<'a> {
             }
         };
 
-        let data = reader.read_reader(
-            "unexpected end of section or function: data segment extends past end of the section",
-        )?;
+        let data = reader.read_reader()?;
         Ok(Data {
             kind,
             data: data.remaining_buffer(),

--- a/crates/wasmparser/src/readers/core/globals.rs
+++ b/crates/wasmparser/src/readers/core/globals.rs
@@ -39,7 +39,7 @@ impl<'a> FromReader<'a> for GlobalType {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
         let content_type = reader.read()?;
         let flags = reader.read_u8()?;
-        if reader.features().shared_everything_threads() {
+        if reader.shared_everything_threads() {
             if flags > 0b11 {
                 bail!(reader.original_position() - 1, "malformed global flags")
             }

--- a/crates/wasmparser/src/readers/core/operators.rs
+++ b/crates/wasmparser/src/readers/core/operators.rs
@@ -275,10 +275,10 @@ impl<'a> IntoIterator for OperatorsReader<'a> {
     ///
     /// # Examples
     /// ```
-    /// # use wasmparser::{Operator, CodeSectionReader, Result, BinaryReader, WasmFeatures};
+    /// # use wasmparser::{Operator, CodeSectionReader, Result, BinaryReader};
     /// # let data: &[u8] = &[
     /// #     0x01, 0x03, 0x00, 0x01, 0x0b];
-    /// let reader = BinaryReader::new(data, 0, WasmFeatures::all());
+    /// let reader = BinaryReader::new(data, 0);
     /// let code_reader = CodeSectionReader::new(reader).unwrap();
     /// for body in code_reader {
     ///     let body = body.expect("function body");
@@ -331,10 +331,10 @@ impl<'a> Iterator for OperatorsIteratorWithOffsets<'a> {
     ///
     /// # Examples
     /// ```
-    /// use wasmparser::{Operator, CodeSectionReader, Result, BinaryReader, WasmFeatures};
+    /// use wasmparser::{Operator, CodeSectionReader, Result, BinaryReader};
     /// # let data: &[u8] = &[
     /// #     0x01, 0x03, 0x00, /* offset = 23 */ 0x01, 0x0b];
-    /// let reader = BinaryReader::new(data, 20, WasmFeatures::all());
+    /// let reader = BinaryReader::new(data, 20);
     /// let code_reader = CodeSectionReader::new(reader).unwrap();
     /// for body in code_reader {
     ///     let body = body.expect("function body");

--- a/crates/wasmparser/src/readers/core/producers.rs
+++ b/crates/wasmparser/src/readers/core/producers.rs
@@ -22,8 +22,8 @@ use crate::{BinaryReader, FromReader, Result, SectionLimited};
 /// ```
 /// # let data: &[u8] = &[0x01, 0x08, 0x6c, 0x61, 0x6e, 0x67, 0x75, 0x61, 0x67, 0x65,
 /// #     0x02, 0x03, 0x77, 0x61, 0x74, 0x01, 0x31, 0x01, 0x43, 0x03, 0x39, 0x2e, 0x30];
-/// # use wasmparser::{ProducersSectionReader, ProducersFieldValue, Result, BinaryReader, WasmFeatures};
-/// let reader = BinaryReader::new(data, 0, WasmFeatures::all());
+/// # use wasmparser::{ProducersSectionReader, ProducersFieldValue, Result, BinaryReader};
+/// let reader = BinaryReader::new(data, 0);
 /// let reader = ProducersSectionReader::new(reader).expect("producers reader");
 /// let field = reader.into_iter().next().unwrap().expect("producers field");
 /// assert!(field.name == "language");

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -455,6 +455,8 @@ impl Validator {
         let mut functions_to_validate = Vec::new();
         let mut last_types = None;
         let mut parser = Parser::new(0);
+        let _ = &mut parser;
+        #[cfg(feature = "features")]
         parser.set_features(self.features);
         for payload in parser.parse_all(bytes) {
             match self.payload(&payload?)? {

--- a/crates/wasmparser/src/validator/func.rs
+++ b/crates/wasmparser/src/validator/func.rs
@@ -80,7 +80,10 @@ impl<T: WasmModuleResources> FuncValidator<T> {
     pub fn validate(&mut self, body: &FunctionBody<'_>) -> Result<()> {
         let mut reader = body.get_binary_reader();
         self.read_locals(&mut reader)?;
-        reader.set_features(self.validator.features);
+        #[cfg(feature = "features")]
+        {
+            reader.set_features(self.validator.features);
+        }
         while !reader.eof() {
             reader.visit_operator(&mut self.visitor(reader.original_position()))??;
         }

--- a/crates/wasmparser/src/validator/names.rs
+++ b/crates/wasmparser/src/validator/names.rs
@@ -304,11 +304,7 @@ impl ComponentName {
     /// Attempts to parse `name` as a valid component name, returning `Err` if
     /// it's not valid.
     pub fn new(name: &str, offset: usize) -> Result<ComponentName> {
-        Self::new_with_features(
-            name,
-            offset,
-            WasmFeatures::default() | WasmFeatures::COMPONENT_MODEL,
-        )
+        Self::new_with_features(name, offset, WasmFeatures::default())
     }
 
     /// Attempts to parse `name` as a valid component name, returning `Err` if

--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -83,7 +83,7 @@ use indexmap::{IndexMap, IndexSet};
 use std::collections::HashMap;
 use std::hash::Hash;
 use wasm_encoder::*;
-use wasmparser::{Validator, WasmFeatures};
+use wasmparser::Validator;
 use wit_parser::{
     abi::{AbiVariant, WasmSignature, WasmType},
     Function, FunctionKind, InterfaceId, LiveTypes, Resolve, Type, TypeDefKind, TypeId, TypeOwner,
@@ -2117,11 +2117,7 @@ impl ComponentEncoder {
         let bytes = state.component.finish();
 
         if self.validate {
-            let mut validator = Validator::new_with_features(
-                WasmFeatures::default() | WasmFeatures::COMPONENT_MODEL,
-            );
-
-            validator
+            Validator::new()
                 .validate_all(&bytes)
                 .context("failed to validate component output")?;
         }

--- a/crates/wit-component/src/gc.rs
+++ b/crates/wit-component/src/gc.rs
@@ -317,11 +317,7 @@ impl<'a> Module<'a> {
                         self.funcs.push(Func {
                             // Specify a dummy definition to get filled in later
                             // when parsing the code section.
-                            def: Definition::Local(FunctionBody::new(BinaryReader::new(
-                                &[],
-                                0,
-                                WasmFeatures::all(),
-                            ))),
+                            def: Definition::Local(FunctionBody::new(BinaryReader::new(&[], 0))),
                             ty,
                         });
                     }

--- a/crates/wit-component/src/metadata.rs
+++ b/crates/wit-component/src/metadata.rs
@@ -50,7 +50,7 @@ use wasm_encoder::{
     ComponentBuilder, ComponentExportKind, ComponentType, ComponentTypeRef, CustomSection,
 };
 use wasm_metadata::Producers;
-use wasmparser::{BinaryReader, Encoding, Parser, Payload, WasmFeatures};
+use wasmparser::{BinaryReader, Encoding, Parser, Payload};
 use wit_parser::{Package, PackageName, Resolve, World, WorldId, WorldItem};
 
 const CURRENT_VERSION: u8 = 0x04;
@@ -257,7 +257,7 @@ impl Bindgen {
         let resolve;
         let encoding;
 
-        let mut reader = BinaryReader::new(data, 0, WasmFeatures::all());
+        let mut reader = BinaryReader::new(data, 0);
         match reader.read_u8()? {
             // Historical 0x03 format where the support here will be deleted in
             // the future

--- a/crates/wit-component/src/semver_check.rs
+++ b/crates/wit-component/src/semver_check.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use anyhow::{bail, Context, Result};
 use wasm_encoder::{ComponentBuilder, ComponentExportKind, ComponentTypeRef};
-use wasmparser::{Validator, WasmFeatures};
+use wasmparser::Validator;
 use wit_parser::{Resolve, WorldId};
 
 /// Tests whether `new` is a semver-compatible upgrade from the world `prev`.
@@ -102,7 +102,7 @@ pub fn semver_check(mut resolve: Resolve, prev: WorldId, new: WorldId) -> Result
     // error message is produced here an attempt is made to make it more
     // understandable but there's only but so good these errors can be with this
     // strategy.
-    Validator::new_with_features(WasmFeatures::default() | WasmFeatures::COMPONENT_MODEL)
+    Validator::new()
         .validate_all(&bytes)
         .context("new world is not semver-compatible with the previous world")?;
 

--- a/crates/wit-component/src/targets.rs
+++ b/crates/wit-component/src/targets.rs
@@ -1,7 +1,7 @@
 use crate::encoding::encode_world;
 use anyhow::{Context, Result};
 use wasm_encoder::{ComponentBuilder, ComponentExportKind, ComponentTypeRef};
-use wasmparser::{Validator, WasmFeatures};
+use wasmparser::Validator;
 use wit_parser::{Resolve, WorldId};
 
 /// This function checks whether `component_to_test` correctly conforms to the world specified.
@@ -36,7 +36,7 @@ pub fn targets(resolve: &Resolve, world: WorldId, component_to_test: &[u8]) -> R
 
     let bytes = root_component.finish();
 
-    Validator::new_with_features(WasmFeatures::default() | WasmFeatures::COMPONENT_MODEL)
+    Validator::new()
         .validate_all(&bytes)
         .context("failed to validate encoded bytes")?;
 

--- a/crates/wit-component/tests/interfaces.rs
+++ b/crates/wit-component/tests/interfaces.rs
@@ -3,7 +3,6 @@ use libtest_mimic::{Arguments, Trial};
 use pretty_assertions::assert_eq;
 use std::fs;
 use std::path::Path;
-use wasmparser::WasmFeatures;
 use wit_component::WitPrinter;
 use wit_parser::{PackageId, Resolve, UnresolvedPackageGroup};
 
@@ -56,15 +55,13 @@ fn run_test(path: &Path, is_dir: bool) -> Result<()> {
 
     assert_print(&resolve, package, path, is_dir)?;
 
-    let features = WasmFeatures::default() | WasmFeatures::COMPONENT_MODEL;
-
     // First convert the WIT package to a binary WebAssembly output, then
     // convert that binary wasm to textual wasm, then assert it matches the
     // expectation.
     let wasm = wit_component::encode(Some(true), &resolve, package)?;
     let wat = wasmprinter::print_bytes(&wasm)?;
     assert_output(&path.with_extension("wat"), &wat)?;
-    wasmparser::Validator::new_with_features(features)
+    wasmparser::Validator::new()
         .validate_all(&wasm)
         .context("failed to validate wasm output")?;
 

--- a/crates/wit-parser/src/decoding.rs
+++ b/crates/wit-parser/src/decoding.rs
@@ -9,7 +9,6 @@ use wasmparser::{
     types,
     types::ComponentAnyTypeId,
     ComponentExternalKind, Parser, Payload, PrimitiveValType, ValidPayload, Validator,
-    WasmFeatures,
 };
 
 /// Represents information about a decoded WebAssembly component.
@@ -44,7 +43,7 @@ impl ComponentInfo {
     /// Creates a new component info by parsing the given WebAssembly component bytes.
 
     fn from_reader(mut reader: impl Read) -> Result<Self> {
-        let mut validator = Validator::new_with_features(WasmFeatures::all());
+        let mut validator = Validator::new();
         let mut externs = Vec::new();
         let mut depth = 1;
         let mut types = None;
@@ -415,7 +414,7 @@ pub fn decode(bytes: &[u8]) -> Result<DecodedWasm> {
 /// component export represents the world. The name of the export is also the
 /// name of the package/world/etc.
 pub fn decode_world(wasm: &[u8]) -> Result<(Resolve, WorldId)> {
-    let mut validator = Validator::new_with_features(WasmFeatures::all());
+    let mut validator = Validator::new();
     let mut exports = Vec::new();
     let mut depth = 1;
     let mut types = None;

--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -9,7 +9,7 @@ use wasm_encoder::reencode::{Error, Reencode, ReencodeComponent, RoundtripReenco
 use wasm_encoder::ModuleType;
 use wasm_tools::Output;
 use wasmparser::types::{CoreTypeId, EntityType, Types};
-use wasmparser::{Payload, ValidPayload, WasmFeatures};
+use wasmparser::{Payload, ValidPayload};
 use wat::Detect;
 use wit_component::{
     embed_component_metadata, ComponentEncoder, DecodedWasm, Linker, StringEncoding, WitPrinter,
@@ -612,10 +612,7 @@ impl WitOpts {
         let decoded_package = decoded.package();
         let bytes = wit_component::encode(None, decoded.resolve(), decoded_package)?;
         if !self.skip_validation {
-            wasmparser::Validator::new_with_features(
-                WasmFeatures::default() | WasmFeatures::COMPONENT_MODEL,
-            )
-            .validate_all(&bytes)?;
+            wasmparser::Validator::new().validate_all(&bytes)?;
         }
         self.output.output_wasm(&self.general, &bytes, self.wat)?;
         Ok(())
@@ -850,7 +847,7 @@ impl UnbundleOpts {
 
         let mut core_types = CoreTypeInterner::default();
         let mut imports = wasm_encoder::ComponentImportSection::new();
-        let mut validator = wasmparser::Validator::new_with_features(WasmFeatures::all());
+        let mut validator = wasmparser::Validator::new();
 
         for module in modules_to_extract.iter().filter_map(|m| *m) {
             // Validate the `module` to get its type information, but don't

--- a/src/bin/wasm-tools/compose.rs
+++ b/src/bin/wasm-tools/compose.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use std::path::{Path, PathBuf};
 use wasm_compose::{composer::ComponentComposer, config::Config};
-use wasmparser::{Validator, WasmFeatures};
+use wasmparser::Validator;
 
 /// WebAssembly component composer.
 ///
@@ -66,15 +66,13 @@ impl Opts {
         if config.skip_validation {
             log::debug!("output validation was skipped");
         } else {
-            Validator::new_with_features(WasmFeatures::default() | WasmFeatures::COMPONENT_MODEL)
-                .validate_all(&bytes)
-                .with_context(|| {
-                    let output = match self.output.output_path() {
-                        Some(s) => format!(" `{}`", s.display()),
-                        None => String::new(),
-                    };
-                    format!("failed to validate output component{output}")
-                })?;
+            Validator::new().validate_all(&bytes).with_context(|| {
+                let output = match self.output.output_path() {
+                    Some(s) => format!(" `{}`", s.display()),
+                    None => String::new(),
+                };
+                format!("failed to validate output component{output}")
+            })?;
 
             log::debug!("output component validated successfully");
         }

--- a/tests/cli/dump-invalid-name-section3.wat.stdout
+++ b/tests/cli/dump-invalid-name-section3.wat.stdout
@@ -4,4 +4,4 @@
   0xa | 04 6e 61 6d | name: "name"
       | 65         
   0xf | 02 07       | ???
- 0x11 |-------------| ... failed to decode 1 more bytes: unexpected end of section (at offset 0x12)
+ 0x11 |-------------| ... failed to decode 1 more bytes: unexpected end-of-file (at offset 0x11)

--- a/tests/local/invalid/empty-br-table.wast
+++ b/tests/local/invalid/empty-br-table.wast
@@ -5,8 +5,8 @@
     "\01\04\01\60\00\00" ;; type section, 1 type, (func)
     "\03\02\01\00" ;; func section, 1 function, type 0
 
-    "\0a\12\01"        ;; code section
-    "\10"              ;; function size
+    "\0a\0d\01"        ;; code section
+    "\0b"              ;; function size
     "\00"              ;; no locals
     "\02\40"           ;; block
     "\41\01"           ;; i32.const 1


### PR DESCRIPTION
Something I've long wanted for `wasmparser` is the ability to constant-propagate decisions about feature selection instead of requiring runtime checks to do so. This should be a performance win for proposals as they become standardized and more and more of wasm is gated behind some feature or another. The goal with this is to enable a mode of `wasmparser` which doesn't require runtime checks of booleans/bits to see whether a proposal is enabled or not.

In lieu of not redesigning everything too much (e.g. adding `F: WasmFeatures` everywhere) this commit adds a new compile time Cargo feature to the crate called `features` which, when disabled, makes `WasmFeatures` a zero-sized type that represent the default active features for `wasmparser`. This enables const-propagating decisions about features throughout the codebase and should help optimize the validator/decoder in niche situations.