### PR TITLE
threads: no shared function expansion

### DIFF
--- a/crates/wast/src/component/expand.rs
+++ b/crates/wast/src/component/expand.rs
@@ -455,7 +455,7 @@ impl<'a> Expander<'a> {
         ) {
             match &mut item.kind {
                 core::ItemKind::Func(t) | core::ItemKind::Tag(core::TagType::Exception(t)) => {
-                    // If the index is already filled in then this is skipped
+                    // If the index is already filled in then this is skipped.
                     if t.index.is_some() {
                         return;
                     }
@@ -476,7 +476,11 @@ impl<'a> Expander<'a> {
                         span: item.span,
                         id: Some(id),
                         name: None,
-                        def: key.to_def(item.span),
+                        // Currently, there is no way in the WebAssembly text
+                        //  format to mark a function `shared` inline; a
+                        // `shared` function must use an explicit type index,
+                        // e.g., `(func (type $ft))`.
+                        def: key.to_def(item.span, /* shared = */ false),
                         parent: None,
                         final_type: None,
                     }));

--- a/crates/wast/src/core/resolve/types.rs
+++ b/crates/wast/src/core/resolve/types.rs
@@ -213,7 +213,10 @@ impl<'a> Expander<'a> {
             span,
             id: Some(id),
             name: None,
-            def: key.to_def(span),
+            // Currently, there is no way in the WebAssembly text format to mark
+            //  a function `shared` inline; a `shared` function must use an
+            // explicit type index, e.g., `(func (type $ft))`.
+            def: key.to_def(span, /* shared = */ false),
             parent: None,
             final_type: None,
         }));
@@ -231,7 +234,7 @@ pub(crate) trait TypeReference<'a>: Default {
 
 pub(crate) trait TypeKey<'a> {
     fn lookup(&self, cx: &Expander<'a>) -> Option<Index<'a>>;
-    fn to_def(&self, span: Span) -> TypeDef<'a>;
+    fn to_def(&self, span: Span, shared: bool) -> TypeDef<'a>;
     fn insert(&self, cx: &mut Expander<'a>, id: Index<'a>);
 }
 
@@ -254,13 +257,13 @@ impl<'a> TypeKey<'a> for FuncKey<'a> {
         cx.func_type_to_idx.get(self).cloned()
     }
 
-    fn to_def(&self, _span: Span) -> TypeDef<'a> {
+    fn to_def(&self, _span: Span, shared: bool) -> TypeDef<'a> {
         TypeDef {
             kind: InnerTypeKind::Func(FunctionType {
                 params: self.0.iter().map(|t| (None, None, *t)).collect(),
                 results: self.1.clone(),
             }),
-            shared: false, // TODO: handle shared
+            shared,
         }
     }
 


### PR DESCRIPTION
If I understand `wast`'s `Expander` correctly (which I may not!), there is no need for it to know how to create type definitions for shared functions because there is no way to write WAT that would mark a function shared in an inline way. Since the only way to create a shared function is with an explicit type ID (e.g., `(func (type $ft))`), we can set `shared = false` when a `TypeDef` must be created.