### PR TITLE
Expand the suite of invalid tests

### DIFF
--- a/tests/local/code-after-end.wast
+++ b/tests/local/code-after-end.wast
@@ -1,0 +1,34 @@
+(assert_invalid
+  (module
+    (func end))
+  "operators remaining after end of function")
+
+(assert_invalid
+  (module
+    (func end block))
+  "operators remaining after end of function")
+
+(assert_invalid
+  (module
+    (func end i32.add))
+  "operators remaining after end of function")
+
+(assert_invalid
+  (module
+    (func end unreachable))
+  "operators remaining after end of function")
+
+(assert_invalid
+  (module
+    (func end br 0))
+  "operators remaining after end of function")
+
+(assert_invalid
+  (module
+    (func end return))
+  "operators remaining after end of function")
+
+(assert_invalid
+  (module
+    (func end return_call 0))
+  "operators remaining after end of function")

--- a/tests/local/exnref/try-table.wast
+++ b/tests/local/exnref/try-table.wast
@@ -1,0 +1,10 @@
+(assert_invalid
+  (module
+    (func
+      block $l (result anyref)
+        try_table (catch_all_ref $l)
+        end
+      end
+    )
+  )
+  "type mismatch: catch_all_ref label must a subtype of (ref exn)")

--- a/tests/local/gc/invalid.wast
+++ b/tests/local/gc/invalid.wast
@@ -29,3 +29,292 @@
   )
  "type mismatch: expected structref, found anyref"
  )
