### PR TITLE
Generate WITs with the latest `wit-smith`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1786,7 +1786,7 @@ dependencies = [
  "wit-component 0.216.0",
  "wit-encoder",
  "wit-parser 0.216.0",
- "wit-smith 0.216.0",
+ "wit-smith",
 ]
 
 [[package]]
@@ -1825,8 +1825,7 @@ dependencies = [
  "wit-component 0.216.0",
  "wit-parser 0.214.0",
  "wit-parser 0.216.0",
- "wit-smith 0.214.0",
- "wit-smith 0.216.0",
+ "wit-smith",
 ]
 
 [[package]]
@@ -2460,20 +2459,6 @@ dependencies = [
  "log",
  "wasmprinter 0.216.0",
  "wit-parser 0.216.0",
-]
-
-[[package]]
-name = "wit-smith"
-version = "0.214.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cf816019a376a912cafb103677a8d28e3cba86b7671b754281e75f4909e129"
-dependencies = [
- "arbitrary",
- "indexmap 2.4.0",
- "log",
- "semver",
- "wit-component 0.214.0",
- "wit-parser 0.214.0",
 ]
 
 [[package]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -37,10 +37,6 @@ version = '0.214.0'
 package = 'wit-component'
 version = '0.214.0'
 
-[dependencies.wit-smith-old]
-package = 'wit-smith'
-version = '0.214.0'
-
 [lib]
 test = false
 doctest = false

--- a/fuzz/src/wit64.rs
+++ b/fuzz/src/wit64.rs
@@ -6,7 +6,7 @@ use wit_parser as wit_parser_new;
 pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
     let wasm = u.arbitrary().and_then(|config| {
         log::debug!("config: {config:#?}");
-        wit_smith_old::smith(&config, u)
+        wit_smith::smith(&config, u)
     })?;
     write_file("doc.wasm", &wasm);
     let r1 = wit_component_old::decode(&wasm).unwrap();


### PR DESCRIPTION
With the new wit64 fuzzer don't use the old `wit-smith` but instead use the newer version. The old version still generates multi-return functions which are no longer supported by default in WIT. This will eventually cause a problem when the newest wit-smith generates features the "old" version no longer supports, but I figure that's a bridge that can be crossed when we get there.

Closes #1757