### PR TITLE
Fix running tests with `RUST_BACKTRACE=1`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,6 +92,13 @@ jobs:
           # want this to break.
           - os: ubuntu-latest
             rust: nightly-2024-02-12
+          # test that if `RUST_BACKTRACE=1` is set in the environment that all
+          # tests with blessed error messages still pass.
+          - os: ubuntu-latest
+            rust: default
+            env:
+              RUST_BACKTRACE: 1
+    env: ${{ matrix.env || fromJSON('{}') }}
     steps:
     - uses: actions/checkout@v4
       with:

--- a/crates/wit-component/tests/components.rs
+++ b/crates/wit-component/tests/components.rs
@@ -147,7 +147,7 @@ fn run_test(path: &Path) -> Result<()> {
             if !test_case.starts_with("error-") {
                 return Err(err);
             }
-            assert_output(&format!("{err:?}"), &error_path)?;
+            assert_output(&format!("{err:#}"), &error_path)?;
             return Ok(());
         }
     };

--- a/crates/wit-component/tests/components/error-default-export-sig-mismatch/error.txt
+++ b/crates/wit-component/tests/components/error-default-export-sig-mismatch/error.txt
@@ -1,5 +1,1 @@
-failed to decode world from module
-
-Caused by:
-    0: module was not valid
-    1: type mismatch for function `a`: expected `[I32, I32] -> [I32]` but found `[] -> []`
+failed to decode world from module: module was not valid: type mismatch for function `a`: expected `[I32, I32] -> [I32]` but found `[] -> []`

--- a/crates/wit-component/tests/components/error-empty-module-import/error.txt
+++ b/crates/wit-component/tests/components/error-empty-module-import/error.txt
@@ -1,5 +1,1 @@
-failed to decode world from module
-
-Caused by:
-    0: module was not valid
-    1: no top-level imported function `foo` specified
+failed to decode world from module: module was not valid: no top-level imported function `foo` specified

--- a/crates/wit-component/tests/components/error-export-sig-mismatch/error.txt
+++ b/crates/wit-component/tests/components/error-export-sig-mismatch/error.txt
@@ -1,6 +1,1 @@
-failed to decode world from module
-
-Caused by:
-    0: module was not valid
-    1: failed to validate exported interface `foo`
-    2: type mismatch for function `a`: expected `[I32, I32] -> [I32]` but found `[] -> []`
+failed to decode world from module: module was not valid: failed to validate exported interface `foo`: type mismatch for function `a`: expected `[I32, I32] -> [I32]` but found `[] -> []`

--- a/crates/wit-component/tests/components/error-import-resource-rep/error.txt
+++ b/crates/wit-component/tests/components/error-import-resource-rep/error.txt
@@ -1,5 +1,1 @@
-failed to decode world from module
-
-Caused by:
-    0: module was not valid
-    1: no top-level imported function `[resource-rep]a` specified
+failed to decode world from module: module was not valid: no top-level imported function `[resource-rep]a` specified

--- a/crates/wit-component/tests/components/error-import-resource-wrong-signature/error.txt
+++ b/crates/wit-component/tests/components/error-import-resource-wrong-signature/error.txt
@@ -1,5 +1,1 @@
-failed to decode world from module
-
-Caused by:
-    0: module was not valid
-    1: type mismatch for function `[resource-drop]a`: expected `[I32] -> []` but found `[I32] -> [I32]`
+failed to decode world from module: module was not valid: type mismatch for function `[resource-drop]a`: expected `[I32] -> []` but found `[I32] -> [I32]`

--- a/crates/wit-component/tests/components/error-import-sig-mismatch/error.txt
+++ b/crates/wit-component/tests/components/error-import-sig-mismatch/error.txt
@@ -1,6 +1,1 @@
-failed to decode world from module
-
-Caused by:
-    0: module was not valid
-    1: failed to validate import interface `foo`
-    2: type mismatch for function `bar`: expected `[I32, I32] -> []` but found `[] -> []`
+failed to decode world from module: module was not valid: failed to validate import interface `foo`: type mismatch for function `bar`: expected `[I32, I32] -> []` but found `[] -> []`

--- a/crates/wit-component/tests/components/error-invalid-module-import/error.txt
+++ b/crates/wit-component/tests/components/error-invalid-module-import/error.txt
@@ -1,5 +1,1 @@
-failed to decode world from module
-
-Caused by:
-    0: module was not valid
-    1: module is only allowed to import functions
+failed to decode world from module: module was not valid: module is only allowed to import functions

