### PR TITLE
Update handling of unreachable code and heap types

### DIFF
--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -1464,7 +1464,7 @@ pub enum AbstractHeapType {
 }
 
 impl AbstractHeapType {
-    const fn as_str(&self, nullable: bool) -> &str {
+    pub(crate) const fn as_str(&self, nullable: bool) -> &str {
         use AbstractHeapType::*;
         match (nullable, self) {
             (_, Any) => "any",
@@ -1483,6 +1483,28 @@ impl AbstractHeapType {
             (_, Exn) => "exn",
             (true, NoExn) => "nullexn",
             (false, NoExn) => "noexn",
+        }
+    }
+
+    pub(crate) fn is_subtype_of(&self, other: AbstractHeapType) -> bool {
+        use AbstractHeapType::*;
+
+        match (self, other) {
+            (a, b) if *a == b => true,
+            (Eq | I31 | Struct | Array | None, Any) => true,
+            (I31 | Struct | Array | None, Eq) => true,
+            (NoExtern, Extern) => true,
+            (NoFunc, Func) => true,
+            (None, I31 | Array | Struct) => true,
+            (NoExn, Exn) => true,
+            // Nothing else matches. (Avoid full wildcard matches so
+            // that adding/modifying variants is easier in the
+            // future.)
+            (
+                Func | Extern | Exn | Any | Eq | Array | I31 | Struct | None | NoFunc | NoExtern
+                | NoExn,
+                _,
+            ) => false,
         }
     }
 }

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -1486,6 +1486,7 @@ impl AbstractHeapType {
         }
     }
 
+    #[cfg(feature = "validate")]
     pub(crate) fn is_subtype_of(&self, other: AbstractHeapType) -> bool {
         use AbstractHeapType::*;
 

--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -2798,25 +2798,7 @@ impl TypeList {
                     shared: b_shared,
                     ty: b_ty,
                 },
-            ) => {
-                a_shared == b_shared
-                    && match (a_ty, b_ty) {
-                        (Eq | I31 | Struct | Array | None, Any) => true,
-                        (I31 | Struct | Array | None, Eq) => true,
-                        (NoExtern, Extern) => true,
-                        (NoFunc, Func) => true,
-                        (None, I31 | Array | Struct) => true,
-                        (NoExn, Exn) => true,
-                        // Nothing else matches. (Avoid full wildcard matches so
-                        // that adding/modifying variants is easier in the
-                        // future.)
-                        (
-                            Func | Extern | Exn | Any | Eq | Array | I31 | Struct | None | NoFunc
-                            | NoExtern | NoExn,
-                            _,
-                        ) => false,
-                    }
-            }
+            ) => a_shared == b_shared && a_ty.is_subtype_of(b_ty),
 
             (HT::Concrete(a), HT::Abstract { shared, ty }) => {
                 let a_ty = &subtype(a_group, a).composite_type;

--- a/tests/local/shared-everything-threads/gc-unreachable.wast
+++ b/tests/local/shared-everything-threads/gc-unreachable.wast
@@ -1,0 +1,152 @@
+(module
+  (func
+    unreachable
+    ref.null (shared eq)
+    ref.eq
+    drop
+
+    ref.null eq
+    ref.eq
+    drop
+  )
+  (func
+    unreachable
+    any.convert_extern
+    ref.cast (ref i31)
+    drop
+  )
+  (func
+    unreachable
+    any.convert_extern
+    ref.cast (ref (shared i31))
+    drop
+  )
+  (func
+    unreachable
+    ref.eq
+    drop
+  )
+  (func
+    (local $a (ref null (shared eq)))
+    unreachable
+    local.get $a
+    ref.eq
+    drop
+  )
+  (func
+    (local $a (ref null eq))
+    unreachable
+    local.get $a
+    ref.eq
+    drop
+  )
+  (func
+    (local $a (ref null eq))
+    unreachable
+    ref.cast (ref eq)
+    local.get $a
+    ref.eq
+    drop
+  )
+  (func
+    (local $a (ref null (shared eq)))
+    unreachable
+    ref.cast (ref (shared eq))
+    local.get $a
+    ref.eq
+    drop
+  )
+  (func
+    (local $a (ref null (shared eq)))
+    unreachable
+    any.convert_extern
+    extern.convert_any
+    any.convert_extern
+    ref.cast (ref (shared eq))
+    local.get $a
+    ref.eq
+    drop
+  )
+  (func
+    (local $a (ref null eq))
+    unreachable
+    any.convert_extern
+    extern.convert_any
+    any.convert_extern
+    ref.cast (ref eq)
+    local.get $a
+    ref.eq
+    drop
+  )
+  (func
+    unreachable
+    any.convert_extern
+    ref.cast (ref (shared array))
+    array.len
+    drop
+  )
+)
+
+(assert_invalid
+  (module
+    (func
+      unreachable
+      any.convert_extern
+      ref.null eq
+      ref.eq
+      drop
+    )
+  )
+  "expected subtype of eq, found any")
+
+(assert_invalid
+  (module
+    (func
+      unreachable
+      extern.convert_any
+      ref.cast (ref (shared i31))
+      drop
+    )
+  )
+  "expected (shared anyref), found (ref (shared extern))")
+
+(assert_invalid
+  (module
+    (func
+      unreachable
+      any.convert_extern
+      ref.cast (ref extern)
+      drop
+    )
+  )
+  "expected externref, found (ref any)")
+(assert_invalid
+  (module
+    (func
+      unreachable
+      any.convert_extern
+      array.len
+      drop
+    )
+  )
+  "expected subtype of array, found any")
+(assert_invalid
+  (module
+    (func
+      unreachable
+      ref.as_non_null
+      i32.eq
+      drop
+    )
+  )
+  "expected i32, found heap type")
+(assert_invalid
+  (module
+    (func
+      block $l
+        unreachable
+        br_on_cast $l (ref any) (ref any)
+      end
+    )
+  )
+  "br_on_cast to label with empty types")

--- a/tests/snapshots/local/shared-everything-threads/gc-unreachable.wast.json
+++ b/tests/snapshots/local/shared-everything-threads/gc-unreachable.wast.json
@@ -1,0 +1,52 @@
+{
+  "source_filename": "tests/local/shared-everything-threads/gc-unreachable.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 1,
+      "filename": "gc-unreachable.0.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 91,
+      "filename": "gc-unreachable.1.wasm",
+      "text": "expected subtype of eq, found any",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 103,
+      "filename": "gc-unreachable.2.wasm",
+      "text": "expected (shared anyref), found (ref (shared extern))",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 114,
+      "filename": "gc-unreachable.3.wasm",
+      "text": "expected externref, found (ref any)",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 124,
+      "filename": "gc-unreachable.4.wasm",
+      "text": "expected subtype of array, found any",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 134,
+      "filename": "gc-unreachable.5.wasm",
+      "text": "expected i32, found heap type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 144,
+      "filename": "gc-unreachable.6.wasm",
+      "text": "br_on_cast to label with empty types",
+      "module_type": "binary"
+    }
+  ]
+}

