### PR TITLE
Fix wasm-smith's page_size calculation

### DIFF
--- a/crates/wasm-smith/src/lib.rs
+++ b/crates/wasm-smith/src/lib.rs
@@ -69,8 +69,8 @@ use wasm_encoder::MemoryType;
 pub use config::InternalOptionalConfig;
 
 pub(crate) fn page_size(mem: &MemoryType) -> u32 {
-    const DEFAULT_WASM_PAGE_SIZE: u32 = 65_536;
-    mem.page_size_log2.unwrap_or(DEFAULT_WASM_PAGE_SIZE)
+    const DEFAULT_WASM_PAGE_SIZE_LOG2: u32 = 16;
+    1 << mem.page_size_log2.unwrap_or(DEFAULT_WASM_PAGE_SIZE_LOG2)
 }
 
 /// Do something an arbitrary number of times.


### PR DESCRIPTION
Pointed out in [this comment] this should help `wasm-smith` generate offsets/data segments with a wider range of valid values in wasm-smith rather than accidentally thinking the page size is much smaller than it actually is.

[this comment]: https://github.com/bytecodealliance/wasm-tools/commit/fe1307be46d0a30b5332ae12b219dd90cc90fbe4#r146408758