### PR TITLE
Recognize `_initialize` in `wasm-tools component new`

### DIFF
--- a/crates/wasm-encoder/src/component/builder.rs
+++ b/crates/wasm-encoder/src/component/builder.rs
@@ -206,6 +206,20 @@ impl ComponentBuilder {
         })
     }
 
+    /// Creates an alias to a previous core instance's exported item.
+    ///
+    /// The `instance` provided is the instance to access and the `name` is the
+    /// item to access.
+    ///
+    /// Returns the index of the new item defined.
+    pub fn alias_core_export(&mut self, instance: u32, name: &str, kind: ExportKind) -> u32 {
+        self.alias(Alias::CoreInstanceExport {
+            instance,
+            kind,
+            name,
+        })
+    }
+
     fn inc_kind(&mut self, kind: ComponentExportKind) -> u32 {
         match kind {
             ComponentExportKind::Func => inc(&mut self.funcs),

--- a/crates/wit-component/tests/components/initialize/component.wat
+++ b/crates/wit-component/tests/components/initialize/component.wat
@@ -1,0 +1,38 @@
+(component
+  (core module (;0;)
+    (type (;0;) (func))
+    (func (;0;) (type 0)
+      unreachable
+    )
+    (func (;1;) (type 0)
+      unreachable
+    )
+    (export "a" (func 0))
+    (export "_initialize" (func 1))
+    (@producers
+      (processed-by "wit-component" "$CARGO_PKG_VERSION")
+      (processed-by "my-fake-bindgen" "123.45")
+    )
+  )
+  (core instance (;0;) (instantiate 0))
+  (alias core export 0 "_initialize" (core func (;0;)))
+  (core module (;1;)
+    (type (;0;) (func))
+    (import "" "" (func (;0;) (type 0)))
+    (start 0)
+  )
+  (core instance (;1;)
+    (export "" (func 0))
+  )
+  (core instance (;2;) (instantiate 1
+      (with "" (instance 1))
+    )
+  )
+  (type (;0;) (func))
+  (alias core export 0 "a" (core func (;1;)))
+  (func (;0;) (type 0) (canon lift (core func 1)))
+  (export (;1;) "a" (func 0))
+  (@producers
+    (processed-by "wit-component" "$CARGO_PKG_VERSION")
+  )
+)

--- a/crates/wit-component/tests/components/initialize/component.wit.print
+++ b/crates/wit-component/tests/components/initialize/component.wit.print
@@ -1,0 +1,5 @@
+package root:component;
+
+world root {
+  export a: func();
+}

--- a/crates/wit-component/tests/components/initialize/module.wat
+++ b/crates/wit-component/tests/components/initialize/module.wat
@@ -1,0 +1,6 @@
+;; This test ensures that the `_initialize` function is hooked up to execute
+;; when the component is instantiated.
+(module
+  (func (export "a") unreachable)
+  (func (export "_initialize") unreachable)
+)

--- a/crates/wit-component/tests/components/initialize/module.wit
+++ b/crates/wit-component/tests/components/initialize/module.wit
@@ -1,0 +1,5 @@
+package foo:foo;
+
+world module {
+  export a: func();
+}


### PR DESCRIPTION
This commit implements recognition of the `_initialize` function from WASIp1 in the componentization process of `wasm-tools component new`. This additionally corresponds to the same function in the proposed [BuildTargets.md](https://github.com/WebAssembly/component-model/pull/378). This is implemented by having a small core wasm module which is just an import and a `start` section get instantiated at the end of a component to run `_initialize` before all other exports.