### PR TITLE
refactor: Remove optional feature attribute from stable feature gates

### DIFF
--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -913,17 +913,9 @@ impl WitPrinter {
     fn print_stability(&mut self, stability: &Stability) {
         match stability {
             Stability::Unknown => {}
-            Stability::Stable {
-                since,
-                feature,
-                deprecated,
-            } => {
+            Stability::Stable { since, deprecated } => {
                 self.output.push_str("@since(version = ");
                 self.output.push_str(&since.to_string());
-                if let Some(feature) = feature {
-                    self.output.push_str(", feature = ");
-                    self.output.push_str(feature);
-                }
                 self.output.push_str(")\n");
                 if let Some(version) = deprecated {
                     self.output.push_str("@deprecated(version = ");

--- a/crates/wit-parser/src/ast.rs
+++ b/crates/wit-parser/src/ast.rs
@@ -1545,19 +1545,9 @@ fn err_expected(
 }
 
 enum Attribute<'a> {
-    Since {
-        span: Span,
-        version: Version,
-        feature: Option<Id<'a>>,
-    },
-    Unstable {
-        span: Span,
-        feature: Id<'a>,
-    },
-    Deprecated {
-        span: Span,
-        version: Version,
-    },
+    Since { span: Span, version: Version },
+    Unstable { span: Span, feature: Id<'a> },
+    Deprecated { span: Span, version: Version },
 }
 
 impl<'a> Attribute<'a> {
@@ -1571,18 +1561,10 @@ impl<'a> Attribute<'a> {
                     eat_id(tokens, "version")?;
                     tokens.expect(Token::Equals)?;
                     let (_span, version) = parse_version(tokens)?;
-                    let feature = if tokens.eat(Token::Comma)? {
-                        eat_id(tokens, "feature")?;
-                        tokens.expect(Token::Equals)?;
-                        Some(parse_id(tokens)?)
-                    } else {
-                        None
-                    };
                     tokens.expect(Token::RightParen)?;
                     Attribute::Since {
                         span: id.span,
                         version,
-                        feature,
                     }
                 }
                 "unstable" => {

--- a/crates/wit-parser/src/ast/resolve.rs
+++ b/crates/wit-parser/src/ast/resolve.rs
@@ -1386,28 +1386,20 @@ impl<'a> Resolver<'a> {
         match attrs {
             [] => Ok(Stability::Unknown),
 
-            [ast::Attribute::Since {
-                version, feature, ..
-            }] => Ok(Stability::Stable {
+            [ast::Attribute::Since { version, .. }] => Ok(Stability::Stable {
                 since: version.clone(),
-                feature: feature.as_ref().map(|s| s.name.to_string()),
                 deprecated: None,
             }),
 
-            [ast::Attribute::Since {
-                version, feature, ..
-            }, ast::Attribute::Deprecated {
+            [ast::Attribute::Since { version, .. }, ast::Attribute::Deprecated {
                 version: deprecated,
                 ..
             }]
             | [ast::Attribute::Deprecated {
                 version: deprecated,
                 ..
-            }, ast::Attribute::Since {
-                version, feature, ..
-            }] => Ok(Stability::Stable {
+            }, ast::Attribute::Since { version, .. }] => Ok(Stability::Stable {
                 since: version.clone(),
-                feature: feature.as_ref().map(|s| s.name.to_string()),
                 deprecated: Some(deprecated.clone()),
             }),
 

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -845,8 +845,6 @@ pub enum Stability {
         #[cfg_attr(feature = "serde", serde(serialize_with = "serialize_version"))]
         #[cfg_attr(feature = "serde", serde(deserialize_with = "deserialize_version"))]
         since: Version,
-        #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none"))]
-        feature: Option<String>,
         #[cfg_attr(
             feature = "serde",
             serde(

--- a/crates/wit-parser/tests/ui/since-and-unstable.wit
+++ b/crates/wit-parser/tests/ui/since-and-unstable.wit
@@ -3,10 +3,10 @@ package a:b@1.0.1;
 @since(version = 1.0.0)
 interface foo1 {}
 
-@since(version = 1.0.0, feature = foo)
+@since(version = 1.0.0)
 interface foo2 {}
 
-@since(version = 1.0.0, feature = foo-bar)
+@since(version = 1.0.0)
 interface foo3 {}
 
 @unstable(feature = foo2)

--- a/crates/wit-parser/tests/ui/since-and-unstable.wit.json
+++ b/crates/wit-parser/tests/ui/since-and-unstable.wit.json
@@ -155,8 +155,7 @@
       "functions": {},
       "stability": {
         "stable": {
-          "since": "1.0.0",
-          "feature": "foo"
+          "since": "1.0.0"
         }
       },
       "package": 0
@@ -167,8 +166,7 @@
       "functions": {},
       "stability": {
         "stable": {
-          "since": "1.0.0",
-          "feature": "foo-bar"
+          "since": "1.0.0"
         }
       },
       "package": 0

--- a/tests/cli/since-on-future-package.wit
+++ b/tests/cli/since-on-future-package.wit
@@ -8,7 +8,7 @@ interface foo {
   @since(version = 0.1.1)
   b: func(s: string) -> string;
 
-  @since(version = 0.1.1, feature = c-please)
+  @since(version = 0.1.1)
   c: func(s: string) -> string;
 }
 


### PR DESCRIPTION
With an eye towards making [the discussion in `component-model`](https://github.com/WebAssembly/component-model/issues/382) a reality, the commits in this PR update the `wasm-tools` to remove

Note that the change to `wit-parser` is a semver breaking change, as we're removing a piece of the `Stability` enum.