### PR TITLE
Recommend `--locked` for `cargo install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ platform](https://www.rust-lang.org/tools/install) and then use the included
 Cargo package manager to install:
 
 ```
-$ cargo install wasm-tools
+$ cargo install --locked wasm-tools
 ```
 
 Alternatively if you use [`cargo


### PR DESCRIPTION
This PR changes `README.md` so it recommends users pass the [`--locked`](https://doc.rust-lang.org/cargo/commands/cargo-install.html#dealing-with-the-lockfile) flag to `cargo install`, which should prevent some surprises. This should also make the behavior more similar to the `cargo binstall` example command right below.