+
+(assert_invalid
+  (module
+    (type $t (func))
+    (func struct.new $t drop))
+  "expected struct type at index 0, found (func ...)")
+
+(assert_invalid
+  (module
+    (type $t (struct))
+    (func struct.get $t 100))
+  "unknown field: field index out of bounds")
+
+(assert_invalid
+  (module
+    (func struct.get 200 100))
+  "unknown type: type index out of bounds")
+
+(assert_invalid
+  (module
+    (type $t (struct))
+    (func array.new $t drop))
+  "expected array type at index 0, found (struct ...)")
+
+(assert_invalid
+  (module
+    (func array.new 100))
+  "unknown type: type index out of bounds")
+
+(assert_invalid
+  (module
+    (type $t (struct))
+    (func (type $t)))
+  "type index 0 is not a function type")
+
+(assert_invalid
+  (module
+    (type $t (struct))
+    (func block (type $t) end))
+  "expected func type at index 0, found (struct ...)")
+
+(assert_invalid
+  (module
+    (func
+      block $l
+        unreachable
+        br_on_non_null $l
+      end
+    )
+  )
+  "type mismatch: br_on_non_null target has no label types")
+
+(assert_invalid
+  (module
+    (func
+      block $l (result i32)
+        unreachable
+        br_on_non_null $l
+      end
+    )
+  )
+  "type mismatch: br_on_non_null target does not end with heap type")
+
+(assert_invalid
+  (module
+    (type $t (struct (field (ref func))))
+    (func
+      struct.new_default $t
+    )
+  )
+  "invalid `struct.new_default`: (ref func) field is not defaultable")
+
+(assert_invalid
+  (module
+    (type $t (struct (field $f i32)))
+    (func
+      unreachable
+      struct.get_u $t $f
+    )
+  )
+  "cannot use struct.get_u with non-packed storage types")
+
+(assert_invalid
+  (module
+    (type $t (array (ref func)))
+    (func
+      array.new_default $t
+    )
+  )
+  "invalid `array.new_default`: (ref func) field is not defaultable")
+
+(assert_invalid
+  (module
+    (type $t (array (ref func)))
+    (func
+      i32.const 0
+      i32.const 0
+      array.new_data $t $d
+      drop
+    )
+    (data $d "xxx")
+  )
+  "array.new_data can only create arrays with numeric and vector elements")
+
+(assert_invalid
+  (module binary
+    "\00asm" "\01\00\00\00"     ;; module header
+
+    "\01\07"                    ;; type section, 7 bytes
+    "\02"                       ;; 2 types
+    "\5e\7f\00"                 ;; (type (array i32))
+    "\60\00\00"                 ;; (type (func))
+
+    "\03\02"                    ;; func section, 2 bytes
+    "\01"                       ;; 1 func
+    "\01"                       ;; type 1
+
+    "\0a\0d"                    ;; code section, 13 bytes
+    "\01"                       ;; 1 count
+    "\0b"                       ;; 11-byte function
+    "\00"                       ;; no locals
+    "\41\00"                    ;; i32.const 0
+    "\41\00"                    ;; i32.const 0
+    "\fb\09\00\00"              ;; array.new_data 0 0
+    "\1a"                       ;; drop
+    "\0b"                       ;; end
+
+    "\0b\06"                    ;; data section, 6 bytes
+    "\01"                       ;; 1 count
+    "\01"                       ;; passive
+    "\03xxx"                    ;; 3 bytes of data "xxx"
+  )
+  "data count section required")
+
+;; slightly modified version of the above with a data count section
+(module binary
+  "\00asm" "\01\00\00\00"     ;; module header
+
+  "\01\07"                    ;; type section, 7 bytes
+  "\02"                       ;; 2 types
+  "\5e\7f\00"                 ;; (type (array i32))
+  "\60\00\00"                 ;; (type (func))
+
+  "\03\02"                    ;; func section, 2 bytes
+  "\01"                       ;; 1 func
+  "\01"                       ;; type 1
+
+  "\0c\01"                    ;; data count section, 1 byte
+  "\01"                       ;; 1 data
+
+  "\0a\0d"                    ;; code section, 13 bytes
+  "\01"                       ;; 1 count
+  "\0b"                       ;; 11-byte function
+  "\00"                       ;; no locals
+  "\41\00"                    ;; i32.const 0
+  "\41\00"                    ;; i32.const 0
+  "\fb\09\00\00"              ;; array.new_data 0 0
+  "\1a"                       ;; drop
+  "\0b"                       ;; end
+
+  "\0b\06"                    ;; data section, 6 bytes
+  "\01"                       ;; 1 count
+  "\01"                       ;; passive
+  "\03xxx"                    ;; 3 bytes of data "xxx"
+)
+
+(assert_invalid
+  (module
+    (type $t (array i8))
+    (func
+      i32.const 0
+      i32.const 0
+      array.new_data $t 100
+      drop
+    )
+  )
+  "unknown data segment 100")
+
+(assert_invalid
+  (module
+    (type $t (array i8))
+    (func
+      i32.const 0
+      i32.const 0
+      array.new_elem $t $e
+      drop
+    )
+    (elem $e funcref)
+  )
+  "type mismatch: array.new_elem can only create arrays with reference elements")
+
+(assert_invalid
+  (module
+    (type $t (array (ref any)))
+    (func
+      i32.const 0
+      i32.const 0
+      array.new_elem $t $e
+      drop
+    )
+    (elem $e funcref)
+  )
+  "invalid array.new_elem instruction: element segment 0 type mismatch: expected (ref any), found funcref")
+
+(assert_invalid
+  (module
+    (type $t1 (array (mut i8)))
+    (type $t2 (array (mut i16)))
+    (func
+      unreachable
+      array.copy $t1 $t2
+    )
+  )
+  "array types do not match: expected i8, found i16")
+
+(assert_invalid
+  (module
+    (type $t1 (array (mut i16)))
+    (type $t2 (array (mut i8)))
+    (func
+      unreachable
+      array.copy $t1 $t2
+    )
+  )
+  "array types do not match: expected i16, found i8")
+
+(assert_invalid
+  (module
+    (type $t1 (array (mut i32)))
+    (type $t2 (array (mut i64)))
+    (func
+      unreachable
+      array.copy $t1 $t2
+    )
+  )
+  "array types do not match: expected i32, found i64")
+
+(assert_invalid
+  (module
+    (type $t1 (array (mut i32)))
+    (type $t2 (array (mut i8)))
+    (func
+      unreachable
+      array.copy $t1 $t2
+    )
+  )
+  "array types do not match: expected i32, found i8")
+
+(assert_invalid
+  (module
+    (type $t1 (array (mut i8)))
+    (type $t2 (array (mut i32)))
+    (func
+      unreachable
+      array.copy $t1 $t2
+    )
+  )
+  "array types do not match: expected i8, found i32")
+
+(module
+  (type $t1 (array (mut i16)))
+  (type $t2 (array (mut i16)))
+  (func
+    unreachable
+    array.copy $t1 $t2
+  )
+)
+
+(assert_invalid
+  (module
+    (type $t1 (array (mut i8)))
+    (type $t2 (array (mut i32)))
+    (func
+      block
+        unreachable
+        br_on_cast_fail 0 anyref anyref
+      end
+    )
+  )
+  "type mismatch: expected a reference type, found nothing")
+
+(assert_invalid
+  (module
+    (table 1 externref)
+    (func
+      i32.const 0
+      call_indirect
+      ))
+  "indirect calls must go through a table with type <= funcref")