--- a/tests/snapshots/local/shared-everything-threads/gc-unreachable.wast/0.print
+++ b/tests/snapshots/local/shared-everything-threads/gc-unreachable.wast/0.print
@@ -1,0 +1,88 @@
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0)
+    unreachable
+    ref.null (shared eq)
+    ref.eq
+    drop
+    ref.null eq
+    ref.eq
+    drop
+  )
+  (func (;1;) (type 0)
+    unreachable
+    any.convert_extern
+    ref.cast (ref i31)
+    drop
+  )
+  (func (;2;) (type 0)
+    unreachable
+    any.convert_extern
+    ref.cast (ref (shared i31))
+    drop
+  )
+  (func (;3;) (type 0)
+    unreachable
+    ref.eq
+    drop
+  )
+  (func (;4;) (type 0)
+    (local $a (ref null (shared eq)))
+    unreachable
+    local.get $a
+    ref.eq
+    drop
+  )
+  (func (;5;) (type 0)
+    (local $a eqref)
+    unreachable
+    local.get $a
+    ref.eq
+    drop
+  )
+  (func (;6;) (type 0)
+    (local $a eqref)
+    unreachable
+    ref.cast (ref eq)
+    local.get $a
+    ref.eq
+    drop
+  )
+  (func (;7;) (type 0)
+    (local $a (ref null (shared eq)))
+    unreachable
+    ref.cast (ref (shared eq))
+    local.get $a
+    ref.eq
+    drop
+  )
+  (func (;8;) (type 0)
+    (local $a (ref null (shared eq)))
+    unreachable
+    any.convert_extern
+    extern.convert_any
+    any.convert_extern
+    ref.cast (ref (shared eq))
+    local.get $a
+    ref.eq
+    drop
+  )
+  (func (;9;) (type 0)
+    (local $a eqref)
+    unreachable
+    any.convert_extern
+    extern.convert_any
+    any.convert_extern
+    ref.cast (ref eq)
+    local.get $a
+    ref.eq
+    drop
+  )
+  (func (;10;) (type 0)
+    unreachable
+    any.convert_extern
+    ref.cast (ref (shared array))
+    array.len
+    drop
+  )
+)


### PR DESCRIPTION
This commit updates validation of wasm modules with unreachable code using gc/heap types. It notably fixes cases with the shared-everything-threads proposal where existing instructions are polymorphic over `shared` and not and wasn't supported before. Specifically code was refactored to use `MaybeType` a bit more to propagate the bottom-ness and the `MaybeType::HeapBot` variant has grown a new `AbstractHeapType` payload for various instructions to use such as `any.convert_extern`.