### PR TITLE
Tweak printing page sizes in text format

### DIFF
--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -1159,7 +1159,11 @@ impl Printer<'_, '_> {
             let p = 1_u64
                 .checked_shl(p)
                 .ok_or_else(|| anyhow!("left shift overflow").context("invalid page size"))?;
-            write!(self.result, "(pagesize {p:#x})")?;
+
+            self.result.write_str(" ")?;
+            self.start_group("pagesize ")?;
+            write!(self.result, "{p:#x}")?;
+            self.end_group()?;
         }
         Ok(())
     }

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/0.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/0.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1(pagesize 0x1))
+  (memory (;0;) 1 (pagesize 0x1))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/1.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/1.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1(pagesize 0x10000))
+  (memory (;0;) 1 (pagesize 0x10000))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/19.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/19.print
@@ -4,6 +4,6 @@
     local.get 0
     memory.grow
   )
-  (memory (;0;) 0(pagesize 0x10000))
+  (memory (;0;) 0 (pagesize 0x10000))
   (export "grow" (func 0))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/2.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/2.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1 2(pagesize 0x1))
+  (memory (;0;) 1 2 (pagesize 0x1))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/23.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/23.print
@@ -21,8 +21,8 @@
     local.get 0
     i32.load8_u
   )
-  (memory $small (;0;) 10(pagesize 0x1))
-  (memory $large (;1;) 1(pagesize 0x10000))
+  (memory $small (;0;) 10 (pagesize 0x1))
+  (memory $large (;1;) 1 (pagesize 0x10000))
   (export "copy-small-to-large" (func 0))
   (export "copy-large-to-small" (func 1))
   (export "load8-small" (func 2))

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/3.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/3.print
@@ -1,3 +1,3 @@
 (module
-  (memory (;0;) 1 2(pagesize 0x10000))
+  (memory (;0;) 1 2 (pagesize 0x10000))
 )

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/4.print
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast/4.print
@@ -18,7 +18,7 @@
     local.get 1
     i32.store
   )
-  (memory (;0;) 0(pagesize 0x1))
+  (memory (;0;) 0 (pagesize 0x1))
   (export "size" (func 0))
   (export "grow" (func 1))
   (export "load" (func 2))


### PR DESCRIPTION
Put a space before `(pagesize ...)` and additionally use `start_group`/`end_group` so it gets colors automatically applied.