--- a/tests/local/invalid.wast
+++ b/tests/local/invalid.wast
@@ -1,0 +1,10 @@
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (func table.init 0 100))
+  "unknown elem segment")
+
+(assert_invalid
+  (module
+    (func else))
+  "else found outside of an `if` block")

--- a/tests/local/missing-features/gc/shared-any.wast
+++ b/tests/local/missing-features/gc/shared-any.wast
@@ -1,0 +1,8 @@
+(assert_invalid
+  (module
+    (func
+      ref.null (shared any)
+      drop
+    )
+  )
+  "shared reference types require the shared-everything-threads proposal")

--- a/tests/local/shared-everything-threads/arrays.wast
+++ b/tests/local/shared-everything-threads/arrays.wast
@@ -849,3 +849,46 @@
   )
   "invalid type"
 )
+
+(assert_invalid
+  (module
+    (type $s (shared (array f32)))
+    (func
+      unreachable
+      array.atomic.get seq_cst $s
+      drop
+    ))
+  "invalid type: `array.atomic.get` only allows `i32`, `i64` and subtypes of `anyref`"
+)
+
+(assert_invalid
+  (module
+    (type $s (shared (array (ref (shared func)))))
+    (func
+      unreachable
+      array.atomic.get seq_cst $s
+      drop
+    ))
+  "invalid type: `array.atomic.get` only allows `i32`, `i64` and subtypes of `anyref`"
+)
+
+(assert_invalid
+  (module
+    (type $s (shared (array i8)))
+    (func
+      unreachable
+      array.atomic.get seq_cst $s
+      drop
+    ))
+  "cannot use array.get with packed storage types"
+)
+
+(assert_invalid
+  (module
+    (type $s (shared (array (mut (ref (shared extern))))))
+    (func
+      unreachable
+      array.atomic.set seq_cst $s
+    ))
+  "invalid type: `array.atomic.set` only allows `i8`, `i16`, `i32`, `i64` and subtypes of `anyref`"
+)

--- a/tests/local/shared-everything-threads/globals.wast
+++ b/tests/local/shared-everything-threads/globals.wast
@@ -367,3 +367,63 @@
     global.atomic.rmw.cmpxchg acq_rel $b)
 )
 
+(assert_invalid
+  (module
+    (global $g (mut funcref) (ref.null func))
+    (func
+      ref.null func
+      global.atomic.rmw.xor acq_rel $g
+      drop
+    )
+  )
+  "invalid type: `global.atomic.rmw.*` only allows `i32` and `i64`")
+
+(assert_invalid
+  (module
+    (func
+      global.atomic.rmw.xor acq_rel 200
+    )
+  )
+  "global index out of bounds")
+
+(assert_invalid
+  (module
+    (global $g (mut funcref) (ref.null func))
+    (func
+      ref.null func
+      global.atomic.rmw.xchg acq_rel $g
+      drop
+    )
+  )
+  "invalid type: `global.atomic.rmw.xchg` only allows `i32`, `i64` and subtypes of `anyref`")
+
+(module
+  (global $g (mut eqref) (ref.null eq))
+  (func
+    ref.null eq
+    global.atomic.rmw.xchg acq_rel $g
+    drop
+  )
+)
+
+(assert_invalid
+  (module
+    (global $g (mut anyref) (ref.null any))
+    (func
+      ref.null any
+      ref.null any
+      global.atomic.rmw.cmpxchg acq_rel $g
+      drop
+    )
+  )
+  "invalid type: `global.atomic.rmw.cmpxchg` only allows `i32`, `i64` and subtypes of `eqref`")
+
+(module
+  (global $g (mut eqref) (ref.null eq))
+  (func
+    ref.null eq
+    ref.null eq
+    global.atomic.rmw.cmpxchg acq_rel $g
+    drop
+  )
+)

--- a/tests/local/shared-everything-threads/structs.wast
+++ b/tests/local/shared-everything-threads/structs.wast
@@ -527,3 +527,46 @@
   )
   "invalid type"
 )