--- a/crates/wit-component/tests/components/error-missing-default-export/error.txt
+++ b/crates/wit-component/tests/components/error-missing-default-export/error.txt
@@ -1,5 +1,1 @@
-failed to decode world from module
-
-Caused by:
-    0: module was not valid
-    1: module does not export required function `a`
+failed to decode world from module: module was not valid: module does not export required function `a`

--- a/crates/wit-component/tests/components/error-missing-export/error.txt
+++ b/crates/wit-component/tests/components/error-missing-export/error.txt
@@ -1,6 +1,1 @@
-failed to decode world from module
-
-Caused by:
-    0: module was not valid
-    1: failed to validate exported interface `foo`
-    2: module does not export required function `foo#a`
+failed to decode world from module: module was not valid: failed to validate exported interface `foo`: module does not export required function `foo#a`

--- a/crates/wit-component/tests/components/error-missing-import-func/error.txt
+++ b/crates/wit-component/tests/components/error-missing-import-func/error.txt
@@ -1,5 +1,1 @@
-failed to decode world from module
-
-Caused by:
-    0: module was not valid
-    1: module requires an import interface named `foo`
+failed to decode world from module: module was not valid: module requires an import interface named `foo`

--- a/crates/wit-component/tests/components/error-missing-import/error.txt
+++ b/crates/wit-component/tests/components/error-missing-import/error.txt
@@ -1,5 +1,1 @@
-failed to decode world from module
-
-Caused by:
-    0: module was not valid
-    1: module requires an import interface named `foo`
+failed to decode world from module: module was not valid: module requires an import interface named `foo`

--- a/crates/wit-component/tests/components/error-missing-module-metadata/error.txt
+++ b/crates/wit-component/tests/components/error-missing-module-metadata/error.txt
@@ -1,4 +1,1 @@
-failed to register indirect shims for main module
-
-Caused by:
-    missing component metadata for import of `new::log`
+failed to register indirect shims for main module: missing component metadata for import of `new::log`

--- a/crates/wit-component/tests/merge.rs
+++ b/crates/wit-component/tests/merge.rs
@@ -52,7 +52,7 @@ fn merging() -> Result<()> {
             }
             Err(e) => {
                 assert!(test_case.starts_with("bad-"), "failed to merge with {e:?}");
-                assert_output(&path.join("error.txt"), &format!("{e:?}"))?;
+                assert_output(&path.join("error.txt"), &format!("{e:#}"))?;
             }
         }
     }

--- a/crates/wit-component/tests/merge/bad-interface1/error.txt
+++ b/crates/wit-component/tests/merge/bad-interface1/error.txt
@@ -1,5 +1,1 @@
-failed to merge package `foo:foo` into existing copy
-
-Caused by:
-    0: failed to merge interface `a`
-    1: expected type `a` to be present
+failed to merge package `foo:foo` into existing copy: failed to merge interface `a`: expected type `a` to be present

--- a/crates/wit-component/tests/merge/bad-interface2/error.txt
+++ b/crates/wit-component/tests/merge/bad-interface2/error.txt
@@ -1,5 +1,1 @@
-failed to merge package `foo:foo` into existing copy
-
-Caused by:
-    0: failed to merge interface `a`
-    1: expected function `a` to be present
+failed to merge package `foo:foo` into existing copy: failed to merge interface `a`: expected function `a` to be present

--- a/crates/wit-component/tests/merge/bad-world1/error.txt
+++ b/crates/wit-component/tests/merge/bad-world1/error.txt
@@ -1,5 +1,1 @@
-failed to merge package `foo:foo` into existing copy
-
-Caused by:
-    0: failed to merge world `foo`
-    1: import `b` not found in target world
+failed to merge package `foo:foo` into existing copy: failed to merge world `foo`: import `b` not found in target world

--- a/crates/wit-component/tests/merge/bad-world2/error.txt
+++ b/crates/wit-component/tests/merge/bad-world2/error.txt
@@ -1,5 +1,1 @@
-failed to merge package `foo:foo` into existing copy
-
-Caused by:
-    0: failed to merge world `foo`
-    1: world contains different number of imports than expected
+failed to merge package `foo:foo` into existing copy: failed to merge world `foo`: world contains different number of imports than expected

