### PR TITLE
threads: ignore sharedness for creation of `TypeInfo`

### DIFF
--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -298,7 +298,6 @@ impl TypeData for SubType {
             CompositeInnerType::Array(_) => 2,
             CompositeInnerType::Struct(ty) => 1 + 2 * ty.fields.len() as u32,
         };
-        // TODO: handle shared?
         TypeInfo::core(size)
     }
 }


### PR DESCRIPTION
`TypeInfo` currently tracks a type's size and whether it borrows anything. I originally had wondered whether it should also track sharedness, but I'm convincing myself this is unnecessary:
- being shared or not shouldn't change the size
- being shared or not doesn't change whether the type borrows

This change removes the TODO.