+
+(assert_invalid
+  (module
+    (type $s (shared (struct (field $f f32))))
+    (func
+      unreachable
+      struct.atomic.get seq_cst $s $f
+      drop
+    ))
+  "invalid type: `struct.atomic.get` only allows `i32`, `i64` and subtypes of `anyref`"
+)
+
+(assert_invalid
+  (module
+    (type $s (shared (struct (field $f (ref (shared func))))))
+    (func
+      unreachable
+      struct.atomic.get seq_cst $s $f
+      drop
+    ))
+  "invalid type: `struct.atomic.get` only allows `i32`, `i64` and subtypes of `anyref`"
+)
+
+(assert_invalid
+  (module
+    (type $s (shared (struct (field $f i8))))
+    (func
+      unreachable
+      struct.atomic.get seq_cst $s $f
+      drop
+    ))
+  "can only use struct `get` with non-packed storage types"
+)
+
+(assert_invalid
+  (module
+    (type $s (shared (struct (field $f (mut (ref (shared extern)))))))
+    (func
+      unreachable
+      struct.atomic.set seq_cst $s $f
+    ))
+  "invalid type: `struct.atomic.set` only allows `i8`, `i16`, `i32`, `i64` and subtypes of `anyref`"
+)

--- a/tests/local/shared-everything-threads/tables.wast
+++ b/tests/local/shared-everything-threads/tables.wast
@@ -172,3 +172,35 @@
       local.get $z
       table.atomic.rmw.cmpxchg seq_cst $a))
   "invalid type")
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (func
+      i32.const 0
+      table.atomic.get seq_cst 0
+    )
+  )
+  "invalid type: `table.atomic.get` only allows subtypes of `anyref`")
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (func
+      i32.const 0
+      ref.null func
+      table.atomic.set seq_cst 0
+    )
+  )
+  "invalid type: `table.atomic.set` only allows subtypes of `anyref`")
+
+(assert_invalid
+  (module
+    (table 1 funcref)
+    (func
+      i32.const 0
+      ref.null func
+      table.atomic.rmw.xchg seq_cst 0
+    )
+  )
+  "invalid type: `table.atomic.rmw.xchg` only allows subtypes of `anyref`")

--- a/tests/snapshots/local/code-after-end.wast.json
+++ b/tests/snapshots/local/code-after-end.wast.json
@@ -1,0 +1,54 @@
+{
+  "source_filename": "tests/local/code-after-end.wast",
+  "commands": [
+    {
+      "type": "assert_invalid",
+      "line": 2,
+      "filename": "code-after-end.0.wasm",
+      "text": "operators remaining after end of function",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 7,
+      "filename": "code-after-end.1.wasm",
+      "text": "operators remaining after end of function",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 12,
+      "filename": "code-after-end.2.wasm",
+      "text": "operators remaining after end of function",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 17,
+      "filename": "code-after-end.3.wasm",
+      "text": "operators remaining after end of function",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 22,
+      "filename": "code-after-end.4.wasm",
+      "text": "operators remaining after end of function",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 27,
+      "filename": "code-after-end.5.wasm",
+      "text": "operators remaining after end of function",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 32,
+      "filename": "code-after-end.6.wasm",
+      "text": "operators remaining after end of function",
+      "module_type": "binary"
+    }
+  ]
+}

--- a/tests/snapshots/local/exnref/try-table.wast.json
+++ b/tests/snapshots/local/exnref/try-table.wast.json
@@ -1,0 +1,12 @@
+{
+  "source_filename": "tests/local/exnref/try-table.wast",
+  "commands": [
+    {
+      "type": "assert_invalid",
+      "line": 2,
+      "filename": "try-table.0.wasm",
+      "text": "type mismatch: catch_all_ref label must a subtype of (ref exn)",
+      "module_type": "binary"
+    }
+  ]
+}

--- a/tests/snapshots/local/gc/invalid.wast.json
+++ b/tests/snapshots/local/gc/invalid.wast.json
@@ -14,6 +14,184 @@
       "filename": "invalid.1.wasm",
       "text": "type mismatch: expected structref, found anyref",
       "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 34,