--- a/crates/wit-component/tests/merge/bad-world3/error.txt
+++ b/crates/wit-component/tests/merge/bad-world3/error.txt
@@ -1,5 +1,1 @@
-failed to merge package `foo:foo` into existing copy
-
-Caused by:
-    0: failed to merge world `foo`
-    1: world contains different number of exports than expected
+failed to merge package `foo:foo` into existing copy: failed to merge world `foo`: world contains different number of exports than expected

--- a/crates/wit-component/tests/merge/bad-world4/error.txt
+++ b/crates/wit-component/tests/merge/bad-world4/error.txt
@@ -1,5 +1,1 @@
-failed to merge package `foo:foo` into existing copy
-
-Caused by:
-    0: failed to merge world `foo`
-    1: export `b` not found in target world
+failed to merge package `foo:foo` into existing copy: failed to merge world `foo`: export `b` not found in target world

--- a/crates/wit-component/tests/merge/bad-world5/error.txt
+++ b/crates/wit-component/tests/merge/bad-world5/error.txt
@@ -1,5 +1,1 @@
-failed to merge package `foo:foo` into existing copy
-
-Caused by:
-    0: failed to merge world `foo`
-    1: import `a` not found in target world
+failed to merge package `foo:foo` into existing copy: failed to merge world `foo`: import `a` not found in target world

--- a/crates/wit-component/tests/targets.rs
+++ b/crates/wit-component/tests/targets.rs
@@ -50,7 +50,7 @@ fn targets() -> Result<()> {
             }
             Err(e) => {
                 assert!(test_case.starts_with("error-"), "{e:?}");
-                assert_output(&path.join("error.txt"), &format!("{e:?}"))?;
+                assert_output(&path.join("error.txt"), &format!("{e:#}"))?;
             }
         }
     }

--- a/crates/wit-component/tests/targets/error-missing-export/error.txt
+++ b/crates/wit-component/tests/targets/error-missing-export/error.txt
@@ -1,5 +1,2 @@
-failed to validate encoded bytes
-
-Caused by:
-    type mismatch for import `foobar`
-    missing export named `test:foo/bar` (at offset 0x1d5)
+failed to validate encoded bytes: type mismatch for import `foobar`
+missing export named `test:foo/bar` (at offset 0x1d5)

--- a/crates/wit-component/tests/targets/error-missing-import/error.txt
+++ b/crates/wit-component/tests/targets/error-missing-import/error.txt
@@ -1,5 +1,2 @@
-failed to validate encoded bytes
-
-Caused by:
-    type mismatch for import `foobar`
-    missing import named `test:foo/foo` (at offset 0x175)
+failed to validate encoded bytes: type mismatch for import `foobar`
+missing import named `test:foo/foo` (at offset 0x175)

--- a/crates/wit-parser/tests/all.rs
+++ b/crates/wit-parser/tests/all.rs
@@ -87,7 +87,7 @@ impl Runner {
                             "some generic platform-agnostic error message",
                         );
                     }
