### PR TITLE
Rename `MaybeType` variants, tweak documentation

### DIFF
--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -160,23 +160,31 @@ pub struct OperatorValidatorAllocations {
 
 /// Type storage within the validator.
 ///
-/// This is used to manage the operand stack and notably isn't just `ValType`
-/// to handle unreachable code and the "bottom" type.
+/// When managing the operand stack in unreachable code, the validator may not
+/// fully know an operand's type. this `Unknown` state is known as the `bottom` type
+/// in the WebAssembly specification. Validating further instructions may give
+/// us more information; either partial (`PartialRef`) or fully known.
 #[derive(Debug, Copy, Clone)]
 enum MaybeType<T = ValType> {
-    /// A "bottom" type which represents unconstrained unreachable code. There
-    /// are no constraints on what this type may be.
-    Bot,
-    /// A "bottom" type for specifically heap types.
+    /// The operand has no available type information due to unreachable code.
     ///
-    /// This type is known to be a reference type, optionally the specific
-    /// abstract heap type listed. This type can be interpeted as either
-    /// `shared` or not-`shared`. Additionally it can be either nullable or
-    /// not. Currently no further refinements are required for wasm
-    /// instructions today, but this may grow in the future.
-    HeapBot(Option<AbstractHeapType>),
-    /// A known type with the type `T`.
-    Type(T),
+    /// This state is known as the `bottom` type in the WebAssembly
+    /// specification. There are no constraints on what this type may be and it
+    /// can match any other type during validation.
+    Unknown,
+    /// The operand is known to be a reference and we may know its abstract
+    /// type.
+    ///
+    /// This state is not fully `Known` because its type can be interpreted as
+    /// either:
+    /// - `shared` or not-`shared`
+    /// -  nullable or not nullable
+    ///
+    /// No further refinements are required for WebAssembly instructions today
+    /// but this may grow in the future.
+    PartialRef(Option<AbstractHeapType>),
+    /// The operand is known to have type `T`.
+    Known(T),
 }
 
 // The validator is pretty performance-sensitive and `MaybeType` is the main
@@ -189,8 +197,8 @@ const _: () = {
 impl core::fmt::Display for MaybeType {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            MaybeType::Bot => write!(f, "bot"),
-            MaybeType::HeapBot(ty) => {
+            MaybeType::Unknown => write!(f, "bot"),
+            MaybeType::PartialRef(ty) => {
                 write!(f, "(ref shared? ")?;
                 match ty {
                     Some(ty) => write!(f, "{}bot", ty.as_str(true))?,
@@ -198,14 +206,14 @@ impl core::fmt::Display for MaybeType {
                 }
                 write!(f, ")")
             }
-            MaybeType::Type(ty) => core::fmt::Display::fmt(ty, f),
+            MaybeType::Known(ty) => core::fmt::Display::fmt(ty, f),
         }
     }
 }
 
 impl From<ValType> for MaybeType {
     fn from(ty: ValType) -> MaybeType {
-        MaybeType::Type(ty)
+        MaybeType::Known(ty)
     }
 }
 
@@ -218,9 +226,9 @@ impl From<RefType> for MaybeType {
 impl From<MaybeType<RefType>> for MaybeType<ValType> {
     fn from(ty: MaybeType<RefType>) -> MaybeType<ValType> {
         match ty {
-            MaybeType::Bot => MaybeType::Bot,
-            MaybeType::HeapBot(ty) => MaybeType::HeapBot(ty),
-            MaybeType::Type(t) => MaybeType::Type(t.into()),
+            MaybeType::Unknown => MaybeType::Unknown,
+            MaybeType::PartialRef(ty) => MaybeType::PartialRef(ty),
+            MaybeType::Known(t) => MaybeType::Known(t.into()),
         }
     }
 }
@@ -228,17 +236,17 @@ impl From<MaybeType<RefType>> for MaybeType<ValType> {
 impl MaybeType<RefType> {
     fn as_non_null(&self) -> MaybeType<RefType> {
         match self {
-            MaybeType::Bot => MaybeType::Bot,
-            MaybeType::HeapBot(ty) => MaybeType::HeapBot(*ty),
-            MaybeType::Type(ty) => MaybeType::Type(ty.as_non_null()),
+            MaybeType::Unknown => MaybeType::Unknown,
+            MaybeType::PartialRef(ty) => MaybeType::PartialRef(*ty),
+            MaybeType::Known(ty) => MaybeType::Known(ty.as_non_null()),
         }
     }
 
     fn is_maybe_shared(&self, resources: &impl WasmModuleResources) -> Option<bool> {
         match self {
-            MaybeType::Bot => None,
-            MaybeType::HeapBot(_) => None,
-            MaybeType::Type(ty) => Some(resources.is_shared(*ty)),
+            MaybeType::Unknown => None,
+            MaybeType::PartialRef(_) => None,
+            MaybeType::Known(ty) => Some(resources.is_shared(*ty)),
         }
     }
 }
@@ -373,8 +381,8 @@ impl OperatorValidator {
     /// A `depth` of 0 will refer to the last operand on the stack.
     pub fn peek_operand_at(&self, depth: usize) -> Option<Option<ValType>> {
         Some(match self.operands.iter().rev().nth(depth)? {
-            MaybeType::Type(t) => Some(*t),
-            MaybeType::Bot | MaybeType::HeapBot(..) => None,
+            MaybeType::Known(t) => Some(*t),
+            MaybeType::Unknown | MaybeType::PartialRef(..) => None,
         })
     }
 
@@ -473,7 +481,7 @@ where
 
         if cfg!(debug_assertions) {
             match maybe_ty {
-                MaybeType::Type(ValType::Ref(r)) => match r.heap_type() {
+                MaybeType::Known(ValType::Ref(r)) => match r.heap_type() {
                     HeapType::Concrete(index) => {
                         debug_assert!(
                             matches!(index, UnpackedIndex::Id(_)),
@@ -565,15 +573,15 @@ where
         // pop it. If we shouldn't have popped it then it's passed to the slow
         // path to get pushed back onto the stack.
         let popped = match self.operands.pop() {
-            Some(MaybeType::Type(actual_ty)) => {
+            Some(MaybeType::Known(actual_ty)) => {
                 if Some(actual_ty) == expected {
                     if let Some(control) = self.control.last() {
                         if self.operands.len() >= control.height {
-                            return Ok(MaybeType::Type(actual_ty));
+                            return Ok(MaybeType::Known(actual_ty));
                         }
                     }
                 }
-                Some(MaybeType::Type(actual_ty))
+                Some(MaybeType::Known(actual_ty))
             }
             other => other,
         };
@@ -596,7 +604,7 @@ where
             None => return Err(self.err_beyond_end(self.offset)),
         };
         let actual = if self.operands.len() == control.height && control.unreachable {
-            MaybeType::Bot
+            MaybeType::Unknown
         } else {
             if self.operands.len() == control.height {
                 let desc = match expected {
@@ -614,13 +622,13 @@ where
         if let Some(expected) = expected {
             match (actual, expected) {
                 // The bottom type matches all expectations
-                (MaybeType::Bot, _) => {}
+                (MaybeType::Unknown, _) => {}
 
                 // The "heap bottom" type only matches other references types,
                 // but not any integer types. Note that if the heap bottom is
                 // known to have a specific abstract heap type then a subtype
                 // check is performed against hte expected type.
-                (MaybeType::HeapBot(actual_ty), ValType::Ref(expected)) => {
+                (MaybeType::PartialRef(actual_ty), ValType::Ref(expected)) => {
                     if let Some(actual) = actual_ty {
                         let expected_shared = self.resources.is_shared(expected);
                         let actual = RefType::new(
@@ -644,7 +652,7 @@ where
 
                 // Use the `is_subtype` predicate to test if a found type matches
                 // the expectation.
-                (MaybeType::Type(actual), expected) => {
+                (MaybeType::Known(actual), expected) => {
                     if !self.resources.is_subtype(actual, expected) {
                         bail!(
                             self.offset,
@@ -657,7 +665,7 @@ where
 
                 // A "heap bottom" type cannot match any numeric types.
                 (
-                    MaybeType::HeapBot(..),
+                    MaybeType::PartialRef(..),
                     ValType::I32 | ValType::I64 | ValType::F32 | ValType::F64 | ValType::V128,
                 ) => {
                     bail!(
@@ -674,10 +682,10 @@ where
     /// Pop a reference type from the operand stack.
     fn pop_ref(&mut self, expected: Option<RefType>) -> Result<MaybeType<RefType>> {
         match self.pop_operand(expected.map(|t| t.into()))? {
-            MaybeType::Bot => Ok(MaybeType::HeapBot(None)),
-            MaybeType::HeapBot(ty) => Ok(MaybeType::HeapBot(ty)),
-            MaybeType::Type(ValType::Ref(rt)) => Ok(MaybeType::Type(rt)),
-            MaybeType::Type(ty) => bail!(
+            MaybeType::Unknown => Ok(MaybeType::PartialRef(None)),
+            MaybeType::PartialRef(ty) => Ok(MaybeType::PartialRef(ty)),
+            MaybeType::Known(ValType::Ref(rt)) => Ok(MaybeType::Known(rt)),
+            MaybeType::Known(ty) => bail!(
                 self.offset,
                 "type mismatch: expected ref but found {}",
                 ty_to_str(ty)
@@ -692,9 +700,9 @@ where
     /// saving extra lookups for concrete types.
     fn pop_maybe_shared_ref(&mut self, expected: AbstractHeapType) -> Result<MaybeType<RefType>> {
         let actual = match self.pop_ref(None)? {
-            MaybeType::Bot => return Ok(MaybeType::Bot),
-            MaybeType::HeapBot(None) => return Ok(MaybeType::HeapBot(None)),
-            MaybeType::HeapBot(Some(actual)) => {
+            MaybeType::Unknown => return Ok(MaybeType::Unknown),
+            MaybeType::PartialRef(None) => return Ok(MaybeType::PartialRef(None)),
+            MaybeType::PartialRef(Some(actual)) => {
                 if !actual.is_subtype_of(expected) {
                     bail!(
                         self.offset,
@@ -703,9 +711,9 @@ where
                         actual.as_str(false),
                     )
                 }
-                return Ok(MaybeType::HeapBot(Some(actual)));
+                return Ok(MaybeType::PartialRef(Some(actual)));
             }
-            MaybeType::Type(ty) => ty,
+            MaybeType::Known(ty) => ty,
         };
         // Change our expectation based on whether we're dealing with an actual
         // shared or unshared type.
@@ -728,7 +736,7 @@ where
                 "type mismatch: expected subtype of {expected}, found {actual}",
             )
         }
-        Ok(MaybeType::Type(actual))
+        Ok(MaybeType::Known(actual))
     }
 
     /// Fetches the type for the local at `idx`, returning an error if it's out
@@ -1772,10 +1780,10 @@ where
         let ty = match (ty1, ty2) {
             // All heap-related types aren't allowed with the `select`
             // instruction
-            (MaybeType::HeapBot(..), _)
-            | (_, MaybeType::HeapBot(..))
-            | (MaybeType::Type(ValType::Ref(_)), _)
-            | (_, MaybeType::Type(ValType::Ref(_))) => {
+            (MaybeType::PartialRef(..), _)
+            | (_, MaybeType::PartialRef(..))
+            | (MaybeType::Known(ValType::Ref(_)), _)
+            | (_, MaybeType::Known(ValType::Ref(_))) => {
                 bail!(
                     self.offset,
                     "type mismatch: select only takes integral types"
@@ -1784,11 +1792,11 @@ where
 
             // If one operand is the "bottom" type then whatever the other
             // operand is is the result of the `select`
-            (MaybeType::Bot, t) | (t, MaybeType::Bot) => t,
+            (MaybeType::Unknown, t) | (t, MaybeType::Unknown) => t,
 
             // Otherwise these are two integral types and they must match for
             // `select` to typecheck.
-            (t @ MaybeType::Type(t1), MaybeType::Type(t2)) => {
+            (t @ MaybeType::Known(t1), MaybeType::Known(t2)) => {
                 if t1 != t2 {
                     bail!(
                         self.offset,
@@ -4478,34 +4486,34 @@ where
     }
     fn visit_any_convert_extern(&mut self) -> Self::Output {
         let any_ref = match self.pop_maybe_shared_ref(AbstractHeapType::Extern)? {
-            MaybeType::Bot | MaybeType::HeapBot(_) => {
-                MaybeType::HeapBot(Some(AbstractHeapType::Any))
+            MaybeType::Unknown | MaybeType::PartialRef(_) => {
+                MaybeType::PartialRef(Some(AbstractHeapType::Any))
             }
-            MaybeType::Type(ty) => {
+            MaybeType::Known(ty) => {
                 let shared = self.resources.is_shared(ty);
                 let heap_type = HeapType::Abstract {
                     shared,
                     ty: AbstractHeapType::Any,
                 };
                 let any_ref = RefType::new(ty.is_nullable(), heap_type).unwrap();
-                MaybeType::Type(any_ref)
+                MaybeType::Known(any_ref)
             }
         };
         self.push_operand(any_ref)
     }
     fn visit_extern_convert_any(&mut self) -> Self::Output {
         let extern_ref = match self.pop_maybe_shared_ref(AbstractHeapType::Any)? {
-            MaybeType::Bot | MaybeType::HeapBot(_) => {
-                MaybeType::HeapBot(Some(AbstractHeapType::Extern))
+            MaybeType::Unknown | MaybeType::PartialRef(_) => {
+                MaybeType::PartialRef(Some(AbstractHeapType::Extern))
             }
-            MaybeType::Type(ty) => {
+            MaybeType::Known(ty) => {
                 let shared = self.resources.is_shared(ty);
                 let heap_type = HeapType::Abstract {
                     shared,
                     ty: AbstractHeapType::Extern,
                 };
                 let extern_ref = RefType::new(ty.is_nullable(), heap_type).unwrap();
-                MaybeType::Type(extern_ref)
+                MaybeType::Known(extern_ref)
             }
         };
         self.push_operand(extern_ref)


### PR DESCRIPTION
This tweaks #1734 to use terms I consider a bit more clear. It also updates the documentation to explain some more of the context that I currently have paged in but may not later.