### PR TITLE
threads: add validation for shared calls

### DIFF
--- a/crates/wasmparser/src/resources.rs
+++ b/crates/wasmparser/src/resources.rs
@@ -50,14 +50,11 @@ pub trait WasmModuleResources {
     /// The sub type must be canonicalized.
     fn sub_type_at(&self, type_index: u32) -> Option<&SubType>;
 
-    /// Returns the type id associated with the given function
-    /// index.
+    /// Returns the type ID associated with the given function index.
     fn type_id_of_function(&self, func_idx: u32) -> Option<CoreTypeId>;
 
-    /// Returns the `FuncType` associated with the given function index.
-    ///
-    /// The function type must be canonicalized.
-    fn type_of_function(&self, func_idx: u32) -> Option<(&FuncType, bool)>;
+    /// Returns the type index associated with the given function index.
+    fn type_index_of_function(&self, func_index: u32) -> Option<u32>;
 
     /// Returns the element type at the given index.
     ///
@@ -153,8 +150,8 @@ where
     fn type_id_of_function(&self, func_idx: u32) -> Option<CoreTypeId> {
         T::type_id_of_function(self, func_idx)
     }
-    fn type_of_function(&self, func_idx: u32) -> Option<(&FuncType, bool)> {
-        T::type_of_function(self, func_idx)
+    fn type_index_of_function(&self, func_idx: u32) -> Option<u32> {
+        T::type_index_of_function(self, func_idx)
     }
     fn check_heap_type(&self, t: &mut HeapType, offset: usize) -> Result<(), BinaryReaderError> {
         T::check_heap_type(self, t, offset)
@@ -210,8 +207,8 @@ where
         T::type_id_of_function(self, func_idx)
     }
 
-    fn type_of_function(&self, func_idx: u32) -> Option<(&FuncType, bool)> {
-        T::type_of_function(self, func_idx)
+    fn type_index_of_function(&self, func_idx: u32) -> Option<u32> {
+        T::type_index_of_function(self, func_idx)
     }
 
     fn check_heap_type(&self, t: &mut HeapType, offset: usize) -> Result<(), BinaryReaderError> {

--- a/crates/wasmparser/src/resources.rs
+++ b/crates/wasmparser/src/resources.rs
@@ -57,7 +57,7 @@ pub trait WasmModuleResources {
     /// Returns the `FuncType` associated with the given function index.
     ///
     /// The function type must be canonicalized.
-    fn type_of_function(&self, func_idx: u32) -> Option<&FuncType>;
+    fn type_of_function(&self, func_idx: u32) -> Option<(&FuncType, bool)>;
 
     /// Returns the element type at the given index.
     ///
@@ -153,7 +153,7 @@ where
     fn type_id_of_function(&self, func_idx: u32) -> Option<CoreTypeId> {
         T::type_id_of_function(self, func_idx)
     }
-    fn type_of_function(&self, func_idx: u32) -> Option<&FuncType> {
+    fn type_of_function(&self, func_idx: u32) -> Option<(&FuncType, bool)> {
         T::type_of_function(self, func_idx)
     }
     fn check_heap_type(&self, t: &mut HeapType, offset: usize) -> Result<(), BinaryReaderError> {
@@ -210,7 +210,7 @@ where
         T::type_id_of_function(self, func_idx)
     }
 
-    fn type_of_function(&self, func_idx: u32) -> Option<&FuncType> {
+    fn type_of_function(&self, func_idx: u32) -> Option<(&FuncType, bool)> {
         T::type_of_function(self, func_idx)
     }
 

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -1331,10 +1331,8 @@ impl WasmModuleResources for OperatorValidatorResources<'_> {
         self.module.types.get(*type_index as usize).copied()
     }
 
-    fn type_of_function(&self, at: u32) -> Option<(&FuncType, bool)> {
-        let type_index = self.module.functions.get(at as usize)?;
-        let ty = &self.sub_type_at(*type_index)?.composite_type;
-        Some((ty.unwrap_func(), ty.shared))
+    fn type_index_of_function(&self, at: u32) -> Option<u32> {
+        self.module.functions.get(at as usize).copied()
     }
 
     fn check_heap_type(&self, t: &mut HeapType, offset: usize) -> Result<()> {
@@ -1408,10 +1406,8 @@ impl WasmModuleResources for ValidatorResources {
         self.0.types.get(type_index as usize).copied()
     }
 
-    fn type_of_function(&self, at: u32) -> Option<(&FuncType, bool)> {
-        let type_index = *self.0.functions.get(at as usize)?;
-        let ty = &self.sub_type_at(type_index)?.composite_type;
-        Some((ty.unwrap_func(), ty.shared))
+    fn type_index_of_function(&self, at: u32) -> Option<u32> {
+        self.0.functions.get(at as usize).copied()
     }
 
     fn check_heap_type(&self, t: &mut HeapType, offset: usize) -> Result<()> {

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -1331,9 +1331,10 @@ impl WasmModuleResources for OperatorValidatorResources<'_> {
         self.module.types.get(*type_index as usize).copied()
     }
 
-    fn type_of_function(&self, at: u32) -> Option<&FuncType> {
+    fn type_of_function(&self, at: u32) -> Option<(&FuncType, bool)> {
         let type_index = self.module.functions.get(at as usize)?;
-        Some(self.sub_type_at(*type_index)?.composite_type.unwrap_func())
+        let ty = &self.sub_type_at(*type_index)?.composite_type;
+        Some((ty.unwrap_func(), ty.shared))
     }
 
     fn check_heap_type(&self, t: &mut HeapType, offset: usize) -> Result<()> {
@@ -1407,9 +1408,10 @@ impl WasmModuleResources for ValidatorResources {
         self.0.types.get(type_index as usize).copied()
     }
 
-    fn type_of_function(&self, at: u32) -> Option<&FuncType> {
+    fn type_of_function(&self, at: u32) -> Option<(&FuncType, bool)> {
         let type_index = *self.0.functions.get(at as usize)?;
-        Some(self.sub_type_at(type_index)?.composite_type.unwrap_func())
+        let ty = &self.sub_type_at(type_index)?.composite_type;
+        Some((ty.unwrap_func(), ty.shared))
     }
 
     fn check_heap_type(&self, t: &mut HeapType, offset: usize) -> Result<()> {

--- a/crates/wasmparser/src/validator/func.rs
+++ b/crates/wasmparser/src/validator/func.rs
@@ -273,7 +273,7 @@ mod tests {
         fn type_id_of_function(&self, _at: u32) -> Option<CoreTypeId> {
             todo!()
         }
-        fn type_of_function(&self, _func_idx: u32) -> Option<(&crate::FuncType, bool)> {
+        fn type_index_of_function(&self, _at: u32) -> Option<u32> {
             todo!()
         }
         fn check_heap_type(&self, _t: &mut HeapType, _offset: usize) -> Result<()> {

--- a/crates/wasmparser/src/validator/func.rs
+++ b/crates/wasmparser/src/validator/func.rs
@@ -273,7 +273,7 @@ mod tests {
         fn type_id_of_function(&self, _at: u32) -> Option<CoreTypeId> {
             todo!()
         }
-        fn type_of_function(&self, _func_idx: u32) -> Option<&crate::FuncType> {
+        fn type_of_function(&self, _func_idx: u32) -> Option<(&crate::FuncType, bool)> {
             todo!()
         }
         fn check_heap_type(&self, _t: &mut HeapType, _offset: usize) -> Result<()> {

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -923,22 +923,13 @@ where
     /// Returns the corresponding function type for the `func` item located at
     /// `function_index`.
     fn type_of_function(&self, function_index: u32) -> Result<&'resources FuncType> {
-        match self.resources.type_of_function(function_index) {
-            Some((f, shared)) => {
-                if self.inner.shared && !shared {
-                    bail!(
-                        self.offset,
-                        "shared functions cannot access unshared functions",
-                    );
-                }
-                Ok(f)
-            }
-            None => {
-                bail!(
-                    self.offset,
-                    "unknown function {function_index}: function index out of bounds",
-                )
-            }
+        if let Some(type_index) = self.resources.type_index_of_function(function_index) {
+            self.func_type_at(type_index)
+        } else {
+            bail!(
+                self.offset,
+                "unknown function {function_index}: function index out of bounds",
+            )
         }
     }
 

--- a/tests/local/shared-everything-threads/funcs.wast
+++ b/tests/local/shared-everything-threads/funcs.wast
@@ -5,7 +5,7 @@
   (func (type $f))
 )
 
-;; Check that unshared functions cannot be called from shared ones.
+;; Check that unshared functions cannot be called from shared functions.
 (assert_invalid
   (module
     (type $shared (shared (func)))
@@ -14,4 +14,51 @@
       call $unshared)
     (func $unshared (type $unshared))
   )
-  "shared functions cannot call unshared functions")
+  "shared functions cannot access unshared functions")
+
+;; Check that unshared globals cannot be accessed from shared functions.
+(assert_invalid
+  (module
+    (global $unshared_global i32 (i32.const 0))
+    (type $shared_func (shared (func)))
+    (func (type $shared_func)
+      global.get $unshared_global
+      drop)
+    )
+  "shared functions cannot access unshared globals")
+
+;; Check that unshared tables cannot be accessed from shared functions.
+(assert_invalid
+  (module
+    (table $unshared_table 1 anyref)
+    (type $shared_func (shared (func)))
+    (func (type $shared_func)
+      i32.const 0
+      table.get $unshared_table
+      drop)
+    )
+  "shared functions cannot access unshared tables")
+
+;; Check that unshared arrays cannot be accessed from shared functions.
+(assert_invalid
+  (module
+    (type $unshared_array (array anyref))
+    (type $shared_func (shared (func)))
+    (func (type $shared_func)
+      (array.new $unshared_array (ref.null any) (i32.const 0))
+      (array.get $unshared_array (i32.const 0))
+      drop)
+    )
+  "shared functions cannot access unshared arrays")
+
+;; Check that unshared structs cannot be accessed from shared functions.
+(assert_invalid
+  (module
+    (type $unshared_struct (struct (field i32)))
+    (type $shared_func (shared (func)))
+    (func (type $shared_func)
+      (struct.new $unshared_struct (i32.const 0))
+      (struct.get $unshared_struct 0)
+      drop)
+    )
+  "shared functions cannot access unshared structs")

--- a/tests/local/shared-everything-threads/funcs.wast
+++ b/tests/local/shared-everything-threads/funcs.wast
@@ -1,0 +1,17 @@
+;; Check that shared functions are valid WAT.
+(module
+  (type $f (shared (func)))
+  (func (import "spectest" "shared-func") (type $f))
+  (func (type $f))
+)
+
+;; Check that unshared functions cannot be called from shared ones.
+(assert_invalid
+  (module
+    (type $shared (shared (func)))
+    (type $unshared (func))
+    (func (type $shared)
+      call $unshared)
+    (func $unshared (type $unshared))
+  )
+  "shared functions cannot call unshared functions")

--- a/tests/local/shared-everything-threads/types.wast
+++ b/tests/local/shared-everything-threads/types.wast
@@ -1,5 +1,3 @@
-;; Check shared attributes for global heap types.
-
 ;; `func` references.
 (module
   ;; Imported (long/short forms, mut, null).

--- a/tests/snapshots/local/shared-everything-threads/funcs.wast.json
+++ b/tests/snapshots/local/shared-everything-threads/funcs.wast.json
@@ -10,7 +10,35 @@
       "type": "assert_invalid",
       "line": 10,
       "filename": "funcs.1.wasm",
-      "text": "shared functions cannot call unshared functions",
+      "text": "shared functions cannot access unshared functions",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 21,
+      "filename": "funcs.2.wasm",
+      "text": "shared functions cannot access unshared globals",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 32,
+      "filename": "funcs.3.wasm",
+      "text": "shared functions cannot access unshared tables",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 44,
+      "filename": "funcs.4.wasm",
+      "text": "shared functions cannot access unshared arrays",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 56,
+      "filename": "funcs.5.wasm",
+      "text": "shared functions cannot access unshared structs",
       "module_type": "binary"
     }
   ]

--- a/tests/snapshots/local/shared-everything-threads/funcs.wast.json
+++ b/tests/snapshots/local/shared-everything-threads/funcs.wast.json
@@ -1,0 +1,17 @@
+{
+  "source_filename": "tests/local/shared-everything-threads/funcs.wast",
+  "commands": [
+    {
+      "type": "module",
+      "line": 2,
+      "filename": "funcs.0.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 10,
+      "filename": "funcs.1.wasm",
+      "text": "shared functions cannot call unshared functions",
+      "module_type": "binary"
+    }
+  ]
+}

--- a/tests/snapshots/local/shared-everything-threads/funcs.wast/0.print
+++ b/tests/snapshots/local/shared-everything-threads/funcs.wast/0.print
@@ -1,0 +1,5 @@
+(module
+  (type $f (;0;) (shared(func)))
+  (import "spectest" "shared-func" (func (;0;) (type $f)))
+  (func (;1;) (type $f))
+)

--- a/tests/snapshots/local/shared-everything-threads/types.wast.json
+++ b/tests/snapshots/local/shared-everything-threads/types.wast.json
@@ -3,390 +3,390 @@
   "commands": [
     {
       "type": "module",
-      "line": 4,
+      "line": 2,
       "filename": "types.0.wasm"
     },
     {
       "type": "assert_invalid",
-      "line": 19,
+      "line": 17,
       "filename": "types.1.wasm",
       "text": "shared globals must have a shared value type",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 22,
+      "line": 20,
       "filename": "types.2.wasm",
       "text": "shared globals must have a shared value type",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 25,
+      "line": 23,
       "filename": "types.3.wasm",
       "text": "type mismatch",
       "module_type": "binary"
     },
     {
       "type": "module",
-      "line": 29,
+      "line": 27,
       "filename": "types.4.wasm"
     },
     {
       "type": "assert_invalid",
-      "line": 44,
+      "line": 42,
       "filename": "types.5.wasm",
       "text": "shared globals must have a shared value type",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 47,
+      "line": 45,
       "filename": "types.6.wasm",
       "text": "shared globals must have a shared value type",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 50,
+      "line": 48,
       "filename": "types.7.wasm",
       "text": "type mismatch",
       "module_type": "binary"
     },
     {
       "type": "module",
-      "line": 54,
+      "line": 52,
       "filename": "types.8.wasm"
     },
     {
       "type": "assert_invalid",
-      "line": 69,
+      "line": 67,
       "filename": "types.9.wasm",
       "text": "shared globals must have a shared value type",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 72,
+      "line": 70,
       "filename": "types.10.wasm",
       "text": "shared globals must have a shared value type",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 75,
+      "line": 73,
       "filename": "types.11.wasm",
       "text": "type mismatch",
       "module_type": "binary"
     },
     {
       "type": "module",
-      "line": 79,
+      "line": 77,
       "filename": "types.12.wasm"
     },
     {
       "type": "assert_invalid",
-      "line": 94,
+      "line": 92,
       "filename": "types.13.wasm",
       "text": "shared globals must have a shared value type",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 97,
+      "line": 95,
       "filename": "types.14.wasm",
       "text": "shared globals must have a shared value type",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 100,
+      "line": 98,
       "filename": "types.15.wasm",
       "text": "type mismatch",
       "module_type": "binary"
     },
     {
       "type": "module",
-      "line": 104,
+      "line": 102,
       "filename": "types.16.wasm"
     },
     {
       "type": "assert_invalid",
-      "line": 119,
+      "line": 117,
       "filename": "types.17.wasm",
       "text": "shared globals must have a shared value type",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 122,
+      "line": 120,
       "filename": "types.18.wasm",
       "text": "shared globals must have a shared value type",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 125,
+      "line": 123,
       "filename": "types.19.wasm",
       "text": "type mismatch",
       "module_type": "binary"
     },
     {
       "type": "module",
-      "line": 129,
+      "line": 127,
       "filename": "types.20.wasm"
     },
     {
       "type": "assert_invalid",
-      "line": 144,
+      "line": 142,
       "filename": "types.21.wasm",
       "text": "shared globals must have a shared value type",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 147,
+      "line": 145,
       "filename": "types.22.wasm",
       "text": "shared globals must have a shared value type",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 150,
+      "line": 148,
       "filename": "types.23.wasm",
       "text": "type mismatch",
       "module_type": "binary"
     },
     {
       "type": "module",
-      "line": 154,
+      "line": 152,
       "filename": "types.24.wasm"
     },
     {
       "type": "assert_invalid",
-      "line": 169,
+      "line": 167,
       "filename": "types.25.wasm",
       "text": "shared globals must have a shared value type",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 172,
+      "line": 170,
       "filename": "types.26.wasm",
       "text": "shared globals must have a shared value type",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 175,
+      "line": 173,
       "filename": "types.27.wasm",
       "text": "type mismatch",
       "module_type": "binary"
     },
     {
       "type": "module",
-      "line": 179,
+      "line": 177,
       "filename": "types.28.wasm"
     },
     {
       "type": "assert_invalid",
-      "line": 194,
+      "line": 192,
       "filename": "types.29.wasm",
       "text": "shared globals must have a shared value type",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 197,
+      "line": 195,
       "filename": "types.30.wasm",
       "text": "shared globals must have a shared value type",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 200,
+      "line": 198,
       "filename": "types.31.wasm",
       "text": "type mismatch",
       "module_type": "binary"
     },
     {
       "type": "module",
-      "line": 204,
+      "line": 202,
       "filename": "types.32.wasm"
     },
     {
       "type": "assert_invalid",
-      "line": 219,
+      "line": 217,
       "filename": "types.33.wasm",
       "text": "shared globals must have a shared value type",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 222,
+      "line": 220,
       "filename": "types.34.wasm",
       "text": "shared globals must have a shared value type",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 225,
+      "line": 223,
       "filename": "types.35.wasm",
       "text": "type mismatch",
       "module_type": "binary"
     },
     {
       "type": "module",
-      "line": 229,
+      "line": 227,
       "filename": "types.36.wasm"
     },
     {
       "type": "assert_invalid",
-      "line": 244,
+      "line": 242,
       "filename": "types.37.wasm",
       "text": "shared globals must have a shared value type",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 247,
+      "line": 245,
       "filename": "types.38.wasm",
       "text": "shared globals must have a shared value type",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 250,
+      "line": 248,
       "filename": "types.39.wasm",
       "text": "type mismatch",
       "module_type": "binary"
     },
     {
       "type": "module",
-      "line": 254,
+      "line": 252,
       "filename": "types.40.wasm"
     },
     {
       "type": "assert_invalid",
-      "line": 269,
+      "line": 267,
       "filename": "types.41.wasm",
       "text": "shared globals must have a shared value type",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 272,
+      "line": 270,
       "filename": "types.42.wasm",
       "text": "shared globals must have a shared value type",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 275,
+      "line": 273,
       "filename": "types.43.wasm",
       "text": "type mismatch",
       "module_type": "binary"
     },
     {
       "type": "module",
-      "line": 279,
+      "line": 277,
       "filename": "types.44.wasm"
     },
     {
       "type": "assert_invalid",
-      "line": 294,
+      "line": 292,
       "filename": "types.45.wasm",
       "text": "shared globals must have a shared value type",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 297,
+      "line": 295,
       "filename": "types.46.wasm",
       "text": "shared globals must have a shared value type",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 300,
+      "line": 298,
       "filename": "types.47.wasm",
       "text": "type mismatch",
       "module_type": "binary"
     },
     {
       "type": "module",
-      "line": 304,
+      "line": 302,
       "filename": "types.48.wasm"
     },
     {
       "type": "assert_invalid",
-      "line": 319,
+      "line": 317,
       "filename": "types.49.wasm",
       "text": "shared globals must have a shared value type",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 324,
+      "line": 322,
       "filename": "types.50.wasm",
       "text": "type mismatch",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 329,
+      "line": 327,
       "filename": "types.51.wasm",
       "text": "shared composite type must contain shared types",
       "module_type": "binary"
     },
     {
       "type": "module",
-      "line": 333,
+      "line": 331,
       "filename": "types.52.wasm"
     },
     {
       "type": "assert_invalid",
-      "line": 348,
+      "line": 346,
       "filename": "types.53.wasm",
       "text": "shared globals must have a shared value type",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 353,
+      "line": 351,
       "filename": "types.54.wasm",
       "text": "type mismatch",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 358,
+      "line": 356,
       "filename": "types.55.wasm",
       "text": "shared composite type must contain shared types",
       "module_type": "binary"
     },
     {
       "type": "module",
-      "line": 362,
+      "line": 360,
       "filename": "types.56.wasm"
     },
     {
       "type": "assert_invalid",
-      "line": 377,
+      "line": 375,
       "filename": "types.57.wasm",
       "text": "shared globals must have a shared value type",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 382,
+      "line": 380,
       "filename": "types.58.wasm",
       "text": "type mismatch",
       "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 387,
+      "line": 385,
       "filename": "types.59.wasm",
       "text": "shared composite type must contain shared types",
       "module_type": "binary"


### PR DESCRIPTION
The shared-everything-threads [proposal] prevents `shared` contexts (e.g., in a `shared` function) from accessing unshared objects. This change adds validation to prevent `shared`-to-unshared calls.

[proposal]: https://github.com/WebAssembly/shared-everything-threads