-                    format!("{:?}", e)
+                    format!("{:#}", e)
                 }
             }
         } else {

--- a/crates/wit-parser/tests/ui/parse-fail/bad-gate3.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-gate3.wit.result
@@ -1,8 +1,5 @@
-this type is not gated by a feature but its interface is gated by a feature
-
-Caused by:
-    found a reference to a interface which is excluded due to its feature not being activated
-         --> tests/ui/parse-fail/bad-gate3.wit:5:8
-          |
-        5 |   type a = u32;
-          |        ^
+this type is not gated by a feature but its interface is gated by a feature: found a reference to a interface which is excluded due to its feature not being activated
+     --> tests/ui/parse-fail/bad-gate3.wit:5:8
+      |
+    5 |   type a = u32;
+      |        ^

--- a/crates/wit-parser/tests/ui/parse-fail/bad-gate4.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-gate4.wit.result
@@ -1,8 +1,5 @@
-failed to update function `[constructor]a`
-
-Caused by:
-    found a reference to a type which is excluded due to its feature not being activated
-         --> tests/ui/parse-fail/bad-gate4.wit:6:5
-          |
-        6 |     constructor();
-          |     ^----------
+failed to update function `[constructor]a`: found a reference to a type which is excluded due to its feature not being activated
+     --> tests/ui/parse-fail/bad-gate4.wit:6:5
+      |
+    6 |     constructor();
+      |     ^----------

--- a/crates/wit-parser/tests/ui/parse-fail/bad-gate5.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-gate5.wit.result
@@ -1,8 +1,5 @@
-failed to update function `[static]a.x`
-
-Caused by:
-    found a reference to a type which is excluded due to its feature not being activated
-         --> tests/ui/parse-fail/bad-gate5.wit:9:5
-          |
-        9 |     x: static func();
-          |     ^
+failed to update function `[static]a.x`: found a reference to a type which is excluded due to its feature not being activated
+     --> tests/ui/parse-fail/bad-gate5.wit:9:5
+      |
+    9 |     x: static func();
+      |     ^

--- a/crates/wit-parser/tests/ui/parse-fail/bad-pkg1.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-pkg1.wit.result
@@ -1,9 +1,5 @@
-failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/bad-pkg1]
-
-Caused by:
-    0: failed to parse package: tests/ui/parse-fail/bad-pkg1
-    1: interface or world `nonexistent` not found in package
-            --> tests/ui/parse-fail/bad-pkg1/root.wit:4:7
-             |
-           4 |   use nonexistent.{};
-             |       ^----------
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/bad-pkg1]: failed to parse package: tests/ui/parse-fail/bad-pkg1: interface or world `nonexistent` not found in package
+     --> tests/ui/parse-fail/bad-pkg1/root.wit:4:7
+      |
+    4 |   use nonexistent.{};
+      |       ^----------

--- a/crates/wit-parser/tests/ui/parse-fail/bad-pkg2.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-pkg2.wit.result
@@ -1,8 +1,5 @@
-failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/bad-pkg2]
-
-Caused by:
-    interface not found in package
-         --> tests/ui/parse-fail/bad-pkg2/root.wit:4:15
-          |
-        4 |   use foo:bar/nonexistent.{};
-          |               ^----------
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/bad-pkg2]: interface not found in package
+     --> tests/ui/parse-fail/bad-pkg2/root.wit:4:15
+      |
+    4 |   use foo:bar/nonexistent.{};
+      |               ^----------

--- a/crates/wit-parser/tests/ui/parse-fail/bad-pkg3.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-pkg3.wit.result
@@ -1,8 +1,5 @@
-failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/bad-pkg3]
-
-Caused by:
-    interface not found in package
-         --> tests/ui/parse-fail/bad-pkg3/root.wit:4:15
-          |
-        4 |   use foo:bar/baz.{};
-          |               ^--
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/bad-pkg3]: interface not found in package
+     --> tests/ui/parse-fail/bad-pkg3/root.wit:4:15
+      |
+    4 |   use foo:bar/baz.{};
+      |               ^--

--- a/crates/wit-parser/tests/ui/parse-fail/bad-pkg4.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-pkg4.wit.result
@@ -1,8 +1,5 @@
-failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/bad-pkg4]
-
-Caused by:
-    type `a-name` not defined in interface
-         --> tests/ui/parse-fail/bad-pkg4/root.wit:3:20
-          |
-        3 |   use foo:bar/baz.{a-name};
-          |                    ^-----
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/bad-pkg4]: type `a-name` not defined in interface
+     --> tests/ui/parse-fail/bad-pkg4/root.wit:3:20
+      |
+    3 |   use foo:bar/baz.{a-name};
+      |                    ^-----

--- a/crates/wit-parser/tests/ui/parse-fail/bad-pkg5.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-pkg5.wit.result
@@ -1,8 +1,5 @@
-failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/bad-pkg5]
-
-Caused by:
-    type `nonexistent` not defined in interface
-         --> tests/ui/parse-fail/bad-pkg5/root.wit:3:20
-          |
-        3 |   use foo:bar/baz.{nonexistent};
-          |                    ^----------
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/bad-pkg5]: type `nonexistent` not defined in interface
+     --> tests/ui/parse-fail/bad-pkg5/root.wit:3:20
+      |
+    3 |   use foo:bar/baz.{nonexistent};
+      |                    ^----------

--- a/crates/wit-parser/tests/ui/parse-fail/bad-pkg6.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-pkg6.wit.result
@@ -1,8 +1,5 @@
-failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/bad-pkg6]
-
-Caused by:
-    package not found
-         --> tests/ui/parse-fail/bad-pkg6/root.wit:3:7
-          |
-        3 |   use foo:bar/baz.{};
-          |       ^------
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/bad-pkg6]: package not found
+     --> tests/ui/parse-fail/bad-pkg6/root.wit:3:7
+      |
+    3 |   use foo:bar/baz.{};
+      |       ^------