+      "filename": "invalid.2.wasm",
+      "text": "expected struct type at index 0, found (func ...)",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 40,
+      "filename": "invalid.3.wasm",
+      "text": "unknown field: field index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 46,
+      "filename": "invalid.4.wasm",
+      "text": "unknown type: type index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 51,
+      "filename": "invalid.5.wasm",
+      "text": "expected array type at index 0, found (struct ...)",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 57,
+      "filename": "invalid.6.wasm",
+      "text": "unknown type: type index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 62,
+      "filename": "invalid.7.wasm",
+      "text": "type index 0 is not a function type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 68,
+      "filename": "invalid.8.wasm",
+      "text": "expected func type at index 0, found (struct ...)",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 74,
+      "filename": "invalid.9.wasm",
+      "text": "type mismatch: br_on_non_null target has no label types",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 85,
+      "filename": "invalid.10.wasm",
+      "text": "type mismatch: br_on_non_null target does not end with heap type",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 96,
+      "filename": "invalid.11.wasm",
+      "text": "invalid `struct.new_default`: (ref func) field is not defaultable",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 105,
+      "filename": "invalid.12.wasm",
+      "text": "cannot use struct.get_u with non-packed storage types",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 115,
+      "filename": "invalid.13.wasm",
+      "text": "invalid `array.new_default`: (ref func) field is not defaultable",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 124,
+      "filename": "invalid.14.wasm",
+      "text": "array.new_data can only create arrays with numeric and vector elements",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 137,
+      "filename": "invalid.15.wasm",
+      "text": "data count section required",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 167,
+      "filename": "invalid.16.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 199,
+      "filename": "invalid.17.wasm",
+      "text": "unknown data segment 100",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 211,
+      "filename": "invalid.18.wasm",
+      "text": "type mismatch: array.new_elem can only create arrays with reference elements",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 224,
+      "filename": "invalid.19.wasm",
+      "text": "invalid array.new_elem instruction: element segment 0 type mismatch: expected (ref any), found funcref",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 237,
+      "filename": "invalid.20.wasm",
+      "text": "array types do not match: expected i8, found i16",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 248,
+      "filename": "invalid.21.wasm",
+      "text": "array types do not match: expected i16, found i8",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 259,
+      "filename": "invalid.22.wasm",
+      "text": "array types do not match: expected i32, found i64",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 270,
+      "filename": "invalid.23.wasm",
+      "text": "array types do not match: expected i32, found i8",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 281,
+      "filename": "invalid.24.wasm",
+      "text": "array types do not match: expected i8, found i32",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 291,
+      "filename": "invalid.25.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 301,
+      "filename": "invalid.26.wasm",
+      "text": "type mismatch: expected a reference type, found nothing",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 314,
+      "filename": "invalid.27.wasm",
+      "text": "indirect calls must go through a table with type <= funcref",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/gc/invalid.wast/16.print
+++ b/tests/snapshots/local/gc/invalid.wast/16.print
@@ -1,0 +1,11 @@
+(module
+  (type (;0;) (array i32))
+  (type (;1;) (func))
+  (func (;0;) (type 1)
+    i32.const 0
+    i32.const 0
+    array.new_data 0 0
+    drop
+  )
+  (data (;0;) "xxx")
+)

--- a/tests/snapshots/local/gc/invalid.wast/25.print
+++ b/tests/snapshots/local/gc/invalid.wast/25.print
@@ -1,0 +1,9 @@
+(module
+  (type $t1 (;0;) (array (mut i16)))
+  (type $t2 (;1;) (array (mut i16)))
+  (type (;2;) (func))
+  (func (;0;) (type 2)
+    unreachable
+    array.copy $t1 $t2
+  )
+)

--- a/tests/snapshots/local/invalid.wast.json
+++ b/tests/snapshots/local/invalid.wast.json
@@ -1,0 +1,19 @@
+{
+  "source_filename": "tests/local/invalid.wast",
+  "commands": [
+    {
+      "type": "assert_invalid",
+      "line": 2,
+      "filename": "invalid.0.wasm",
+      "text": "unknown elem segment",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 8,
+      "filename": "invalid.1.wasm",
+      "text": "else found outside of an `if` block",
+      "module_type": "binary"
+    }
+  ]
+}

--- a/tests/snapshots/local/missing-features/gc/shared-any.wast.json
+++ b/tests/snapshots/local/missing-features/gc/shared-any.wast.json
@@ -1,0 +1,12 @@
+{
+  "source_filename": "tests/local/missing-features/gc/shared-any.wast",
+  "commands": [
+    {
+      "type": "assert_invalid",
+      "line": 2,
+      "filename": "shared-any.0.wasm",
+      "text": "shared reference types require the shared-everything-threads proposal",
+      "module_type": "binary"
+    }
+  ]
+}

