### PR TITLE
Don't print custom section data with `--skeleton`

### DIFF
--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -2756,7 +2756,11 @@ impl Printer<'_, '_> {
             write!(self.result, " ({place})")?;
         }
         self.result.write_str(" ")?;
-        self.print_bytes(section.data())?;
+        if self.config.print_skeleton {
+            self.result.write_str("...")?;
+        } else {
+            self.print_bytes(section.data())?;
+        }
         self.end_group()?;
         Ok(())
     }

--- a/tests/cli/print-skeleton.wat
+++ b/tests/cli/print-skeleton.wat
@@ -6,4 +6,5 @@
   (data (i32.const 0) "1234")
   (table 1 funcref)
   (elem (i32.const 0) func $f)
+  (@custom "hello" (after data) "data")
 )

--- a/tests/cli/print-skeleton.wat.stdout
+++ b/tests/cli/print-skeleton.wat.stdout
@@ -5,4 +5,5 @@
   (memory (;0;) 0)
   (elem (;0;) (i32.const 0) ...)
   (data (;0;) (i32.const 0) ...)
+  (@custom "hello" (after data) ...)
 )


### PR DESCRIPTION
Custom sections can be quite large with dwarf debugging information so print only `...` in `--skeleton` mode.