--- a/crates/wit-parser/tests/ui/parse-fail/bad-resource15.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-resource15.wit.result
@@ -1,8 +1,5 @@
-failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/bad-resource15]
-
-Caused by:
-    type used in a handle must be a resource
-         --> tests/ui/parse-fail/bad-resource15/foo.wit:6:16
-          |
-        6 |   type t = own<r>;
-          |                ^
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/bad-resource15]: type used in a handle must be a resource
+     --> tests/ui/parse-fail/bad-resource15/foo.wit:6:16
+      |
+    6 |   type t = own<r>;
+      |                ^

--- a/crates/wit-parser/tests/ui/parse-fail/conflicting-package.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/conflicting-package.wit.result
@@ -1,10 +1,5 @@
-failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/conflicting-package]
-
-Caused by:
-    0: failed to parse package: tests/ui/parse-fail/conflicting-package
-    1: failed to start resolving path: tests/ui/parse-fail/conflicting-package/b.wit
-    2: package identifier `foo:b` does not match previous package name of `foo:a`
-            --> tests/ui/parse-fail/conflicting-package/b.wit:1:9
-             |
-           1 | package foo:b;
-             |         ^----
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/conflicting-package]: failed to parse package: tests/ui/parse-fail/conflicting-package: failed to start resolving path: tests/ui/parse-fail/conflicting-package/b.wit: package identifier `foo:b` does not match previous package name of `foo:a`
+     --> tests/ui/parse-fail/conflicting-package/b.wit:1:9
+      |
+    1 | package foo:b;
+      |         ^----

--- a/crates/wit-parser/tests/ui/parse-fail/duplicate-interface2.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/duplicate-interface2.wit.result
@@ -1,9 +1,5 @@
-failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/duplicate-interface2]
-
-Caused by:
-    0: failed to parse package: tests/ui/parse-fail/duplicate-interface2
-    1: duplicate item named `foo`
-            --> tests/ui/parse-fail/duplicate-interface2/foo2.wit:3:11
-             |
-           3 | interface foo {}
-             |           ^--
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/duplicate-interface2]: failed to parse package: tests/ui/parse-fail/duplicate-interface2: duplicate item named `foo`
+     --> tests/ui/parse-fail/duplicate-interface2/foo2.wit:3:11
+      |
+    3 | interface foo {}
+      |           ^--

--- a/crates/wit-parser/tests/ui/parse-fail/include-foreign.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/include-foreign.wit.result
@@ -1,8 +1,5 @@
-failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/include-foreign]
-
-Caused by:
-    world not found in package
-         --> tests/ui/parse-fail/include-foreign/root.wit:4:19
-          |
-        4 |   include foo:bar/bar;
-          |                   ^--
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/include-foreign]: world not found in package
+     --> tests/ui/parse-fail/include-foreign/root.wit:4:19
+      |
+    4 |   include foo:bar/bar;
+      |                   ^--

--- a/crates/wit-parser/tests/ui/parse-fail/multi-file-missing-delimiter.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/multi-file-missing-delimiter.wit.result
@@ -1,9 +1,5 @@
-failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/multi-file-missing-delimiter]
-
-Caused by:
-    0: failed to parse package: tests/ui/parse-fail/multi-file-missing-delimiter
-    1: expected `type`, `resource` or `func`, found eof
-            --> tests/ui/parse-fail/multi-file-missing-delimiter/observe.wit:6:1
-             |
-           6 | 
-             | ^
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/multi-file-missing-delimiter]: failed to parse package: tests/ui/parse-fail/multi-file-missing-delimiter: expected `type`, `resource` or `func`, found eof
+     --> tests/ui/parse-fail/multi-file-missing-delimiter/observe.wit:6:1
+      |
+    6 | 
+      | ^