--- a/tests/snapshots/local/shared-everything-threads/arrays.wast.json
+++ b/tests/snapshots/local/shared-everything-threads/arrays.wast.json
@@ -487,6 +487,34 @@
       "filename": "arrays.86.wasm",
       "text": "invalid type",
       "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 854,
+      "filename": "arrays.87.wasm",
+      "text": "invalid type: `array.atomic.get` only allows `i32`, `i64` and subtypes of `anyref`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 865,
+      "filename": "arrays.88.wasm",
+      "text": "invalid type: `array.atomic.get` only allows `i32`, `i64` and subtypes of `anyref`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 876,
+      "filename": "arrays.89.wasm",
+      "text": "cannot use array.get with packed storage types",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 887,
+      "filename": "arrays.90.wasm",
+      "text": "invalid type: `array.atomic.set` only allows `i8`, `i16`, `i32`, `i64` and subtypes of `anyref`",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/shared-everything-threads/globals.wast.json
+++ b/tests/snapshots/local/shared-everything-threads/globals.wast.json
@@ -167,6 +167,44 @@
       "type": "module",
       "line": 277,
       "filename": "globals.24.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 371,
+      "filename": "globals.25.wasm",
+      "text": "invalid type: `global.atomic.rmw.*` only allows `i32` and `i64`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 382,
+      "filename": "globals.26.wasm",
+      "text": "global index out of bounds",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 390,
+      "filename": "globals.27.wasm",
+      "text": "invalid type: `global.atomic.rmw.xchg` only allows `i32`, `i64` and subtypes of `anyref`",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 400,
+      "filename": "globals.28.wasm"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 410,
+      "filename": "globals.29.wasm",
+      "text": "invalid type: `global.atomic.rmw.cmpxchg` only allows `i32`, `i64` and subtypes of `eqref`",
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 421,
+      "filename": "globals.30.wasm"
     }
   ]
 }

--- a/tests/snapshots/local/shared-everything-threads/globals.wast/28.print
+++ b/tests/snapshots/local/shared-everything-threads/globals.wast/28.print
@@ -1,0 +1,9 @@
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0)
+    ref.null eq
+    global.atomic.rmw.xchg acq_rel $g
+    drop
+  )
+  (global $g (;0;) (mut eqref) ref.null eq)
+)

--- a/tests/snapshots/local/shared-everything-threads/globals.wast/30.print
+++ b/tests/snapshots/local/shared-everything-threads/globals.wast/30.print
@@ -1,0 +1,10 @@
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0)
+    ref.null eq
+    ref.null eq
+    global.atomic.rmw.cmpxchg acq_rel $g
+    drop
+  )
+  (global $g (;0;) (mut eqref) ref.null eq)
+)

--- a/tests/snapshots/local/shared-everything-threads/structs.wast.json
+++ b/tests/snapshots/local/shared-everything-threads/structs.wast.json
@@ -212,6 +212,34 @@
       "filename": "structs.31.wasm",
       "text": "invalid type",
       "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 532,
+      "filename": "structs.32.wasm",
+      "text": "invalid type: `struct.atomic.get` only allows `i32`, `i64` and subtypes of `anyref`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 543,
+      "filename": "structs.33.wasm",
+      "text": "invalid type: `struct.atomic.get` only allows `i32`, `i64` and subtypes of `anyref`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 554,
+      "filename": "structs.34.wasm",
+      "text": "can only use struct `get` with non-packed storage types",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 565,
+      "filename": "structs.35.wasm",
+      "text": "invalid type: `struct.atomic.set` only allows `i8`, `i16`, `i32`, `i64` and subtypes of `anyref`",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/shared-everything-threads/tables.wast.json
+++ b/tests/snapshots/local/shared-everything-threads/tables.wast.json
@@ -62,6 +62,27 @@
       "filename": "tables.9.wasm",
       "text": "invalid type",
       "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 177,
+      "filename": "tables.10.wasm",
+      "text": "invalid type: `table.atomic.get` only allows subtypes of `anyref`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 187,
+      "filename": "tables.11.wasm",
+      "text": "invalid type: `table.atomic.set` only allows subtypes of `anyref`",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 198,
+      "filename": "tables.12.wasm",
+      "text": "invalid type: `table.atomic.rmw.xchg` only allows subtypes of `anyref`",
+      "module_type": "binary"
     }
   ]
 }


### PR DESCRIPTION
This commit goes through some of the coverage information for the operator validator for the roundtrip test suite and fills in gaps of modules which are invalid but were previously not tested anywhere.