--- a/crates/wit-parser/tests/ui/parse-fail/multi-package-deps-share-nest.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/multi-package-deps-share-nest.wit.result
@@ -1,6 +1,3 @@
-failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/multi-package-deps-share-nest]
-
-Caused by:
-    package foo:shared is defined in two different locations:
-    * tests/ui/parse-fail/multi-package-deps-share-nest/deps/dep2/types.wit:3:9
-    * tests/ui/parse-fail/multi-package-deps-share-nest/deps/dep1/types.wit:3:9
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/multi-package-deps-share-nest]: package foo:shared is defined in two different locations:
+* tests/ui/parse-fail/multi-package-deps-share-nest/deps/dep2/types.wit:3:9
+* tests/ui/parse-fail/multi-package-deps-share-nest/deps/dep1/types.wit:3:9

--- a/crates/wit-parser/tests/ui/parse-fail/multiple-package-docs.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/multiple-package-docs.wit.result
@@ -1,10 +1,5 @@
-failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/multiple-package-docs]
-
-Caused by:
-    0: failed to parse package: tests/ui/parse-fail/multiple-package-docs
-    1: failed to start resolving path: tests/ui/parse-fail/multiple-package-docs/b.wit
-    2: found doc comments on multiple 'package' items
-            --> tests/ui/parse-fail/multiple-package-docs/b.wit:1:1
-             |
-           1 | /// Multiple package docs, B
-             | ^---------------------------
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/multiple-package-docs]: failed to parse package: tests/ui/parse-fail/multiple-package-docs: failed to start resolving path: tests/ui/parse-fail/multiple-package-docs/b.wit: found doc comments on multiple 'package' items
+     --> tests/ui/parse-fail/multiple-package-docs/b.wit:1:1
+      |
+    1 | /// Multiple package docs, B
+      | ^---------------------------

--- a/crates/wit-parser/tests/ui/parse-fail/no-access-to-sibling-use.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/no-access-to-sibling-use.wit.result
@@ -1,9 +1,5 @@
-failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/no-access-to-sibling-use]
-
-Caused by:
-    0: failed to parse package: tests/ui/parse-fail/no-access-to-sibling-use
-    1: interface or world `bar-renamed` does not exist
-            --> tests/ui/parse-fail/no-access-to-sibling-use/foo.wit:3:5
-             |
-           3 | use bar-renamed;
-             |     ^----------
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/no-access-to-sibling-use]: failed to parse package: tests/ui/parse-fail/no-access-to-sibling-use: interface or world `bar-renamed` does not exist
+     --> tests/ui/parse-fail/no-access-to-sibling-use/foo.wit:3:5
+      |
+    3 | use bar-renamed;
+      |     ^----------

--- a/crates/wit-parser/tests/ui/parse-fail/non-existance-world-include.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/non-existance-world-include.wit.result
@@ -1,8 +1,5 @@
-failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/non-existance-world-include]
-
-Caused by:
-    world not found in package
-         --> tests/ui/parse-fail/non-existance-world-include/root.wit:4:19
-          |
-        4 |   include foo:baz/non-existance;
-          |                   ^------------
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/non-existance-world-include]: world not found in package
+     --> tests/ui/parse-fail/non-existance-world-include/root.wit:4:19
+      |
+    4 |   include foo:baz/non-existance;
+      |                   ^------------

--- a/crates/wit-parser/tests/ui/parse-fail/pkg-cycle.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/pkg-cycle.wit.result
@@ -1,8 +1,5 @@
-failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/pkg-cycle]
-
-Caused by:
-    package depends on itself
-         --> tests/ui/parse-fail/pkg-cycle/deps/a1/root.wit:3:7
-          |
-        3 |   use foo:a1/foo.{};
-          |       ^-----
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/pkg-cycle]: package depends on itself
+     --> tests/ui/parse-fail/pkg-cycle/deps/a1/root.wit:3:7
+      |
+    3 |   use foo:a1/foo.{};
+      |       ^-----

--- a/crates/wit-parser/tests/ui/parse-fail/pkg-cycle2.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/pkg-cycle2.wit.result
@@ -1,8 +1,5 @@
-failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/pkg-cycle2]
-
-Caused by:
-    package depends on itself
-         --> tests/ui/parse-fail/pkg-cycle2/deps/a1/root.wit:3:7
-          |
-        3 |   use foo:a2/foo.{};
-          |       ^-----
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/pkg-cycle2]: package depends on itself
+     --> tests/ui/parse-fail/pkg-cycle2/deps/a1/root.wit:3:7
+      |
+    3 |   use foo:a2/foo.{};
+      |       ^-----

--- a/crates/wit-parser/tests/ui/parse-fail/resources-multiple-returns-borrow.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/resources-multiple-returns-borrow.wit.result
@@ -1,8 +1,5 @@
-failed to update function `[method]r1.f1`
-
-Caused by:
-    function returns a type which contains a `borrow<T>` which is not supported
-         --> tests/ui/parse-fail/resources-multiple-returns-borrow.wit:7:5
-          |
-        7 |     f1: func() -> (a: s32, handle: borrow<r1>);
-          |     ^-
+failed to update function `[method]r1.f1`: function returns a type which contains a `borrow<T>` which is not supported
+     --> tests/ui/parse-fail/resources-multiple-returns-borrow.wit:7:5
+      |
+    7 |     f1: func() -> (a: s32, handle: borrow<r1>);
+      |     ^-

--- a/crates/wit-parser/tests/ui/parse-fail/resources-return-borrow.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/resources-return-borrow.wit.result
@@ -1,8 +1,5 @@
-failed to update function `[method]r1.f1`
-
-Caused by:
-    function returns a type which contains a `borrow<T>` which is not supported
-         --> tests/ui/parse-fail/resources-return-borrow.wit:7:5
-          |
-        7 |     f1: func() -> borrow<r1>;
-          |     ^-
+failed to update function `[method]r1.f1`: function returns a type which contains a `borrow<T>` which is not supported
+     --> tests/ui/parse-fail/resources-return-borrow.wit:7:5
+      |
+    7 |     f1: func() -> borrow<r1>;
+      |     ^-

--- a/crates/wit-parser/tests/ui/parse-fail/return-borrow1.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/return-borrow1.wit.result
@@ -1,8 +1,5 @@
-failed to update function `x`
-
-Caused by:
-    function returns a type which contains a `borrow<T>` which is not supported
-         --> tests/ui/parse-fail/return-borrow1.wit:6:3
-          |
-        6 |   x: func() -> borrow<y>;
-          |   ^
+failed to update function `x`: function returns a type which contains a `borrow<T>` which is not supported
+     --> tests/ui/parse-fail/return-borrow1.wit:6:3
+      |
+    6 |   x: func() -> borrow<y>;
+      |   ^

--- a/crates/wit-parser/tests/ui/parse-fail/return-borrow2.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/return-borrow2.wit.result
@@ -1,8 +1,5 @@
-failed to update function `[method]y.x`
-
-Caused by:
-    function returns a type which contains a `borrow<T>` which is not supported
-         --> tests/ui/parse-fail/return-borrow2.wit:5:5
-          |
-        5 |     x: func() -> borrow<y>;
-          |     ^
+failed to update function `[method]y.x`: function returns a type which contains a `borrow<T>` which is not supported
+     --> tests/ui/parse-fail/return-borrow2.wit:5:5
+      |
+    5 |     x: func() -> borrow<y>;
+      |     ^

--- a/crates/wit-parser/tests/ui/parse-fail/return-borrow6.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/return-borrow6.wit.result
@@ -1,8 +1,5 @@
-failed to update function `x`
-
-Caused by:
-    function returns a type which contains a `borrow<T>` which is not supported
-         --> tests/ui/parse-fail/return-borrow6.wit:6:3
-          |
-        6 |   x: func() -> tuple<borrow<y>>;
-          |   ^
+failed to update function `x`: function returns a type which contains a `borrow<T>` which is not supported
+     --> tests/ui/parse-fail/return-borrow6.wit:6:3
+      |
+    6 |   x: func() -> tuple<borrow<y>>;
+      |   ^

--- a/crates/wit-parser/tests/ui/parse-fail/return-borrow7.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/return-borrow7.wit.result
@@ -1,8 +1,5 @@
-failed to update function `x`
-
-Caused by:
-    function returns a type which contains a `borrow<T>` which is not supported
-         --> tests/ui/parse-fail/return-borrow7.wit:10:3
-          |
-       10 |   x: func() -> y2;
-          |   ^
+failed to update function `x`: function returns a type which contains a `borrow<T>` which is not supported
+     --> tests/ui/parse-fail/return-borrow7.wit:10:3
+      |
+   10 |   x: func() -> y2;
+      |   ^

--- a/crates/wit-parser/tests/ui/parse-fail/return-borrow8.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/return-borrow8.wit.result
@@ -1,9 +1,5 @@
-failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/return-borrow8]
-
-Caused by:
-    0: failed to update function `x`
-    1: function returns a type which contains a `borrow<T>` which is not supported
-            --> tests/ui/parse-fail/return-borrow8/foo.wit:6:3
-             |
-           6 |   x: func() -> r;
-             |   ^
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/return-borrow8]: failed to update function `x`: function returns a type which contains a `borrow<T>` which is not supported
+     --> tests/ui/parse-fail/return-borrow8/foo.wit:6:3
+      |
+    6 |   x: func() -> r;
+      |   ^

--- a/crates/wit-parser/tests/ui/parse-fail/type-and-resource-same-name.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/type-and-resource-same-name.wit.result
@@ -1,8 +1,5 @@
-failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/type-and-resource-same-name]
-
-Caused by:
-    type used in a handle must be a resource
-         --> tests/ui/parse-fail/type-and-resource-same-name/foo.wit:7:20
-          |
-        7 |   type t2 = borrow<a>;
-          |                    ^
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/type-and-resource-same-name]: type used in a handle must be a resource
+     --> tests/ui/parse-fail/type-and-resource-same-name/foo.wit:7:20
+      |
+    7 |   type t2 = borrow<a>;
+      |                    ^

--- a/crates/wit-parser/tests/ui/parse-fail/unresolved-use10.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/unresolved-use10.wit.result
@@ -1,9 +1,5 @@
-failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/unresolved-use10]
-
-Caused by:
-    0: failed to parse package: tests/ui/parse-fail/unresolved-use10
-    1: name `thing` is not defined
-            --> tests/ui/parse-fail/unresolved-use10/bar.wit:4:12
-             |
-           4 |   use foo.{thing};
-             |            ^----
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/unresolved-use10]: failed to parse package: tests/ui/parse-fail/unresolved-use10: name `thing` is not defined
+     --> tests/ui/parse-fail/unresolved-use10/bar.wit:4:12
+      |
+    4 |   use foo.{thing};
+      |            ^----

--- a/crates/wit-parser/tests/ui/parse-fail/use-and-include-world.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/use-and-include-world.wit.result
@@ -1,9 +1,5 @@
-failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/use-and-include-world]
-
-Caused by:
-    0: failed to parse package: tests/ui/parse-fail/use-and-include-world
-    1: name `bar` is defined as an interface, not a world
-            --> tests/ui/parse-fail/use-and-include-world/root.wit:6:21
-             |
-           6 |     include foo:baz/bar;
-             |                     ^--
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/use-and-include-world]: failed to parse package: tests/ui/parse-fail/use-and-include-world: name `bar` is defined as an interface, not a world
+     --> tests/ui/parse-fail/use-and-include-world/root.wit:6:21
+      |
+    6 |     include foo:baz/bar;
+      |                     ^--

--- a/crates/wit-parser/tests/ui/parse-fail/use-world.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/use-world.wit.result
@@ -1,8 +1,5 @@
-failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/use-world]
-
-Caused by:
-    interface not found in package
-         --> tests/ui/parse-fail/use-world/root.wit:3:13
-          |
-        3 | use foo:baz/bar;
-          |             ^--
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/use-world]: interface not found in package
+     --> tests/ui/parse-fail/use-world/root.wit:3:13
+      |
+    3 | use foo:baz/bar;
+      |             ^--

--- a/crates/wit-parser/tests/ui/parse-fail/very-nested-packages.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/very-nested-packages.wit.result
@@ -1,8 +1,5 @@
-failed to handle nested package in: tests/ui/parse-fail/very-nested-packages.wit
-
-Caused by:
-    nested packages must be placed at the top-level
-         --> tests/ui/parse-fail/very-nested-packages.wit:4:11
-          |
-        4 |   package a:c2 {
-          |           ^---
+failed to handle nested package in: tests/ui/parse-fail/very-nested-packages.wit: nested packages must be placed at the top-level
+     --> tests/ui/parse-fail/very-nested-packages.wit:4:11
+      |
+    4 |   package a:c2 {
+      |           ^---


### PR DESCRIPTION
The previous version of test output used the `:?` formatter for `anyhow::Error` which would include the native backtrace when `RUST_BACKTRACE=1` is set. This commit updates formatters to use `:#` which is a bit less readable but doesn't include the backtrace when this env var is set. Additionally a test is added to CI to ensure this doesn't regress in the future.

This is adapted from #1578.

Closes #1578