### PR TITLE
json-from-wast: Include binary form of text files where possible

### DIFF
--- a/src/bin/wasm-tools/json_from_wast.rs
+++ b/src/bin/wasm-tools/json_from_wast.rs
@@ -131,19 +131,19 @@ impl<'a> JsonBuilder<'a> {
         let line = self.lineno(directive.span());
         let command = match directive {
             WastDirective::Module(module) => {
-                let (name, _module_type, filename) = self.emit_file(module)?;
+                let (name, file) = self.emit_file(module, false)?;
                 json::Command::Module {
                     line,
                     name: name.map(|s| self.module_name(s)),
-                    filename,
+                    file,
                 }
             }
             WastDirective::ModuleDefinition(module) => {
-                let (name, _module_type, filename) = self.emit_file(module)?;
+                let (name, file) = self.emit_file(module, false)?;
                 json::Command::ModuleDefinition {
                     line,
                     name: name.map(|s| self.module_name(s)),
-                    filename,
+                    file,
                 }
             }
             WastDirective::ModuleInstance {
@@ -159,12 +159,11 @@ impl<'a> JsonBuilder<'a> {
                 message,
             } => {
                 let line = self.lineno(module.span());
-                let (_name, module_type, filename) = self.emit_file(module)?;
+                let (_name, file) = self.emit_file(module, true)?;
                 json::Command::AssertMalformed {
                     line,
-                    filename,
                     text: message,
-                    module_type,
+                    file,
                 }
             }
             WastDirective::AssertInvalid {
@@ -173,12 +172,11 @@ impl<'a> JsonBuilder<'a> {
                 message,
             } => {
                 let line = self.lineno(module.span());
-                let (_name, module_type, filename) = self.emit_file(module)?;
+                let (_name, file) = self.emit_file(module, false)?;
                 json::Command::AssertInvalid {
                     line,
-                    filename,
                     text: message,
-                    module_type,
+                    file,
                 }
             }
             WastDirective::Register {
@@ -200,12 +198,11 @@ impl<'a> JsonBuilder<'a> {
                 message,
             } => {
                 let line = self.lineno(module.span());
-                let (_name, module_type, filename) = self.emit_file(QuoteWat::Wat(module))?;
+                let (_name, file) = self.emit_file(QuoteWat::Wat(module), false)?;
                 json::Command::AssertUninstantiable {
                     line,
-                    filename,
                     text: message,
-                    module_type,
+                    file,
                 }
             }
             WastDirective::AssertTrap {
@@ -244,12 +241,11 @@ impl<'a> JsonBuilder<'a> {
                 message,
             } => {
                 let line = self.lineno(module.span());
-                let (_name, module_type, filename) = self.emit_file(QuoteWat::Wat(module))?;
+                let (_name, file) = self.emit_file(QuoteWat::Wat(module), false)?;
                 json::Command::AssertUnlinkable {
                     line,
                     text: message,
-                    module_type,
-                    filename,
+                    file,
                 }
             }
             WastDirective::AssertException { span: _, exec } => json::Command::AssertException {
@@ -288,7 +284,8 @@ impl<'a> JsonBuilder<'a> {
     fn emit_file(
         &mut self,
         mut module: QuoteWat<'a>,
-    ) -> Result<(Option<&'a str>, &'a str, String)> {
+        malformed: bool,
+    ) -> Result<(Option<&'a str>, json::WasmFile)> {
         let name = module.name().map(|i| i.name());
         let (contents, module_type, ext) = match module.to_test()? {
             QuoteWatTest::Text(s) => (s, "text", "wat"),
@@ -302,12 +299,25 @@ impl<'a> JsonBuilder<'a> {
         let fileno = self.files;
         self.files += 1;
         let filename = format!("{stem}.{fileno}.{ext}");
-        let dst = match &self.opts.wasm_dir {
-            Some(dir) => dir.join(&filename),
-            None => filename.clone().into(),
+        let binary_filename = format!("{stem}.{fileno}.wasm");
+        let (dst, binary_dst) = match &self.opts.wasm_dir {
+            Some(dir) => (dir.join(&filename), dir.join(&binary_filename)),
+            None => (filename.clone().into(), binary_filename.clone().into()),
         };
         std::fs::write(&dst, &contents).with_context(|| format!("failed to write file {dst:?}"))?;
-        Ok((name, module_type, filename))
+        let mut ret = json::WasmFile {
+            module_type,
+            filename,
+            binary_filename: None,
+        };
+        if module_type == "text" && !malformed {
+            if let Ok(bytes) = module.encode() {
+                std::fs::write(&binary_dst, &bytes)
+                    .with_context(|| format!("failed to write file {binary_dst:?}"))?;
+                ret.binary_filename = Some(binary_filename);
+            }
+        }
+        Ok((name, ret))
     }
 
     fn action(&self, exec: WastExecute<'a>) -> Result<json::Action<'a>> {
@@ -565,13 +575,15 @@ mod json {
             line: u32,
             #[serde(skip_serializing_if = "Option::is_none")]
             name: Option<String>,
-            filename: String,
+            #[serde(flatten)]
+            file: WasmFile,
         },
         ModuleDefinition {
             line: u32,
             #[serde(skip_serializing_if = "Option::is_none")]
             name: Option<String>,
-            filename: String,
+            #[serde(flatten)]
+            file: WasmFile,
         },
         ModuleInstance {
             line: u32,
@@ -582,15 +594,15 @@ mod json {
         },
         AssertMalformed {
             line: u32,
-            filename: String,
+            #[serde(flatten)]
+            file: WasmFile,
             text: &'a str,
-            module_type: &'a str,
         },
         AssertInvalid {
             line: u32,
-            filename: String,
+            #[serde(flatten)]
+            file: WasmFile,
             text: &'a str,
-            module_type: &'a str,
         },
         Register {
             line: u32,
@@ -601,9 +613,9 @@ mod json {
         },
         AssertUnlinkable {
             line: u32,
-            filename: String,
+            #[serde(flatten)]
+            file: WasmFile,
             text: &'a str,
-            module_type: &'a str,
         },
         AssertReturn {
             line: u32,
@@ -630,9 +642,9 @@ mod json {
         },
         AssertUninstantiable {
             line: u32,
-            filename: String,
+            #[serde(flatten)]
+            file: WasmFile,
             text: &'a str,
-            module_type: &'a str,
         },
         Thread {
             line: u32,
@@ -645,6 +657,14 @@ mod json {
             line: u32,
             thread: &'a str,
         },
+    }
+
+    #[derive(Serialize)]
+    pub struct WasmFile {
+        pub filename: String,
+        pub module_type: &'static str,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub binary_filename: Option<String>,
     }
 
     #[derive(Serialize)]

--- a/tests/snapshots/local/atomics.wast.json
+++ b/tests/snapshots/local/atomics.wast.json
@@ -4,19 +4,21 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "atomics.0.wasm"
+      "filename": "atomics.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 6,
-      "filename": "atomics.1.wasm"
+      "filename": "atomics.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 16,
       "filename": "atomics.2.wasm",
-      "text": "unknown memory 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 1"
     }
   ]
 }

--- a/tests/snapshots/local/bad-nan.wast.json
+++ b/tests/snapshots/local/bad-nan.wast.json
@@ -5,22 +5,22 @@
       "type": "assert_malformed",
       "line": 2,
       "filename": "bad-nan.0.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 6,
       "filename": "bad-nan.1.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 10,
       "filename": "bad-nan.2.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     }
   ]
 }

--- a/tests/snapshots/local/branch-hinting/branch-hinting-simple.wast.json
+++ b/tests/snapshots/local/branch-hinting/branch-hinting-simple.wast.json
@@ -4,43 +4,47 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "branch-hinting-simple.0.wasm"
+      "filename": "branch-hinting-simple.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 26,
-      "filename": "branch-hinting-simple.1.wasm"
+      "filename": "branch-hinting-simple.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 37,
-      "filename": "branch-hinting-simple.2.wasm"
+      "filename": "branch-hinting-simple.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 62,
       "filename": "branch-hinting-simple.3.wat",
-      "text": "expected valid module field",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "expected valid module field"
     },
     {
       "type": "assert_invalid",
       "line": 65,
       "filename": "branch-hinting-simple.4.wat",
-      "text": "expected a string",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "expected a string"
     },
     {
       "type": "assert_invalid",
       "line": 68,
       "filename": "branch-hinting-simple.5.wat",
-      "text": "invalid value for branch hint",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "invalid value for branch hint"
     },
     {
       "type": "module",
       "line": 72,
-      "filename": "branch-hinting-simple.6.wasm"
+      "filename": "branch-hinting-simple.6.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/code-after-end.wast.json
+++ b/tests/snapshots/local/code-after-end.wast.json
@@ -5,50 +5,50 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "code-after-end.0.wasm",
-      "text": "operators remaining after end of function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "operators remaining after end of function"
     },
     {
       "type": "assert_invalid",
       "line": 7,
       "filename": "code-after-end.1.wasm",
-      "text": "operators remaining after end of function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "operators remaining after end of function"
     },
     {
       "type": "assert_invalid",
       "line": 12,
       "filename": "code-after-end.2.wasm",
-      "text": "operators remaining after end of function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "operators remaining after end of function"
     },
     {
       "type": "assert_invalid",
       "line": 17,
       "filename": "code-after-end.3.wasm",
-      "text": "operators remaining after end of function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "operators remaining after end of function"
     },
     {
       "type": "assert_invalid",
       "line": 22,
       "filename": "code-after-end.4.wasm",
-      "text": "operators remaining after end of function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "operators remaining after end of function"
     },
     {
       "type": "assert_invalid",
       "line": 27,
       "filename": "code-after-end.5.wasm",
-      "text": "operators remaining after end of function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "operators remaining after end of function"
     },
     {
       "type": "assert_invalid",
       "line": 32,
       "filename": "code-after-end.6.wasm",
-      "text": "operators remaining after end of function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "operators remaining after end of function"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/a.wast.json
+++ b/tests/snapshots/local/component-model/a.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "a.0.wasm"
+      "filename": "a.0.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/adapt.wast.json
+++ b/tests/snapshots/local/component-model/adapt.wast.json
@@ -4,131 +4,133 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "adapt.0.wasm"
+      "filename": "adapt.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 75,
       "filename": "adapt.1.wasm",
-      "text": "canonical encoding option `utf8` conflicts with option `utf16`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "canonical encoding option `utf8` conflicts with option `utf16`"
     },
     {
       "type": "assert_invalid",
       "line": 82,
       "filename": "adapt.2.wasm",
-      "text": "canonical encoding option `utf8` conflicts with option `latin1-utf16`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "canonical encoding option `utf8` conflicts with option `latin1-utf16`"
     },
     {
       "type": "assert_invalid",
       "line": 89,
       "filename": "adapt.3.wasm",
-      "text": "canonical encoding option `utf16` conflicts with option `latin1-utf16`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "canonical encoding option `utf16` conflicts with option `latin1-utf16`"
     },
     {
       "type": "assert_invalid",
       "line": 96,
       "filename": "adapt.4.wasm",
-      "text": "memory index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "memory index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 103,
       "filename": "adapt.5.wasm",
-      "text": "`memory` is specified more than once",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "`memory` is specified more than once"
     },
     {
       "type": "assert_invalid",
       "line": 112,
       "filename": "adapt.6.wasm",
-      "text": "canonical option `memory` is required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "canonical option `memory` is required"
     },
     {
       "type": "assert_invalid",
       "line": 122,
       "filename": "adapt.7.wasm",
-      "text": "canonical option `realloc` is required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "canonical option `realloc` is required"
     },
     {
       "type": "assert_invalid",
       "line": 137,
       "filename": "adapt.8.wasm",
-      "text": "canonical option `realloc` is specified more than once",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "canonical option `realloc` is specified more than once"
     },
     {
       "type": "assert_invalid",
       "line": 155,
       "filename": "adapt.9.wasm",
-      "text": "canonical option `realloc` uses a core function with an incorrect signature",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "canonical option `realloc` uses a core function with an incorrect signature"
     },
     {
       "type": "assert_invalid",
       "line": 172,
       "filename": "adapt.10.wasm",
-      "text": "canonical option `post-return` uses a core function with an incorrect signature",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "canonical option `post-return` uses a core function with an incorrect signature"
     },
     {
       "type": "assert_invalid",
       "line": 191,
       "filename": "adapt.11.wasm",
-      "text": "canonical option `post-return` is specified more than once",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "canonical option `post-return` is specified more than once"
     },
     {
       "type": "assert_invalid",
       "line": 211,
       "filename": "adapt.12.wasm",
-      "text": "canonical option `post-return` cannot be specified for lowerings",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "canonical option `post-return` cannot be specified for lowerings"
     },
     {
       "type": "module",
       "line": 230,
-      "filename": "adapt.13.wasm"
+      "filename": "adapt.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 248,
       "filename": "adapt.14.wat",
-      "text": "unknown instance: failed to find name `$i`",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown instance: failed to find name `$i`"
     },
     {
       "type": "assert_invalid",
       "line": 256,
       "filename": "adapt.15.wasm",
-      "text": "lowered parameter types `[]` do not match parameter types `[I32]`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "lowered parameter types `[]` do not match parameter types `[I32]`"
     },
     {
       "type": "assert_invalid",
       "line": 264,
       "filename": "adapt.16.wasm",
-      "text": "lowered result types `[]` do not match result types `[I32]`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "lowered result types `[]` do not match result types `[I32]`"
     },
     {
       "type": "assert_invalid",
       "line": 272,
       "filename": "adapt.17.wasm",
-      "text": "not a function type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not a function type"
     },
     {
       "type": "assert_invalid",
       "line": 281,
       "filename": "adapt.18.wat",
-      "text": "unknown core func: failed to find name `$f`",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown core func: failed to find name `$f`"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/alias.wast.json
+++ b/tests/snapshots/local/component-model/alias.wast.json
@@ -4,176 +4,193 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "alias.0.wasm"
+      "filename": "alias.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 9,
-      "filename": "alias.1.wasm"
+      "filename": "alias.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 18,
-      "filename": "alias.2.wasm"
+      "filename": "alias.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 30,
-      "filename": "alias.3.wasm"
+      "filename": "alias.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 62,
-      "filename": "alias.4.wasm"
+      "filename": "alias.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 73,
-      "filename": "alias.5.wasm"
+      "filename": "alias.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 101,
       "filename": "alias.6.wasm",
-      "text": "export `a` for instance 0 is not a module",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "export `a` for instance 0 is not a module"
     },
     {
       "type": "assert_invalid",
       "line": 108,
       "filename": "alias.7.wasm",
-      "text": "export `a` for instance 0 is not a module",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "export `a` for instance 0 is not a module"
     },
     {
       "type": "assert_invalid",
       "line": 118,
       "filename": "alias.8.wasm",
-      "text": "core instance 0 has no export named `a`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "core instance 0 has no export named `a`"
     },
     {
       "type": "assert_invalid",
       "line": 126,
       "filename": "alias.9.wasm",
-      "text": "core instance 0 has no export named `a`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "core instance 0 has no export named `a`"
     },
     {
       "type": "assert_invalid",
       "line": 134,
       "filename": "alias.10.wasm",
-      "text": "instance 0 has no export named `a`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "instance 0 has no export named `a`"
     },
     {
       "type": "assert_invalid",
       "line": 142,
       "filename": "alias.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 153,
       "name": "PARENT",
-      "filename": "alias.12.wasm"
+      "filename": "alias.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 165,
-      "filename": "alias.13.wasm"
+      "filename": "alias.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 194,
       "name": "a",
-      "filename": "alias.14.wasm"
+      "filename": "alias.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 213,
-      "filename": "alias.15.wasm"
+      "filename": "alias.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 218,
-      "filename": "alias.16.wasm"
+      "filename": "alias.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 223,
-      "filename": "alias.17.wasm"
+      "filename": "alias.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 228,
       "name": "C",
-      "filename": "alias.18.wasm"
+      "filename": "alias.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 239,
       "name": "C",
-      "filename": "alias.19.wasm"
+      "filename": "alias.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 245,
       "name": "C",
-      "filename": "alias.20.wasm"
+      "filename": "alias.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 252,
       "filename": "alias.21.wasm",
-      "text": "invalid outer alias count of 100",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid outer alias count of 100"
     },
     {
       "type": "assert_invalid",
       "line": 256,
       "filename": "alias.22.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 260,
       "filename": "alias.23.wasm",
-      "text": "invalid outer alias count of 100",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid outer alias count of 100"
     },
     {
       "type": "assert_invalid",
       "line": 264,
       "filename": "alias.24.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 268,
       "filename": "alias.25.wasm",
-      "text": "invalid outer alias count of 100",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid outer alias count of 100"
     },
     {
       "type": "assert_invalid",
       "line": 272,
       "filename": "alias.26.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "module",
       "line": 275,
-      "filename": "alias.27.wasm"
+      "filename": "alias.27.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 283,
-      "filename": "alias.28.wasm"
+      "filename": "alias.28.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/big.wast.json
+++ b/tests/snapshots/local/component-model/big.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "big.0.wasm"
+      "filename": "big.0.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/definedtypes.wast.json
+++ b/tests/snapshots/local/component-model/definedtypes.wast.json
@@ -5,175 +5,176 @@
       "type": "module",
       "line": 1,
       "name": "C",
-      "filename": "definedtypes.0.wasm"
+      "filename": "definedtypes.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 46,
       "filename": "definedtypes.1.wat",
-      "text": "variant case cannot refine itself",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "variant case cannot refine itself"
     },
     {
       "type": "assert_invalid",
       "line": 53,
       "filename": "definedtypes.2.wat",
-      "text": "unknown variant case",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown variant case"
     },
     {
       "type": "assert_invalid",
       "line": 60,
       "filename": "definedtypes.3.wat",
-      "text": "unknown variant case",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown variant case"
     },
     {
       "type": "assert_invalid",
       "line": 69,
       "filename": "definedtypes.4.wasm",
-      "text": "variant case can only refine a previously defined case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "variant case can only refine a previously defined case"
     },
     {
       "type": "assert_invalid",
       "line": 77,
       "filename": "definedtypes.5.wasm",
-      "text": "variant case can only refine a previously defined case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "variant case can only refine a previously defined case"
     },
     {
       "type": "assert_invalid",
       "line": 85,
       "filename": "definedtypes.6.wat",
-      "text": "duplicate variant case identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate variant case identifier"
     },
     {
       "type": "assert_invalid",
       "line": 93,
       "filename": "definedtypes.7.wasm",
-      "text": "type index 0 is not a defined type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index 0 is not a defined type"
     },
     {
       "type": "assert_invalid",
       "line": 100,
       "filename": "definedtypes.8.wasm",
-      "text": "type index 0 is not a defined type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index 0 is not a defined type"
     },
     {
       "type": "assert_invalid",
       "line": 107,
       "filename": "definedtypes.9.wasm",
-      "text": "type index 0 is not a defined type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index 0 is not a defined type"
     },
     {
       "type": "assert_invalid",
       "line": 114,
       "filename": "definedtypes.10.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 117,
       "filename": "definedtypes.11.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 120,
       "filename": "definedtypes.12.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 123,
       "filename": "definedtypes.13.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 126,
       "filename": "definedtypes.14.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 129,
       "filename": "definedtypes.15.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 133,
       "filename": "definedtypes.16.wasm",
-      "text": "record field name `A-b-C-d` conflicts with previous field name `a-B-c-D`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "record field name `A-b-C-d` conflicts with previous field name `a-B-c-D`"
     },
     {
       "type": "assert_invalid",
       "line": 136,
       "filename": "definedtypes.17.wasm",
-      "text": "variant case name `x` conflicts with previous case name `x`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "variant case name `x` conflicts with previous case name `x`"
     },
     {
       "type": "assert_invalid",
       "line": 139,
       "filename": "definedtypes.18.wasm",
-      "text": "flag name `X` conflicts with previous flag name `x`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "flag name `X` conflicts with previous flag name `x`"
     },
     {
       "type": "assert_invalid",
       "line": 142,
       "filename": "definedtypes.19.wasm",
-      "text": "enum tag name `X` conflicts with previous tag name `x`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "enum tag name `X` conflicts with previous tag name `x`"
     },
     {
       "type": "assert_invalid",
       "line": 146,
       "filename": "definedtypes.20.wasm",
-      "text": "name cannot be empty",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "name cannot be empty"
     },
     {
       "type": "assert_invalid",
       "line": 149,
       "filename": "definedtypes.21.wasm",
-      "text": "name cannot be empty",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "name cannot be empty"
     },
     {
       "type": "assert_invalid",
       "line": 152,
       "filename": "definedtypes.22.wasm",
-      "text": "name cannot be empty",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "name cannot be empty"
     },
     {
       "type": "assert_invalid",
       "line": 155,
       "filename": "definedtypes.23.wasm",
-      "text": "name cannot be empty",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "name cannot be empty"
     },
     {
       "type": "assert_invalid",
       "line": 159,
       "filename": "definedtypes.24.wasm",
-      "text": "variant type must have at least one case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "variant type must have at least one case"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/empty.wast.json
+++ b/tests/snapshots/local/component-model/empty.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 2,
-      "filename": "empty.0.wasm"
+      "filename": "empty.0.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/example.wast.json
+++ b/tests/snapshots/local/component-model/example.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "example.0.wasm"
+      "filename": "example.0.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/export-ascription.wast.json
+++ b/tests/snapshots/local/component-model/export-ascription.wast.json
@@ -4,26 +4,28 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "export-ascription.0.wasm"
+      "filename": "export-ascription.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 7,
-      "filename": "export-ascription.1.wasm"
+      "filename": "export-ascription.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 14,
       "filename": "export-ascription.2.wasm",
-      "text": "ascribed type of export is not compatible",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "ascribed type of export is not compatible"
     },
     {
       "type": "assert_invalid",
       "line": 22,
       "filename": "export-ascription.3.wasm",
-      "text": "missing expected export `f`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "missing expected export `f`"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/export-introduces-alias.wast.json
+++ b/tests/snapshots/local/component-model/export-introduces-alias.wast.json
@@ -4,29 +4,33 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "export-introduces-alias.0.wasm"
+      "filename": "export-introduces-alias.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 8,
-      "filename": "export-introduces-alias.1.wasm"
+      "filename": "export-introduces-alias.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 16,
-      "filename": "export-introduces-alias.2.wasm"
+      "filename": "export-introduces-alias.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 30,
       "filename": "export-introduces-alias.3.wat",
-      "text": "duplicate type identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate type identifier"
     },
     {
       "type": "module",
       "line": 38,
-      "filename": "export-introduces-alias.4.wasm"
+      "filename": "export-introduces-alias.4.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/export.wast.json
+++ b/tests/snapshots/local/component-model/export.wast.json
@@ -5,93 +5,96 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "export.0.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 6,
       "filename": "export.1.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 10,
       "filename": "export.2.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 14,
       "filename": "export.3.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 18,
       "filename": "export.4.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "module",
       "line": 21,
-      "filename": "export.5.wasm"
+      "filename": "export.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 36,
       "filename": "export.6.wasm",
-      "text": "cannot be used more than once",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "cannot be used more than once"
     },
     {
       "type": "module",
       "line": 44,
-      "filename": "export.7.wasm"
+      "filename": "export.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 50,
-      "filename": "export.8.wasm"
+      "filename": "export.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 57,
       "filename": "export.9.wasm",
-      "text": "not a valid export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not a valid export name"
     },
     {
       "type": "assert_invalid",
       "line": 60,
       "filename": "export.10.wasm",
-      "text": "not a valid export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not a valid export name"
     },
     {
       "type": "assert_invalid",
       "line": 63,
       "filename": "export.11.wasm",
-      "text": "not a valid extern name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not a valid extern name"
     },
     {
       "type": "assert_invalid",
       "line": 66,
       "filename": "export.12.wasm",
-      "text": "not a valid export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not a valid export name"
     },
     {
       "type": "assert_invalid",
       "line": 69,
       "filename": "export.13.wasm",
-      "text": "not a valid export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not a valid export name"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/func.wast.json
+++ b/tests/snapshots/local/component-model/func.wast.json
@@ -4,69 +4,74 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "func.0.wasm"
+      "filename": "func.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 8,
       "filename": "func.1.wasm",
-      "text": "multiple returns on a function is now a gated feature",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "multiple returns on a function is now a gated feature"
     },
     {
       "type": "module",
       "line": 13,
-      "filename": "func.2.wasm"
+      "filename": "func.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 22,
       "filename": "func.3.wasm",
-      "text": "function parameter name `FOO` conflicts with previous parameter name `foo`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function parameter name `FOO` conflicts with previous parameter name `foo`"
     },
     {
       "type": "assert_invalid",
       "line": 30,
       "filename": "func.4.wasm",
-      "text": "canonical option `memory` is required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "canonical option `memory` is required"
     },
     {
       "type": "module",
       "line": 44,
-      "filename": "func.5.wasm"
+      "filename": "func.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 53,
-      "filename": "func.6.wasm"
+      "filename": "func.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 65,
-      "filename": "func.7.wasm"
+      "filename": "func.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 82,
       "filename": "func.8.wasm",
-      "text": "canonical option `realloc` is required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "canonical option `realloc` is required"
     },
     {
       "type": "assert_invalid",
       "line": 105,
       "filename": "func.9.wasm",
-      "text": "canonical option `realloc` is required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "canonical option `realloc` is required"
     },
     {
       "type": "assert_invalid",
       "line": 117,
       "filename": "func.10.wasm",
-      "text": "canonical option `realloc` is required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "canonical option `realloc` is required"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/gc.wast.json
+++ b/tests/snapshots/local/component-model/gc.wast.json
@@ -4,31 +4,34 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "gc.0.wasm"
+      "filename": "gc.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 11,
-      "filename": "gc.1.wasm"
+      "filename": "gc.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 21,
-      "filename": "gc.2.wasm"
+      "filename": "gc.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 35,
       "filename": "gc.3.wasm",
-      "text": "unexpected data at the end of the section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected data at the end of the section"
     },
     {
       "type": "assert_malformed",
       "line": 47,
       "filename": "gc.4.wasm",
-      "text": "invalid leading byte (0x60) for non-final sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid leading byte (0x60) for non-final sub type"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/import-extended.wast.json
+++ b/tests/snapshots/local/component-model/import-extended.wast.json
@@ -4,17 +4,20 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "import-extended.0.wasm"
+      "filename": "import-extended.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 9,
-      "filename": "import-extended.1.wasm"
+      "filename": "import-extended.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 20,
-      "filename": "import-extended.2.wasm"
+      "filename": "import-extended.2.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/import.wast.json
+++ b/tests/snapshots/local/component-model/import.wast.json
@@ -4,516 +4,525 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "import.0.wasm"
+      "filename": "import.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 16,
       "filename": "import.1.wasm",
-      "text": "type index 0 is not an instance type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index 0 is not an instance type"
     },
     {
       "type": "assert_invalid",
       "line": 23,
       "filename": "import.2.wasm",
-      "text": "core type index 0 is not a module type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "core type index 0 is not a module type"
     },
     {
       "type": "assert_invalid",
       "line": 30,
       "filename": "import.3.wasm",
-      "text": "type index 0 is not a function type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index 0 is not a function type"
     },
     {
       "type": "assert_invalid",
       "line": 38,
       "filename": "import.4.wasm",
-      "text": "duplicate import name `:`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate import name `:`"
     },
     {
       "type": "assert_invalid",
       "line": 46,
       "filename": "import.5.wasm",
-      "text": "duplicate import name `:`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate import name `:`"
     },
     {
       "type": "assert_invalid",
       "line": 54,
       "filename": "import.6.wasm",
-      "text": "duplicate import name `:a`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate import name `:a`"
     },
     {
       "type": "assert_invalid",
       "line": 62,
       "filename": "import.7.wasm",
-      "text": "duplicate import name `:a`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate import name `:a`"
     },
     {
       "type": "assert_malformed",
       "line": 71,
       "filename": "import.8.wat",
-      "text": "import name `a` conflicts with previous name `a`",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import name `a` conflicts with previous name `a`"
     },
     {
       "type": "assert_malformed",
       "line": 78,
       "filename": "import.9.wat",
-      "text": "import name `a` conflicts with previous name `a`",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import name `a` conflicts with previous name `a`"
     },
     {
       "type": "assert_invalid",
       "line": 87,
       "filename": "import.10.wasm",
-      "text": "type index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 93,
       "filename": "import.11.wasm",
-      "text": "type index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 101,
       "filename": "import.12.wasm",
-      "text": "value index 0 was not used as part of an instantiation, start function, or export",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "value index 0 was not used as part of an instantiation, start function, or export"
     },
     {
       "type": "module",
       "line": 106,
-      "filename": "import.13.wasm"
+      "filename": "import.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 111,
-      "filename": "import.14.wasm"
+      "filename": "import.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 125,
       "filename": "import.15.wasm",
-      "text": "conflicts with previous name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "conflicts with previous name"
     },
     {
       "type": "assert_invalid",
       "line": 132,
       "filename": "import.16.wasm",
-      "text": "`` is not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "`` is not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 135,
       "filename": "import.17.wasm",
-      "text": "`` is not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "`` is not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 138,
       "filename": "import.18.wasm",
-      "text": "not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 141,
       "filename": "import.19.wasm",
-      "text": "not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 144,
       "filename": "import.20.wasm",
-      "text": "`wasi/http` is not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "`wasi/http` is not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 147,
       "filename": "import.21.wasm",
-      "text": "`TyPeS` is not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "`TyPeS` is not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 150,
       "filename": "import.22.wasm",
-      "text": "`WaSi` is not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "`WaSi` is not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 153,
       "filename": "import.23.wasm",
-      "text": "`HtTp` is not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "`HtTp` is not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 156,
       "filename": "import.24.wasm",
-      "text": "empty string",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "empty string"
     },
     {
       "type": "assert_invalid",
       "line": 159,
       "filename": "import.25.wasm",
-      "text": "unexpected character '.'",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected character '.'"
     },
     {
       "type": "assert_invalid",
       "line": 162,
       "filename": "import.26.wasm",
-      "text": "unexpected end of input",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of input"
     },
     {
       "type": "assert_invalid",
       "line": 165,
       "filename": "import.27.wasm",
-      "text": "unexpected character 'a'",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected character 'a'"
     },
     {
       "type": "assert_invalid",
       "line": 168,
       "filename": "import.28.wasm",
-      "text": "unexpected character 'b'",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected character 'b'"
     },
     {
       "type": "assert_invalid",
       "line": 171,
       "filename": "import.29.wasm",
-      "text": "unexpected character 'x'",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected character 'x'"
     },
     {
       "type": "assert_invalid",
       "line": 174,
       "filename": "import.30.wasm",
-      "text": "empty identifier segment",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "empty identifier segment"
     },
     {
       "type": "assert_invalid",
       "line": 177,
       "filename": "import.31.wasm",
-      "text": "empty identifier segment",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "empty identifier segment"
     },
     {
       "type": "assert_invalid",
       "line": 180,
       "filename": "import.32.wasm",
-      "text": "expected `/` after package name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected `/` after package name"
     },
     {
       "type": "assert_invalid",
       "line": 183,
       "filename": "import.33.wasm",
-      "text": "trailing characters found: `/qux`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "trailing characters found: `/qux`"
     },
     {
       "type": "module",
       "line": 186,
-      "filename": "import.34.wasm"
+      "filename": "import.34.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 191,
-      "filename": "import.35.wasm"
+      "filename": "import.35.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 203,
       "filename": "import.36.wasm",
-      "text": "expected `<` at ``",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected `<` at ``"
     },
     {
       "type": "assert_invalid",
       "line": 206,
       "filename": "import.37.wasm",
-      "text": "`` is not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "`` is not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 209,
       "filename": "import.38.wasm",
-      "text": "`` is not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "`` is not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 212,
       "filename": "import.39.wasm",
-      "text": "`` is not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "`` is not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 215,
       "filename": "import.40.wasm",
-      "text": "`` is not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "`` is not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 218,
       "filename": "import.41.wasm",
-      "text": "`` is not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "`` is not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 221,
       "filename": "import.42.wasm",
-      "text": "expected `{` at `>`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected `{` at `>`"
     },
     {
       "type": "assert_invalid",
       "line": 224,
       "filename": "import.43.wasm",
-      "text": "expected `>=` or `<` at start of version range",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected `>=` or `<` at start of version range"
     },
     {
       "type": "assert_invalid",
       "line": 227,
       "filename": "import.44.wasm",
-      "text": "`xyz` is not a valid semver",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "`xyz` is not a valid semver"
     },
     {
       "type": "assert_invalid",
       "line": 230,
       "filename": "import.45.wasm",
-      "text": "`1.2.3 >=2.3.4` is not a valid semver",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "`1.2.3 >=2.3.4` is not a valid semver"
     },
     {
       "type": "module",
       "line": 233,
-      "filename": "import.46.wasm"
+      "filename": "import.46.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 241,
       "filename": "import.47.wasm",
-      "text": "expected `<` at ``",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected `<` at ``"
     },
     {
       "type": "assert_invalid",
       "line": 244,
       "filename": "import.48.wasm",
-      "text": "`` is not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "`` is not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 247,
       "filename": "import.49.wasm",
-      "text": "`` is not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "`` is not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 250,
       "filename": "import.50.wasm",
-      "text": "`` is not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "`` is not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 253,
       "filename": "import.51.wasm",
-      "text": "`` is not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "`` is not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 256,
       "filename": "import.52.wasm",
-      "text": "`` is not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "`` is not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 259,
       "filename": "import.53.wasm",
-      "text": "expected `>` at ``",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected `>` at ``"
     },
     {
       "type": "assert_invalid",
       "line": 262,
       "filename": "import.54.wasm",
-      "text": "is not a valid semver",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "is not a valid semver"
     },
     {
       "type": "assert_invalid",
       "line": 265,
       "filename": "import.55.wasm",
-      "text": "expected `>` at ``",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected `>` at ``"
     },
     {
       "type": "assert_invalid",
       "line": 268,
       "filename": "import.56.wasm",
-      "text": "expected `integrity=<`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected `integrity=<`"
     },
     {
       "type": "assert_invalid",
       "line": 271,
       "filename": "import.57.wasm",
-      "text": "trailing characters found: `x`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "trailing characters found: `x`"
     },
     {
       "type": "module",
       "line": 274,
-      "filename": "import.58.wasm"
+      "filename": "import.58.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 281,
       "filename": "import.59.wasm",
-      "text": "expected `<` at ``",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected `<` at ``"
     },
     {
       "type": "assert_invalid",
       "line": 284,
       "filename": "import.60.wasm",
-      "text": "failed to find `>`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "failed to find `>`"
     },
     {
       "type": "assert_invalid",
       "line": 287,
       "filename": "import.61.wasm",
-      "text": "url cannot contain `<`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "url cannot contain `<`"
     },
     {
       "type": "assert_invalid",
       "line": 291,
       "filename": "import.62.wasm",
-      "text": "not a valid extern name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not a valid extern name"
     },
     {
       "type": "assert_invalid",
       "line": 299,
       "filename": "import.63.wasm",
-      "text": "not a valid extern name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not a valid extern name"
     },
     {
       "type": "assert_invalid",
       "line": 302,
       "filename": "import.64.wasm",
-      "text": "not a valid extern name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not a valid extern name"
     },
     {
       "type": "assert_invalid",
       "line": 305,
       "filename": "import.65.wasm",
-      "text": "not a valid extern name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not a valid extern name"
     },
     {
       "type": "module",
       "line": 308,
-      "filename": "import.66.wasm"
+      "filename": "import.66.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 321,
       "filename": "import.67.wasm",
-      "text": "integrity hash cannot be empty",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integrity hash cannot be empty"
     },
     {
       "type": "assert_invalid",
       "line": 324,
       "filename": "import.68.wasm",
-      "text": "expected `-` after hash algorithm",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected `-` after hash algorithm"
     },
     {
       "type": "assert_invalid",
       "line": 327,
       "filename": "import.69.wasm",
-      "text": "not valid base64",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not valid base64"
     },
     {
       "type": "assert_invalid",
       "line": 330,
       "filename": "import.70.wasm",
-      "text": "not valid base64",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not valid base64"
     },
     {
       "type": "assert_invalid",
       "line": 333,
       "filename": "import.71.wasm",
-      "text": "not valid base64",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not valid base64"
     },
     {
       "type": "assert_invalid",
       "line": 336,
       "filename": "import.72.wasm",
-      "text": "not valid base64",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not valid base64"
     },
     {
       "type": "assert_invalid",
       "line": 339,
       "filename": "import.73.wasm",
-      "text": "not valid base64",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not valid base64"
     },
     {
       "type": "assert_invalid",
       "line": 342,
       "filename": "import.74.wasm",
-      "text": "unrecognized hash algorithm",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unrecognized hash algorithm"
     },
     {
       "type": "module",
       "line": 350,
-      "filename": "import.75.wasm"
+      "filename": "import.75.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/imports-exports.wast.json
+++ b/tests/snapshots/local/component-model/imports-exports.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "imports-exports.0.wasm"
+      "filename": "imports-exports.0.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/inline-exports.wast.json
+++ b/tests/snapshots/local/component-model/inline-exports.wast.json
@@ -4,14 +4,15 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "inline-exports.0.wasm"
+      "filename": "inline-exports.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 6,
       "filename": "inline-exports.1.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/instance-type.wast.json
+++ b/tests/snapshots/local/component-model/instance-type.wast.json
@@ -4,76 +4,81 @@
     {
       "type": "module",
       "line": 2,
-      "filename": "instance-type.0.wasm"
+      "filename": "instance-type.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 68,
-      "filename": "instance-type.1.wasm"
+      "filename": "instance-type.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 73,
-      "filename": "instance-type.2.wasm"
+      "filename": "instance-type.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 83,
-      "filename": "instance-type.3.wasm"
+      "filename": "instance-type.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 107,
-      "filename": "instance-type.4.wasm"
+      "filename": "instance-type.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 179,
       "filename": "instance-type.5.wasm",
-      "text": "export name `a` conflicts with previous name `a`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "export name `a` conflicts with previous name `a`"
     },
     {
       "type": "assert_invalid",
       "line": 186,
       "filename": "instance-type.6.wasm",
-      "text": "type index 0 is not an instance type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index 0 is not an instance type"
     },
     {
       "type": "assert_invalid",
       "line": 194,
       "filename": "instance-type.7.wasm",
-      "text": "core type index 0 is not a module type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "core type index 0 is not a module type"
     },
     {
       "type": "assert_invalid",
       "line": 202,
       "filename": "instance-type.8.wat",
-      "text": "unknown core type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown core type"
     },
     {
       "type": "assert_invalid",
       "line": 209,
       "filename": "instance-type.9.wasm",
-      "text": "type index 0 is not a function type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index 0 is not a function type"
     },
     {
       "type": "assert_invalid",
       "line": 217,
       "filename": "instance-type.10.wasm",
-      "text": "type index 0 is not a function type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index 0 is not a function type"
     },
     {
       "type": "assert_invalid",
       "line": 225,
       "filename": "instance-type.11.wasm",
-      "text": "type index 0 is not a function type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index 0 is not a function type"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/instantiate.wast.json
+++ b/tests/snapshots/local/component-model/instantiate.wast.json
@@ -4,625 +4,646 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "instantiate.0.wasm"
+      "filename": "instantiate.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 6,
-      "filename": "instantiate.1.wasm"
+      "filename": "instantiate.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 12,
-      "filename": "instantiate.2.wasm"
+      "filename": "instantiate.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 18,
-      "filename": "instantiate.3.wasm"
+      "filename": "instantiate.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 24,
-      "filename": "instantiate.4.wasm"
+      "filename": "instantiate.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 30,
-      "filename": "instantiate.5.wasm"
+      "filename": "instantiate.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 36,
-      "filename": "instantiate.6.wasm"
+      "filename": "instantiate.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 53,
-      "filename": "instantiate.7.wasm"
+      "filename": "instantiate.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 76,
-      "filename": "instantiate.8.wasm"
+      "filename": "instantiate.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 83,
-      "filename": "instantiate.9.wasm"
+      "filename": "instantiate.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 99,
-      "filename": "instantiate.10.wasm"
+      "filename": "instantiate.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 136,
       "filename": "instantiate.11.wasm",
-      "text": "unknown module",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown module"
     },
     {
       "type": "assert_invalid",
       "line": 141,
       "filename": "instantiate.12.wasm",
-      "text": "unknown component",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown component"
     },
     {
       "type": "assert_invalid",
       "line": 146,
       "filename": "instantiate.13.wasm",
-      "text": "unknown module",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown module"
     },
     {
       "type": "module",
       "line": 152,
-      "filename": "instantiate.14.wasm"
+      "filename": "instantiate.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 158,
       "filename": "instantiate.15.wasm",
-      "text": "missing module instantiation argument",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "missing module instantiation argument"
     },
     {
       "type": "assert_invalid",
       "line": 164,
       "filename": "instantiate.16.wasm",
-      "text": "missing import named `a`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "missing import named `a`"
     },
     {
       "type": "assert_invalid",
       "line": 171,
       "filename": "instantiate.17.wasm",
-      "text": "expected func, found component",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected func, found component"
     },
     {
       "type": "assert_invalid",
       "line": 181,
       "filename": "instantiate.18.wasm",
-      "text": "expected 0 results, found 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected 0 results, found 1"
     },
     {
       "type": "assert_invalid",
       "line": 191,
       "filename": "instantiate.19.wasm",
-      "text": "expected 0 parameters, found 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected 0 parameters, found 1"
     },
     {
       "type": "assert_invalid",
       "line": 201,
       "filename": "instantiate.20.wasm",
-      "text": "type mismatch in import `::`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch in import `::`"
     },
     {
       "type": "assert_invalid",
       "line": 215,
       "filename": "instantiate.21.wasm",
-      "text": "missing expected import `::foobar`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "missing expected import `::foobar`"
     },
     {
       "type": "assert_invalid",
       "line": 226,
       "filename": "instantiate.22.wasm",
-      "text": "missing expected export `x`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "missing expected export `x`"
     },
     {
       "type": "module",
       "line": 236,
-      "filename": "instantiate.23.wasm"
+      "filename": "instantiate.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 250,
-      "filename": "instantiate.24.wasm"
+      "filename": "instantiate.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 262,
-      "filename": "instantiate.25.wasm"
+      "filename": "instantiate.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 280,
       "filename": "instantiate.26.wasm",
-      "text": "expected: [] -> []",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected: [] -> []"
     },
     {
       "type": "assert_invalid",
       "line": 288,
       "filename": "instantiate.27.wasm",
-      "text": "expected: [] -> []",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected: [] -> []"
     },
     {
       "type": "assert_invalid",
       "line": 296,
       "filename": "instantiate.28.wasm",
-      "text": "expected global type i32, found i64",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected global type i32, found i64"
     },
     {
       "type": "assert_invalid",
       "line": 304,
       "filename": "instantiate.29.wasm",
-      "text": "expected table element type funcref, found externref",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected table element type funcref, found externref"
     },
     {
       "type": "assert_invalid",
       "line": 312,
       "filename": "instantiate.30.wasm",
-      "text": "mismatch in table limits",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "mismatch in table limits"
     },
     {
       "type": "assert_invalid",
       "line": 320,
       "filename": "instantiate.31.wasm",
-      "text": "mismatch in table limits",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "mismatch in table limits"
     },
     {
       "type": "assert_invalid",
       "line": 328,
       "filename": "instantiate.32.wasm",
-      "text": "mismatch in table limits",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "mismatch in table limits"
     },
     {
       "type": "assert_invalid",
       "line": 336,
       "filename": "instantiate.33.wasm",
-      "text": "mismatch in the shared flag for memories",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "mismatch in the shared flag for memories"
     },
     {
       "type": "assert_invalid",
       "line": 344,
       "filename": "instantiate.34.wasm",
-      "text": "mismatch in memory limits",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "mismatch in memory limits"
     },
     {
       "type": "assert_invalid",
       "line": 352,
       "filename": "instantiate.35.wasm",
-      "text": "type mismatch in export `g`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch in export `g`"
     },
     {
       "type": "assert_invalid",
       "line": 362,
       "filename": "instantiate.36.wasm",
-      "text": "unknown module",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown module"
     },
     {
       "type": "module",
       "line": 367,
-      "filename": "instantiate.37.wasm"
+      "filename": "instantiate.37.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 386,
       "filename": "instantiate.38.wasm",
-      "text": "function index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 390,
       "filename": "instantiate.39.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 394,
       "filename": "instantiate.40.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 398,
       "filename": "instantiate.41.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 402,
       "filename": "instantiate.42.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 406,
       "filename": "instantiate.43.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 410,
       "filename": "instantiate.44.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 414,
       "filename": "instantiate.45.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 418,
       "filename": "instantiate.46.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 422,
       "filename": "instantiate.47.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 426,
       "filename": "instantiate.48.wasm",
-      "text": "duplicate module instantiation argument named ``",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate module instantiation argument named ``"
     },
     {
       "type": "assert_invalid",
       "line": 438,
       "filename": "instantiate.49.wasm",
-      "text": "duplicate module instantiation argument named ``",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate module instantiation argument named ``"
     },
     {
       "type": "assert_invalid",
       "line": 449,
       "filename": "instantiate.50.wasm",
-      "text": "expected global, found func",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected global, found func"
     },
     {
       "type": "assert_invalid",
       "line": 460,
       "filename": "instantiate.51.wasm",
-      "text": "instantiation argument `a` conflicts with previous argument `a`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "instantiation argument `a` conflicts with previous argument `a`"
     },
     {
       "type": "assert_invalid",
       "line": 471,
       "filename": "instantiate.52.wasm",
-      "text": "expected func, found component",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected func, found component"
     },
     {
       "type": "assert_invalid",
       "line": 480,
       "filename": "instantiate.53.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 489,
       "filename": "instantiate.54.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 498,
       "filename": "instantiate.55.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 507,
       "filename": "instantiate.56.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 516,
       "filename": "instantiate.57.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 525,
       "filename": "instantiate.58.wasm",
-      "text": "export name `a` conflicts with previous name `a`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "export name `a` conflicts with previous name `a`"
     },
     {
       "type": "module",
       "line": 534,
-      "filename": "instantiate.59.wasm"
+      "filename": "instantiate.59.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 549,
-      "filename": "instantiate.60.wasm"
+      "filename": "instantiate.60.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 566,
       "filename": "instantiate.61.wasm",
-      "text": "export name `` already defined",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "export name `` already defined"
     },
     {
       "type": "assert_invalid",
       "line": 577,
       "filename": "instantiate.62.wasm",
-      "text": "no export named `a`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "no export named `a`"
     },
     {
       "type": "assert_invalid",
       "line": 585,
       "filename": "instantiate.63.wasm",
-      "text": "index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 591,
       "filename": "instantiate.64.wasm",
-      "text": "module instantiation argument `` does not export an item named `table`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "module instantiation argument `` does not export an item named `table`"
     },
     {
       "type": "module",
       "line": 623,
-      "filename": "instantiate.65.wasm"
+      "filename": "instantiate.65.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 637,
       "filename": "instantiate.66.wasm",
-      "text": "expected primitive `u32` found primitive `string`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected primitive `u32` found primitive `string`"
     },
     {
       "type": "module",
       "line": 661,
-      "filename": "instantiate.67.wasm"
+      "filename": "instantiate.67.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 676,
-      "filename": "instantiate.68.wasm"
+      "filename": "instantiate.68.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 690,
       "filename": "instantiate.69.wasm",
-      "text": "expected parameter named `y`, found `x`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected parameter named `y`, found `x`"
     },
     {
       "type": "assert_invalid",
       "line": 700,
       "filename": "instantiate.70.wasm",
-      "text": "type mismatch in function parameter `x`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch in function parameter `x`"
     },
     {
       "type": "assert_invalid",
       "line": 710,
       "filename": "instantiate.71.wasm",
-      "text": "mismatched result names",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "mismatched result names"
     },
     {
       "type": "assert_invalid",
       "line": 720,
       "filename": "instantiate.72.wasm",
-      "text": "type mismatch with result type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch with result type"
     },
     {
       "type": "assert_invalid",
       "line": 731,
       "filename": "instantiate.73.wasm",
-      "text": "type mismatch in instance export `a`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch in instance export `a`"
     },
     {
       "type": "assert_invalid",
       "line": 742,
       "filename": "instantiate.74.wasm",
-      "text": "expected primitive, found record",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected primitive, found record"
     },
     {
       "type": "assert_invalid",
       "line": 754,
       "filename": "instantiate.75.wasm",
-      "text": "expected record, found u32",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected record, found u32"
     },
     {
       "type": "assert_invalid",
       "line": 766,
       "filename": "instantiate.76.wasm",
-      "text": "expected u32, found tuple",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected u32, found tuple"
     },
     {
       "type": "assert_invalid",
       "line": 779,
       "filename": "instantiate.77.wasm",
-      "text": "type mismatch in record field `x`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch in record field `x`"
     },
     {
       "type": "assert_invalid",
       "line": 792,
       "filename": "instantiate.78.wasm",
-      "text": "expected 1 fields, found 2",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected 1 fields, found 2"
     },
     {
       "type": "assert_invalid",
       "line": 804,
       "filename": "instantiate.79.wasm",
-      "text": "expected field name `a`, found `b`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected field name `a`, found `b`"
     },
     {
       "type": "assert_invalid",
       "line": 816,
       "filename": "instantiate.80.wasm",
-      "text": "expected 1 cases, found 2",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected 1 cases, found 2"
     },
     {
       "type": "assert_invalid",
       "line": 828,
       "filename": "instantiate.81.wasm",
-      "text": "expected case named `x`, found `y`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected case named `x`, found `y`"
     },
     {
       "type": "assert_invalid",
       "line": 840,
       "filename": "instantiate.82.wasm",
-      "text": "expected case `x` to have a type, found none",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected case `x` to have a type, found none"
     },
     {
       "type": "assert_invalid",
       "line": 852,
       "filename": "instantiate.83.wasm",
-      "text": "expected case `x` to have no type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected case `x` to have no type"
     },
     {
       "type": "assert_invalid",
       "line": 864,
       "filename": "instantiate.84.wasm",
-      "text": "type mismatch in variant case `x`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch in variant case `x`"
     },
     {
       "type": "assert_invalid",
       "line": 876,
       "filename": "instantiate.85.wasm",
-      "text": "expected 1 types, found 2",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected 1 types, found 2"
     },
     {
       "type": "assert_invalid",
       "line": 888,
       "filename": "instantiate.86.wasm",
-      "text": "type mismatch in tuple field 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch in tuple field 0"
     },
     {
       "type": "assert_invalid",
       "line": 900,
       "filename": "instantiate.87.wasm",
-      "text": "mismatch in flags elements",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "mismatch in flags elements"
     },
     {
       "type": "assert_invalid",
       "line": 912,
       "filename": "instantiate.88.wasm",
-      "text": "mismatch in enum elements",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "mismatch in enum elements"
     },
     {
       "type": "assert_invalid",
       "line": 924,
       "filename": "instantiate.89.wasm",
-      "text": "type mismatch in ok variant",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch in ok variant"
     },
     {
       "type": "assert_invalid",
       "line": 936,
       "filename": "instantiate.90.wasm",
-      "text": "type mismatch in err variant",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch in err variant"
     },
     {
       "type": "assert_invalid",
       "line": 948,
       "filename": "instantiate.91.wasm",
-      "text": "expected ok type to not be present",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected ok type to not be present"
     },
     {
       "type": "assert_invalid",
       "line": 960,
       "filename": "instantiate.92.wasm",
-      "text": "expected ok type, but found none",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected ok type, but found none"
     },
     {
       "type": "assert_invalid",
       "line": 972,
       "filename": "instantiate.93.wasm",
-      "text": "expected err type to not be present",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected err type to not be present"
     },
     {
       "type": "assert_invalid",
       "line": 984,
       "filename": "instantiate.94.wasm",
-      "text": "expected err type, but found none",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected err type, but found none"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/invalid.wast.json
+++ b/tests/snapshots/local/component-model/invalid.wast.json
@@ -5,29 +5,29 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "invalid.0.wasm",
-      "text": "type index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index out of bounds"
     },
     {
       "type": "assert_malformed",
       "line": 11,
       "filename": "invalid.1.wat",
-      "text": "unknown func",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown func"
     },
     {
       "type": "assert_malformed",
       "line": 17,
       "filename": "invalid.2.wat",
-      "text": "outer count of `100` is too large",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "outer count of `100` is too large"
     },
     {
       "type": "assert_malformed",
       "line": 23,
       "filename": "invalid.3.wat",
-      "text": "outer component `nonexistent` not found",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "outer component `nonexistent` not found"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/link.wast.json
+++ b/tests/snapshots/local/component-model/link.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "link.0.wasm"
+      "filename": "link.0.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/lots-of-aliases.wast.json
+++ b/tests/snapshots/local/component-model/lots-of-aliases.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "lots-of-aliases.0.wasm"
+      "filename": "lots-of-aliases.0.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/lower.wast.json
+++ b/tests/snapshots/local/component-model/lower.wast.json
@@ -5,15 +5,15 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "lower.0.wasm",
-      "text": "canonical option `memory` is required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "canonical option `memory` is required"
     },
     {
       "type": "assert_invalid",
       "line": 10,
       "filename": "lower.1.wasm",
-      "text": "canonical option `memory` is required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "canonical option `memory` is required"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/memory64.wast.json
+++ b/tests/snapshots/local/component-model/memory64.wast.json
@@ -5,15 +5,15 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "memory64.0.wasm",
-      "text": "mismatch in index type used for memories",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "mismatch in index type used for memories"
     },
     {
       "type": "assert_invalid",
       "line": 13,
       "filename": "memory64.1.wasm",
-      "text": "mismatch in index type used for memories",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "mismatch in index type used for memories"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/module-link.wast.json
+++ b/tests/snapshots/local/component-model/module-link.wast.json
@@ -4,12 +4,14 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "module-link.0.wasm"
+      "filename": "module-link.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 10,
-      "filename": "module-link.1.wasm"
+      "filename": "module-link.1.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/more-flags.wast.json
+++ b/tests/snapshots/local/component-model/more-flags.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "more-flags.0.wasm"
+      "filename": "more-flags.0.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/multiple-returns.wast.json
+++ b/tests/snapshots/local/component-model/multiple-returns.wast.json
@@ -4,33 +4,35 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "multiple-returns.0.wasm"
+      "filename": "multiple-returns.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 5,
-      "filename": "multiple-returns.1.wasm"
+      "filename": "multiple-returns.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 15,
       "filename": "multiple-returns.2.wasm",
-      "text": "component start function has a result count of 1 but the function type has a result count of 2",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "component start function has a result count of 1 but the function type has a result count of 2"
     },
     {
       "type": "assert_invalid",
       "line": 26,
       "filename": "multiple-returns.3.wasm",
-      "text": "function result name cannot be empty",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function result name cannot be empty"
     },
     {
       "type": "assert_invalid",
       "line": 33,
       "filename": "multiple-returns.4.wasm",
-      "text": "function result name `foo` conflicts with previous result name `FOO`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function result name `foo` conflicts with previous result name `FOO`"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/naming.wast.json
+++ b/tests/snapshots/local/component-model/naming.wast.json
@@ -4,117 +4,119 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "naming.0.wasm"
+      "filename": "naming.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 8,
       "filename": "naming.1.wasm",
-      "text": "`1` is not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "`1` is not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 16,
       "filename": "naming.2.wasm",
-      "text": "instance 0 has no export named `Xml`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "instance 0 has no export named `Xml`"
     },
     {
       "type": "assert_invalid",
       "line": 24,
       "filename": "naming.3.wasm",
-      "text": "flag name `a-1-c` is not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "flag name `a-1-c` is not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 31,
       "filename": "naming.4.wasm",
-      "text": "enum tag name `NevEr` is not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "enum tag name `NevEr` is not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 38,
       "filename": "naming.5.wasm",
-      "text": "record field name `GoNnA` is not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "record field name `GoNnA` is not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 45,
       "filename": "naming.6.wasm",
-      "text": "variant case name `GIVe` is not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "variant case name `GIVe` is not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 53,
       "filename": "naming.7.wasm",
-      "text": "function parameter name `yOu` is not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function parameter name `yOu` is not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 60,
       "filename": "naming.8.wasm",
-      "text": "name `uP` is not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "name `uP` is not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 67,
       "filename": "naming.9.wasm",
-      "text": "`NevEr` is not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "`NevEr` is not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 74,
       "filename": "naming.10.wasm",
-      "text": "`GonnA` is not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "`GonnA` is not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 81,
       "filename": "naming.11.wasm",
-      "text": "`lET` is not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "`lET` is not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 88,
       "filename": "naming.12.wasm",
-      "text": "`YoU` is not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "`YoU` is not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 95,
       "filename": "naming.13.wasm",
-      "text": "`DOWn` is not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "`DOWn` is not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 102,
       "filename": "naming.14.wasm",
-      "text": "character `A` is not lowercase in package name/namespace",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "character `A` is not lowercase in package name/namespace"
     },
     {
       "type": "assert_invalid",
       "line": 108,
       "filename": "naming.15.wasm",
-      "text": "character `B` is not lowercase in package name/namespace",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "character `B` is not lowercase in package name/namespace"
     },
     {
       "type": "module",
       "line": 113,
-      "filename": "naming.16.wasm"
+      "filename": "naming.16.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/nested-modules.wast.json
+++ b/tests/snapshots/local/component-model/nested-modules.wast.json
@@ -4,24 +4,27 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "nested-modules.0.wasm"
+      "filename": "nested-modules.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 21,
-      "filename": "nested-modules.1.wasm"
+      "filename": "nested-modules.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 28,
       "filename": "nested-modules.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 38,
-      "filename": "nested-modules.3.wasm"
+      "filename": "nested-modules.3.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/resources.wast.json
+++ b/tests/snapshots/local/component-model/resources.wast.json
@@ -4,710 +4,757 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "resources.0.wasm"
+      "filename": "resources.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 5,
-      "filename": "resources.1.wasm"
+      "filename": "resources.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 13,
-      "filename": "resources.2.wasm"
+      "filename": "resources.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 19,
-      "filename": "resources.3.wasm"
+      "filename": "resources.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 28,
-      "filename": "resources.4.wasm"
+      "filename": "resources.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 50,
       "filename": "resources.5.wasm",
-      "text": "resources can only be represented by `i32`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "resources can only be represented by `i32`"
     },
     {
       "type": "assert_invalid",
       "line": 56,
       "filename": "resources.6.wasm",
-      "text": "type index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 62,
       "filename": "resources.7.wasm",
-      "text": "type index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 68,
       "filename": "resources.8.wasm",
-      "text": "not a resource type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not a resource type"
     },
     {
       "type": "assert_invalid",
       "line": 75,
       "filename": "resources.9.wasm",
-      "text": "not a resource type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not a resource type"
     },
     {
       "type": "assert_invalid",
       "line": 82,
       "filename": "resources.10.wasm",
-      "text": "not a local resource",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not a local resource"
     },
     {
       "type": "assert_invalid",
       "line": 89,
       "filename": "resources.11.wasm",
-      "text": "not a local resource",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not a local resource"
     },
     {
       "type": "assert_invalid",
       "line": 96,
       "filename": "resources.12.wasm",
-      "text": "not a resource type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not a resource type"
     },
     {
       "type": "assert_invalid",
       "line": 103,
       "filename": "resources.13.wasm",
-      "text": "type index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 109,
       "filename": "resources.14.wasm",
-      "text": "not a resource type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not a resource type"
     },
     {
       "type": "assert_invalid",
       "line": 116,
       "filename": "resources.15.wasm",
-      "text": "not a resource type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not a resource type"
     },
     {
       "type": "assert_invalid",
       "line": 123,
       "filename": "resources.16.wasm",
-      "text": "wrong signature for a destructor",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "wrong signature for a destructor"
     },
     {
       "type": "assert_invalid",
       "line": 134,
       "filename": "resources.17.wasm",
-      "text": "function index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 140,
       "filename": "resources.18.wasm",
-      "text": "resource types are not the same",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "resource types are not the same"
     },
     {
       "type": "module",
       "line": 154,
-      "filename": "resources.19.wasm"
+      "filename": "resources.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 163,
       "filename": "resources.20.wasm",
-      "text": "resources can only be defined within a concrete component",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "resources can only be defined within a concrete component"
     },
     {
       "type": "assert_invalid",
       "line": 171,
       "filename": "resources.21.wasm",
-      "text": "resources can only be defined within a concrete component",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "resources can only be defined within a concrete component"
     },
     {
       "type": "module",
       "line": 178,
-      "filename": "resources.22.wasm"
+      "filename": "resources.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 189,
-      "filename": "resources.23.wasm"
+      "filename": "resources.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 199,
       "name": "C",
-      "filename": "resources.24.wasm"
+      "filename": "resources.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 218,
-      "filename": "resources.25.wasm"
+      "filename": "resources.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 223,
       "name": "C",
-      "filename": "resources.26.wasm"
+      "filename": "resources.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 232,
-      "filename": "resources.27.wasm"
+      "filename": "resources.27.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 249,
-      "filename": "resources.28.wasm"
+      "filename": "resources.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 261,
-      "filename": "resources.29.wasm"
+      "filename": "resources.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 274,
-      "filename": "resources.30.wasm"
+      "filename": "resources.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 280,
-      "filename": "resources.31.wasm"
+      "filename": "resources.31.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 287,
-      "filename": "resources.32.wasm"
+      "filename": "resources.32.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 293,
-      "filename": "resources.33.wasm"
+      "filename": "resources.33.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 300,
       "name": "P",
-      "filename": "resources.34.wasm"
+      "filename": "resources.34.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 317,
-      "filename": "resources.35.wasm"
+      "filename": "resources.35.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 339,
       "filename": "resources.36.wasm",
-      "text": "not a local resource",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not a local resource"
     },
     {
       "type": "module",
       "line": 350,
-      "filename": "resources.37.wasm"
+      "filename": "resources.37.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 360,
-      "filename": "resources.38.wasm"
+      "filename": "resources.38.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 372,
-      "filename": "resources.39.wasm"
+      "filename": "resources.39.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 388,
-      "filename": "resources.40.wasm"
+      "filename": "resources.40.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 409,
       "filename": "resources.41.wasm",
-      "text": "resource types are not the same",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "resource types are not the same"
     },
     {
       "type": "module",
       "line": 431,
-      "filename": "resources.42.wasm"
+      "filename": "resources.42.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 457,
-      "filename": "resources.43.wasm"
+      "filename": "resources.43.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 484,
       "filename": "resources.44.wasm",
-      "text": "expected resource, found defined type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected resource, found defined type"
     },
     {
       "type": "assert_invalid",
       "line": 494,
       "filename": "resources.45.wasm",
-      "text": "expected defined type, found resource",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected defined type, found resource"
     },
     {
       "type": "assert_invalid",
       "line": 505,
       "filename": "resources.46.wasm",
-      "text": "resource types are not the same",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "resource types are not the same"
     },
     {
       "type": "module",
       "line": 519,
-      "filename": "resources.47.wasm"
+      "filename": "resources.47.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 533,
       "filename": "resources.48.wasm",
-      "text": "func not valid to be used as import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "func not valid to be used as import"
     },
     {
       "type": "assert_invalid",
       "line": 540,
       "filename": "resources.49.wasm",
-      "text": "func not valid to be used as import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "func not valid to be used as import"
     },
     {
       "type": "assert_invalid",
       "line": 549,
       "filename": "resources.50.wasm",
-      "text": "func not valid to be used as export",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "func not valid to be used as export"
     },
     {
       "type": "module",
       "line": 559,
-      "filename": "resources.51.wasm"
+      "filename": "resources.51.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 569,
-      "filename": "resources.52.wasm"
+      "filename": "resources.52.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 583,
-      "filename": "resources.53.wasm"
+      "filename": "resources.53.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 601,
-      "filename": "resources.54.wasm"
+      "filename": "resources.54.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 617,
-      "filename": "resources.55.wasm"
+      "filename": "resources.55.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 649,
-      "filename": "resources.56.wasm"
+      "filename": "resources.56.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 669,
-      "filename": "resources.57.wasm"
+      "filename": "resources.57.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 693,
       "filename": "resources.58.wasm",
-      "text": "resource types are not the same",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "resource types are not the same"
     },
     {
       "type": "module",
       "line": 713,
-      "filename": "resources.59.wasm"
+      "filename": "resources.59.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 736,
       "filename": "resources.60.wasm",
-      "text": "missing import named `x`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "missing import named `x`"
     },
     {
       "type": "assert_invalid",
       "line": 744,
       "filename": "resources.61.wasm",
-      "text": "missing import named `y`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "missing import named `y`"
     },
     {
       "type": "assert_invalid",
       "line": 756,
       "filename": "resources.62.wasm",
-      "text": "resource types are not the same",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "resource types are not the same"
     },
     {
       "type": "module",
       "line": 771,
       "name": "A",
-      "filename": "resources.63.wasm"
+      "filename": "resources.63.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 795,
       "filename": "resources.64.wasm",
-      "text": "refers to resources not defined in the current component",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "refers to resources not defined in the current component"
     },
     {
       "type": "assert_invalid",
       "line": 801,
       "filename": "resources.65.wasm",
-      "text": "refers to resources not defined in the current component",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "refers to resources not defined in the current component"
     },
     {
       "type": "assert_invalid",
       "line": 808,
       "filename": "resources.66.wasm",
-      "text": "refers to resources not defined in the current component",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "refers to resources not defined in the current component"
     },
     {
       "type": "assert_invalid",
       "line": 815,
       "filename": "resources.67.wasm",
-      "text": "refers to resources not defined in the current component",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "refers to resources not defined in the current component"
     },
     {
       "type": "assert_invalid",
       "line": 822,
       "filename": "resources.68.wasm",
-      "text": "refers to resources not defined in the current component",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "refers to resources not defined in the current component"
     },
     {
       "type": "assert_invalid",
       "line": 830,
       "filename": "resources.69.wasm",
-      "text": "expected component, found instance",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected component, found instance"
     },
     {
       "type": "assert_invalid",
       "line": 846,
       "filename": "resources.70.wasm",
-      "text": "type mismatch for import `y`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch for import `y`"
     },
     {
       "type": "module",
       "line": 866,
-      "filename": "resources.71.wasm"
+      "filename": "resources.71.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 890,
       "filename": "resources.72.wasm",
-      "text": "failed to find `.` character",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "failed to find `.` character"
     },
     {
       "type": "assert_invalid",
       "line": 895,
       "filename": "resources.73.wasm",
-      "text": "not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 898,
       "filename": "resources.74.wasm",
-      "text": "should return one value",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "should return one value"
     },
     {
       "type": "assert_invalid",
       "line": 901,
       "filename": "resources.75.wasm",
-      "text": "should return `(own $T)`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "should return `(own $T)`"
     },
     {
       "type": "assert_invalid",
       "line": 904,
       "filename": "resources.76.wasm",
-      "text": "import name `[constructor]a` is not valid",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "import name `[constructor]a` is not valid"
     },
     {
       "type": "assert_invalid",
       "line": 909,
       "filename": "resources.77.wasm",
-      "text": "function does not match expected resource name `b`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function does not match expected resource name `b`"
     },
     {
       "type": "module",
       "line": 913,
-      "filename": "resources.78.wasm"
+      "filename": "resources.78.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 916,
-      "filename": "resources.79.wasm"
+      "filename": "resources.79.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 922,
       "filename": "resources.80.wasm",
-      "text": "failed to find `.` character",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "failed to find `.` character"
     },
     {
       "type": "assert_invalid",
       "line": 925,
       "filename": "resources.81.wasm",
-      "text": "failed to find `.` character",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "failed to find `.` character"
     },
     {
       "type": "assert_invalid",
       "line": 928,
       "filename": "resources.82.wasm",
-      "text": "not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 931,
       "filename": "resources.83.wasm",
-      "text": "not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 934,
       "filename": "resources.84.wasm",
-      "text": "not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 937,
       "filename": "resources.85.wasm",
-      "text": "is not a func",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "is not a func"
     },
     {
       "type": "assert_invalid",
       "line": 940,
       "filename": "resources.86.wasm",
-      "text": "should have at least one argument",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "should have at least one argument"
     },
     {
       "type": "assert_invalid",
       "line": 943,
       "filename": "resources.87.wasm",
-      "text": "should have a first argument called `self`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "should have a first argument called `self`"
     },
     {
       "type": "assert_invalid",
       "line": 946,
       "filename": "resources.88.wasm",
-      "text": "should take a first argument of `(borrow $T)`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "should take a first argument of `(borrow $T)`"
     },
     {
       "type": "assert_invalid",
       "line": 949,
       "filename": "resources.89.wasm",
-      "text": "does not match expected resource name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "does not match expected resource name"
     },
     {
       "type": "module",
       "line": 953,
-      "filename": "resources.90.wasm"
+      "filename": "resources.90.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 959,
       "filename": "resources.91.wasm",
-      "text": "failed to find `.` character",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "failed to find `.` character"
     },
     {
       "type": "assert_invalid",
       "line": 962,
       "filename": "resources.92.wasm",
-      "text": "failed to find `.` character",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "failed to find `.` character"
     },
     {
       "type": "assert_invalid",
       "line": 965,
       "filename": "resources.93.wasm",
-      "text": "not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 968,
       "filename": "resources.94.wasm",
-      "text": "not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 971,
       "filename": "resources.95.wasm",
-      "text": "not in kebab case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "not in kebab case"
     },
     {
       "type": "assert_invalid",
       "line": 974,
       "filename": "resources.96.wasm",
-      "text": "is not a func",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "is not a func"
     },
     {
       "type": "assert_invalid",
       "line": 977,
       "filename": "resources.97.wasm",
-      "text": "static resource name is not known in this context",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "static resource name is not known in this context"
     },
     {
       "type": "module",
       "line": 980,
-      "filename": "resources.98.wasm"
+      "filename": "resources.98.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 986,
       "filename": "resources.99.wasm",
-      "text": "resource used in function does not have a name in this context",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "resource used in function does not have a name in this context"
     },
     {
       "type": "module",
       "line": 993,
-      "filename": "resources.100.wasm"
+      "filename": "resources.100.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 1002,
       "filename": "resources.101.wasm",
-      "text": "resource used in function does not have a name in this context",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "resource used in function does not have a name in this context"
     },
     {
       "type": "assert_invalid",
       "line": 1013,
       "filename": "resources.102.wasm",
-      "text": "function does not match expected resource name `b`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function does not match expected resource name `b`"
     },
     {
       "type": "assert_invalid",
       "line": 1023,
       "filename": "resources.103.wasm",
-      "text": "resource used in function does not have a name in this context",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "resource used in function does not have a name in this context"
     },
     {
       "type": "module",
       "line": 1035,
-      "filename": "resources.104.wasm"
+      "filename": "resources.104.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 1043,
-      "filename": "resources.105.wasm"
+      "filename": "resources.105.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 1049,
-      "filename": "resources.106.wasm"
+      "filename": "resources.106.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 1084,
       "filename": "resources.107.wasm",
-      "text": "resource types are not the same",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "resource types are not the same"
     },
     {
       "type": "module",
       "line": 1104,
-      "filename": "resources.108.wasm"
+      "filename": "resources.108.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 1119,
-      "filename": "resources.109.wasm"
+      "filename": "resources.109.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 1130,
       "filename": "resources.110.wasm",
-      "text": "function result cannot contain a `borrow` type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function result cannot contain a `borrow` type"
     },
     {
       "type": "assert_invalid",
       "line": 1136,
       "filename": "resources.111.wasm",
-      "text": "function result cannot contain a `borrow` type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function result cannot contain a `borrow` type"
     },
     {
       "type": "assert_invalid",
       "line": 1142,
       "filename": "resources.112.wasm",
-      "text": "function result cannot contain a `borrow` type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function result cannot contain a `borrow` type"
     },
     {
       "type": "assert_invalid",
       "line": 1148,
       "filename": "resources.113.wasm",
-      "text": "function result cannot contain a `borrow` type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function result cannot contain a `borrow` type"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/start.wast.json
+++ b/tests/snapshots/local/component-model/start.wast.json
@@ -5,60 +5,62 @@
       "type": "assert_invalid",
       "line": 3,
       "filename": "start.0.wasm",
-      "text": "start function requires 1 arguments",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "start function requires 1 arguments"
     },
     {
       "type": "assert_invalid",
       "line": 10,
       "filename": "start.1.wasm",
-      "text": "start function requires 1 arguments",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "start function requires 1 arguments"
     },
     {
       "type": "assert_invalid",
       "line": 18,
       "filename": "start.2.wasm",
-      "text": "cannot be used more than once",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "cannot be used more than once"
     },
     {
       "type": "assert_invalid",
       "line": 26,
       "filename": "start.3.wasm",
-      "text": "type mismatch for component start function argument 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch for component start function argument 1"
     },
     {
       "type": "module",
       "line": 34,
-      "filename": "start.4.wasm"
+      "filename": "start.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 41,
-      "filename": "start.5.wasm"
+      "filename": "start.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 48,
       "filename": "start.6.wasm",
-      "text": "cannot have more than one start",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "cannot have more than one start"
     },
     {
       "type": "assert_invalid",
       "line": 56,
       "filename": "start.7.wasm",
-      "text": "start function results size is out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "start function results size is out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 78,
       "filename": "start.8.wasm",
-      "text": "unexpected content in the component start section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content in the component start section"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/string.wast.json
+++ b/tests/snapshots/local/component-model/string.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "string.0.wasm"
+      "filename": "string.0.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/type-export-restrictions.wast.json
+++ b/tests/snapshots/local/component-model/type-export-restrictions.wast.json
@@ -5,295 +5,313 @@
       "type": "assert_invalid",
       "line": 4,
       "filename": "type-export-restrictions.0.wasm",
-      "text": "type not valid to be used as export",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type not valid to be used as export"
     },
     {
       "type": "assert_invalid",
       "line": 12,
       "filename": "type-export-restrictions.1.wasm",
-      "text": "type not valid to be used as export",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type not valid to be used as export"
     },
     {
       "type": "assert_invalid",
       "line": 20,
       "filename": "type-export-restrictions.2.wasm",
-      "text": "type not valid to be used as export",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type not valid to be used as export"
     },
     {
       "type": "assert_invalid",
       "line": 28,
       "filename": "type-export-restrictions.3.wasm",
-      "text": "type not valid to be used as export",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type not valid to be used as export"
     },
     {
       "type": "assert_invalid",
       "line": 36,
       "filename": "type-export-restrictions.4.wasm",
-      "text": "type not valid to be used as export",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type not valid to be used as export"
     },
     {
       "type": "assert_invalid",
       "line": 44,
       "filename": "type-export-restrictions.5.wasm",
-      "text": "type not valid to be used as export",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type not valid to be used as export"
     },
     {
       "type": "assert_invalid",
       "line": 54,
       "filename": "type-export-restrictions.6.wasm",
-      "text": "type not valid to be used as export",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type not valid to be used as export"
     },
     {
       "type": "assert_invalid",
       "line": 62,
       "filename": "type-export-restrictions.7.wasm",
-      "text": "type not valid to be used as export",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type not valid to be used as export"
     },
     {
       "type": "assert_invalid",
       "line": 70,
       "filename": "type-export-restrictions.8.wasm",
-      "text": "type not valid to be used as export",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type not valid to be used as export"
     },
     {
       "type": "assert_invalid",
       "line": 78,
       "filename": "type-export-restrictions.9.wasm",
-      "text": "type not valid to be used as export",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type not valid to be used as export"
     },
     {
       "type": "assert_invalid",
       "line": 86,
       "filename": "type-export-restrictions.10.wasm",
-      "text": "type not valid to be used as export",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type not valid to be used as export"
     },
     {
       "type": "module",
       "line": 94,
-      "filename": "type-export-restrictions.11.wasm"
+      "filename": "type-export-restrictions.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 105,
-      "filename": "type-export-restrictions.12.wasm"
+      "filename": "type-export-restrictions.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 114,
       "filename": "type-export-restrictions.13.wasm",
-      "text": "type not valid to be used as import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type not valid to be used as import"
     },
     {
       "type": "module",
       "line": 120,
-      "filename": "type-export-restrictions.14.wasm"
+      "filename": "type-export-restrictions.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 127,
       "filename": "type-export-restrictions.15.wasm",
-      "text": "func not valid to be used as import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "func not valid to be used as import"
     },
     {
       "type": "assert_invalid",
       "line": 135,
       "filename": "type-export-restrictions.16.wasm",
-      "text": "type not valid to be used as export",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type not valid to be used as export"
     },
     {
       "type": "assert_invalid",
       "line": 145,
       "filename": "type-export-restrictions.17.wasm",
-      "text": "func not valid to be used as export",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "func not valid to be used as export"
     },
     {
       "type": "assert_invalid",
       "line": 153,
       "filename": "type-export-restrictions.18.wasm",
-      "text": "type not valid to be used as export",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type not valid to be used as export"
     },
     {
       "type": "module",
       "line": 163,
-      "filename": "type-export-restrictions.19.wasm"
+      "filename": "type-export-restrictions.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 172,
       "filename": "type-export-restrictions.20.wasm",
-      "text": "instance not valid to be used as export",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "instance not valid to be used as export"
     },
     {
       "type": "assert_invalid",
       "line": 184,
       "filename": "type-export-restrictions.21.wasm",
-      "text": "func not valid to be used as export",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "func not valid to be used as export"
     },
     {
       "type": "assert_invalid",
       "line": 197,
       "filename": "type-export-restrictions.22.wasm",
-      "text": "func not valid to be used as export",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "func not valid to be used as export"
     },
     {
       "type": "assert_invalid",
       "line": 213,
       "filename": "type-export-restrictions.23.wasm",
-      "text": "func not valid to be used as export",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "func not valid to be used as export"
     },
     {
       "type": "module",
       "line": 229,
-      "filename": "type-export-restrictions.24.wasm"
+      "filename": "type-export-restrictions.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 242,
-      "filename": "type-export-restrictions.25.wasm"
+      "filename": "type-export-restrictions.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 258,
-      "filename": "type-export-restrictions.26.wasm"
+      "filename": "type-export-restrictions.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 271,
       "filename": "type-export-restrictions.27.wasm",
-      "text": "func not valid to be used as import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "func not valid to be used as import"
     },
     {
       "type": "module",
       "line": 279,
-      "filename": "type-export-restrictions.28.wasm"
+      "filename": "type-export-restrictions.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 284,
-      "filename": "type-export-restrictions.29.wasm"
+      "filename": "type-export-restrictions.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 294,
       "filename": "type-export-restrictions.30.wasm",
-      "text": "func not valid to be used as import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "func not valid to be used as import"
     },
     {
       "type": "assert_invalid",
       "line": 303,
       "filename": "type-export-restrictions.31.wasm",
-      "text": "func not valid to be used as export",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "func not valid to be used as export"
     },
     {
       "type": "module",
       "line": 315,
-      "filename": "type-export-restrictions.32.wasm"
+      "filename": "type-export-restrictions.32.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 335,
-      "filename": "type-export-restrictions.33.wasm"
+      "filename": "type-export-restrictions.33.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 339,
-      "filename": "type-export-restrictions.34.wasm"
+      "filename": "type-export-restrictions.34.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 344,
-      "filename": "type-export-restrictions.35.wasm"
+      "filename": "type-export-restrictions.35.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 348,
-      "filename": "type-export-restrictions.36.wasm"
+      "filename": "type-export-restrictions.36.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 356,
       "filename": "type-export-restrictions.37.wasm",
-      "text": "instance not valid to be used as export",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "instance not valid to be used as export"
     },
     {
       "type": "module",
       "line": 378,
-      "filename": "type-export-restrictions.38.wasm"
+      "filename": "type-export-restrictions.38.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 385,
       "filename": "type-export-restrictions.39.wasm",
-      "text": "instance not valid to be used as import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "instance not valid to be used as import"
     },
     {
       "type": "module",
       "line": 396,
       "name": "C",
-      "filename": "type-export-restrictions.40.wasm"
+      "filename": "type-export-restrictions.40.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 412,
-      "filename": "type-export-restrictions.41.wasm"
+      "filename": "type-export-restrictions.41.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 427,
       "filename": "type-export-restrictions.42.wasm",
-      "text": "type not valid to be used as import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type not valid to be used as import"
     },
     {
       "type": "assert_invalid",
       "line": 437,
       "filename": "type-export-restrictions.43.wasm",
-      "text": "type not valid to be used as export",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type not valid to be used as export"
     },
     {
       "type": "assert_invalid",
       "line": 448,
       "filename": "type-export-restrictions.44.wasm",
-      "text": "type not valid to be used as import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type not valid to be used as import"
     },
     {
       "type": "assert_invalid",
       "line": 455,
       "filename": "type-export-restrictions.45.wasm",
-      "text": "type not valid to be used as export",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type not valid to be used as export"
     },
     {
       "type": "module",
       "line": 462,
-      "filename": "type-export-restrictions.46.wasm"
+      "filename": "type-export-restrictions.46.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/types.wast.json
+++ b/tests/snapshots/local/component-model/types.wast.json
@@ -5,303 +5,312 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "types.0.wasm",
-      "text": "type index 0 is not a function type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index 0 is not a function type"
     },
     {
       "type": "assert_invalid",
       "line": 9,
       "filename": "types.1.wasm",
-      "text": "core type index 0 is not a module type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "core type index 0 is not a module type"
     },
     {
       "type": "assert_invalid",
       "line": 16,
       "filename": "types.2.wasm",
-      "text": "type index 0 is not an instance type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index 0 is not an instance type"
     },
     {
       "type": "assert_invalid",
       "line": 23,
       "filename": "types.3.wasm",
-      "text": "type index 0 is not an instance type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index 0 is not an instance type"
     },
     {
       "type": "assert_invalid",
       "line": 32,
       "filename": "types.4.wasm",
-      "text": "core type index 0 is not a module type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "core type index 0 is not a module type"
     },
     {
       "type": "assert_invalid",
       "line": 41,
       "filename": "types.5.wasm",
-      "text": "type index 0 is not a function type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index 0 is not a function type"
     },
     {
       "type": "assert_invalid",
       "line": 50,
       "filename": "types.6.wasm",
-      "text": "module index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "module index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 56,
       "filename": "types.7.wasm",
-      "text": "instance index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "instance index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 62,
       "filename": "types.8.wasm",
-      "text": "type index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 70,
       "filename": "types.9.wasm",
-      "text": "export name `a` already defined",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "export name `a` already defined"
     },
     {
       "type": "assert_invalid",
       "line": 79,
       "filename": "types.10.wasm",
-      "text": "duplicate import name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate import name"
     },
     {
       "type": "assert_invalid",
       "line": 88,
       "filename": "types.11.wasm",
-      "text": "memory size must be at most",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "memory size must be at most"
     },
     {
       "type": "assert_invalid",
       "line": 96,
       "filename": "types.12.wasm",
-      "text": "type index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 104,
       "filename": "types.13.wasm",
-      "text": "export name `A` conflicts with previous name `a`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "export name `A` conflicts with previous name `a`"
     },
     {
       "type": "assert_invalid",
       "line": 113,
       "filename": "types.14.wasm",
-      "text": "import name `a` conflicts with previous name `A`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "import name `a` conflicts with previous name `A`"
     },
     {
       "type": "assert_invalid",
       "line": 122,
       "filename": "types.15.wat",
-      "text": "unknown core type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown core type"
     },
     {
       "type": "assert_invalid",
       "line": 128,
       "filename": "types.16.wasm",
-      "text": "type index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index out of bounds"
     },
     {
       "type": "module",
       "line": 135,
       "name": "c",
-      "filename": "types.17.wasm"
+      "filename": "types.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 143,
       "filename": "types.18.wat",
-      "text": "unknown type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 149,
       "filename": "types.19.wasm",
-      "text": "type index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 157,
       "filename": "types.20.wasm",
-      "text": "invalid outer alias count of 100",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid outer alias count of 100"
     },
     {
       "type": "assert_invalid",
       "line": 166,
       "filename": "types.21.wasm",
-      "text": "name `` already defined",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "name `` already defined"
     },
     {
       "type": "assert_invalid",
       "line": 178,
       "filename": "types.22.wasm",
-      "text": "type index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 186,
       "filename": "types.23.wasm",
-      "text": "export name `FOO-bar-BAZ` conflicts with previous name `foo-BAR-baz`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "export name `FOO-bar-BAZ` conflicts with previous name `foo-BAR-baz`"
     },
     {
       "type": "assert_invalid",
       "line": 195,
       "filename": "types.24.wat",
-      "text": "unknown type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 201,
       "filename": "types.25.wasm",
-      "text": "type index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 209,
       "filename": "types.26.wasm",
-      "text": "invalid outer alias count of 100",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid outer alias count of 100"
     },
     {
       "type": "assert_invalid",
       "line": 218,
       "filename": "types.27.wasm",
-      "text": "name `` already defined",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "name `` already defined"
     },
     {
       "type": "assert_invalid",
       "line": 230,
       "filename": "types.28.wasm",
-      "text": "function parameter name cannot be empty",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function parameter name cannot be empty"
     },
     {
       "type": "module",
       "line": 235,
-      "filename": "types.29.wasm"
+      "filename": "types.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 239,
       "name": "C",
-      "filename": "types.30.wasm"
+      "filename": "types.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 247,
       "name": "C",
-      "filename": "types.31.wasm"
+      "filename": "types.31.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 257,
       "name": "C",
-      "filename": "types.32.wasm"
+      "filename": "types.32.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 267,
-      "filename": "types.33.wasm"
+      "filename": "types.33.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 274,
-      "filename": "types.34.wasm"
+      "filename": "types.34.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 283,
       "filename": "types.35.wasm",
-      "text": "variant type must have at least one case",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "variant type must have at least one case"
     },
     {
       "type": "assert_invalid",
       "line": 289,
       "filename": "types.36.wasm",
-      "text": "enum type must have at least one variant",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "enum type must have at least one variant"
     },
     {
       "type": "assert_invalid",
       "line": 295,
       "filename": "types.37.wasm",
-      "text": "record type must have at least one field",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "record type must have at least one field"
     },
     {
       "type": "assert_invalid",
       "line": 301,
       "filename": "types.38.wasm",
-      "text": "flags must have at least one entry",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "flags must have at least one entry"
     },
     {
       "type": "assert_invalid",
       "line": 307,
       "filename": "types.39.wasm",
-      "text": "tuple type must have at least one type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "tuple type must have at least one type"
     },
     {
       "type": "module",
       "line": 312,
       "name": "c",
-      "filename": "types.40.wasm"
+      "filename": "types.40.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 322,
       "filename": "types.41.wasm",
-      "text": "cannot have more than 32 flags",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "cannot have more than 32 flags"
     },
     {
       "type": "module",
       "line": 362,
-      "filename": "types.42.wasm"
+      "filename": "types.42.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 391,
       "filename": "types.43.wasm",
-      "text": "type index 0 is a module type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index 0 is a module type"
     },
     {
       "type": "assert_invalid",
       "line": 398,
       "filename": "types.44.wasm",
-      "text": "type index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index out of bounds"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/very-nested.wast.json
+++ b/tests/snapshots/local/component-model/very-nested.wast.json
@@ -5,36 +5,36 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "very-nested.0.wasm",
-      "text": "conflicts with previous name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "conflicts with previous name"
     },
     {
       "type": "assert_invalid",
       "line": 1568,
       "filename": "very-nested.1.wasm",
-      "text": "effective type size exceeds the limit",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "effective type size exceeds the limit"
     },
     {
       "type": "assert_invalid",
       "line": 1689,
       "filename": "very-nested.2.wasm",
-      "text": "effective type size exceeds the limit",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "effective type size exceeds the limit"
     },
     {
       "type": "assert_invalid",
       "line": 1779,
       "filename": "very-nested.3.wasm",
-      "text": "effective type size exceeds the limit",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "effective type size exceeds the limit"
     },
     {
       "type": "assert_malformed",
       "line": 1869,
       "filename": "very-nested.4.wat",
-      "text": "nesting too deep",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "nesting too deep"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/virtualize.wast.json
+++ b/tests/snapshots/local/component-model/virtualize.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "virtualize.0.wasm"
+      "filename": "virtualize.0.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/wrong-order.wast.json
+++ b/tests/snapshots/local/component-model/wrong-order.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "wrong-order.0.wasm",
-      "text": "section out of order",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section out of order"
     }
   ]
 }

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes-invalid.wast.json
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes-invalid.wast.json
@@ -5,127 +5,127 @@
       "type": "assert_malformed",
       "line": 3,
       "filename": "custom-page-sizes-invalid.0.wat",
-      "text": "invalid custom page size",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "invalid custom page size"
     },
     {
       "type": "assert_invalid",
       "line": 9,
       "filename": "custom-page-sizes-invalid.1.wasm",
-      "text": "invalid custom page size",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid custom page size"
     },
     {
       "type": "assert_invalid",
       "line": 13,
       "filename": "custom-page-sizes-invalid.2.wasm",
-      "text": "invalid custom page size",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid custom page size"
     },
     {
       "type": "assert_invalid",
       "line": 17,
       "filename": "custom-page-sizes-invalid.3.wasm",
-      "text": "invalid custom page size",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid custom page size"
     },
     {
       "type": "assert_invalid",
       "line": 21,
       "filename": "custom-page-sizes-invalid.4.wasm",
-      "text": "invalid custom page size",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid custom page size"
     },
     {
       "type": "assert_invalid",
       "line": 25,
       "filename": "custom-page-sizes-invalid.5.wasm",
-      "text": "invalid custom page size",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid custom page size"
     },
     {
       "type": "assert_invalid",
       "line": 29,
       "filename": "custom-page-sizes-invalid.6.wasm",
-      "text": "invalid custom page size",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid custom page size"
     },
     {
       "type": "assert_invalid",
       "line": 33,
       "filename": "custom-page-sizes-invalid.7.wasm",
-      "text": "invalid custom page size",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid custom page size"
     },
     {
       "type": "assert_invalid",
       "line": 37,
       "filename": "custom-page-sizes-invalid.8.wasm",
-      "text": "invalid custom page size",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid custom page size"
     },
     {
       "type": "assert_invalid",
       "line": 41,
       "filename": "custom-page-sizes-invalid.9.wasm",
-      "text": "invalid custom page size",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid custom page size"
     },
     {
       "type": "assert_invalid",
       "line": 45,
       "filename": "custom-page-sizes-invalid.10.wasm",
-      "text": "invalid custom page size",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid custom page size"
     },
     {
       "type": "assert_invalid",
       "line": 49,
       "filename": "custom-page-sizes-invalid.11.wasm",
-      "text": "invalid custom page size",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid custom page size"
     },
     {
       "type": "assert_invalid",
       "line": 53,
       "filename": "custom-page-sizes-invalid.12.wasm",
-      "text": "invalid custom page size",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid custom page size"
     },
     {
       "type": "assert_invalid",
       "line": 57,
       "filename": "custom-page-sizes-invalid.13.wasm",
-      "text": "invalid custom page size",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid custom page size"
     },
     {
       "type": "assert_invalid",
       "line": 61,
       "filename": "custom-page-sizes-invalid.14.wasm",
-      "text": "invalid custom page size",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid custom page size"
     },
     {
       "type": "assert_invalid",
       "line": 65,
       "filename": "custom-page-sizes-invalid.15.wasm",
-      "text": "invalid custom page size",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid custom page size"
     },
     {
       "type": "assert_invalid",
       "line": 71,
       "filename": "custom-page-sizes-invalid.16.wasm",
-      "text": "invalid custom page size",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid custom page size"
     },
     {
       "type": "assert_malformed",
       "line": 78,
       "filename": "custom-page-sizes-invalid.17.wasm",
-      "text": "invalid custom page size",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid custom page size"
     }
   ]
 }

--- a/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast.json
+++ b/tests/snapshots/local/custom-page-sizes/custom-page-sizes.wast.json
@@ -4,27 +4,32 @@
     {
       "type": "module",
       "line": 2,
-      "filename": "custom-page-sizes.0.wasm"
+      "filename": "custom-page-sizes.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 3,
-      "filename": "custom-page-sizes.1.wasm"
+      "filename": "custom-page-sizes.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 6,
-      "filename": "custom-page-sizes.2.wasm"
+      "filename": "custom-page-sizes.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 7,
-      "filename": "custom-page-sizes.3.wasm"
+      "filename": "custom-page-sizes.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 10,
-      "filename": "custom-page-sizes.4.wasm"
+      "filename": "custom-page-sizes.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -277,7 +282,8 @@
     {
       "type": "module",
       "line": 46,
-      "filename": "custom-page-sizes.5.wasm"
+      "filename": "custom-page-sizes.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -332,7 +338,8 @@
     {
       "type": "module",
       "line": 57,
-      "filename": "custom-page-sizes.6.wasm"
+      "filename": "custom-page-sizes.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/local/data-count-big.wast.json
+++ b/tests/snapshots/local/data-count-big.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "data-count-big.0.wasm",
-      "text": "data count section specifies too many data segments",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "data count section specifies too many data segments"
     }
   ]
 }

--- a/tests/snapshots/local/duplicate.wast.json
+++ b/tests/snapshots/local/duplicate.wast.json
@@ -5,106 +5,106 @@
       "type": "assert_malformed",
       "line": 1,
       "filename": "duplicate.0.wat",
-      "text": "duplicate func identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate func identifier"
     },
     {
       "type": "assert_malformed",
       "line": 5,
       "filename": "duplicate.1.wat",
-      "text": "duplicate func identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate func identifier"
     },
     {
       "type": "assert_malformed",
       "line": 9,
       "filename": "duplicate.2.wat",
-      "text": "duplicate func identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate func identifier"
     },
     {
       "type": "assert_malformed",
       "line": 14,
       "filename": "duplicate.3.wat",
-      "text": "duplicate global identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate global identifier"
     },
     {
       "type": "assert_malformed",
       "line": 18,
       "filename": "duplicate.4.wat",
-      "text": "duplicate global identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate global identifier"
     },
     {
       "type": "assert_malformed",
       "line": 22,
       "filename": "duplicate.5.wat",
-      "text": "duplicate global identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate global identifier"
     },
     {
       "type": "assert_malformed",
       "line": 27,
       "filename": "duplicate.6.wat",
-      "text": "duplicate memory identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate memory identifier"
     },
     {
       "type": "assert_malformed",
       "line": 31,
       "filename": "duplicate.7.wat",
-      "text": "duplicate memory identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate memory identifier"
     },
     {
       "type": "assert_malformed",
       "line": 35,
       "filename": "duplicate.8.wat",
-      "text": "duplicate memory identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate memory identifier"
     },
     {
       "type": "assert_malformed",
       "line": 40,
       "filename": "duplicate.9.wat",
-      "text": "duplicate table identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate table identifier"
     },
     {
       "type": "assert_malformed",
       "line": 44,
       "filename": "duplicate.10.wat",
-      "text": "duplicate table identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate table identifier"
     },
     {
       "type": "assert_malformed",
       "line": 48,
       "filename": "duplicate.11.wat",
-      "text": "duplicate table identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate table identifier"
     },
     {
       "type": "assert_malformed",
       "line": 53,
       "filename": "duplicate.12.wat",
-      "text": "duplicate local identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate local identifier"
     },
     {
       "type": "assert_malformed",
       "line": 55,
       "filename": "duplicate.13.wat",
-      "text": "duplicate local identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate local identifier"
     },
     {
       "type": "assert_malformed",
       "line": 57,
       "filename": "duplicate.14.wat",
-      "text": "duplicate local identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate local identifier"
     }
   ]
 }

--- a/tests/snapshots/local/dylink0.wast.json
+++ b/tests/snapshots/local/dylink0.wast.json
@@ -4,47 +4,56 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "dylink0.0.wasm"
+      "filename": "dylink0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 5,
-      "filename": "dylink0.1.wasm"
+      "filename": "dylink0.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 10,
-      "filename": "dylink0.2.wasm"
+      "filename": "dylink0.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 19,
-      "filename": "dylink0.3.wasm"
+      "filename": "dylink0.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 27,
-      "filename": "dylink0.4.wasm"
+      "filename": "dylink0.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 34,
-      "filename": "dylink0.5.wasm"
+      "filename": "dylink0.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 41,
-      "filename": "dylink0.6.wasm"
+      "filename": "dylink0.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 51,
-      "filename": "dylink0.7.wasm"
+      "filename": "dylink0.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 64,
-      "filename": "dylink0.8.wasm"
+      "filename": "dylink0.8.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/elem.wast.json
+++ b/tests/snapshots/local/elem.wast.json
@@ -4,28 +4,29 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "elem.0.wasm"
+      "filename": "elem.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 11,
       "filename": "elem.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 18,
       "filename": "elem.2.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_malformed",
       "line": 25,
       "filename": "elem.3.wat",
-      "text": "folded instruction",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "folded instruction"
     }
   ]
 }

--- a/tests/snapshots/local/empty-elem.wast.json
+++ b/tests/snapshots/local/empty-elem.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "empty-elem.0.wasm"
+      "filename": "empty-elem.0.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/empty.wast.json
+++ b/tests/snapshots/local/empty.wast.json
@@ -5,36 +5,36 @@
       "type": "assert_malformed",
       "line": 1,
       "filename": "empty.0.wat",
-      "text": "x",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "x"
     },
     {
       "type": "assert_malformed",
       "line": 2,
       "filename": "empty.1.wat",
-      "text": "x",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "x"
     },
     {
       "type": "assert_malformed",
       "line": 3,
       "filename": "empty.2.wat",
-      "text": "x",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "x"
     },
     {
       "type": "assert_malformed",
       "line": 4,
       "filename": "empty.3.wat",
-      "text": "x",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "x"
     },
     {
       "type": "assert_malformed",
       "line": 5,
       "filename": "empty.4.wat",
-      "text": "x",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "x"
     }
   ]
 }

--- a/tests/snapshots/local/exnref/exnref.wast.json
+++ b/tests/snapshots/local/exnref/exnref.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "exnref.0.wasm"
+      "filename": "exnref.0.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/exnref/throw_ref.wast.json
+++ b/tests/snapshots/local/exnref/throw_ref.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "throw_ref.0.wasm"
+      "filename": "throw_ref.0.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/exnref/try-table.wast.json
+++ b/tests/snapshots/local/exnref/try-table.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "try-table.0.wasm",
-      "text": "type mismatch: catch_all_ref label must a subtype of (ref exn)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch: catch_all_ref label must a subtype of (ref exn)"
     }
   ]
 }

--- a/tests/snapshots/local/externref-elem-segment.wast.json
+++ b/tests/snapshots/local/externref-elem-segment.wast.json
@@ -4,21 +4,22 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "externref-elem-segment.0.wasm"
+      "filename": "externref-elem-segment.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 7,
       "filename": "externref-elem-segment.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 14,
       "filename": "externref-elem-segment.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/local/function-references/bad-call-ref-ty.wast.json
+++ b/tests/snapshots/local/function-references/bad-call-ref-ty.wast.json
@@ -5,29 +5,29 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "bad-call-ref-ty.0.wasm",
-      "text": "expected (ref null $type), found funcref",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected (ref null $type), found funcref"
     },
     {
       "type": "assert_invalid",
       "line": 11,
       "filename": "bad-call-ref-ty.1.wasm",
-      "text": "expected i32 but nothing on stack",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected i32 but nothing on stack"
     },
     {
       "type": "assert_invalid",
       "line": 20,
       "filename": "bad-call-ref-ty.2.wasm",
-      "text": "type index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 29,
       "filename": "bad-call-ref-ty.3.wasm",
-      "text": "type index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index out of bounds"
     }
   ]
 }

--- a/tests/snapshots/local/function-references/call_ref/br_on_non_null.wast.json
+++ b/tests/snapshots/local/function-references/call_ref/br_on_non_null.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "br_on_non_null.0.wasm"
+      "filename": "br_on_non_null.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -64,12 +65,14 @@
     {
       "type": "module",
       "line": 42,
-      "filename": "br_on_non_null.1.wasm"
+      "filename": "br_on_non_null.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 50,
-      "filename": "br_on_non_null.2.wasm"
+      "filename": "br_on_non_null.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/local/function-references/call_ref/br_on_null.wast.json
+++ b/tests/snapshots/local/function-references/call_ref/br_on_null.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "br_on_null.0.wasm"
+      "filename": "br_on_null.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -64,12 +65,14 @@
     {
       "type": "module",
       "line": 38,
-      "filename": "br_on_null.1.wasm"
+      "filename": "br_on_null.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 46,
-      "filename": "br_on_null.2.wasm"
+      "filename": "br_on_null.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/local/function-references/call_ref/call_ref.wast.json
+++ b/tests/snapshots/local/function-references/call_ref/call_ref.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "call_ref.0.wasm"
+      "filename": "call_ref.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -495,7 +496,8 @@
     {
       "type": "module",
       "line": 129,
-      "filename": "call_ref.1.wasm"
+      "filename": "call_ref.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -510,7 +512,8 @@
     {
       "type": "module",
       "line": 138,
-      "filename": "call_ref.2.wasm"
+      "filename": "call_ref.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -525,7 +528,8 @@
     {
       "type": "module",
       "line": 151,
-      "filename": "call_ref.3.wasm"
+      "filename": "call_ref.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -541,22 +545,22 @@
       "type": "assert_invalid",
       "line": 168,
       "filename": "call_ref.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 184,
       "filename": "call_ref.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 201,
       "filename": "call_ref.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/local/function-references/call_ref/ref_as_non_null.wast.json
+++ b/tests/snapshots/local/function-references/call_ref/ref_as_non_null.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "ref_as_non_null.0.wasm"
+      "filename": "ref_as_non_null.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -60,13 +61,14 @@
       "type": "assert_invalid",
       "line": 32,
       "filename": "ref_as_non_null.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 41,
-      "filename": "ref_as_non_null.2.wasm"
+      "filename": "ref_as_non_null.2.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/function-references/call_ref/return_call_ref.wast.json
+++ b/tests/snapshots/local/function-references/call_ref/return_call_ref.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "return_call_ref.0.wasm"
+      "filename": "return_call_ref.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -595,54 +596,56 @@
     {
       "type": "module",
       "line": 213,
-      "filename": "return_call_ref.1.wasm"
+      "filename": "return_call_ref.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 232,
       "filename": "return_call_ref.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 243,
       "filename": "return_call_ref.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 254,
       "filename": "return_call_ref.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 265,
       "filename": "return_call_ref.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 276,
       "filename": "return_call_ref.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 287,
       "filename": "return_call_ref.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 299,
-      "filename": "return_call_ref.8.wasm"
+      "filename": "return_call_ref.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -657,7 +660,8 @@
     {
       "type": "module",
       "line": 308,
-      "filename": "return_call_ref.9.wasm"
+      "filename": "return_call_ref.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -672,7 +676,8 @@
     {
       "type": "module",
       "line": 321,
-      "filename": "return_call_ref.10.wasm"
+      "filename": "return_call_ref.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -688,22 +693,22 @@
       "type": "assert_invalid",
       "line": 337,
       "filename": "return_call_ref.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 353,
       "filename": "return_call_ref.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 369,
       "filename": "return_call_ref.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/local/function-references/return-call.wast.json
+++ b/tests/snapshots/local/function-references/return-call.wast.json
@@ -5,22 +5,22 @@
       "type": "assert_invalid",
       "line": 7,
       "filename": "return-call.0.wasm",
-      "text": "type mismatch: current function requires result type [i32] but callee returns [i32 i32]",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch: current function requires result type [i32] but callee returns [i32 i32]"
     },
     {
       "type": "assert_invalid",
       "line": 17,
       "filename": "return-call.1.wasm",
-      "text": "type mismatch: current function requires result type [i32] but callee returns [i32 i32]",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch: current function requires result type [i32] but callee returns [i32 i32]"
     },
     {
       "type": "assert_invalid",
       "line": 29,
       "filename": "return-call.2.wasm",
-      "text": "type mismatch: expected (ref null $type), found funcref",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch: expected (ref null $type), found funcref"
     }
   ]
 }

--- a/tests/snapshots/local/function-references/table-nonnull.wast.json
+++ b/tests/snapshots/local/function-references/table-nonnull.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "table-nonnull.0.wasm"
+      "filename": "table-nonnull.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/local/gc/br-on-non-null.wast.json
+++ b/tests/snapshots/local/gc/br-on-non-null.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "br-on-non-null.0.wasm",
-      "text": "expected anyref, found funcref",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected anyref, found funcref"
     }
   ]
 }

--- a/tests/snapshots/local/gc/gc-array-types-invalid.wast.json
+++ b/tests/snapshots/local/gc/gc-array-types-invalid.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 4,
       "filename": "gc-array-types-invalid.0.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     }
   ]
 }

--- a/tests/snapshots/local/gc/gc-rec-groups-invalid.wast.json
+++ b/tests/snapshots/local/gc/gc-rec-groups-invalid.wast.json
@@ -5,15 +5,15 @@
       "type": "assert_invalid",
       "line": 4,
       "filename": "gc-rec-groups-invalid.0.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 19,
       "filename": "gc-rec-groups-invalid.1.wasm",
-      "text": "sub type must match super type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type must match super type"
     }
   ]
 }

--- a/tests/snapshots/local/gc/gc-struct-types-invalid.wast.json
+++ b/tests/snapshots/local/gc/gc-struct-types-invalid.wast.json
@@ -5,22 +5,22 @@
       "type": "assert_malformed",
       "line": 4,
       "filename": "gc-struct-types-invalid.0.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 10,
       "filename": "gc-struct-types-invalid.1.wat",
-      "text": "expected `)`",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "expected `)`"
     },
     {
       "type": "assert_malformed",
       "line": 16,
       "filename": "gc-struct-types-invalid.2.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     }
   ]
 }

--- a/tests/snapshots/local/gc/gc-subtyping-too-deep.wast.json
+++ b/tests/snapshots/local/gc/gc-subtyping-too-deep.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "gc-subtyping-too-deep.0.wasm",
-      "text": "sub type hierarchy too deep: found depth 64, cannot exceed depth 63",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type hierarchy too deep: found depth 64, cannot exceed depth 63"
     }
   ]
 }

--- a/tests/snapshots/local/gc/invalid.wast.json
+++ b/tests/snapshots/local/gc/invalid.wast.json
@@ -5,193 +5,195 @@
       "type": "assert_invalid",
       "line": 4,
       "filename": "invalid.0.wasm",
-      "text": "type mismatch: expected structref, found anyref",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch: expected structref, found anyref"
     },
     {
       "type": "assert_invalid",
       "line": 18,
       "filename": "invalid.1.wasm",
-      "text": "type mismatch: expected structref, found anyref",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch: expected structref, found anyref"
     },
     {
       "type": "assert_invalid",
       "line": 34,
       "filename": "invalid.2.wasm",
-      "text": "expected struct type at index 0, found (func ...)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected struct type at index 0, found (func ...)"
     },
     {
       "type": "assert_invalid",
       "line": 40,
       "filename": "invalid.3.wasm",
-      "text": "unknown field: field index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown field: field index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 46,
       "filename": "invalid.4.wasm",
-      "text": "unknown type: type index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type: type index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 51,
       "filename": "invalid.5.wasm",
-      "text": "expected array type at index 0, found (struct ...)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected array type at index 0, found (struct ...)"
     },
     {
       "type": "assert_invalid",
       "line": 57,
       "filename": "invalid.6.wasm",
-      "text": "unknown type: type index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type: type index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 62,
       "filename": "invalid.7.wasm",
-      "text": "type index 0 is not a function type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index 0 is not a function type"
     },
     {
       "type": "assert_invalid",
       "line": 68,
       "filename": "invalid.8.wasm",
-      "text": "expected func type at index 0, found (struct ...)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected func type at index 0, found (struct ...)"
     },
     {
       "type": "assert_invalid",
       "line": 74,
       "filename": "invalid.9.wasm",
-      "text": "type mismatch: br_on_non_null target has no label types",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch: br_on_non_null target has no label types"
     },
     {
       "type": "assert_invalid",
       "line": 85,
       "filename": "invalid.10.wasm",
-      "text": "type mismatch: br_on_non_null target does not end with heap type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch: br_on_non_null target does not end with heap type"
     },
     {
       "type": "assert_invalid",
       "line": 96,
       "filename": "invalid.11.wasm",
-      "text": "invalid `struct.new_default`: (ref func) field is not defaultable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid `struct.new_default`: (ref func) field is not defaultable"
     },
     {
       "type": "assert_invalid",
       "line": 105,
       "filename": "invalid.12.wasm",
-      "text": "cannot use struct.get_u with non-packed storage types",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "cannot use struct.get_u with non-packed storage types"
     },
     {
       "type": "assert_invalid",
       "line": 115,
       "filename": "invalid.13.wasm",
-      "text": "invalid `array.new_default`: (ref func) field is not defaultable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid `array.new_default`: (ref func) field is not defaultable"
     },
     {
       "type": "assert_invalid",
       "line": 124,
       "filename": "invalid.14.wasm",
-      "text": "array.new_data can only create arrays with numeric and vector elements",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array.new_data can only create arrays with numeric and vector elements"
     },
     {
       "type": "assert_invalid",
       "line": 137,
       "filename": "invalid.15.wasm",
-      "text": "data count section required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "data count section required"
     },
     {
       "type": "module",
       "line": 167,
-      "filename": "invalid.16.wasm"
+      "filename": "invalid.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 199,
       "filename": "invalid.17.wasm",
-      "text": "unknown data segment 100",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown data segment 100"
     },
     {
       "type": "assert_invalid",
       "line": 211,
       "filename": "invalid.18.wasm",
-      "text": "type mismatch: array.new_elem can only create arrays with reference elements",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch: array.new_elem can only create arrays with reference elements"
     },
     {
       "type": "assert_invalid",
       "line": 224,
       "filename": "invalid.19.wasm",
-      "text": "invalid array.new_elem instruction: element segment 0 type mismatch: expected (ref any), found funcref",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid array.new_elem instruction: element segment 0 type mismatch: expected (ref any), found funcref"
     },
     {
       "type": "assert_invalid",
       "line": 237,
       "filename": "invalid.20.wasm",
-      "text": "array types do not match: expected i8, found i16",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array types do not match: expected i8, found i16"
     },
     {
       "type": "assert_invalid",
       "line": 248,
       "filename": "invalid.21.wasm",
-      "text": "array types do not match: expected i16, found i8",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array types do not match: expected i16, found i8"
     },
     {
       "type": "assert_invalid",
       "line": 259,
       "filename": "invalid.22.wasm",
-      "text": "array types do not match: expected i32, found i64",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array types do not match: expected i32, found i64"
     },
     {
       "type": "assert_invalid",
       "line": 270,
       "filename": "invalid.23.wasm",
-      "text": "array types do not match: expected i32, found i8",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array types do not match: expected i32, found i8"
     },
     {
       "type": "assert_invalid",
       "line": 281,
       "filename": "invalid.24.wasm",
-      "text": "array types do not match: expected i8, found i32",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array types do not match: expected i8, found i32"
     },
     {
       "type": "module",
       "line": 291,
-      "filename": "invalid.25.wasm"
+      "filename": "invalid.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 301,
       "filename": "invalid.26.wasm",
-      "text": "type mismatch: expected a reference type, found nothing",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch: expected a reference type, found nothing"
     },
     {
       "type": "assert_invalid",
       "line": 314,
       "filename": "invalid.27.wasm",
-      "text": "indirect calls must go through a table with type <= funcref",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "indirect calls must go through a table with type <= funcref"
     }
   ]
 }

--- a/tests/snapshots/local/gc/subtype-of-self-recursive-type.wast.json
+++ b/tests/snapshots/local/gc/subtype-of-self-recursive-type.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "subtype-of-self-recursive-type.0.wasm"
+      "filename": "subtype-of-self-recursive-type.0.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/gc/type-equivalence.wast.json
+++ b/tests/snapshots/local/gc/type-equivalence.wast.json
@@ -4,29 +4,33 @@
     {
       "type": "module",
       "line": 8,
-      "filename": "type-equivalence.0.wasm"
+      "filename": "type-equivalence.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 19,
-      "filename": "type-equivalence.1.wasm"
+      "filename": "type-equivalence.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 35,
-      "filename": "type-equivalence.2.wasm"
+      "filename": "type-equivalence.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 40,
       "filename": "type-equivalence.3.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "module",
       "line": 52,
-      "filename": "type-equivalence.4.wasm"
+      "filename": "type-equivalence.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -41,7 +45,8 @@
     {
       "type": "module",
       "line": 70,
-      "filename": "type-equivalence.5.wasm"
+      "filename": "type-equivalence.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -56,7 +61,8 @@
     {
       "type": "module",
       "line": 101,
-      "filename": "type-equivalence.6.wasm"
+      "filename": "type-equivalence.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -66,12 +72,14 @@
     {
       "type": "module",
       "line": 106,
-      "filename": "type-equivalence.7.wasm"
+      "filename": "type-equivalence.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 114,
-      "filename": "type-equivalence.8.wasm"
+      "filename": "type-equivalence.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -81,7 +89,8 @@
     {
       "type": "module",
       "line": 124,
-      "filename": "type-equivalence.9.wasm"
+      "filename": "type-equivalence.9.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/gc/type-subtyping.wast.json
+++ b/tests/snapshots/local/gc/type-subtyping.wast.json
@@ -4,98 +4,113 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "type-subtyping.0.wasm"
+      "filename": "type-subtyping.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 15,
-      "filename": "type-subtyping.1.wasm"
+      "filename": "type-subtyping.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 24,
-      "filename": "type-subtyping.2.wasm"
+      "filename": "type-subtyping.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 37,
-      "filename": "type-subtyping.3.wasm"
+      "filename": "type-subtyping.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 43,
-      "filename": "type-subtyping.4.wasm"
+      "filename": "type-subtyping.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 53,
-      "filename": "type-subtyping.5.wasm"
+      "filename": "type-subtyping.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 68,
-      "filename": "type-subtyping.6.wasm"
+      "filename": "type-subtyping.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 89,
-      "filename": "type-subtyping.7.wasm"
+      "filename": "type-subtyping.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 115,
-      "filename": "type-subtyping.8.wasm"
+      "filename": "type-subtyping.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 124,
-      "filename": "type-subtyping.9.wasm"
+      "filename": "type-subtyping.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 140,
       "filename": "type-subtyping.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 151,
-      "filename": "type-subtyping.11.wasm"
+      "filename": "type-subtyping.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 159,
-      "filename": "type-subtyping.12.wasm"
+      "filename": "type-subtyping.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 177,
-      "filename": "type-subtyping.13.wasm"
+      "filename": "type-subtyping.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 188,
-      "filename": "type-subtyping.14.wasm"
+      "filename": "type-subtyping.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 206,
       "filename": "type-subtyping.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 216,
       "filename": "type-subtyping.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 229,
-      "filename": "type-subtyping.17.wasm"
+      "filename": "type-subtyping.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -170,7 +185,8 @@
     {
       "type": "module",
       "line": 290,
-      "filename": "type-subtyping.18.wasm"
+      "filename": "type-subtyping.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -215,7 +231,8 @@
     {
       "type": "module",
       "line": 320,
-      "filename": "type-subtyping.19.wasm"
+      "filename": "type-subtyping.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -235,7 +252,8 @@
     {
       "type": "module",
       "line": 332,
-      "filename": "type-subtyping.20.wasm"
+      "filename": "type-subtyping.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -255,7 +273,8 @@
     {
       "type": "module",
       "line": 394,
-      "filename": "type-subtyping.21.wasm"
+      "filename": "type-subtyping.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -287,7 +306,8 @@
     {
       "type": "module",
       "line": 458,
-      "filename": "type-subtyping.22.wasm"
+      "filename": "type-subtyping.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -297,33 +317,35 @@
     {
       "type": "module",
       "line": 469,
-      "filename": "type-subtyping.23.wasm"
+      "filename": "type-subtyping.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 483,
       "filename": "type-subtyping.24.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 493,
       "filename": "type-subtyping.25.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 503,
       "filename": "type-subtyping.26.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 512,
-      "filename": "type-subtyping.27.wasm"
+      "filename": "type-subtyping.27.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -334,20 +356,21 @@
       "type": "assert_unlinkable",
       "line": 521,
       "filename": "type-subtyping.28.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 529,
       "filename": "type-subtyping.29.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 538,
-      "filename": "type-subtyping.30.wasm"
+      "filename": "type-subtyping.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -357,12 +380,14 @@
     {
       "type": "module",
       "line": 544,
-      "filename": "type-subtyping.31.wasm"
+      "filename": "type-subtyping.31.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 550,
-      "filename": "type-subtyping.32.wasm"
+      "filename": "type-subtyping.32.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -372,12 +397,14 @@
     {
       "type": "module",
       "line": 560,
-      "filename": "type-subtyping.33.wasm"
+      "filename": "type-subtyping.33.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 570,
-      "filename": "type-subtyping.34.wasm"
+      "filename": "type-subtyping.34.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -388,13 +415,14 @@
       "type": "assert_unlinkable",
       "line": 578,
       "filename": "type-subtyping.35.wasm",
-      "text": "incompatible import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import"
     },
     {
       "type": "module",
       "line": 586,
-      "filename": "type-subtyping.36.wasm"
+      "filename": "type-subtyping.36.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -404,12 +432,14 @@
     {
       "type": "module",
       "line": 593,
-      "filename": "type-subtyping.37.wasm"
+      "filename": "type-subtyping.37.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 600,
-      "filename": "type-subtyping.38.wasm"
+      "filename": "type-subtyping.38.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -419,12 +449,14 @@
     {
       "type": "module",
       "line": 611,
-      "filename": "type-subtyping.39.wasm"
+      "filename": "type-subtyping.39.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 624,
-      "filename": "type-subtyping.40.wasm"
+      "filename": "type-subtyping.40.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -434,12 +466,14 @@
     {
       "type": "module",
       "line": 631,
-      "filename": "type-subtyping.41.wasm"
+      "filename": "type-subtyping.41.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 640,
-      "filename": "type-subtyping.42.wasm"
+      "filename": "type-subtyping.42.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -449,12 +483,14 @@
     {
       "type": "module",
       "line": 649,
-      "filename": "type-subtyping.43.wasm"
+      "filename": "type-subtyping.43.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 664,
-      "filename": "type-subtyping.44.wasm"
+      "filename": "type-subtyping.44.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -465,13 +501,14 @@
       "type": "assert_unlinkable",
       "line": 671,
       "filename": "type-subtyping.45.wasm",
-      "text": "incompatible import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import"
     },
     {
       "type": "module",
       "line": 678,
-      "filename": "type-subtyping.46.wasm"
+      "filename": "type-subtyping.46.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -482,99 +519,99 @@
       "type": "assert_unlinkable",
       "line": 686,
       "filename": "type-subtyping.47.wasm",
-      "text": "incompatible import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import"
     },
     {
       "type": "assert_invalid",
       "line": 699,
       "filename": "type-subtyping.48.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 707,
       "filename": "type-subtyping.49.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 715,
       "filename": "type-subtyping.50.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 723,
       "filename": "type-subtyping.51.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 736,
       "filename": "type-subtyping.52.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 744,
       "filename": "type-subtyping.53.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 752,
       "filename": "type-subtyping.54.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 760,
       "filename": "type-subtyping.55.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 768,
       "filename": "type-subtyping.56.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 776,
       "filename": "type-subtyping.57.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 784,
       "filename": "type-subtyping.58.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 792,
       "filename": "type-subtyping.59.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 800,
       "filename": "type-subtyping.60.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     }
   ]
 }

--- a/tests/snapshots/local/id.wast.json
+++ b/tests/snapshots/local/id.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_malformed",
       "line": 2,
       "filename": "id.0.wat",
-      "text": "empty identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty identifier"
     }
   ]
 }

--- a/tests/snapshots/local/if-else-parsing.wast.json
+++ b/tests/snapshots/local/if-else-parsing.wast.json
@@ -4,42 +4,43 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "if-else-parsing.0.wasm"
+      "filename": "if-else-parsing.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 17,
       "filename": "if-else-parsing.1.wat",
-      "text": "no `then`",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "no `then`"
     },
     {
       "type": "assert_invalid",
       "line": 23,
       "filename": "if-else-parsing.2.wat",
-      "text": "no `then`",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "no `then`"
     },
     {
       "type": "assert_invalid",
       "line": 29,
       "filename": "if-else-parsing.3.wat",
-      "text": "expected `(`",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "expected `(`"
     },
     {
       "type": "assert_invalid",
       "line": 34,
       "filename": "if-else-parsing.4.wat",
-      "text": "no `then`",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "no `then`"
     },
     {
       "type": "assert_invalid",
       "line": 39,
       "filename": "if-else-parsing.5.wat",
-      "text": "expected `(`",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "expected `(`"
     }
   ]
 }

--- a/tests/snapshots/local/instance.wast.json
+++ b/tests/snapshots/local/instance.wast.json
@@ -5,7 +5,8 @@
       "type": "module_definition",
       "line": 3,
       "name": "M",
-      "filename": "instance.0.wasm"
+      "filename": "instance.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module_instance",
@@ -34,7 +35,8 @@
     {
       "type": "module",
       "line": 15,
-      "filename": "instance.1.wasm"
+      "filename": "instance.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -98,7 +100,8 @@
     {
       "type": "module",
       "line": 62,
-      "filename": "instance.2.wasm"
+      "filename": "instance.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -163,7 +166,8 @@
       "type": "module_definition",
       "line": 109,
       "name": "N",
-      "filename": "instance.3.wasm"
+      "filename": "instance.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module_instance",
@@ -180,7 +184,8 @@
     {
       "type": "module",
       "line": 128,
-      "filename": "instance.4.wasm"
+      "filename": "instance.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/local/invalid-funcref-in-data-segment.wast.json
+++ b/tests/snapshots/local/invalid-funcref-in-data-segment.wast.json
@@ -5,15 +5,15 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "invalid-funcref-in-data-segment.0.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10,
       "filename": "invalid-funcref-in-data-segment.1.wasm",
-      "text": "undeclared function reference",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "undeclared function reference"
     }
   ]
 }

--- a/tests/snapshots/local/invalid-init-expr.wast.json
+++ b/tests/snapshots/local/invalid-init-expr.wast.json
@@ -5,15 +5,15 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "invalid-init-expr.0.wasm",
-      "text": "non-constant operator",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "non-constant operator"
     },
     {
       "type": "assert_invalid",
       "line": 8,
       "filename": "invalid-init-expr.1.wasm",
-      "text": "non-constant operator",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "non-constant operator"
     }
   ]
 }

--- a/tests/snapshots/local/invalid-unreachable.wast.json
+++ b/tests/snapshots/local/invalid-unreachable.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "invalid-unreachable.0.wasm",
-      "text": "expected v128 but nothing on stack",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected v128 but nothing on stack"
     }
   ]
 }

--- a/tests/snapshots/local/invalid-utf8-id.wast.json
+++ b/tests/snapshots/local/invalid-utf8-id.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_malformed",
       "line": 2,
       "filename": "invalid-utf8-id.0.wat",
-      "text": "malformed UTF-8 encoding of string-based id",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding of string-based id"
     }
   ]
 }

--- a/tests/snapshots/local/invalid.wast.json
+++ b/tests/snapshots/local/invalid.wast.json
@@ -5,15 +5,15 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "invalid.0.wasm",
-      "text": "unknown elem segment",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown elem segment"
     },
     {
       "type": "assert_invalid",
       "line": 8,
       "filename": "invalid.1.wasm",
-      "text": "else found outside of an `if` block",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "else found outside of an `if` block"
     }
   ]
 }

--- a/tests/snapshots/local/invalid/bad_br_table.wast.json
+++ b/tests/snapshots/local/invalid/bad_br_table.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "bad_br_table.0.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     }
   ]
 }

--- a/tests/snapshots/local/invalid/crash-0000.wast.json
+++ b/tests/snapshots/local/invalid/crash-0000.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "crash-0000.0.wasm",
-      "text": "unexpected data at the end of the section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected data at the end of the section"
     }
   ]
 }

--- a/tests/snapshots/local/invalid/crash-1eefc5597ae263919265239b0dba6a033eb80384.wast.json
+++ b/tests/snapshots/local/invalid/crash-1eefc5597ae263919265239b0dba6a033eb80384.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "crash-1eefc5597ae263919265239b0dba6a033eb80384.0.wasm",
-      "text": "type index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index out of bounds"
     }
   ]
 }

--- a/tests/snapshots/local/invalid/crash-9001106adb60c9b427167d0606700fd16d5b3a82.wast.json
+++ b/tests/snapshots/local/invalid/crash-9001106adb60c9b427167d0606700fd16d5b3a82.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "crash-9001106adb60c9b427167d0606700fd16d5b3a82.0.wasm",
-      "text": "unexpected data at the end of the section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected data at the end of the section"
     }
   ]
 }

--- a/tests/snapshots/local/invalid/empty-br-table.wast.json
+++ b/tests/snapshots/local/invalid/empty-br-table.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "empty-br-table.0.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     }
   ]
 }

--- a/tests/snapshots/local/invalid/float1.wast.json
+++ b/tests/snapshots/local/invalid/float1.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "float1.0.wasm",
-      "text": "values remaining on stack",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "values remaining on stack"
     }
   ]
 }

--- a/tests/snapshots/local/invalid/func.wast.json
+++ b/tests/snapshots/local/invalid/func.wast.json
@@ -5,57 +5,57 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "func.0.wasm",
-      "text": "operators remaining after end of function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "operators remaining after end of function"
     },
     {
       "type": "assert_invalid",
       "line": 23,
       "filename": "func.1.wasm",
-      "text": "operators remaining after end of function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "operators remaining after end of function"
     },
     {
       "type": "assert_invalid",
       "line": 44,
       "filename": "func.2.wasm",
-      "text": "operators remaining after end of function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "operators remaining after end of function"
     },
     {
       "type": "assert_invalid",
       "line": 65,
       "filename": "func.3.wasm",
-      "text": "operators remaining after end of function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "operators remaining after end of function"
     },
     {
       "type": "assert_invalid",
       "line": 70,
       "filename": "func.4.wasm",
-      "text": "operators remaining after end of function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "operators remaining after end of function"
     },
     {
       "type": "assert_invalid",
       "line": 75,
       "filename": "func.5.wasm",
-      "text": "operators remaining after end of function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "operators remaining after end of function"
     },
     {
       "type": "assert_invalid",
       "line": 80,
       "filename": "func.6.wasm",
-      "text": "operators remaining after end of function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "operators remaining after end of function"
     },
     {
       "type": "assert_invalid",
       "line": 85,
       "filename": "func.7.wasm",
-      "text": "operators remaining after end of function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "operators remaining after end of function"
     }
   ]
 }

--- a/tests/snapshots/local/invalid/invalid-ty.wast.json
+++ b/tests/snapshots/local/invalid/invalid-ty.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "invalid-ty.0.wasm",
-      "text": "type index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index out of bounds"
     }
   ]
 }

--- a/tests/snapshots/local/invalid/invalid-ty2.wast.json
+++ b/tests/snapshots/local/invalid/invalid-ty2.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "invalid-ty2.0.wasm",
-      "text": "type index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type index out of bounds"
     }
   ]
 }

--- a/tests/snapshots/local/invalid/issue139.wast.json
+++ b/tests/snapshots/local/invalid/issue139.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "issue139.0.wasm",
-      "text": "function and code section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function and code section have inconsistent lengths"
     }
   ]
 }

--- a/tests/snapshots/local/invalid/issue192.wast.json
+++ b/tests/snapshots/local/invalid/issue192.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "issue192.0.wasm",
-      "text": "control frames remain at end of function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "control frames remain at end of function"
     }
   ]
 }

--- a/tests/snapshots/local/invalid/oom-5f99d8174393cb86cc06b5d04dd7a92c208e0056.wast.json
+++ b/tests/snapshots/local/invalid/oom-5f99d8174393cb86cc06b5d04dd7a92c208e0056.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "oom-5f99d8174393cb86cc06b5d04dd7a92c208e0056.0.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     }
   ]
 }

--- a/tests/snapshots/local/invalid/oom-84d4e20fc7fecc07ba0a1e3e2426d1f4e72ca8cb.wast.json
+++ b/tests/snapshots/local/invalid/oom-84d4e20fc7fecc07ba0a1e3e2426d1f4e72ca8cb.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "oom-84d4e20fc7fecc07ba0a1e3e2426d1f4e72ca8cb.0.wasm",
-      "text": "unexpected end-of-file",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end-of-file"
     }
   ]
 }

--- a/tests/snapshots/local/invalid/table-init.wast.json
+++ b/tests/snapshots/local/invalid/table-init.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "table-init.0.wasm",
-      "text": "nothing on stack",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "nothing on stack"
     }
   ]
 }

--- a/tests/snapshots/local/issue192.wast.json
+++ b/tests/snapshots/local/issue192.wast.json
@@ -4,21 +4,22 @@
     {
       "type": "module",
       "line": 2,
-      "filename": "issue192.0.wasm"
+      "filename": "issue192.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 12,
       "filename": "issue192.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 22,
       "filename": "issue192.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/local/issue194.wast.json
+++ b/tests/snapshots/local/issue194.wast.json
@@ -4,21 +4,22 @@
     {
       "type": "module",
       "line": 2,
-      "filename": "issue194.0.wasm"
+      "filename": "issue194.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 15,
       "filename": "issue194.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 28,
       "filename": "issue194.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/local/labels.wast.json
+++ b/tests/snapshots/local/labels.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "labels.0.wasm"
+      "filename": "labels.0.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/legacy-exceptions/rethrow.wast.json
+++ b/tests/snapshots/local/legacy-exceptions/rethrow.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "rethrow.0.wasm"
+      "filename": "rethrow.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_exception",
@@ -193,22 +194,22 @@
       "type": "assert_invalid",
       "line": 118,
       "filename": "rethrow.1.wasm",
-      "text": "invalid rethrow label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid rethrow label"
     },
     {
       "type": "assert_invalid",
       "line": 119,
       "filename": "rethrow.2.wasm",
-      "text": "invalid rethrow label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid rethrow label"
     },
     {
       "type": "assert_invalid",
       "line": 120,
       "filename": "rethrow.3.wasm",
-      "text": "invalid rethrow label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid rethrow label"
     }
   ]
 }

--- a/tests/snapshots/local/legacy-exceptions/throw.wast.json
+++ b/tests/snapshots/local/legacy-exceptions/throw.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "throw.0.wasm"
+      "filename": "throw.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -110,22 +111,22 @@
       "type": "assert_invalid",
       "line": 52,
       "filename": "throw.1.wasm",
-      "text": "unknown tag 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown tag 0"
     },
     {
       "type": "assert_invalid",
       "line": 53,
       "filename": "throw.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 55,
       "filename": "throw.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/local/legacy-exceptions/try_catch.wast.json
+++ b/tests/snapshots/local/legacy-exceptions/try_catch.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "try_catch.0.wasm"
+      "filename": "try_catch.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -14,7 +15,8 @@
     {
       "type": "module",
       "line": 10,
-      "filename": "try_catch.1.wasm"
+      "filename": "try_catch.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -543,7 +545,8 @@
     {
       "type": "module",
       "line": 258,
-      "filename": "try_catch.2.wasm"
+      "filename": "try_catch.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -564,36 +567,36 @@
       "type": "assert_invalid",
       "line": 297,
       "filename": "try_catch.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 299,
       "filename": "try_catch.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 301,
       "filename": "try_catch.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 303,
       "filename": "try_catch.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 308,
       "filename": "try_catch.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/local/legacy-exceptions/try_delegate.wast.json
+++ b/tests/snapshots/local/legacy-exceptions/try_delegate.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "try_delegate.0.wasm"
+      "filename": "try_delegate.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -318,8 +319,8 @@
       "type": "assert_invalid",
       "line": 273,
       "filename": "try_delegate.1.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     }
   ]
 }

--- a/tests/snapshots/local/memory64.wast.json
+++ b/tests/snapshots/local/memory64.wast.json
@@ -4,27 +4,29 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "memory64.0.wasm"
+      "filename": "memory64.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 128,
       "filename": "memory64.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 131,
       "filename": "memory64.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 134,
       "name": "table64",
-      "filename": "memory64.3.wasm"
+      "filename": "memory64.3.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/component-model/types.wast.json
+++ b/tests/snapshots/local/missing-features/component-model/types.wast.json
@@ -5,22 +5,22 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "types.0.wasm",
-      "text": "SIMD support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "SIMD support is not enabled"
     },
     {
       "type": "assert_invalid",
       "line": 8,
       "filename": "types.1.wasm",
-      "text": "unknown type 0: type index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type 0: type index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 14,
       "filename": "types.2.wasm",
-      "text": "reference types support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "reference types support is not enabled"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/component-model/value-not-enabled.wast.json
+++ b/tests/snapshots/local/missing-features/component-model/value-not-enabled.wast.json
@@ -5,50 +5,50 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "value-not-enabled.0.wasm",
-      "text": "support for component model `value`s is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "support for component model `value`s is not enabled"
     },
     {
       "type": "assert_invalid",
       "line": 9,
       "filename": "value-not-enabled.1.wasm",
-      "text": "support for component model `value`s is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "support for component model `value`s is not enabled"
     },
     {
       "type": "assert_invalid",
       "line": 15,
       "filename": "value-not-enabled.2.wasm",
-      "text": "support for component model `value`s is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "support for component model `value`s is not enabled"
     },
     {
       "type": "assert_invalid",
       "line": 21,
       "filename": "value-not-enabled.3.wasm",
-      "text": "support for component model `value`s is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "support for component model `value`s is not enabled"
     },
     {
       "type": "assert_invalid",
       "line": 26,
       "filename": "value-not-enabled.4.wasm",
-      "text": "support for component model `value`s is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "support for component model `value`s is not enabled"
     },
     {
       "type": "assert_invalid",
       "line": 32,
       "filename": "value-not-enabled.5.wasm",
-      "text": "support for component model `value`s is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "support for component model `value`s is not enabled"
     },
     {
       "type": "assert_invalid",
       "line": 38,
       "filename": "value-not-enabled.6.wasm",
-      "text": "support for component model `value`s is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "support for component model `value`s is not enabled"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/component-not-enabled.wast.json
+++ b/tests/snapshots/local/missing-features/component-not-enabled.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "component-not-enabled.0.wasm",
-      "text": "unknown binary version and encoding combination: 0xa and 0x1, note: encoded as a component but the WebAssembly component model feature is not enabled - enable the feature to allow component validation",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version and encoding combination: 0xa and 0x1, note: encoded as a component but the WebAssembly component model feature is not enabled - enable the feature to allow component validation"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/custom-page-sizes.wast.json
+++ b/tests/snapshots/local/missing-features/custom-page-sizes.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "custom-page-sizes.0.wasm",
-      "text": "the custom page sizes proposal must be enabled to customize a memory's page size",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "the custom page sizes proposal must be enabled to customize a memory's page size"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/floats-disabled.wast.json
+++ b/tests/snapshots/local/missing-features/floats-disabled.wast.json
@@ -5,15 +5,15 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "floats-disabled.0.wasm",
-      "text": "floating-point support is disabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "floating-point support is disabled"
     },
     {
       "type": "assert_invalid",
       "line": 7,
       "filename": "floats-disabled.1.wasm",
-      "text": "floating-point support is disabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "floating-point support is disabled"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/gc/gc-types-disabled.wast.json
+++ b/tests/snapshots/local/missing-features/gc/gc-types-disabled.wast.json
@@ -5,39 +5,41 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "gc-types-disabled.0.wasm",
-      "text": "gc types are disallowed",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "gc types are disallowed"
     },
     {
       "type": "assert_invalid",
       "line": 8,
       "filename": "gc-types-disabled.1.wasm",
-      "text": "gc types are disallowed",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "gc types are disallowed"
     },
     {
       "type": "module",
       "line": 13,
-      "filename": "gc-types-disabled.2.wasm"
+      "filename": "gc-types-disabled.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 17,
-      "filename": "gc-types-disabled.3.wasm"
+      "filename": "gc-types-disabled.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 23,
       "filename": "gc-types-disabled.4.wasm",
-      "text": "cannot define array types",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "cannot define array types"
     },
     {
       "type": "assert_invalid",
       "line": 29,
       "filename": "gc-types-disabled.5.wasm",
-      "text": "cannot define struct types",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "cannot define struct types"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/gc/shared-any.wast.json
+++ b/tests/snapshots/local/missing-features/gc/shared-any.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "shared-any.0.wasm",
-      "text": "shared reference types require the shared-everything-threads proposal",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared reference types require the shared-everything-threads proposal"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/gc/shared-everything-threads-arrays.wast.json
+++ b/tests/snapshots/local/missing-features/gc/shared-everything-threads-arrays.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 4,
       "filename": "shared-everything-threads-arrays.0.wasm",
-      "text": "shared-everything-threads support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared-everything-threads support is not enabled"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/gc/shared-everything-threads-structs.wast.json
+++ b/tests/snapshots/local/missing-features/gc/shared-everything-threads-structs.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 4,
       "filename": "shared-everything-threads-structs.0.wasm",
-      "text": "shared-everything-threads support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared-everything-threads support is not enabled"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/globals.wast.json
+++ b/tests/snapshots/local/missing-features/globals.wast.json
@@ -5,22 +5,22 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "globals.0.wasm",
-      "text": "global.get of locally defined global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "global.get of locally defined global"
     },
     {
       "type": "assert_invalid",
       "line": 9,
       "filename": "globals.1.wasm",
-      "text": "global.get of locally defined global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "global.get of locally defined global"
     },
     {
       "type": "assert_invalid",
       "line": 17,
       "filename": "globals.2.wasm",
-      "text": "global.get of locally defined global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "global.get of locally defined global"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/issue540.wast.json
+++ b/tests/snapshots/local/missing-features/issue540.wast.json
@@ -4,17 +4,20 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "issue540.0.wasm"
+      "filename": "issue540.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 12,
-      "filename": "issue540.1.wasm"
+      "filename": "issue540.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 24,
-      "filename": "issue540.2.wasm"
+      "filename": "issue540.2.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/missing-exceptions.wast.json
+++ b/tests/snapshots/local/missing-features/missing-exceptions.wast.json
@@ -5,15 +5,15 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "missing-exceptions.0.wasm",
-      "text": "exceptions proposal not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "exceptions proposal not enabled"
     },
     {
       "type": "assert_invalid",
       "line": 9,
       "filename": "missing-exceptions.1.wasm",
-      "text": "exceptions proposal not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "exceptions proposal not enabled"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/multi-value-function-block-type.wast.json
+++ b/tests/snapshots/local/missing-features/multi-value-function-block-type.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "multi-value-function-block-type.0.wasm",
-      "text": "blocks, loops, and ifs may only produce a resulttype when multi-value is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "blocks, loops, and ifs may only produce a resulttype when multi-value is not enabled"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/mutable-global-disabled.wast.json
+++ b/tests/snapshots/local/missing-features/mutable-global-disabled.wast.json
@@ -5,15 +5,15 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "mutable-global-disabled.0.wasm",
-      "text": "mutable global support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "mutable global support is not enabled"
     },
     {
       "type": "assert_invalid",
       "line": 9,
       "filename": "mutable-global-disabled.1.wasm",
-      "text": "mutable global support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "mutable global support is not enabled"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/rec-group.wast.json
+++ b/tests/snapshots/local/missing-features/rec-group.wast.json
@@ -5,22 +5,22 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "rec-group.0.wasm",
-      "text": "requires `gc` proposal to be enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "requires `gc` proposal to be enabled"
     },
     {
       "type": "assert_invalid",
       "line": 6,
       "filename": "rec-group.1.wasm",
-      "text": "requires `gc` proposal to be enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "requires `gc` proposal to be enabled"
     },
     {
       "type": "assert_invalid",
       "line": 10,
       "filename": "rec-group.2.wasm",
-      "text": "requires `gc` proposal to be enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "requires `gc` proposal to be enabled"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/reference-types/function-references.wast.json
+++ b/tests/snapshots/local/missing-features/reference-types/function-references.wast.json
@@ -5,22 +5,22 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "function-references.0.wasm",
-      "text": "function references required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function references required"
     },
     {
       "type": "assert_invalid",
       "line": 5,
       "filename": "function-references.1.wasm",
-      "text": "function references required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function references required"
     },
     {
       "type": "assert_invalid",
       "line": 8,
       "filename": "function-references.2.wasm",
-      "text": "function references required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function references required"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/reference-types/gc-indexed-types.wast.json
+++ b/tests/snapshots/local/missing-features/reference-types/gc-indexed-types.wast.json
@@ -5,22 +5,22 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "gc-indexed-types.0.wasm",
-      "text": "array indexed types not supported without the gc feature",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array indexed types not supported without the gc feature"
     },
     {
       "type": "assert_invalid",
       "line": 5,
       "filename": "gc-indexed-types.1.wasm",
-      "text": "array indexed types not supported without the gc feature",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array indexed types not supported without the gc feature"
     },
     {
       "type": "assert_invalid",
       "line": 8,
       "filename": "gc-indexed-types.2.wasm",
-      "text": "struct indexed types not supported without the gc feature",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "struct indexed types not supported without the gc feature"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/reference-types/gc.wast.json
+++ b/tests/snapshots/local/missing-features/reference-types/gc.wast.json
@@ -5,78 +5,78 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "gc.0.wasm",
-      "text": "heap types not supported without the gc feature",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "heap types not supported without the gc feature"
     },
     {
       "type": "assert_invalid",
       "line": 5,
       "filename": "gc.1.wasm",
-      "text": "heap types not supported without the gc feature",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "heap types not supported without the gc feature"
     },
     {
       "type": "assert_invalid",
       "line": 8,
       "filename": "gc.2.wasm",
-      "text": "heap types not supported without the gc feature",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "heap types not supported without the gc feature"
     },
     {
       "type": "assert_invalid",
       "line": 11,
       "filename": "gc.3.wasm",
-      "text": "heap types not supported without the gc feature",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "heap types not supported without the gc feature"
     },
     {
       "type": "assert_invalid",
       "line": 14,
       "filename": "gc.4.wasm",
-      "text": "heap types not supported without the gc feature",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "heap types not supported without the gc feature"
     },
     {
       "type": "assert_invalid",
       "line": 17,
       "filename": "gc.5.wasm",
-      "text": "heap types not supported without the gc feature",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "heap types not supported without the gc feature"
     },
     {
       "type": "assert_invalid",
       "line": 20,
       "filename": "gc.6.wasm",
-      "text": "heap types not supported without the gc feature",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "heap types not supported without the gc feature"
     },
     {
       "type": "assert_invalid",
       "line": 23,
       "filename": "gc.7.wasm",
-      "text": "heap types not supported without the gc feature",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "heap types not supported without the gc feature"
     },
     {
       "type": "assert_invalid",
       "line": 26,
       "filename": "gc.8.wasm",
-      "text": "heap types not supported without the gc feature",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "heap types not supported without the gc feature"
     },
     {
       "type": "assert_invalid",
       "line": 29,
       "filename": "gc.9.wasm",
-      "text": "heap types not supported without the gc feature",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "heap types not supported without the gc feature"
     },
     {
       "type": "assert_invalid",
       "line": 32,
       "filename": "gc.10.wasm",
-      "text": "heap types not supported without the gc feature",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "heap types not supported without the gc feature"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/reference-types/shared-everything-threads-types.wast.json
+++ b/tests/snapshots/local/missing-features/reference-types/shared-everything-threads-types.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 4,
       "filename": "shared-everything-threads-types.0.wasm",
-      "text": "shared reference types require the shared-everything-threads proposal",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared reference types require the shared-everything-threads proposal"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/reference-types/v128-without-simd-feature.wast.json
+++ b/tests/snapshots/local/missing-features/reference-types/v128-without-simd-feature.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "v128-without-simd-feature.0.wasm",
-      "text": "SIMD support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "SIMD support is not enabled"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/saturating-float-to-int-disabled.wast.json
+++ b/tests/snapshots/local/missing-features/saturating-float-to-int-disabled.wast.json
@@ -5,57 +5,57 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "saturating-float-to-int-disabled.0.wasm",
-      "text": "saturating float to int conversions support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "saturating float to int conversions support is not enabled"
     },
     {
       "type": "assert_invalid",
       "line": 12,
       "filename": "saturating-float-to-int-disabled.1.wasm",
-      "text": "saturating float to int conversions support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "saturating float to int conversions support is not enabled"
     },
     {
       "type": "assert_invalid",
       "line": 22,
       "filename": "saturating-float-to-int-disabled.2.wasm",
-      "text": "saturating float to int conversions support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "saturating float to int conversions support is not enabled"
     },
     {
       "type": "assert_invalid",
       "line": 32,
       "filename": "saturating-float-to-int-disabled.3.wasm",
-      "text": "saturating float to int conversions support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "saturating float to int conversions support is not enabled"
     },
     {
       "type": "assert_invalid",
       "line": 42,
       "filename": "saturating-float-to-int-disabled.4.wasm",
-      "text": "saturating float to int conversions support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "saturating float to int conversions support is not enabled"
     },
     {
       "type": "assert_invalid",
       "line": 52,
       "filename": "saturating-float-to-int-disabled.5.wasm",
-      "text": "saturating float to int conversions support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "saturating float to int conversions support is not enabled"
     },
     {
       "type": "assert_invalid",
       "line": 62,
       "filename": "saturating-float-to-int-disabled.6.wasm",
-      "text": "saturating float to int conversions support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "saturating float to int conversions support is not enabled"
     },
     {
       "type": "assert_invalid",
       "line": 72,
       "filename": "saturating-float-to-int-disabled.7.wasm",
-      "text": "saturating float to int conversions support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "saturating float to int conversions support is not enabled"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/shared-everything-threads-arrays.wast.json
+++ b/tests/snapshots/local/missing-features/shared-everything-threads-arrays.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "shared-everything-threads-arrays.0.wasm",
-      "text": "shared composite types require the shared-everything-threads proposal",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared composite types require the shared-everything-threads proposal"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/shared-everything-threads-globals.wast.json
+++ b/tests/snapshots/local/missing-features/shared-everything-threads-globals.wast.json
@@ -5,22 +5,22 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "shared-everything-threads-globals.0.wasm",
-      "text": "shared globals require the shared-everything-threads proposal",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals require the shared-everything-threads proposal"
     },
     {
       "type": "assert_invalid",
       "line": 8,
       "filename": "shared-everything-threads-globals.1.wasm",
-      "text": "shared globals require the shared-everything-threads proposal",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals require the shared-everything-threads proposal"
     },
     {
       "type": "assert_invalid",
       "line": 14,
       "filename": "shared-everything-threads-globals.2.wasm",
-      "text": "shared-everything-threads support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared-everything-threads support is not enabled"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/shared-everything-threads-structs.wast.json
+++ b/tests/snapshots/local/missing-features/shared-everything-threads-structs.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "shared-everything-threads-structs.0.wasm",
-      "text": "shared composite types require the shared-everything-threads proposal",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared composite types require the shared-everything-threads proposal"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/shared-everything-threads-tables.wast.json
+++ b/tests/snapshots/local/missing-features/shared-everything-threads-tables.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "shared-everything-threads-tables.0.wasm",
-      "text": "shared tables require the shared-everything-threads proposal",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared tables require the shared-everything-threads proposal"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/shared-everything-threads-types.wast.json
+++ b/tests/snapshots/local/missing-features/shared-everything-threads-types.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "shared-everything-threads-types.0.wasm",
-      "text": "shared composite types require the shared-everything-threads proposal",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared composite types require the shared-everything-threads proposal"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/sign-extension-disabled.wast.json
+++ b/tests/snapshots/local/missing-features/sign-extension-disabled.wast.json
@@ -5,36 +5,36 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "sign-extension-disabled.0.wasm",
-      "text": "sign extension operations support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sign extension operations support is not enabled"
     },
     {
       "type": "assert_invalid",
       "line": 12,
       "filename": "sign-extension-disabled.1.wasm",
-      "text": "sign extension operations support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sign extension operations support is not enabled"
     },
     {
       "type": "assert_invalid",
       "line": 22,
       "filename": "sign-extension-disabled.2.wasm",
-      "text": "sign extension operations support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sign extension operations support is not enabled"
     },
     {
       "type": "assert_invalid",
       "line": 32,
       "filename": "sign-extension-disabled.3.wasm",
-      "text": "sign extension operations support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sign extension operations support is not enabled"
     },
     {
       "type": "assert_invalid",
       "line": 42,
       "filename": "sign-extension-disabled.4.wasm",
-      "text": "sign extension operations support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sign extension operations support is not enabled"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/v128-without-simd-feature.wast.json
+++ b/tests/snapshots/local/missing-features/v128-without-simd-feature.wast.json
@@ -5,50 +5,50 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "v128-without-simd-feature.0.wasm",
-      "text": "SIMD support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "SIMD support is not enabled"
     },
     {
       "type": "assert_invalid",
       "line": 5,
       "filename": "v128-without-simd-feature.1.wasm",
-      "text": "SIMD support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "SIMD support is not enabled"
     },
     {
       "type": "assert_invalid",
       "line": 8,
       "filename": "v128-without-simd-feature.2.wasm",
-      "text": "SIMD support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "SIMD support is not enabled"
     },
     {
       "type": "assert_invalid",
       "line": 11,
       "filename": "v128-without-simd-feature.3.wasm",
-      "text": "SIMD support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "SIMD support is not enabled"
     },
     {
       "type": "assert_invalid",
       "line": 14,
       "filename": "v128-without-simd-feature.4.wasm",
-      "text": "SIMD support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "SIMD support is not enabled"
     },
     {
       "type": "assert_invalid",
       "line": 17,
       "filename": "v128-without-simd-feature.5.wasm",
-      "text": "SIMD support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "SIMD support is not enabled"
     },
     {
       "type": "assert_invalid",
       "line": 20,
       "filename": "v128-without-simd-feature.6.wasm",
-      "text": "SIMD support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "SIMD support is not enabled"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/wasmtime905.wast.json
+++ b/tests/snapshots/local/missing-features/wasmtime905.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "wasmtime905.0.wasm",
-      "text": "reference types support is not enabled",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "reference types support is not enabled"
     }
   ]
 }

--- a/tests/snapshots/local/multi-memory.wast.json
+++ b/tests/snapshots/local/multi-memory.wast.json
@@ -4,26 +4,28 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "multi-memory.0.wasm"
+      "filename": "multi-memory.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 205,
       "filename": "multi-memory.1.wasm",
-      "text": "unknown memory 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 1"
     },
     {
       "type": "assert_malformed",
       "line": 216,
       "filename": "multi-memory.2.wat",
-      "text": "unknown memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown memory"
     },
     {
       "type": "module",
       "line": 221,
-      "filename": "multi-memory.3.wasm"
+      "filename": "multi-memory.3.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/multi-memory64.wast.json
+++ b/tests/snapshots/local/multi-memory64.wast.json
@@ -5,13 +5,15 @@
       "type": "module",
       "line": 1,
       "name": "copy_between_memories",
-      "filename": "multi-memory64.0.wasm"
+      "filename": "multi-memory64.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 13,
       "name": "copy_between_memories",
-      "filename": "multi-memory64.1.wasm"
+      "filename": "multi-memory64.1.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/names.wast.json
+++ b/tests/snapshots/local/names.wast.json
@@ -4,32 +4,38 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "names.0.wasm"
+      "filename": "names.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 2,
-      "filename": "names.1.wasm"
+      "filename": "names.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 4,
-      "filename": "names.2.wasm"
+      "filename": "names.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 10,
-      "filename": "names.3.wasm"
+      "filename": "names.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 18,
-      "filename": "names.4.wasm"
+      "filename": "names.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 21,
-      "filename": "names.5.wasm"
+      "filename": "names.5.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/order.wast.json
+++ b/tests/snapshots/local/order.wast.json
@@ -5,15 +5,15 @@
       "type": "assert_malformed",
       "line": 2,
       "filename": "order.0.wat",
-      "text": "import after function",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after function"
     },
     {
       "type": "assert_malformed",
       "line": 8,
       "filename": "order.1.wat",
-      "text": "import after function",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after function"
     }
   ]
 }

--- a/tests/snapshots/local/producers.wast.json
+++ b/tests/snapshots/local/producers.wast.json
@@ -4,39 +4,45 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "producers.0.wasm"
+      "filename": "producers.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 5,
-      "filename": "producers.1.wasm"
+      "filename": "producers.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 11,
-      "filename": "producers.2.wasm"
+      "filename": "producers.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 20,
-      "filename": "producers.3.wasm"
+      "filename": "producers.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 26,
       "filename": "producers.4.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "module",
       "line": 31,
-      "filename": "producers.5.wasm"
+      "filename": "producers.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 41,
-      "filename": "producers.6.wasm"
+      "filename": "producers.6.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/relaxed-simd.wast.json
+++ b/tests/snapshots/local/relaxed-simd.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 2,
-      "filename": "relaxed-simd.0.wasm"
+      "filename": "relaxed-simd.0.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/shared-everything-threads/arrays.wast.json
+++ b/tests/snapshots/local/shared-everything-threads/arrays.wast.json
@@ -4,517 +4,578 @@
     {
       "type": "module",
       "line": 2,
-      "filename": "arrays.0.wasm"
+      "filename": "arrays.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 16,
       "filename": "arrays.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 26,
       "filename": "arrays.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 37,
       "filename": "arrays.3.wasm",
-      "text": "sub type must match super type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type must match super type"
     },
     {
       "type": "assert_invalid",
       "line": 46,
       "filename": "arrays.4.wasm",
-      "text": "sub type must match super type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type must match super type"
     },
     {
       "type": "assert_invalid",
       "line": 55,
       "filename": "arrays.5.wasm",
-      "text": "must contain shared type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "must contain shared type"
     },
     {
       "type": "module",
       "line": 62,
-      "filename": "arrays.6.wasm"
+      "filename": "arrays.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 67,
-      "filename": "arrays.7.wasm"
+      "filename": "arrays.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 72,
-      "filename": "arrays.8.wasm"
+      "filename": "arrays.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 118,
-      "filename": "arrays.9.wasm"
+      "filename": "arrays.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 143,
       "filename": "arrays.10.wasm",
-      "text": "array is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array is immutable"
     },
     {
       "type": "assert_invalid",
       "line": 152,
       "filename": "arrays.11.wasm",
-      "text": "array is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array is immutable"
     },
     {
       "type": "assert_invalid",
       "line": 161,
       "filename": "arrays.12.wasm",
-      "text": "array is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array is immutable"
     },
     {
       "type": "assert_invalid",
       "line": 170,
       "filename": "arrays.13.wasm",
-      "text": "array is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array is immutable"
     },
     {
       "type": "assert_invalid",
       "line": 179,
       "filename": "arrays.14.wasm",
-      "text": "array is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array is immutable"
     },
     {
       "type": "assert_invalid",
       "line": 188,
       "filename": "arrays.15.wasm",
-      "text": "array is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array is immutable"
     },
     {
       "type": "assert_invalid",
       "line": 197,
       "filename": "arrays.16.wasm",
-      "text": "array is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array is immutable"
     },
     {
       "type": "assert_invalid",
       "line": 206,
       "filename": "arrays.17.wasm",
-      "text": "array is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array is immutable"
     },
     {
       "type": "module",
       "line": 216,
-      "filename": "arrays.18.wasm"
+      "filename": "arrays.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 224,
-      "filename": "arrays.19.wasm"
+      "filename": "arrays.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 232,
-      "filename": "arrays.20.wasm"
+      "filename": "arrays.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 240,
-      "filename": "arrays.21.wasm"
+      "filename": "arrays.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 248,
-      "filename": "arrays.22.wasm"
+      "filename": "arrays.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 256,
-      "filename": "arrays.23.wasm"
+      "filename": "arrays.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 264,
-      "filename": "arrays.24.wasm"
+      "filename": "arrays.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 272,
-      "filename": "arrays.25.wasm"
+      "filename": "arrays.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 280,
-      "filename": "arrays.26.wasm"
+      "filename": "arrays.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 288,
-      "filename": "arrays.27.wasm"
+      "filename": "arrays.27.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 296,
-      "filename": "arrays.28.wasm"
+      "filename": "arrays.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 304,
-      "filename": "arrays.29.wasm"
+      "filename": "arrays.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 312,
-      "filename": "arrays.30.wasm"
+      "filename": "arrays.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 320,
-      "filename": "arrays.31.wasm"
+      "filename": "arrays.31.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 328,
-      "filename": "arrays.32.wasm"
+      "filename": "arrays.32.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 337,
-      "filename": "arrays.33.wasm"
+      "filename": "arrays.33.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 346,
-      "filename": "arrays.34.wasm"
+      "filename": "arrays.34.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 355,
-      "filename": "arrays.35.wasm"
+      "filename": "arrays.35.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 364,
-      "filename": "arrays.36.wasm"
+      "filename": "arrays.36.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 373,
-      "filename": "arrays.37.wasm"
+      "filename": "arrays.37.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 382,
-      "filename": "arrays.38.wasm"
+      "filename": "arrays.38.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 391,
-      "filename": "arrays.39.wasm"
+      "filename": "arrays.39.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 400,
-      "filename": "arrays.40.wasm"
+      "filename": "arrays.40.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 409,
-      "filename": "arrays.41.wasm"
+      "filename": "arrays.41.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 418,
-      "filename": "arrays.42.wasm"
+      "filename": "arrays.42.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 427,
-      "filename": "arrays.43.wasm"
+      "filename": "arrays.43.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 436,
-      "filename": "arrays.44.wasm"
+      "filename": "arrays.44.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 445,
-      "filename": "arrays.45.wasm"
+      "filename": "arrays.45.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 454,
-      "filename": "arrays.46.wasm"
+      "filename": "arrays.46.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 463,
-      "filename": "arrays.47.wasm"
+      "filename": "arrays.47.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 472,
-      "filename": "arrays.48.wasm"
+      "filename": "arrays.48.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 481,
-      "filename": "arrays.49.wasm"
+      "filename": "arrays.49.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 490,
-      "filename": "arrays.50.wasm"
+      "filename": "arrays.50.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 499,
-      "filename": "arrays.51.wasm"
+      "filename": "arrays.51.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 508,
-      "filename": "arrays.52.wasm"
+      "filename": "arrays.52.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 517,
-      "filename": "arrays.53.wasm"
+      "filename": "arrays.53.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 526,
-      "filename": "arrays.54.wasm"
+      "filename": "arrays.54.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 535,
-      "filename": "arrays.55.wasm"
+      "filename": "arrays.55.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 544,
-      "filename": "arrays.56.wasm"
+      "filename": "arrays.56.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 553,
-      "filename": "arrays.57.wasm"
+      "filename": "arrays.57.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 562,
-      "filename": "arrays.58.wasm"
+      "filename": "arrays.58.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 571,
-      "filename": "arrays.59.wasm"
+      "filename": "arrays.59.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 580,
-      "filename": "arrays.60.wasm"
+      "filename": "arrays.60.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 589,
-      "filename": "arrays.61.wasm"
+      "filename": "arrays.61.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 598,
-      "filename": "arrays.62.wasm"
+      "filename": "arrays.62.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 607,
-      "filename": "arrays.63.wasm"
+      "filename": "arrays.63.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 616,
-      "filename": "arrays.64.wasm"
+      "filename": "arrays.64.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 625,
-      "filename": "arrays.65.wasm"
+      "filename": "arrays.65.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 634,
-      "filename": "arrays.66.wasm"
+      "filename": "arrays.66.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 643,
-      "filename": "arrays.67.wasm"
+      "filename": "arrays.67.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 652,
-      "filename": "arrays.68.wasm"
+      "filename": "arrays.68.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 662,
-      "filename": "arrays.69.wasm"
+      "filename": "arrays.69.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 672,
-      "filename": "arrays.70.wasm"
+      "filename": "arrays.70.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 682,
-      "filename": "arrays.71.wasm"
+      "filename": "arrays.71.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 692,
-      "filename": "arrays.72.wasm"
+      "filename": "arrays.72.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 702,
-      "filename": "arrays.73.wasm"
+      "filename": "arrays.73.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 713,
       "filename": "arrays.74.wasm",
-      "text": "packed storage type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "packed storage type"
     },
     {
       "type": "assert_invalid",
       "line": 723,
       "filename": "arrays.75.wasm",
-      "text": "non-packed storage type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "non-packed storage type"
     },
     {
       "type": "assert_invalid",
       "line": 733,
       "filename": "arrays.76.wasm",
-      "text": "non-packed storage type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "non-packed storage type"
     },
     {
       "type": "assert_invalid",
       "line": 743,
       "filename": "arrays.77.wasm",
-      "text": "non-packed storage type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "non-packed storage type"
     },
     {
       "type": "assert_invalid",
       "line": 753,
       "filename": "arrays.78.wasm",
-      "text": "non-packed storage type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "non-packed storage type"
     },
     {
       "type": "assert_invalid",
       "line": 763,
       "filename": "arrays.79.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 774,
       "filename": "arrays.80.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 785,
       "filename": "arrays.81.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 796,
       "filename": "arrays.82.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 807,
       "filename": "arrays.83.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 818,
       "filename": "arrays.84.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 829,
       "filename": "arrays.85.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 841,
       "filename": "arrays.86.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 854,
       "filename": "arrays.87.wasm",
-      "text": "invalid type: `array.atomic.get` only allows `i32`, `i64` and subtypes of `anyref`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type: `array.atomic.get` only allows `i32`, `i64` and subtypes of `anyref`"
     },
     {
       "type": "assert_invalid",
       "line": 865,
       "filename": "arrays.88.wasm",
-      "text": "invalid type: `array.atomic.get` only allows `i32`, `i64` and subtypes of `anyref`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type: `array.atomic.get` only allows `i32`, `i64` and subtypes of `anyref`"
     },
     {
       "type": "assert_invalid",
       "line": 876,
       "filename": "arrays.89.wasm",
-      "text": "cannot use array.get with packed storage types",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "cannot use array.get with packed storage types"
     },
     {
       "type": "assert_invalid",
       "line": 887,
       "filename": "arrays.90.wasm",
-      "text": "invalid type: `array.atomic.set` only allows `i8`, `i16`, `i32`, `i64` and subtypes of `anyref`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type: `array.atomic.set` only allows `i8`, `i16`, `i32`, `i64` and subtypes of `anyref`"
     }
   ]
 }

--- a/tests/snapshots/local/shared-everything-threads/funcs.wast.json
+++ b/tests/snapshots/local/shared-everything-threads/funcs.wast.json
@@ -4,42 +4,43 @@
     {
       "type": "module",
       "line": 2,
-      "filename": "funcs.0.wasm"
+      "filename": "funcs.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 10,
       "filename": "funcs.1.wasm",
-      "text": "shared functions cannot access unshared functions",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared functions cannot access unshared functions"
     },
     {
       "type": "assert_invalid",
       "line": 21,
       "filename": "funcs.2.wasm",
-      "text": "shared functions cannot access unshared globals",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared functions cannot access unshared globals"
     },
     {
       "type": "assert_invalid",
       "line": 32,
       "filename": "funcs.3.wasm",
-      "text": "shared functions cannot access unshared tables",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared functions cannot access unshared tables"
     },
     {
       "type": "assert_invalid",
       "line": 44,
       "filename": "funcs.4.wasm",
-      "text": "shared functions cannot access unshared arrays",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared functions cannot access unshared arrays"
     },
     {
       "type": "assert_invalid",
       "line": 56,
       "filename": "funcs.5.wasm",
-      "text": "shared functions cannot access unshared structs",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared functions cannot access unshared structs"
     }
   ]
 }

--- a/tests/snapshots/local/shared-everything-threads/gc-unreachable.wast.json
+++ b/tests/snapshots/local/shared-everything-threads/gc-unreachable.wast.json
@@ -4,49 +4,50 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "gc-unreachable.0.wasm"
+      "filename": "gc-unreachable.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 91,
       "filename": "gc-unreachable.1.wasm",
-      "text": "expected subtype of eq, found any",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected subtype of eq, found any"
     },
     {
       "type": "assert_invalid",
       "line": 103,
       "filename": "gc-unreachable.2.wasm",
-      "text": "expected (shared anyref), found (ref (shared extern))",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected (shared anyref), found (ref (shared extern))"
     },
     {
       "type": "assert_invalid",
       "line": 114,
       "filename": "gc-unreachable.3.wasm",
-      "text": "expected externref, found (ref any)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected externref, found (ref any)"
     },
     {
       "type": "assert_invalid",
       "line": 124,
       "filename": "gc-unreachable.4.wasm",
-      "text": "expected subtype of array, found any",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected subtype of array, found any"
     },
     {
       "type": "assert_invalid",
       "line": 134,
       "filename": "gc-unreachable.5.wasm",
-      "text": "expected i32, found heap type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "expected i32, found heap type"
     },
     {
       "type": "assert_invalid",
       "line": 144,
       "filename": "gc-unreachable.6.wasm",
-      "text": "br_on_cast to label with empty types",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "br_on_cast to label with empty types"
     }
   ]
 }

--- a/tests/snapshots/local/shared-everything-threads/globals.wast.json
+++ b/tests/snapshots/local/shared-everything-threads/globals.wast.json
@@ -4,207 +4,213 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "globals.0.wasm"
+      "filename": "globals.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 30,
       "filename": "globals.1.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 34,
       "filename": "globals.2.wasm",
-      "text": "shared value type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared value type"
     },
     {
       "type": "module",
       "line": 38,
-      "filename": "globals.3.wasm"
+      "filename": "globals.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 51,
       "filename": "globals.4.wasm",
-      "text": "global is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "global is immutable"
     },
     {
       "type": "assert_invalid",
       "line": 58,
       "filename": "globals.5.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 65,
       "filename": "globals.6.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 72,
       "filename": "globals.7.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 79,
       "filename": "globals.8.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 86,
       "filename": "globals.9.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 93,
       "filename": "globals.10.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 100,
       "filename": "globals.11.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 107,
       "filename": "globals.12.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 114,
       "filename": "globals.13.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 121,
       "filename": "globals.14.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 128,
       "filename": "globals.15.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 135,
       "filename": "globals.16.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 142,
       "filename": "globals.17.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 149,
       "filename": "globals.18.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 156,
       "filename": "globals.19.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 163,
       "filename": "globals.20.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 170,
       "filename": "globals.21.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 177,
       "filename": "globals.22.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "module",
       "line": 184,
-      "filename": "globals.23.wasm"
+      "filename": "globals.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 277,
-      "filename": "globals.24.wasm"
+      "filename": "globals.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 371,
       "filename": "globals.25.wasm",
-      "text": "invalid type: `global.atomic.rmw.*` only allows `i32` and `i64`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type: `global.atomic.rmw.*` only allows `i32` and `i64`"
     },
     {
       "type": "assert_invalid",
       "line": 382,
       "filename": "globals.26.wasm",
-      "text": "global index out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "global index out of bounds"
     },
     {
       "type": "assert_invalid",
       "line": 390,
       "filename": "globals.27.wasm",
-      "text": "invalid type: `global.atomic.rmw.xchg` only allows `i32`, `i64` and subtypes of `anyref`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type: `global.atomic.rmw.xchg` only allows `i32`, `i64` and subtypes of `anyref`"
     },
     {
       "type": "module",
       "line": 400,
-      "filename": "globals.28.wasm"
+      "filename": "globals.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 410,
       "filename": "globals.29.wasm",
-      "text": "invalid type: `global.atomic.rmw.cmpxchg` only allows `i32`, `i64` and subtypes of `eqref`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type: `global.atomic.rmw.cmpxchg` only allows `i32`, `i64` and subtypes of `eqref`"
     },
     {
       "type": "module",
       "line": 421,
-      "filename": "globals.30.wasm"
+      "filename": "globals.30.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/shared-everything-threads/i31.wast.json
+++ b/tests/snapshots/local/shared-everything-threads/i31.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "i31.0.wasm"
+      "filename": "i31.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -421,7 +422,8 @@
       "type": "module",
       "line": 61,
       "name": "tables_of_i31ref",
-      "filename": "i31.1.wasm"
+      "filename": "i31.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -787,7 +789,8 @@
       "type": "module",
       "line": 124,
       "name": "env",
-      "filename": "i31.2.wasm"
+      "filename": "i31.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -798,7 +801,8 @@
       "type": "module",
       "line": 129,
       "name": "i31ref_of_global_table_initializer",
-      "filename": "i31.3.wasm"
+      "filename": "i31.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -864,7 +868,8 @@
       "type": "module",
       "line": 141,
       "name": "i31ref_of_global_global_initializer",
-      "filename": "i31.4.wasm"
+      "filename": "i31.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -885,7 +890,8 @@
       "type": "module",
       "line": 151,
       "name": "anyref_global_of_i31ref",
-      "filename": "i31.5.wasm"
+      "filename": "i31.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -943,7 +949,8 @@
       "type": "module",
       "line": 169,
       "name": "anyref_table_of_i31ref",
-      "filename": "i31.6.wasm"
+      "filename": "i31.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/local/shared-everything-threads/polymorphism.wast.json
+++ b/tests/snapshots/local/shared-everything-threads/polymorphism.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "polymorphism.0.wasm"
+      "filename": "polymorphism.0.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/shared-everything-threads/ref-equivalence.wast.json
+++ b/tests/snapshots/local/shared-everything-threads/ref-equivalence.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "ref-equivalence.0.wasm"
+      "filename": "ref-equivalence.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -1963,71 +1964,71 @@
       "type": "assert_invalid",
       "line": 122,
       "filename": "ref-equivalence.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 130,
       "filename": "ref-equivalence.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 138,
       "filename": "ref-equivalence.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 146,
       "filename": "ref-equivalence.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 154,
       "filename": "ref-equivalence.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 162,
       "filename": "ref-equivalence.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 172,
       "filename": "ref-equivalence.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 180,
       "filename": "ref-equivalence.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 188,
       "filename": "ref-equivalence.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 196,
       "filename": "ref-equivalence.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/local/shared-everything-threads/structs.wast.json
+++ b/tests/snapshots/local/shared-everything-threads/structs.wast.json
@@ -4,242 +4,248 @@
     {
       "type": "module",
       "line": 2,
-      "filename": "structs.0.wasm"
+      "filename": "structs.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 16,
       "filename": "structs.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 26,
       "filename": "structs.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 37,
       "filename": "structs.3.wasm",
-      "text": "must match super type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "must match super type"
     },
     {
       "type": "assert_invalid",
       "line": 46,
       "filename": "structs.4.wasm",
-      "text": "must match super type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "must match super type"
     },
     {
       "type": "assert_invalid",
       "line": 55,
       "filename": "structs.5.wasm",
-      "text": "must contain shared type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "must contain shared type"
     },
     {
       "type": "module",
       "line": 62,
-      "filename": "structs.6.wasm"
+      "filename": "structs.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 67,
-      "filename": "structs.7.wasm"
+      "filename": "structs.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 72,
-      "filename": "structs.8.wasm"
+      "filename": "structs.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 95,
-      "filename": "structs.9.wasm"
+      "filename": "structs.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 104,
       "filename": "structs.10.wasm",
-      "text": "field is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "field is immutable"
     },
     {
       "type": "assert_invalid",
       "line": 113,
       "filename": "structs.11.wasm",
-      "text": "field is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "field is immutable"
     },
     {
       "type": "assert_invalid",
       "line": 122,
       "filename": "structs.12.wasm",
-      "text": "field is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "field is immutable"
     },
     {
       "type": "assert_invalid",
       "line": 131,
       "filename": "structs.13.wasm",
-      "text": "field is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "field is immutable"
     },
     {
       "type": "assert_invalid",
       "line": 140,
       "filename": "structs.14.wasm",
-      "text": "field is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "field is immutable"
     },
     {
       "type": "assert_invalid",
       "line": 149,
       "filename": "structs.15.wasm",
-      "text": "field is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "field is immutable"
     },
     {
       "type": "assert_invalid",
       "line": 158,
       "filename": "structs.16.wasm",
-      "text": "field is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "field is immutable"
     },
     {
       "type": "assert_invalid",
       "line": 167,
       "filename": "structs.17.wasm",
-      "text": "field is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "field is immutable"
     },
     {
       "type": "module",
       "line": 177,
-      "filename": "structs.18.wasm"
+      "filename": "structs.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 404,
       "filename": "structs.19.wasm",
-      "text": "non-packed storage type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "non-packed storage type"
     },
     {
       "type": "assert_invalid",
       "line": 413,
       "filename": "structs.20.wasm",
-      "text": "non-packed storage types",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "non-packed storage types"
     },
     {
       "type": "assert_invalid",
       "line": 422,
       "filename": "structs.21.wasm",
-      "text": "non-packed storage types",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "non-packed storage types"
     },
     {
       "type": "assert_invalid",
       "line": 431,
       "filename": "structs.22.wasm",
-      "text": "non-packed storage types",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "non-packed storage types"
     },
     {
       "type": "assert_invalid",
       "line": 440,
       "filename": "structs.23.wasm",
-      "text": "non-packed storage types",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "non-packed storage types"
     },
     {
       "type": "assert_invalid",
       "line": 449,
       "filename": "structs.24.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 459,
       "filename": "structs.25.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 469,
       "filename": "structs.26.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 479,
       "filename": "structs.27.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 489,
       "filename": "structs.28.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 499,
       "filename": "structs.29.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 509,
       "filename": "structs.30.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 520,
       "filename": "structs.31.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 532,
       "filename": "structs.32.wasm",
-      "text": "invalid type: `struct.atomic.get` only allows `i32`, `i64` and subtypes of `anyref`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type: `struct.atomic.get` only allows `i32`, `i64` and subtypes of `anyref`"
     },
     {
       "type": "assert_invalid",
       "line": 543,
       "filename": "structs.33.wasm",
-      "text": "invalid type: `struct.atomic.get` only allows `i32`, `i64` and subtypes of `anyref`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type: `struct.atomic.get` only allows `i32`, `i64` and subtypes of `anyref`"
     },
     {
       "type": "assert_invalid",
       "line": 554,
       "filename": "structs.34.wasm",
-      "text": "can only use struct `get` with non-packed storage types",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "can only use struct `get` with non-packed storage types"
     },
     {
       "type": "assert_invalid",
       "line": 565,
       "filename": "structs.35.wasm",
-      "text": "invalid type: `struct.atomic.set` only allows `i8`, `i16`, `i32`, `i64` and subtypes of `anyref`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type: `struct.atomic.set` only allows `i8`, `i16`, `i32`, `i64` and subtypes of `anyref`"
     }
   ]
 }

--- a/tests/snapshots/local/shared-everything-threads/tables.wast.json
+++ b/tests/snapshots/local/shared-everything-threads/tables.wast.json
@@ -4,85 +4,89 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "tables.0.wasm"
+      "filename": "tables.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 17,
-      "filename": "tables.1.wasm"
+      "filename": "tables.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 22,
       "filename": "tables.2.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 26,
       "filename": "tables.3.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 32,
       "filename": "tables.4.wat",
-      "text": "expected a u64",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "expected a u64"
     },
     {
       "type": "assert_invalid",
       "line": 36,
       "filename": "tables.5.wasm",
-      "text": "shared tables must have a shared element type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared tables must have a shared element type"
     },
     {
       "type": "assert_invalid",
       "line": 40,
       "filename": "tables.6.wasm",
-      "text": "shared tables must have a shared element type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared tables must have a shared element type"
     },
     {
       "type": "module",
       "line": 46,
-      "filename": "tables.7.wasm"
+      "filename": "tables.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 115,
-      "filename": "tables.8.wasm"
+      "filename": "tables.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 167,
       "filename": "tables.9.wasm",
-      "text": "invalid type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type"
     },
     {
       "type": "assert_invalid",
       "line": 177,
       "filename": "tables.10.wasm",
-      "text": "invalid type: `table.atomic.get` only allows subtypes of `anyref`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type: `table.atomic.get` only allows subtypes of `anyref`"
     },
     {
       "type": "assert_invalid",
       "line": 187,
       "filename": "tables.11.wasm",
-      "text": "invalid type: `table.atomic.set` only allows subtypes of `anyref`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type: `table.atomic.set` only allows subtypes of `anyref`"
     },
     {
       "type": "assert_invalid",
       "line": 198,
       "filename": "tables.12.wasm",
-      "text": "invalid type: `table.atomic.rmw.xchg` only allows subtypes of `anyref`",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid type: `table.atomic.rmw.xchg` only allows subtypes of `anyref`"
     }
   ]
 }

--- a/tests/snapshots/local/shared-everything-threads/types.wast.json
+++ b/tests/snapshots/local/shared-everything-threads/types.wast.json
@@ -4,392 +4,407 @@
     {
       "type": "module",
       "line": 2,
-      "filename": "types.0.wasm"
+      "filename": "types.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 17,
       "filename": "types.1.wasm",
-      "text": "shared globals must have a shared value type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals must have a shared value type"
     },
     {
       "type": "assert_invalid",
       "line": 20,
       "filename": "types.2.wasm",
-      "text": "shared globals must have a shared value type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals must have a shared value type"
     },
     {
       "type": "assert_invalid",
       "line": 23,
       "filename": "types.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 27,
-      "filename": "types.4.wasm"
+      "filename": "types.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 42,
       "filename": "types.5.wasm",
-      "text": "shared globals must have a shared value type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals must have a shared value type"
     },
     {
       "type": "assert_invalid",
       "line": 45,
       "filename": "types.6.wasm",
-      "text": "shared globals must have a shared value type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals must have a shared value type"
     },
     {
       "type": "assert_invalid",
       "line": 48,
       "filename": "types.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 52,
-      "filename": "types.8.wasm"
+      "filename": "types.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 67,
       "filename": "types.9.wasm",
-      "text": "shared globals must have a shared value type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals must have a shared value type"
     },
     {
       "type": "assert_invalid",
       "line": 70,
       "filename": "types.10.wasm",
-      "text": "shared globals must have a shared value type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals must have a shared value type"
     },
     {
       "type": "assert_invalid",
       "line": 73,
       "filename": "types.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 77,
-      "filename": "types.12.wasm"
+      "filename": "types.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 92,
       "filename": "types.13.wasm",
-      "text": "shared globals must have a shared value type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals must have a shared value type"
     },
     {
       "type": "assert_invalid",
       "line": 95,
       "filename": "types.14.wasm",
-      "text": "shared globals must have a shared value type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals must have a shared value type"
     },
     {
       "type": "assert_invalid",
       "line": 98,
       "filename": "types.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 102,
-      "filename": "types.16.wasm"
+      "filename": "types.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 117,
       "filename": "types.17.wasm",
-      "text": "shared globals must have a shared value type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals must have a shared value type"
     },
     {
       "type": "assert_invalid",
       "line": 120,
       "filename": "types.18.wasm",
-      "text": "shared globals must have a shared value type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals must have a shared value type"
     },
     {
       "type": "assert_invalid",
       "line": 123,
       "filename": "types.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 127,
-      "filename": "types.20.wasm"
+      "filename": "types.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 142,
       "filename": "types.21.wasm",
-      "text": "shared globals must have a shared value type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals must have a shared value type"
     },
     {
       "type": "assert_invalid",
       "line": 145,
       "filename": "types.22.wasm",
-      "text": "shared globals must have a shared value type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals must have a shared value type"
     },
     {
       "type": "assert_invalid",
       "line": 148,
       "filename": "types.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 152,
-      "filename": "types.24.wasm"
+      "filename": "types.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 167,
       "filename": "types.25.wasm",
-      "text": "shared globals must have a shared value type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals must have a shared value type"
     },
     {
       "type": "assert_invalid",
       "line": 170,
       "filename": "types.26.wasm",
-      "text": "shared globals must have a shared value type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals must have a shared value type"
     },
     {
       "type": "assert_invalid",
       "line": 173,
       "filename": "types.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 177,
-      "filename": "types.28.wasm"
+      "filename": "types.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 192,
       "filename": "types.29.wasm",
-      "text": "shared globals must have a shared value type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals must have a shared value type"
     },
     {
       "type": "assert_invalid",
       "line": 195,
       "filename": "types.30.wasm",
-      "text": "shared globals must have a shared value type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals must have a shared value type"
     },
     {
       "type": "assert_invalid",
       "line": 198,
       "filename": "types.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 202,
-      "filename": "types.32.wasm"
+      "filename": "types.32.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 217,
       "filename": "types.33.wasm",
-      "text": "shared globals must have a shared value type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals must have a shared value type"
     },
     {
       "type": "assert_invalid",
       "line": 220,
       "filename": "types.34.wasm",
-      "text": "shared globals must have a shared value type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals must have a shared value type"
     },
     {
       "type": "assert_invalid",
       "line": 223,
       "filename": "types.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 227,
-      "filename": "types.36.wasm"
+      "filename": "types.36.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 242,
       "filename": "types.37.wasm",
-      "text": "shared globals must have a shared value type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals must have a shared value type"
     },
     {
       "type": "assert_invalid",
       "line": 245,
       "filename": "types.38.wasm",
-      "text": "shared globals must have a shared value type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals must have a shared value type"
     },
     {
       "type": "assert_invalid",
       "line": 248,
       "filename": "types.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 252,
-      "filename": "types.40.wasm"
+      "filename": "types.40.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 267,
       "filename": "types.41.wasm",
-      "text": "shared globals must have a shared value type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals must have a shared value type"
     },
     {
       "type": "assert_invalid",
       "line": 270,
       "filename": "types.42.wasm",
-      "text": "shared globals must have a shared value type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals must have a shared value type"
     },
     {
       "type": "assert_invalid",
       "line": 273,
       "filename": "types.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 277,
-      "filename": "types.44.wasm"
+      "filename": "types.44.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 292,
       "filename": "types.45.wasm",
-      "text": "shared globals must have a shared value type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals must have a shared value type"
     },
     {
       "type": "assert_invalid",
       "line": 295,
       "filename": "types.46.wasm",
-      "text": "shared globals must have a shared value type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals must have a shared value type"
     },
     {
       "type": "assert_invalid",
       "line": 298,
       "filename": "types.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 302,
-      "filename": "types.48.wasm"
+      "filename": "types.48.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 317,
       "filename": "types.49.wasm",
-      "text": "shared globals must have a shared value type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals must have a shared value type"
     },
     {
       "type": "assert_invalid",
       "line": 322,
       "filename": "types.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 327,
       "filename": "types.51.wasm",
-      "text": "shared composite type must contain shared types",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared composite type must contain shared types"
     },
     {
       "type": "module",
       "line": 331,
-      "filename": "types.52.wasm"
+      "filename": "types.52.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 346,
       "filename": "types.53.wasm",
-      "text": "shared globals must have a shared value type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals must have a shared value type"
     },
     {
       "type": "assert_invalid",
       "line": 351,
       "filename": "types.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 356,
       "filename": "types.55.wasm",
-      "text": "shared composite type must contain shared types",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared composite type must contain shared types"
     },
     {
       "type": "module",
       "line": 360,
-      "filename": "types.56.wasm"
+      "filename": "types.56.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 375,
       "filename": "types.57.wasm",
-      "text": "shared globals must have a shared value type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared globals must have a shared value type"
     },
     {
       "type": "assert_invalid",
       "line": 380,
       "filename": "types.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 385,
       "filename": "types.59.wasm",
-      "text": "shared composite type must contain shared types",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared composite type must contain shared types"
     }
   ]
 }

--- a/tests/snapshots/local/table-funcref.wast.json
+++ b/tests/snapshots/local/table-funcref.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_malformed",
       "line": 2,
       "filename": "table-funcref.0.wasm",
-      "text": "indirect calls must go through a table with type <= funcref",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "indirect calls must go through a table with type <= funcref"
     }
   ]
 }

--- a/tests/snapshots/local/table-too-big.wast.json
+++ b/tests/snapshots/local/table-too-big.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "table-too-big.0.wasm",
-      "text": "minimum table size is out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "minimum table size is out of bounds"
     }
   ]
 }

--- a/tests/snapshots/local/tail-call-after-end.wast.json
+++ b/tests/snapshots/local/tail-call-after-end.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "tail-call-after-end.0.wasm",
-      "text": "operators remaining after end of function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "operators remaining after end of function"
     }
   ]
 }

--- a/tests/snapshots/local/threads.wast.json
+++ b/tests/snapshots/local/threads.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "threads.0.wasm",
-      "text": "must always specify maximum alignment",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "must always specify maximum alignment"
     }
   ]
 }

--- a/tests/snapshots/local/unreachable-block.wast.json
+++ b/tests/snapshots/local/unreachable-block.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "unreachable-block.0.wasm"
+      "filename": "unreachable-block.0.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/unreachable-valid.wast.json
+++ b/tests/snapshots/local/unreachable-valid.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "unreachable-valid.0.wasm"
+      "filename": "unreachable-valid.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",

--- a/tests/snapshots/local/upstream-threads/LB.wast.json
+++ b/tests/snapshots/local/upstream-threads/LB.wast.json
@@ -5,7 +5,8 @@
       "type": "module",
       "line": 1,
       "name": "Mem",
-      "filename": "LB.0.wasm"
+      "filename": "LB.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "thread",
@@ -22,7 +23,8 @@
         {
           "type": "module",
           "line": 7,
-          "filename": "LB.1.wasm"
+          "filename": "LB.1.wasm",
+          "module_type": "binary"
         },
         {
           "type": "action",
@@ -50,7 +52,8 @@
         {
           "type": "module",
           "line": 24,
-          "filename": "LB.2.wasm"
+          "filename": "LB.2.wasm",
+          "module_type": "binary"
         },
         {
           "type": "action",
@@ -77,7 +80,8 @@
       "type": "module",
       "line": 43,
       "name": "Check",
-      "filename": "LB.3.wasm"
+      "filename": "LB.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/local/upstream-threads/LB_atomic.wast.json
+++ b/tests/snapshots/local/upstream-threads/LB_atomic.wast.json
@@ -5,7 +5,8 @@
       "type": "module",
       "line": 1,
       "name": "Mem",
-      "filename": "LB_atomic.0.wasm"
+      "filename": "LB_atomic.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "thread",
@@ -22,7 +23,8 @@
         {
           "type": "module",
           "line": 7,
-          "filename": "LB_atomic.1.wasm"
+          "filename": "LB_atomic.1.wasm",
+          "module_type": "binary"
         },
         {
           "type": "action",
@@ -50,7 +52,8 @@
         {
           "type": "module",
           "line": 24,
-          "filename": "LB_atomic.2.wasm"
+          "filename": "LB_atomic.2.wasm",
+          "module_type": "binary"
         },
         {
           "type": "action",
@@ -77,7 +80,8 @@
       "type": "module",
       "line": 43,
       "name": "Check",
-      "filename": "LB_atomic.3.wasm"
+      "filename": "LB_atomic.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/local/upstream-threads/MP.wast.json
+++ b/tests/snapshots/local/upstream-threads/MP.wast.json
@@ -5,7 +5,8 @@
       "type": "module",
       "line": 1,
       "name": "Mem",
-      "filename": "MP.0.wasm"
+      "filename": "MP.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "thread",
@@ -22,7 +23,8 @@
         {
           "type": "module",
           "line": 7,
-          "filename": "MP.1.wasm"
+          "filename": "MP.1.wasm",
+          "module_type": "binary"
         },
         {
           "type": "action",
@@ -50,7 +52,8 @@
         {
           "type": "module",
           "line": 19,
-          "filename": "MP.2.wasm"
+          "filename": "MP.2.wasm",
+          "module_type": "binary"
         },
         {
           "type": "action",
@@ -77,7 +80,8 @@
       "type": "module",
       "line": 40,
       "name": "Check",
-      "filename": "MP.3.wasm"
+      "filename": "MP.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/local/upstream-threads/MP_atomic.wast.json
+++ b/tests/snapshots/local/upstream-threads/MP_atomic.wast.json
@@ -5,7 +5,8 @@
       "type": "module",
       "line": 1,
       "name": "Mem",
-      "filename": "MP_atomic.0.wasm"
+      "filename": "MP_atomic.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "thread",
@@ -22,7 +23,8 @@
         {
           "type": "module",
           "line": 7,
-          "filename": "MP_atomic.1.wasm"
+          "filename": "MP_atomic.1.wasm",
+          "module_type": "binary"
         },
         {
           "type": "action",
@@ -50,7 +52,8 @@
         {
           "type": "module",
           "line": 19,
-          "filename": "MP_atomic.2.wasm"
+          "filename": "MP_atomic.2.wasm",
+          "module_type": "binary"
         },
         {
           "type": "action",
@@ -77,7 +80,8 @@
       "type": "module",
       "line": 40,
       "name": "Check",
-      "filename": "MP_atomic.3.wasm"
+      "filename": "MP_atomic.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/local/upstream-threads/MP_wait.wast.json
+++ b/tests/snapshots/local/upstream-threads/MP_wait.wast.json
@@ -5,7 +5,8 @@
       "type": "module",
       "line": 1,
       "name": "Mem",
-      "filename": "MP_wait.0.wasm"
+      "filename": "MP_wait.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "thread",
@@ -22,7 +23,8 @@
         {
           "type": "module",
           "line": 7,
-          "filename": "MP_wait.1.wasm"
+          "filename": "MP_wait.1.wasm",
+          "module_type": "binary"
         },
         {
           "type": "action",
@@ -50,7 +52,8 @@
         {
           "type": "module",
           "line": 19,
-          "filename": "MP_wait.2.wasm"
+          "filename": "MP_wait.2.wasm",
+          "module_type": "binary"
         },
         {
           "type": "action",
@@ -77,7 +80,8 @@
       "type": "module",
       "line": 40,
       "name": "Check",
-      "filename": "MP_wait.3.wasm"
+      "filename": "MP_wait.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/local/upstream-threads/SB.wast.json
+++ b/tests/snapshots/local/upstream-threads/SB.wast.json
@@ -5,7 +5,8 @@
       "type": "module",
       "line": 1,
       "name": "Mem",
-      "filename": "SB.0.wasm"
+      "filename": "SB.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "thread",
@@ -22,7 +23,8 @@
         {
           "type": "module",
           "line": 7,
-          "filename": "SB.1.wasm"
+          "filename": "SB.1.wasm",
+          "module_type": "binary"
         },
         {
           "type": "action",
@@ -50,7 +52,8 @@
         {
           "type": "module",
           "line": 24,
-          "filename": "SB.2.wasm"
+          "filename": "SB.2.wasm",
+          "module_type": "binary"
         },
         {
           "type": "action",
@@ -77,7 +80,8 @@
       "type": "module",
       "line": 43,
       "name": "Check",
-      "filename": "SB.3.wasm"
+      "filename": "SB.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/local/upstream-threads/SB_atomic.wast.json
+++ b/tests/snapshots/local/upstream-threads/SB_atomic.wast.json
@@ -5,7 +5,8 @@
       "type": "module",
       "line": 1,
       "name": "Mem",
-      "filename": "SB_atomic.0.wasm"
+      "filename": "SB_atomic.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "thread",
@@ -22,7 +23,8 @@
         {
           "type": "module",
           "line": 7,
-          "filename": "SB_atomic.1.wasm"
+          "filename": "SB_atomic.1.wasm",
+          "module_type": "binary"
         },
         {
           "type": "action",
@@ -50,7 +52,8 @@
         {
           "type": "module",
           "line": 24,
-          "filename": "SB_atomic.2.wasm"
+          "filename": "SB_atomic.2.wasm",
+          "module_type": "binary"
         },
         {
           "type": "action",
@@ -77,7 +80,8 @@
       "type": "module",
       "line": 43,
       "name": "Check",
-      "filename": "SB_atomic.3.wasm"
+      "filename": "SB_atomic.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/local/upstream-threads/wait_notify.wast.json
+++ b/tests/snapshots/local/upstream-threads/wait_notify.wast.json
@@ -5,7 +5,8 @@
       "type": "module",
       "line": 2,
       "name": "Mem",
-      "filename": "wait_notify.0.wasm"
+      "filename": "wait_notify.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "thread",
@@ -22,7 +23,8 @@
         {
           "type": "module",
           "line": 8,
-          "filename": "wait_notify.1.wasm"
+          "filename": "wait_notify.1.wasm",
+          "module_type": "binary"
         },
         {
           "type": "assert_return",
@@ -56,7 +58,8 @@
         {
           "type": "module",
           "line": 20,
-          "filename": "wait_notify.2.wasm"
+          "filename": "wait_notify.2.wasm",
+          "module_type": "binary"
         },
         {
           "type": "assert_return",

--- a/tests/snapshots/testsuite/address.wast.json
+++ b/tests/snapshots/testsuite/address.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "address.0.wasm"
+      "filename": "address.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1745,13 +1746,14 @@
       "type": "assert_malformed",
       "line": 214,
       "filename": "address.1.wat",
-      "text": "i32 constant",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "i32 constant"
     },
     {
       "type": "module",
       "line": 223,
-      "filename": "address.2.wasm"
+      "filename": "address.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4166,7 +4168,8 @@
     {
       "type": "module",
       "line": 514,
-      "filename": "address.3.wasm"
+      "filename": "address.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4526,7 +4529,8 @@
     {
       "type": "module",
       "line": 564,
-      "filename": "address.4.wasm"
+      "filename": "address.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/align.wast.json
+++ b/tests/snapshots/testsuite/align.wast.json
@@ -4,703 +4,727 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "align.0.wasm"
+      "filename": "align.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 4,
-      "filename": "align.1.wasm"
+      "filename": "align.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 5,
-      "filename": "align.2.wasm"
+      "filename": "align.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 6,
-      "filename": "align.3.wasm"
+      "filename": "align.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 7,
-      "filename": "align.4.wasm"
+      "filename": "align.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 8,
-      "filename": "align.5.wasm"
+      "filename": "align.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 9,
-      "filename": "align.6.wasm"
+      "filename": "align.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 10,
-      "filename": "align.7.wasm"
+      "filename": "align.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 11,
-      "filename": "align.8.wasm"
+      "filename": "align.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 12,
-      "filename": "align.9.wasm"
+      "filename": "align.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 13,
-      "filename": "align.10.wasm"
+      "filename": "align.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 14,
-      "filename": "align.11.wasm"
+      "filename": "align.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 15,
-      "filename": "align.12.wasm"
+      "filename": "align.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 16,
-      "filename": "align.13.wasm"
+      "filename": "align.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 17,
-      "filename": "align.14.wasm"
+      "filename": "align.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 18,
-      "filename": "align.15.wasm"
+      "filename": "align.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 19,
-      "filename": "align.16.wasm"
+      "filename": "align.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 20,
-      "filename": "align.17.wasm"
+      "filename": "align.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 21,
-      "filename": "align.18.wasm"
+      "filename": "align.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 22,
-      "filename": "align.19.wasm"
+      "filename": "align.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 23,
-      "filename": "align.20.wasm"
+      "filename": "align.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 24,
-      "filename": "align.21.wasm"
+      "filename": "align.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 25,
-      "filename": "align.22.wasm"
+      "filename": "align.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 28,
       "filename": "align.23.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 34,
       "filename": "align.24.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 40,
       "filename": "align.25.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 46,
       "filename": "align.26.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 52,
       "filename": "align.27.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 58,
       "filename": "align.28.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 64,
       "filename": "align.29.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 70,
       "filename": "align.30.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 76,
       "filename": "align.31.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 82,
       "filename": "align.32.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 88,
       "filename": "align.33.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 94,
       "filename": "align.34.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 100,
       "filename": "align.35.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 106,
       "filename": "align.36.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 112,
       "filename": "align.37.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 118,
       "filename": "align.38.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 124,
       "filename": "align.39.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 130,
       "filename": "align.40.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 136,
       "filename": "align.41.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 142,
       "filename": "align.42.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 148,
       "filename": "align.43.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 154,
       "filename": "align.44.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 160,
       "filename": "align.45.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 166,
       "filename": "align.46.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 172,
       "filename": "align.47.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 178,
       "filename": "align.48.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 184,
       "filename": "align.49.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 190,
       "filename": "align.50.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 197,
       "filename": "align.51.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 203,
       "filename": "align.52.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 209,
       "filename": "align.53.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 215,
       "filename": "align.54.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 221,
       "filename": "align.55.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 227,
       "filename": "align.56.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 233,
       "filename": "align.57.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 239,
       "filename": "align.58.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 245,
       "filename": "align.59.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 251,
       "filename": "align.60.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 257,
       "filename": "align.61.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 263,
       "filename": "align.62.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 269,
       "filename": "align.63.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 275,
       "filename": "align.64.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 281,
       "filename": "align.65.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 287,
       "filename": "align.66.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 293,
       "filename": "align.67.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 299,
       "filename": "align.68.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_invalid",
       "line": 306,
       "filename": "align.69.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 310,
       "filename": "align.70.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 314,
       "filename": "align.71.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 318,
       "filename": "align.72.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 322,
       "filename": "align.73.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 326,
       "filename": "align.74.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 330,
       "filename": "align.75.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 334,
       "filename": "align.76.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 338,
       "filename": "align.77.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 342,
       "filename": "align.78.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 346,
       "filename": "align.79.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 350,
       "filename": "align.80.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 354,
       "filename": "align.81.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 358,
       "filename": "align.82.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 363,
       "filename": "align.83.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 367,
       "filename": "align.84.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 371,
       "filename": "align.85.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 375,
       "filename": "align.86.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 379,
       "filename": "align.87.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 383,
       "filename": "align.88.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 387,
       "filename": "align.89.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 391,
       "filename": "align.90.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 395,
       "filename": "align.91.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 399,
       "filename": "align.92.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 403,
       "filename": "align.93.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 407,
       "filename": "align.94.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 411,
       "filename": "align.95.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 415,
       "filename": "align.96.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 420,
       "filename": "align.97.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 424,
       "filename": "align.98.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 428,
       "filename": "align.99.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 432,
       "filename": "align.100.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 436,
       "filename": "align.101.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 440,
       "filename": "align.102.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 444,
       "filename": "align.103.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 448,
       "filename": "align.104.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 452,
       "filename": "align.105.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "module",
       "line": 458,
-      "filename": "align.106.wasm"
+      "filename": "align.106.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1773,7 +1797,8 @@
     {
       "type": "module",
       "line": 854,
-      "filename": "align.107.wasm"
+      "filename": "align.107.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -1818,43 +1843,43 @@
       "type": "assert_invalid",
       "line": 873,
       "filename": "align.108.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_malformed",
       "line": 892,
       "filename": "align.109.wasm",
-      "text": "malformed memop flags",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed memop flags"
     },
     {
       "type": "assert_malformed",
       "line": 911,
       "filename": "align.110.wasm",
-      "text": "malformed memop flags",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed memop flags"
     },
     {
       "type": "assert_malformed",
       "line": 930,
       "filename": "align.111.wasm",
-      "text": "malformed memop flags",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed memop flags"
     },
     {
       "type": "assert_malformed",
       "line": 949,
       "filename": "align.112.wasm",
-      "text": "malformed memop flags",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed memop flags"
     },
     {
       "type": "assert_malformed",
       "line": 968,
       "filename": "align.113.wasm",
-      "text": "malformed memop flags",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed memop flags"
     }
   ]
 }

--- a/tests/snapshots/testsuite/binary-leb128.wast.json
+++ b/tests/snapshots/testsuite/binary-leb128.wast.json
@@ -4,573 +4,606 @@
     {
       "type": "module",
       "line": 2,
-      "filename": "binary-leb128.0.wasm"
+      "filename": "binary-leb128.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 7,
-      "filename": "binary-leb128.1.wasm"
+      "filename": "binary-leb128.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 12,
-      "filename": "binary-leb128.2.wasm"
+      "filename": "binary-leb128.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 18,
-      "filename": "binary-leb128.3.wasm"
+      "filename": "binary-leb128.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 24,
-      "filename": "binary-leb128.4.wasm"
+      "filename": "binary-leb128.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 32,
-      "filename": "binary-leb128.5.wasm"
+      "filename": "binary-leb128.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 41,
-      "filename": "binary-leb128.6.wasm"
+      "filename": "binary-leb128.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 49,
-      "filename": "binary-leb128.7.wasm"
+      "filename": "binary-leb128.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 57,
-      "filename": "binary-leb128.8.wasm"
+      "filename": "binary-leb128.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 66,
-      "filename": "binary-leb128.9.wasm"
+      "filename": "binary-leb128.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 75,
-      "filename": "binary-leb128.10.wasm"
+      "filename": "binary-leb128.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 87,
-      "filename": "binary-leb128.11.wasm"
+      "filename": "binary-leb128.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 99,
-      "filename": "binary-leb128.12.wasm"
+      "filename": "binary-leb128.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 111,
-      "filename": "binary-leb128.13.wasm"
+      "filename": "binary-leb128.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 120,
-      "filename": "binary-leb128.14.wasm"
+      "filename": "binary-leb128.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 133,
-      "filename": "binary-leb128.15.wasm"
+      "filename": "binary-leb128.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 146,
-      "filename": "binary-leb128.16.wasm"
+      "filename": "binary-leb128.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 158,
-      "filename": "binary-leb128.17.wasm"
+      "filename": "binary-leb128.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 165,
-      "filename": "binary-leb128.18.wasm"
+      "filename": "binary-leb128.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 172,
-      "filename": "binary-leb128.19.wasm"
+      "filename": "binary-leb128.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 179,
-      "filename": "binary-leb128.20.wasm"
+      "filename": "binary-leb128.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 187,
-      "filename": "binary-leb128.21.wasm"
+      "filename": "binary-leb128.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 194,
-      "filename": "binary-leb128.22.wasm"
+      "filename": "binary-leb128.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 201,
-      "filename": "binary-leb128.23.wasm"
+      "filename": "binary-leb128.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 208,
-      "filename": "binary-leb128.24.wasm"
+      "filename": "binary-leb128.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 218,
       "filename": "binary-leb128.25.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 226,
       "filename": "binary-leb128.26.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 235,
       "filename": "binary-leb128.27.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 246,
       "filename": "binary-leb128.28.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 257,
       "filename": "binary-leb128.29.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 268,
       "filename": "binary-leb128.30.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 279,
       "filename": "binary-leb128.31.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 291,
       "filename": "binary-leb128.32.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 303,
       "filename": "binary-leb128.33.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 318,
       "filename": "binary-leb128.34.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 333,
       "filename": "binary-leb128.35.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 348,
       "filename": "binary-leb128.36.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 360,
       "filename": "binary-leb128.37.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 376,
       "filename": "binary-leb128.38.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 392,
       "filename": "binary-leb128.39.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 405,
       "filename": "binary-leb128.40.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 424,
       "filename": "binary-leb128.41.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 443,
       "filename": "binary-leb128.42.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 462,
       "filename": "binary-leb128.43.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 483,
       "filename": "binary-leb128.44.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 493,
       "filename": "binary-leb128.45.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 504,
       "filename": "binary-leb128.46.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 514,
       "filename": "binary-leb128.47.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 526,
       "filename": "binary-leb128.48.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 534,
       "filename": "binary-leb128.49.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 542,
       "filename": "binary-leb128.50.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 551,
       "filename": "binary-leb128.51.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 560,
       "filename": "binary-leb128.52.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 571,
       "filename": "binary-leb128.53.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 582,
       "filename": "binary-leb128.54.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 593,
       "filename": "binary-leb128.55.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 604,
       "filename": "binary-leb128.56.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 616,
       "filename": "binary-leb128.57.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 628,
       "filename": "binary-leb128.58.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 643,
       "filename": "binary-leb128.59.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 658,
       "filename": "binary-leb128.60.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 673,
       "filename": "binary-leb128.61.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 686,
       "filename": "binary-leb128.62.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 702,
       "filename": "binary-leb128.63.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 718,
       "filename": "binary-leb128.64.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 731,
       "filename": "binary-leb128.65.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 751,
       "filename": "binary-leb128.66.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 771,
       "filename": "binary-leb128.67.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 789,
       "filename": "binary-leb128.68.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 808,
       "filename": "binary-leb128.69.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 827,
       "filename": "binary-leb128.70.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 846,
       "filename": "binary-leb128.71.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 866,
       "filename": "binary-leb128.72.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 888,
       "filename": "binary-leb128.73.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 898,
       "filename": "binary-leb128.74.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 908,
       "filename": "binary-leb128.75.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 918,
       "filename": "binary-leb128.76.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 929,
       "filename": "binary-leb128.77.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 939,
       "filename": "binary-leb128.78.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 949,
       "filename": "binary-leb128.79.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 959,
       "filename": "binary-leb128.80.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "module",
       "line": 969,
-      "filename": "binary-leb128.81.wasm"
+      "filename": "binary-leb128.81.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 990,
       "filename": "binary-leb128.82.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "module",
       "line": 1007,
-      "filename": "binary-leb128.83.wasm"
+      "filename": "binary-leb128.83.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 1015,
-      "filename": "binary-leb128.84.wasm"
+      "filename": "binary-leb128.84.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 1024,
-      "filename": "binary-leb128.85.wasm"
+      "filename": "binary-leb128.85.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 1035,
-      "filename": "binary-leb128.86.wasm"
+      "filename": "binary-leb128.86.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 1043,
-      "filename": "binary-leb128.87.wasm"
+      "filename": "binary-leb128.87.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 1052,
-      "filename": "binary-leb128.88.wasm"
+      "filename": "binary-leb128.88.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 1061,
-      "filename": "binary-leb128.89.wasm"
+      "filename": "binary-leb128.89.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 1073,
       "filename": "binary-leb128.90.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     }
   ]
 }

--- a/tests/snapshots/testsuite/binary.wast.json
+++ b/tests/snapshots/testsuite/binary.wast.json
@@ -4,904 +4,923 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "binary.0.wasm"
+      "filename": "binary.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 2,
-      "filename": "binary.1.wasm"
+      "filename": "binary.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 3,
       "name": "M1",
-      "filename": "binary.2.wasm"
+      "filename": "binary.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 4,
       "name": "M2",
-      "filename": "binary.3.wasm"
+      "filename": "binary.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 6,
       "filename": "binary.4.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 7,
       "filename": "binary.5.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 8,
       "filename": "binary.6.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 9,
       "filename": "binary.7.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 10,
       "filename": "binary.8.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 11,
       "filename": "binary.9.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 12,
       "filename": "binary.10.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 13,
       "filename": "binary.11.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 14,
       "filename": "binary.12.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 15,
       "filename": "binary.13.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 16,
       "filename": "binary.14.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 17,
       "filename": "binary.15.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 18,
       "filename": "binary.16.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 21,
       "filename": "binary.17.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 24,
       "filename": "binary.18.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 25,
       "filename": "binary.19.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 28,
       "filename": "binary.20.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 31,
       "filename": "binary.21.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 34,
       "filename": "binary.22.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 37,
       "filename": "binary.23.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 38,
       "filename": "binary.24.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 39,
       "filename": "binary.25.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 40,
       "filename": "binary.26.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 41,
       "filename": "binary.27.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 42,
       "filename": "binary.28.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 43,
       "filename": "binary.29.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 44,
       "filename": "binary.30.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 45,
       "filename": "binary.31.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 48,
       "filename": "binary.32.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 49,
       "filename": "binary.33.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 50,
       "filename": "binary.34.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 51,
       "filename": "binary.35.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 52,
       "filename": "binary.36.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 56,
       "filename": "binary.37.wasm",
-      "text": "END opcode expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "END opcode expected"
     },
     {
       "type": "assert_malformed",
       "line": 77,
       "filename": "binary.38.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 93,
       "filename": "binary.39.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 113,
       "filename": "binary.40.wasm",
-      "text": "illegal opcode",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "illegal opcode"
     },
     {
       "type": "assert_malformed",
       "line": 126,
       "filename": "binary.41.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 146,
       "filename": "binary.42.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 166,
       "filename": "binary.43.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 185,
       "filename": "binary.44.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 204,
       "filename": "binary.45.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 224,
       "filename": "binary.46.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 243,
       "filename": "binary.47.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 262,
       "filename": "binary.48.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 280,
       "filename": "binary.49.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 298,
       "filename": "binary.50.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 317,
       "filename": "binary.51.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 334,
       "filename": "binary.52.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 351,
       "filename": "binary.53.wasm",
-      "text": "too many locals",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "too many locals"
     },
     {
       "type": "assert_malformed",
       "line": 367,
       "filename": "binary.54.wasm",
-      "text": "too many locals",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "too many locals"
     },
     {
       "type": "module",
       "line": 385,
-      "filename": "binary.55.wasm"
+      "filename": "binary.55.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 401,
       "filename": "binary.56.wasm",
-      "text": "function and code section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function and code section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 411,
       "filename": "binary.57.wasm",
-      "text": "function and code section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function and code section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 420,
       "filename": "binary.58.wasm",
-      "text": "function and code section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function and code section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 431,
       "filename": "binary.59.wasm",
-      "text": "function and code section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function and code section have inconsistent lengths"
     },
     {
       "type": "module",
       "line": 441,
-      "filename": "binary.60.wasm"
+      "filename": "binary.60.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 447,
-      "filename": "binary.61.wasm"
+      "filename": "binary.61.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 454,
       "filename": "binary.62.wasm",
-      "text": "data count and data section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "data count and data section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 464,
       "filename": "binary.63.wasm",
-      "text": "data count and data section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "data count and data section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 474,
       "filename": "binary.64.wasm",
-      "text": "data count section required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "data count section required"
     },
     {
       "type": "assert_malformed",
       "line": 496,
       "filename": "binary.65.wasm",
-      "text": "data count section required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "data count section required"
     },
     {
       "type": "assert_malformed",
       "line": 515,
       "filename": "binary.66.wasm",
-      "text": "illegal opcode",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "illegal opcode"
     },
     {
       "type": "assert_malformed",
       "line": 541,
       "filename": "binary.67.wasm",
-      "text": "malformed reference type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed reference type"
     },
     {
       "type": "module",
       "line": 566,
-      "filename": "binary.68.wasm"
+      "filename": "binary.68.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 590,
-      "filename": "binary.69.wasm"
+      "filename": "binary.69.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 615,
-      "filename": "binary.70.wasm"
+      "filename": "binary.70.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 622,
       "filename": "binary.71.wasm",
-      "text": "length out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "length out of bounds"
     },
     {
       "type": "assert_malformed",
       "line": 633,
       "filename": "binary.72.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 643,
-      "filename": "binary.73.wasm"
+      "filename": "binary.73.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 652,
       "filename": "binary.74.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 662,
       "filename": "binary.75.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 673,
       "filename": "binary.76.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 683,
       "filename": "binary.77.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 694,
       "filename": "binary.78.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 704,
       "filename": "binary.79.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 717,
       "filename": "binary.80.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 736,
       "filename": "binary.81.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 760,
-      "filename": "binary.82.wasm"
+      "filename": "binary.82.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 767,
       "filename": "binary.83.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 777,
       "filename": "binary.84.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 786,
       "filename": "binary.85.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 796,
       "filename": "binary.86.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "module",
       "line": 807,
-      "filename": "binary.87.wasm"
+      "filename": "binary.87.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 814,
       "filename": "binary.88.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 824,
       "filename": "binary.89.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 832,
       "filename": "binary.90.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 841,
       "filename": "binary.91.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 850,
       "filename": "binary.92.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "module",
       "line": 860,
-      "filename": "binary.93.wasm"
+      "filename": "binary.93.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 867,
       "filename": "binary.94.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 878,
       "filename": "binary.95.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 888,
-      "filename": "binary.96.wasm"
+      "filename": "binary.96.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 901,
       "filename": "binary.97.wasm",
-      "text": "length out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "length out of bounds"
     },
     {
       "type": "assert_malformed",
       "line": 922,
       "filename": "binary.98.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 942,
-      "filename": "binary.99.wasm"
+      "filename": "binary.99.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 956,
       "filename": "binary.100.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 972,
       "filename": "binary.101.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 989,
       "filename": "binary.102.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 1006,
-      "filename": "binary.103.wasm"
+      "filename": "binary.103.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 1015,
       "filename": "binary.104.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 1028,
       "filename": "binary.105.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1041,
       "filename": "binary.106.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 1055,
       "filename": "binary.107.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 1068,
-      "filename": "binary.108.wasm"
+      "filename": "binary.108.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 1086,
       "filename": "binary.109.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "module",
       "line": 1119,
-      "filename": "binary.110.wasm"
+      "filename": "binary.110.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 1133,
       "filename": "binary.111.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1150,
       "filename": "binary.112.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1162,
       "filename": "binary.113.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1174,
       "filename": "binary.114.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1184,
       "filename": "binary.115.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1194,
       "filename": "binary.116.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1204,
       "filename": "binary.117.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1214,
       "filename": "binary.118.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1224,
       "filename": "binary.119.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1234,
       "filename": "binary.120.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1244,
       "filename": "binary.121.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1254,
       "filename": "binary.122.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1264,
       "filename": "binary.123.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1274,
       "filename": "binary.124.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1284,
       "filename": "binary.125.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1294,
       "filename": "binary.126.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1304,
       "filename": "binary.127.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1314,
       "filename": "binary.128.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1324,
       "filename": "binary.129.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1335,
       "filename": "binary.130.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1346,
       "filename": "binary.131.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1356,
       "filename": "binary.132.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1366,
       "filename": "binary.133.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     }
   ]
 }

--- a/tests/snapshots/testsuite/block.wast.json
+++ b/tests/snapshots/testsuite/block.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "block.0.wasm"
+      "filename": "block.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -768,1191 +769,1191 @@
       "type": "assert_malformed",
       "line": 422,
       "filename": "block.1.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 429,
       "filename": "block.2.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 436,
       "filename": "block.3.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 443,
       "filename": "block.4.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 450,
       "filename": "block.5.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 457,
       "filename": "block.6.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 464,
       "filename": "block.7.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 468,
       "filename": "block.8.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 475,
       "filename": "block.9.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 482,
       "filename": "block.10.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 489,
       "filename": "block.11.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_invalid",
       "line": 497,
       "filename": "block.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 505,
       "filename": "block.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 509,
       "filename": "block.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 513,
       "filename": "block.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 517,
       "filename": "block.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 522,
       "filename": "block.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 528,
       "filename": "block.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 534,
       "filename": "block.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 540,
       "filename": "block.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 546,
       "filename": "block.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 552,
       "filename": "block.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 558,
       "filename": "block.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 564,
       "filename": "block.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 570,
       "filename": "block.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 576,
       "filename": "block.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 583,
       "filename": "block.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 592,
       "filename": "block.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 601,
       "filename": "block.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 611,
       "filename": "block.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 617,
       "filename": "block.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 623,
       "filename": "block.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 629,
       "filename": "block.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 635,
       "filename": "block.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 641,
       "filename": "block.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 647,
       "filename": "block.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 653,
       "filename": "block.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 659,
       "filename": "block.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 665,
       "filename": "block.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 671,
       "filename": "block.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 677,
       "filename": "block.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 683,
       "filename": "block.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 689,
       "filename": "block.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 695,
       "filename": "block.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 701,
       "filename": "block.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 707,
       "filename": "block.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 713,
       "filename": "block.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 719,
       "filename": "block.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 725,
       "filename": "block.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 732,
       "filename": "block.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 738,
       "filename": "block.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 744,
       "filename": "block.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 750,
       "filename": "block.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 756,
       "filename": "block.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 762,
       "filename": "block.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 768,
       "filename": "block.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 774,
       "filename": "block.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 780,
       "filename": "block.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 786,
       "filename": "block.59.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 792,
       "filename": "block.60.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 798,
       "filename": "block.61.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 805,
       "filename": "block.62.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 811,
       "filename": "block.63.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 817,
       "filename": "block.64.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 823,
       "filename": "block.65.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 829,
       "filename": "block.66.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 836,
       "filename": "block.67.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 842,
       "filename": "block.68.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 848,
       "filename": "block.69.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 854,
       "filename": "block.70.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 860,
       "filename": "block.71.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 867,
       "filename": "block.72.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 873,
       "filename": "block.73.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 879,
       "filename": "block.74.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 885,
       "filename": "block.75.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 892,
       "filename": "block.76.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 898,
       "filename": "block.77.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 904,
       "filename": "block.78.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 910,
       "filename": "block.79.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 916,
       "filename": "block.80.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 922,
       "filename": "block.81.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 928,
       "filename": "block.82.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 934,
       "filename": "block.83.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 940,
       "filename": "block.84.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 946,
       "filename": "block.85.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 952,
       "filename": "block.86.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 958,
       "filename": "block.87.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 964,
       "filename": "block.88.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 970,
       "filename": "block.89.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 977,
       "filename": "block.90.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 983,
       "filename": "block.91.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 989,
       "filename": "block.92.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 995,
       "filename": "block.93.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1001,
       "filename": "block.94.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1008,
       "filename": "block.95.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1014,
       "filename": "block.96.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1020,
       "filename": "block.97.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1026,
       "filename": "block.98.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1032,
       "filename": "block.99.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1038,
       "filename": "block.100.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1044,
       "filename": "block.101.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1050,
       "filename": "block.102.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1056,
       "filename": "block.103.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1062,
       "filename": "block.104.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1068,
       "filename": "block.105.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1074,
       "filename": "block.106.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1080,
       "filename": "block.107.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1087,
       "filename": "block.108.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1093,
       "filename": "block.109.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1099,
       "filename": "block.110.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1105,
       "filename": "block.111.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1111,
       "filename": "block.112.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1118,
       "filename": "block.113.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1124,
       "filename": "block.114.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1130,
       "filename": "block.115.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1136,
       "filename": "block.116.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1142,
       "filename": "block.117.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1149,
       "filename": "block.118.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1155,
       "filename": "block.119.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1161,
       "filename": "block.120.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1167,
       "filename": "block.121.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1173,
       "filename": "block.122.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1180,
       "filename": "block.123.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1188,
       "filename": "block.124.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1196,
       "filename": "block.125.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1204,
       "filename": "block.126.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1212,
       "filename": "block.127.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1220,
       "filename": "block.128.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1228,
       "filename": "block.129.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1236,
       "filename": "block.130.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1244,
       "filename": "block.131.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1252,
       "filename": "block.132.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1260,
       "filename": "block.133.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1268,
       "filename": "block.134.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1276,
       "filename": "block.135.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1285,
       "filename": "block.136.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1291,
       "filename": "block.137.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1297,
       "filename": "block.138.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1303,
       "filename": "block.139.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1309,
       "filename": "block.140.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1316,
       "filename": "block.141.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1322,
       "filename": "block.142.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1328,
       "filename": "block.143.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1334,
       "filename": "block.144.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1340,
       "filename": "block.145.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1347,
       "filename": "block.146.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1353,
       "filename": "block.147.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1359,
       "filename": "block.148.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1365,
       "filename": "block.149.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1371,
       "filename": "block.150.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1377,
       "filename": "block.151.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1383,
       "filename": "block.152.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1389,
       "filename": "block.153.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1395,
       "filename": "block.154.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1401,
       "filename": "block.155.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1407,
       "filename": "block.156.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1413,
       "filename": "block.157.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1419,
       "filename": "block.158.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1426,
       "filename": "block.159.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1432,
       "filename": "block.160.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1438,
       "filename": "block.161.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1444,
       "filename": "block.162.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1450,
       "filename": "block.163.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1456,
       "filename": "block.164.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1462,
       "filename": "block.165.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1468,
       "filename": "block.166.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1475,
       "filename": "block.167.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1479,
       "filename": "block.168.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1485,
       "filename": "block.169.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1489,
       "filename": "block.170.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     }
   ]
 }

--- a/tests/snapshots/testsuite/br.wast.json
+++ b/tests/snapshots/testsuite/br.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "br.0.wasm"
+      "filename": "br.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1165,141 +1166,141 @@
       "type": "assert_invalid",
       "line": 471,
       "filename": "br.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 478,
       "filename": "br.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 484,
       "filename": "br.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 490,
       "filename": "br.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 497,
       "filename": "br.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 506,
       "filename": "br.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 515,
       "filename": "br.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 524,
       "filename": "br.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 535,
       "filename": "br.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 546,
       "filename": "br.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 558,
       "filename": "br.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 574,
       "filename": "br.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 586,
       "filename": "br.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 598,
       "filename": "br.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 610,
       "filename": "br.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 622,
       "filename": "br.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 634,
       "filename": "br.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 647,
       "filename": "br.18.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 651,
       "filename": "br.19.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 655,
       "filename": "br.20.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     }
   ]
 }

--- a/tests/snapshots/testsuite/br_if.wast.json
+++ b/tests/snapshots/testsuite/br_if.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "br_if.0.wasm"
+      "filename": "br_if.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1532,204 +1533,204 @@
       "type": "assert_invalid",
       "line": 481,
       "filename": "br_if.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 485,
       "filename": "br_if.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 489,
       "filename": "br_if.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 493,
       "filename": "br_if.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 498,
       "filename": "br_if.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 502,
       "filename": "br_if.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 506,
       "filename": "br_if.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 510,
       "filename": "br_if.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 515,
       "filename": "br_if.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 521,
       "filename": "br_if.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 527,
       "filename": "br_if.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 533,
       "filename": "br_if.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 540,
       "filename": "br_if.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 546,
       "filename": "br_if.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 552,
       "filename": "br_if.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 560,
       "filename": "br_if.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 569,
       "filename": "br_if.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 575,
       "filename": "br_if.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 581,
       "filename": "br_if.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 587,
       "filename": "br_if.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 593,
       "filename": "br_if.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 599,
       "filename": "br_if.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 606,
       "filename": "br_if.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 618,
       "filename": "br_if.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 630,
       "filename": "br_if.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 641,
       "filename": "br_if.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 654,
       "filename": "br_if.27.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 658,
       "filename": "br_if.28.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 662,
       "filename": "br_if.29.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     }
   ]
 }

--- a/tests/snapshots/testsuite/br_table.wast.json
+++ b/tests/snapshots/testsuite/br_table.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "br_table.0.wasm"
+      "filename": "br_table.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2744,169 +2745,169 @@
       "type": "assert_invalid",
       "line": 1193,
       "filename": "br_table.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1200,
       "filename": "br_table.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1207,
       "filename": "br_table.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1213,
       "filename": "br_table.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1221,
       "filename": "br_table.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1232,
       "filename": "br_table.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1243,
       "filename": "br_table.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1249,
       "filename": "br_table.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1255,
       "filename": "br_table.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1261,
       "filename": "br_table.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1267,
       "filename": "br_table.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1276,
       "filename": "br_table.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1283,
       "filename": "br_table.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1295,
       "filename": "br_table.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1307,
       "filename": "br_table.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1318,
       "filename": "br_table.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1330,
       "filename": "br_table.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1342,
       "filename": "br_table.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1356,
       "filename": "br_table.19.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 1362,
       "filename": "br_table.20.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 1368,
       "filename": "br_table.21.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 1375,
       "filename": "br_table.22.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 1381,
       "filename": "br_table.23.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 1387,
       "filename": "br_table.24.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     }
   ]
 }

--- a/tests/snapshots/testsuite/bulk.wast.json
+++ b/tests/snapshots/testsuite/bulk.wast.json
@@ -4,17 +4,20 @@
     {
       "type": "module",
       "line": 2,
-      "filename": "bulk.0.wasm"
+      "filename": "bulk.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 6,
-      "filename": "bulk.1.wasm"
+      "filename": "bulk.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 13,
-      "filename": "bulk.2.wasm"
+      "filename": "bulk.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -333,7 +336,8 @@
     {
       "type": "module",
       "line": 57,
-      "filename": "bulk.3.wasm"
+      "filename": "bulk.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -918,7 +922,8 @@
     {
       "type": "module",
       "line": 115,
-      "filename": "bulk.4.wasm"
+      "filename": "bulk.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -1180,7 +1185,8 @@
     {
       "type": "module",
       "line": 154,
-      "filename": "bulk.5.wasm"
+      "filename": "bulk.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -1314,17 +1320,20 @@
     {
       "type": "module",
       "line": 181,
-      "filename": "bulk.6.wasm"
+      "filename": "bulk.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 196,
-      "filename": "bulk.7.wasm"
+      "filename": "bulk.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 199,
-      "filename": "bulk.8.wasm"
+      "filename": "bulk.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -1556,7 +1565,8 @@
     {
       "type": "module",
       "line": 244,
-      "filename": "bulk.9.wasm"
+      "filename": "bulk.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -1690,17 +1700,20 @@
     {
       "type": "module",
       "line": 274,
-      "filename": "bulk.10.wasm"
+      "filename": "bulk.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 297,
-      "filename": "bulk.11.wasm"
+      "filename": "bulk.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 300,
-      "filename": "bulk.12.wasm"
+      "filename": "bulk.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",

--- a/tests/snapshots/testsuite/call.wast.json
+++ b/tests/snapshots/testsuite/call.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "call.0.wasm"
+      "filename": "call.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1210,127 +1211,127 @@
       "type": "assert_invalid",
       "line": 381,
       "filename": "call.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 388,
       "filename": "call.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 396,
       "filename": "call.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 403,
       "filename": "call.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 410,
       "filename": "call.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 417,
       "filename": "call.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 425,
       "filename": "call.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 432,
       "filename": "call.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 439,
       "filename": "call.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 446,
       "filename": "call.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 454,
       "filename": "call.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 463,
       "filename": "call.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 472,
       "filename": "call.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 481,
       "filename": "call.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 490,
       "filename": "call.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 499,
       "filename": "call.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 512,
       "filename": "call.17.wasm",
-      "text": "unknown function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function"
     },
     {
       "type": "assert_invalid",
       "line": 516,
       "filename": "call.18.wasm",
-      "text": "unknown function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function"
     }
   ]
 }

--- a/tests/snapshots/testsuite/call_indirect.wast.json
+++ b/tests/snapshots/testsuite/call_indirect.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "call_indirect.0.wasm"
+      "filename": "call_indirect.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2195,7 +2196,8 @@
     {
       "type": "module",
       "line": 623,
-      "filename": "call_indirect.1.wasm"
+      "filename": "call_indirect.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2512,237 +2514,238 @@
       "type": "assert_malformed",
       "line": 669,
       "filename": "call_indirect.2.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 681,
       "filename": "call_indirect.3.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 693,
       "filename": "call_indirect.4.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 705,
       "filename": "call_indirect.5.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 717,
       "filename": "call_indirect.6.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 729,
       "filename": "call_indirect.7.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 739,
       "filename": "call_indirect.8.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 746,
       "filename": "call_indirect.9.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 756,
       "filename": "call_indirect.10.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 766,
       "filename": "call_indirect.11.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 776,
       "filename": "call_indirect.12.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_invalid",
       "line": 791,
       "filename": "call_indirect.13.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 799,
       "filename": "call_indirect.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 807,
       "filename": "call_indirect.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 816,
       "filename": "call_indirect.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 824,
       "filename": "call_indirect.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 832,
       "filename": "call_indirect.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 840,
       "filename": "call_indirect.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 851,
       "filename": "call_indirect.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 859,
       "filename": "call_indirect.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 868,
       "filename": "call_indirect.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 878,
       "filename": "call_indirect.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 888,
       "filename": "call_indirect.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 898,
       "filename": "call_indirect.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 909,
       "filename": "call_indirect.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 922,
       "filename": "call_indirect.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 935,
       "filename": "call_indirect.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 948,
       "filename": "call_indirect.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 961,
       "filename": "call_indirect.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 977,
       "filename": "call_indirect.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 997,
       "filename": "call_indirect.32.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 1004,
       "filename": "call_indirect.33.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 1015,
       "filename": "call_indirect.34.wasm",
-      "text": "unknown function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function"
     },
     {
       "type": "module",
       "line": 1024,
-      "filename": "call_indirect.35.wasm"
+      "filename": "call_indirect.35.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/comments.wast.json
+++ b/tests/snapshots/testsuite/comments.wast.json
@@ -4,27 +4,33 @@
     {
       "type": "module",
       "line": 10,
-      "filename": "comments.0.wasm"
+      "filename": "comments.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 57,
-      "filename": "comments.1.wasm"
+      "filename": "comments.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 67,
-      "filename": "comments.2.wasm"
+      "filename": "comments.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 76,
-      "filename": "comments.3.wasm"
+      "filename": "comments.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 83,
-      "filename": "comments.4.wat"
+      "filename": "comments.4.wat",
+      "module_type": "text",
+      "binary_filename": "comments.4.wasm"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/const.wast.json
+++ b/tests/snapshots/testsuite/const.wast.json
@@ -4,1049 +4,1152 @@
     {
       "type": "module",
       "line": 5,
-      "filename": "const.0.wasm"
+      "filename": "const.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 6,
-      "filename": "const.1.wasm"
+      "filename": "const.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 8,
       "filename": "const.2.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 12,
       "filename": "const.3.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 16,
       "filename": "const.4.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 20,
       "filename": "const.5.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 24,
-      "filename": "const.6.wasm"
+      "filename": "const.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 25,
-      "filename": "const.7.wasm"
+      "filename": "const.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 27,
       "filename": "const.8.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 31,
       "filename": "const.9.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 35,
       "filename": "const.10.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 39,
       "filename": "const.11.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 43,
-      "filename": "const.12.wasm"
+      "filename": "const.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 44,
-      "filename": "const.13.wasm"
+      "filename": "const.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 45,
-      "filename": "const.14.wasm"
+      "filename": "const.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 46,
-      "filename": "const.15.wasm"
+      "filename": "const.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 47,
-      "filename": "const.16.wasm"
+      "filename": "const.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 48,
-      "filename": "const.17.wasm"
+      "filename": "const.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 49,
-      "filename": "const.18.wasm"
+      "filename": "const.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 50,
-      "filename": "const.19.wasm"
+      "filename": "const.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 51,
-      "filename": "const.20.wasm"
+      "filename": "const.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 52,
-      "filename": "const.21.wasm"
+      "filename": "const.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 53,
-      "filename": "const.22.wasm"
+      "filename": "const.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 54,
-      "filename": "const.23.wasm"
+      "filename": "const.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 55,
-      "filename": "const.24.wasm"
+      "filename": "const.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 56,
-      "filename": "const.25.wasm"
+      "filename": "const.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 57,
-      "filename": "const.26.wasm"
+      "filename": "const.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 58,
-      "filename": "const.27.wasm"
+      "filename": "const.27.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 59,
-      "filename": "const.28.wasm"
+      "filename": "const.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 60,
-      "filename": "const.29.wasm"
+      "filename": "const.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 61,
-      "filename": "const.30.wasm"
+      "filename": "const.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 62,
-      "filename": "const.31.wasm"
+      "filename": "const.31.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 63,
-      "filename": "const.32.wasm"
+      "filename": "const.32.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 64,
-      "filename": "const.33.wasm"
+      "filename": "const.33.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 65,
-      "filename": "const.34.wasm"
+      "filename": "const.34.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 66,
-      "filename": "const.35.wasm"
+      "filename": "const.35.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 68,
       "filename": "const.36.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 72,
       "filename": "const.37.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 76,
       "filename": "const.38.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 80,
       "filename": "const.39.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 84,
       "filename": "const.40.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 88,
       "filename": "const.41.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 92,
       "filename": "const.42.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 96,
       "filename": "const.43.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 100,
       "filename": "const.44.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 104,
       "filename": "const.45.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 108,
       "filename": "const.46.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 112,
       "filename": "const.47.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 116,
       "filename": "const.48.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 120,
       "filename": "const.49.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 124,
       "filename": "const.50.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 128,
       "filename": "const.51.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 132,
       "filename": "const.52.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 136,
       "filename": "const.53.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 140,
       "filename": "const.54.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 145,
-      "filename": "const.55.wasm"
+      "filename": "const.55.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 146,
-      "filename": "const.56.wasm"
+      "filename": "const.56.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 147,
-      "filename": "const.57.wasm"
+      "filename": "const.57.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 148,
-      "filename": "const.58.wasm"
+      "filename": "const.58.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 149,
-      "filename": "const.59.wasm"
+      "filename": "const.59.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 150,
-      "filename": "const.60.wasm"
+      "filename": "const.60.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 151,
-      "filename": "const.61.wasm"
+      "filename": "const.61.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 152,
-      "filename": "const.62.wasm"
+      "filename": "const.62.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 153,
-      "filename": "const.63.wasm"
+      "filename": "const.63.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 154,
-      "filename": "const.64.wasm"
+      "filename": "const.64.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 155,
-      "filename": "const.65.wasm"
+      "filename": "const.65.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 156,
-      "filename": "const.66.wasm"
+      "filename": "const.66.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 157,
-      "filename": "const.67.wasm"
+      "filename": "const.67.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 158,
-      "filename": "const.68.wasm"
+      "filename": "const.68.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 159,
-      "filename": "const.69.wasm"
+      "filename": "const.69.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 160,
-      "filename": "const.70.wasm"
+      "filename": "const.70.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 161,
-      "filename": "const.71.wasm"
+      "filename": "const.71.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 162,
-      "filename": "const.72.wasm"
+      "filename": "const.72.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 164,
-      "filename": "const.73.wasm"
+      "filename": "const.73.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 165,
-      "filename": "const.74.wasm"
+      "filename": "const.74.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 166,
-      "filename": "const.75.wasm"
+      "filename": "const.75.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 167,
-      "filename": "const.76.wasm"
+      "filename": "const.76.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 168,
-      "filename": "const.77.wasm"
+      "filename": "const.77.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 169,
-      "filename": "const.78.wasm"
+      "filename": "const.78.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 170,
-      "filename": "const.79.wasm"
+      "filename": "const.79.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 171,
-      "filename": "const.80.wasm"
+      "filename": "const.80.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 172,
-      "filename": "const.81.wasm"
+      "filename": "const.81.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 173,
-      "filename": "const.82.wasm"
+      "filename": "const.82.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 174,
-      "filename": "const.83.wasm"
+      "filename": "const.83.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 175,
-      "filename": "const.84.wasm"
+      "filename": "const.84.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 176,
-      "filename": "const.85.wasm"
+      "filename": "const.85.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 177,
-      "filename": "const.86.wasm"
+      "filename": "const.86.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 178,
-      "filename": "const.87.wasm"
+      "filename": "const.87.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 179,
-      "filename": "const.88.wasm"
+      "filename": "const.88.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 180,
-      "filename": "const.89.wasm"
+      "filename": "const.89.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 181,
-      "filename": "const.90.wasm"
+      "filename": "const.90.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 185,
       "filename": "const.91.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 189,
       "filename": "const.92.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 193,
       "filename": "const.93.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 197,
       "filename": "const.94.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 201,
       "filename": "const.95.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 205,
       "filename": "const.96.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 209,
       "filename": "const.97.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 213,
       "filename": "const.98.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 217,
       "filename": "const.99.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 221,
       "filename": "const.100.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 225,
       "filename": "const.101.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 229,
       "filename": "const.102.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 233,
       "filename": "const.103.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 237,
       "filename": "const.104.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 241,
       "filename": "const.105.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 245,
       "filename": "const.106.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 249,
       "filename": "const.107.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 253,
       "filename": "const.108.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 257,
       "filename": "const.109.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 264,
-      "filename": "const.110.wasm"
+      "filename": "const.110.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 265,
-      "filename": "const.111.wasm"
+      "filename": "const.111.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 267,
       "filename": "const.112.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 271,
       "filename": "const.113.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "module",
       "line": 275,
-      "filename": "const.114.wasm"
+      "filename": "const.114.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 276,
-      "filename": "const.115.wasm"
+      "filename": "const.115.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 278,
       "filename": "const.116.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 282,
       "filename": "const.117.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "module",
       "line": 286,
-      "filename": "const.118.wasm"
+      "filename": "const.118.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 287,
-      "filename": "const.119.wasm"
+      "filename": "const.119.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 289,
       "filename": "const.120.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 293,
       "filename": "const.121.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "module",
       "line": 297,
-      "filename": "const.122.wasm"
+      "filename": "const.122.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 298,
-      "filename": "const.123.wasm"
+      "filename": "const.123.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 300,
       "filename": "const.124.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 304,
       "filename": "const.125.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "module",
       "line": 308,
-      "filename": "const.126.wasm"
+      "filename": "const.126.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 309,
-      "filename": "const.127.wasm"
+      "filename": "const.127.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 310,
-      "filename": "const.128.wasm"
+      "filename": "const.128.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 311,
-      "filename": "const.129.wasm"
+      "filename": "const.129.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 312,
-      "filename": "const.130.wasm"
+      "filename": "const.130.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 313,
-      "filename": "const.131.wasm"
+      "filename": "const.131.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 314,
-      "filename": "const.132.wasm"
+      "filename": "const.132.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 315,
-      "filename": "const.133.wasm"
+      "filename": "const.133.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 316,
-      "filename": "const.134.wasm"
+      "filename": "const.134.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 317,
-      "filename": "const.135.wasm"
+      "filename": "const.135.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 319,
       "filename": "const.136.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 323,
       "filename": "const.137.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 327,
       "filename": "const.138.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 331,
       "filename": "const.139.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "module",
       "line": 335,
-      "filename": "const.140.wasm"
+      "filename": "const.140.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 336,
-      "filename": "const.141.wasm"
+      "filename": "const.141.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 338,
       "filename": "const.142.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 342,
       "filename": "const.143.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "module",
       "line": 346,
-      "filename": "const.144.wasm"
+      "filename": "const.144.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 347,
-      "filename": "const.145.wasm"
+      "filename": "const.145.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 349,
       "filename": "const.146.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 353,
       "filename": "const.147.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "module",
       "line": 357,
-      "filename": "const.148.wasm"
+      "filename": "const.148.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 358,
-      "filename": "const.149.wasm"
+      "filename": "const.149.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 359,
-      "filename": "const.150.wasm"
+      "filename": "const.150.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 360,
-      "filename": "const.151.wasm"
+      "filename": "const.151.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 361,
-      "filename": "const.152.wasm"
+      "filename": "const.152.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 362,
-      "filename": "const.153.wasm"
+      "filename": "const.153.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 363,
-      "filename": "const.154.wasm"
+      "filename": "const.154.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 364,
-      "filename": "const.155.wasm"
+      "filename": "const.155.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 366,
       "filename": "const.156.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 370,
       "filename": "const.157.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 374,
       "filename": "const.158.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 378,
       "filename": "const.159.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "module",
       "line": 382,
-      "filename": "const.160.wasm"
+      "filename": "const.160.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 383,
-      "filename": "const.161.wasm"
+      "filename": "const.161.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 385,
       "filename": "const.162.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 389,
       "filename": "const.163.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "module",
       "line": 393,
-      "filename": "const.164.wasm"
+      "filename": "const.164.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 394,
-      "filename": "const.165.wasm"
+      "filename": "const.165.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 396,
       "filename": "const.166.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 400,
       "filename": "const.167.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "module",
       "line": 404,
-      "filename": "const.168.wasm"
+      "filename": "const.168.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 405,
-      "filename": "const.169.wasm"
+      "filename": "const.169.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 406,
-      "filename": "const.170.wasm"
+      "filename": "const.170.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 407,
-      "filename": "const.171.wasm"
+      "filename": "const.171.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 410,
       "filename": "const.172.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 414,
       "filename": "const.173.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 419,
       "filename": "const.174.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 423,
       "filename": "const.175.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 428,
       "filename": "const.176.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 432,
       "filename": "const.177.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "module",
       "line": 440,
-      "filename": "const.178.wasm"
+      "filename": "const.178.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1066,7 +1169,8 @@
     {
       "type": "module",
       "line": 442,
-      "filename": "const.179.wasm"
+      "filename": "const.179.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1086,7 +1190,8 @@
     {
       "type": "module",
       "line": 444,
-      "filename": "const.180.wasm"
+      "filename": "const.180.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1106,7 +1211,8 @@
     {
       "type": "module",
       "line": 446,
-      "filename": "const.181.wasm"
+      "filename": "const.181.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1126,7 +1232,8 @@
     {
       "type": "module",
       "line": 448,
-      "filename": "const.182.wasm"
+      "filename": "const.182.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1146,7 +1253,8 @@
     {
       "type": "module",
       "line": 450,
-      "filename": "const.183.wasm"
+      "filename": "const.183.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1166,7 +1274,8 @@
     {
       "type": "module",
       "line": 452,
-      "filename": "const.184.wasm"
+      "filename": "const.184.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1186,7 +1295,8 @@
     {
       "type": "module",
       "line": 454,
-      "filename": "const.185.wasm"
+      "filename": "const.185.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1206,7 +1316,8 @@
     {
       "type": "module",
       "line": 456,
-      "filename": "const.186.wasm"
+      "filename": "const.186.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1226,7 +1337,8 @@
     {
       "type": "module",
       "line": 458,
-      "filename": "const.187.wasm"
+      "filename": "const.187.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1246,7 +1358,8 @@
     {
       "type": "module",
       "line": 460,
-      "filename": "const.188.wasm"
+      "filename": "const.188.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1266,7 +1379,8 @@
     {
       "type": "module",
       "line": 462,
-      "filename": "const.189.wasm"
+      "filename": "const.189.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1286,7 +1400,8 @@
     {
       "type": "module",
       "line": 464,
-      "filename": "const.190.wasm"
+      "filename": "const.190.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1306,7 +1421,8 @@
     {
       "type": "module",
       "line": 466,
-      "filename": "const.191.wasm"
+      "filename": "const.191.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1326,7 +1442,8 @@
     {
       "type": "module",
       "line": 468,
-      "filename": "const.192.wasm"
+      "filename": "const.192.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1346,7 +1463,8 @@
     {
       "type": "module",
       "line": 470,
-      "filename": "const.193.wasm"
+      "filename": "const.193.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1366,7 +1484,8 @@
     {
       "type": "module",
       "line": 472,
-      "filename": "const.194.wasm"
+      "filename": "const.194.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1386,7 +1505,8 @@
     {
       "type": "module",
       "line": 474,
-      "filename": "const.195.wasm"
+      "filename": "const.195.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1406,7 +1526,8 @@
     {
       "type": "module",
       "line": 476,
-      "filename": "const.196.wasm"
+      "filename": "const.196.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1426,7 +1547,8 @@
     {
       "type": "module",
       "line": 478,
-      "filename": "const.197.wasm"
+      "filename": "const.197.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1446,7 +1568,8 @@
     {
       "type": "module",
       "line": 480,
-      "filename": "const.198.wasm"
+      "filename": "const.198.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1466,7 +1589,8 @@
     {
       "type": "module",
       "line": 482,
-      "filename": "const.199.wasm"
+      "filename": "const.199.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1486,7 +1610,8 @@
     {
       "type": "module",
       "line": 484,
-      "filename": "const.200.wasm"
+      "filename": "const.200.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1506,7 +1631,8 @@
     {
       "type": "module",
       "line": 486,
-      "filename": "const.201.wasm"
+      "filename": "const.201.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1526,7 +1652,8 @@
     {
       "type": "module",
       "line": 488,
-      "filename": "const.202.wasm"
+      "filename": "const.202.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1546,7 +1673,8 @@
     {
       "type": "module",
       "line": 490,
-      "filename": "const.203.wasm"
+      "filename": "const.203.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1566,7 +1694,8 @@
     {
       "type": "module",
       "line": 492,
-      "filename": "const.204.wasm"
+      "filename": "const.204.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1586,7 +1715,8 @@
     {
       "type": "module",
       "line": 494,
-      "filename": "const.205.wasm"
+      "filename": "const.205.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1606,7 +1736,8 @@
     {
       "type": "module",
       "line": 497,
-      "filename": "const.206.wasm"
+      "filename": "const.206.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1626,7 +1757,8 @@
     {
       "type": "module",
       "line": 499,
-      "filename": "const.207.wasm"
+      "filename": "const.207.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1646,7 +1778,8 @@
     {
       "type": "module",
       "line": 501,
-      "filename": "const.208.wasm"
+      "filename": "const.208.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1666,7 +1799,8 @@
     {
       "type": "module",
       "line": 503,
-      "filename": "const.209.wasm"
+      "filename": "const.209.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1686,7 +1820,8 @@
     {
       "type": "module",
       "line": 505,
-      "filename": "const.210.wasm"
+      "filename": "const.210.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1706,7 +1841,8 @@
     {
       "type": "module",
       "line": 507,
-      "filename": "const.211.wasm"
+      "filename": "const.211.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1726,7 +1862,8 @@
     {
       "type": "module",
       "line": 509,
-      "filename": "const.212.wasm"
+      "filename": "const.212.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1746,7 +1883,8 @@
     {
       "type": "module",
       "line": 511,
-      "filename": "const.213.wasm"
+      "filename": "const.213.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1766,7 +1904,8 @@
     {
       "type": "module",
       "line": 513,
-      "filename": "const.214.wasm"
+      "filename": "const.214.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1786,7 +1925,8 @@
     {
       "type": "module",
       "line": 515,
-      "filename": "const.215.wasm"
+      "filename": "const.215.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1806,7 +1946,8 @@
     {
       "type": "module",
       "line": 517,
-      "filename": "const.216.wasm"
+      "filename": "const.216.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1826,7 +1967,8 @@
     {
       "type": "module",
       "line": 519,
-      "filename": "const.217.wasm"
+      "filename": "const.217.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1846,7 +1988,8 @@
     {
       "type": "module",
       "line": 521,
-      "filename": "const.218.wasm"
+      "filename": "const.218.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1866,7 +2009,8 @@
     {
       "type": "module",
       "line": 523,
-      "filename": "const.219.wasm"
+      "filename": "const.219.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1886,7 +2030,8 @@
     {
       "type": "module",
       "line": 525,
-      "filename": "const.220.wasm"
+      "filename": "const.220.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1906,7 +2051,8 @@
     {
       "type": "module",
       "line": 527,
-      "filename": "const.221.wasm"
+      "filename": "const.221.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1926,7 +2072,8 @@
     {
       "type": "module",
       "line": 529,
-      "filename": "const.222.wasm"
+      "filename": "const.222.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1946,7 +2093,8 @@
     {
       "type": "module",
       "line": 531,
-      "filename": "const.223.wasm"
+      "filename": "const.223.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1966,7 +2114,8 @@
     {
       "type": "module",
       "line": 533,
-      "filename": "const.224.wasm"
+      "filename": "const.224.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1986,7 +2135,8 @@
     {
       "type": "module",
       "line": 535,
-      "filename": "const.225.wasm"
+      "filename": "const.225.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2006,7 +2156,8 @@
     {
       "type": "module",
       "line": 537,
-      "filename": "const.226.wasm"
+      "filename": "const.226.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2026,7 +2177,8 @@
     {
       "type": "module",
       "line": 539,
-      "filename": "const.227.wasm"
+      "filename": "const.227.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2046,7 +2198,8 @@
     {
       "type": "module",
       "line": 541,
-      "filename": "const.228.wasm"
+      "filename": "const.228.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2066,7 +2219,8 @@
     {
       "type": "module",
       "line": 543,
-      "filename": "const.229.wasm"
+      "filename": "const.229.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2086,7 +2240,8 @@
     {
       "type": "module",
       "line": 546,
-      "filename": "const.230.wasm"
+      "filename": "const.230.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2106,7 +2261,8 @@
     {
       "type": "module",
       "line": 548,
-      "filename": "const.231.wasm"
+      "filename": "const.231.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2126,7 +2282,8 @@
     {
       "type": "module",
       "line": 550,
-      "filename": "const.232.wasm"
+      "filename": "const.232.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2146,7 +2303,8 @@
     {
       "type": "module",
       "line": 552,
-      "filename": "const.233.wasm"
+      "filename": "const.233.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2166,7 +2324,8 @@
     {
       "type": "module",
       "line": 554,
-      "filename": "const.234.wasm"
+      "filename": "const.234.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2186,7 +2345,8 @@
     {
       "type": "module",
       "line": 556,
-      "filename": "const.235.wasm"
+      "filename": "const.235.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2206,7 +2366,8 @@
     {
       "type": "module",
       "line": 558,
-      "filename": "const.236.wasm"
+      "filename": "const.236.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2226,7 +2387,8 @@
     {
       "type": "module",
       "line": 560,
-      "filename": "const.237.wasm"
+      "filename": "const.237.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2246,7 +2408,8 @@
     {
       "type": "module",
       "line": 564,
-      "filename": "const.238.wasm"
+      "filename": "const.238.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2266,7 +2429,8 @@
     {
       "type": "module",
       "line": 566,
-      "filename": "const.239.wasm"
+      "filename": "const.239.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2286,7 +2450,8 @@
     {
       "type": "module",
       "line": 568,
-      "filename": "const.240.wasm"
+      "filename": "const.240.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2306,7 +2471,8 @@
     {
       "type": "module",
       "line": 570,
-      "filename": "const.241.wasm"
+      "filename": "const.241.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2326,7 +2492,8 @@
     {
       "type": "module",
       "line": 572,
-      "filename": "const.242.wasm"
+      "filename": "const.242.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2346,7 +2513,8 @@
     {
       "type": "module",
       "line": 574,
-      "filename": "const.243.wasm"
+      "filename": "const.243.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2366,7 +2534,8 @@
     {
       "type": "module",
       "line": 576,
-      "filename": "const.244.wasm"
+      "filename": "const.244.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2386,7 +2555,8 @@
     {
       "type": "module",
       "line": 578,
-      "filename": "const.245.wasm"
+      "filename": "const.245.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2406,7 +2576,8 @@
     {
       "type": "module",
       "line": 580,
-      "filename": "const.246.wasm"
+      "filename": "const.246.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2426,7 +2597,8 @@
     {
       "type": "module",
       "line": 582,
-      "filename": "const.247.wasm"
+      "filename": "const.247.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2446,7 +2618,8 @@
     {
       "type": "module",
       "line": 584,
-      "filename": "const.248.wasm"
+      "filename": "const.248.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2466,7 +2639,8 @@
     {
       "type": "module",
       "line": 586,
-      "filename": "const.249.wasm"
+      "filename": "const.249.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2486,7 +2660,8 @@
     {
       "type": "module",
       "line": 588,
-      "filename": "const.250.wasm"
+      "filename": "const.250.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2506,7 +2681,8 @@
     {
       "type": "module",
       "line": 590,
-      "filename": "const.251.wasm"
+      "filename": "const.251.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2526,7 +2702,8 @@
     {
       "type": "module",
       "line": 592,
-      "filename": "const.252.wasm"
+      "filename": "const.252.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2546,7 +2723,8 @@
     {
       "type": "module",
       "line": 594,
-      "filename": "const.253.wasm"
+      "filename": "const.253.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2566,7 +2744,8 @@
     {
       "type": "module",
       "line": 596,
-      "filename": "const.254.wasm"
+      "filename": "const.254.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2586,7 +2765,8 @@
     {
       "type": "module",
       "line": 598,
-      "filename": "const.255.wasm"
+      "filename": "const.255.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2606,7 +2786,8 @@
     {
       "type": "module",
       "line": 600,
-      "filename": "const.256.wasm"
+      "filename": "const.256.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2626,7 +2807,8 @@
     {
       "type": "module",
       "line": 602,
-      "filename": "const.257.wasm"
+      "filename": "const.257.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2646,7 +2828,8 @@
     {
       "type": "module",
       "line": 604,
-      "filename": "const.258.wasm"
+      "filename": "const.258.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2666,7 +2849,8 @@
     {
       "type": "module",
       "line": 606,
-      "filename": "const.259.wasm"
+      "filename": "const.259.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2686,7 +2870,8 @@
     {
       "type": "module",
       "line": 608,
-      "filename": "const.260.wasm"
+      "filename": "const.260.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2706,7 +2891,8 @@
     {
       "type": "module",
       "line": 610,
-      "filename": "const.261.wasm"
+      "filename": "const.261.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2726,7 +2912,8 @@
     {
       "type": "module",
       "line": 612,
-      "filename": "const.262.wasm"
+      "filename": "const.262.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2746,7 +2933,8 @@
     {
       "type": "module",
       "line": 614,
-      "filename": "const.263.wasm"
+      "filename": "const.263.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2766,7 +2954,8 @@
     {
       "type": "module",
       "line": 616,
-      "filename": "const.264.wasm"
+      "filename": "const.264.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2786,7 +2975,8 @@
     {
       "type": "module",
       "line": 618,
-      "filename": "const.265.wasm"
+      "filename": "const.265.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2806,7 +2996,8 @@
     {
       "type": "module",
       "line": 621,
-      "filename": "const.266.wasm"
+      "filename": "const.266.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2826,7 +3017,8 @@
     {
       "type": "module",
       "line": 623,
-      "filename": "const.267.wasm"
+      "filename": "const.267.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2846,7 +3038,8 @@
     {
       "type": "module",
       "line": 625,
-      "filename": "const.268.wasm"
+      "filename": "const.268.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2866,7 +3059,8 @@
     {
       "type": "module",
       "line": 627,
-      "filename": "const.269.wasm"
+      "filename": "const.269.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2886,7 +3080,8 @@
     {
       "type": "module",
       "line": 629,
-      "filename": "const.270.wasm"
+      "filename": "const.270.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2906,7 +3101,8 @@
     {
       "type": "module",
       "line": 631,
-      "filename": "const.271.wasm"
+      "filename": "const.271.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2926,7 +3122,8 @@
     {
       "type": "module",
       "line": 633,
-      "filename": "const.272.wasm"
+      "filename": "const.272.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2946,7 +3143,8 @@
     {
       "type": "module",
       "line": 635,
-      "filename": "const.273.wasm"
+      "filename": "const.273.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2966,7 +3164,8 @@
     {
       "type": "module",
       "line": 637,
-      "filename": "const.274.wasm"
+      "filename": "const.274.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2986,7 +3185,8 @@
     {
       "type": "module",
       "line": 639,
-      "filename": "const.275.wasm"
+      "filename": "const.275.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3006,7 +3206,8 @@
     {
       "type": "module",
       "line": 641,
-      "filename": "const.276.wasm"
+      "filename": "const.276.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3026,7 +3227,8 @@
     {
       "type": "module",
       "line": 643,
-      "filename": "const.277.wasm"
+      "filename": "const.277.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3046,7 +3248,8 @@
     {
       "type": "module",
       "line": 645,
-      "filename": "const.278.wasm"
+      "filename": "const.278.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3066,7 +3269,8 @@
     {
       "type": "module",
       "line": 647,
-      "filename": "const.279.wasm"
+      "filename": "const.279.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3086,7 +3290,8 @@
     {
       "type": "module",
       "line": 650,
-      "filename": "const.280.wasm"
+      "filename": "const.280.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3106,7 +3311,8 @@
     {
       "type": "module",
       "line": 652,
-      "filename": "const.281.wasm"
+      "filename": "const.281.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3126,7 +3332,8 @@
     {
       "type": "module",
       "line": 654,
-      "filename": "const.282.wasm"
+      "filename": "const.282.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3146,7 +3353,8 @@
     {
       "type": "module",
       "line": 656,
-      "filename": "const.283.wasm"
+      "filename": "const.283.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3166,7 +3374,8 @@
     {
       "type": "module",
       "line": 658,
-      "filename": "const.284.wasm"
+      "filename": "const.284.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3186,7 +3395,8 @@
     {
       "type": "module",
       "line": 660,
-      "filename": "const.285.wasm"
+      "filename": "const.285.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3206,7 +3416,8 @@
     {
       "type": "module",
       "line": 662,
-      "filename": "const.286.wasm"
+      "filename": "const.286.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3226,7 +3437,8 @@
     {
       "type": "module",
       "line": 664,
-      "filename": "const.287.wasm"
+      "filename": "const.287.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3246,7 +3458,8 @@
     {
       "type": "module",
       "line": 668,
-      "filename": "const.288.wasm"
+      "filename": "const.288.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3266,7 +3479,8 @@
     {
       "type": "module",
       "line": 670,
-      "filename": "const.289.wasm"
+      "filename": "const.289.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3286,7 +3500,8 @@
     {
       "type": "module",
       "line": 672,
-      "filename": "const.290.wasm"
+      "filename": "const.290.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3306,7 +3521,8 @@
     {
       "type": "module",
       "line": 674,
-      "filename": "const.291.wasm"
+      "filename": "const.291.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3326,7 +3542,8 @@
     {
       "type": "module",
       "line": 676,
-      "filename": "const.292.wasm"
+      "filename": "const.292.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3346,7 +3563,8 @@
     {
       "type": "module",
       "line": 678,
-      "filename": "const.293.wasm"
+      "filename": "const.293.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3366,7 +3584,8 @@
     {
       "type": "module",
       "line": 680,
-      "filename": "const.294.wasm"
+      "filename": "const.294.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3386,7 +3605,8 @@
     {
       "type": "module",
       "line": 682,
-      "filename": "const.295.wasm"
+      "filename": "const.295.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3406,7 +3626,8 @@
     {
       "type": "module",
       "line": 684,
-      "filename": "const.296.wasm"
+      "filename": "const.296.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3426,7 +3647,8 @@
     {
       "type": "module",
       "line": 686,
-      "filename": "const.297.wasm"
+      "filename": "const.297.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3446,7 +3668,8 @@
     {
       "type": "module",
       "line": 688,
-      "filename": "const.298.wasm"
+      "filename": "const.298.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3466,7 +3689,8 @@
     {
       "type": "module",
       "line": 690,
-      "filename": "const.299.wasm"
+      "filename": "const.299.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3486,7 +3710,8 @@
     {
       "type": "module",
       "line": 692,
-      "filename": "const.300.wasm"
+      "filename": "const.300.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3506,7 +3731,8 @@
     {
       "type": "module",
       "line": 694,
-      "filename": "const.301.wasm"
+      "filename": "const.301.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3526,7 +3752,8 @@
     {
       "type": "module",
       "line": 696,
-      "filename": "const.302.wasm"
+      "filename": "const.302.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3546,7 +3773,8 @@
     {
       "type": "module",
       "line": 698,
-      "filename": "const.303.wasm"
+      "filename": "const.303.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3566,7 +3794,8 @@
     {
       "type": "module",
       "line": 700,
-      "filename": "const.304.wasm"
+      "filename": "const.304.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3586,7 +3815,8 @@
     {
       "type": "module",
       "line": 702,
-      "filename": "const.305.wasm"
+      "filename": "const.305.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3606,7 +3836,8 @@
     {
       "type": "module",
       "line": 704,
-      "filename": "const.306.wasm"
+      "filename": "const.306.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3626,7 +3857,8 @@
     {
       "type": "module",
       "line": 706,
-      "filename": "const.307.wasm"
+      "filename": "const.307.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3646,7 +3878,8 @@
     {
       "type": "module",
       "line": 708,
-      "filename": "const.308.wasm"
+      "filename": "const.308.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3666,7 +3899,8 @@
     {
       "type": "module",
       "line": 710,
-      "filename": "const.309.wasm"
+      "filename": "const.309.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3686,7 +3920,8 @@
     {
       "type": "module",
       "line": 712,
-      "filename": "const.310.wasm"
+      "filename": "const.310.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3706,7 +3941,8 @@
     {
       "type": "module",
       "line": 714,
-      "filename": "const.311.wasm"
+      "filename": "const.311.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3726,7 +3962,8 @@
     {
       "type": "module",
       "line": 716,
-      "filename": "const.312.wasm"
+      "filename": "const.312.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3746,7 +3983,8 @@
     {
       "type": "module",
       "line": 718,
-      "filename": "const.313.wasm"
+      "filename": "const.313.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3766,7 +4004,8 @@
     {
       "type": "module",
       "line": 720,
-      "filename": "const.314.wasm"
+      "filename": "const.314.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3786,7 +4025,8 @@
     {
       "type": "module",
       "line": 722,
-      "filename": "const.315.wasm"
+      "filename": "const.315.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3806,7 +4046,8 @@
     {
       "type": "module",
       "line": 726,
-      "filename": "const.316.wasm"
+      "filename": "const.316.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3826,7 +4067,8 @@
     {
       "type": "module",
       "line": 728,
-      "filename": "const.317.wasm"
+      "filename": "const.317.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3846,7 +4088,8 @@
     {
       "type": "module",
       "line": 730,
-      "filename": "const.318.wasm"
+      "filename": "const.318.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3866,7 +4109,8 @@
     {
       "type": "module",
       "line": 732,
-      "filename": "const.319.wasm"
+      "filename": "const.319.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3886,7 +4130,8 @@
     {
       "type": "module",
       "line": 734,
-      "filename": "const.320.wasm"
+      "filename": "const.320.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3906,7 +4151,8 @@
     {
       "type": "module",
       "line": 736,
-      "filename": "const.321.wasm"
+      "filename": "const.321.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3926,7 +4172,8 @@
     {
       "type": "module",
       "line": 740,
-      "filename": "const.322.wasm"
+      "filename": "const.322.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3946,7 +4193,8 @@
     {
       "type": "module",
       "line": 742,
-      "filename": "const.323.wasm"
+      "filename": "const.323.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3966,7 +4214,8 @@
     {
       "type": "module",
       "line": 744,
-      "filename": "const.324.wasm"
+      "filename": "const.324.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3986,7 +4235,8 @@
     {
       "type": "module",
       "line": 746,
-      "filename": "const.325.wasm"
+      "filename": "const.325.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4006,7 +4256,8 @@
     {
       "type": "module",
       "line": 748,
-      "filename": "const.326.wasm"
+      "filename": "const.326.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4026,7 +4277,8 @@
     {
       "type": "module",
       "line": 750,
-      "filename": "const.327.wasm"
+      "filename": "const.327.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4046,7 +4298,8 @@
     {
       "type": "module",
       "line": 752,
-      "filename": "const.328.wasm"
+      "filename": "const.328.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4066,7 +4319,8 @@
     {
       "type": "module",
       "line": 754,
-      "filename": "const.329.wasm"
+      "filename": "const.329.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4086,7 +4340,8 @@
     {
       "type": "module",
       "line": 756,
-      "filename": "const.330.wasm"
+      "filename": "const.330.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4106,7 +4361,8 @@
     {
       "type": "module",
       "line": 758,
-      "filename": "const.331.wasm"
+      "filename": "const.331.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4126,7 +4382,8 @@
     {
       "type": "module",
       "line": 760,
-      "filename": "const.332.wasm"
+      "filename": "const.332.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4146,7 +4403,8 @@
     {
       "type": "module",
       "line": 762,
-      "filename": "const.333.wasm"
+      "filename": "const.333.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4166,7 +4424,8 @@
     {
       "type": "module",
       "line": 764,
-      "filename": "const.334.wasm"
+      "filename": "const.334.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4186,7 +4445,8 @@
     {
       "type": "module",
       "line": 766,
-      "filename": "const.335.wasm"
+      "filename": "const.335.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4206,7 +4466,8 @@
     {
       "type": "module",
       "line": 768,
-      "filename": "const.336.wasm"
+      "filename": "const.336.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4226,7 +4487,8 @@
     {
       "type": "module",
       "line": 770,
-      "filename": "const.337.wasm"
+      "filename": "const.337.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4246,7 +4508,8 @@
     {
       "type": "module",
       "line": 772,
-      "filename": "const.338.wasm"
+      "filename": "const.338.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4266,7 +4529,8 @@
     {
       "type": "module",
       "line": 774,
-      "filename": "const.339.wasm"
+      "filename": "const.339.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4286,7 +4550,8 @@
     {
       "type": "module",
       "line": 776,
-      "filename": "const.340.wasm"
+      "filename": "const.340.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4306,7 +4571,8 @@
     {
       "type": "module",
       "line": 778,
-      "filename": "const.341.wasm"
+      "filename": "const.341.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4326,7 +4592,8 @@
     {
       "type": "module",
       "line": 780,
-      "filename": "const.342.wasm"
+      "filename": "const.342.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4346,7 +4613,8 @@
     {
       "type": "module",
       "line": 782,
-      "filename": "const.343.wasm"
+      "filename": "const.343.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4366,7 +4634,8 @@
     {
       "type": "module",
       "line": 784,
-      "filename": "const.344.wasm"
+      "filename": "const.344.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4386,7 +4655,8 @@
     {
       "type": "module",
       "line": 786,
-      "filename": "const.345.wasm"
+      "filename": "const.345.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4406,7 +4676,8 @@
     {
       "type": "module",
       "line": 788,
-      "filename": "const.346.wasm"
+      "filename": "const.346.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4426,7 +4697,8 @@
     {
       "type": "module",
       "line": 790,
-      "filename": "const.347.wasm"
+      "filename": "const.347.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4446,7 +4718,8 @@
     {
       "type": "module",
       "line": 793,
-      "filename": "const.348.wasm"
+      "filename": "const.348.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4466,7 +4739,8 @@
     {
       "type": "module",
       "line": 795,
-      "filename": "const.349.wasm"
+      "filename": "const.349.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4486,7 +4760,8 @@
     {
       "type": "module",
       "line": 797,
-      "filename": "const.350.wasm"
+      "filename": "const.350.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4506,7 +4781,8 @@
     {
       "type": "module",
       "line": 799,
-      "filename": "const.351.wasm"
+      "filename": "const.351.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4526,7 +4802,8 @@
     {
       "type": "module",
       "line": 801,
-      "filename": "const.352.wasm"
+      "filename": "const.352.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4546,7 +4823,8 @@
     {
       "type": "module",
       "line": 803,
-      "filename": "const.353.wasm"
+      "filename": "const.353.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4566,7 +4844,8 @@
     {
       "type": "module",
       "line": 805,
-      "filename": "const.354.wasm"
+      "filename": "const.354.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4586,7 +4865,8 @@
     {
       "type": "module",
       "line": 807,
-      "filename": "const.355.wasm"
+      "filename": "const.355.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4606,7 +4886,8 @@
     {
       "type": "module",
       "line": 809,
-      "filename": "const.356.wasm"
+      "filename": "const.356.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4626,7 +4907,8 @@
     {
       "type": "module",
       "line": 811,
-      "filename": "const.357.wasm"
+      "filename": "const.357.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4646,7 +4928,8 @@
     {
       "type": "module",
       "line": 813,
-      "filename": "const.358.wasm"
+      "filename": "const.358.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4666,7 +4949,8 @@
     {
       "type": "module",
       "line": 815,
-      "filename": "const.359.wasm"
+      "filename": "const.359.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4686,7 +4970,8 @@
     {
       "type": "module",
       "line": 817,
-      "filename": "const.360.wasm"
+      "filename": "const.360.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4706,7 +4991,8 @@
     {
       "type": "module",
       "line": 819,
-      "filename": "const.361.wasm"
+      "filename": "const.361.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4726,7 +5012,8 @@
     {
       "type": "module",
       "line": 821,
-      "filename": "const.362.wasm"
+      "filename": "const.362.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4746,7 +5033,8 @@
     {
       "type": "module",
       "line": 823,
-      "filename": "const.363.wasm"
+      "filename": "const.363.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4766,7 +5054,8 @@
     {
       "type": "module",
       "line": 825,
-      "filename": "const.364.wasm"
+      "filename": "const.364.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4786,7 +5075,8 @@
     {
       "type": "module",
       "line": 827,
-      "filename": "const.365.wasm"
+      "filename": "const.365.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4806,7 +5096,8 @@
     {
       "type": "module",
       "line": 829,
-      "filename": "const.366.wasm"
+      "filename": "const.366.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4826,7 +5117,8 @@
     {
       "type": "module",
       "line": 831,
-      "filename": "const.367.wasm"
+      "filename": "const.367.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4846,7 +5138,8 @@
     {
       "type": "module",
       "line": 833,
-      "filename": "const.368.wasm"
+      "filename": "const.368.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4866,7 +5159,8 @@
     {
       "type": "module",
       "line": 835,
-      "filename": "const.369.wasm"
+      "filename": "const.369.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4886,7 +5180,8 @@
     {
       "type": "module",
       "line": 837,
-      "filename": "const.370.wasm"
+      "filename": "const.370.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4906,7 +5201,8 @@
     {
       "type": "module",
       "line": 839,
-      "filename": "const.371.wasm"
+      "filename": "const.371.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4926,7 +5222,8 @@
     {
       "type": "module",
       "line": 841,
-      "filename": "const.372.wasm"
+      "filename": "const.372.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4946,7 +5243,8 @@
     {
       "type": "module",
       "line": 843,
-      "filename": "const.373.wasm"
+      "filename": "const.373.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4966,7 +5264,8 @@
     {
       "type": "module",
       "line": 846,
-      "filename": "const.374.wasm"
+      "filename": "const.374.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4986,7 +5285,8 @@
     {
       "type": "module",
       "line": 848,
-      "filename": "const.375.wasm"
+      "filename": "const.375.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5006,7 +5306,8 @@
     {
       "type": "module",
       "line": 850,
-      "filename": "const.376.wasm"
+      "filename": "const.376.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5026,7 +5327,8 @@
     {
       "type": "module",
       "line": 852,
-      "filename": "const.377.wasm"
+      "filename": "const.377.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5046,7 +5348,8 @@
     {
       "type": "module",
       "line": 854,
-      "filename": "const.378.wasm"
+      "filename": "const.378.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5066,7 +5369,8 @@
     {
       "type": "module",
       "line": 856,
-      "filename": "const.379.wasm"
+      "filename": "const.379.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5086,7 +5390,8 @@
     {
       "type": "module",
       "line": 858,
-      "filename": "const.380.wasm"
+      "filename": "const.380.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5106,7 +5411,8 @@
     {
       "type": "module",
       "line": 860,
-      "filename": "const.381.wasm"
+      "filename": "const.381.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5126,7 +5432,8 @@
     {
       "type": "module",
       "line": 864,
-      "filename": "const.382.wasm"
+      "filename": "const.382.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5146,7 +5453,8 @@
     {
       "type": "module",
       "line": 866,
-      "filename": "const.383.wasm"
+      "filename": "const.383.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5166,7 +5474,8 @@
     {
       "type": "module",
       "line": 868,
-      "filename": "const.384.wasm"
+      "filename": "const.384.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5186,7 +5495,8 @@
     {
       "type": "module",
       "line": 870,
-      "filename": "const.385.wasm"
+      "filename": "const.385.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5206,7 +5516,8 @@
     {
       "type": "module",
       "line": 872,
-      "filename": "const.386.wasm"
+      "filename": "const.386.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5226,7 +5537,8 @@
     {
       "type": "module",
       "line": 874,
-      "filename": "const.387.wasm"
+      "filename": "const.387.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5246,7 +5558,8 @@
     {
       "type": "module",
       "line": 876,
-      "filename": "const.388.wasm"
+      "filename": "const.388.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5266,7 +5579,8 @@
     {
       "type": "module",
       "line": 878,
-      "filename": "const.389.wasm"
+      "filename": "const.389.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5286,7 +5600,8 @@
     {
       "type": "module",
       "line": 880,
-      "filename": "const.390.wasm"
+      "filename": "const.390.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5306,7 +5621,8 @@
     {
       "type": "module",
       "line": 882,
-      "filename": "const.391.wasm"
+      "filename": "const.391.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5326,7 +5642,8 @@
     {
       "type": "module",
       "line": 884,
-      "filename": "const.392.wasm"
+      "filename": "const.392.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5346,7 +5663,8 @@
     {
       "type": "module",
       "line": 886,
-      "filename": "const.393.wasm"
+      "filename": "const.393.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5366,7 +5684,8 @@
     {
       "type": "module",
       "line": 888,
-      "filename": "const.394.wasm"
+      "filename": "const.394.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5386,7 +5705,8 @@
     {
       "type": "module",
       "line": 890,
-      "filename": "const.395.wasm"
+      "filename": "const.395.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5406,7 +5726,8 @@
     {
       "type": "module",
       "line": 892,
-      "filename": "const.396.wasm"
+      "filename": "const.396.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5426,7 +5747,8 @@
     {
       "type": "module",
       "line": 894,
-      "filename": "const.397.wasm"
+      "filename": "const.397.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5446,7 +5768,8 @@
     {
       "type": "module",
       "line": 896,
-      "filename": "const.398.wasm"
+      "filename": "const.398.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5466,7 +5789,8 @@
     {
       "type": "module",
       "line": 898,
-      "filename": "const.399.wasm"
+      "filename": "const.399.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5486,7 +5810,8 @@
     {
       "type": "module",
       "line": 900,
-      "filename": "const.400.wasm"
+      "filename": "const.400.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5506,7 +5831,8 @@
     {
       "type": "module",
       "line": 902,
-      "filename": "const.401.wasm"
+      "filename": "const.401.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5526,7 +5852,8 @@
     {
       "type": "module",
       "line": 904,
-      "filename": "const.402.wasm"
+      "filename": "const.402.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5546,7 +5873,8 @@
     {
       "type": "module",
       "line": 906,
-      "filename": "const.403.wasm"
+      "filename": "const.403.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5566,7 +5894,8 @@
     {
       "type": "module",
       "line": 908,
-      "filename": "const.404.wasm"
+      "filename": "const.404.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5586,7 +5915,8 @@
     {
       "type": "module",
       "line": 910,
-      "filename": "const.405.wasm"
+      "filename": "const.405.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5606,7 +5936,8 @@
     {
       "type": "module",
       "line": 912,
-      "filename": "const.406.wasm"
+      "filename": "const.406.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5626,7 +5957,8 @@
     {
       "type": "module",
       "line": 914,
-      "filename": "const.407.wasm"
+      "filename": "const.407.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5646,7 +5978,8 @@
     {
       "type": "module",
       "line": 916,
-      "filename": "const.408.wasm"
+      "filename": "const.408.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5666,7 +5999,8 @@
     {
       "type": "module",
       "line": 918,
-      "filename": "const.409.wasm"
+      "filename": "const.409.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5686,7 +6020,8 @@
     {
       "type": "module",
       "line": 921,
-      "filename": "const.410.wasm"
+      "filename": "const.410.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5706,7 +6041,8 @@
     {
       "type": "module",
       "line": 923,
-      "filename": "const.411.wasm"
+      "filename": "const.411.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5726,7 +6062,8 @@
     {
       "type": "module",
       "line": 925,
-      "filename": "const.412.wasm"
+      "filename": "const.412.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5746,7 +6083,8 @@
     {
       "type": "module",
       "line": 927,
-      "filename": "const.413.wasm"
+      "filename": "const.413.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5766,7 +6104,8 @@
     {
       "type": "module",
       "line": 929,
-      "filename": "const.414.wasm"
+      "filename": "const.414.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5786,7 +6125,8 @@
     {
       "type": "module",
       "line": 931,
-      "filename": "const.415.wasm"
+      "filename": "const.415.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5806,7 +6146,8 @@
     {
       "type": "module",
       "line": 933,
-      "filename": "const.416.wasm"
+      "filename": "const.416.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5826,7 +6167,8 @@
     {
       "type": "module",
       "line": 935,
-      "filename": "const.417.wasm"
+      "filename": "const.417.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5846,7 +6188,8 @@
     {
       "type": "module",
       "line": 937,
-      "filename": "const.418.wasm"
+      "filename": "const.418.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5866,7 +6209,8 @@
     {
       "type": "module",
       "line": 939,
-      "filename": "const.419.wasm"
+      "filename": "const.419.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5886,7 +6230,8 @@
     {
       "type": "module",
       "line": 941,
-      "filename": "const.420.wasm"
+      "filename": "const.420.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5906,7 +6251,8 @@
     {
       "type": "module",
       "line": 943,
-      "filename": "const.421.wasm"
+      "filename": "const.421.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5926,7 +6272,8 @@
     {
       "type": "module",
       "line": 945,
-      "filename": "const.422.wasm"
+      "filename": "const.422.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5946,7 +6293,8 @@
     {
       "type": "module",
       "line": 947,
-      "filename": "const.423.wasm"
+      "filename": "const.423.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5966,7 +6314,8 @@
     {
       "type": "module",
       "line": 949,
-      "filename": "const.424.wasm"
+      "filename": "const.424.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5986,7 +6335,8 @@
     {
       "type": "module",
       "line": 951,
-      "filename": "const.425.wasm"
+      "filename": "const.425.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6006,7 +6356,8 @@
     {
       "type": "module",
       "line": 953,
-      "filename": "const.426.wasm"
+      "filename": "const.426.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6026,7 +6377,8 @@
     {
       "type": "module",
       "line": 955,
-      "filename": "const.427.wasm"
+      "filename": "const.427.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6046,7 +6398,8 @@
     {
       "type": "module",
       "line": 957,
-      "filename": "const.428.wasm"
+      "filename": "const.428.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6066,7 +6419,8 @@
     {
       "type": "module",
       "line": 959,
-      "filename": "const.429.wasm"
+      "filename": "const.429.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6086,7 +6440,8 @@
     {
       "type": "module",
       "line": 961,
-      "filename": "const.430.wasm"
+      "filename": "const.430.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6106,7 +6461,8 @@
     {
       "type": "module",
       "line": 963,
-      "filename": "const.431.wasm"
+      "filename": "const.431.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6126,7 +6482,8 @@
     {
       "type": "module",
       "line": 965,
-      "filename": "const.432.wasm"
+      "filename": "const.432.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6146,7 +6503,8 @@
     {
       "type": "module",
       "line": 967,
-      "filename": "const.433.wasm"
+      "filename": "const.433.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6166,7 +6524,8 @@
     {
       "type": "module",
       "line": 969,
-      "filename": "const.434.wasm"
+      "filename": "const.434.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6186,7 +6545,8 @@
     {
       "type": "module",
       "line": 971,
-      "filename": "const.435.wasm"
+      "filename": "const.435.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6206,7 +6566,8 @@
     {
       "type": "module",
       "line": 973,
-      "filename": "const.436.wasm"
+      "filename": "const.436.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6226,7 +6587,8 @@
     {
       "type": "module",
       "line": 975,
-      "filename": "const.437.wasm"
+      "filename": "const.437.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6246,7 +6608,8 @@
     {
       "type": "module",
       "line": 978,
-      "filename": "const.438.wasm"
+      "filename": "const.438.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6266,7 +6629,8 @@
     {
       "type": "module",
       "line": 980,
-      "filename": "const.439.wasm"
+      "filename": "const.439.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6286,7 +6650,8 @@
     {
       "type": "module",
       "line": 982,
-      "filename": "const.440.wasm"
+      "filename": "const.440.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6306,7 +6671,8 @@
     {
       "type": "module",
       "line": 984,
-      "filename": "const.441.wasm"
+      "filename": "const.441.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6326,7 +6692,8 @@
     {
       "type": "module",
       "line": 986,
-      "filename": "const.442.wasm"
+      "filename": "const.442.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6346,7 +6713,8 @@
     {
       "type": "module",
       "line": 988,
-      "filename": "const.443.wasm"
+      "filename": "const.443.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6366,7 +6734,8 @@
     {
       "type": "module",
       "line": 990,
-      "filename": "const.444.wasm"
+      "filename": "const.444.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6386,7 +6755,8 @@
     {
       "type": "module",
       "line": 992,
-      "filename": "const.445.wasm"
+      "filename": "const.445.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6406,7 +6776,8 @@
     {
       "type": "module",
       "line": 996,
-      "filename": "const.446.wasm"
+      "filename": "const.446.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6426,7 +6797,8 @@
     {
       "type": "module",
       "line": 998,
-      "filename": "const.447.wasm"
+      "filename": "const.447.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6446,7 +6818,8 @@
     {
       "type": "module",
       "line": 1000,
-      "filename": "const.448.wasm"
+      "filename": "const.448.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6466,7 +6839,8 @@
     {
       "type": "module",
       "line": 1002,
-      "filename": "const.449.wasm"
+      "filename": "const.449.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6486,7 +6860,8 @@
     {
       "type": "module",
       "line": 1004,
-      "filename": "const.450.wasm"
+      "filename": "const.450.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6506,7 +6881,8 @@
     {
       "type": "module",
       "line": 1006,
-      "filename": "const.451.wasm"
+      "filename": "const.451.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6526,7 +6902,8 @@
     {
       "type": "module",
       "line": 1008,
-      "filename": "const.452.wasm"
+      "filename": "const.452.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6546,7 +6923,8 @@
     {
       "type": "module",
       "line": 1010,
-      "filename": "const.453.wasm"
+      "filename": "const.453.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6566,7 +6944,8 @@
     {
       "type": "module",
       "line": 1012,
-      "filename": "const.454.wasm"
+      "filename": "const.454.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6586,7 +6965,8 @@
     {
       "type": "module",
       "line": 1014,
-      "filename": "const.455.wasm"
+      "filename": "const.455.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6606,7 +6986,8 @@
     {
       "type": "module",
       "line": 1016,
-      "filename": "const.456.wasm"
+      "filename": "const.456.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6626,7 +7007,8 @@
     {
       "type": "module",
       "line": 1018,
-      "filename": "const.457.wasm"
+      "filename": "const.457.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6646,7 +7028,8 @@
     {
       "type": "module",
       "line": 1020,
-      "filename": "const.458.wasm"
+      "filename": "const.458.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6666,7 +7049,8 @@
     {
       "type": "module",
       "line": 1022,
-      "filename": "const.459.wasm"
+      "filename": "const.459.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6686,7 +7070,8 @@
     {
       "type": "module",
       "line": 1024,
-      "filename": "const.460.wasm"
+      "filename": "const.460.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6706,7 +7091,8 @@
     {
       "type": "module",
       "line": 1026,
-      "filename": "const.461.wasm"
+      "filename": "const.461.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6726,7 +7112,8 @@
     {
       "type": "module",
       "line": 1028,
-      "filename": "const.462.wasm"
+      "filename": "const.462.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6746,7 +7133,8 @@
     {
       "type": "module",
       "line": 1030,
-      "filename": "const.463.wasm"
+      "filename": "const.463.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6766,7 +7154,8 @@
     {
       "type": "module",
       "line": 1032,
-      "filename": "const.464.wasm"
+      "filename": "const.464.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6786,7 +7175,8 @@
     {
       "type": "module",
       "line": 1034,
-      "filename": "const.465.wasm"
+      "filename": "const.465.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6806,7 +7196,8 @@
     {
       "type": "module",
       "line": 1036,
-      "filename": "const.466.wasm"
+      "filename": "const.466.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6826,7 +7217,8 @@
     {
       "type": "module",
       "line": 1038,
-      "filename": "const.467.wasm"
+      "filename": "const.467.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6846,7 +7238,8 @@
     {
       "type": "module",
       "line": 1040,
-      "filename": "const.468.wasm"
+      "filename": "const.468.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6866,7 +7259,8 @@
     {
       "type": "module",
       "line": 1042,
-      "filename": "const.469.wasm"
+      "filename": "const.469.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6886,7 +7280,8 @@
     {
       "type": "module",
       "line": 1044,
-      "filename": "const.470.wasm"
+      "filename": "const.470.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6906,7 +7301,8 @@
     {
       "type": "module",
       "line": 1046,
-      "filename": "const.471.wasm"
+      "filename": "const.471.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6926,7 +7322,8 @@
     {
       "type": "module",
       "line": 1048,
-      "filename": "const.472.wasm"
+      "filename": "const.472.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6946,7 +7343,8 @@
     {
       "type": "module",
       "line": 1050,
-      "filename": "const.473.wasm"
+      "filename": "const.473.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6966,7 +7364,8 @@
     {
       "type": "module",
       "line": 1054,
-      "filename": "const.474.wasm"
+      "filename": "const.474.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6986,7 +7385,8 @@
     {
       "type": "module",
       "line": 1056,
-      "filename": "const.475.wasm"
+      "filename": "const.475.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -7006,7 +7406,8 @@
     {
       "type": "module",
       "line": 1058,
-      "filename": "const.476.wasm"
+      "filename": "const.476.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -7026,7 +7427,8 @@
     {
       "type": "module",
       "line": 1060,
-      "filename": "const.477.wasm"
+      "filename": "const.477.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/conversions.wast.json
+++ b/tests/snapshots/testsuite/conversions.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "conversions.0.wasm"
+      "filename": "conversions.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -11535,176 +11536,176 @@
       "type": "assert_invalid",
       "line": 678,
       "filename": "conversions.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 679,
       "filename": "conversions.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 680,
       "filename": "conversions.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 681,
       "filename": "conversions.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 682,
       "filename": "conversions.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 683,
       "filename": "conversions.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 684,
       "filename": "conversions.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 685,
       "filename": "conversions.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 686,
       "filename": "conversions.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 687,
       "filename": "conversions.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 688,
       "filename": "conversions.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 689,
       "filename": "conversions.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 690,
       "filename": "conversions.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 691,
       "filename": "conversions.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 692,
       "filename": "conversions.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 693,
       "filename": "conversions.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 694,
       "filename": "conversions.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 695,
       "filename": "conversions.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 696,
       "filename": "conversions.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 697,
       "filename": "conversions.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 698,
       "filename": "conversions.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 699,
       "filename": "conversions.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 700,
       "filename": "conversions.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 701,
       "filename": "conversions.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 702,
       "filename": "conversions.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/custom.wast.json
+++ b/tests/snapshots/testsuite/custom.wast.json
@@ -4,73 +4,76 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "custom.0.wasm"
+      "filename": "custom.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 14,
-      "filename": "custom.1.wasm"
+      "filename": "custom.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 50,
-      "filename": "custom.2.wasm"
+      "filename": "custom.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 61,
       "filename": "custom.3.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 69,
       "filename": "custom.4.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 77,
       "filename": "custom.5.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 85,
       "filename": "custom.6.wasm",
-      "text": "length out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "length out of bounds"
     },
     {
       "type": "assert_malformed",
       "line": 93,
       "filename": "custom.7.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 102,
       "filename": "custom.8.wasm",
-      "text": "function and code section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function and code section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 115,
       "filename": "custom.9.wasm",
-      "text": "length out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "length out of bounds"
     },
     {
       "type": "assert_malformed",
       "line": 123,
       "filename": "custom.10.wasm",
-      "text": "data count and data section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "data count and data section have inconsistent lengths"
     }
   ]
 }

--- a/tests/snapshots/testsuite/data.wast.json
+++ b/tests/snapshots/testsuite/data.wast.json
@@ -4,379 +4,404 @@
     {
       "type": "module",
       "line": 5,
-      "filename": "data.0.wasm"
+      "filename": "data.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 35,
-      "filename": "data.1.wasm"
+      "filename": "data.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 39,
-      "filename": "data.2.wasm"
+      "filename": "data.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 44,
-      "filename": "data.3.wasm"
+      "filename": "data.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 52,
-      "filename": "data.4.wasm"
+      "filename": "data.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 62,
-      "filename": "data.5.wasm"
+      "filename": "data.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 67,
-      "filename": "data.6.wasm"
+      "filename": "data.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 73,
-      "filename": "data.7.wasm"
+      "filename": "data.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 78,
-      "filename": "data.8.wasm"
+      "filename": "data.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 85,
       "filename": "data.9.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 89,
       "filename": "data.10.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "module",
       "line": 96,
-      "filename": "data.11.wasm"
+      "filename": "data.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 101,
-      "filename": "data.12.wasm"
+      "filename": "data.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 107,
-      "filename": "data.13.wasm"
+      "filename": "data.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 112,
-      "filename": "data.14.wasm"
+      "filename": "data.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 116,
-      "filename": "data.15.wasm"
+      "filename": "data.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 121,
-      "filename": "data.16.wasm"
+      "filename": "data.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 126,
-      "filename": "data.17.wasm"
+      "filename": "data.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 131,
-      "filename": "data.18.wasm"
+      "filename": "data.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 135,
-      "filename": "data.19.wasm"
+      "filename": "data.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 140,
-      "filename": "data.20.wasm"
+      "filename": "data.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 145,
-      "filename": "data.21.wasm"
+      "filename": "data.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 150,
-      "filename": "data.22.wasm"
+      "filename": "data.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 155,
-      "filename": "data.23.wasm"
+      "filename": "data.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 161,
-      "filename": "data.24.wasm"
+      "filename": "data.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 167,
-      "filename": "data.25.wasm"
+      "filename": "data.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 172,
-      "filename": "data.26.wasm"
+      "filename": "data.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_uninstantiable",
       "line": 180,
       "filename": "data.27.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 188,
       "filename": "data.28.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 196,
       "filename": "data.29.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 203,
       "filename": "data.30.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 210,
       "filename": "data.31.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 227,
       "filename": "data.32.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 236,
       "filename": "data.33.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 243,
       "filename": "data.34.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 251,
       "filename": "data.35.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 259,
       "filename": "data.36.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 267,
       "filename": "data.37.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 274,
       "filename": "data.38.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 282,
       "filename": "data.39.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 289,
       "filename": "data.40.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_invalid",
       "line": 299,
       "filename": "data.41.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 307,
       "filename": "data.42.wasm",
-      "text": "unknown memory 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 1"
     },
     {
       "type": "assert_invalid",
       "line": 320,
       "filename": "data.43.wasm",
-      "text": "unknown memory 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 0"
     },
     {
       "type": "assert_invalid",
       "line": 331,
       "filename": "data.44.wasm",
-      "text": "unknown memory 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 1"
     },
     {
       "type": "assert_invalid",
       "line": 343,
       "filename": "data.45.wasm",
-      "text": "unknown memory 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 1"
     },
     {
       "type": "assert_invalid",
       "line": 365,
       "filename": "data.46.wasm",
-      "text": "unknown memory 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 1"
     },
     {
       "type": "assert_invalid",
       "line": 384,
       "filename": "data.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 392,
       "filename": "data.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 400,
       "filename": "data.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 408,
       "filename": "data.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 416,
       "filename": "data.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 425,
       "filename": "data.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 434,
       "filename": "data.53.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 442,
       "filename": "data.54.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 450,
       "filename": "data.55.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 458,
       "filename": "data.56.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 466,
       "filename": "data.57.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 475,
       "filename": "data.58.wasm",
-      "text": "unknown global 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global 0"
     },
     {
       "type": "assert_invalid",
       "line": 483,
       "filename": "data.59.wasm",
-      "text": "unknown global 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global 1"
     },
     {
       "type": "assert_invalid",
       "line": 492,
       "filename": "data.60.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     }
   ]
 }

--- a/tests/snapshots/testsuite/elem.wast.json
+++ b/tests/snapshots/testsuite/elem.wast.json
@@ -4,47 +4,56 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "elem.0.wasm"
+      "filename": "elem.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 80,
-      "filename": "elem.1.wasm"
+      "filename": "elem.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 90,
-      "filename": "elem.2.wasm"
+      "filename": "elem.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 95,
-      "filename": "elem.3.wasm"
+      "filename": "elem.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 101,
-      "filename": "elem.4.wasm"
+      "filename": "elem.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 110,
-      "filename": "elem.5.wasm"
+      "filename": "elem.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 120,
-      "filename": "elem.6.wasm"
+      "filename": "elem.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 127,
-      "filename": "elem.7.wasm"
+      "filename": "elem.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 134,
-      "filename": "elem.8.wasm"
+      "filename": "elem.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -79,7 +88,8 @@
     {
       "type": "module",
       "line": 153,
-      "filename": "elem.9.wasm"
+      "filename": "elem.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -115,154 +125,165 @@
       "type": "assert_invalid",
       "line": 171,
       "filename": "elem.10.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 175,
       "filename": "elem.11.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "module",
       "line": 182,
-      "filename": "elem.12.wasm"
+      "filename": "elem.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 187,
-      "filename": "elem.13.wasm"
+      "filename": "elem.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 193,
-      "filename": "elem.14.wasm"
+      "filename": "elem.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 197,
-      "filename": "elem.15.wasm"
+      "filename": "elem.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 202,
-      "filename": "elem.16.wasm"
+      "filename": "elem.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 207,
-      "filename": "elem.17.wasm"
+      "filename": "elem.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 212,
-      "filename": "elem.18.wasm"
+      "filename": "elem.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 218,
-      "filename": "elem.19.wasm"
+      "filename": "elem.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 224,
-      "filename": "elem.20.wasm"
+      "filename": "elem.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 230,
-      "filename": "elem.21.wasm"
+      "filename": "elem.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_uninstantiable",
       "line": 239,
       "filename": "elem.22.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 248,
       "filename": "elem.23.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 257,
       "filename": "elem.24.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 266,
       "filename": "elem.25.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 273,
       "filename": "elem.26.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 281,
       "filename": "elem.27.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 290,
       "filename": "elem.28.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 298,
       "filename": "elem.29.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 307,
       "filename": "elem.30.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 315,
       "filename": "elem.31.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 324,
       "filename": "elem.32.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 332,
       "filename": "elem.33.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "module",
       "line": 342,
-      "filename": "elem.34.wasm"
+      "filename": "elem.34.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -277,7 +298,8 @@
     {
       "type": "module",
       "line": 352,
-      "filename": "elem.35.wasm"
+      "filename": "elem.35.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -293,146 +315,147 @@
       "type": "assert_invalid",
       "line": 365,
       "filename": "elem.36.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 375,
       "filename": "elem.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 383,
       "filename": "elem.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 391,
       "filename": "elem.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 399,
       "filename": "elem.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 407,
       "filename": "elem.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 416,
       "filename": "elem.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 426,
       "filename": "elem.43.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 434,
       "filename": "elem.44.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 442,
       "filename": "elem.45.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 450,
       "filename": "elem.46.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 458,
       "filename": "elem.47.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 467,
       "filename": "elem.48.wasm",
-      "text": "unknown global 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global 0"
     },
     {
       "type": "assert_invalid",
       "line": 475,
       "filename": "elem.49.wasm",
-      "text": "unknown global 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global 1"
     },
     {
       "type": "assert_invalid",
       "line": 484,
       "filename": "elem.50.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 495,
       "filename": "elem.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 503,
       "filename": "elem.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 511,
       "filename": "elem.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 519,
       "filename": "elem.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 527,
       "filename": "elem.55.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "module",
       "line": 537,
-      "filename": "elem.56.wasm"
+      "filename": "elem.56.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -452,7 +475,8 @@
     {
       "type": "module",
       "line": 550,
-      "filename": "elem.57.wasm"
+      "filename": "elem.57.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -473,7 +497,8 @@
       "type": "module",
       "line": 565,
       "name": "module1",
-      "filename": "elem.58.wasm"
+      "filename": "elem.58.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -528,7 +553,8 @@
       "type": "module",
       "line": 589,
       "name": "module2",
-      "filename": "elem.59.wasm"
+      "filename": "elem.59.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -582,7 +608,8 @@
       "type": "module",
       "line": 602,
       "name": "module3",
-      "filename": "elem.60.wasm"
+      "filename": "elem.60.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -636,35 +663,36 @@
       "type": "assert_invalid",
       "line": 618,
       "filename": "elem.61.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 623,
       "filename": "elem.62.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 628,
       "filename": "elem.63.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 637,
       "filename": "elem.64.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 646,
       "name": "m",
-      "filename": "elem.65.wasm"
+      "filename": "elem.65.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -799,7 +827,8 @@
     {
       "type": "module",
       "line": 664,
-      "filename": "elem.66.wasm"
+      "filename": "elem.66.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -847,7 +876,8 @@
       "type": "module",
       "line": 673,
       "name": "module4",
-      "filename": "elem.67.wasm"
+      "filename": "elem.67.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -858,7 +888,8 @@
     {
       "type": "module",
       "line": 682,
-      "filename": "elem.68.wasm"
+      "filename": "elem.68.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/endianness.wast.json
+++ b/tests/snapshots/testsuite/endianness.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "endianness.0.wasm"
+      "filename": "endianness.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/exports.wast.json
+++ b/tests/snapshots/testsuite/exports.wast.json
@@ -4,63 +4,75 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "exports.0.wasm"
+      "filename": "exports.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 4,
-      "filename": "exports.1.wasm"
+      "filename": "exports.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 5,
-      "filename": "exports.2.wasm"
+      "filename": "exports.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 7,
-      "filename": "exports.3.wasm"
+      "filename": "exports.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 8,
-      "filename": "exports.4.wasm"
+      "filename": "exports.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 9,
-      "filename": "exports.5.wasm"
+      "filename": "exports.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 10,
-      "filename": "exports.6.wasm"
+      "filename": "exports.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 11,
-      "filename": "exports.7.wasm"
+      "filename": "exports.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 12,
-      "filename": "exports.8.wasm"
+      "filename": "exports.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 13,
-      "filename": "exports.9.wasm"
+      "filename": "exports.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 14,
-      "filename": "exports.10.wasm"
+      "filename": "exports.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 16,
       "name": "Func",
-      "filename": "exports.11.wasm"
+      "filename": "exports.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -106,13 +118,15 @@
     {
       "type": "module",
       "line": 24,
-      "filename": "exports.12.wasm"
+      "filename": "exports.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 25,
       "name": "Other1",
-      "filename": "exports.13.wasm"
+      "filename": "exports.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -138,7 +152,8 @@
     {
       "type": "module",
       "line": 28,
-      "filename": "exports.14.wasm"
+      "filename": "exports.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -189,108 +204,118 @@
       "type": "assert_invalid",
       "line": 39,
       "filename": "exports.15.wasm",
-      "text": "unknown function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function"
     },
     {
       "type": "assert_invalid",
       "line": 43,
       "filename": "exports.16.wasm",
-      "text": "unknown function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function"
     },
     {
       "type": "assert_invalid",
       "line": 47,
       "filename": "exports.17.wasm",
-      "text": "unknown function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function"
     },
     {
       "type": "assert_invalid",
       "line": 51,
       "filename": "exports.18.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 55,
       "filename": "exports.19.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 59,
       "filename": "exports.20.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 63,
       "filename": "exports.21.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 67,
       "filename": "exports.22.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "module",
       "line": 74,
-      "filename": "exports.23.wasm"
+      "filename": "exports.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 75,
-      "filename": "exports.24.wasm"
+      "filename": "exports.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 76,
-      "filename": "exports.25.wasm"
+      "filename": "exports.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 78,
-      "filename": "exports.26.wasm"
+      "filename": "exports.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 79,
-      "filename": "exports.27.wasm"
+      "filename": "exports.27.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 80,
-      "filename": "exports.28.wasm"
+      "filename": "exports.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 81,
-      "filename": "exports.29.wasm"
+      "filename": "exports.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 82,
-      "filename": "exports.30.wasm"
+      "filename": "exports.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 83,
-      "filename": "exports.31.wasm"
+      "filename": "exports.31.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 85,
       "name": "Global",
-      "filename": "exports.32.wasm"
+      "filename": "exports.32.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -324,13 +349,15 @@
     {
       "type": "module",
       "line": 91,
-      "filename": "exports.33.wasm"
+      "filename": "exports.33.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 92,
       "name": "Other2",
-      "filename": "exports.34.wasm"
+      "filename": "exports.34.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -351,307 +378,336 @@
       "type": "assert_invalid",
       "line": 96,
       "filename": "exports.35.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 100,
       "filename": "exports.36.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 104,
       "filename": "exports.37.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 108,
       "filename": "exports.38.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 112,
       "filename": "exports.39.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 116,
       "filename": "exports.40.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 120,
       "filename": "exports.41.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 124,
       "filename": "exports.42.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "module",
       "line": 131,
-      "filename": "exports.43.wasm"
+      "filename": "exports.43.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 132,
-      "filename": "exports.44.wasm"
+      "filename": "exports.44.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 133,
-      "filename": "exports.45.wasm"
+      "filename": "exports.45.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 135,
-      "filename": "exports.46.wasm"
+      "filename": "exports.46.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 136,
-      "filename": "exports.47.wasm"
+      "filename": "exports.47.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 137,
-      "filename": "exports.48.wasm"
+      "filename": "exports.48.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 138,
-      "filename": "exports.49.wasm"
+      "filename": "exports.49.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 139,
-      "filename": "exports.50.wasm"
+      "filename": "exports.50.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 140,
-      "filename": "exports.51.wasm"
+      "filename": "exports.51.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 141,
-      "filename": "exports.52.wasm"
+      "filename": "exports.52.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 142,
-      "filename": "exports.53.wasm"
+      "filename": "exports.53.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 143,
-      "filename": "exports.54.wasm"
+      "filename": "exports.54.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 144,
-      "filename": "exports.55.wasm"
+      "filename": "exports.55.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 145,
-      "filename": "exports.56.wasm"
+      "filename": "exports.56.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 146,
-      "filename": "exports.57.wasm"
+      "filename": "exports.57.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 151,
       "filename": "exports.58.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 155,
       "filename": "exports.59.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 159,
       "filename": "exports.60.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 163,
       "filename": "exports.61.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 167,
       "filename": "exports.62.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 171,
       "filename": "exports.63.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 175,
       "filename": "exports.64.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 179,
       "filename": "exports.65.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "module",
       "line": 186,
-      "filename": "exports.66.wasm"
+      "filename": "exports.66.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 187,
-      "filename": "exports.67.wasm"
+      "filename": "exports.67.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 191,
-      "filename": "exports.68.wasm"
+      "filename": "exports.68.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 192,
-      "filename": "exports.69.wasm"
+      "filename": "exports.69.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 193,
-      "filename": "exports.70.wasm"
+      "filename": "exports.70.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 194,
-      "filename": "exports.71.wasm"
+      "filename": "exports.71.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 195,
-      "filename": "exports.72.wasm"
+      "filename": "exports.72.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 196,
-      "filename": "exports.73.wasm"
+      "filename": "exports.73.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 197,
-      "filename": "exports.74.wasm"
+      "filename": "exports.74.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 198,
-      "filename": "exports.75.wasm"
+      "filename": "exports.75.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 199,
-      "filename": "exports.76.wasm"
+      "filename": "exports.76.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 200,
-      "filename": "exports.77.wasm"
+      "filename": "exports.77.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 201,
-      "filename": "exports.78.wasm"
+      "filename": "exports.78.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 202,
-      "filename": "exports.79.wasm"
+      "filename": "exports.79.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 207,
       "filename": "exports.80.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 211,
       "filename": "exports.81.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 215,
       "filename": "exports.82.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 219,
       "filename": "exports.83.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 228,
       "filename": "exports.84.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 232,
       "filename": "exports.85.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 236,
       "filename": "exports.86.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     }
   ]
 }

--- a/tests/snapshots/testsuite/f32.wast.json
+++ b/tests/snapshots/testsuite/f32.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 5,
-      "filename": "f32.0.wasm"
+      "filename": "f32.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -59610,92 +59611,92 @@
       "type": "assert_invalid",
       "line": 2523,
       "filename": "f32.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2524,
       "filename": "f32.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2525,
       "filename": "f32.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2526,
       "filename": "f32.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2527,
       "filename": "f32.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2528,
       "filename": "f32.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2529,
       "filename": "f32.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2530,
       "filename": "f32.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2531,
       "filename": "f32.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2532,
       "filename": "f32.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2533,
       "filename": "f32.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 2537,
       "filename": "f32.12.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 2541,
       "filename": "f32.13.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     }
   ]
 }

--- a/tests/snapshots/testsuite/f32_bitwise.wast.json
+++ b/tests/snapshots/testsuite/f32_bitwise.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "f32_bitwise.0.wasm"
+      "filename": "f32_bitwise.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -8506,22 +8507,22 @@
       "type": "assert_invalid",
       "line": 374,
       "filename": "f32_bitwise.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 375,
       "filename": "f32_bitwise.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 376,
       "filename": "f32_bitwise.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/f32_cmp.wast.json
+++ b/tests/snapshots/testsuite/f32_cmp.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "f32_cmp.0.wasm"
+      "filename": "f32_cmp.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -57610,43 +57611,43 @@
       "type": "assert_invalid",
       "line": 2417,
       "filename": "f32_cmp.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2418,
       "filename": "f32_cmp.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2419,
       "filename": "f32_cmp.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2420,
       "filename": "f32_cmp.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2421,
       "filename": "f32_cmp.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2422,
       "filename": "f32_cmp.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/f64.wast.json
+++ b/tests/snapshots/testsuite/f64.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 5,
-      "filename": "f64.0.wasm"
+      "filename": "f64.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -59610,92 +59611,92 @@
       "type": "assert_invalid",
       "line": 2523,
       "filename": "f64.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2524,
       "filename": "f64.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2525,
       "filename": "f64.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2526,
       "filename": "f64.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2527,
       "filename": "f64.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2528,
       "filename": "f64.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2529,
       "filename": "f64.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2530,
       "filename": "f64.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2531,
       "filename": "f64.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2532,
       "filename": "f64.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2533,
       "filename": "f64.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 2537,
       "filename": "f64.12.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 2541,
       "filename": "f64.13.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     }
   ]
 }

--- a/tests/snapshots/testsuite/f64_bitwise.wast.json
+++ b/tests/snapshots/testsuite/f64_bitwise.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "f64_bitwise.0.wasm"
+      "filename": "f64_bitwise.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -8506,22 +8507,22 @@
       "type": "assert_invalid",
       "line": 374,
       "filename": "f64_bitwise.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 375,
       "filename": "f64_bitwise.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 376,
       "filename": "f64_bitwise.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/f64_cmp.wast.json
+++ b/tests/snapshots/testsuite/f64_cmp.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "f64_cmp.0.wasm"
+      "filename": "f64_cmp.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -57610,43 +57611,43 @@
       "type": "assert_invalid",
       "line": 2417,
       "filename": "f64_cmp.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2418,
       "filename": "f64_cmp.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2419,
       "filename": "f64_cmp.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2420,
       "filename": "f64_cmp.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2421,
       "filename": "f64_cmp.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2422,
       "filename": "f64_cmp.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/fac.wast.json
+++ b/tests/snapshots/testsuite/fac.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "fac.0.wasm"
+      "filename": "fac.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/float_exprs.wast.json
+++ b/tests/snapshots/testsuite/float_exprs.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 6,
-      "filename": "float_exprs.0.wasm"
+      "filename": "float_exprs.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -149,7 +150,8 @@
     {
       "type": "module",
       "line": 19,
-      "filename": "float_exprs.1.wasm"
+      "filename": "float_exprs.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -434,7 +436,8 @@
     {
       "type": "module",
       "line": 40,
-      "filename": "float_exprs.2.wasm"
+      "filename": "float_exprs.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -519,7 +522,8 @@
     {
       "type": "module",
       "line": 54,
-      "filename": "float_exprs.3.wasm"
+      "filename": "float_exprs.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -604,7 +608,8 @@
     {
       "type": "module",
       "line": 68,
-      "filename": "float_exprs.4.wasm"
+      "filename": "float_exprs.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -649,7 +654,8 @@
     {
       "type": "module",
       "line": 80,
-      "filename": "float_exprs.5.wasm"
+      "filename": "float_exprs.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -814,7 +820,8 @@
     {
       "type": "module",
       "line": 99,
-      "filename": "float_exprs.6.wasm"
+      "filename": "float_exprs.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -859,7 +866,8 @@
     {
       "type": "module",
       "line": 111,
-      "filename": "float_exprs.7.wasm"
+      "filename": "float_exprs.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1024,7 +1032,8 @@
     {
       "type": "module",
       "line": 129,
-      "filename": "float_exprs.8.wasm"
+      "filename": "float_exprs.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1069,7 +1078,8 @@
     {
       "type": "module",
       "line": 141,
-      "filename": "float_exprs.9.wasm"
+      "filename": "float_exprs.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1114,7 +1124,8 @@
     {
       "type": "module",
       "line": 153,
-      "filename": "float_exprs.10.wasm"
+      "filename": "float_exprs.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1159,7 +1170,8 @@
     {
       "type": "module",
       "line": 165,
-      "filename": "float_exprs.11.wasm"
+      "filename": "float_exprs.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1204,7 +1216,8 @@
     {
       "type": "module",
       "line": 177,
-      "filename": "float_exprs.12.wasm"
+      "filename": "float_exprs.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1249,7 +1262,8 @@
     {
       "type": "module",
       "line": 189,
-      "filename": "float_exprs.13.wasm"
+      "filename": "float_exprs.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1294,7 +1308,8 @@
     {
       "type": "module",
       "line": 201,
-      "filename": "float_exprs.14.wasm"
+      "filename": "float_exprs.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1379,7 +1394,8 @@
     {
       "type": "module",
       "line": 215,
-      "filename": "float_exprs.15.wasm"
+      "filename": "float_exprs.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1544,7 +1560,8 @@
     {
       "type": "module",
       "line": 233,
-      "filename": "float_exprs.16.wasm"
+      "filename": "float_exprs.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1749,7 +1766,8 @@
     {
       "type": "module",
       "line": 253,
-      "filename": "float_exprs.17.wasm"
+      "filename": "float_exprs.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2034,7 +2052,8 @@
     {
       "type": "module",
       "line": 273,
-      "filename": "float_exprs.18.wasm"
+      "filename": "float_exprs.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2319,7 +2338,8 @@
     {
       "type": "module",
       "line": 293,
-      "filename": "float_exprs.19.wasm"
+      "filename": "float_exprs.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2604,7 +2624,8 @@
     {
       "type": "module",
       "line": 313,
-      "filename": "float_exprs.20.wasm"
+      "filename": "float_exprs.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2889,7 +2910,8 @@
     {
       "type": "module",
       "line": 333,
-      "filename": "float_exprs.21.wasm"
+      "filename": "float_exprs.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3214,7 +3236,8 @@
     {
       "type": "module",
       "line": 353,
-      "filename": "float_exprs.22.wasm"
+      "filename": "float_exprs.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3539,7 +3562,8 @@
     {
       "type": "module",
       "line": 373,
-      "filename": "float_exprs.23.wasm"
+      "filename": "float_exprs.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3864,7 +3888,8 @@
     {
       "type": "module",
       "line": 399,
-      "filename": "float_exprs.24.wasm"
+      "filename": "float_exprs.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4189,7 +4214,8 @@
     {
       "type": "module",
       "line": 425,
-      "filename": "float_exprs.25.wasm"
+      "filename": "float_exprs.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4434,7 +4460,8 @@
     {
       "type": "module",
       "line": 447,
-      "filename": "float_exprs.26.wasm"
+      "filename": "float_exprs.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4539,7 +4566,8 @@
     {
       "type": "module",
       "line": 460,
-      "filename": "float_exprs.27.wasm"
+      "filename": "float_exprs.27.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4744,7 +4772,8 @@
     {
       "type": "module",
       "line": 481,
-      "filename": "float_exprs.28.wasm"
+      "filename": "float_exprs.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4849,7 +4878,8 @@
     {
       "type": "module",
       "line": 494,
-      "filename": "float_exprs.29.wasm"
+      "filename": "float_exprs.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5094,7 +5124,8 @@
     {
       "type": "module",
       "line": 523,
-      "filename": "float_exprs.30.wasm"
+      "filename": "float_exprs.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5339,7 +5370,8 @@
     {
       "type": "module",
       "line": 544,
-      "filename": "float_exprs.31.wasm"
+      "filename": "float_exprs.31.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5584,7 +5616,8 @@
     {
       "type": "module",
       "line": 565,
-      "filename": "float_exprs.32.wasm"
+      "filename": "float_exprs.32.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5829,7 +5862,8 @@
     {
       "type": "module",
       "line": 586,
-      "filename": "float_exprs.33.wasm"
+      "filename": "float_exprs.33.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6074,7 +6108,8 @@
     {
       "type": "module",
       "line": 607,
-      "filename": "float_exprs.34.wasm"
+      "filename": "float_exprs.34.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6119,7 +6154,8 @@
     {
       "type": "module",
       "line": 619,
-      "filename": "float_exprs.35.wasm"
+      "filename": "float_exprs.35.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6224,7 +6260,8 @@
     {
       "type": "module",
       "line": 633,
-      "filename": "float_exprs.36.wasm"
+      "filename": "float_exprs.36.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6489,7 +6526,8 @@
     {
       "type": "module",
       "line": 655,
-      "filename": "float_exprs.37.wasm"
+      "filename": "float_exprs.37.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6734,7 +6772,8 @@
     {
       "type": "module",
       "line": 677,
-      "filename": "float_exprs.38.wasm"
+      "filename": "float_exprs.38.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6979,7 +7018,8 @@
     {
       "type": "module",
       "line": 699,
-      "filename": "float_exprs.39.wasm"
+      "filename": "float_exprs.39.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -7224,7 +7264,8 @@
     {
       "type": "module",
       "line": 721,
-      "filename": "float_exprs.40.wasm"
+      "filename": "float_exprs.40.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -7469,7 +7510,8 @@
     {
       "type": "module",
       "line": 742,
-      "filename": "float_exprs.41.wasm"
+      "filename": "float_exprs.41.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -8114,7 +8156,8 @@
     {
       "type": "module",
       "line": 817,
-      "filename": "float_exprs.42.wasm"
+      "filename": "float_exprs.42.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -8369,7 +8412,8 @@
     {
       "type": "module",
       "line": 852,
-      "filename": "float_exprs.43.wasm"
+      "filename": "float_exprs.43.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -8624,7 +8668,8 @@
     {
       "type": "module",
       "line": 889,
-      "filename": "float_exprs.44.wasm"
+      "filename": "float_exprs.44.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -9397,7 +9442,8 @@
     {
       "type": "module",
       "line": 936,
-      "filename": "float_exprs.45.wasm"
+      "filename": "float_exprs.45.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -10170,7 +10216,8 @@
     {
       "type": "module",
       "line": 983,
-      "filename": "float_exprs.46.wasm"
+      "filename": "float_exprs.46.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -10943,7 +10990,8 @@
     {
       "type": "module",
       "line": 1062,
-      "filename": "float_exprs.47.wasm"
+      "filename": "float_exprs.47.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -11588,7 +11636,8 @@
     {
       "type": "module",
       "line": 1109,
-      "filename": "float_exprs.48.wasm"
+      "filename": "float_exprs.48.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -12233,7 +12282,8 @@
     {
       "type": "module",
       "line": 1189,
-      "filename": "float_exprs.49.wasm"
+      "filename": "float_exprs.49.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -12268,7 +12318,8 @@
     {
       "type": "module",
       "line": 1204,
-      "filename": "float_exprs.50.wasm"
+      "filename": "float_exprs.50.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -12288,7 +12339,8 @@
     {
       "type": "module",
       "line": 1223,
-      "filename": "float_exprs.51.wasm"
+      "filename": "float_exprs.51.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -12308,7 +12360,8 @@
     {
       "type": "module",
       "line": 1245,
-      "filename": "float_exprs.52.wasm"
+      "filename": "float_exprs.52.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -12333,7 +12386,8 @@
     {
       "type": "module",
       "line": 1256,
-      "filename": "float_exprs.53.wasm"
+      "filename": "float_exprs.53.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -12358,7 +12412,8 @@
     {
       "type": "module",
       "line": 1267,
-      "filename": "float_exprs.54.wasm"
+      "filename": "float_exprs.54.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -12387,7 +12442,8 @@
     {
       "type": "module",
       "line": 1284,
-      "filename": "float_exprs.55.wasm"
+      "filename": "float_exprs.55.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -12480,7 +12536,8 @@
     {
       "type": "module",
       "line": 1305,
-      "filename": "float_exprs.56.wasm"
+      "filename": "float_exprs.56.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -12505,7 +12562,8 @@
     {
       "type": "module",
       "line": 1316,
-      "filename": "float_exprs.57.wasm"
+      "filename": "float_exprs.57.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -12550,7 +12608,8 @@
     {
       "type": "module",
       "line": 1331,
-      "filename": "float_exprs.58.wasm"
+      "filename": "float_exprs.58.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -12915,7 +12974,8 @@
     {
       "type": "module",
       "line": 1363,
-      "filename": "float_exprs.59.wasm"
+      "filename": "float_exprs.59.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -13160,7 +13220,8 @@
     {
       "type": "module",
       "line": 1387,
-      "filename": "float_exprs.60.wasm"
+      "filename": "float_exprs.60.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -13405,7 +13466,8 @@
     {
       "type": "module",
       "line": 1412,
-      "filename": "float_exprs.61.wasm"
+      "filename": "float_exprs.61.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -13513,7 +13575,8 @@
     {
       "type": "module",
       "line": 1451,
-      "filename": "float_exprs.62.wasm"
+      "filename": "float_exprs.62.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -13621,7 +13684,8 @@
     {
       "type": "module",
       "line": 1493,
-      "filename": "float_exprs.63.wasm"
+      "filename": "float_exprs.63.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -13674,7 +13738,8 @@
     {
       "type": "module",
       "line": 1587,
-      "filename": "float_exprs.64.wasm"
+      "filename": "float_exprs.64.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -13727,7 +13792,8 @@
     {
       "type": "module",
       "line": 1640,
-      "filename": "float_exprs.65.wasm"
+      "filename": "float_exprs.65.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -13924,7 +13990,8 @@
     {
       "type": "module",
       "line": 1660,
-      "filename": "float_exprs.66.wasm"
+      "filename": "float_exprs.66.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -14121,7 +14188,8 @@
     {
       "type": "module",
       "line": 1680,
-      "filename": "float_exprs.67.wasm"
+      "filename": "float_exprs.67.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -14318,7 +14386,8 @@
     {
       "type": "module",
       "line": 1700,
-      "filename": "float_exprs.68.wasm"
+      "filename": "float_exprs.68.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -14483,7 +14552,8 @@
     {
       "type": "module",
       "line": 1720,
-      "filename": "float_exprs.69.wasm"
+      "filename": "float_exprs.69.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -14688,7 +14758,8 @@
     {
       "type": "module",
       "line": 1749,
-      "filename": "float_exprs.70.wasm"
+      "filename": "float_exprs.70.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -14973,7 +15044,8 @@
     {
       "type": "module",
       "line": 1773,
-      "filename": "float_exprs.71.wasm"
+      "filename": "float_exprs.71.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -15298,7 +15370,8 @@
     {
       "type": "module",
       "line": 1795,
-      "filename": "float_exprs.72.wasm"
+      "filename": "float_exprs.72.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -15583,7 +15656,8 @@
     {
       "type": "module",
       "line": 1817,
-      "filename": "float_exprs.73.wasm"
+      "filename": "float_exprs.73.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -15788,7 +15862,8 @@
     {
       "type": "module",
       "line": 1839,
-      "filename": "float_exprs.74.wasm"
+      "filename": "float_exprs.74.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -16033,7 +16108,8 @@
     {
       "type": "module",
       "line": 1861,
-      "filename": "float_exprs.75.wasm"
+      "filename": "float_exprs.75.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -16278,7 +16354,8 @@
     {
       "type": "module",
       "line": 1883,
-      "filename": "float_exprs.76.wasm"
+      "filename": "float_exprs.76.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -16523,7 +16600,8 @@
     {
       "type": "module",
       "line": 1906,
-      "filename": "float_exprs.77.wasm"
+      "filename": "float_exprs.77.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -16584,7 +16662,8 @@
     {
       "type": "module",
       "line": 1920,
-      "filename": "float_exprs.78.wasm"
+      "filename": "float_exprs.78.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -16901,7 +16980,8 @@
     {
       "type": "module",
       "line": 1964,
-      "filename": "float_exprs.79.wasm"
+      "filename": "float_exprs.79.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -16962,7 +17042,8 @@
     {
       "type": "module",
       "line": 1980,
-      "filename": "float_exprs.80.wasm"
+      "filename": "float_exprs.80.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -17007,7 +17088,8 @@
     {
       "type": "module",
       "line": 1994,
-      "filename": "float_exprs.81.wasm"
+      "filename": "float_exprs.81.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -17372,7 +17454,8 @@
     {
       "type": "module",
       "line": 2045,
-      "filename": "float_exprs.82.wasm"
+      "filename": "float_exprs.82.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -17425,7 +17508,8 @@
     {
       "type": "module",
       "line": 2129,
-      "filename": "float_exprs.83.wasm"
+      "filename": "float_exprs.83.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -17478,7 +17562,8 @@
     {
       "type": "module",
       "line": 2143,
-      "filename": "float_exprs.84.wasm"
+      "filename": "float_exprs.84.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -17595,7 +17680,8 @@
     {
       "type": "module",
       "line": 2164,
-      "filename": "float_exprs.85.wasm"
+      "filename": "float_exprs.85.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -17792,7 +17878,8 @@
     {
       "type": "module",
       "line": 2203,
-      "filename": "float_exprs.86.wasm"
+      "filename": "float_exprs.86.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -17827,7 +17914,8 @@
     {
       "type": "module",
       "line": 2218,
-      "filename": "float_exprs.87.wasm"
+      "filename": "float_exprs.87.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -17862,7 +17950,8 @@
     {
       "type": "module",
       "line": 2272,
-      "filename": "float_exprs.88.wasm"
+      "filename": "float_exprs.88.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -18059,7 +18148,8 @@
     {
       "type": "module",
       "line": 2304,
-      "filename": "float_exprs.89.wasm"
+      "filename": "float_exprs.89.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -18772,7 +18862,8 @@
     {
       "type": "module",
       "line": 2420,
-      "filename": "float_exprs.90.wasm"
+      "filename": "float_exprs.90.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -18873,7 +18964,8 @@
     {
       "type": "module",
       "line": 2454,
-      "filename": "float_exprs.91.wasm"
+      "filename": "float_exprs.91.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -19022,7 +19114,8 @@
     {
       "type": "module",
       "line": 2475,
-      "filename": "float_exprs.92.wasm"
+      "filename": "float_exprs.92.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -19083,7 +19176,8 @@
     {
       "type": "module",
       "line": 2490,
-      "filename": "float_exprs.93.wasm"
+      "filename": "float_exprs.93.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -19144,7 +19238,8 @@
     {
       "type": "module",
       "line": 2503,
-      "filename": "float_exprs.94.wasm"
+      "filename": "float_exprs.94.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -19389,7 +19484,8 @@
     {
       "type": "module",
       "line": 2532,
-      "filename": "float_exprs.95.wasm"
+      "filename": "float_exprs.95.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -19418,7 +19514,8 @@
     {
       "type": "module",
       "line": 2542,
-      "filename": "float_exprs.96.wasm"
+      "filename": "float_exprs.96.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -19463,7 +19560,8 @@
     {
       "type": "module",
       "line": 2612,
-      "filename": "float_exprs.97.wasm"
+      "filename": "float_exprs.97.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/float_literals.wast.json
+++ b/tests/snapshots/testsuite/float_literals.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "float_literals.0.wasm"
+      "filename": "float_literals.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1479,7 +1480,8 @@
     {
       "type": "module",
       "line": 224,
-      "filename": "float_literals.1.wasm"
+      "filename": "float_literals.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1500,547 +1502,547 @@
       "type": "assert_malformed",
       "line": 236,
       "filename": "float_literals.2.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 240,
       "filename": "float_literals.3.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 244,
       "filename": "float_literals.4.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 248,
       "filename": "float_literals.5.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 252,
       "filename": "float_literals.6.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 256,
       "filename": "float_literals.7.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 260,
       "filename": "float_literals.8.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 264,
       "filename": "float_literals.9.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 268,
       "filename": "float_literals.10.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 272,
       "filename": "float_literals.11.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 276,
       "filename": "float_literals.12.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 280,
       "filename": "float_literals.13.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 284,
       "filename": "float_literals.14.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 288,
       "filename": "float_literals.15.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 292,
       "filename": "float_literals.16.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 296,
       "filename": "float_literals.17.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 300,
       "filename": "float_literals.18.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 304,
       "filename": "float_literals.19.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 308,
       "filename": "float_literals.20.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 312,
       "filename": "float_literals.21.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 316,
       "filename": "float_literals.22.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 320,
       "filename": "float_literals.23.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 324,
       "filename": "float_literals.24.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 328,
       "filename": "float_literals.25.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 332,
       "filename": "float_literals.26.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 336,
       "filename": "float_literals.27.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 340,
       "filename": "float_literals.28.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 344,
       "filename": "float_literals.29.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 348,
       "filename": "float_literals.30.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 352,
       "filename": "float_literals.31.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 356,
       "filename": "float_literals.32.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 360,
       "filename": "float_literals.33.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 364,
       "filename": "float_literals.34.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 368,
       "filename": "float_literals.35.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 372,
       "filename": "float_literals.36.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 376,
       "filename": "float_literals.37.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 380,
       "filename": "float_literals.38.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 384,
       "filename": "float_literals.39.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 388,
       "filename": "float_literals.40.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 393,
       "filename": "float_literals.41.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 397,
       "filename": "float_literals.42.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 401,
       "filename": "float_literals.43.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 405,
       "filename": "float_literals.44.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 409,
       "filename": "float_literals.45.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 413,
       "filename": "float_literals.46.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 417,
       "filename": "float_literals.47.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 421,
       "filename": "float_literals.48.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 425,
       "filename": "float_literals.49.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 429,
       "filename": "float_literals.50.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 433,
       "filename": "float_literals.51.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 437,
       "filename": "float_literals.52.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 441,
       "filename": "float_literals.53.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 445,
       "filename": "float_literals.54.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 449,
       "filename": "float_literals.55.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 453,
       "filename": "float_literals.56.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 457,
       "filename": "float_literals.57.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 461,
       "filename": "float_literals.58.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 465,
       "filename": "float_literals.59.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 469,
       "filename": "float_literals.60.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 473,
       "filename": "float_literals.61.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 477,
       "filename": "float_literals.62.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 481,
       "filename": "float_literals.63.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 485,
       "filename": "float_literals.64.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 489,
       "filename": "float_literals.65.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 493,
       "filename": "float_literals.66.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 497,
       "filename": "float_literals.67.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 501,
       "filename": "float_literals.68.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 505,
       "filename": "float_literals.69.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 509,
       "filename": "float_literals.70.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 513,
       "filename": "float_literals.71.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 517,
       "filename": "float_literals.72.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 521,
       "filename": "float_literals.73.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 525,
       "filename": "float_literals.74.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 529,
       "filename": "float_literals.75.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 533,
       "filename": "float_literals.76.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 537,
       "filename": "float_literals.77.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 541,
       "filename": "float_literals.78.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 545,
       "filename": "float_literals.79.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     }
   ]
 }

--- a/tests/snapshots/testsuite/float_memory.wast.json
+++ b/tests/snapshots/testsuite/float_memory.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 5,
-      "filename": "float_memory.0.wasm"
+      "filename": "float_memory.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -195,7 +196,8 @@
     {
       "type": "module",
       "line": 30,
-      "filename": "float_memory.1.wasm"
+      "filename": "float_memory.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -386,7 +388,8 @@
     {
       "type": "module",
       "line": 57,
-      "filename": "float_memory.2.wasm"
+      "filename": "float_memory.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -577,7 +580,8 @@
     {
       "type": "module",
       "line": 82,
-      "filename": "float_memory.3.wasm"
+      "filename": "float_memory.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -768,7 +772,8 @@
     {
       "type": "module",
       "line": 109,
-      "filename": "float_memory.4.wasm"
+      "filename": "float_memory.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -959,7 +964,8 @@
     {
       "type": "module",
       "line": 134,
-      "filename": "float_memory.5.wasm"
+      "filename": "float_memory.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/float_misc.wast.json
+++ b/tests/snapshots/testsuite/float_misc.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 17,
-      "filename": "float_misc.0.wasm"
+      "filename": "float_misc.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/forward.wast.json
+++ b/tests/snapshots/testsuite/forward.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "forward.0.wasm"
+      "filename": "forward.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/func.wast.json
+++ b/tests/snapshots/testsuite/func.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "func.0.wasm"
+      "filename": "func.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1754,26 +1755,28 @@
     {
       "type": "module",
       "line": 422,
-      "filename": "func.1.wasm"
+      "filename": "func.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 436,
       "filename": "func.2.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_malformed",
       "line": 448,
       "filename": "func.3.wat",
-      "text": "unknown type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown type"
     },
     {
       "type": "module",
       "line": 459,
-      "filename": "func.4.wasm"
+      "filename": "func.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1833,7 +1836,8 @@
     {
       "type": "module",
       "line": 488,
-      "filename": "func.5.wasm"
+      "filename": "func.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1879,491 +1883,491 @@
       "type": "assert_malformed",
       "line": 560,
       "filename": "func.6.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 567,
       "filename": "func.7.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 574,
       "filename": "func.8.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 581,
       "filename": "func.9.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 588,
       "filename": "func.10.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 595,
       "filename": "func.11.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 602,
       "filename": "func.12.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 609,
       "filename": "func.13.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 616,
       "filename": "func.14.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 623,
       "filename": "func.15.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_invalid",
       "line": 634,
       "filename": "func.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 638,
       "filename": "func.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 642,
       "filename": "func.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 650,
       "filename": "func.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 654,
       "filename": "func.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 658,
       "filename": "func.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 666,
       "filename": "func.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 670,
       "filename": "func.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 674,
       "filename": "func.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 678,
       "filename": "func.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 682,
       "filename": "func.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 687,
       "filename": "func.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 693,
       "filename": "func.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 699,
       "filename": "func.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 705,
       "filename": "func.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 711,
       "filename": "func.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 717,
       "filename": "func.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 723,
       "filename": "func.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 730,
       "filename": "func.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 736,
       "filename": "func.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 742,
       "filename": "func.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 748,
       "filename": "func.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 754,
       "filename": "func.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 760,
       "filename": "func.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 767,
       "filename": "func.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 773,
       "filename": "func.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 779,
       "filename": "func.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 785,
       "filename": "func.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 791,
       "filename": "func.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 797,
       "filename": "func.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 803,
       "filename": "func.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 809,
       "filename": "func.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 815,
       "filename": "func.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 822,
       "filename": "func.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 828,
       "filename": "func.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 834,
       "filename": "func.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 840,
       "filename": "func.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 846,
       "filename": "func.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 852,
       "filename": "func.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 858,
       "filename": "func.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 864,
       "filename": "func.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 870,
       "filename": "func.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 877,
       "filename": "func.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 883,
       "filename": "func.59.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 889,
       "filename": "func.60.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 895,
       "filename": "func.61.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 901,
       "filename": "func.62.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 907,
       "filename": "func.63.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 917,
       "filename": "func.64.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 921,
       "filename": "func.65.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 925,
       "filename": "func.66.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 929,
       "filename": "func.67.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 933,
       "filename": "func.68.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 937,
       "filename": "func.69.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 943,
       "filename": "func.70.wat",
-      "text": "duplicate func",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate func"
     },
     {
       "type": "assert_malformed",
       "line": 947,
       "filename": "func.71.wat",
-      "text": "duplicate func",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate func"
     },
     {
       "type": "assert_malformed",
       "line": 951,
       "filename": "func.72.wat",
-      "text": "duplicate func",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate func"
     },
     {
       "type": "assert_malformed",
       "line": 956,
       "filename": "func.73.wat",
-      "text": "duplicate local",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate local"
     },
     {
       "type": "assert_malformed",
       "line": 958,
       "filename": "func.74.wat",
-      "text": "duplicate local",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate local"
     },
     {
       "type": "assert_malformed",
       "line": 960,
       "filename": "func.75.wat",
-      "text": "duplicate local",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate local"
     }
   ]
 }

--- a/tests/snapshots/testsuite/func_ptrs.wast.json
+++ b/tests/snapshots/testsuite/func_ptrs.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "func_ptrs.0.wasm"
+      "filename": "func_ptrs.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -79,55 +80,56 @@
       "type": "assert_invalid",
       "line": 32,
       "filename": "func_ptrs.1.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 33,
       "filename": "func_ptrs.2.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 36,
       "filename": "func_ptrs.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 40,
       "filename": "func_ptrs.4.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 44,
       "filename": "func_ptrs.5.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 48,
       "filename": "func_ptrs.6.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 49,
       "filename": "func_ptrs.7.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "module",
       "line": 51,
-      "filename": "func_ptrs.8.wasm"
+      "filename": "func_ptrs.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -502,7 +504,8 @@
     {
       "type": "module",
       "line": 93,
-      "filename": "func_ptrs.9.wasm"
+      "filename": "func_ptrs.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/global.wast.json
+++ b/tests/snapshots/testsuite/global.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "global.0.wasm"
+      "filename": "global.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -870,350 +871,354 @@
       "type": "assert_invalid",
       "line": 273,
       "filename": "global.1.wasm",
-      "text": "global is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "global is immutable"
     },
     {
       "type": "assert_invalid",
       "line": 278,
       "filename": "global.2.wasm",
-      "text": "global is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "global is immutable"
     },
     {
       "type": "module",
       "line": 283,
-      "filename": "global.3.wasm"
+      "filename": "global.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 284,
-      "filename": "global.4.wasm"
+      "filename": "global.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 287,
       "filename": "global.5.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 292,
       "filename": "global.6.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 297,
       "filename": "global.7.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 302,
       "filename": "global.8.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 307,
       "filename": "global.9.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 312,
       "filename": "global.10.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 317,
       "filename": "global.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 322,
       "filename": "global.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 327,
       "filename": "global.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 332,
       "filename": "global.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 337,
       "filename": "global.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 342,
       "filename": "global.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 347,
       "filename": "global.17.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 352,
       "filename": "global.18.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 356,
       "filename": "global.19.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 361,
       "filename": "global.20.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 366,
       "filename": "global.21.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 371,
       "filename": "global.22.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "module",
       "line": 375,
-      "filename": "global.23.wasm"
+      "filename": "global.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 379,
       "filename": "global.24.wasm",
-      "text": "malformed mutability",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed mutability"
     },
     {
       "type": "assert_malformed",
       "line": 392,
       "filename": "global.25.wasm",
-      "text": "malformed mutability",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed mutability"
     },
     {
       "type": "module",
       "line": 405,
-      "filename": "global.26.wasm"
+      "filename": "global.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 409,
       "filename": "global.27.wasm",
-      "text": "malformed mutability",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed mutability"
     },
     {
       "type": "assert_malformed",
       "line": 421,
       "filename": "global.28.wasm",
-      "text": "malformed mutability",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed mutability"
     },
     {
       "type": "assert_invalid",
       "line": 435,
       "filename": "global.29.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 440,
       "filename": "global.30.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 448,
       "filename": "global.31.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 456,
       "filename": "global.32.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 466,
       "filename": "global.33.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 471,
       "filename": "global.34.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 479,
       "filename": "global.35.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 487,
       "filename": "global.36.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 497,
       "filename": "global.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 506,
       "filename": "global.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 516,
       "filename": "global.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 526,
       "filename": "global.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 536,
       "filename": "global.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 546,
       "filename": "global.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 556,
       "filename": "global.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 566,
       "filename": "global.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 576,
       "filename": "global.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 585,
       "filename": "global.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 594,
       "filename": "global.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 604,
       "filename": "global.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 622,
       "filename": "global.49.wat",
-      "text": "duplicate global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate global"
     },
     {
       "type": "assert_malformed",
       "line": 626,
       "filename": "global.50.wat",
-      "text": "duplicate global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate global"
     },
     {
       "type": "assert_malformed",
       "line": 630,
       "filename": "global.51.wat",
-      "text": "duplicate global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate global"
     }
   ]
 }

--- a/tests/snapshots/testsuite/i32.wast.json
+++ b/tests/snapshots/testsuite/i32.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "i32.0.wasm"
+      "filename": "i32.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -8772,596 +8773,596 @@
       "type": "assert_invalid",
       "line": 444,
       "filename": "i32.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 452,
       "filename": "i32.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 461,
       "filename": "i32.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 470,
       "filename": "i32.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 479,
       "filename": "i32.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 488,
       "filename": "i32.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 497,
       "filename": "i32.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 506,
       "filename": "i32.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 515,
       "filename": "i32.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 523,
       "filename": "i32.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 531,
       "filename": "i32.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 540,
       "filename": "i32.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 556,
       "filename": "i32.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 565,
       "filename": "i32.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 574,
       "filename": "i32.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 583,
       "filename": "i32.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 592,
       "filename": "i32.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 601,
       "filename": "i32.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 611,
       "filename": "i32.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 619,
       "filename": "i32.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 627,
       "filename": "i32.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 636,
       "filename": "i32.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 645,
       "filename": "i32.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 654,
       "filename": "i32.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 663,
       "filename": "i32.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 672,
       "filename": "i32.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 681,
       "filename": "i32.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 691,
       "filename": "i32.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 701,
       "filename": "i32.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 710,
       "filename": "i32.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 719,
       "filename": "i32.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 728,
       "filename": "i32.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 737,
       "filename": "i32.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 746,
       "filename": "i32.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 755,
       "filename": "i32.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 763,
       "filename": "i32.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 771,
       "filename": "i32.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 779,
       "filename": "i32.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 787,
       "filename": "i32.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 796,
       "filename": "i32.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 805,
       "filename": "i32.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 821,
       "filename": "i32.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 837,
       "filename": "i32.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 846,
       "filename": "i32.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 855,
       "filename": "i32.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 864,
       "filename": "i32.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 873,
       "filename": "i32.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 882,
       "filename": "i32.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 891,
       "filename": "i32.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 900,
       "filename": "i32.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 909,
       "filename": "i32.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 918,
       "filename": "i32.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 927,
       "filename": "i32.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 936,
       "filename": "i32.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 948,
       "filename": "i32.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 949,
       "filename": "i32.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 950,
       "filename": "i32.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 951,
       "filename": "i32.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 952,
       "filename": "i32.59.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 953,
       "filename": "i32.60.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 954,
       "filename": "i32.61.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 955,
       "filename": "i32.62.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 956,
       "filename": "i32.63.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 957,
       "filename": "i32.64.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 958,
       "filename": "i32.65.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 959,
       "filename": "i32.66.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 960,
       "filename": "i32.67.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 961,
       "filename": "i32.68.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 962,
       "filename": "i32.69.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 963,
       "filename": "i32.70.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 964,
       "filename": "i32.71.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 965,
       "filename": "i32.72.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 966,
       "filename": "i32.73.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 967,
       "filename": "i32.74.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 968,
       "filename": "i32.75.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 969,
       "filename": "i32.76.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 970,
       "filename": "i32.77.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 971,
       "filename": "i32.78.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 972,
       "filename": "i32.79.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 973,
       "filename": "i32.80.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 974,
       "filename": "i32.81.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 975,
       "filename": "i32.82.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 976,
       "filename": "i32.83.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 979,
       "filename": "i32.84.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 983,
       "filename": "i32.85.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     }
   ]
 }

--- a/tests/snapshots/testsuite/i64.wast.json
+++ b/tests/snapshots/testsuite/i64.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "i64.0.wasm"
+      "filename": "i64.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -8972,218 +8973,218 @@
       "type": "assert_invalid",
       "line": 457,
       "filename": "i64.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 458,
       "filename": "i64.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 459,
       "filename": "i64.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 460,
       "filename": "i64.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 461,
       "filename": "i64.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 462,
       "filename": "i64.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 463,
       "filename": "i64.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 464,
       "filename": "i64.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 465,
       "filename": "i64.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 466,
       "filename": "i64.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 467,
       "filename": "i64.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 468,
       "filename": "i64.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 469,
       "filename": "i64.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 470,
       "filename": "i64.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 471,
       "filename": "i64.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 472,
       "filename": "i64.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 473,
       "filename": "i64.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 474,
       "filename": "i64.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 475,
       "filename": "i64.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 476,
       "filename": "i64.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 477,
       "filename": "i64.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 478,
       "filename": "i64.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 479,
       "filename": "i64.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 480,
       "filename": "i64.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 481,
       "filename": "i64.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 482,
       "filename": "i64.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 483,
       "filename": "i64.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 484,
       "filename": "i64.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 485,
       "filename": "i64.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 488,
       "filename": "i64.30.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 492,
       "filename": "i64.31.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     }
   ]
 }

--- a/tests/snapshots/testsuite/if.wast.json
+++ b/tests/snapshots/testsuite/if.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "if.0.wasm"
+      "filename": "if.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2626,813 +2627,813 @@
       "type": "assert_malformed",
       "line": 736,
       "filename": "if.1.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 745,
       "filename": "if.2.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 754,
       "filename": "if.3.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 763,
       "filename": "if.4.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 772,
       "filename": "if.5.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 781,
       "filename": "if.6.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 788,
       "filename": "if.7.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 796,
       "filename": "if.8.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 806,
       "filename": "if.9.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 816,
       "filename": "if.10.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 826,
       "filename": "if.11.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_invalid",
       "line": 836,
       "filename": "if.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 844,
       "filename": "if.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 848,
       "filename": "if.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 852,
       "filename": "if.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 856,
       "filename": "if.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 861,
       "filename": "if.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 865,
       "filename": "if.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 869,
       "filename": "if.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 873,
       "filename": "if.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 878,
       "filename": "if.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 884,
       "filename": "if.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 890,
       "filename": "if.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 896,
       "filename": "if.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 903,
       "filename": "if.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 909,
       "filename": "if.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 915,
       "filename": "if.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 921,
       "filename": "if.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 928,
       "filename": "if.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 934,
       "filename": "if.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 940,
       "filename": "if.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 947,
       "filename": "if.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 953,
       "filename": "if.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 959,
       "filename": "if.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 966,
       "filename": "if.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 972,
       "filename": "if.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 979,
       "filename": "if.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 985,
       "filename": "if.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 991,
       "filename": "if.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 998,
       "filename": "if.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1004,
       "filename": "if.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1010,
       "filename": "if.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1017,
       "filename": "if.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1023,
       "filename": "if.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1029,
       "filename": "if.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1036,
       "filename": "if.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1042,
       "filename": "if.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1048,
       "filename": "if.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1055,
       "filename": "if.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1062,
       "filename": "if.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1069,
       "filename": "if.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1077,
       "filename": "if.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1083,
       "filename": "if.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1089,
       "filename": "if.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1096,
       "filename": "if.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1102,
       "filename": "if.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1109,
       "filename": "if.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1119,
       "filename": "if.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1129,
       "filename": "if.59.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1140,
       "filename": "if.60.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1146,
       "filename": "if.61.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1152,
       "filename": "if.62.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1158,
       "filename": "if.63.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1165,
       "filename": "if.64.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1174,
       "filename": "if.65.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1183,
       "filename": "if.66.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1192,
       "filename": "if.67.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1202,
       "filename": "if.68.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1211,
       "filename": "if.69.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1220,
       "filename": "if.70.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1229,
       "filename": "if.71.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1239,
       "filename": "if.72.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1248,
       "filename": "if.73.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1257,
       "filename": "if.74.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1266,
       "filename": "if.75.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1275,
       "filename": "if.76.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1285,
       "filename": "if.77.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1296,
       "filename": "if.78.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1304,
       "filename": "if.79.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1313,
       "filename": "if.80.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1322,
       "filename": "if.81.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1331,
       "filename": "if.82.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1341,
       "filename": "if.83.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1350,
       "filename": "if.84.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1359,
       "filename": "if.85.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1368,
       "filename": "if.86.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1376,
       "filename": "if.87.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1384,
       "filename": "if.88.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1393,
       "filename": "if.89.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1409,
       "filename": "if.90.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1418,
       "filename": "if.91.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1427,
       "filename": "if.92.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1436,
       "filename": "if.93.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1445,
       "filename": "if.94.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1454,
       "filename": "if.95.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1464,
       "filename": "if.96.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1470,
       "filename": "if.97.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1476,
       "filename": "if.98.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1482,
       "filename": "if.99.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1488,
       "filename": "if.100.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1494,
       "filename": "if.101.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1500,
       "filename": "if.102.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1506,
       "filename": "if.103.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1513,
       "filename": "if.104.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1517,
       "filename": "if.105.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1522,
       "filename": "if.106.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1526,
       "filename": "if.107.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1530,
       "filename": "if.108.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1534,
       "filename": "if.109.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1538,
       "filename": "if.110.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1542,
       "filename": "if.111.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1546,
       "filename": "if.112.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1550,
       "filename": "if.113.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1554,
       "filename": "if.114.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1558,
       "filename": "if.115.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1562,
       "filename": "if.116.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     }
   ]
 }

--- a/tests/snapshots/testsuite/imports.wast.json
+++ b/tests/snapshots/testsuite/imports.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "imports.0.wasm"
+      "filename": "imports.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -14,7 +15,8 @@
     {
       "type": "module",
       "line": 26,
-      "filename": "imports.1.wasm"
+      "filename": "imports.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -50,13 +52,14 @@
       "type": "assert_invalid",
       "line": 89,
       "filename": "imports.2.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "module",
       "line": 97,
-      "filename": "imports.3.wasm"
+      "filename": "imports.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -76,7 +79,8 @@
     {
       "type": "module",
       "line": 107,
-      "filename": "imports.4.wasm"
+      "filename": "imports.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -105,210 +109,218 @@
     {
       "type": "module",
       "line": 116,
-      "filename": "imports.5.wasm"
+      "filename": "imports.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 117,
-      "filename": "imports.6.wasm"
+      "filename": "imports.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 118,
-      "filename": "imports.7.wasm"
+      "filename": "imports.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 119,
-      "filename": "imports.8.wasm"
+      "filename": "imports.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 120,
-      "filename": "imports.9.wasm"
+      "filename": "imports.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 121,
-      "filename": "imports.10.wasm"
+      "filename": "imports.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 122,
-      "filename": "imports.11.wasm"
+      "filename": "imports.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 125,
       "filename": "imports.12.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 129,
       "filename": "imports.13.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 134,
       "filename": "imports.14.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 138,
       "filename": "imports.15.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 142,
       "filename": "imports.16.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 146,
       "filename": "imports.17.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 150,
       "filename": "imports.18.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 154,
       "filename": "imports.19.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 158,
       "filename": "imports.20.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 162,
       "filename": "imports.21.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 166,
       "filename": "imports.22.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 170,
       "filename": "imports.23.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 174,
       "filename": "imports.24.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 178,
       "filename": "imports.25.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 182,
       "filename": "imports.26.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 186,
       "filename": "imports.27.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 190,
       "filename": "imports.28.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 194,
       "filename": "imports.29.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 199,
       "filename": "imports.30.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 203,
       "filename": "imports.31.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 207,
       "filename": "imports.32.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 211,
       "filename": "imports.33.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 215,
       "filename": "imports.34.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 219,
       "filename": "imports.35.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 226,
-      "filename": "imports.36.wasm"
+      "filename": "imports.36.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -418,162 +430,166 @@
     {
       "type": "module",
       "line": 254,
-      "filename": "imports.37.wasm"
+      "filename": "imports.37.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 255,
-      "filename": "imports.38.wasm"
+      "filename": "imports.38.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 256,
-      "filename": "imports.39.wasm"
+      "filename": "imports.39.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 259,
       "filename": "imports.40.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 263,
       "filename": "imports.41.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 268,
       "filename": "imports.42.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 272,
       "filename": "imports.43.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 276,
       "filename": "imports.44.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 280,
       "filename": "imports.45.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 284,
       "filename": "imports.46.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 288,
       "filename": "imports.47.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 292,
       "filename": "imports.48.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 296,
       "filename": "imports.49.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 300,
       "filename": "imports.50.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 304,
       "filename": "imports.51.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 308,
       "filename": "imports.52.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 312,
       "filename": "imports.53.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 317,
       "filename": "imports.54.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 321,
       "filename": "imports.55.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 325,
       "filename": "imports.56.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 329,
       "filename": "imports.57.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 333,
       "filename": "imports.58.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 337,
       "filename": "imports.59.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 344,
-      "filename": "imports.60.wasm"
+      "filename": "imports.60.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -663,7 +679,8 @@
     {
       "type": "module",
       "line": 363,
-      "filename": "imports.61.wasm"
+      "filename": "imports.61.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -753,196 +770,218 @@
     {
       "type": "module",
       "line": 381,
-      "filename": "imports.62.wasm"
+      "filename": "imports.62.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 388,
-      "filename": "imports.63.wasm"
+      "filename": "imports.63.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 389,
-      "filename": "imports.64.wasm"
+      "filename": "imports.64.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 390,
-      "filename": "imports.65.wasm"
+      "filename": "imports.65.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 391,
-      "filename": "imports.66.wasm"
+      "filename": "imports.66.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 392,
-      "filename": "imports.67.wasm"
+      "filename": "imports.67.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 393,
-      "filename": "imports.68.wasm"
+      "filename": "imports.68.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 394,
-      "filename": "imports.69.wasm"
+      "filename": "imports.69.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 395,
-      "filename": "imports.70.wasm"
+      "filename": "imports.70.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 396,
-      "filename": "imports.71.wasm"
+      "filename": "imports.71.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 397,
-      "filename": "imports.72.wasm"
+      "filename": "imports.72.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 398,
-      "filename": "imports.73.wasm"
+      "filename": "imports.73.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 399,
-      "filename": "imports.74.wasm"
+      "filename": "imports.74.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 400,
-      "filename": "imports.75.wasm"
+      "filename": "imports.75.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 401,
-      "filename": "imports.76.wasm"
+      "filename": "imports.76.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 402,
-      "filename": "imports.77.wasm"
+      "filename": "imports.77.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 403,
-      "filename": "imports.78.wasm"
+      "filename": "imports.78.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 404,
-      "filename": "imports.79.wasm"
+      "filename": "imports.79.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 405,
-      "filename": "imports.80.wasm"
+      "filename": "imports.80.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 406,
-      "filename": "imports.81.wasm"
+      "filename": "imports.81.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 407,
-      "filename": "imports.82.wasm"
+      "filename": "imports.82.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 410,
       "filename": "imports.83.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 414,
       "filename": "imports.84.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 419,
       "filename": "imports.85.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 423,
       "filename": "imports.86.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 427,
       "filename": "imports.87.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 431,
       "filename": "imports.88.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 435,
       "filename": "imports.89.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 439,
       "filename": "imports.90.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 444,
       "filename": "imports.91.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 448,
       "filename": "imports.92.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 452,
       "filename": "imports.93.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 456,
       "filename": "imports.94.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 464,
-      "filename": "imports.95.wasm"
+      "filename": "imports.95.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1022,7 +1061,8 @@
     {
       "type": "module",
       "line": 476,
-      "filename": "imports.96.wasm"
+      "filename": "imports.96.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1103,170 +1143,180 @@
       "type": "assert_invalid",
       "line": 488,
       "filename": "imports.97.wasm",
-      "text": "multiple memories",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "multiple memories"
     },
     {
       "type": "assert_invalid",
       "line": 492,
       "filename": "imports.98.wasm",
-      "text": "multiple memories",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "multiple memories"
     },
     {
       "type": "assert_invalid",
       "line": 496,
       "filename": "imports.99.wasm",
-      "text": "multiple memories",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "multiple memories"
     },
     {
       "type": "module",
       "line": 500,
-      "filename": "imports.100.wasm"
+      "filename": "imports.100.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 501,
-      "filename": "imports.101.wasm"
+      "filename": "imports.101.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 502,
-      "filename": "imports.102.wasm"
+      "filename": "imports.102.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 503,
-      "filename": "imports.103.wasm"
+      "filename": "imports.103.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 504,
-      "filename": "imports.104.wasm"
+      "filename": "imports.104.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 505,
-      "filename": "imports.105.wasm"
+      "filename": "imports.105.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 506,
-      "filename": "imports.106.wasm"
+      "filename": "imports.106.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 507,
-      "filename": "imports.107.wasm"
+      "filename": "imports.107.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 508,
-      "filename": "imports.108.wasm"
+      "filename": "imports.108.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 511,
       "filename": "imports.109.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 515,
       "filename": "imports.110.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 520,
       "filename": "imports.111.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 524,
       "filename": "imports.112.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 528,
       "filename": "imports.113.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 532,
       "filename": "imports.114.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 537,
       "filename": "imports.115.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 541,
       "filename": "imports.116.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 545,
       "filename": "imports.117.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 549,
       "filename": "imports.118.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 553,
       "filename": "imports.119.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 557,
       "filename": "imports.120.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 562,
       "filename": "imports.121.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 566,
       "filename": "imports.122.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 570,
-      "filename": "imports.123.wasm"
+      "filename": "imports.123.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1372,118 +1422,119 @@
       "type": "assert_malformed",
       "line": 584,
       "filename": "imports.124.wat",
-      "text": "import after function",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after function"
     },
     {
       "type": "assert_malformed",
       "line": 588,
       "filename": "imports.125.wat",
-      "text": "import after function",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after function"
     },
     {
       "type": "assert_malformed",
       "line": 592,
       "filename": "imports.126.wat",
-      "text": "import after function",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after function"
     },
     {
       "type": "assert_malformed",
       "line": 596,
       "filename": "imports.127.wat",
-      "text": "import after function",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after function"
     },
     {
       "type": "assert_malformed",
       "line": 601,
       "filename": "imports.128.wat",
-      "text": "import after global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after global"
     },
     {
       "type": "assert_malformed",
       "line": 605,
       "filename": "imports.129.wat",
-      "text": "import after global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after global"
     },
     {
       "type": "assert_malformed",
       "line": 609,
       "filename": "imports.130.wat",
-      "text": "import after global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after global"
     },
     {
       "type": "assert_malformed",
       "line": 613,
       "filename": "imports.131.wat",
-      "text": "import after global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after global"
     },
     {
       "type": "assert_malformed",
       "line": 618,
       "filename": "imports.132.wat",
-      "text": "import after table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after table"
     },
     {
       "type": "assert_malformed",
       "line": 622,
       "filename": "imports.133.wat",
-      "text": "import after table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after table"
     },
     {
       "type": "assert_malformed",
       "line": 626,
       "filename": "imports.134.wat",
-      "text": "import after table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after table"
     },
     {
       "type": "assert_malformed",
       "line": 630,
       "filename": "imports.135.wat",
-      "text": "import after table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after table"
     },
     {
       "type": "assert_malformed",
       "line": 635,
       "filename": "imports.136.wat",
-      "text": "import after memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after memory"
     },
     {
       "type": "assert_malformed",
       "line": 639,
       "filename": "imports.137.wat",
-      "text": "import after memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after memory"
     },
     {
       "type": "assert_malformed",
       "line": 643,
       "filename": "imports.138.wat",
-      "text": "import after memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after memory"
     },
     {
       "type": "assert_malformed",
       "line": 647,
       "filename": "imports.139.wat",
-      "text": "import after memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after memory"
     },
     {
       "type": "module",
       "line": 654,
-      "filename": "imports.140.wasm"
+      "filename": "imports.140.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1494,8 +1545,8 @@
       "type": "assert_unlinkable",
       "line": 657,
       "filename": "imports.141.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     }
   ]
 }

--- a/tests/snapshots/testsuite/inline-module.wast.json
+++ b/tests/snapshots/testsuite/inline-module.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "inline-module.0.wasm"
+      "filename": "inline-module.0.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/int_exprs.wast.json
+++ b/tests/snapshots/testsuite/int_exprs.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 6,
-      "filename": "int_exprs.0.wasm"
+      "filename": "int_exprs.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -105,7 +106,8 @@
     {
       "type": "module",
       "line": 25,
-      "filename": "int_exprs.1.wasm"
+      "filename": "int_exprs.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -150,7 +152,8 @@
     {
       "type": "module",
       "line": 35,
-      "filename": "int_exprs.2.wasm"
+      "filename": "int_exprs.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -175,7 +178,8 @@
     {
       "type": "module",
       "line": 44,
-      "filename": "int_exprs.3.wasm"
+      "filename": "int_exprs.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -260,7 +264,8 @@
     {
       "type": "module",
       "line": 63,
-      "filename": "int_exprs.4.wasm"
+      "filename": "int_exprs.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -345,7 +350,8 @@
     {
       "type": "module",
       "line": 82,
-      "filename": "int_exprs.5.wasm"
+      "filename": "int_exprs.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -430,7 +436,8 @@
     {
       "type": "module",
       "line": 101,
-      "filename": "int_exprs.6.wasm"
+      "filename": "int_exprs.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -495,7 +502,8 @@
     {
       "type": "module",
       "line": 120,
-      "filename": "int_exprs.7.wasm"
+      "filename": "int_exprs.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -560,7 +568,8 @@
     {
       "type": "module",
       "line": 139,
-      "filename": "int_exprs.8.wasm"
+      "filename": "int_exprs.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -645,7 +654,8 @@
     {
       "type": "module",
       "line": 158,
-      "filename": "int_exprs.9.wasm"
+      "filename": "int_exprs.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -690,7 +700,8 @@
     {
       "type": "module",
       "line": 171,
-      "filename": "int_exprs.10.wasm"
+      "filename": "int_exprs.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -735,7 +746,8 @@
     {
       "type": "module",
       "line": 184,
-      "filename": "int_exprs.11.wasm"
+      "filename": "int_exprs.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -800,7 +812,8 @@
     {
       "type": "module",
       "line": 203,
-      "filename": "int_exprs.12.wasm"
+      "filename": "int_exprs.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -965,7 +978,8 @@
     {
       "type": "module",
       "line": 226,
-      "filename": "int_exprs.13.wasm"
+      "filename": "int_exprs.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1130,7 +1144,8 @@
     {
       "type": "module",
       "line": 249,
-      "filename": "int_exprs.14.wasm"
+      "filename": "int_exprs.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1295,7 +1310,8 @@
     {
       "type": "module",
       "line": 272,
-      "filename": "int_exprs.15.wasm"
+      "filename": "int_exprs.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1460,7 +1476,8 @@
     {
       "type": "module",
       "line": 295,
-      "filename": "int_exprs.16.wasm"
+      "filename": "int_exprs.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1625,7 +1642,8 @@
     {
       "type": "module",
       "line": 318,
-      "filename": "int_exprs.17.wasm"
+      "filename": "int_exprs.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1790,7 +1808,8 @@
     {
       "type": "module",
       "line": 341,
-      "filename": "int_exprs.18.wasm"
+      "filename": "int_exprs.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",

--- a/tests/snapshots/testsuite/int_literals.wast.json
+++ b/tests/snapshots/testsuite/int_literals.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "int_literals.0.wasm"
+      "filename": "int_literals.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -460,141 +461,141 @@
       "type": "assert_malformed",
       "line": 72,
       "filename": "int_literals.1.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 76,
       "filename": "int_literals.2.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 80,
       "filename": "int_literals.3.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 84,
       "filename": "int_literals.4.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 88,
       "filename": "int_literals.5.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 92,
       "filename": "int_literals.6.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 96,
       "filename": "int_literals.7.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 100,
       "filename": "int_literals.8.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 104,
       "filename": "int_literals.9.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 108,
       "filename": "int_literals.10.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 113,
       "filename": "int_literals.11.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 117,
       "filename": "int_literals.12.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 121,
       "filename": "int_literals.13.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 125,
       "filename": "int_literals.14.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 129,
       "filename": "int_literals.15.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 133,
       "filename": "int_literals.16.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 137,
       "filename": "int_literals.17.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 141,
       "filename": "int_literals.18.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 145,
       "filename": "int_literals.19.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 149,
       "filename": "int_literals.20.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     }
   ]
 }

--- a/tests/snapshots/testsuite/labels.wast.json
+++ b/tests/snapshots/testsuite/labels.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "labels.0.wasm"
+      "filename": "labels.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -435,22 +436,22 @@
       "type": "assert_invalid",
       "line": 318,
       "filename": "labels.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 322,
       "filename": "labels.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 326,
       "filename": "labels.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/left-to-right.wast.json
+++ b/tests/snapshots/testsuite/left-to-right.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "left-to-right.0.wasm"
+      "filename": "left-to-right.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/linking.wast.json
+++ b/tests/snapshots/testsuite/linking.wast.json
@@ -5,7 +5,8 @@
       "type": "module",
       "line": 3,
       "name": "Mf",
-      "filename": "linking.0.wasm"
+      "filename": "linking.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -17,7 +18,8 @@
       "type": "module",
       "line": 9,
       "name": "Nf",
-      "filename": "linking.1.wasm"
+      "filename": "linking.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -86,7 +88,8 @@
     {
       "type": "module",
       "line": 22,
-      "filename": "linking.2.wasm"
+      "filename": "linking.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -97,21 +100,22 @@
       "type": "assert_unlinkable",
       "line": 28,
       "filename": "linking.3.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 32,
       "filename": "linking.4.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 39,
       "name": "Mg",
-      "filename": "linking.5.wasm"
+      "filename": "linking.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -123,7 +127,8 @@
       "type": "module",
       "line": 50,
       "name": "Ng",
-      "filename": "linking.6.wasm"
+      "filename": "linking.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -362,21 +367,22 @@
       "type": "assert_unlinkable",
       "line": 87,
       "filename": "linking.7.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 91,
       "filename": "linking.8.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 96,
       "name": "Mref_ex",
-      "filename": "linking.9.wasm"
+      "filename": "linking.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -388,41 +394,43 @@
       "type": "module",
       "line": 104,
       "name": "Mref_im",
-      "filename": "linking.10.wasm"
+      "filename": "linking.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 113,
       "filename": "linking.11.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 117,
       "filename": "linking.12.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 123,
       "filename": "linking.13.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 127,
       "filename": "linking.14.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 134,
       "name": "Mt",
-      "filename": "linking.15.wasm"
+      "filename": "linking.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -434,7 +442,8 @@
       "type": "module",
       "line": 149,
       "name": "Nt",
-      "filename": "linking.16.wasm"
+      "filename": "linking.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -763,7 +772,8 @@
       "type": "module",
       "line": 191,
       "name": "Ot",
-      "filename": "linking.17.wasm"
+      "filename": "linking.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1163,13 +1173,15 @@
     {
       "type": "module",
       "line": 229,
-      "filename": "linking.18.wasm"
+      "filename": "linking.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 235,
       "name": "G1",
-      "filename": "linking.19.wasm"
+      "filename": "linking.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1181,7 +1193,8 @@
       "type": "module",
       "line": 237,
       "name": "G2",
-      "filename": "linking.20.wasm"
+      "filename": "linking.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1202,15 +1215,15 @@
       "type": "assert_uninstantiable",
       "line": 244,
       "filename": "linking.21.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_unlinkable",
       "line": 253,
       "filename": "linking.22.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_trap",
@@ -1232,8 +1245,8 @@
       "type": "assert_uninstantiable",
       "line": 267,
       "filename": "linking.23.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_return",
@@ -1276,8 +1289,8 @@
       "type": "assert_uninstantiable",
       "line": 279,
       "filename": "linking.24.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_return",
@@ -1304,7 +1317,8 @@
       "type": "module",
       "line": 291,
       "name": "Mtable_ex",
-      "filename": "linking.25.wasm"
+      "filename": "linking.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1315,27 +1329,29 @@
     {
       "type": "module",
       "line": 297,
-      "filename": "linking.26.wasm"
+      "filename": "linking.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 303,
       "filename": "linking.27.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 307,
       "filename": "linking.28.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 314,
       "name": "Mm",
-      "filename": "linking.29.wasm"
+      "filename": "linking.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1347,7 +1363,8 @@
       "type": "module",
       "line": 324,
       "name": "Nm",
-      "filename": "linking.30.wasm"
+      "filename": "linking.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1416,7 +1433,8 @@
       "type": "module",
       "line": 340,
       "name": "Om",
-      "filename": "linking.31.wasm"
+      "filename": "linking.31.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1505,20 +1523,22 @@
     {
       "type": "module",
       "line": 354,
-      "filename": "linking.32.wasm"
+      "filename": "linking.32.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_uninstantiable",
       "line": 360,
       "filename": "linking.33.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "module",
       "line": 367,
       "name": "Pm",
-      "filename": "linking.34.wasm"
+      "filename": "linking.34.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1692,8 +1712,8 @@
       "type": "assert_unlinkable",
       "line": 385,
       "filename": "linking.35.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_return",
@@ -1720,8 +1740,8 @@
       "type": "assert_uninstantiable",
       "line": 398,
       "filename": "linking.36.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_return",
@@ -1769,8 +1789,8 @@
       "type": "assert_uninstantiable",
       "line": 410,
       "filename": "linking.37.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_return",
@@ -1797,7 +1817,8 @@
       "type": "module",
       "line": 422,
       "name": "Ms",
-      "filename": "linking.38.wasm"
+      "filename": "linking.38.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1809,8 +1830,8 @@
       "type": "assert_uninstantiable",
       "line": 436,
       "filename": "linking.39.wasm",
-      "text": "unreachable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unreachable"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/load.wast.json
+++ b/tests/snapshots/testsuite/load.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "load.0.wasm"
+      "filename": "load.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -543,414 +544,414 @@
       "type": "assert_malformed",
       "line": 214,
       "filename": "load.1.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 221,
       "filename": "load.2.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 228,
       "filename": "load.3.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 235,
       "filename": "load.4.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 242,
       "filename": "load.5.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 249,
       "filename": "load.6.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 257,
       "filename": "load.7.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 264,
       "filename": "load.8.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 271,
       "filename": "load.9.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 279,
       "filename": "load.10.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 286,
       "filename": "load.11.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 294,
       "filename": "load.12.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 301,
       "filename": "load.13.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_invalid",
       "line": 312,
       "filename": "load.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 316,
       "filename": "load.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 320,
       "filename": "load.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 324,
       "filename": "load.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 328,
       "filename": "load.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 332,
       "filename": "load.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 336,
       "filename": "load.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 340,
       "filename": "load.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 344,
       "filename": "load.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 348,
       "filename": "load.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 352,
       "filename": "load.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 356,
       "filename": "load.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 360,
       "filename": "load.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 364,
       "filename": "load.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 371,
       "filename": "load.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 372,
       "filename": "load.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 373,
       "filename": "load.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 374,
       "filename": "load.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 375,
       "filename": "load.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 376,
       "filename": "load.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 377,
       "filename": "load.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 378,
       "filename": "load.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 379,
       "filename": "load.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 380,
       "filename": "load.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 381,
       "filename": "load.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 382,
       "filename": "load.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 383,
       "filename": "load.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 384,
       "filename": "load.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 388,
       "filename": "load.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 397,
       "filename": "load.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 407,
       "filename": "load.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 417,
       "filename": "load.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 427,
       "filename": "load.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 437,
       "filename": "load.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 447,
       "filename": "load.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 457,
       "filename": "load.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 467,
       "filename": "load.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 476,
       "filename": "load.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 485,
       "filename": "load.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 495,
       "filename": "load.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 512,
       "filename": "load.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 522,
       "filename": "load.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 532,
       "filename": "load.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 542,
       "filename": "load.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 551,
       "filename": "load.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 560,
       "filename": "load.59.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/local_get.wast.json
+++ b/tests/snapshots/testsuite/local_get.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "local_get.0.wasm"
+      "filename": "local_get.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -397,113 +398,113 @@
       "type": "assert_invalid",
       "line": 149,
       "filename": "local_get.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 153,
       "filename": "local_get.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 157,
       "filename": "local_get.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 165,
       "filename": "local_get.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 169,
       "filename": "local_get.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 173,
       "filename": "local_get.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 181,
       "filename": "local_get.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 185,
       "filename": "local_get.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 189,
       "filename": "local_get.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 193,
       "filename": "local_get.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 201,
       "filename": "local_get.11.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 205,
       "filename": "local_get.12.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 210,
       "filename": "local_get.13.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 214,
       "filename": "local_get.14.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 219,
       "filename": "local_get.15.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 223,
       "filename": "local_get.16.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     }
   ]
 }

--- a/tests/snapshots/testsuite/local_set.wast.json
+++ b/tests/snapshots/testsuite/local_set.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "local_set.0.wasm"
+      "filename": "local_set.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -312,232 +313,232 @@
       "type": "assert_invalid",
       "line": 148,
       "filename": "local_set.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 152,
       "filename": "local_set.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 156,
       "filename": "local_set.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 160,
       "filename": "local_set.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 169,
       "filename": "local_set.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 173,
       "filename": "local_set.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 177,
       "filename": "local_set.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 181,
       "filename": "local_set.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 186,
       "filename": "local_set.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 194,
       "filename": "local_set.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 203,
       "filename": "local_set.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 212,
       "filename": "local_set.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 221,
       "filename": "local_set.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 230,
       "filename": "local_set.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 239,
       "filename": "local_set.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 248,
       "filename": "local_set.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 257,
       "filename": "local_set.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 265,
       "filename": "local_set.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 273,
       "filename": "local_set.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 282,
       "filename": "local_set.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 301,
       "filename": "local_set.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 305,
       "filename": "local_set.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 309,
       "filename": "local_set.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 317,
       "filename": "local_set.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 321,
       "filename": "local_set.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 325,
       "filename": "local_set.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 329,
       "filename": "local_set.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 337,
       "filename": "local_set.28.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 341,
       "filename": "local_set.29.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 346,
       "filename": "local_set.30.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 350,
       "filename": "local_set.31.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 355,
       "filename": "local_set.32.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 359,
       "filename": "local_set.33.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     }
   ]
 }

--- a/tests/snapshots/testsuite/local_tee.wast.json
+++ b/tests/snapshots/testsuite/local_tee.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "local_tee.0.wasm"
+      "filename": "local_tee.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1091,288 +1092,288 @@
       "type": "assert_invalid",
       "line": 371,
       "filename": "local_tee.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 375,
       "filename": "local_tee.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 379,
       "filename": "local_tee.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 384,
       "filename": "local_tee.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 388,
       "filename": "local_tee.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 392,
       "filename": "local_tee.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 396,
       "filename": "local_tee.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 404,
       "filename": "local_tee.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 408,
       "filename": "local_tee.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 412,
       "filename": "local_tee.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 417,
       "filename": "local_tee.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 421,
       "filename": "local_tee.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 425,
       "filename": "local_tee.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 429,
       "filename": "local_tee.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 434,
       "filename": "local_tee.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 442,
       "filename": "local_tee.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 451,
       "filename": "local_tee.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 460,
       "filename": "local_tee.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 469,
       "filename": "local_tee.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 478,
       "filename": "local_tee.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 487,
       "filename": "local_tee.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 496,
       "filename": "local_tee.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 505,
       "filename": "local_tee.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 513,
       "filename": "local_tee.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 521,
       "filename": "local_tee.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 530,
       "filename": "local_tee.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 546,
       "filename": "local_tee.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 554,
       "filename": "local_tee.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 562,
       "filename": "local_tee.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 571,
       "filename": "local_tee.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 580,
       "filename": "local_tee.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 589,
       "filename": "local_tee.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 599,
       "filename": "local_tee.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 603,
       "filename": "local_tee.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 607,
       "filename": "local_tee.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 615,
       "filename": "local_tee.36.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 619,
       "filename": "local_tee.37.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 624,
       "filename": "local_tee.38.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 628,
       "filename": "local_tee.39.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 633,
       "filename": "local_tee.40.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 637,
       "filename": "local_tee.41.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     }
   ]
 }

--- a/tests/snapshots/testsuite/loop.wast.json
+++ b/tests/snapshots/testsuite/loop.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "loop.0.wasm"
+      "filename": "loop.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1347,295 +1348,295 @@
       "type": "assert_malformed",
       "line": 526,
       "filename": "loop.1.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 533,
       "filename": "loop.2.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 540,
       "filename": "loop.3.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 547,
       "filename": "loop.4.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 554,
       "filename": "loop.5.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 561,
       "filename": "loop.6.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 568,
       "filename": "loop.7.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 572,
       "filename": "loop.8.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 579,
       "filename": "loop.9.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 586,
       "filename": "loop.10.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 593,
       "filename": "loop.11.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_invalid",
       "line": 601,
       "filename": "loop.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 609,
       "filename": "loop.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 613,
       "filename": "loop.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 617,
       "filename": "loop.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 621,
       "filename": "loop.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 626,
       "filename": "loop.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 632,
       "filename": "loop.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 638,
       "filename": "loop.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 644,
       "filename": "loop.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 650,
       "filename": "loop.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 656,
       "filename": "loop.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 662,
       "filename": "loop.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 668,
       "filename": "loop.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 674,
       "filename": "loop.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 680,
       "filename": "loop.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 686,
       "filename": "loop.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 693,
       "filename": "loop.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 702,
       "filename": "loop.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 711,
       "filename": "loop.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 721,
       "filename": "loop.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 727,
       "filename": "loop.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 733,
       "filename": "loop.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 739,
       "filename": "loop.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 745,
       "filename": "loop.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 751,
       "filename": "loop.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 757,
       "filename": "loop.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 763,
       "filename": "loop.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 770,
       "filename": "loop.39.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 774,
       "filename": "loop.40.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 779,
       "filename": "loop.41.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 783,
       "filename": "loop.42.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     }
   ]
 }

--- a/tests/snapshots/testsuite/memory.wast.json
+++ b/tests/snapshots/testsuite/memory.wast.json
@@ -4,51 +4,58 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "memory.0.wasm"
+      "filename": "memory.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 4,
-      "filename": "memory.1.wasm"
+      "filename": "memory.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 5,
-      "filename": "memory.2.wasm"
+      "filename": "memory.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 6,
-      "filename": "memory.3.wasm"
+      "filename": "memory.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 7,
-      "filename": "memory.4.wasm"
+      "filename": "memory.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 8,
-      "filename": "memory.5.wasm"
+      "filename": "memory.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 10,
       "filename": "memory.6.wasm",
-      "text": "multiple memories",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "multiple memories"
     },
     {
       "type": "assert_invalid",
       "line": 11,
       "filename": "memory.7.wasm",
-      "text": "multiple memories",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "multiple memories"
     },
     {
       "type": "module",
       "line": 13,
-      "filename": "memory.8.wasm"
+      "filename": "memory.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -68,7 +75,8 @@
     {
       "type": "module",
       "line": 15,
-      "filename": "memory.9.wasm"
+      "filename": "memory.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -88,7 +96,8 @@
     {
       "type": "module",
       "line": 17,
-      "filename": "memory.10.wasm"
+      "filename": "memory.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -109,139 +118,140 @@
       "type": "assert_invalid",
       "line": 20,
       "filename": "memory.11.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 21,
       "filename": "memory.12.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 22,
       "filename": "memory.13.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 25,
       "filename": "memory.14.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 29,
       "filename": "memory.15.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 33,
       "filename": "memory.16.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 37,
       "filename": "memory.17.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 41,
       "filename": "memory.18.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 45,
       "filename": "memory.19.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 51,
       "filename": "memory.20.wasm",
-      "text": "size minimum must not be greater than maximum",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "size minimum must not be greater than maximum"
     },
     {
       "type": "assert_invalid",
       "line": 55,
       "filename": "memory.21.wasm",
-      "text": "memory size must be at most 65536 pages (4GiB)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
       "type": "assert_invalid",
       "line": 59,
       "filename": "memory.22.wasm",
-      "text": "memory size must be at most 65536 pages (4GiB)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
       "type": "assert_invalid",
       "line": 63,
       "filename": "memory.23.wasm",
-      "text": "memory size must be at most 65536 pages (4GiB)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
       "type": "assert_invalid",
       "line": 67,
       "filename": "memory.24.wasm",
-      "text": "memory size must be at most 65536 pages (4GiB)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
       "type": "assert_invalid",
       "line": 71,
       "filename": "memory.25.wasm",
-      "text": "memory size must be at most 65536 pages (4GiB)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
       "type": "assert_invalid",
       "line": 75,
       "filename": "memory.26.wasm",
-      "text": "memory size must be at most 65536 pages (4GiB)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
       "type": "assert_malformed",
       "line": 80,
       "filename": "memory.27.wat",
-      "text": "i32 constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "i32 constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 84,
       "filename": "memory.28.wat",
-      "text": "i32 constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "i32 constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 88,
       "filename": "memory.29.wat",
-      "text": "i32 constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "i32 constant out of range"
     },
     {
       "type": "module",
       "line": 92,
-      "filename": "memory.30.wasm"
+      "filename": "memory.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1077,27 +1087,28 @@
       "type": "assert_malformed",
       "line": 231,
       "filename": "memory.31.wat",
-      "text": "duplicate memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate memory"
     },
     {
       "type": "assert_malformed",
       "line": 235,
       "filename": "memory.32.wat",
-      "text": "duplicate memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate memory"
     },
     {
       "type": "assert_malformed",
       "line": 239,
       "filename": "memory.33.wat",
-      "text": "duplicate memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate memory"
     },
     {
       "type": "module",
       "line": 246,
-      "filename": "memory.34.wasm"
+      "filename": "memory.34.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/memory_copy.wast.json
+++ b/tests/snapshots/testsuite/memory_copy.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 6,
-      "filename": "memory_copy.0.wasm"
+      "filename": "memory_copy.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -618,7 +619,8 @@
     {
       "type": "module",
       "line": 48,
-      "filename": "memory_copy.1.wasm"
+      "filename": "memory_copy.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -1232,7 +1234,8 @@
     {
       "type": "module",
       "line": 90,
-      "filename": "memory_copy.2.wasm"
+      "filename": "memory_copy.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -1846,7 +1849,8 @@
     {
       "type": "module",
       "line": 132,
-      "filename": "memory_copy.3.wasm"
+      "filename": "memory_copy.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -2460,7 +2464,8 @@
     {
       "type": "module",
       "line": 174,
-      "filename": "memory_copy.4.wasm"
+      "filename": "memory_copy.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -3074,7 +3079,8 @@
     {
       "type": "module",
       "line": 216,
-      "filename": "memory_copy.5.wasm"
+      "filename": "memory_copy.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -3688,7 +3694,8 @@
     {
       "type": "module",
       "line": 258,
-      "filename": "memory_copy.6.wasm"
+      "filename": "memory_copy.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -4302,7 +4309,8 @@
     {
       "type": "module",
       "line": 300,
-      "filename": "memory_copy.7.wasm"
+      "filename": "memory_copy.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -4916,7 +4924,8 @@
     {
       "type": "module",
       "line": 342,
-      "filename": "memory_copy.8.wasm"
+      "filename": "memory_copy.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -11924,7 +11933,8 @@
     {
       "type": "module",
       "line": 703,
-      "filename": "memory_copy.9.wasm"
+      "filename": "memory_copy.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18952,7 +18962,8 @@
     {
       "type": "module",
       "line": 1065,
-      "filename": "memory_copy.10.wasm"
+      "filename": "memory_copy.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -25960,7 +25971,8 @@
     {
       "type": "module",
       "line": 1426,
-      "filename": "memory_copy.11.wasm"
+      "filename": "memory_copy.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -32988,7 +33000,8 @@
     {
       "type": "module",
       "line": 1788,
-      "filename": "memory_copy.12.wasm"
+      "filename": "memory_copy.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -39996,7 +40009,8 @@
     {
       "type": "module",
       "line": 2149,
-      "filename": "memory_copy.13.wasm"
+      "filename": "memory_copy.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -47004,7 +47018,8 @@
     {
       "type": "module",
       "line": 2510,
-      "filename": "memory_copy.14.wasm"
+      "filename": "memory_copy.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -54012,7 +54027,8 @@
     {
       "type": "module",
       "line": 2871,
-      "filename": "memory_copy.15.wasm"
+      "filename": "memory_copy.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -61020,7 +61036,8 @@
     {
       "type": "module",
       "line": 3232,
-      "filename": "memory_copy.16.wasm"
+      "filename": "memory_copy.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -68028,7 +68045,8 @@
     {
       "type": "module",
       "line": 3593,
-      "filename": "memory_copy.17.wasm"
+      "filename": "memory_copy.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -75036,7 +75054,8 @@
     {
       "type": "module",
       "line": 3954,
-      "filename": "memory_copy.18.wasm"
+      "filename": "memory_copy.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -82045,454 +82064,455 @@
       "type": "assert_invalid",
       "line": 4316,
       "filename": "memory_copy.19.wasm",
-      "text": "unknown memory 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 0"
     },
     {
       "type": "assert_invalid",
       "line": 4322,
       "filename": "memory_copy.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4329,
       "filename": "memory_copy.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4336,
       "filename": "memory_copy.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4343,
       "filename": "memory_copy.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4350,
       "filename": "memory_copy.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4357,
       "filename": "memory_copy.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4364,
       "filename": "memory_copy.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4371,
       "filename": "memory_copy.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4378,
       "filename": "memory_copy.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4385,
       "filename": "memory_copy.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4392,
       "filename": "memory_copy.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4399,
       "filename": "memory_copy.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4406,
       "filename": "memory_copy.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4413,
       "filename": "memory_copy.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4420,
       "filename": "memory_copy.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4427,
       "filename": "memory_copy.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4434,
       "filename": "memory_copy.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4441,
       "filename": "memory_copy.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4448,
       "filename": "memory_copy.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4455,
       "filename": "memory_copy.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4462,
       "filename": "memory_copy.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4469,
       "filename": "memory_copy.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4476,
       "filename": "memory_copy.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4483,
       "filename": "memory_copy.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4490,
       "filename": "memory_copy.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4497,
       "filename": "memory_copy.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4504,
       "filename": "memory_copy.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4511,
       "filename": "memory_copy.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4518,
       "filename": "memory_copy.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4525,
       "filename": "memory_copy.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4532,
       "filename": "memory_copy.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4539,
       "filename": "memory_copy.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4546,
       "filename": "memory_copy.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4553,
       "filename": "memory_copy.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4560,
       "filename": "memory_copy.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4567,
       "filename": "memory_copy.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4574,
       "filename": "memory_copy.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4581,
       "filename": "memory_copy.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4588,
       "filename": "memory_copy.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4595,
       "filename": "memory_copy.59.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4602,
       "filename": "memory_copy.60.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4609,
       "filename": "memory_copy.61.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4616,
       "filename": "memory_copy.62.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4623,
       "filename": "memory_copy.63.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4630,
       "filename": "memory_copy.64.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4637,
       "filename": "memory_copy.65.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4644,
       "filename": "memory_copy.66.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4651,
       "filename": "memory_copy.67.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4658,
       "filename": "memory_copy.68.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4665,
       "filename": "memory_copy.69.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4672,
       "filename": "memory_copy.70.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4679,
       "filename": "memory_copy.71.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4686,
       "filename": "memory_copy.72.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4693,
       "filename": "memory_copy.73.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4700,
       "filename": "memory_copy.74.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4707,
       "filename": "memory_copy.75.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4714,
       "filename": "memory_copy.76.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4721,
       "filename": "memory_copy.77.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4728,
       "filename": "memory_copy.78.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4735,
       "filename": "memory_copy.79.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4742,
       "filename": "memory_copy.80.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4749,
       "filename": "memory_copy.81.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4756,
       "filename": "memory_copy.82.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 4763,
-      "filename": "memory_copy.83.wasm"
+      "filename": "memory_copy.83.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -82590,7 +82610,8 @@
     {
       "type": "module",
       "line": 4789,
-      "filename": "memory_copy.84.wasm"
+      "filename": "memory_copy.84.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -82688,7 +82709,8 @@
     {
       "type": "module",
       "line": 4815,
-      "filename": "memory_copy.85.wasm"
+      "filename": "memory_copy.85.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -82703,7 +82725,8 @@
     {
       "type": "module",
       "line": 4821,
-      "filename": "memory_copy.86.wasm"
+      "filename": "memory_copy.86.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -82718,7 +82741,8 @@
     {
       "type": "module",
       "line": 4827,
-      "filename": "memory_copy.87.wasm"
+      "filename": "memory_copy.87.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -82733,7 +82757,8 @@
     {
       "type": "module",
       "line": 4833,
-      "filename": "memory_copy.88.wasm"
+      "filename": "memory_copy.88.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -82748,7 +82773,8 @@
     {
       "type": "module",
       "line": 4839,
-      "filename": "memory_copy.89.wasm"
+      "filename": "memory_copy.89.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -82818,7 +82844,8 @@
     {
       "type": "module",
       "line": 4863,
-      "filename": "memory_copy.90.wasm"
+      "filename": "memory_copy.90.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -82832,7 +82859,8 @@
     {
       "type": "module",
       "line": 4869,
-      "filename": "memory_copy.91.wasm"
+      "filename": "memory_copy.91.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -82847,7 +82875,8 @@
     {
       "type": "module",
       "line": 4875,
-      "filename": "memory_copy.92.wasm"
+      "filename": "memory_copy.92.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -82861,7 +82890,8 @@
     {
       "type": "module",
       "line": 4881,
-      "filename": "memory_copy.93.wasm"
+      "filename": "memory_copy.93.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -82876,7 +82906,8 @@
     {
       "type": "module",
       "line": 4887,
-      "filename": "memory_copy.94.wasm"
+      "filename": "memory_copy.94.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -82890,7 +82921,8 @@
     {
       "type": "module",
       "line": 4893,
-      "filename": "memory_copy.95.wasm"
+      "filename": "memory_copy.95.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -82905,7 +82937,8 @@
     {
       "type": "module",
       "line": 4899,
-      "filename": "memory_copy.96.wasm"
+      "filename": "memory_copy.96.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",

--- a/tests/snapshots/testsuite/memory_fill.wast.json
+++ b/tests/snapshots/testsuite/memory_fill.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 6,
-      "filename": "memory_fill.0.wasm"
+      "filename": "memory_fill.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -74,7 +75,8 @@
     {
       "type": "module",
       "line": 28,
-      "filename": "memory_fill.1.wasm"
+      "filename": "memory_fill.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -89,7 +91,8 @@
     {
       "type": "module",
       "line": 46,
-      "filename": "memory_fill.2.wasm"
+      "filename": "memory_fill.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -104,7 +107,8 @@
     {
       "type": "module",
       "line": 64,
-      "filename": "memory_fill.3.wasm"
+      "filename": "memory_fill.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -146,7 +150,8 @@
     {
       "type": "module",
       "line": 84,
-      "filename": "memory_fill.4.wasm"
+      "filename": "memory_fill.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -160,7 +165,8 @@
     {
       "type": "module",
       "line": 102,
-      "filename": "memory_fill.5.wasm"
+      "filename": "memory_fill.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -175,7 +181,8 @@
     {
       "type": "module",
       "line": 120,
-      "filename": "memory_fill.6.wasm"
+      "filename": "memory_fill.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -273,7 +280,8 @@
     {
       "type": "module",
       "line": 145,
-      "filename": "memory_fill.7.wasm"
+      "filename": "memory_fill.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -428,454 +436,455 @@
       "type": "assert_invalid",
       "line": 175,
       "filename": "memory_fill.8.wasm",
-      "text": "unknown memory 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 0"
     },
     {
       "type": "assert_invalid",
       "line": 181,
       "filename": "memory_fill.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 188,
       "filename": "memory_fill.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 195,
       "filename": "memory_fill.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 202,
       "filename": "memory_fill.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 209,
       "filename": "memory_fill.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 216,
       "filename": "memory_fill.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 223,
       "filename": "memory_fill.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 230,
       "filename": "memory_fill.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 237,
       "filename": "memory_fill.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 244,
       "filename": "memory_fill.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 251,
       "filename": "memory_fill.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 258,
       "filename": "memory_fill.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 265,
       "filename": "memory_fill.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 272,
       "filename": "memory_fill.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 279,
       "filename": "memory_fill.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 286,
       "filename": "memory_fill.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 293,
       "filename": "memory_fill.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 300,
       "filename": "memory_fill.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 307,
       "filename": "memory_fill.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 314,
       "filename": "memory_fill.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 321,
       "filename": "memory_fill.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 328,
       "filename": "memory_fill.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 335,
       "filename": "memory_fill.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 342,
       "filename": "memory_fill.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 349,
       "filename": "memory_fill.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 356,
       "filename": "memory_fill.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 363,
       "filename": "memory_fill.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 370,
       "filename": "memory_fill.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 377,
       "filename": "memory_fill.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 384,
       "filename": "memory_fill.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 391,
       "filename": "memory_fill.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 398,
       "filename": "memory_fill.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 405,
       "filename": "memory_fill.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 412,
       "filename": "memory_fill.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 419,
       "filename": "memory_fill.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 426,
       "filename": "memory_fill.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 433,
       "filename": "memory_fill.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 440,
       "filename": "memory_fill.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 447,
       "filename": "memory_fill.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 454,
       "filename": "memory_fill.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 461,
       "filename": "memory_fill.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 468,
       "filename": "memory_fill.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 475,
       "filename": "memory_fill.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 482,
       "filename": "memory_fill.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 489,
       "filename": "memory_fill.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 496,
       "filename": "memory_fill.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 503,
       "filename": "memory_fill.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 510,
       "filename": "memory_fill.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 517,
       "filename": "memory_fill.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 524,
       "filename": "memory_fill.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 531,
       "filename": "memory_fill.59.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 538,
       "filename": "memory_fill.60.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 545,
       "filename": "memory_fill.61.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 552,
       "filename": "memory_fill.62.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 559,
       "filename": "memory_fill.63.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 566,
       "filename": "memory_fill.64.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 573,
       "filename": "memory_fill.65.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 580,
       "filename": "memory_fill.66.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 587,
       "filename": "memory_fill.67.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 594,
       "filename": "memory_fill.68.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 601,
       "filename": "memory_fill.69.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 608,
       "filename": "memory_fill.70.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 615,
       "filename": "memory_fill.71.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 621,
-      "filename": "memory_fill.72.wasm"
+      "filename": "memory_fill.72.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -931,7 +940,8 @@
     {
       "type": "module",
       "line": 643,
-      "filename": "memory_fill.73.wasm"
+      "filename": "memory_fill.73.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -987,7 +997,8 @@
     {
       "type": "module",
       "line": 665,
-      "filename": "memory_fill.74.wasm"
+      "filename": "memory_fill.74.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",

--- a/tests/snapshots/testsuite/memory_grow.wast.json
+++ b/tests/snapshots/testsuite/memory_grow.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "memory_grow.0.wasm"
+      "filename": "memory_grow.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -274,7 +275,8 @@
     {
       "type": "module",
       "line": 36,
-      "filename": "memory_grow.1.wasm"
+      "filename": "memory_grow.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -439,7 +441,8 @@
     {
       "type": "module",
       "line": 50,
-      "filename": "memory_grow.2.wasm"
+      "filename": "memory_grow.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -604,7 +607,8 @@
     {
       "type": "module",
       "line": 66,
-      "filename": "memory_grow.3.wasm"
+      "filename": "memory_grow.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -853,7 +857,8 @@
     {
       "type": "module",
       "line": 101,
-      "filename": "memory_grow.4.wasm"
+      "filename": "memory_grow.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1387,7 +1392,8 @@
       "type": "module",
       "line": 312,
       "name": "Mgm",
-      "filename": "memory_grow.5.wasm"
+      "filename": "memory_grow.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1415,7 +1421,8 @@
       "type": "module",
       "line": 318,
       "name": "Mgim1",
-      "filename": "memory_grow.6.wasm"
+      "filename": "memory_grow.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1443,7 +1450,8 @@
       "type": "module",
       "line": 325,
       "name": "Mgim2",
-      "filename": "memory_grow.7.wasm"
+      "filename": "memory_grow.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1465,50 +1473,50 @@
       "type": "assert_invalid",
       "line": 334,
       "filename": "memory_grow.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 343,
       "filename": "memory_grow.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 353,
       "filename": "memory_grow.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 363,
       "filename": "memory_grow.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 374,
       "filename": "memory_grow.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 384,
       "filename": "memory_grow.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 393,
       "filename": "memory_grow.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/memory_init.wast.json
+++ b/tests/snapshots/testsuite/memory_init.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 6,
-      "filename": "memory_init.0.wasm"
+      "filename": "memory_init.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -618,7 +619,8 @@
     {
       "type": "module",
       "line": 50,
-      "filename": "memory_init.1.wasm"
+      "filename": "memory_init.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -1232,7 +1234,8 @@
     {
       "type": "module",
       "line": 94,
-      "filename": "memory_init.2.wasm"
+      "filename": "memory_init.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -1846,7 +1849,8 @@
     {
       "type": "module",
       "line": 138,
-      "filename": "memory_init.3.wasm"
+      "filename": "memory_init.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -2461,20 +2465,21 @@
       "type": "assert_invalid",
       "line": 190,
       "filename": "memory_init.4.wasm",
-      "text": "unknown data segment",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown data segment"
     },
     {
       "type": "assert_invalid",
       "line": 196,
       "filename": "memory_init.5.wasm",
-      "text": "unknown data segment",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown data segment"
     },
     {
       "type": "module",
       "line": 203,
-      "filename": "memory_init.6.wasm"
+      "filename": "memory_init.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -2488,7 +2493,8 @@
     {
       "type": "module",
       "line": 211,
-      "filename": "memory_init.7.wasm"
+      "filename": "memory_init.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -2503,7 +2509,8 @@
     {
       "type": "module",
       "line": 219,
-      "filename": "memory_init.8.wasm"
+      "filename": "memory_init.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -2519,20 +2526,21 @@
       "type": "assert_invalid",
       "line": 227,
       "filename": "memory_init.9.wasm",
-      "text": "unknown memory 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 0"
     },
     {
       "type": "assert_invalid",
       "line": 233,
       "filename": "memory_init.10.wasm",
-      "text": "unknown data segment 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown data segment 1"
     },
     {
       "type": "module",
       "line": 240,
-      "filename": "memory_init.11.wasm"
+      "filename": "memory_init.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -2546,7 +2554,8 @@
     {
       "type": "module",
       "line": 248,
-      "filename": "memory_init.12.wasm"
+      "filename": "memory_init.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -2561,7 +2570,8 @@
     {
       "type": "module",
       "line": 255,
-      "filename": "memory_init.13.wasm"
+      "filename": "memory_init.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -2576,7 +2586,8 @@
     {
       "type": "module",
       "line": 262,
-      "filename": "memory_init.14.wasm"
+      "filename": "memory_init.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -2591,7 +2602,8 @@
     {
       "type": "module",
       "line": 269,
-      "filename": "memory_init.15.wasm"
+      "filename": "memory_init.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -2606,7 +2618,8 @@
     {
       "type": "module",
       "line": 276,
-      "filename": "memory_init.16.wasm"
+      "filename": "memory_init.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -2620,7 +2633,8 @@
     {
       "type": "module",
       "line": 283,
-      "filename": "memory_init.17.wasm"
+      "filename": "memory_init.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -2635,7 +2649,8 @@
     {
       "type": "module",
       "line": 290,
-      "filename": "memory_init.18.wasm"
+      "filename": "memory_init.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -2649,7 +2664,8 @@
     {
       "type": "module",
       "line": 297,
-      "filename": "memory_init.19.wasm"
+      "filename": "memory_init.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -2663,7 +2679,8 @@
     {
       "type": "module",
       "line": 304,
-      "filename": "memory_init.20.wasm"
+      "filename": "memory_init.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -2679,447 +2696,448 @@
       "type": "assert_invalid",
       "line": 312,
       "filename": "memory_init.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 320,
       "filename": "memory_init.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 328,
       "filename": "memory_init.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 336,
       "filename": "memory_init.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 344,
       "filename": "memory_init.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 352,
       "filename": "memory_init.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 360,
       "filename": "memory_init.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 368,
       "filename": "memory_init.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 376,
       "filename": "memory_init.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 384,
       "filename": "memory_init.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 392,
       "filename": "memory_init.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 400,
       "filename": "memory_init.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 408,
       "filename": "memory_init.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 416,
       "filename": "memory_init.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 424,
       "filename": "memory_init.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 432,
       "filename": "memory_init.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 440,
       "filename": "memory_init.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 448,
       "filename": "memory_init.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 456,
       "filename": "memory_init.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 464,
       "filename": "memory_init.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 472,
       "filename": "memory_init.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 480,
       "filename": "memory_init.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 488,
       "filename": "memory_init.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 496,
       "filename": "memory_init.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 504,
       "filename": "memory_init.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 512,
       "filename": "memory_init.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 520,
       "filename": "memory_init.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 528,
       "filename": "memory_init.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 536,
       "filename": "memory_init.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 544,
       "filename": "memory_init.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 552,
       "filename": "memory_init.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 560,
       "filename": "memory_init.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 568,
       "filename": "memory_init.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 576,
       "filename": "memory_init.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 584,
       "filename": "memory_init.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 592,
       "filename": "memory_init.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 600,
       "filename": "memory_init.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 608,
       "filename": "memory_init.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 616,
       "filename": "memory_init.59.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 624,
       "filename": "memory_init.60.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 632,
       "filename": "memory_init.61.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 640,
       "filename": "memory_init.62.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 648,
       "filename": "memory_init.63.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 656,
       "filename": "memory_init.64.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 664,
       "filename": "memory_init.65.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 672,
       "filename": "memory_init.66.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 680,
       "filename": "memory_init.67.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 688,
       "filename": "memory_init.68.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 696,
       "filename": "memory_init.69.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 704,
       "filename": "memory_init.70.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 712,
       "filename": "memory_init.71.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 720,
       "filename": "memory_init.72.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 728,
       "filename": "memory_init.73.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 736,
       "filename": "memory_init.74.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 744,
       "filename": "memory_init.75.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 752,
       "filename": "memory_init.76.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 760,
       "filename": "memory_init.77.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 768,
       "filename": "memory_init.78.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 776,
       "filename": "memory_init.79.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 784,
       "filename": "memory_init.80.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 792,
       "filename": "memory_init.81.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 800,
       "filename": "memory_init.82.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 808,
       "filename": "memory_init.83.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 815,
-      "filename": "memory_init.84.wasm"
+      "filename": "memory_init.84.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -3171,7 +3189,8 @@
     {
       "type": "module",
       "line": 838,
-      "filename": "memory_init.85.wasm"
+      "filename": "memory_init.85.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -3223,7 +3242,8 @@
     {
       "type": "module",
       "line": 861,
-      "filename": "memory_init.86.wasm"
+      "filename": "memory_init.86.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -3275,7 +3295,8 @@
     {
       "type": "module",
       "line": 884,
-      "filename": "memory_init.87.wasm"
+      "filename": "memory_init.87.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -3327,7 +3348,8 @@
     {
       "type": "module",
       "line": 907,
-      "filename": "memory_init.88.wasm"
+      "filename": "memory_init.88.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -3379,7 +3401,8 @@
     {
       "type": "module",
       "line": 930,
-      "filename": "memory_init.89.wasm"
+      "filename": "memory_init.89.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -3431,7 +3454,8 @@
     {
       "type": "module",
       "line": 954,
-      "filename": "memory_init.90.wasm"
+      "filename": "memory_init.90.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/memory_redundancy.wast.json
+++ b/tests/snapshots/testsuite/memory_redundancy.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 5,
-      "filename": "memory_redundancy.0.wasm"
+      "filename": "memory_redundancy.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/memory_size.wast.json
+++ b/tests/snapshots/testsuite/memory_size.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "memory_size.0.wasm"
+      "filename": "memory_size.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -114,7 +115,8 @@
     {
       "type": "module",
       "line": 15,
-      "filename": "memory_size.1.wasm"
+      "filename": "memory_size.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -224,7 +226,8 @@
     {
       "type": "module",
       "line": 29,
-      "filename": "memory_size.2.wasm"
+      "filename": "memory_size.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -394,7 +397,8 @@
     {
       "type": "module",
       "line": 47,
-      "filename": "memory_size.3.wasm"
+      "filename": "memory_size.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -565,15 +569,15 @@
       "type": "assert_invalid",
       "line": 69,
       "filename": "memory_size.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 78,
       "filename": "memory_size.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/memory_trap.wast.json
+++ b/tests/snapshots/testsuite/memory_trap.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "memory_trap.0.wasm"
+      "filename": "memory_trap.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -238,7 +239,8 @@
     {
       "type": "module",
       "line": 35,
-      "filename": "memory_trap.1.wasm"
+      "filename": "memory_trap.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",

--- a/tests/snapshots/testsuite/names.wast.json
+++ b/tests/snapshots/testsuite/names.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "names.0.wasm"
+      "filename": "names.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -24,7 +25,8 @@
     {
       "type": "module",
       "line": 12,
-      "filename": "names.1.wasm"
+      "filename": "names.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -44,7 +46,8 @@
     {
       "type": "module",
       "line": 19,
-      "filename": "names.2.wasm"
+      "filename": "names.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -7234,7 +7237,8 @@
     {
       "type": "module",
       "line": 1095,
-      "filename": "names.3.wasm"
+      "filename": "names.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/nop.wast.json
+++ b/tests/snapshots/testsuite/nop.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "nop.0.wasm"
+      "filename": "nop.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1561,29 +1562,29 @@
       "type": "assert_invalid",
       "line": 412,
       "filename": "nop.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 416,
       "filename": "nop.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 420,
       "filename": "nop.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 424,
       "filename": "nop.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/obsolete-keywords.wast.json
+++ b/tests/snapshots/testsuite/obsolete-keywords.wast.json
@@ -5,78 +5,78 @@
       "type": "assert_malformed",
       "line": 3,
       "filename": "obsolete-keywords.0.wat",
-      "text": "unknown operator current_memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator current_memory"
     },
     {
       "type": "assert_malformed",
       "line": 11,
       "filename": "obsolete-keywords.1.wat",
-      "text": "unknown operator grow_memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator grow_memory"
     },
     {
       "type": "assert_malformed",
       "line": 20,
       "filename": "obsolete-keywords.2.wat",
-      "text": "unknown operator get_local",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator get_local"
     },
     {
       "type": "assert_malformed",
       "line": 27,
       "filename": "obsolete-keywords.3.wat",
-      "text": "unknown operator set_local",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator set_local"
     },
     {
       "type": "assert_malformed",
       "line": 34,
       "filename": "obsolete-keywords.4.wat",
-      "text": "unknown operator tee_local",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator tee_local"
     },
     {
       "type": "assert_malformed",
       "line": 41,
       "filename": "obsolete-keywords.5.wat",
-      "text": "unknown operator anyfunc",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator anyfunc"
     },
     {
       "type": "assert_malformed",
       "line": 48,
       "filename": "obsolete-keywords.6.wat",
-      "text": "unknown operator get_global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator get_global"
     },
     {
       "type": "assert_malformed",
       "line": 56,
       "filename": "obsolete-keywords.7.wat",
-      "text": "unknown operator set_global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator set_global"
     },
     {
       "type": "assert_malformed",
       "line": 64,
       "filename": "obsolete-keywords.8.wat",
-      "text": "unknown operator i32.wrap/i64",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator i32.wrap/i64"
     },
     {
       "type": "assert_malformed",
       "line": 71,
       "filename": "obsolete-keywords.9.wat",
-      "text": "unknown operator i32.trunc_s:sat/f32",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator i32.trunc_s:sat/f32"
     },
     {
       "type": "assert_malformed",
       "line": 78,
       "filename": "obsolete-keywords.10.wat",
-      "text": "unknown operator f32x4.convert_s/i32x4",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator f32x4.convert_s/i32x4"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/annotations/annotations.wast.json
+++ b/tests/snapshots/testsuite/proposals/annotations/annotations.wast.json
@@ -4,503 +4,519 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "annotations.0.wasm"
+      "filename": "annotations.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 23,
       "filename": "annotations.1.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 24,
       "filename": "annotations.2.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 25,
       "filename": "annotations.3.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 26,
       "filename": "annotations.4.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 27,
       "filename": "annotations.5.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 28,
       "filename": "annotations.6.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 29,
       "filename": "annotations.7.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 30,
       "filename": "annotations.8.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 31,
       "filename": "annotations.9.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "module",
       "line": 32,
-      "filename": "annotations.10.wat"
+      "filename": "annotations.10.wat",
+      "module_type": "text",
+      "binary_filename": "annotations.10.wasm"
     },
     {
       "type": "module",
       "line": 33,
-      "filename": "annotations.11.wat"
+      "filename": "annotations.11.wat",
+      "module_type": "text",
+      "binary_filename": "annotations.11.wasm"
     },
     {
       "type": "assert_malformed",
       "line": 34,
       "filename": "annotations.12.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 35,
       "filename": "annotations.13.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "module",
       "line": 36,
-      "filename": "annotations.14.wat"
+      "filename": "annotations.14.wat",
+      "module_type": "text",
+      "binary_filename": "annotations.14.wasm"
     },
     {
       "type": "assert_malformed",
       "line": 37,
       "filename": "annotations.15.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 38,
       "filename": "annotations.16.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 39,
       "filename": "annotations.17.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 40,
       "filename": "annotations.18.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 41,
       "filename": "annotations.19.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 42,
       "filename": "annotations.20.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 43,
       "filename": "annotations.21.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 44,
       "filename": "annotations.22.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 45,
       "filename": "annotations.23.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 46,
       "filename": "annotations.24.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 47,
       "filename": "annotations.25.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 48,
       "filename": "annotations.26.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 49,
       "filename": "annotations.27.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 50,
       "filename": "annotations.28.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 51,
       "filename": "annotations.29.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 52,
       "filename": "annotations.30.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 53,
       "filename": "annotations.31.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 54,
       "filename": "annotations.32.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "module",
       "line": 55,
-      "filename": "annotations.33.wat"
+      "filename": "annotations.33.wat",
+      "module_type": "text",
+      "binary_filename": "annotations.33.wasm"
     },
     {
       "type": "assert_malformed",
       "line": 56,
       "filename": "annotations.34.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 57,
       "filename": "annotations.35.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 58,
       "filename": "annotations.36.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 59,
       "filename": "annotations.37.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 60,
       "filename": "annotations.38.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 61,
       "filename": "annotations.39.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 62,
       "filename": "annotations.40.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 63,
       "filename": "annotations.41.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 64,
       "filename": "annotations.42.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 65,
       "filename": "annotations.43.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 66,
       "filename": "annotations.44.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 67,
       "filename": "annotations.45.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 68,
       "filename": "annotations.46.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 70,
       "filename": "annotations.47.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 72,
       "filename": "annotations.48.wat",
-      "text": "empty annotation id",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty annotation id"
     },
     {
       "type": "assert_malformed",
       "line": 73,
       "filename": "annotations.49.wat",
-      "text": "empty annotation id",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty annotation id"
     },
     {
       "type": "assert_malformed",
       "line": 74,
       "filename": "annotations.50.wat",
-      "text": "empty annotation id",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty annotation id"
     },
     {
       "type": "assert_malformed",
       "line": 75,
       "filename": "annotations.51.wat",
-      "text": "empty annotation id",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty annotation id"
     },
     {
       "type": "assert_malformed",
       "line": 76,
       "filename": "annotations.52.wat",
-      "text": "empty annotation id",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty annotation id"
     },
     {
       "type": "assert_malformed",
       "line": 77,
       "filename": "annotations.53.wat",
-      "text": "empty annotation id",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty annotation id"
     },
     {
       "type": "assert_malformed",
       "line": 78,
       "filename": "annotations.54.wat",
-      "text": "empty annotation id",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty annotation id"
     },
     {
       "type": "assert_malformed",
       "line": 79,
       "filename": "annotations.55.wat",
-      "text": "malformed UTF-8",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8"
     },
     {
       "type": "assert_malformed",
       "line": 81,
       "filename": "annotations.56.wat",
-      "text": "unclosed annotation",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unclosed annotation"
     },
     {
       "type": "assert_malformed",
       "line": 82,
       "filename": "annotations.57.wat",
-      "text": "unclosed annotation",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unclosed annotation"
     },
     {
       "type": "assert_malformed",
       "line": 83,
       "filename": "annotations.58.wat",
-      "text": "unclosed annotation",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unclosed annotation"
     },
     {
       "type": "assert_malformed",
       "line": 84,
       "filename": "annotations.59.wat",
-      "text": "unclosed annotation",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unclosed annotation"
     },
     {
       "type": "assert_malformed",
       "line": 86,
       "filename": "annotations.60.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 87,
       "filename": "annotations.61.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 88,
       "filename": "annotations.62.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 89,
       "filename": "annotations.63.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 91,
       "filename": "annotations.64.wat",
-      "text": "unclosed string",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unclosed string"
     },
     {
       "type": "assert_malformed",
       "line": 92,
       "filename": "annotations.65.wat",
-      "text": "unclosed string",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unclosed string"
     },
     {
       "type": "assert_malformed",
       "line": 94,
       "filename": "annotations.66.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 95,
       "filename": "annotations.67.wat",
-      "text": "empty identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty identifier"
     },
     {
       "type": "assert_malformed",
       "line": 96,
       "filename": "annotations.68.wat",
-      "text": "empty identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty identifier"
     },
     {
       "type": "module",
       "line": 98,
       "name": "m",
-      "filename": "annotations.69.wasm"
+      "filename": "annotations.69.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 129,
       "name": "m1",
-      "filename": "annotations.70.wasm"
+      "filename": "annotations.70.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 154,
       "name": "m2",
-      "filename": "annotations.71.wasm"
+      "filename": "annotations.71.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 206,
-      "filename": "annotations.72.wat"
+      "filename": "annotations.72.wat",
+      "module_type": "text",
+      "binary_filename": "annotations.72.wasm"
     },
     {
       "type": "module",
       "line": 207,
-      "filename": "annotations.73.wat"
+      "filename": "annotations.73.wat",
+      "module_type": "text",
+      "binary_filename": "annotations.73.wasm"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/annotations/id.wast.json
+++ b/tests/snapshots/testsuite/proposals/annotations/id.wast.json
@@ -4,49 +4,50 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "id.0.wasm"
+      "filename": "id.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 26,
       "filename": "id.1.wat",
-      "text": "empty identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty identifier"
     },
     {
       "type": "assert_malformed",
       "line": 27,
       "filename": "id.2.wat",
-      "text": "empty identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty identifier"
     },
     {
       "type": "assert_malformed",
       "line": 28,
       "filename": "id.3.wat",
-      "text": "empty identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty identifier"
     },
     {
       "type": "assert_malformed",
       "line": 29,
       "filename": "id.4.wat",
-      "text": "empty identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty identifier"
     },
     {
       "type": "assert_malformed",
       "line": 30,
       "filename": "id.5.wat",
-      "text": "empty identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty identifier"
     },
     {
       "type": "assert_malformed",
       "line": 31,
       "filename": "id.6.wat",
-      "text": "malformed UTF-8",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/annotations/simd_lane.wast.json
+++ b/tests/snapshots/testsuite/proposals/annotations/simd_lane.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_lane.0.wasm"
+      "filename": "simd_lane.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -8068,958 +8069,959 @@
       "type": "assert_malformed",
       "line": 398,
       "filename": "simd_lane.1.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 399,
       "filename": "simd_lane.2.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 400,
       "filename": "simd_lane.3.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 401,
       "filename": "simd_lane.4.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 402,
       "filename": "simd_lane.5.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 403,
       "filename": "simd_lane.6.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 404,
       "filename": "simd_lane.7.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 405,
       "filename": "simd_lane.8.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 406,
       "filename": "simd_lane.9.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 407,
       "filename": "simd_lane.10.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 408,
       "filename": "simd_lane.11.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 409,
       "filename": "simd_lane.12.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 410,
       "filename": "simd_lane.13.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 411,
       "filename": "simd_lane.14.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 415,
       "filename": "simd_lane.15.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 416,
       "filename": "simd_lane.16.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 417,
       "filename": "simd_lane.17.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 418,
       "filename": "simd_lane.18.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 419,
       "filename": "simd_lane.19.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 420,
       "filename": "simd_lane.20.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 421,
       "filename": "simd_lane.21.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 422,
       "filename": "simd_lane.22.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 423,
       "filename": "simd_lane.23.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 424,
       "filename": "simd_lane.24.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 425,
       "filename": "simd_lane.25.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 426,
       "filename": "simd_lane.26.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 427,
       "filename": "simd_lane.27.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 428,
       "filename": "simd_lane.28.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_invalid",
       "line": 432,
       "filename": "simd_lane.29.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 433,
       "filename": "simd_lane.30.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 434,
       "filename": "simd_lane.31.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 435,
       "filename": "simd_lane.32.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 436,
       "filename": "simd_lane.33.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 437,
       "filename": "simd_lane.34.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 438,
       "filename": "simd_lane.35.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 439,
       "filename": "simd_lane.36.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 440,
       "filename": "simd_lane.37.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 441,
       "filename": "simd_lane.38.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 442,
       "filename": "simd_lane.39.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 443,
       "filename": "simd_lane.40.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 444,
       "filename": "simd_lane.41.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 445,
       "filename": "simd_lane.42.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 446,
       "filename": "simd_lane.43.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 447,
       "filename": "simd_lane.44.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 448,
       "filename": "simd_lane.45.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 449,
       "filename": "simd_lane.46.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 450,
       "filename": "simd_lane.47.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 451,
       "filename": "simd_lane.48.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 452,
       "filename": "simd_lane.49.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 453,
       "filename": "simd_lane.50.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 454,
       "filename": "simd_lane.51.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 455,
       "filename": "simd_lane.52.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 456,
       "filename": "simd_lane.53.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 457,
       "filename": "simd_lane.54.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 458,
       "filename": "simd_lane.55.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 459,
       "filename": "simd_lane.56.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 463,
       "filename": "simd_lane.57.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 464,
       "filename": "simd_lane.58.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 465,
       "filename": "simd_lane.59.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 466,
       "filename": "simd_lane.60.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 467,
       "filename": "simd_lane.61.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 468,
       "filename": "simd_lane.62.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 469,
       "filename": "simd_lane.63.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 470,
       "filename": "simd_lane.64.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 471,
       "filename": "simd_lane.65.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 472,
       "filename": "simd_lane.66.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 473,
       "filename": "simd_lane.67.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 477,
       "filename": "simd_lane.68.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 478,
       "filename": "simd_lane.69.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 479,
       "filename": "simd_lane.70.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 480,
       "filename": "simd_lane.71.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 481,
       "filename": "simd_lane.72.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 482,
       "filename": "simd_lane.73.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 483,
       "filename": "simd_lane.74.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 484,
       "filename": "simd_lane.75.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 485,
       "filename": "simd_lane.76.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 486,
       "filename": "simd_lane.77.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 487,
       "filename": "simd_lane.78.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 488,
       "filename": "simd_lane.79.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 489,
       "filename": "simd_lane.80.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 490,
       "filename": "simd_lane.81.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 494,
       "filename": "simd_lane.82.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 495,
       "filename": "simd_lane.83.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 496,
       "filename": "simd_lane.84.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 497,
       "filename": "simd_lane.85.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 499,
       "filename": "simd_lane.86.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 500,
       "filename": "simd_lane.87.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 503,
       "filename": "simd_lane.88.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 505,
       "filename": "simd_lane.89.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 507,
       "filename": "simd_lane.90.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 510,
       "filename": "simd_lane.91.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 515,
       "filename": "simd_lane.92.wat",
-      "text": "invalid lane length",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "invalid lane length"
     },
     {
       "type": "assert_malformed",
       "line": 518,
       "filename": "simd_lane.93.wat",
-      "text": "invalid lane length",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "invalid lane length"
     },
     {
       "type": "assert_malformed",
       "line": 521,
       "filename": "simd_lane.94.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 525,
       "filename": "simd_lane.95.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_invalid",
       "line": 529,
       "filename": "simd_lane.96.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_malformed",
       "line": 536,
       "filename": "simd_lane.97.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 537,
       "filename": "simd_lane.98.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 538,
       "filename": "simd_lane.99.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 539,
       "filename": "simd_lane.100.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 540,
       "filename": "simd_lane.101.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 541,
       "filename": "simd_lane.102.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 545,
       "filename": "simd_lane.103.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 549,
       "filename": "simd_lane.104.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 555,
       "filename": "simd_lane.105.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 559,
       "filename": "simd_lane.106.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 570,
       "filename": "simd_lane.107.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 571,
       "filename": "simd_lane.108.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 572,
       "filename": "simd_lane.109.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 573,
       "filename": "simd_lane.110.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 574,
       "filename": "simd_lane.111.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 575,
       "filename": "simd_lane.112.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 576,
       "filename": "simd_lane.113.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 577,
       "filename": "simd_lane.114.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 578,
       "filename": "simd_lane.115.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 579,
       "filename": "simd_lane.116.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 581,
       "filename": "simd_lane.117.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 582,
       "filename": "simd_lane.118.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 583,
       "filename": "simd_lane.119.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 584,
       "filename": "simd_lane.120.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 588,
       "filename": "simd_lane.121.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 589,
       "filename": "simd_lane.122.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 590,
       "filename": "simd_lane.123.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 591,
       "filename": "simd_lane.124.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 592,
       "filename": "simd_lane.125.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 593,
       "filename": "simd_lane.126.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 594,
       "filename": "simd_lane.127.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 595,
       "filename": "simd_lane.128.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 596,
       "filename": "simd_lane.129.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 597,
       "filename": "simd_lane.130.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 600,
       "filename": "simd_lane.131.wat",
-      "text": "invalid lane length",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "invalid lane length"
     },
     {
       "type": "assert_malformed",
       "line": 604,
       "filename": "simd_lane.132.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 608,
       "filename": "simd_lane.133.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 612,
       "filename": "simd_lane.134.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 616,
       "filename": "simd_lane.135.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 620,
       "filename": "simd_lane.136.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "module",
       "line": 628,
-      "filename": "simd_lane.137.wasm"
+      "filename": "simd_lane.137.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -9880,7 +9882,8 @@
     {
       "type": "module",
       "line": 703,
-      "filename": "simd_lane.138.wasm"
+      "filename": "simd_lane.138.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -10901,7 +10904,8 @@
     {
       "type": "module",
       "line": 799,
-      "filename": "simd_lane.139.wasm"
+      "filename": "simd_lane.139.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -11146,7 +11150,8 @@
     {
       "type": "module",
       "line": 830,
-      "filename": "simd_lane.140.wasm"
+      "filename": "simd_lane.140.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -11508,407 +11513,414 @@
       "type": "assert_malformed",
       "line": 877,
       "filename": "simd_lane.141.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 878,
       "filename": "simd_lane.142.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 879,
       "filename": "simd_lane.143.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 880,
       "filename": "simd_lane.144.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 881,
       "filename": "simd_lane.145.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 882,
       "filename": "simd_lane.146.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 883,
       "filename": "simd_lane.147.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "module",
       "line": 887,
-      "filename": "simd_lane.148.wasm"
+      "filename": "simd_lane.148.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 888,
-      "filename": "simd_lane.149.wasm"
+      "filename": "simd_lane.149.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 889,
-      "filename": "simd_lane.150.wasm"
+      "filename": "simd_lane.150.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 890,
-      "filename": "simd_lane.151.wasm"
+      "filename": "simd_lane.151.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 891,
-      "filename": "simd_lane.152.wasm"
+      "filename": "simd_lane.152.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 892,
-      "filename": "simd_lane.153.wasm"
+      "filename": "simd_lane.153.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 893,
-      "filename": "simd_lane.154.wasm"
+      "filename": "simd_lane.154.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 897,
       "filename": "simd_lane.155.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 902,
       "filename": "simd_lane.156.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 910,
       "filename": "simd_lane.157.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 918,
       "filename": "simd_lane.158.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 926,
       "filename": "simd_lane.159.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 934,
       "filename": "simd_lane.160.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 942,
       "filename": "simd_lane.161.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 950,
       "filename": "simd_lane.162.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 958,
       "filename": "simd_lane.163.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 966,
       "filename": "simd_lane.164.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 974,
       "filename": "simd_lane.165.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 982,
       "filename": "simd_lane.166.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 990,
       "filename": "simd_lane.167.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 998,
       "filename": "simd_lane.168.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 1006,
       "filename": "simd_lane.169.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1014,
       "filename": "simd_lane.170.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1022,
       "filename": "simd_lane.171.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 1030,
       "filename": "simd_lane.172.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1038,
       "filename": "simd_lane.173.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1046,
       "filename": "simd_lane.174.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 1054,
       "filename": "simd_lane.175.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1062,
       "filename": "simd_lane.176.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1070,
       "filename": "simd_lane.177.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1078,
       "filename": "simd_lane.178.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 1086,
       "filename": "simd_lane.179.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1094,
       "filename": "simd_lane.180.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1102,
       "filename": "simd_lane.181.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1110,
       "filename": "simd_lane.182.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 1118,
       "filename": "simd_lane.183.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1126,
       "filename": "simd_lane.184.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1134,
       "filename": "simd_lane.185.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1142,
       "filename": "simd_lane.186.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 1150,
       "filename": "simd_lane.187.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1158,
       "filename": "simd_lane.188.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1166,
       "filename": "simd_lane.189.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1174,
       "filename": "simd_lane.190.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 1182,
       "filename": "simd_lane.191.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1190,
       "filename": "simd_lane.192.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1198,
       "filename": "simd_lane.193.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1206,
       "filename": "simd_lane.194.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 1214,
       "filename": "simd_lane.195.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1222,
       "filename": "simd_lane.196.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1230,
       "filename": "simd_lane.197.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1238,
       "filename": "simd_lane.198.wat",
-      "text": "invalid lane length",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "invalid lane length"
     },
     {
       "type": "assert_invalid",
       "line": 1249,
       "filename": "simd_lane.199.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1259,
       "filename": "simd_lane.200.wat",
-      "text": "invalid lane length",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "invalid lane length"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/annotations/token.wast.json
+++ b/tests/snapshots/testsuite/proposals/annotations/token.wast.json
@@ -5,358 +5,393 @@
       "type": "assert_malformed",
       "line": 4,
       "filename": "token.0.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 8,
       "filename": "token.1.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 15,
-      "filename": "token.2.wasm"
+      "filename": "token.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 18,
-      "filename": "token.3.wasm"
+      "filename": "token.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 21,
-      "filename": "token.4.wasm"
+      "filename": "token.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 24,
-      "filename": "token.5.wasm"
+      "filename": "token.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 27,
-      "filename": "token.6.wasm"
+      "filename": "token.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 30,
-      "filename": "token.7.wasm"
+      "filename": "token.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 33,
-      "filename": "token.8.wasm"
+      "filename": "token.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 38,
-      "filename": "token.9.wasm"
+      "filename": "token.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 43,
-      "filename": "token.10.wasm"
+      "filename": "token.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 47,
-      "filename": "token.11.wasm"
+      "filename": "token.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 54,
-      "filename": "token.12.wasm"
+      "filename": "token.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 58,
-      "filename": "token.13.wasm"
+      "filename": "token.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 62,
-      "filename": "token.14.wasm"
+      "filename": "token.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 66,
-      "filename": "token.15.wasm"
+      "filename": "token.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 70,
-      "filename": "token.16.wasm"
+      "filename": "token.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 74,
-      "filename": "token.17.wasm"
+      "filename": "token.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 82,
-      "filename": "token.18.wasm"
+      "filename": "token.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 86,
       "filename": "token.19.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 92,
       "filename": "token.20.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 98,
-      "filename": "token.21.wasm"
+      "filename": "token.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 102,
       "filename": "token.22.wat",
-      "text": "unknown label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown label"
     },
     {
       "type": "assert_malformed",
       "line": 108,
       "filename": "token.23.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 114,
-      "filename": "token.24.wasm"
+      "filename": "token.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 118,
       "filename": "token.25.wat",
-      "text": "unknown label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown label"
     },
     {
       "type": "assert_malformed",
       "line": 124,
       "filename": "token.26.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 130,
-      "filename": "token.27.wasm"
+      "filename": "token.27.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 133,
-      "filename": "token.28.wasm"
+      "filename": "token.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 140,
-      "filename": "token.29.wasm"
+      "filename": "token.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 144,
       "filename": "token.30.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 150,
-      "filename": "token.31.wasm"
+      "filename": "token.31.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 154,
       "filename": "token.32.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 160,
-      "filename": "token.33.wasm"
+      "filename": "token.33.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 164,
       "filename": "token.34.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 170,
-      "filename": "token.35.wasm"
+      "filename": "token.35.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 174,
       "filename": "token.36.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 180,
-      "filename": "token.37.wasm"
+      "filename": "token.37.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 184,
       "filename": "token.38.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 190,
-      "filename": "token.39.wasm"
+      "filename": "token.39.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 194,
       "filename": "token.40.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 200,
-      "filename": "token.41.wasm"
+      "filename": "token.41.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 204,
       "filename": "token.42.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 210,
-      "filename": "token.43.wasm"
+      "filename": "token.43.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 214,
       "filename": "token.44.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 220,
-      "filename": "token.45.wasm"
+      "filename": "token.45.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 224,
       "filename": "token.46.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 230,
-      "filename": "token.47.wasm"
+      "filename": "token.47.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 234,
       "filename": "token.48.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 240,
-      "filename": "token.49.wasm"
+      "filename": "token.49.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 244,
       "filename": "token.50.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 250,
-      "filename": "token.51.wasm"
+      "filename": "token.51.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 254,
       "filename": "token.52.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 260,
-      "filename": "token.53.wasm"
+      "filename": "token.53.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 264,
       "filename": "token.54.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 270,
-      "filename": "token.55.wasm"
+      "filename": "token.55.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 274,
       "filename": "token.56.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 282,
       "filename": "token.57.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 288,
       "filename": "token.58.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 294,
       "filename": "token.59.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 300,
       "filename": "token.60.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/exception-handling/binary.wast.json
+++ b/tests/snapshots/testsuite/proposals/exception-handling/binary.wast.json
@@ -4,904 +4,923 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "binary.0.wasm"
+      "filename": "binary.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 2,
-      "filename": "binary.1.wasm"
+      "filename": "binary.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 3,
       "name": "M1",
-      "filename": "binary.2.wasm"
+      "filename": "binary.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 4,
       "name": "M2",
-      "filename": "binary.3.wasm"
+      "filename": "binary.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 6,
       "filename": "binary.4.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 7,
       "filename": "binary.5.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 8,
       "filename": "binary.6.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 9,
       "filename": "binary.7.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 10,
       "filename": "binary.8.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 11,
       "filename": "binary.9.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 12,
       "filename": "binary.10.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 13,
       "filename": "binary.11.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 14,
       "filename": "binary.12.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 15,
       "filename": "binary.13.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 16,
       "filename": "binary.14.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 17,
       "filename": "binary.15.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 18,
       "filename": "binary.16.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 21,
       "filename": "binary.17.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 24,
       "filename": "binary.18.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 25,
       "filename": "binary.19.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 28,
       "filename": "binary.20.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 31,
       "filename": "binary.21.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 34,
       "filename": "binary.22.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 37,
       "filename": "binary.23.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 38,
       "filename": "binary.24.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 39,
       "filename": "binary.25.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 40,
       "filename": "binary.26.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 41,
       "filename": "binary.27.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 42,
       "filename": "binary.28.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 43,
       "filename": "binary.29.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 44,
       "filename": "binary.30.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 45,
       "filename": "binary.31.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 48,
       "filename": "binary.32.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 49,
       "filename": "binary.33.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 50,
       "filename": "binary.34.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 51,
       "filename": "binary.35.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 52,
       "filename": "binary.36.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 56,
       "filename": "binary.37.wasm",
-      "text": "END opcode expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "END opcode expected"
     },
     {
       "type": "assert_malformed",
       "line": 77,
       "filename": "binary.38.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 93,
       "filename": "binary.39.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 113,
       "filename": "binary.40.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 126,
       "filename": "binary.41.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 146,
       "filename": "binary.42.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 166,
       "filename": "binary.43.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 185,
       "filename": "binary.44.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 204,
       "filename": "binary.45.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 224,
       "filename": "binary.46.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 243,
       "filename": "binary.47.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 262,
       "filename": "binary.48.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 280,
       "filename": "binary.49.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 298,
       "filename": "binary.50.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 317,
       "filename": "binary.51.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 334,
       "filename": "binary.52.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 351,
       "filename": "binary.53.wasm",
-      "text": "too many locals",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "too many locals"
     },
     {
       "type": "assert_malformed",
       "line": 367,
       "filename": "binary.54.wasm",
-      "text": "too many locals",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "too many locals"
     },
     {
       "type": "module",
       "line": 385,
-      "filename": "binary.55.wasm"
+      "filename": "binary.55.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 401,
       "filename": "binary.56.wasm",
-      "text": "function and code section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function and code section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 411,
       "filename": "binary.57.wasm",
-      "text": "function and code section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function and code section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 420,
       "filename": "binary.58.wasm",
-      "text": "function and code section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function and code section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 431,
       "filename": "binary.59.wasm",
-      "text": "function and code section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function and code section have inconsistent lengths"
     },
     {
       "type": "module",
       "line": 441,
-      "filename": "binary.60.wasm"
+      "filename": "binary.60.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 447,
-      "filename": "binary.61.wasm"
+      "filename": "binary.61.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 454,
       "filename": "binary.62.wasm",
-      "text": "data count and data section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "data count and data section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 464,
       "filename": "binary.63.wasm",
-      "text": "data count and data section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "data count and data section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 474,
       "filename": "binary.64.wasm",
-      "text": "data count section required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "data count section required"
     },
     {
       "type": "assert_malformed",
       "line": 496,
       "filename": "binary.65.wasm",
-      "text": "data count section required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "data count section required"
     },
     {
       "type": "assert_malformed",
       "line": 515,
       "filename": "binary.66.wasm",
-      "text": "illegal opcode",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "illegal opcode"
     },
     {
       "type": "assert_malformed",
       "line": 541,
       "filename": "binary.67.wasm",
-      "text": "malformed reference type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed reference type"
     },
     {
       "type": "module",
       "line": 566,
-      "filename": "binary.68.wasm"
+      "filename": "binary.68.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 590,
-      "filename": "binary.69.wasm"
+      "filename": "binary.69.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 615,
-      "filename": "binary.70.wasm"
+      "filename": "binary.70.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 622,
       "filename": "binary.71.wasm",
-      "text": "length out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "length out of bounds"
     },
     {
       "type": "assert_malformed",
       "line": 633,
       "filename": "binary.72.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 643,
-      "filename": "binary.73.wasm"
+      "filename": "binary.73.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 652,
       "filename": "binary.74.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 662,
       "filename": "binary.75.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 673,
       "filename": "binary.76.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 683,
       "filename": "binary.77.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 694,
       "filename": "binary.78.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 704,
       "filename": "binary.79.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 717,
       "filename": "binary.80.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 736,
       "filename": "binary.81.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 760,
-      "filename": "binary.82.wasm"
+      "filename": "binary.82.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 767,
       "filename": "binary.83.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 777,
       "filename": "binary.84.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 786,
       "filename": "binary.85.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 796,
       "filename": "binary.86.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "module",
       "line": 807,
-      "filename": "binary.87.wasm"
+      "filename": "binary.87.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 814,
       "filename": "binary.88.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 824,
       "filename": "binary.89.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 832,
       "filename": "binary.90.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 841,
       "filename": "binary.91.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 850,
       "filename": "binary.92.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "module",
       "line": 860,
-      "filename": "binary.93.wasm"
+      "filename": "binary.93.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 867,
       "filename": "binary.94.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 878,
       "filename": "binary.95.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 888,
-      "filename": "binary.96.wasm"
+      "filename": "binary.96.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 901,
       "filename": "binary.97.wasm",
-      "text": "length out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "length out of bounds"
     },
     {
       "type": "assert_malformed",
       "line": 922,
       "filename": "binary.98.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 942,
-      "filename": "binary.99.wasm"
+      "filename": "binary.99.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 956,
       "filename": "binary.100.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 972,
       "filename": "binary.101.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 989,
       "filename": "binary.102.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 1006,
-      "filename": "binary.103.wasm"
+      "filename": "binary.103.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 1015,
       "filename": "binary.104.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 1028,
       "filename": "binary.105.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1041,
       "filename": "binary.106.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 1055,
       "filename": "binary.107.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 1068,
-      "filename": "binary.108.wasm"
+      "filename": "binary.108.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 1086,
       "filename": "binary.109.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "module",
       "line": 1119,
-      "filename": "binary.110.wasm"
+      "filename": "binary.110.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 1133,
       "filename": "binary.111.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1150,
       "filename": "binary.112.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1162,
       "filename": "binary.113.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1174,
       "filename": "binary.114.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1184,
       "filename": "binary.115.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1194,
       "filename": "binary.116.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1204,
       "filename": "binary.117.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1214,
       "filename": "binary.118.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1224,
       "filename": "binary.119.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1234,
       "filename": "binary.120.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1244,
       "filename": "binary.121.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1254,
       "filename": "binary.122.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1264,
       "filename": "binary.123.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1274,
       "filename": "binary.124.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1284,
       "filename": "binary.125.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1294,
       "filename": "binary.126.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1304,
       "filename": "binary.127.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1314,
       "filename": "binary.128.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1324,
       "filename": "binary.129.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1335,
       "filename": "binary.130.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1346,
       "filename": "binary.131.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1356,
       "filename": "binary.132.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1366,
       "filename": "binary.133.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/exception-handling/exports.wast.json
+++ b/tests/snapshots/testsuite/proposals/exception-handling/exports.wast.json
@@ -4,63 +4,75 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "exports.0.wasm"
+      "filename": "exports.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 4,
-      "filename": "exports.1.wasm"
+      "filename": "exports.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 5,
-      "filename": "exports.2.wasm"
+      "filename": "exports.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 7,
-      "filename": "exports.3.wasm"
+      "filename": "exports.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 8,
-      "filename": "exports.4.wasm"
+      "filename": "exports.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 9,
-      "filename": "exports.5.wasm"
+      "filename": "exports.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 10,
-      "filename": "exports.6.wasm"
+      "filename": "exports.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 11,
-      "filename": "exports.7.wasm"
+      "filename": "exports.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 12,
-      "filename": "exports.8.wasm"
+      "filename": "exports.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 13,
-      "filename": "exports.9.wasm"
+      "filename": "exports.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 14,
-      "filename": "exports.10.wasm"
+      "filename": "exports.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 16,
       "name": "Func",
-      "filename": "exports.11.wasm"
+      "filename": "exports.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -106,13 +118,15 @@
     {
       "type": "module",
       "line": 24,
-      "filename": "exports.12.wasm"
+      "filename": "exports.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 25,
       "name": "Other1",
-      "filename": "exports.13.wasm"
+      "filename": "exports.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -138,7 +152,8 @@
     {
       "type": "module",
       "line": 28,
-      "filename": "exports.14.wasm"
+      "filename": "exports.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -189,115 +204,125 @@
       "type": "assert_invalid",
       "line": 39,
       "filename": "exports.15.wasm",
-      "text": "unknown function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function"
     },
     {
       "type": "assert_invalid",
       "line": 43,
       "filename": "exports.16.wasm",
-      "text": "unknown function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function"
     },
     {
       "type": "assert_invalid",
       "line": 47,
       "filename": "exports.17.wasm",
-      "text": "unknown function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function"
     },
     {
       "type": "assert_invalid",
       "line": 51,
       "filename": "exports.18.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 55,
       "filename": "exports.19.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 59,
       "filename": "exports.20.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 63,
       "filename": "exports.21.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 67,
       "filename": "exports.22.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 71,
       "filename": "exports.23.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "module",
       "line": 78,
-      "filename": "exports.24.wasm"
+      "filename": "exports.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 79,
-      "filename": "exports.25.wasm"
+      "filename": "exports.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 80,
-      "filename": "exports.26.wasm"
+      "filename": "exports.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 82,
-      "filename": "exports.27.wasm"
+      "filename": "exports.27.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 83,
-      "filename": "exports.28.wasm"
+      "filename": "exports.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 84,
-      "filename": "exports.29.wasm"
+      "filename": "exports.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 85,
-      "filename": "exports.30.wasm"
+      "filename": "exports.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 86,
-      "filename": "exports.31.wasm"
+      "filename": "exports.31.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 87,
-      "filename": "exports.32.wasm"
+      "filename": "exports.32.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 89,
       "name": "Global",
-      "filename": "exports.33.wasm"
+      "filename": "exports.33.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -331,13 +356,15 @@
     {
       "type": "module",
       "line": 95,
-      "filename": "exports.34.wasm"
+      "filename": "exports.34.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 96,
       "name": "Other2",
-      "filename": "exports.35.wasm"
+      "filename": "exports.35.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -358,307 +385,336 @@
       "type": "assert_invalid",
       "line": 100,
       "filename": "exports.36.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 104,
       "filename": "exports.37.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 108,
       "filename": "exports.38.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 112,
       "filename": "exports.39.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 116,
       "filename": "exports.40.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 120,
       "filename": "exports.41.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 124,
       "filename": "exports.42.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 128,
       "filename": "exports.43.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "module",
       "line": 135,
-      "filename": "exports.44.wasm"
+      "filename": "exports.44.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 136,
-      "filename": "exports.45.wasm"
+      "filename": "exports.45.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 137,
-      "filename": "exports.46.wasm"
+      "filename": "exports.46.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 139,
-      "filename": "exports.47.wasm"
+      "filename": "exports.47.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 140,
-      "filename": "exports.48.wasm"
+      "filename": "exports.48.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 141,
-      "filename": "exports.49.wasm"
+      "filename": "exports.49.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 142,
-      "filename": "exports.50.wasm"
+      "filename": "exports.50.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 143,
-      "filename": "exports.51.wasm"
+      "filename": "exports.51.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 144,
-      "filename": "exports.52.wasm"
+      "filename": "exports.52.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 145,
-      "filename": "exports.53.wasm"
+      "filename": "exports.53.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 146,
-      "filename": "exports.54.wasm"
+      "filename": "exports.54.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 147,
-      "filename": "exports.55.wasm"
+      "filename": "exports.55.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 148,
-      "filename": "exports.56.wasm"
+      "filename": "exports.56.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 149,
-      "filename": "exports.57.wasm"
+      "filename": "exports.57.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 150,
-      "filename": "exports.58.wasm"
+      "filename": "exports.58.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 155,
       "filename": "exports.59.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 159,
       "filename": "exports.60.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 163,
       "filename": "exports.61.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 167,
       "filename": "exports.62.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 171,
       "filename": "exports.63.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 175,
       "filename": "exports.64.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 179,
       "filename": "exports.65.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 183,
       "filename": "exports.66.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "module",
       "line": 190,
-      "filename": "exports.67.wasm"
+      "filename": "exports.67.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 191,
-      "filename": "exports.68.wasm"
+      "filename": "exports.68.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 195,
-      "filename": "exports.69.wasm"
+      "filename": "exports.69.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 196,
-      "filename": "exports.70.wasm"
+      "filename": "exports.70.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 197,
-      "filename": "exports.71.wasm"
+      "filename": "exports.71.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 198,
-      "filename": "exports.72.wasm"
+      "filename": "exports.72.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 199,
-      "filename": "exports.73.wasm"
+      "filename": "exports.73.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 200,
-      "filename": "exports.74.wasm"
+      "filename": "exports.74.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 201,
-      "filename": "exports.75.wasm"
+      "filename": "exports.75.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 202,
-      "filename": "exports.76.wasm"
+      "filename": "exports.76.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 203,
-      "filename": "exports.77.wasm"
+      "filename": "exports.77.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 204,
-      "filename": "exports.78.wasm"
+      "filename": "exports.78.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 205,
-      "filename": "exports.79.wasm"
+      "filename": "exports.79.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 206,
-      "filename": "exports.80.wasm"
+      "filename": "exports.80.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 211,
       "filename": "exports.81.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 215,
       "filename": "exports.82.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 219,
       "filename": "exports.83.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 223,
       "filename": "exports.84.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 232,
       "filename": "exports.85.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 236,
       "filename": "exports.86.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 240,
       "filename": "exports.87.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/exception-handling/imports.wast.json
+++ b/tests/snapshots/testsuite/proposals/exception-handling/imports.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "imports.0.wasm"
+      "filename": "imports.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -14,7 +15,8 @@
     {
       "type": "module",
       "line": 30,
-      "filename": "imports.1.wasm"
+      "filename": "imports.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -50,13 +52,14 @@
       "type": "assert_invalid",
       "line": 96,
       "filename": "imports.2.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "module",
       "line": 104,
-      "filename": "imports.3.wasm"
+      "filename": "imports.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -76,7 +79,8 @@
     {
       "type": "module",
       "line": 114,
-      "filename": "imports.4.wasm"
+      "filename": "imports.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -105,252 +109,260 @@
     {
       "type": "module",
       "line": 123,
-      "filename": "imports.5.wasm"
+      "filename": "imports.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 124,
-      "filename": "imports.6.wasm"
+      "filename": "imports.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 125,
-      "filename": "imports.7.wasm"
+      "filename": "imports.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 126,
-      "filename": "imports.8.wasm"
+      "filename": "imports.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 127,
-      "filename": "imports.9.wasm"
+      "filename": "imports.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 128,
-      "filename": "imports.10.wasm"
+      "filename": "imports.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 129,
-      "filename": "imports.11.wasm"
+      "filename": "imports.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 132,
       "filename": "imports.12.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 136,
       "filename": "imports.13.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 141,
       "filename": "imports.14.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 145,
       "filename": "imports.15.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 149,
       "filename": "imports.16.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 153,
       "filename": "imports.17.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 157,
       "filename": "imports.18.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 161,
       "filename": "imports.19.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 165,
       "filename": "imports.20.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 169,
       "filename": "imports.21.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 173,
       "filename": "imports.22.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 177,
       "filename": "imports.23.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 181,
       "filename": "imports.24.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 185,
       "filename": "imports.25.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 189,
       "filename": "imports.26.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 193,
       "filename": "imports.27.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 197,
       "filename": "imports.28.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 201,
       "filename": "imports.29.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 206,
       "filename": "imports.30.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 210,
       "filename": "imports.31.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 214,
       "filename": "imports.32.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 218,
       "filename": "imports.33.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 222,
       "filename": "imports.34.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 226,
       "filename": "imports.35.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 230,
       "filename": "imports.36.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 235,
       "filename": "imports.37.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 239,
       "filename": "imports.38.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 243,
       "filename": "imports.39.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 247,
       "filename": "imports.40.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 251,
       "filename": "imports.41.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 258,
-      "filename": "imports.42.wasm"
+      "filename": "imports.42.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -460,162 +472,166 @@
     {
       "type": "module",
       "line": 286,
-      "filename": "imports.43.wasm"
+      "filename": "imports.43.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 287,
-      "filename": "imports.44.wasm"
+      "filename": "imports.44.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 288,
-      "filename": "imports.45.wasm"
+      "filename": "imports.45.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 291,
       "filename": "imports.46.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 295,
       "filename": "imports.47.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 300,
       "filename": "imports.48.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 304,
       "filename": "imports.49.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 308,
       "filename": "imports.50.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 312,
       "filename": "imports.51.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 316,
       "filename": "imports.52.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 320,
       "filename": "imports.53.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 324,
       "filename": "imports.54.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 328,
       "filename": "imports.55.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 332,
       "filename": "imports.56.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 336,
       "filename": "imports.57.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 340,
       "filename": "imports.58.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 344,
       "filename": "imports.59.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 349,
       "filename": "imports.60.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 353,
       "filename": "imports.61.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 357,
       "filename": "imports.62.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 361,
       "filename": "imports.63.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 365,
       "filename": "imports.64.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 369,
       "filename": "imports.65.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 376,
-      "filename": "imports.66.wasm"
+      "filename": "imports.66.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -705,7 +721,8 @@
     {
       "type": "module",
       "line": 395,
-      "filename": "imports.67.wasm"
+      "filename": "imports.67.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -795,196 +812,218 @@
     {
       "type": "module",
       "line": 413,
-      "filename": "imports.68.wasm"
+      "filename": "imports.68.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 420,
-      "filename": "imports.69.wasm"
+      "filename": "imports.69.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 421,
-      "filename": "imports.70.wasm"
+      "filename": "imports.70.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 422,
-      "filename": "imports.71.wasm"
+      "filename": "imports.71.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 423,
-      "filename": "imports.72.wasm"
+      "filename": "imports.72.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 424,
-      "filename": "imports.73.wasm"
+      "filename": "imports.73.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 425,
-      "filename": "imports.74.wasm"
+      "filename": "imports.74.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 426,
-      "filename": "imports.75.wasm"
+      "filename": "imports.75.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 427,
-      "filename": "imports.76.wasm"
+      "filename": "imports.76.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 428,
-      "filename": "imports.77.wasm"
+      "filename": "imports.77.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 429,
-      "filename": "imports.78.wasm"
+      "filename": "imports.78.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 430,
-      "filename": "imports.79.wasm"
+      "filename": "imports.79.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 431,
-      "filename": "imports.80.wasm"
+      "filename": "imports.80.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 432,
-      "filename": "imports.81.wasm"
+      "filename": "imports.81.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 433,
-      "filename": "imports.82.wasm"
+      "filename": "imports.82.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 434,
-      "filename": "imports.83.wasm"
+      "filename": "imports.83.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 435,
-      "filename": "imports.84.wasm"
+      "filename": "imports.84.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 436,
-      "filename": "imports.85.wasm"
+      "filename": "imports.85.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 437,
-      "filename": "imports.86.wasm"
+      "filename": "imports.86.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 438,
-      "filename": "imports.87.wasm"
+      "filename": "imports.87.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 439,
-      "filename": "imports.88.wasm"
+      "filename": "imports.88.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 442,
       "filename": "imports.89.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 446,
       "filename": "imports.90.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 451,
       "filename": "imports.91.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 455,
       "filename": "imports.92.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 459,
       "filename": "imports.93.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 463,
       "filename": "imports.94.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 467,
       "filename": "imports.95.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 471,
       "filename": "imports.96.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 476,
       "filename": "imports.97.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 480,
       "filename": "imports.98.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 484,
       "filename": "imports.99.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 488,
       "filename": "imports.100.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 496,
-      "filename": "imports.101.wasm"
+      "filename": "imports.101.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1064,7 +1103,8 @@
     {
       "type": "module",
       "line": 508,
-      "filename": "imports.102.wasm"
+      "filename": "imports.102.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1145,170 +1185,180 @@
       "type": "assert_invalid",
       "line": 520,
       "filename": "imports.103.wasm",
-      "text": "multiple memories",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "multiple memories"
     },
     {
       "type": "assert_invalid",
       "line": 524,
       "filename": "imports.104.wasm",
-      "text": "multiple memories",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "multiple memories"
     },
     {
       "type": "assert_invalid",
       "line": 528,
       "filename": "imports.105.wasm",
-      "text": "multiple memories",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "multiple memories"
     },
     {
       "type": "module",
       "line": 532,
-      "filename": "imports.106.wasm"
+      "filename": "imports.106.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 533,
-      "filename": "imports.107.wasm"
+      "filename": "imports.107.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 534,
-      "filename": "imports.108.wasm"
+      "filename": "imports.108.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 535,
-      "filename": "imports.109.wasm"
+      "filename": "imports.109.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 536,
-      "filename": "imports.110.wasm"
+      "filename": "imports.110.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 537,
-      "filename": "imports.111.wasm"
+      "filename": "imports.111.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 538,
-      "filename": "imports.112.wasm"
+      "filename": "imports.112.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 539,
-      "filename": "imports.113.wasm"
+      "filename": "imports.113.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 540,
-      "filename": "imports.114.wasm"
+      "filename": "imports.114.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 543,
       "filename": "imports.115.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 547,
       "filename": "imports.116.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 552,
       "filename": "imports.117.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 556,
       "filename": "imports.118.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 560,
       "filename": "imports.119.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 564,
       "filename": "imports.120.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 569,
       "filename": "imports.121.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 573,
       "filename": "imports.122.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 577,
       "filename": "imports.123.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 581,
       "filename": "imports.124.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 585,
       "filename": "imports.125.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 589,
       "filename": "imports.126.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 594,
       "filename": "imports.127.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 598,
       "filename": "imports.128.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 602,
-      "filename": "imports.129.wasm"
+      "filename": "imports.129.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1414,118 +1464,119 @@
       "type": "assert_malformed",
       "line": 616,
       "filename": "imports.130.wat",
-      "text": "import after function",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after function"
     },
     {
       "type": "assert_malformed",
       "line": 620,
       "filename": "imports.131.wat",
-      "text": "import after function",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after function"
     },
     {
       "type": "assert_malformed",
       "line": 624,
       "filename": "imports.132.wat",
-      "text": "import after function",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after function"
     },
     {
       "type": "assert_malformed",
       "line": 628,
       "filename": "imports.133.wat",
-      "text": "import after function",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after function"
     },
     {
       "type": "assert_malformed",
       "line": 633,
       "filename": "imports.134.wat",
-      "text": "import after global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after global"
     },
     {
       "type": "assert_malformed",
       "line": 637,
       "filename": "imports.135.wat",
-      "text": "import after global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after global"
     },
     {
       "type": "assert_malformed",
       "line": 641,
       "filename": "imports.136.wat",
-      "text": "import after global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after global"
     },
     {
       "type": "assert_malformed",
       "line": 645,
       "filename": "imports.137.wat",
-      "text": "import after global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after global"
     },
     {
       "type": "assert_malformed",
       "line": 650,
       "filename": "imports.138.wat",
-      "text": "import after table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after table"
     },
     {
       "type": "assert_malformed",
       "line": 654,
       "filename": "imports.139.wat",
-      "text": "import after table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after table"
     },
     {
       "type": "assert_malformed",
       "line": 658,
       "filename": "imports.140.wat",
-      "text": "import after table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after table"
     },
     {
       "type": "assert_malformed",
       "line": 662,
       "filename": "imports.141.wat",
-      "text": "import after table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after table"
     },
     {
       "type": "assert_malformed",
       "line": 667,
       "filename": "imports.142.wat",
-      "text": "import after memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after memory"
     },
     {
       "type": "assert_malformed",
       "line": 671,
       "filename": "imports.143.wat",
-      "text": "import after memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after memory"
     },
     {
       "type": "assert_malformed",
       "line": 675,
       "filename": "imports.144.wat",
-      "text": "import after memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after memory"
     },
     {
       "type": "assert_malformed",
       "line": 679,
       "filename": "imports.145.wat",
-      "text": "import after memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after memory"
     },
     {
       "type": "module",
       "line": 686,
-      "filename": "imports.146.wasm"
+      "filename": "imports.146.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1536,8 +1587,8 @@
       "type": "assert_unlinkable",
       "line": 689,
       "filename": "imports.147.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/exception-handling/ref_null.wast.json
+++ b/tests/snapshots/testsuite/proposals/exception-handling/ref_null.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "ref_null.0.wasm"
+      "filename": "ref_null.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/exception-handling/tag.wast.json
+++ b/tests/snapshots/testsuite/proposals/exception-handling/tag.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "tag.0.wasm"
+      "filename": "tag.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -14,14 +15,15 @@
     {
       "type": "module",
       "line": 13,
-      "filename": "tag.1.wasm"
+      "filename": "tag.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 19,
       "filename": "tag.2.wasm",
-      "text": "non-empty tag result type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "non-empty tag result type"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/exception-handling/throw.wast.json
+++ b/tests/snapshots/testsuite/proposals/exception-handling/throw.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "throw.0.wasm"
+      "filename": "throw.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -128,22 +129,22 @@
       "type": "assert_invalid",
       "line": 51,
       "filename": "throw.1.wasm",
-      "text": "unknown tag 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown tag 0"
     },
     {
       "type": "assert_invalid",
       "line": 52,
       "filename": "throw.2.wasm",
-      "text": "type mismatch: instruction requires [i32] but stack has []",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch: instruction requires [i32] but stack has []"
     },
     {
       "type": "assert_invalid",
       "line": 54,
       "filename": "throw.3.wasm",
-      "text": "type mismatch: instruction requires [i32] but stack has [i64]",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch: instruction requires [i32] but stack has [i64]"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/exception-handling/throw_ref.wast.json
+++ b/tests/snapshots/testsuite/proposals/exception-handling/throw_ref.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "throw_ref.0.wasm"
+      "filename": "throw_ref.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_exception",
@@ -193,15 +194,15 @@
       "type": "assert_invalid",
       "line": 117,
       "filename": "throw_ref.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 118,
       "filename": "throw_ref.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/exception-handling/try_table.wast.json
+++ b/tests/snapshots/testsuite/proposals/exception-handling/try_table.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "try_table.0.wasm"
+      "filename": "try_table.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -14,7 +15,8 @@
     {
       "type": "module",
       "line": 10,
-      "filename": "try_table.1.wasm"
+      "filename": "try_table.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -723,7 +725,8 @@
     {
       "type": "module",
       "line": 303,
-      "filename": "try_table.2.wasm"
+      "filename": "try_table.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -744,69 +747,70 @@
       "type": "assert_malformed",
       "line": 328,
       "filename": "try_table.3.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 333,
       "filename": "try_table.4.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "module",
       "line": 337,
-      "filename": "try_table.5.wasm"
+      "filename": "try_table.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 348,
       "filename": "try_table.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 352,
       "filename": "try_table.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 357,
       "filename": "try_table.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 361,
       "filename": "try_table.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 365,
       "filename": "try_table.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 369,
       "filename": "try_table.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 373,
       "filename": "try_table.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/extended-const/data.wast.json
+++ b/tests/snapshots/testsuite/proposals/extended-const/data.wast.json
@@ -4,399 +4,428 @@
     {
       "type": "module",
       "line": 5,
-      "filename": "data.0.wasm"
+      "filename": "data.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 35,
-      "filename": "data.1.wasm"
+      "filename": "data.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 39,
-      "filename": "data.2.wasm"
+      "filename": "data.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 44,
-      "filename": "data.3.wasm"
+      "filename": "data.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 52,
-      "filename": "data.4.wasm"
+      "filename": "data.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 62,
-      "filename": "data.5.wasm"
+      "filename": "data.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 67,
-      "filename": "data.6.wasm"
+      "filename": "data.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 73,
-      "filename": "data.7.wasm"
+      "filename": "data.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 78,
-      "filename": "data.8.wasm"
+      "filename": "data.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 85,
       "filename": "data.9.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 89,
       "filename": "data.10.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "module",
       "line": 96,
-      "filename": "data.11.wasm"
+      "filename": "data.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 101,
-      "filename": "data.12.wasm"
+      "filename": "data.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 107,
-      "filename": "data.13.wasm"
+      "filename": "data.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 112,
-      "filename": "data.14.wasm"
+      "filename": "data.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 116,
-      "filename": "data.15.wasm"
+      "filename": "data.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 121,
-      "filename": "data.16.wasm"
+      "filename": "data.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 126,
-      "filename": "data.17.wasm"
+      "filename": "data.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 131,
-      "filename": "data.18.wasm"
+      "filename": "data.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 135,
-      "filename": "data.19.wasm"
+      "filename": "data.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 140,
-      "filename": "data.20.wasm"
+      "filename": "data.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 145,
-      "filename": "data.21.wasm"
+      "filename": "data.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 150,
-      "filename": "data.22.wasm"
+      "filename": "data.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 155,
-      "filename": "data.23.wasm"
+      "filename": "data.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 161,
-      "filename": "data.24.wasm"
+      "filename": "data.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 167,
-      "filename": "data.25.wasm"
+      "filename": "data.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 172,
-      "filename": "data.26.wasm"
+      "filename": "data.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 179,
-      "filename": "data.27.wasm"
+      "filename": "data.27.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 184,
-      "filename": "data.28.wasm"
+      "filename": "data.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 189,
-      "filename": "data.29.wasm"
+      "filename": "data.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 196,
-      "filename": "data.30.wasm"
+      "filename": "data.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_uninstantiable",
       "line": 212,
       "filename": "data.31.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 220,
       "filename": "data.32.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 228,
       "filename": "data.33.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 235,
       "filename": "data.34.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 242,
       "filename": "data.35.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 259,
       "filename": "data.36.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 268,
       "filename": "data.37.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 275,
       "filename": "data.38.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 283,
       "filename": "data.39.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 291,
       "filename": "data.40.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 299,
       "filename": "data.41.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 306,
       "filename": "data.42.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 314,
       "filename": "data.43.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 321,
       "filename": "data.44.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_invalid",
       "line": 331,
       "filename": "data.45.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 339,
       "filename": "data.46.wasm",
-      "text": "unknown memory 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 1"
     },
     {
       "type": "assert_invalid",
       "line": 352,
       "filename": "data.47.wasm",
-      "text": "unknown memory 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 0"
     },
     {
       "type": "assert_invalid",
       "line": 363,
       "filename": "data.48.wasm",
-      "text": "unknown memory 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 1"
     },
     {
       "type": "assert_invalid",
       "line": 375,
       "filename": "data.49.wasm",
-      "text": "unknown memory 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 1"
     },
     {
       "type": "assert_invalid",
       "line": 397,
       "filename": "data.50.wasm",
-      "text": "unknown memory 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 1"
     },
     {
       "type": "assert_invalid",
       "line": 416,
       "filename": "data.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 424,
       "filename": "data.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 432,
       "filename": "data.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 440,
       "filename": "data.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 448,
       "filename": "data.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 457,
       "filename": "data.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 466,
       "filename": "data.57.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 474,
       "filename": "data.58.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 482,
       "filename": "data.59.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 490,
       "filename": "data.60.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 498,
       "filename": "data.61.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 507,
       "filename": "data.62.wasm",
-      "text": "unknown global 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global 0"
     },
     {
       "type": "assert_invalid",
       "line": 515,
       "filename": "data.63.wasm",
-      "text": "unknown global 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global 1"
     },
     {
       "type": "assert_invalid",
       "line": 524,
       "filename": "data.64.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/extended-const/elem.wast.json
+++ b/tests/snapshots/testsuite/proposals/extended-const/elem.wast.json
@@ -4,47 +4,56 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "elem.0.wasm"
+      "filename": "elem.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 80,
-      "filename": "elem.1.wasm"
+      "filename": "elem.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 90,
-      "filename": "elem.2.wasm"
+      "filename": "elem.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 95,
-      "filename": "elem.3.wasm"
+      "filename": "elem.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 101,
-      "filename": "elem.4.wasm"
+      "filename": "elem.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 110,
-      "filename": "elem.5.wasm"
+      "filename": "elem.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 120,
-      "filename": "elem.6.wasm"
+      "filename": "elem.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 127,
-      "filename": "elem.7.wasm"
+      "filename": "elem.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 134,
-      "filename": "elem.8.wasm"
+      "filename": "elem.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -79,7 +88,8 @@
     {
       "type": "module",
       "line": 153,
-      "filename": "elem.9.wasm"
+      "filename": "elem.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -115,154 +125,165 @@
       "type": "assert_invalid",
       "line": 171,
       "filename": "elem.10.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 175,
       "filename": "elem.11.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "module",
       "line": 182,
-      "filename": "elem.12.wasm"
+      "filename": "elem.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 187,
-      "filename": "elem.13.wasm"
+      "filename": "elem.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 193,
-      "filename": "elem.14.wasm"
+      "filename": "elem.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 197,
-      "filename": "elem.15.wasm"
+      "filename": "elem.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 202,
-      "filename": "elem.16.wasm"
+      "filename": "elem.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 207,
-      "filename": "elem.17.wasm"
+      "filename": "elem.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 212,
-      "filename": "elem.18.wasm"
+      "filename": "elem.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 218,
-      "filename": "elem.19.wasm"
+      "filename": "elem.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 224,
-      "filename": "elem.20.wasm"
+      "filename": "elem.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 230,
-      "filename": "elem.21.wasm"
+      "filename": "elem.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_uninstantiable",
       "line": 239,
       "filename": "elem.22.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 248,
       "filename": "elem.23.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 257,
       "filename": "elem.24.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 266,
       "filename": "elem.25.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 273,
       "filename": "elem.26.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 281,
       "filename": "elem.27.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 290,
       "filename": "elem.28.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 298,
       "filename": "elem.29.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 307,
       "filename": "elem.30.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 315,
       "filename": "elem.31.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 324,
       "filename": "elem.32.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 332,
       "filename": "elem.33.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "module",
       "line": 342,
-      "filename": "elem.34.wasm"
+      "filename": "elem.34.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -277,7 +298,8 @@
     {
       "type": "module",
       "line": 352,
-      "filename": "elem.35.wasm"
+      "filename": "elem.35.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -293,153 +315,154 @@
       "type": "assert_invalid",
       "line": 365,
       "filename": "elem.36.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 375,
       "filename": "elem.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 383,
       "filename": "elem.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 391,
       "filename": "elem.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 399,
       "filename": "elem.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 407,
       "filename": "elem.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 416,
       "filename": "elem.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 426,
       "filename": "elem.43.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 434,
       "filename": "elem.44.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 442,
       "filename": "elem.45.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 450,
       "filename": "elem.46.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 458,
       "filename": "elem.47.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 467,
       "filename": "elem.48.wasm",
-      "text": "unknown global 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global 0"
     },
     {
       "type": "assert_invalid",
       "line": 475,
       "filename": "elem.49.wasm",
-      "text": "unknown global 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global 1"
     },
     {
       "type": "assert_invalid",
       "line": 484,
       "filename": "elem.50.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 495,
       "filename": "elem.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 503,
       "filename": "elem.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 511,
       "filename": "elem.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 519,
       "filename": "elem.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 527,
       "filename": "elem.55.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 536,
       "filename": "elem.56.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "module",
       "line": 546,
-      "filename": "elem.57.wasm"
+      "filename": "elem.57.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -459,7 +482,8 @@
     {
       "type": "module",
       "line": 559,
-      "filename": "elem.58.wasm"
+      "filename": "elem.58.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -480,7 +504,8 @@
       "type": "module",
       "line": 574,
       "name": "module1",
-      "filename": "elem.59.wasm"
+      "filename": "elem.59.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -535,7 +560,8 @@
       "type": "module",
       "line": 598,
       "name": "module2",
-      "filename": "elem.60.wasm"
+      "filename": "elem.60.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -589,7 +615,8 @@
       "type": "module",
       "line": 611,
       "name": "module3",
-      "filename": "elem.61.wasm"
+      "filename": "elem.61.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -643,35 +670,36 @@
       "type": "assert_invalid",
       "line": 627,
       "filename": "elem.62.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 632,
       "filename": "elem.63.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 637,
       "filename": "elem.64.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 646,
       "filename": "elem.65.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 655,
       "name": "m",
-      "filename": "elem.66.wasm"
+      "filename": "elem.66.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -806,7 +834,8 @@
     {
       "type": "module",
       "line": 673,
-      "filename": "elem.67.wasm"
+      "filename": "elem.67.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -854,7 +883,8 @@
       "type": "module",
       "line": 682,
       "name": "module4",
-      "filename": "elem.68.wasm"
+      "filename": "elem.68.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -865,7 +895,8 @@
     {
       "type": "module",
       "line": 691,
-      "filename": "elem.69.wasm"
+      "filename": "elem.69.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -885,7 +916,8 @@
     {
       "type": "module",
       "line": 705,
-      "filename": "elem.70.wasm"
+      "filename": "elem.70.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -925,7 +957,8 @@
     {
       "type": "module",
       "line": 716,
-      "filename": "elem.71.wasm"
+      "filename": "elem.71.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -965,7 +998,8 @@
     {
       "type": "module",
       "line": 727,
-      "filename": "elem.72.wasm"
+      "filename": "elem.72.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1005,7 +1039,8 @@
     {
       "type": "module",
       "line": 740,
-      "filename": "elem.73.wasm"
+      "filename": "elem.73.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/extended-const/global.wast.json
+++ b/tests/snapshots/testsuite/proposals/extended-const/global.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "global.0.wasm"
+      "filename": "global.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -930,350 +931,354 @@
       "type": "assert_invalid",
       "line": 285,
       "filename": "global.1.wasm",
-      "text": "global is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "global is immutable"
     },
     {
       "type": "assert_invalid",
       "line": 290,
       "filename": "global.2.wasm",
-      "text": "global is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "global is immutable"
     },
     {
       "type": "module",
       "line": 295,
-      "filename": "global.3.wasm"
+      "filename": "global.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 296,
-      "filename": "global.4.wasm"
+      "filename": "global.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 299,
       "filename": "global.5.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 304,
       "filename": "global.6.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 309,
       "filename": "global.7.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 314,
       "filename": "global.8.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 319,
       "filename": "global.9.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 324,
       "filename": "global.10.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 329,
       "filename": "global.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 334,
       "filename": "global.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 339,
       "filename": "global.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 344,
       "filename": "global.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 349,
       "filename": "global.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 354,
       "filename": "global.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 359,
       "filename": "global.17.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 364,
       "filename": "global.18.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 368,
       "filename": "global.19.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 373,
       "filename": "global.20.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 378,
       "filename": "global.21.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 383,
       "filename": "global.22.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "module",
       "line": 387,
-      "filename": "global.23.wasm"
+      "filename": "global.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 391,
       "filename": "global.24.wasm",
-      "text": "malformed mutability",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed mutability"
     },
     {
       "type": "assert_malformed",
       "line": 404,
       "filename": "global.25.wasm",
-      "text": "malformed mutability",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed mutability"
     },
     {
       "type": "module",
       "line": 417,
-      "filename": "global.26.wasm"
+      "filename": "global.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 421,
       "filename": "global.27.wasm",
-      "text": "malformed mutability",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed mutability"
     },
     {
       "type": "assert_malformed",
       "line": 433,
       "filename": "global.28.wasm",
-      "text": "malformed mutability",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed mutability"
     },
     {
       "type": "assert_invalid",
       "line": 447,
       "filename": "global.29.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 452,
       "filename": "global.30.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 460,
       "filename": "global.31.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 468,
       "filename": "global.32.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 478,
       "filename": "global.33.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 483,
       "filename": "global.34.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 491,
       "filename": "global.35.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 499,
       "filename": "global.36.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 509,
       "filename": "global.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 518,
       "filename": "global.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 528,
       "filename": "global.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 538,
       "filename": "global.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 548,
       "filename": "global.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 558,
       "filename": "global.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 568,
       "filename": "global.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 578,
       "filename": "global.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 588,
       "filename": "global.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 597,
       "filename": "global.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 606,
       "filename": "global.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 616,
       "filename": "global.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 634,
       "filename": "global.49.wat",
-      "text": "duplicate global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate global"
     },
     {
       "type": "assert_malformed",
       "line": 638,
       "filename": "global.50.wat",
-      "text": "duplicate global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate global"
     },
     {
       "type": "assert_malformed",
       "line": 642,
       "filename": "global.51.wat",
-      "text": "duplicate global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate global"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/function-references/binary.wast.json
+++ b/tests/snapshots/testsuite/proposals/function-references/binary.wast.json
@@ -4,904 +4,923 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "binary.0.wasm"
+      "filename": "binary.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 2,
-      "filename": "binary.1.wasm"
+      "filename": "binary.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 3,
       "name": "M1",
-      "filename": "binary.2.wasm"
+      "filename": "binary.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 4,
       "name": "M2",
-      "filename": "binary.3.wasm"
+      "filename": "binary.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 6,
       "filename": "binary.4.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 7,
       "filename": "binary.5.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 8,
       "filename": "binary.6.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 9,
       "filename": "binary.7.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 10,
       "filename": "binary.8.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 11,
       "filename": "binary.9.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 12,
       "filename": "binary.10.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 13,
       "filename": "binary.11.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 14,
       "filename": "binary.12.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 15,
       "filename": "binary.13.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 16,
       "filename": "binary.14.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 17,
       "filename": "binary.15.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 18,
       "filename": "binary.16.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 21,
       "filename": "binary.17.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 24,
       "filename": "binary.18.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 25,
       "filename": "binary.19.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 28,
       "filename": "binary.20.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 31,
       "filename": "binary.21.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 34,
       "filename": "binary.22.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 37,
       "filename": "binary.23.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 38,
       "filename": "binary.24.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 39,
       "filename": "binary.25.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 40,
       "filename": "binary.26.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 41,
       "filename": "binary.27.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 42,
       "filename": "binary.28.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 43,
       "filename": "binary.29.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 44,
       "filename": "binary.30.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 45,
       "filename": "binary.31.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 48,
       "filename": "binary.32.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 49,
       "filename": "binary.33.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 50,
       "filename": "binary.34.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 51,
       "filename": "binary.35.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 52,
       "filename": "binary.36.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 56,
       "filename": "binary.37.wasm",
-      "text": "END opcode expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "END opcode expected"
     },
     {
       "type": "assert_malformed",
       "line": 77,
       "filename": "binary.38.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 93,
       "filename": "binary.39.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 113,
       "filename": "binary.40.wasm",
-      "text": "illegal opcode",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "illegal opcode"
     },
     {
       "type": "assert_malformed",
       "line": 126,
       "filename": "binary.41.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 146,
       "filename": "binary.42.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 166,
       "filename": "binary.43.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 185,
       "filename": "binary.44.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 204,
       "filename": "binary.45.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 224,
       "filename": "binary.46.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 243,
       "filename": "binary.47.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 262,
       "filename": "binary.48.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 280,
       "filename": "binary.49.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 298,
       "filename": "binary.50.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 317,
       "filename": "binary.51.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 334,
       "filename": "binary.52.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 351,
       "filename": "binary.53.wasm",
-      "text": "too many locals",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "too many locals"
     },
     {
       "type": "assert_malformed",
       "line": 367,
       "filename": "binary.54.wasm",
-      "text": "too many locals",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "too many locals"
     },
     {
       "type": "module",
       "line": 385,
-      "filename": "binary.55.wasm"
+      "filename": "binary.55.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 401,
       "filename": "binary.56.wasm",
-      "text": "function and code section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function and code section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 411,
       "filename": "binary.57.wasm",
-      "text": "function and code section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function and code section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 420,
       "filename": "binary.58.wasm",
-      "text": "function and code section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function and code section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 431,
       "filename": "binary.59.wasm",
-      "text": "function and code section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function and code section have inconsistent lengths"
     },
     {
       "type": "module",
       "line": 441,
-      "filename": "binary.60.wasm"
+      "filename": "binary.60.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 447,
-      "filename": "binary.61.wasm"
+      "filename": "binary.61.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 454,
       "filename": "binary.62.wasm",
-      "text": "data count and data section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "data count and data section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 464,
       "filename": "binary.63.wasm",
-      "text": "data count and data section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "data count and data section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 474,
       "filename": "binary.64.wasm",
-      "text": "data count section required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "data count section required"
     },
     {
       "type": "assert_malformed",
       "line": 496,
       "filename": "binary.65.wasm",
-      "text": "data count section required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "data count section required"
     },
     {
       "type": "assert_malformed",
       "line": 515,
       "filename": "binary.66.wasm",
-      "text": "illegal opcode",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "illegal opcode"
     },
     {
       "type": "assert_malformed",
       "line": 541,
       "filename": "binary.67.wasm",
-      "text": "malformed reference type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed reference type"
     },
     {
       "type": "module",
       "line": 566,
-      "filename": "binary.68.wasm"
+      "filename": "binary.68.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 590,
-      "filename": "binary.69.wasm"
+      "filename": "binary.69.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 615,
-      "filename": "binary.70.wasm"
+      "filename": "binary.70.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 622,
       "filename": "binary.71.wasm",
-      "text": "length out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "length out of bounds"
     },
     {
       "type": "assert_malformed",
       "line": 633,
       "filename": "binary.72.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 643,
-      "filename": "binary.73.wasm"
+      "filename": "binary.73.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 652,
       "filename": "binary.74.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 662,
       "filename": "binary.75.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 673,
       "filename": "binary.76.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 683,
       "filename": "binary.77.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 694,
       "filename": "binary.78.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 704,
       "filename": "binary.79.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 717,
       "filename": "binary.80.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 736,
       "filename": "binary.81.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 760,
-      "filename": "binary.82.wasm"
+      "filename": "binary.82.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 767,
       "filename": "binary.83.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 777,
       "filename": "binary.84.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 786,
       "filename": "binary.85.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 796,
       "filename": "binary.86.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "module",
       "line": 807,
-      "filename": "binary.87.wasm"
+      "filename": "binary.87.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 814,
       "filename": "binary.88.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 824,
       "filename": "binary.89.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 832,
       "filename": "binary.90.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 841,
       "filename": "binary.91.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 850,
       "filename": "binary.92.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "module",
       "line": 860,
-      "filename": "binary.93.wasm"
+      "filename": "binary.93.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 867,
       "filename": "binary.94.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 878,
       "filename": "binary.95.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 888,
-      "filename": "binary.96.wasm"
+      "filename": "binary.96.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 901,
       "filename": "binary.97.wasm",
-      "text": "length out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "length out of bounds"
     },
     {
       "type": "assert_malformed",
       "line": 922,
       "filename": "binary.98.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 942,
-      "filename": "binary.99.wasm"
+      "filename": "binary.99.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 956,
       "filename": "binary.100.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 972,
       "filename": "binary.101.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 989,
       "filename": "binary.102.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 1006,
-      "filename": "binary.103.wasm"
+      "filename": "binary.103.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 1015,
       "filename": "binary.104.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 1028,
       "filename": "binary.105.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1041,
       "filename": "binary.106.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 1055,
       "filename": "binary.107.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 1068,
-      "filename": "binary.108.wasm"
+      "filename": "binary.108.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 1086,
       "filename": "binary.109.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "module",
       "line": 1119,
-      "filename": "binary.110.wasm"
+      "filename": "binary.110.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 1133,
       "filename": "binary.111.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1150,
       "filename": "binary.112.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1162,
       "filename": "binary.113.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1174,
       "filename": "binary.114.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1184,
       "filename": "binary.115.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1194,
       "filename": "binary.116.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1204,
       "filename": "binary.117.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1214,
       "filename": "binary.118.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1224,
       "filename": "binary.119.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1234,
       "filename": "binary.120.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1244,
       "filename": "binary.121.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1254,
       "filename": "binary.122.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1264,
       "filename": "binary.123.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1274,
       "filename": "binary.124.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1284,
       "filename": "binary.125.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1294,
       "filename": "binary.126.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1304,
       "filename": "binary.127.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1314,
       "filename": "binary.128.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1324,
       "filename": "binary.129.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1335,
       "filename": "binary.130.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1346,
       "filename": "binary.131.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1356,
       "filename": "binary.132.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1366,
       "filename": "binary.133.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/function-references/br_on_non_null.wast.json
+++ b/tests/snapshots/testsuite/proposals/function-references/br_on_non_null.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "br_on_non_null.0.wasm"
+      "filename": "br_on_non_null.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -64,12 +65,14 @@
     {
       "type": "module",
       "line": 43,
-      "filename": "br_on_non_null.1.wasm"
+      "filename": "br_on_non_null.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 51,
-      "filename": "br_on_non_null.2.wasm"
+      "filename": "br_on_non_null.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/function-references/br_on_null.wast.json
+++ b/tests/snapshots/testsuite/proposals/function-references/br_on_null.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "br_on_null.0.wasm"
+      "filename": "br_on_null.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -64,12 +65,14 @@
     {
       "type": "module",
       "line": 38,
-      "filename": "br_on_null.1.wasm"
+      "filename": "br_on_null.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 46,
-      "filename": "br_on_null.2.wasm"
+      "filename": "br_on_null.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/function-references/br_table.wast.json
+++ b/tests/snapshots/testsuite/proposals/function-references/br_table.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "br_table.0.wasm"
+      "filename": "br_table.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2972,169 +2973,169 @@
       "type": "assert_invalid",
       "line": 1267,
       "filename": "br_table.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1274,
       "filename": "br_table.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1281,
       "filename": "br_table.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1287,
       "filename": "br_table.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1295,
       "filename": "br_table.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1306,
       "filename": "br_table.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1317,
       "filename": "br_table.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1323,
       "filename": "br_table.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1329,
       "filename": "br_table.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1335,
       "filename": "br_table.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1341,
       "filename": "br_table.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1350,
       "filename": "br_table.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1357,
       "filename": "br_table.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1369,
       "filename": "br_table.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1381,
       "filename": "br_table.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1392,
       "filename": "br_table.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1404,
       "filename": "br_table.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1416,
       "filename": "br_table.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1430,
       "filename": "br_table.19.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 1436,
       "filename": "br_table.20.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 1442,
       "filename": "br_table.21.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 1449,
       "filename": "br_table.22.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 1455,
       "filename": "br_table.23.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 1461,
       "filename": "br_table.24.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/function-references/call_ref.wast.json
+++ b/tests/snapshots/testsuite/proposals/function-references/call_ref.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "call_ref.0.wasm"
+      "filename": "call_ref.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -495,7 +496,8 @@
     {
       "type": "module",
       "line": 129,
-      "filename": "call_ref.1.wasm"
+      "filename": "call_ref.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -510,7 +512,8 @@
     {
       "type": "module",
       "line": 138,
-      "filename": "call_ref.2.wasm"
+      "filename": "call_ref.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -525,7 +528,8 @@
     {
       "type": "module",
       "line": 151,
-      "filename": "call_ref.3.wasm"
+      "filename": "call_ref.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -541,22 +545,22 @@
       "type": "assert_invalid",
       "line": 168,
       "filename": "call_ref.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 184,
       "filename": "call_ref.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 201,
       "filename": "call_ref.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/function-references/custom.wast.json
+++ b/tests/snapshots/testsuite/proposals/function-references/custom.wast.json
@@ -4,73 +4,76 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "custom.0.wasm"
+      "filename": "custom.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 14,
-      "filename": "custom.1.wasm"
+      "filename": "custom.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 50,
-      "filename": "custom.2.wasm"
+      "filename": "custom.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 61,
       "filename": "custom.3.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 69,
       "filename": "custom.4.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 77,
       "filename": "custom.5.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 85,
       "filename": "custom.6.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 93,
       "filename": "custom.7.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 102,
       "filename": "custom.8.wasm",
-      "text": "function and code section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function and code section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 115,
       "filename": "custom.9.wasm",
-      "text": "length out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "length out of bounds"
     },
     {
       "type": "assert_malformed",
       "line": 123,
       "filename": "custom.10.wasm",
-      "text": "data count and data section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "data count and data section have inconsistent lengths"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/function-references/data.wast.json
+++ b/tests/snapshots/testsuite/proposals/function-references/data.wast.json
@@ -4,365 +4,390 @@
     {
       "type": "module",
       "line": 5,
-      "filename": "data.0.wasm"
+      "filename": "data.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 35,
-      "filename": "data.1.wasm"
+      "filename": "data.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 39,
-      "filename": "data.2.wasm"
+      "filename": "data.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 44,
-      "filename": "data.3.wasm"
+      "filename": "data.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 52,
-      "filename": "data.4.wasm"
+      "filename": "data.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 62,
-      "filename": "data.5.wasm"
+      "filename": "data.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 67,
-      "filename": "data.6.wasm"
+      "filename": "data.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 73,
-      "filename": "data.7.wasm"
+      "filename": "data.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 78,
-      "filename": "data.8.wasm"
+      "filename": "data.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 87,
-      "filename": "data.9.wasm"
+      "filename": "data.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 92,
-      "filename": "data.10.wasm"
+      "filename": "data.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 98,
-      "filename": "data.11.wasm"
+      "filename": "data.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 103,
-      "filename": "data.12.wasm"
+      "filename": "data.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 107,
-      "filename": "data.13.wasm"
+      "filename": "data.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 112,
-      "filename": "data.14.wasm"
+      "filename": "data.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 117,
-      "filename": "data.15.wasm"
+      "filename": "data.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 122,
-      "filename": "data.16.wasm"
+      "filename": "data.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 126,
-      "filename": "data.17.wasm"
+      "filename": "data.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 131,
-      "filename": "data.18.wasm"
+      "filename": "data.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 136,
-      "filename": "data.19.wasm"
+      "filename": "data.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 141,
-      "filename": "data.20.wasm"
+      "filename": "data.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 146,
-      "filename": "data.21.wasm"
+      "filename": "data.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 152,
-      "filename": "data.22.wasm"
+      "filename": "data.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 158,
-      "filename": "data.23.wasm"
+      "filename": "data.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 163,
-      "filename": "data.24.wasm"
+      "filename": "data.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_uninstantiable",
       "line": 171,
       "filename": "data.25.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 179,
       "filename": "data.26.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 187,
       "filename": "data.27.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 194,
       "filename": "data.28.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 201,
       "filename": "data.29.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 218,
       "filename": "data.30.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 227,
       "filename": "data.31.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 234,
       "filename": "data.32.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 242,
       "filename": "data.33.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 250,
       "filename": "data.34.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 258,
       "filename": "data.35.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 265,
       "filename": "data.36.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 273,
       "filename": "data.37.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 280,
       "filename": "data.38.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_invalid",
       "line": 290,
       "filename": "data.39.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 298,
       "filename": "data.40.wasm",
-      "text": "unknown memory 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 1"
     },
     {
       "type": "assert_invalid",
       "line": 311,
       "filename": "data.41.wasm",
-      "text": "unknown memory 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 0"
     },
     {
       "type": "assert_invalid",
       "line": 322,
       "filename": "data.42.wasm",
-      "text": "unknown memory 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 1"
     },
     {
       "type": "assert_invalid",
       "line": 334,
       "filename": "data.43.wasm",
-      "text": "unknown memory 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 1"
     },
     {
       "type": "assert_invalid",
       "line": 356,
       "filename": "data.44.wasm",
-      "text": "unknown memory 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 1"
     },
     {
       "type": "assert_invalid",
       "line": 375,
       "filename": "data.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 383,
       "filename": "data.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 391,
       "filename": "data.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 399,
       "filename": "data.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 407,
       "filename": "data.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 416,
       "filename": "data.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 425,
       "filename": "data.51.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 433,
       "filename": "data.52.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 441,
       "filename": "data.53.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 449,
       "filename": "data.54.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 457,
       "filename": "data.55.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 466,
       "filename": "data.56.wasm",
-      "text": "unknown global 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global 0"
     },
     {
       "type": "assert_invalid",
       "line": 474,
       "filename": "data.57.wasm",
-      "text": "unknown global 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global 1"
     },
     {
       "type": "assert_invalid",
       "line": 483,
       "filename": "data.58.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/function-references/elem.wast.json
+++ b/tests/snapshots/testsuite/proposals/function-references/elem.wast.json
@@ -4,52 +4,62 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "elem.0.wasm"
+      "filename": "elem.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 80,
-      "filename": "elem.1.wasm"
+      "filename": "elem.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 87,
-      "filename": "elem.2.wasm"
+      "filename": "elem.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 98,
-      "filename": "elem.3.wasm"
+      "filename": "elem.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 103,
-      "filename": "elem.4.wasm"
+      "filename": "elem.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 109,
-      "filename": "elem.5.wasm"
+      "filename": "elem.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 118,
-      "filename": "elem.6.wasm"
+      "filename": "elem.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 128,
-      "filename": "elem.7.wasm"
+      "filename": "elem.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 135,
-      "filename": "elem.8.wasm"
+      "filename": "elem.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 142,
-      "filename": "elem.9.wasm"
+      "filename": "elem.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -84,7 +94,8 @@
     {
       "type": "module",
       "line": 161,
-      "filename": "elem.10.wasm"
+      "filename": "elem.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -119,345 +130,394 @@
     {
       "type": "module",
       "line": 181,
-      "filename": "elem.11.wasm"
+      "filename": "elem.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 186,
-      "filename": "elem.12.wasm"
+      "filename": "elem.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 192,
-      "filename": "elem.13.wasm"
+      "filename": "elem.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 196,
-      "filename": "elem.14.wasm"
+      "filename": "elem.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 201,
-      "filename": "elem.15.wasm"
+      "filename": "elem.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 206,
-      "filename": "elem.16.wasm"
+      "filename": "elem.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 211,
-      "filename": "elem.17.wasm"
+      "filename": "elem.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 217,
-      "filename": "elem.18.wasm"
+      "filename": "elem.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 223,
-      "filename": "elem.19.wasm"
+      "filename": "elem.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 229,
-      "filename": "elem.20.wasm"
+      "filename": "elem.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 238,
-      "filename": "elem.21.wasm"
+      "filename": "elem.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 243,
-      "filename": "elem.22.wasm"
+      "filename": "elem.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 255,
-      "filename": "elem.23.wasm"
+      "filename": "elem.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 260,
-      "filename": "elem.24.wasm"
+      "filename": "elem.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 272,
-      "filename": "elem.25.wasm"
+      "filename": "elem.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 277,
-      "filename": "elem.26.wasm"
+      "filename": "elem.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 289,
-      "filename": "elem.27.wasm"
+      "filename": "elem.27.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 294,
-      "filename": "elem.28.wasm"
+      "filename": "elem.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 306,
-      "filename": "elem.29.wasm"
+      "filename": "elem.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 311,
-      "filename": "elem.30.wasm"
+      "filename": "elem.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 322,
-      "filename": "elem.31.wasm"
+      "filename": "elem.31.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 327,
-      "filename": "elem.32.wasm"
+      "filename": "elem.32.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 339,
-      "filename": "elem.33.wasm"
+      "filename": "elem.33.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 344,
-      "filename": "elem.34.wasm"
+      "filename": "elem.34.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 355,
-      "filename": "elem.35.wasm"
+      "filename": "elem.35.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 360,
-      "filename": "elem.36.wasm"
+      "filename": "elem.36.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 372,
-      "filename": "elem.37.wasm"
+      "filename": "elem.37.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 377,
-      "filename": "elem.38.wasm"
+      "filename": "elem.38.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 388,
-      "filename": "elem.39.wasm"
+      "filename": "elem.39.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 393,
-      "filename": "elem.40.wasm"
+      "filename": "elem.40.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 405,
-      "filename": "elem.41.wasm"
+      "filename": "elem.41.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 410,
-      "filename": "elem.42.wasm"
+      "filename": "elem.42.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 421,
-      "filename": "elem.43.wasm"
+      "filename": "elem.43.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 426,
-      "filename": "elem.44.wasm"
+      "filename": "elem.44.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 439,
-      "filename": "elem.45.wasm"
+      "filename": "elem.45.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 444,
-      "filename": "elem.46.wasm"
+      "filename": "elem.46.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 456,
-      "filename": "elem.47.wasm"
+      "filename": "elem.47.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 461,
-      "filename": "elem.48.wasm"
+      "filename": "elem.48.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 473,
-      "filename": "elem.49.wasm"
+      "filename": "elem.49.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 478,
-      "filename": "elem.50.wasm"
+      "filename": "elem.50.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 490,
-      "filename": "elem.51.wasm"
+      "filename": "elem.51.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 495,
-      "filename": "elem.52.wasm"
+      "filename": "elem.52.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 508,
       "filename": "elem.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 516,
       "filename": "elem.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 530,
-      "filename": "elem.55.wasm"
+      "filename": "elem.55.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 535,
-      "filename": "elem.56.wasm"
+      "filename": "elem.56.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 547,
-      "filename": "elem.57.wasm"
+      "filename": "elem.57.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 552,
-      "filename": "elem.58.wasm"
+      "filename": "elem.58.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 564,
-      "filename": "elem.59.wasm"
+      "filename": "elem.59.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 569,
-      "filename": "elem.60.wasm"
+      "filename": "elem.60.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_uninstantiable",
       "line": 585,
       "filename": "elem.61.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 594,
       "filename": "elem.62.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 603,
       "filename": "elem.63.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 612,
       "filename": "elem.64.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 619,
       "filename": "elem.65.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 627,
       "filename": "elem.66.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 636,
       "filename": "elem.67.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 644,
       "filename": "elem.68.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 653,
       "filename": "elem.69.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 661,
       "filename": "elem.70.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 670,
       "filename": "elem.71.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 678,
       "filename": "elem.72.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "module",
       "line": 689,
-      "filename": "elem.73.wasm"
+      "filename": "elem.73.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -472,7 +532,8 @@
     {
       "type": "module",
       "line": 699,
-      "filename": "elem.74.wasm"
+      "filename": "elem.74.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -488,153 +549,154 @@
       "type": "assert_invalid",
       "line": 713,
       "filename": "elem.75.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 724,
       "filename": "elem.76.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 732,
       "filename": "elem.77.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 740,
       "filename": "elem.78.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 748,
       "filename": "elem.79.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 756,
       "filename": "elem.80.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 765,
       "filename": "elem.81.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 775,
       "filename": "elem.82.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 783,
       "filename": "elem.83.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 791,
       "filename": "elem.84.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 799,
       "filename": "elem.85.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 807,
       "filename": "elem.86.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 816,
       "filename": "elem.87.wasm",
-      "text": "unknown global 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global 0"
     },
     {
       "type": "assert_invalid",
       "line": 824,
       "filename": "elem.88.wasm",
-      "text": "unknown global 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global 1"
     },
     {
       "type": "assert_invalid",
       "line": 833,
       "filename": "elem.89.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 845,
       "filename": "elem.90.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 853,
       "filename": "elem.91.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 861,
       "filename": "elem.92.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 869,
       "filename": "elem.93.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 877,
       "filename": "elem.94.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 886,
       "filename": "elem.95.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "module",
       "line": 896,
-      "filename": "elem.96.wasm"
+      "filename": "elem.96.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -654,7 +716,8 @@
     {
       "type": "module",
       "line": 909,
-      "filename": "elem.97.wasm"
+      "filename": "elem.97.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -675,7 +738,8 @@
       "type": "module",
       "line": 925,
       "name": "module1",
-      "filename": "elem.98.wasm"
+      "filename": "elem.98.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -730,7 +794,8 @@
       "type": "module",
       "line": 949,
       "name": "module2",
-      "filename": "elem.99.wasm"
+      "filename": "elem.99.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -784,7 +849,8 @@
       "type": "module",
       "line": 962,
       "name": "module3",
-      "filename": "elem.100.wasm"
+      "filename": "elem.100.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -838,35 +904,36 @@
       "type": "assert_invalid",
       "line": 978,
       "filename": "elem.101.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 983,
       "filename": "elem.102.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 988,
       "filename": "elem.103.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 997,
       "filename": "elem.104.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 1006,
       "name": "m",
-      "filename": "elem.105.wasm"
+      "filename": "elem.105.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1001,7 +1068,8 @@
     {
       "type": "module",
       "line": 1024,
-      "filename": "elem.106.wasm"
+      "filename": "elem.106.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1049,7 +1117,8 @@
       "type": "module",
       "line": 1033,
       "name": "module4",
-      "filename": "elem.107.wasm"
+      "filename": "elem.107.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1060,7 +1129,8 @@
     {
       "type": "module",
       "line": 1042,
-      "filename": "elem.108.wasm"
+      "filename": "elem.108.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/function-references/func.wast.json
+++ b/tests/snapshots/testsuite/proposals/function-references/func.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "func.0.wasm"
+      "filename": "func.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1754,26 +1755,28 @@
     {
       "type": "module",
       "line": 422,
-      "filename": "func.1.wasm"
+      "filename": "func.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 436,
       "filename": "func.2.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_malformed",
       "line": 448,
       "filename": "func.3.wat",
-      "text": "unknown type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown type"
     },
     {
       "type": "module",
       "line": 459,
-      "filename": "func.4.wasm"
+      "filename": "func.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1833,7 +1836,8 @@
     {
       "type": "module",
       "line": 488,
-      "filename": "func.5.wasm"
+      "filename": "func.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1879,512 +1883,512 @@
       "type": "assert_malformed",
       "line": 560,
       "filename": "func.6.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 567,
       "filename": "func.7.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 574,
       "filename": "func.8.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 581,
       "filename": "func.9.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 588,
       "filename": "func.10.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 595,
       "filename": "func.11.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 602,
       "filename": "func.12.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 609,
       "filename": "func.13.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 616,
       "filename": "func.14.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 623,
       "filename": "func.15.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_invalid",
       "line": 631,
       "filename": "func.16.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 635,
       "filename": "func.17.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 647,
       "filename": "func.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 651,
       "filename": "func.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 655,
       "filename": "func.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 660,
       "filename": "func.21.wasm",
-      "text": "uninitialized local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "uninitialized local"
     },
     {
       "type": "assert_invalid",
       "line": 671,
       "filename": "func.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 675,
       "filename": "func.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 679,
       "filename": "func.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 687,
       "filename": "func.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 691,
       "filename": "func.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 695,
       "filename": "func.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 699,
       "filename": "func.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 703,
       "filename": "func.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 708,
       "filename": "func.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 714,
       "filename": "func.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 720,
       "filename": "func.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 726,
       "filename": "func.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 732,
       "filename": "func.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 738,
       "filename": "func.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 744,
       "filename": "func.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 751,
       "filename": "func.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 757,
       "filename": "func.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 763,
       "filename": "func.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 769,
       "filename": "func.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 775,
       "filename": "func.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 781,
       "filename": "func.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 788,
       "filename": "func.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 794,
       "filename": "func.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 800,
       "filename": "func.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 806,
       "filename": "func.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 812,
       "filename": "func.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 818,
       "filename": "func.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 824,
       "filename": "func.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 830,
       "filename": "func.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 836,
       "filename": "func.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 843,
       "filename": "func.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 849,
       "filename": "func.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 855,
       "filename": "func.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 861,
       "filename": "func.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 867,
       "filename": "func.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 873,
       "filename": "func.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 879,
       "filename": "func.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 885,
       "filename": "func.59.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 891,
       "filename": "func.60.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 898,
       "filename": "func.61.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 904,
       "filename": "func.62.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 910,
       "filename": "func.63.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 916,
       "filename": "func.64.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 922,
       "filename": "func.65.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 928,
       "filename": "func.66.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 938,
       "filename": "func.67.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 942,
       "filename": "func.68.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 946,
       "filename": "func.69.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 950,
       "filename": "func.70.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 954,
       "filename": "func.71.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 958,
       "filename": "func.72.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 965,
       "filename": "func.73.wat",
-      "text": "duplicate func",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate func"
     },
     {
       "type": "assert_malformed",
       "line": 969,
       "filename": "func.74.wat",
-      "text": "duplicate func",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate func"
     },
     {
       "type": "assert_malformed",
       "line": 973,
       "filename": "func.75.wat",
-      "text": "duplicate func",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate func"
     },
     {
       "type": "assert_malformed",
       "line": 978,
       "filename": "func.76.wat",
-      "text": "duplicate local",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate local"
     },
     {
       "type": "assert_malformed",
       "line": 982,
       "filename": "func.77.wat",
-      "text": "duplicate local",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate local"
     },
     {
       "type": "assert_malformed",
       "line": 986,
       "filename": "func.78.wat",
-      "text": "duplicate local",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate local"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/function-references/global.wast.json
+++ b/tests/snapshots/testsuite/proposals/function-references/global.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "global.0.wasm"
+      "filename": "global.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -870,336 +871,340 @@
       "type": "assert_invalid",
       "line": 273,
       "filename": "global.1.wasm",
-      "text": "immutable global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "immutable global"
     },
     {
       "type": "assert_invalid",
       "line": 278,
       "filename": "global.2.wasm",
-      "text": "immutable global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "immutable global"
     },
     {
       "type": "module",
       "line": 283,
-      "filename": "global.3.wasm"
+      "filename": "global.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 284,
-      "filename": "global.4.wasm"
+      "filename": "global.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 287,
       "filename": "global.5.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 292,
       "filename": "global.6.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 297,
       "filename": "global.7.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 302,
       "filename": "global.8.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 307,
       "filename": "global.9.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 312,
       "filename": "global.10.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 317,
       "filename": "global.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 322,
       "filename": "global.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 327,
       "filename": "global.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 332,
       "filename": "global.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 337,
       "filename": "global.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 342,
       "filename": "global.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 347,
       "filename": "global.17.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 352,
       "filename": "global.18.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 357,
       "filename": "global.19.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 362,
       "filename": "global.20.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "module",
       "line": 366,
-      "filename": "global.21.wasm"
+      "filename": "global.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 370,
       "filename": "global.22.wasm",
-      "text": "malformed mutability",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed mutability"
     },
     {
       "type": "assert_malformed",
       "line": 383,
       "filename": "global.23.wasm",
-      "text": "malformed mutability",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed mutability"
     },
     {
       "type": "module",
       "line": 396,
-      "filename": "global.24.wasm"
+      "filename": "global.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 400,
       "filename": "global.25.wasm",
-      "text": "malformed mutability",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed mutability"
     },
     {
       "type": "assert_malformed",
       "line": 412,
       "filename": "global.26.wasm",
-      "text": "malformed mutability",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed mutability"
     },
     {
       "type": "assert_invalid",
       "line": 426,
       "filename": "global.27.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 431,
       "filename": "global.28.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 439,
       "filename": "global.29.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 447,
       "filename": "global.30.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 457,
       "filename": "global.31.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 462,
       "filename": "global.32.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 470,
       "filename": "global.33.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 478,
       "filename": "global.34.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 488,
       "filename": "global.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 497,
       "filename": "global.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 507,
       "filename": "global.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 517,
       "filename": "global.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 527,
       "filename": "global.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 537,
       "filename": "global.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 547,
       "filename": "global.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 557,
       "filename": "global.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 567,
       "filename": "global.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 576,
       "filename": "global.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 585,
       "filename": "global.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 595,
       "filename": "global.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 613,
       "filename": "global.47.wat",
-      "text": "duplicate global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate global"
     },
     {
       "type": "assert_malformed",
       "line": 617,
       "filename": "global.48.wat",
-      "text": "duplicate global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate global"
     },
     {
       "type": "assert_malformed",
       "line": 621,
       "filename": "global.49.wat",
-      "text": "duplicate global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate global"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/function-references/if.wast.json
+++ b/tests/snapshots/testsuite/proposals/function-references/if.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "if.0.wasm"
+      "filename": "if.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2626,813 +2627,813 @@
       "type": "assert_malformed",
       "line": 736,
       "filename": "if.1.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 745,
       "filename": "if.2.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 754,
       "filename": "if.3.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 763,
       "filename": "if.4.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 772,
       "filename": "if.5.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 781,
       "filename": "if.6.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 788,
       "filename": "if.7.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 796,
       "filename": "if.8.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 806,
       "filename": "if.9.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 816,
       "filename": "if.10.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 826,
       "filename": "if.11.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_invalid",
       "line": 836,
       "filename": "if.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 844,
       "filename": "if.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 848,
       "filename": "if.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 852,
       "filename": "if.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 856,
       "filename": "if.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 861,
       "filename": "if.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 865,
       "filename": "if.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 869,
       "filename": "if.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 873,
       "filename": "if.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 878,
       "filename": "if.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 884,
       "filename": "if.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 890,
       "filename": "if.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 896,
       "filename": "if.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 903,
       "filename": "if.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 909,
       "filename": "if.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 915,
       "filename": "if.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 921,
       "filename": "if.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 928,
       "filename": "if.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 934,
       "filename": "if.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 940,
       "filename": "if.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 947,
       "filename": "if.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 953,
       "filename": "if.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 959,
       "filename": "if.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 966,
       "filename": "if.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 972,
       "filename": "if.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 979,
       "filename": "if.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 985,
       "filename": "if.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 991,
       "filename": "if.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 998,
       "filename": "if.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1004,
       "filename": "if.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1010,
       "filename": "if.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1017,
       "filename": "if.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1023,
       "filename": "if.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1029,
       "filename": "if.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1036,
       "filename": "if.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1042,
       "filename": "if.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1048,
       "filename": "if.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1055,
       "filename": "if.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1062,
       "filename": "if.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1069,
       "filename": "if.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1077,
       "filename": "if.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1083,
       "filename": "if.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1089,
       "filename": "if.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1096,
       "filename": "if.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1102,
       "filename": "if.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1109,
       "filename": "if.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1119,
       "filename": "if.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1129,
       "filename": "if.59.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1140,
       "filename": "if.60.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1146,
       "filename": "if.61.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1152,
       "filename": "if.62.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1158,
       "filename": "if.63.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1165,
       "filename": "if.64.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1174,
       "filename": "if.65.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1183,
       "filename": "if.66.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1192,
       "filename": "if.67.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1202,
       "filename": "if.68.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1211,
       "filename": "if.69.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1220,
       "filename": "if.70.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1229,
       "filename": "if.71.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1239,
       "filename": "if.72.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1248,
       "filename": "if.73.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1257,
       "filename": "if.74.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1266,
       "filename": "if.75.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1275,
       "filename": "if.76.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1285,
       "filename": "if.77.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1296,
       "filename": "if.78.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1304,
       "filename": "if.79.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1313,
       "filename": "if.80.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1322,
       "filename": "if.81.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1331,
       "filename": "if.82.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1341,
       "filename": "if.83.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1350,
       "filename": "if.84.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1359,
       "filename": "if.85.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1368,
       "filename": "if.86.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1376,
       "filename": "if.87.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1384,
       "filename": "if.88.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1393,
       "filename": "if.89.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1409,
       "filename": "if.90.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1418,
       "filename": "if.91.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1427,
       "filename": "if.92.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1436,
       "filename": "if.93.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1445,
       "filename": "if.94.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1454,
       "filename": "if.95.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1464,
       "filename": "if.96.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1470,
       "filename": "if.97.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1476,
       "filename": "if.98.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1482,
       "filename": "if.99.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1488,
       "filename": "if.100.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1494,
       "filename": "if.101.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1500,
       "filename": "if.102.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1506,
       "filename": "if.103.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1513,
       "filename": "if.104.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1517,
       "filename": "if.105.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1522,
       "filename": "if.106.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1526,
       "filename": "if.107.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1530,
       "filename": "if.108.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1534,
       "filename": "if.109.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1538,
       "filename": "if.110.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1542,
       "filename": "if.111.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1546,
       "filename": "if.112.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1550,
       "filename": "if.113.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1554,
       "filename": "if.114.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1558,
       "filename": "if.115.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1562,
       "filename": "if.116.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/function-references/linking.wast.json
+++ b/tests/snapshots/testsuite/proposals/function-references/linking.wast.json
@@ -5,7 +5,8 @@
       "type": "module",
       "line": 3,
       "name": "Mf",
-      "filename": "linking.0.wasm"
+      "filename": "linking.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -17,7 +18,8 @@
       "type": "module",
       "line": 9,
       "name": "Nf",
-      "filename": "linking.1.wasm"
+      "filename": "linking.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -86,7 +88,8 @@
     {
       "type": "module",
       "line": 22,
-      "filename": "linking.2.wasm"
+      "filename": "linking.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -97,21 +100,22 @@
       "type": "assert_unlinkable",
       "line": 28,
       "filename": "linking.3.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 32,
       "filename": "linking.4.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 39,
       "name": "Mg",
-      "filename": "linking.5.wasm"
+      "filename": "linking.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -123,7 +127,8 @@
       "type": "module",
       "line": 50,
       "name": "Ng",
-      "filename": "linking.6.wasm"
+      "filename": "linking.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -362,21 +367,22 @@
       "type": "assert_unlinkable",
       "line": 87,
       "filename": "linking.7.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 91,
       "filename": "linking.8.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 96,
       "name": "Mref_ex",
-      "filename": "linking.9.wasm"
+      "filename": "linking.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -388,258 +394,260 @@
       "type": "module",
       "line": 112,
       "name": "Mref_im",
-      "filename": "linking.10.wasm"
+      "filename": "linking.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 133,
       "filename": "linking.11.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 138,
       "filename": "linking.12.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 142,
       "filename": "linking.13.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 146,
       "filename": "linking.14.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 151,
       "filename": "linking.15.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 155,
       "filename": "linking.16.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 159,
       "filename": "linking.17.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 164,
       "filename": "linking.18.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 168,
       "filename": "linking.19.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 172,
       "filename": "linking.20.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 176,
       "filename": "linking.21.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 181,
       "filename": "linking.22.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 185,
       "filename": "linking.23.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 189,
       "filename": "linking.24.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 193,
       "filename": "linking.25.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 199,
       "filename": "linking.26.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 203,
       "filename": "linking.27.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 207,
       "filename": "linking.28.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 211,
       "filename": "linking.29.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 216,
       "filename": "linking.30.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 220,
       "filename": "linking.31.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 224,
       "filename": "linking.32.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 228,
       "filename": "linking.33.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 233,
       "filename": "linking.34.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 237,
       "filename": "linking.35.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 241,
       "filename": "linking.36.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 245,
       "filename": "linking.37.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 250,
       "filename": "linking.38.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 254,
       "filename": "linking.39.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 258,
       "filename": "linking.40.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 262,
       "filename": "linking.41.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 267,
       "filename": "linking.42.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 271,
       "filename": "linking.43.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 275,
       "filename": "linking.44.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 279,
       "filename": "linking.45.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 286,
       "name": "Mt",
-      "filename": "linking.46.wasm"
+      "filename": "linking.46.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -651,7 +659,8 @@
       "type": "module",
       "line": 301,
       "name": "Nt",
-      "filename": "linking.47.wasm"
+      "filename": "linking.47.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -980,7 +989,8 @@
       "type": "module",
       "line": 343,
       "name": "Ot",
-      "filename": "linking.48.wasm"
+      "filename": "linking.48.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1380,13 +1390,15 @@
     {
       "type": "module",
       "line": 381,
-      "filename": "linking.49.wasm"
+      "filename": "linking.49.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 387,
       "name": "G1",
-      "filename": "linking.50.wasm"
+      "filename": "linking.50.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1398,7 +1410,8 @@
       "type": "module",
       "line": 389,
       "name": "G2",
-      "filename": "linking.51.wasm"
+      "filename": "linking.51.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1419,15 +1432,15 @@
       "type": "assert_uninstantiable",
       "line": 396,
       "filename": "linking.52.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_unlinkable",
       "line": 405,
       "filename": "linking.53.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_trap",
@@ -1449,8 +1462,8 @@
       "type": "assert_uninstantiable",
       "line": 419,
       "filename": "linking.54.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_return",
@@ -1493,8 +1506,8 @@
       "type": "assert_uninstantiable",
       "line": 431,
       "filename": "linking.55.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_return",
@@ -1521,7 +1534,8 @@
       "type": "module",
       "line": 443,
       "name": "Mtable_ex",
-      "filename": "linking.56.wasm"
+      "filename": "linking.56.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1532,55 +1546,57 @@
     {
       "type": "module",
       "line": 451,
-      "filename": "linking.57.wasm"
+      "filename": "linking.57.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 459,
       "filename": "linking.58.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 463,
       "filename": "linking.59.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 468,
       "filename": "linking.60.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 472,
       "filename": "linking.61.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 477,
       "filename": "linking.62.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 481,
       "filename": "linking.63.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 488,
       "name": "Mm",
-      "filename": "linking.64.wasm"
+      "filename": "linking.64.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1592,7 +1608,8 @@
       "type": "module",
       "line": 498,
       "name": "Nm",
-      "filename": "linking.65.wasm"
+      "filename": "linking.65.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1661,7 +1678,8 @@
       "type": "module",
       "line": 514,
       "name": "Om",
-      "filename": "linking.66.wasm"
+      "filename": "linking.66.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1750,20 +1768,22 @@
     {
       "type": "module",
       "line": 528,
-      "filename": "linking.67.wasm"
+      "filename": "linking.67.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_uninstantiable",
       "line": 534,
       "filename": "linking.68.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "module",
       "line": 541,
       "name": "Pm",
-      "filename": "linking.69.wasm"
+      "filename": "linking.69.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1937,8 +1957,8 @@
       "type": "assert_unlinkable",
       "line": 559,
       "filename": "linking.70.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_return",
@@ -1965,8 +1985,8 @@
       "type": "assert_uninstantiable",
       "line": 572,
       "filename": "linking.71.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_return",
@@ -2014,8 +2034,8 @@
       "type": "assert_uninstantiable",
       "line": 584,
       "filename": "linking.72.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_return",
@@ -2042,7 +2062,8 @@
       "type": "module",
       "line": 596,
       "name": "Ms",
-      "filename": "linking.73.wasm"
+      "filename": "linking.73.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -2054,8 +2075,8 @@
       "type": "assert_uninstantiable",
       "line": 610,
       "filename": "linking.74.wasm",
-      "text": "unreachable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unreachable"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/function-references/local_get.wast.json
+++ b/tests/snapshots/testsuite/proposals/function-references/local_get.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "local_get.0.wasm"
+      "filename": "local_get.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -397,113 +398,113 @@
       "type": "assert_invalid",
       "line": 149,
       "filename": "local_get.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 153,
       "filename": "local_get.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 157,
       "filename": "local_get.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 165,
       "filename": "local_get.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 169,
       "filename": "local_get.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 173,
       "filename": "local_get.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 181,
       "filename": "local_get.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 185,
       "filename": "local_get.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 189,
       "filename": "local_get.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 193,
       "filename": "local_get.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 201,
       "filename": "local_get.11.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 205,
       "filename": "local_get.12.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 210,
       "filename": "local_get.13.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 214,
       "filename": "local_get.14.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 219,
       "filename": "local_get.15.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 223,
       "filename": "local_get.16.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/function-references/local_init.wast.json
+++ b/tests/snapshots/testsuite/proposals/function-references/local_init.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "local_init.0.wasm"
+      "filename": "local_init.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -70,34 +71,35 @@
       "type": "assert_invalid",
       "line": 26,
       "filename": "local_init.1.wasm",
-      "text": "uninitialized local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "uninitialized local"
     },
     {
       "type": "assert_invalid",
       "line": 30,
       "filename": "local_init.2.wasm",
-      "text": "uninitialized local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "uninitialized local"
     },
     {
       "type": "assert_invalid",
       "line": 40,
       "filename": "local_init.3.wasm",
-      "text": "uninitialized local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "uninitialized local"
     },
     {
       "type": "assert_invalid",
       "line": 53,
       "filename": "local_init.4.wasm",
-      "text": "uninitialized local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "uninitialized local"
     },
     {
       "type": "module",
       "line": 66,
-      "filename": "local_init.5.wasm"
+      "filename": "local_init.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/function-references/ref.wast.json
+++ b/tests/snapshots/testsuite/proposals/function-references/ref.wast.json
@@ -4,91 +4,92 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "ref.0.wasm"
+      "filename": "ref.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 28,
       "filename": "ref.1.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 32,
       "filename": "ref.2.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 37,
       "filename": "ref.3.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 42,
       "filename": "ref.4.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 47,
       "filename": "ref.5.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 52,
       "filename": "ref.6.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 56,
       "filename": "ref.7.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 60,
       "filename": "ref.8.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 65,
       "filename": "ref.9.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 69,
       "filename": "ref.10.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 73,
       "filename": "ref.11.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 78,
       "filename": "ref.12.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/function-references/ref_as_non_null.wast.json
+++ b/tests/snapshots/testsuite/proposals/function-references/ref_as_non_null.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "ref_as_non_null.0.wasm"
+      "filename": "ref_as_non_null.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -60,13 +61,14 @@
       "type": "assert_invalid",
       "line": 32,
       "filename": "ref_as_non_null.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 41,
-      "filename": "ref_as_non_null.2.wasm"
+      "filename": "ref_as_non_null.2.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/function-references/ref_func.wast.json
+++ b/tests/snapshots/testsuite/proposals/function-references/ref_func.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "ref_func.0.wasm"
+      "filename": "ref_func.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -14,7 +15,8 @@
     {
       "type": "module",
       "line": 6,
-      "filename": "ref_func.1.wasm"
+      "filename": "ref_func.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -183,27 +185,28 @@
       "type": "assert_invalid",
       "line": 69,
       "filename": "ref_func.2.wasm",
-      "text": "unknown function 7",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function 7"
     },
     {
       "type": "module",
       "line": 80,
-      "filename": "ref_func.3.wasm"
+      "filename": "ref_func.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 109,
       "filename": "ref_func.4.wasm",
-      "text": "undeclared function reference",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "undeclared function reference"
     },
     {
       "type": "assert_invalid",
       "line": 113,
       "filename": "ref_func.5.wasm",
-      "text": "undeclared function reference",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "undeclared function reference"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/function-references/ref_is_null.wast.json
+++ b/tests/snapshots/testsuite/proposals/function-references/ref_is_null.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "ref_is_null.0.wasm"
+      "filename": "ref_is_null.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -347,21 +348,22 @@
     {
       "type": "module",
       "line": 71,
-      "filename": "ref_is_null.1.wasm"
+      "filename": "ref_is_null.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 79,
       "filename": "ref_is_null.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 83,
       "filename": "ref_is_null.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/function-references/ref_null.wast.json
+++ b/tests/snapshots/testsuite/proposals/function-references/ref_null.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "ref_null.0.wasm"
+      "filename": "ref_null.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/function-references/return_call.wast.json
+++ b/tests/snapshots/testsuite/proposals/function-references/return_call.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "return_call.0.wasm"
+      "filename": "return_call.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -586,88 +587,90 @@
       "type": "assert_invalid",
       "line": 124,
       "filename": "return_call.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 131,
       "filename": "return_call.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 139,
       "filename": "return_call.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 146,
       "filename": "return_call.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 153,
-      "filename": "return_call.5.wasm"
+      "filename": "return_call.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 158,
-      "filename": "return_call.6.wasm"
+      "filename": "return_call.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 164,
       "filename": "return_call.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 171,
       "filename": "return_call.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 178,
       "filename": "return_call.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 185,
       "filename": "return_call.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 192,
       "filename": "return_call.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 204,
       "filename": "return_call.12.wasm",
-      "text": "unknown function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function"
     },
     {
       "type": "assert_invalid",
       "line": 208,
       "filename": "return_call.13.wasm",
-      "text": "unknown function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/function-references/return_call_indirect.wast.json
+++ b/tests/snapshots/testsuite/proposals/function-references/return_call_indirect.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "return_call_indirect.0.wasm"
+      "filename": "return_call_indirect.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -886,193 +887,195 @@
       "type": "assert_malformed",
       "line": 273,
       "filename": "return_call_indirect.1.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 285,
       "filename": "return_call_indirect.2.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 297,
       "filename": "return_call_indirect.3.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 309,
       "filename": "return_call_indirect.4.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 321,
       "filename": "return_call_indirect.5.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 333,
       "filename": "return_call_indirect.6.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 345,
       "filename": "return_call_indirect.7.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 352,
       "filename": "return_call_indirect.8.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 362,
       "filename": "return_call_indirect.9.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 372,
       "filename": "return_call_indirect.10.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 384,
       "filename": "return_call_indirect.11.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_invalid",
       "line": 399,
       "filename": "return_call_indirect.12.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 407,
       "filename": "return_call_indirect.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 415,
       "filename": "return_call_indirect.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 424,
       "filename": "return_call_indirect.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 432,
       "filename": "return_call_indirect.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 440,
-      "filename": "return_call_indirect.17.wasm"
+      "filename": "return_call_indirect.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 446,
-      "filename": "return_call_indirect.18.wasm"
+      "filename": "return_call_indirect.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 455,
       "filename": "return_call_indirect.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 463,
       "filename": "return_call_indirect.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 472,
       "filename": "return_call_indirect.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 482,
       "filename": "return_call_indirect.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 492,
       "filename": "return_call_indirect.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 502,
       "filename": "return_call_indirect.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 512,
       "filename": "return_call_indirect.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 526,
       "filename": "return_call_indirect.26.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 533,
       "filename": "return_call_indirect.27.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 544,
       "filename": "return_call_indirect.28.wasm",
-      "text": "unknown function 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function 0"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/function-references/return_call_ref.wast.json
+++ b/tests/snapshots/testsuite/proposals/function-references/return_call_ref.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "return_call_ref.0.wasm"
+      "filename": "return_call_ref.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -595,54 +596,56 @@
     {
       "type": "module",
       "line": 213,
-      "filename": "return_call_ref.1.wasm"
+      "filename": "return_call_ref.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 232,
       "filename": "return_call_ref.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 243,
       "filename": "return_call_ref.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 254,
       "filename": "return_call_ref.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 265,
       "filename": "return_call_ref.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 276,
       "filename": "return_call_ref.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 287,
       "filename": "return_call_ref.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 299,
-      "filename": "return_call_ref.8.wasm"
+      "filename": "return_call_ref.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -657,7 +660,8 @@
     {
       "type": "module",
       "line": 308,
-      "filename": "return_call_ref.9.wasm"
+      "filename": "return_call_ref.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -672,7 +676,8 @@
     {
       "type": "module",
       "line": 321,
-      "filename": "return_call_ref.10.wasm"
+      "filename": "return_call_ref.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -688,29 +693,29 @@
       "type": "assert_invalid",
       "line": 337,
       "filename": "return_call_ref.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 353,
       "filename": "return_call_ref.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 369,
       "filename": "return_call_ref.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 379,
       "filename": "return_call_ref.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/function-references/select.wast.json
+++ b/tests/snapshots/testsuite/proposals/function-references/select.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "select.0.wasm"
+      "filename": "select.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2834,221 +2835,223 @@
       "type": "assert_invalid",
       "line": 364,
       "filename": "select.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 368,
       "filename": "select.2.wasm",
-      "text": "invalid result arity",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid result arity"
     },
     {
       "type": "assert_invalid",
       "line": 372,
       "filename": "select.3.wasm",
-      "text": "invalid result arity",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid result arity"
     },
     {
       "type": "assert_invalid",
       "line": 384,
       "filename": "select.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 392,
       "filename": "select.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 398,
       "filename": "select.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 403,
-      "filename": "select.7.wasm"
+      "filename": "select.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 408,
       "filename": "select.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 414,
       "filename": "select.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 420,
       "filename": "select.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 427,
       "filename": "select.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 431,
       "filename": "select.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 435,
       "filename": "select.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 439,
       "filename": "select.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 443,
       "filename": "select.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 449,
       "filename": "select.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 457,
       "filename": "select.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 465,
       "filename": "select.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 473,
       "filename": "select.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 482,
       "filename": "select.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 491,
       "filename": "select.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 500,
       "filename": "select.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 509,
       "filename": "select.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 518,
       "filename": "select.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 527,
       "filename": "select.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 536,
       "filename": "select.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 545,
       "filename": "select.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 557,
       "filename": "select.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 561,
       "filename": "select.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 565,
       "filename": "select.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 572,
       "filename": "select.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 579,
-      "filename": "select.32.wasm"
+      "filename": "select.32.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/function-references/table-sub.wast.json
+++ b/tests/snapshots/testsuite/proposals/function-references/table-sub.wast.json
@@ -4,21 +4,22 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "table-sub.0.wasm"
+      "filename": "table-sub.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 13,
       "filename": "table-sub.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 24,
       "filename": "table-sub.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/function-references/table.wast.json
+++ b/tests/snapshots/testsuite/proposals/function-references/table.wast.json
@@ -4,180 +4,196 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "table.0.wasm"
+      "filename": "table.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 4,
-      "filename": "table.1.wasm"
+      "filename": "table.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 5,
-      "filename": "table.2.wasm"
+      "filename": "table.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 6,
-      "filename": "table.3.wasm"
+      "filename": "table.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 7,
-      "filename": "table.4.wasm"
+      "filename": "table.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 8,
-      "filename": "table.5.wasm"
+      "filename": "table.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 9,
-      "filename": "table.6.wasm"
+      "filename": "table.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 11,
-      "filename": "table.7.wasm"
+      "filename": "table.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 12,
-      "filename": "table.8.wasm"
+      "filename": "table.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 13,
-      "filename": "table.9.wasm"
+      "filename": "table.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 15,
-      "filename": "table.10.wasm"
+      "filename": "table.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 16,
-      "filename": "table.11.wasm"
+      "filename": "table.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 18,
-      "filename": "table.12.wasm"
+      "filename": "table.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 19,
-      "filename": "table.13.wasm"
+      "filename": "table.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 20,
-      "filename": "table.14.wasm"
+      "filename": "table.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 22,
       "filename": "table.15.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 23,
       "filename": "table.16.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 27,
       "filename": "table.17.wasm",
-      "text": "size minimum must not be greater than maximum",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "size minimum must not be greater than maximum"
     },
     {
       "type": "assert_invalid",
       "line": 31,
       "filename": "table.18.wasm",
-      "text": "size minimum must not be greater than maximum",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "size minimum must not be greater than maximum"
     },
     {
       "type": "assert_malformed",
       "line": 36,
       "filename": "table.19.wat",
-      "text": "i32 constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "i32 constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 40,
       "filename": "table.20.wat",
-      "text": "i32 constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "i32 constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 44,
       "filename": "table.21.wat",
-      "text": "i32 constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "i32 constant out of range"
     },
     {
       "type": "assert_invalid",
       "line": 49,
       "filename": "table.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 53,
       "filename": "table.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 57,
       "filename": "table.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 61,
       "filename": "table.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 65,
       "filename": "table.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 69,
       "filename": "table.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 73,
       "filename": "table.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 80,
-      "filename": "table.29.wasm"
+      "filename": "table.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -187,7 +203,8 @@
     {
       "type": "module",
       "line": 87,
-      "filename": "table.30.wasm"
+      "filename": "table.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -263,43 +280,43 @@
       "type": "assert_invalid",
       "line": 114,
       "filename": "table.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 122,
       "filename": "table.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 130,
       "filename": "table.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 141,
       "filename": "table.34.wat",
-      "text": "duplicate table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate table"
     },
     {
       "type": "assert_malformed",
       "line": 148,
       "filename": "table.35.wat",
-      "text": "duplicate table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate table"
     },
     {
       "type": "assert_malformed",
       "line": 155,
       "filename": "table.36.wat",
-      "text": "duplicate table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate table"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/function-references/type-equivalence.wast.json
+++ b/tests/snapshots/testsuite/proposals/function-references/type-equivalence.wast.json
@@ -4,31 +4,34 @@
     {
       "type": "module",
       "line": 5,
-      "filename": "type-equivalence.0.wasm"
+      "filename": "type-equivalence.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 16,
-      "filename": "type-equivalence.1.wasm"
+      "filename": "type-equivalence.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 31,
       "filename": "type-equivalence.2.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 38,
       "filename": "type-equivalence.3.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "module",
       "line": 50,
-      "filename": "type-equivalence.4.wasm"
+      "filename": "type-equivalence.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -43,7 +46,8 @@
     {
       "type": "module",
       "line": 68,
-      "filename": "type-equivalence.5.wasm"
+      "filename": "type-equivalence.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -58,7 +62,8 @@
     {
       "type": "module",
       "line": 99,
-      "filename": "type-equivalence.6.wasm"
+      "filename": "type-equivalence.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -68,12 +73,14 @@
     {
       "type": "module",
       "line": 104,
-      "filename": "type-equivalence.7.wasm"
+      "filename": "type-equivalence.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 112,
-      "filename": "type-equivalence.8.wasm"
+      "filename": "type-equivalence.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -83,7 +90,8 @@
     {
       "type": "module",
       "line": 122,
-      "filename": "type-equivalence.9.wasm"
+      "filename": "type-equivalence.9.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/function-references/unreached-invalid.wast.json
+++ b/tests/snapshots/testsuite/proposals/function-references/unreached-invalid.wast.json
@@ -5,848 +5,848 @@
       "type": "assert_invalid",
       "line": 4,
       "filename": "unreached-invalid.0.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 8,
       "filename": "unreached-invalid.1.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 12,
       "filename": "unreached-invalid.2.wasm",
-      "text": "unknown function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function"
     },
     {
       "type": "assert_invalid",
       "line": 16,
       "filename": "unreached-invalid.3.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 21,
       "filename": "unreached-invalid.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 27,
       "filename": "unreached-invalid.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 33,
       "filename": "unreached-invalid.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 42,
       "filename": "unreached-invalid.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 46,
       "filename": "unreached-invalid.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 50,
       "filename": "unreached-invalid.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 56,
       "filename": "unreached-invalid.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 60,
       "filename": "unreached-invalid.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 64,
       "filename": "unreached-invalid.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 71,
       "filename": "unreached-invalid.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 77,
       "filename": "unreached-invalid.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 83,
       "filename": "unreached-invalid.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 89,
       "filename": "unreached-invalid.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 95,
       "filename": "unreached-invalid.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 101,
       "filename": "unreached-invalid.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 107,
       "filename": "unreached-invalid.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 113,
       "filename": "unreached-invalid.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 119,
       "filename": "unreached-invalid.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 125,
       "filename": "unreached-invalid.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 132,
       "filename": "unreached-invalid.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 138,
       "filename": "unreached-invalid.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 144,
       "filename": "unreached-invalid.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 150,
       "filename": "unreached-invalid.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 156,
       "filename": "unreached-invalid.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 162,
       "filename": "unreached-invalid.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 168,
       "filename": "unreached-invalid.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 174,
       "filename": "unreached-invalid.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 180,
       "filename": "unreached-invalid.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 186,
       "filename": "unreached-invalid.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 193,
       "filename": "unreached-invalid.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 199,
       "filename": "unreached-invalid.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 205,
       "filename": "unreached-invalid.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 211,
       "filename": "unreached-invalid.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 217,
       "filename": "unreached-invalid.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 223,
       "filename": "unreached-invalid.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 229,
       "filename": "unreached-invalid.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 235,
       "filename": "unreached-invalid.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 241,
       "filename": "unreached-invalid.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 247,
       "filename": "unreached-invalid.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 253,
       "filename": "unreached-invalid.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 259,
       "filename": "unreached-invalid.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 265,
       "filename": "unreached-invalid.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 271,
       "filename": "unreached-invalid.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 277,
       "filename": "unreached-invalid.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 284,
       "filename": "unreached-invalid.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 290,
       "filename": "unreached-invalid.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 296,
       "filename": "unreached-invalid.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 302,
       "filename": "unreached-invalid.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 308,
       "filename": "unreached-invalid.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 314,
       "filename": "unreached-invalid.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 321,
       "filename": "unreached-invalid.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 327,
       "filename": "unreached-invalid.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 334,
       "filename": "unreached-invalid.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 340,
       "filename": "unreached-invalid.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 348,
       "filename": "unreached-invalid.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 354,
       "filename": "unreached-invalid.59.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 360,
       "filename": "unreached-invalid.60.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 366,
       "filename": "unreached-invalid.61.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 372,
       "filename": "unreached-invalid.62.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 378,
       "filename": "unreached-invalid.63.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 384,
       "filename": "unreached-invalid.64.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 390,
       "filename": "unreached-invalid.65.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 396,
       "filename": "unreached-invalid.66.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 402,
       "filename": "unreached-invalid.67.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 409,
       "filename": "unreached-invalid.68.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 415,
       "filename": "unreached-invalid.69.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 421,
       "filename": "unreached-invalid.70.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 427,
       "filename": "unreached-invalid.71.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 433,
       "filename": "unreached-invalid.72.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 439,
       "filename": "unreached-invalid.73.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 445,
       "filename": "unreached-invalid.74.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 451,
       "filename": "unreached-invalid.75.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 457,
       "filename": "unreached-invalid.76.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 463,
       "filename": "unreached-invalid.77.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 470,
       "filename": "unreached-invalid.78.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 477,
       "filename": "unreached-invalid.79.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 484,
       "filename": "unreached-invalid.80.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 490,
       "filename": "unreached-invalid.81.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 498,
       "filename": "unreached-invalid.82.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 507,
       "filename": "unreached-invalid.83.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 515,
       "filename": "unreached-invalid.84.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 521,
       "filename": "unreached-invalid.85.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 527,
       "filename": "unreached-invalid.86.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 540,
       "filename": "unreached-invalid.87.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 546,
       "filename": "unreached-invalid.88.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 552,
       "filename": "unreached-invalid.89.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 558,
       "filename": "unreached-invalid.90.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 565,
       "filename": "unreached-invalid.91.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 571,
       "filename": "unreached-invalid.92.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 577,
       "filename": "unreached-invalid.93.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 584,
       "filename": "unreached-invalid.94.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 590,
       "filename": "unreached-invalid.95.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 596,
       "filename": "unreached-invalid.96.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 604,
       "filename": "unreached-invalid.97.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 611,
       "filename": "unreached-invalid.98.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 617,
       "filename": "unreached-invalid.99.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 623,
       "filename": "unreached-invalid.100.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 629,
       "filename": "unreached-invalid.101.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 637,
       "filename": "unreached-invalid.102.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 643,
       "filename": "unreached-invalid.103.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 649,
       "filename": "unreached-invalid.104.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 656,
       "filename": "unreached-invalid.105.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 662,
       "filename": "unreached-invalid.106.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 669,
       "filename": "unreached-invalid.107.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 676,
       "filename": "unreached-invalid.108.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 687,
       "filename": "unreached-invalid.109.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 698,
       "filename": "unreached-invalid.110.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 710,
       "filename": "unreached-invalid.111.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 715,
       "filename": "unreached-invalid.112.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 721,
       "filename": "unreached-invalid.113.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 726,
       "filename": "unreached-invalid.114.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 731,
       "filename": "unreached-invalid.115.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 737,
       "filename": "unreached-invalid.116.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 744,
       "filename": "unreached-invalid.117.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 749,
       "filename": "unreached-invalid.118.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 764,
       "filename": "unreached-invalid.119.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 774,
       "filename": "unreached-invalid.120.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/function-references/unreached-valid.wast.json
+++ b/tests/snapshots/testsuite/proposals/function-references/unreached-valid.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "unreached-valid.0.wasm"
+      "filename": "unreached-valid.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -119,7 +120,8 @@
     {
       "type": "module",
       "line": 63,
-      "filename": "unreached-valid.1.wasm"
+      "filename": "unreached-valid.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",

--- a/tests/snapshots/testsuite/proposals/gc/array.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/array.wast.json
@@ -4,38 +4,41 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "array.0.wasm"
+      "filename": "array.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 28,
       "filename": "array.1.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "module",
       "line": 37,
-      "filename": "array.2.wasm"
+      "filename": "array.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 49,
       "filename": "array.3.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 53,
       "filename": "array.4.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "module",
       "line": 60,
-      "filename": "array.5.wasm"
+      "filename": "array.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -161,7 +164,8 @@
     {
       "type": "module",
       "line": 106,
-      "filename": "array.6.wasm"
+      "filename": "array.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -287,7 +291,8 @@
     {
       "type": "module",
       "line": 151,
-      "filename": "array.7.wasm"
+      "filename": "array.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -448,7 +453,8 @@
     {
       "type": "module",
       "line": 205,
-      "filename": "array.8.wasm"
+      "filename": "array.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -615,27 +621,28 @@
       "type": "assert_invalid",
       "line": 265,
       "filename": "array.9.wasm",
-      "text": "array is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array is immutable"
     },
     {
       "type": "assert_invalid",
       "line": 275,
       "filename": "array.10.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 288,
       "filename": "array.11.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "module",
       "line": 304,
-      "filename": "array.12.wasm"
+      "filename": "array.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",

--- a/tests/snapshots/testsuite/proposals/gc/array_copy.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/array_copy.wast.json
@@ -5,34 +5,35 @@
       "type": "assert_invalid",
       "line": 6,
       "filename": "array_copy.0.wasm",
-      "text": "array is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array is immutable"
     },
     {
       "type": "assert_invalid",
       "line": 18,
       "filename": "array_copy.1.wasm",
-      "text": "array types do not match",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array types do not match"
     },
     {
       "type": "assert_invalid",
       "line": 30,
       "filename": "array_copy.2.wasm",
-      "text": "array types do not match",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array types do not match"
     },
     {
       "type": "assert_invalid",
       "line": 42,
       "filename": "array_copy.3.wasm",
-      "text": "array types do not match",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array types do not match"
     },
     {
       "type": "module",
       "line": 54,
-      "filename": "array_copy.4.wasm"
+      "filename": "array_copy.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",

--- a/tests/snapshots/testsuite/proposals/gc/array_fill.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/array_fill.wast.json
@@ -5,27 +5,28 @@
       "type": "assert_invalid",
       "line": 6,
       "filename": "array_fill.0.wasm",
-      "text": "array is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array is immutable"
     },
     {
       "type": "assert_invalid",
       "line": 17,
       "filename": "array_fill.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 28,
       "filename": "array_fill.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 38,
-      "filename": "array_fill.3.wasm"
+      "filename": "array_fill.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",

--- a/tests/snapshots/testsuite/proposals/gc/array_init_data.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/array_init_data.wast.json
@@ -5,20 +5,21 @@
       "type": "assert_invalid",
       "line": 6,
       "filename": "array_init_data.0.wasm",
-      "text": "array is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array is immutable"
     },
     {
       "type": "assert_invalid",
       "line": 19,
       "filename": "array_init_data.1.wasm",
-      "text": "array type is not numeric or vector",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array type is not numeric or vector"
     },
     {
       "type": "module",
       "line": 31,
-      "filename": "array_init_data.2.wasm"
+      "filename": "array_init_data.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",

--- a/tests/snapshots/testsuite/proposals/gc/array_init_elem.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/array_init_elem.wast.json
@@ -5,27 +5,28 @@
       "type": "assert_invalid",
       "line": 6,
       "filename": "array_init_elem.0.wasm",
-      "text": "array is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array is immutable"
     },
     {
       "type": "assert_invalid",
       "line": 19,
       "filename": "array_init_elem.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 32,
       "filename": "array_init_elem.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 44,
-      "filename": "array_init_elem.3.wasm"
+      "filename": "array_init_elem.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",

--- a/tests/snapshots/testsuite/proposals/gc/binary-gc.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/binary-gc.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_malformed",
       "line": 2,
       "filename": "binary-gc.0.wasm",
-      "text": "malformed mutability",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed mutability"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/binary.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/binary.wast.json
@@ -4,904 +4,923 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "binary.0.wasm"
+      "filename": "binary.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 2,
-      "filename": "binary.1.wasm"
+      "filename": "binary.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 3,
       "name": "M1",
-      "filename": "binary.2.wasm"
+      "filename": "binary.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 4,
       "name": "M2",
-      "filename": "binary.3.wasm"
+      "filename": "binary.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 6,
       "filename": "binary.4.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 7,
       "filename": "binary.5.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 8,
       "filename": "binary.6.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 9,
       "filename": "binary.7.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 10,
       "filename": "binary.8.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 11,
       "filename": "binary.9.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 12,
       "filename": "binary.10.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 13,
       "filename": "binary.11.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 14,
       "filename": "binary.12.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 15,
       "filename": "binary.13.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 16,
       "filename": "binary.14.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 17,
       "filename": "binary.15.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 18,
       "filename": "binary.16.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 21,
       "filename": "binary.17.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 24,
       "filename": "binary.18.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 25,
       "filename": "binary.19.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 28,
       "filename": "binary.20.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 31,
       "filename": "binary.21.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 34,
       "filename": "binary.22.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 37,
       "filename": "binary.23.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 38,
       "filename": "binary.24.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 39,
       "filename": "binary.25.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 40,
       "filename": "binary.26.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 41,
       "filename": "binary.27.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 42,
       "filename": "binary.28.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 43,
       "filename": "binary.29.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 44,
       "filename": "binary.30.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 45,
       "filename": "binary.31.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 48,
       "filename": "binary.32.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 49,
       "filename": "binary.33.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 50,
       "filename": "binary.34.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 51,
       "filename": "binary.35.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 52,
       "filename": "binary.36.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 56,
       "filename": "binary.37.wasm",
-      "text": "END opcode expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "END opcode expected"
     },
     {
       "type": "assert_malformed",
       "line": 77,
       "filename": "binary.38.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 93,
       "filename": "binary.39.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 113,
       "filename": "binary.40.wasm",
-      "text": "illegal opcode",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "illegal opcode"
     },
     {
       "type": "assert_malformed",
       "line": 126,
       "filename": "binary.41.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 146,
       "filename": "binary.42.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 166,
       "filename": "binary.43.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 185,
       "filename": "binary.44.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 204,
       "filename": "binary.45.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 224,
       "filename": "binary.46.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 243,
       "filename": "binary.47.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 262,
       "filename": "binary.48.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 280,
       "filename": "binary.49.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 298,
       "filename": "binary.50.wasm",
-      "text": "zero byte expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "zero byte expected"
     },
     {
       "type": "assert_malformed",
       "line": 317,
       "filename": "binary.51.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 334,
       "filename": "binary.52.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 351,
       "filename": "binary.53.wasm",
-      "text": "too many locals",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "too many locals"
     },
     {
       "type": "assert_malformed",
       "line": 367,
       "filename": "binary.54.wasm",
-      "text": "too many locals",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "too many locals"
     },
     {
       "type": "module",
       "line": 385,
-      "filename": "binary.55.wasm"
+      "filename": "binary.55.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 401,
       "filename": "binary.56.wasm",
-      "text": "function and code section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function and code section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 411,
       "filename": "binary.57.wasm",
-      "text": "function and code section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function and code section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 420,
       "filename": "binary.58.wasm",
-      "text": "function and code section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function and code section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 431,
       "filename": "binary.59.wasm",
-      "text": "function and code section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function and code section have inconsistent lengths"
     },
     {
       "type": "module",
       "line": 441,
-      "filename": "binary.60.wasm"
+      "filename": "binary.60.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 447,
-      "filename": "binary.61.wasm"
+      "filename": "binary.61.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 454,
       "filename": "binary.62.wasm",
-      "text": "data count and data section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "data count and data section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 464,
       "filename": "binary.63.wasm",
-      "text": "data count and data section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "data count and data section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 474,
       "filename": "binary.64.wasm",
-      "text": "data count section required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "data count section required"
     },
     {
       "type": "assert_malformed",
       "line": 496,
       "filename": "binary.65.wasm",
-      "text": "data count section required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "data count section required"
     },
     {
       "type": "assert_malformed",
       "line": 515,
       "filename": "binary.66.wasm",
-      "text": "illegal opcode",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "illegal opcode"
     },
     {
       "type": "assert_malformed",
       "line": 541,
       "filename": "binary.67.wasm",
-      "text": "malformed reference type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed reference type"
     },
     {
       "type": "module",
       "line": 566,
-      "filename": "binary.68.wasm"
+      "filename": "binary.68.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 590,
-      "filename": "binary.69.wasm"
+      "filename": "binary.69.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 615,
-      "filename": "binary.70.wasm"
+      "filename": "binary.70.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 622,
       "filename": "binary.71.wasm",
-      "text": "length out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "length out of bounds"
     },
     {
       "type": "assert_malformed",
       "line": 633,
       "filename": "binary.72.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 643,
-      "filename": "binary.73.wasm"
+      "filename": "binary.73.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 652,
       "filename": "binary.74.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 662,
       "filename": "binary.75.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 673,
       "filename": "binary.76.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 683,
       "filename": "binary.77.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 694,
       "filename": "binary.78.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 704,
       "filename": "binary.79.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 717,
       "filename": "binary.80.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 736,
       "filename": "binary.81.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 760,
-      "filename": "binary.82.wasm"
+      "filename": "binary.82.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 767,
       "filename": "binary.83.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 777,
       "filename": "binary.84.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 786,
       "filename": "binary.85.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 796,
       "filename": "binary.86.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "module",
       "line": 807,
-      "filename": "binary.87.wasm"
+      "filename": "binary.87.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 814,
       "filename": "binary.88.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 824,
       "filename": "binary.89.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 832,
       "filename": "binary.90.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 841,
       "filename": "binary.91.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 850,
       "filename": "binary.92.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "module",
       "line": 860,
-      "filename": "binary.93.wasm"
+      "filename": "binary.93.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 867,
       "filename": "binary.94.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 878,
       "filename": "binary.95.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 888,
-      "filename": "binary.96.wasm"
+      "filename": "binary.96.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 901,
       "filename": "binary.97.wasm",
-      "text": "length out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "length out of bounds"
     },
     {
       "type": "assert_malformed",
       "line": 922,
       "filename": "binary.98.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 942,
-      "filename": "binary.99.wasm"
+      "filename": "binary.99.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 956,
       "filename": "binary.100.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 972,
       "filename": "binary.101.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 989,
       "filename": "binary.102.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 1006,
-      "filename": "binary.103.wasm"
+      "filename": "binary.103.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 1015,
       "filename": "binary.104.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 1028,
       "filename": "binary.105.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1041,
       "filename": "binary.106.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 1055,
       "filename": "binary.107.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 1068,
-      "filename": "binary.108.wasm"
+      "filename": "binary.108.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 1086,
       "filename": "binary.109.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "module",
       "line": 1119,
-      "filename": "binary.110.wasm"
+      "filename": "binary.110.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 1133,
       "filename": "binary.111.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1150,
       "filename": "binary.112.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1162,
       "filename": "binary.113.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1174,
       "filename": "binary.114.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1184,
       "filename": "binary.115.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1194,
       "filename": "binary.116.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1204,
       "filename": "binary.117.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1214,
       "filename": "binary.118.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1224,
       "filename": "binary.119.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1234,
       "filename": "binary.120.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1244,
       "filename": "binary.121.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1254,
       "filename": "binary.122.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1264,
       "filename": "binary.123.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1274,
       "filename": "binary.124.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1284,
       "filename": "binary.125.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1294,
       "filename": "binary.126.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1304,
       "filename": "binary.127.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1314,
       "filename": "binary.128.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1324,
       "filename": "binary.129.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1335,
       "filename": "binary.130.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1346,
       "filename": "binary.131.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1356,
       "filename": "binary.132.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1366,
       "filename": "binary.133.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/br_if.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/br_if.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "br_if.0.wasm"
+      "filename": "br_if.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1532,211 +1533,211 @@
       "type": "assert_invalid",
       "line": 481,
       "filename": "br_if.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 485,
       "filename": "br_if.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 489,
       "filename": "br_if.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 493,
       "filename": "br_if.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 498,
       "filename": "br_if.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 502,
       "filename": "br_if.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 506,
       "filename": "br_if.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 510,
       "filename": "br_if.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 515,
       "filename": "br_if.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 521,
       "filename": "br_if.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 527,
       "filename": "br_if.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 533,
       "filename": "br_if.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 540,
       "filename": "br_if.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 546,
       "filename": "br_if.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 552,
       "filename": "br_if.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 560,
       "filename": "br_if.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 569,
       "filename": "br_if.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 575,
       "filename": "br_if.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 581,
       "filename": "br_if.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 587,
       "filename": "br_if.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 593,
       "filename": "br_if.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 599,
       "filename": "br_if.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 606,
       "filename": "br_if.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 618,
       "filename": "br_if.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 630,
       "filename": "br_if.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 641,
       "filename": "br_if.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 654,
       "filename": "br_if.27.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 658,
       "filename": "br_if.28.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 662,
       "filename": "br_if.29.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 668,
       "filename": "br_if.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/br_on_cast.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/br_on_cast.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "br_on_cast.0.wasm"
+      "filename": "br_on_cast.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -523,7 +524,8 @@
     {
       "type": "module",
       "line": 104,
-      "filename": "br_on_cast.1.wasm"
+      "filename": "br_on_cast.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -546,49 +548,50 @@
     {
       "type": "module",
       "line": 211,
-      "filename": "br_on_cast.2.wasm"
+      "filename": "br_on_cast.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 226,
       "filename": "br_on_cast.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 235,
       "filename": "br_on_cast.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 244,
       "filename": "br_on_cast.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 253,
       "filename": "br_on_cast.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 261,
       "filename": "br_on_cast.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 272,
       "filename": "br_on_cast.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/br_on_cast_fail.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/br_on_cast_fail.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "br_on_cast_fail.0.wasm"
+      "filename": "br_on_cast_fail.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -523,7 +524,8 @@
     {
       "type": "module",
       "line": 104,
-      "filename": "br_on_cast_fail.1.wasm"
+      "filename": "br_on_cast_fail.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -546,49 +548,50 @@
     {
       "type": "module",
       "line": 226,
-      "filename": "br_on_cast_fail.2.wasm"
+      "filename": "br_on_cast_fail.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 241,
       "filename": "br_on_cast_fail.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 250,
       "filename": "br_on_cast_fail.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 259,
       "filename": "br_on_cast_fail.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 268,
       "filename": "br_on_cast_fail.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 276,
       "filename": "br_on_cast_fail.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 287,
       "filename": "br_on_cast_fail.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/br_on_non_null.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/br_on_non_null.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "br_on_non_null.0.wasm"
+      "filename": "br_on_non_null.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -64,12 +65,14 @@
     {
       "type": "module",
       "line": 43,
-      "filename": "br_on_non_null.1.wasm"
+      "filename": "br_on_non_null.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 51,
-      "filename": "br_on_non_null.2.wasm"
+      "filename": "br_on_non_null.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -115,8 +118,8 @@
       "type": "assert_invalid",
       "line": 78,
       "filename": "br_on_non_null.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/br_on_null.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/br_on_null.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "br_on_null.0.wasm"
+      "filename": "br_on_null.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -64,12 +65,14 @@
     {
       "type": "module",
       "line": 38,
-      "filename": "br_on_null.1.wasm"
+      "filename": "br_on_null.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 46,
-      "filename": "br_on_null.2.wasm"
+      "filename": "br_on_null.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -115,8 +118,8 @@
       "type": "assert_invalid",
       "line": 82,
       "filename": "br_on_null.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/br_table.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/br_table.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "br_table.0.wasm"
+      "filename": "br_table.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2972,169 +2973,169 @@
       "type": "assert_invalid",
       "line": 1267,
       "filename": "br_table.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1274,
       "filename": "br_table.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1281,
       "filename": "br_table.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1287,
       "filename": "br_table.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1295,
       "filename": "br_table.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1306,
       "filename": "br_table.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1317,
       "filename": "br_table.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1323,
       "filename": "br_table.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1329,
       "filename": "br_table.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1335,
       "filename": "br_table.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1341,
       "filename": "br_table.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1350,
       "filename": "br_table.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1357,
       "filename": "br_table.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1369,
       "filename": "br_table.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1381,
       "filename": "br_table.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1392,
       "filename": "br_table.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1404,
       "filename": "br_table.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1416,
       "filename": "br_table.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1430,
       "filename": "br_table.19.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 1436,
       "filename": "br_table.20.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 1442,
       "filename": "br_table.21.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 1449,
       "filename": "br_table.22.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 1455,
       "filename": "br_table.23.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 1461,
       "filename": "br_table.24.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/call_ref.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/call_ref.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "call_ref.0.wasm"
+      "filename": "call_ref.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -495,7 +496,8 @@
     {
       "type": "module",
       "line": 129,
-      "filename": "call_ref.1.wasm"
+      "filename": "call_ref.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -510,7 +512,8 @@
     {
       "type": "module",
       "line": 138,
-      "filename": "call_ref.2.wasm"
+      "filename": "call_ref.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -525,7 +528,8 @@
     {
       "type": "module",
       "line": 151,
-      "filename": "call_ref.3.wasm"
+      "filename": "call_ref.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -541,29 +545,29 @@
       "type": "assert_invalid",
       "line": 168,
       "filename": "call_ref.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 184,
       "filename": "call_ref.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 201,
       "filename": "call_ref.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 211,
       "filename": "call_ref.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/data.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/data.wast.json
@@ -4,375 +4,402 @@
     {
       "type": "module",
       "line": 5,
-      "filename": "data.0.wasm"
+      "filename": "data.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 35,
-      "filename": "data.1.wasm"
+      "filename": "data.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 39,
-      "filename": "data.2.wasm"
+      "filename": "data.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 44,
-      "filename": "data.3.wasm"
+      "filename": "data.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 52,
-      "filename": "data.4.wasm"
+      "filename": "data.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 62,
-      "filename": "data.5.wasm"
+      "filename": "data.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 67,
-      "filename": "data.6.wasm"
+      "filename": "data.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 73,
-      "filename": "data.7.wasm"
+      "filename": "data.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 78,
-      "filename": "data.8.wasm"
+      "filename": "data.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 84,
-      "filename": "data.9.wasm"
+      "filename": "data.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 85,
-      "filename": "data.10.wasm"
+      "filename": "data.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 90,
-      "filename": "data.11.wasm"
+      "filename": "data.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 95,
-      "filename": "data.12.wasm"
+      "filename": "data.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 101,
-      "filename": "data.13.wasm"
+      "filename": "data.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 106,
-      "filename": "data.14.wasm"
+      "filename": "data.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 110,
-      "filename": "data.15.wasm"
+      "filename": "data.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 115,
-      "filename": "data.16.wasm"
+      "filename": "data.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 120,
-      "filename": "data.17.wasm"
+      "filename": "data.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 125,
-      "filename": "data.18.wasm"
+      "filename": "data.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 129,
-      "filename": "data.19.wasm"
+      "filename": "data.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 134,
-      "filename": "data.20.wasm"
+      "filename": "data.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 139,
-      "filename": "data.21.wasm"
+      "filename": "data.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 144,
-      "filename": "data.22.wasm"
+      "filename": "data.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 149,
-      "filename": "data.23.wasm"
+      "filename": "data.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 155,
-      "filename": "data.24.wasm"
+      "filename": "data.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 161,
-      "filename": "data.25.wasm"
+      "filename": "data.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 166,
-      "filename": "data.26.wasm"
+      "filename": "data.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_uninstantiable",
       "line": 174,
       "filename": "data.27.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 182,
       "filename": "data.28.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 190,
       "filename": "data.29.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 197,
       "filename": "data.30.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 204,
       "filename": "data.31.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 221,
       "filename": "data.32.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 230,
       "filename": "data.33.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 237,
       "filename": "data.34.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 245,
       "filename": "data.35.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 253,
       "filename": "data.36.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 261,
       "filename": "data.37.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 268,
       "filename": "data.38.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 276,
       "filename": "data.39.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 283,
       "filename": "data.40.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_invalid",
       "line": 293,
       "filename": "data.41.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 301,
       "filename": "data.42.wasm",
-      "text": "unknown memory 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 1"
     },
     {
       "type": "assert_invalid",
       "line": 314,
       "filename": "data.43.wasm",
-      "text": "unknown memory 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 0"
     },
     {
       "type": "assert_invalid",
       "line": 325,
       "filename": "data.44.wasm",
-      "text": "unknown memory 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 1"
     },
     {
       "type": "assert_invalid",
       "line": 337,
       "filename": "data.45.wasm",
-      "text": "unknown memory 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 1"
     },
     {
       "type": "assert_invalid",
       "line": 359,
       "filename": "data.46.wasm",
-      "text": "unknown memory 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 1"
     },
     {
       "type": "assert_invalid",
       "line": 378,
       "filename": "data.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 386,
       "filename": "data.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 394,
       "filename": "data.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 402,
       "filename": "data.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 410,
       "filename": "data.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 419,
       "filename": "data.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 428,
       "filename": "data.53.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 436,
       "filename": "data.54.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 444,
       "filename": "data.55.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 452,
       "filename": "data.56.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 460,
       "filename": "data.57.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 469,
       "filename": "data.58.wasm",
-      "text": "unknown global 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global 0"
     },
     {
       "type": "assert_invalid",
       "line": 477,
       "filename": "data.59.wasm",
-      "text": "unknown global 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global 1"
     },
     {
       "type": "assert_invalid",
       "line": 486,
       "filename": "data.60.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/elem.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/elem.wast.json
@@ -4,52 +4,62 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "elem.0.wasm"
+      "filename": "elem.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 80,
-      "filename": "elem.1.wasm"
+      "filename": "elem.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 87,
-      "filename": "elem.2.wasm"
+      "filename": "elem.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 98,
-      "filename": "elem.3.wasm"
+      "filename": "elem.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 103,
-      "filename": "elem.4.wasm"
+      "filename": "elem.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 109,
-      "filename": "elem.5.wasm"
+      "filename": "elem.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 118,
-      "filename": "elem.6.wasm"
+      "filename": "elem.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 128,
-      "filename": "elem.7.wasm"
+      "filename": "elem.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 135,
-      "filename": "elem.8.wasm"
+      "filename": "elem.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 142,
-      "filename": "elem.9.wasm"
+      "filename": "elem.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -84,7 +94,8 @@
     {
       "type": "module",
       "line": 161,
-      "filename": "elem.10.wasm"
+      "filename": "elem.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -119,355 +130,406 @@
     {
       "type": "module",
       "line": 178,
-      "filename": "elem.11.wasm"
+      "filename": "elem.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 182,
-      "filename": "elem.12.wasm"
+      "filename": "elem.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 190,
-      "filename": "elem.13.wasm"
+      "filename": "elem.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 195,
-      "filename": "elem.14.wasm"
+      "filename": "elem.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 201,
-      "filename": "elem.15.wasm"
+      "filename": "elem.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 205,
-      "filename": "elem.16.wasm"
+      "filename": "elem.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 210,
-      "filename": "elem.17.wasm"
+      "filename": "elem.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 215,
-      "filename": "elem.18.wasm"
+      "filename": "elem.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 220,
-      "filename": "elem.19.wasm"
+      "filename": "elem.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 226,
-      "filename": "elem.20.wasm"
+      "filename": "elem.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 232,
-      "filename": "elem.21.wasm"
+      "filename": "elem.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 238,
-      "filename": "elem.22.wasm"
+      "filename": "elem.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 247,
-      "filename": "elem.23.wasm"
+      "filename": "elem.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 252,
-      "filename": "elem.24.wasm"
+      "filename": "elem.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 264,
-      "filename": "elem.25.wasm"
+      "filename": "elem.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 269,
-      "filename": "elem.26.wasm"
+      "filename": "elem.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 281,
-      "filename": "elem.27.wasm"
+      "filename": "elem.27.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 286,
-      "filename": "elem.28.wasm"
+      "filename": "elem.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 298,
-      "filename": "elem.29.wasm"
+      "filename": "elem.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 303,
-      "filename": "elem.30.wasm"
+      "filename": "elem.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 315,
-      "filename": "elem.31.wasm"
+      "filename": "elem.31.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 320,
-      "filename": "elem.32.wasm"
+      "filename": "elem.32.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 331,
-      "filename": "elem.33.wasm"
+      "filename": "elem.33.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 336,
-      "filename": "elem.34.wasm"
+      "filename": "elem.34.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 348,
-      "filename": "elem.35.wasm"
+      "filename": "elem.35.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 353,
-      "filename": "elem.36.wasm"
+      "filename": "elem.36.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 364,
-      "filename": "elem.37.wasm"
+      "filename": "elem.37.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 369,
-      "filename": "elem.38.wasm"
+      "filename": "elem.38.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 381,
-      "filename": "elem.39.wasm"
+      "filename": "elem.39.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 386,
-      "filename": "elem.40.wasm"
+      "filename": "elem.40.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 397,
-      "filename": "elem.41.wasm"
+      "filename": "elem.41.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 402,
-      "filename": "elem.42.wasm"
+      "filename": "elem.42.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 414,
-      "filename": "elem.43.wasm"
+      "filename": "elem.43.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 419,
-      "filename": "elem.44.wasm"
+      "filename": "elem.44.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 430,
-      "filename": "elem.45.wasm"
+      "filename": "elem.45.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 435,
-      "filename": "elem.46.wasm"
+      "filename": "elem.46.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 448,
-      "filename": "elem.47.wasm"
+      "filename": "elem.47.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 453,
-      "filename": "elem.48.wasm"
+      "filename": "elem.48.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 465,
-      "filename": "elem.49.wasm"
+      "filename": "elem.49.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 470,
-      "filename": "elem.50.wasm"
+      "filename": "elem.50.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 482,
-      "filename": "elem.51.wasm"
+      "filename": "elem.51.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 487,
-      "filename": "elem.52.wasm"
+      "filename": "elem.52.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 499,
-      "filename": "elem.53.wasm"
+      "filename": "elem.53.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 504,
-      "filename": "elem.54.wasm"
+      "filename": "elem.54.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 517,
       "filename": "elem.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 525,
       "filename": "elem.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 539,
-      "filename": "elem.57.wasm"
+      "filename": "elem.57.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 544,
-      "filename": "elem.58.wasm"
+      "filename": "elem.58.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 556,
-      "filename": "elem.59.wasm"
+      "filename": "elem.59.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 561,
-      "filename": "elem.60.wasm"
+      "filename": "elem.60.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 573,
-      "filename": "elem.61.wasm"
+      "filename": "elem.61.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 578,
-      "filename": "elem.62.wasm"
+      "filename": "elem.62.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_uninstantiable",
       "line": 594,
       "filename": "elem.63.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 603,
       "filename": "elem.64.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 612,
       "filename": "elem.65.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 621,
       "filename": "elem.66.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 628,
       "filename": "elem.67.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 636,
       "filename": "elem.68.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 645,
       "filename": "elem.69.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 653,
       "filename": "elem.70.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 662,
       "filename": "elem.71.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 670,
       "filename": "elem.72.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 679,
       "filename": "elem.73.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 687,
       "filename": "elem.74.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "module",
       "line": 698,
-      "filename": "elem.75.wasm"
+      "filename": "elem.75.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -482,7 +544,8 @@
     {
       "type": "module",
       "line": 708,
-      "filename": "elem.76.wasm"
+      "filename": "elem.76.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -498,153 +561,154 @@
       "type": "assert_invalid",
       "line": 722,
       "filename": "elem.77.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 733,
       "filename": "elem.78.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 741,
       "filename": "elem.79.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 749,
       "filename": "elem.80.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 757,
       "filename": "elem.81.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 765,
       "filename": "elem.82.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 774,
       "filename": "elem.83.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 784,
       "filename": "elem.84.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 792,
       "filename": "elem.85.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 800,
       "filename": "elem.86.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 808,
       "filename": "elem.87.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 816,
       "filename": "elem.88.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 825,
       "filename": "elem.89.wasm",
-      "text": "unknown global 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global 0"
     },
     {
       "type": "assert_invalid",
       "line": 833,
       "filename": "elem.90.wasm",
-      "text": "unknown global 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global 1"
     },
     {
       "type": "assert_invalid",
       "line": 842,
       "filename": "elem.91.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 854,
       "filename": "elem.92.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 862,
       "filename": "elem.93.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 870,
       "filename": "elem.94.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 878,
       "filename": "elem.95.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 886,
       "filename": "elem.96.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 895,
       "filename": "elem.97.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "module",
       "line": 905,
-      "filename": "elem.98.wasm"
+      "filename": "elem.98.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -664,7 +728,8 @@
     {
       "type": "module",
       "line": 918,
-      "filename": "elem.99.wasm"
+      "filename": "elem.99.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -685,7 +750,8 @@
       "type": "module",
       "line": 934,
       "name": "module1",
-      "filename": "elem.100.wasm"
+      "filename": "elem.100.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -740,7 +806,8 @@
       "type": "module",
       "line": 958,
       "name": "module2",
-      "filename": "elem.101.wasm"
+      "filename": "elem.101.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -794,7 +861,8 @@
       "type": "module",
       "line": 971,
       "name": "module3",
-      "filename": "elem.102.wasm"
+      "filename": "elem.102.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -848,35 +916,36 @@
       "type": "assert_invalid",
       "line": 987,
       "filename": "elem.103.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 992,
       "filename": "elem.104.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 997,
       "filename": "elem.105.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1006,
       "filename": "elem.106.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 1015,
       "name": "m",
-      "filename": "elem.107.wasm"
+      "filename": "elem.107.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1011,7 +1080,8 @@
     {
       "type": "module",
       "line": 1033,
-      "filename": "elem.108.wasm"
+      "filename": "elem.108.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1059,7 +1129,8 @@
       "type": "module",
       "line": 1042,
       "name": "module4",
-      "filename": "elem.109.wasm"
+      "filename": "elem.109.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1070,7 +1141,8 @@
     {
       "type": "module",
       "line": 1051,
-      "filename": "elem.110.wasm"
+      "filename": "elem.110.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/gc/extern.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/extern.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "extern.0.wasm"
+      "filename": "extern.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",

--- a/tests/snapshots/testsuite/proposals/gc/func.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/func.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "func.0.wasm"
+      "filename": "func.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1754,26 +1755,28 @@
     {
       "type": "module",
       "line": 422,
-      "filename": "func.1.wasm"
+      "filename": "func.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 436,
       "filename": "func.2.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_malformed",
       "line": 448,
       "filename": "func.3.wat",
-      "text": "unknown type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown type"
     },
     {
       "type": "module",
       "line": 459,
-      "filename": "func.4.wasm"
+      "filename": "func.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1833,7 +1836,8 @@
     {
       "type": "module",
       "line": 488,
-      "filename": "func.5.wasm"
+      "filename": "func.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1879,512 +1883,512 @@
       "type": "assert_malformed",
       "line": 560,
       "filename": "func.6.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 567,
       "filename": "func.7.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 574,
       "filename": "func.8.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 581,
       "filename": "func.9.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 588,
       "filename": "func.10.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 595,
       "filename": "func.11.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 602,
       "filename": "func.12.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 609,
       "filename": "func.13.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 616,
       "filename": "func.14.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 623,
       "filename": "func.15.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_invalid",
       "line": 631,
       "filename": "func.16.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 635,
       "filename": "func.17.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 647,
       "filename": "func.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 651,
       "filename": "func.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 655,
       "filename": "func.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 660,
       "filename": "func.21.wasm",
-      "text": "uninitialized local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "uninitialized local"
     },
     {
       "type": "assert_invalid",
       "line": 671,
       "filename": "func.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 675,
       "filename": "func.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 679,
       "filename": "func.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 687,
       "filename": "func.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 691,
       "filename": "func.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 695,
       "filename": "func.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 699,
       "filename": "func.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 703,
       "filename": "func.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 708,
       "filename": "func.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 714,
       "filename": "func.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 720,
       "filename": "func.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 726,
       "filename": "func.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 732,
       "filename": "func.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 738,
       "filename": "func.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 744,
       "filename": "func.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 751,
       "filename": "func.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 757,
       "filename": "func.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 763,
       "filename": "func.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 769,
       "filename": "func.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 775,
       "filename": "func.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 781,
       "filename": "func.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 788,
       "filename": "func.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 794,
       "filename": "func.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 800,
       "filename": "func.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 806,
       "filename": "func.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 812,
       "filename": "func.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 818,
       "filename": "func.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 824,
       "filename": "func.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 830,
       "filename": "func.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 836,
       "filename": "func.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 843,
       "filename": "func.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 849,
       "filename": "func.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 855,
       "filename": "func.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 861,
       "filename": "func.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 867,
       "filename": "func.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 873,
       "filename": "func.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 879,
       "filename": "func.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 885,
       "filename": "func.59.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 891,
       "filename": "func.60.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 898,
       "filename": "func.61.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 904,
       "filename": "func.62.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 910,
       "filename": "func.63.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 916,
       "filename": "func.64.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 922,
       "filename": "func.65.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 928,
       "filename": "func.66.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 938,
       "filename": "func.67.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 942,
       "filename": "func.68.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 946,
       "filename": "func.69.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 950,
       "filename": "func.70.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 954,
       "filename": "func.71.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 958,
       "filename": "func.72.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 965,
       "filename": "func.73.wat",
-      "text": "duplicate func",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate func"
     },
     {
       "type": "assert_malformed",
       "line": 969,
       "filename": "func.74.wat",
-      "text": "duplicate func",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate func"
     },
     {
       "type": "assert_malformed",
       "line": 973,
       "filename": "func.75.wat",
-      "text": "duplicate func",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate func"
     },
     {
       "type": "assert_malformed",
       "line": 978,
       "filename": "func.76.wat",
-      "text": "duplicate local",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate local"
     },
     {
       "type": "assert_malformed",
       "line": 982,
       "filename": "func.77.wat",
-      "text": "duplicate local",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate local"
     },
     {
       "type": "assert_malformed",
       "line": 986,
       "filename": "func.78.wat",
-      "text": "duplicate local",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate local"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/global.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/global.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "global.0.wasm"
+      "filename": "global.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -870,330 +871,337 @@
       "type": "assert_invalid",
       "line": 273,
       "filename": "global.1.wasm",
-      "text": "immutable global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "immutable global"
     },
     {
       "type": "assert_invalid",
       "line": 278,
       "filename": "global.2.wasm",
-      "text": "immutable global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "immutable global"
     },
     {
       "type": "module",
       "line": 283,
-      "filename": "global.3.wasm"
+      "filename": "global.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 284,
-      "filename": "global.4.wasm"
+      "filename": "global.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 287,
       "filename": "global.5.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 292,
       "filename": "global.6.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 297,
       "filename": "global.7.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 302,
       "filename": "global.8.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 307,
       "filename": "global.9.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 312,
       "filename": "global.10.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 317,
       "filename": "global.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 322,
       "filename": "global.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 327,
       "filename": "global.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 332,
       "filename": "global.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 337,
       "filename": "global.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 342,
       "filename": "global.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 347,
       "filename": "global.17.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 352,
       "filename": "global.18.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 357,
       "filename": "global.19.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "module",
       "line": 361,
-      "filename": "global.20.wasm"
+      "filename": "global.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 362,
-      "filename": "global.21.wasm"
+      "filename": "global.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 365,
       "filename": "global.22.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "module",
       "line": 369,
-      "filename": "global.23.wasm"
+      "filename": "global.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 373,
       "filename": "global.24.wasm",
-      "text": "malformed mutability",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed mutability"
     },
     {
       "type": "assert_malformed",
       "line": 386,
       "filename": "global.25.wasm",
-      "text": "malformed mutability",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed mutability"
     },
     {
       "type": "module",
       "line": 399,
-      "filename": "global.26.wasm"
+      "filename": "global.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 403,
       "filename": "global.27.wasm",
-      "text": "malformed mutability",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed mutability"
     },
     {
       "type": "assert_malformed",
       "line": 415,
       "filename": "global.28.wasm",
-      "text": "malformed mutability",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed mutability"
     },
     {
       "type": "assert_invalid",
       "line": 429,
       "filename": "global.29.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 434,
       "filename": "global.30.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 442,
       "filename": "global.31.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 450,
       "filename": "global.32.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 460,
       "filename": "global.33.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 465,
       "filename": "global.34.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 473,
       "filename": "global.35.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 481,
       "filename": "global.36.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 491,
       "filename": "global.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 500,
       "filename": "global.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 510,
       "filename": "global.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 520,
       "filename": "global.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 530,
       "filename": "global.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 540,
       "filename": "global.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 550,
       "filename": "global.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 560,
       "filename": "global.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 570,
       "filename": "global.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 579,
       "filename": "global.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 588,
       "filename": "global.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 598,
       "filename": "global.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 617,
-      "filename": "global.49.wasm"
+      "filename": "global.49.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1203,7 +1211,8 @@
     {
       "type": "module",
       "line": 622,
-      "filename": "global.50.wasm"
+      "filename": "global.50.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1306,36 +1315,36 @@
       "type": "assert_invalid",
       "line": 655,
       "filename": "global.51.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 663,
       "filename": "global.52.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_malformed",
       "line": 674,
       "filename": "global.53.wat",
-      "text": "duplicate global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate global"
     },
     {
       "type": "assert_malformed",
       "line": 681,
       "filename": "global.54.wat",
-      "text": "duplicate global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate global"
     },
     {
       "type": "assert_malformed",
       "line": 688,
       "filename": "global.55.wat",
-      "text": "duplicate global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate global"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/i31.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/i31.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "i31.0.wasm"
+      "filename": "i31.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -421,7 +422,8 @@
       "type": "module",
       "line": 61,
       "name": "tables_of_i31ref",
-      "filename": "i31.1.wasm"
+      "filename": "i31.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -787,7 +789,8 @@
       "type": "module",
       "line": 123,
       "name": "env",
-      "filename": "i31.2.wasm"
+      "filename": "i31.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -798,7 +801,8 @@
       "type": "module",
       "line": 128,
       "name": "i31ref_of_global_table_initializer",
-      "filename": "i31.3.wasm"
+      "filename": "i31.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -864,7 +868,8 @@
       "type": "module",
       "line": 140,
       "name": "i31ref_of_global_global_initializer",
-      "filename": "i31.4.wasm"
+      "filename": "i31.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -885,7 +890,8 @@
       "type": "module",
       "line": 150,
       "name": "anyref_global_of_i31ref",
-      "filename": "i31.5.wasm"
+      "filename": "i31.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -943,7 +949,8 @@
       "type": "module",
       "line": 168,
       "name": "anyref_table_of_i31ref",
-      "filename": "i31.6.wasm"
+      "filename": "i31.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/gc/if.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/if.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "if.0.wasm"
+      "filename": "if.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2626,813 +2627,813 @@
       "type": "assert_malformed",
       "line": 736,
       "filename": "if.1.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 745,
       "filename": "if.2.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 754,
       "filename": "if.3.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 763,
       "filename": "if.4.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 772,
       "filename": "if.5.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 781,
       "filename": "if.6.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 788,
       "filename": "if.7.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 796,
       "filename": "if.8.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 806,
       "filename": "if.9.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 816,
       "filename": "if.10.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 826,
       "filename": "if.11.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_invalid",
       "line": 836,
       "filename": "if.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 844,
       "filename": "if.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 848,
       "filename": "if.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 852,
       "filename": "if.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 856,
       "filename": "if.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 861,
       "filename": "if.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 865,
       "filename": "if.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 869,
       "filename": "if.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 873,
       "filename": "if.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 878,
       "filename": "if.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 884,
       "filename": "if.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 890,
       "filename": "if.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 896,
       "filename": "if.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 903,
       "filename": "if.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 909,
       "filename": "if.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 915,
       "filename": "if.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 921,
       "filename": "if.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 928,
       "filename": "if.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 934,
       "filename": "if.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 940,
       "filename": "if.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 947,
       "filename": "if.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 953,
       "filename": "if.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 959,
       "filename": "if.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 966,
       "filename": "if.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 972,
       "filename": "if.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 979,
       "filename": "if.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 985,
       "filename": "if.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 991,
       "filename": "if.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 998,
       "filename": "if.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1004,
       "filename": "if.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1010,
       "filename": "if.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1017,
       "filename": "if.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1023,
       "filename": "if.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1029,
       "filename": "if.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1036,
       "filename": "if.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1042,
       "filename": "if.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1048,
       "filename": "if.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1055,
       "filename": "if.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1062,
       "filename": "if.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1069,
       "filename": "if.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1077,
       "filename": "if.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1083,
       "filename": "if.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1089,
       "filename": "if.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1096,
       "filename": "if.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1102,
       "filename": "if.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1109,
       "filename": "if.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1119,
       "filename": "if.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1129,
       "filename": "if.59.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1140,
       "filename": "if.60.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1146,
       "filename": "if.61.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1152,
       "filename": "if.62.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1158,
       "filename": "if.63.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1165,
       "filename": "if.64.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1174,
       "filename": "if.65.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1183,
       "filename": "if.66.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1192,
       "filename": "if.67.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1202,
       "filename": "if.68.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1211,
       "filename": "if.69.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1220,
       "filename": "if.70.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1229,
       "filename": "if.71.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1239,
       "filename": "if.72.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1248,
       "filename": "if.73.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1257,
       "filename": "if.74.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1266,
       "filename": "if.75.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1275,
       "filename": "if.76.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1285,
       "filename": "if.77.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1296,
       "filename": "if.78.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1304,
       "filename": "if.79.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1313,
       "filename": "if.80.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1322,
       "filename": "if.81.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1331,
       "filename": "if.82.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1341,
       "filename": "if.83.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1350,
       "filename": "if.84.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1359,
       "filename": "if.85.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1368,
       "filename": "if.86.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1376,
       "filename": "if.87.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1384,
       "filename": "if.88.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1393,
       "filename": "if.89.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1409,
       "filename": "if.90.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1418,
       "filename": "if.91.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1427,
       "filename": "if.92.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1436,
       "filename": "if.93.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1445,
       "filename": "if.94.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1454,
       "filename": "if.95.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1464,
       "filename": "if.96.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1470,
       "filename": "if.97.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1476,
       "filename": "if.98.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1482,
       "filename": "if.99.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1488,
       "filename": "if.100.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1494,
       "filename": "if.101.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1500,
       "filename": "if.102.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1506,
       "filename": "if.103.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1513,
       "filename": "if.104.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1517,
       "filename": "if.105.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1522,
       "filename": "if.106.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1526,
       "filename": "if.107.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1530,
       "filename": "if.108.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1534,
       "filename": "if.109.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1538,
       "filename": "if.110.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1542,
       "filename": "if.111.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1546,
       "filename": "if.112.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1550,
       "filename": "if.113.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1554,
       "filename": "if.114.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1558,
       "filename": "if.115.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1562,
       "filename": "if.116.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/linking.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/linking.wast.json
@@ -5,7 +5,8 @@
       "type": "module",
       "line": 3,
       "name": "Mf",
-      "filename": "linking.0.wasm"
+      "filename": "linking.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -17,7 +18,8 @@
       "type": "module",
       "line": 9,
       "name": "Nf",
-      "filename": "linking.1.wasm"
+      "filename": "linking.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -86,7 +88,8 @@
     {
       "type": "module",
       "line": 22,
-      "filename": "linking.2.wasm"
+      "filename": "linking.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -97,21 +100,22 @@
       "type": "assert_unlinkable",
       "line": 28,
       "filename": "linking.3.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 32,
       "filename": "linking.4.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 39,
       "name": "Mg",
-      "filename": "linking.5.wasm"
+      "filename": "linking.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -123,7 +127,8 @@
       "type": "module",
       "line": 50,
       "name": "Ng",
-      "filename": "linking.6.wasm"
+      "filename": "linking.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -362,21 +367,22 @@
       "type": "assert_unlinkable",
       "line": 87,
       "filename": "linking.7.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 91,
       "filename": "linking.8.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 96,
       "name": "Mref_ex",
-      "filename": "linking.9.wasm"
+      "filename": "linking.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -388,230 +394,232 @@
       "type": "module",
       "line": 112,
       "name": "Mref_im",
-      "filename": "linking.10.wasm"
+      "filename": "linking.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 133,
       "filename": "linking.11.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 138,
       "filename": "linking.12.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 142,
       "filename": "linking.13.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 146,
       "filename": "linking.14.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 151,
       "filename": "linking.15.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 155,
       "filename": "linking.16.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 159,
       "filename": "linking.17.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 164,
       "filename": "linking.18.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 168,
       "filename": "linking.19.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 172,
       "filename": "linking.20.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 176,
       "filename": "linking.21.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 182,
       "filename": "linking.22.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 186,
       "filename": "linking.23.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 190,
       "filename": "linking.24.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 194,
       "filename": "linking.25.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 199,
       "filename": "linking.26.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 203,
       "filename": "linking.27.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 207,
       "filename": "linking.28.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 211,
       "filename": "linking.29.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 216,
       "filename": "linking.30.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 220,
       "filename": "linking.31.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 224,
       "filename": "linking.32.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 228,
       "filename": "linking.33.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 233,
       "filename": "linking.34.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 237,
       "filename": "linking.35.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 241,
       "filename": "linking.36.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 245,
       "filename": "linking.37.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 250,
       "filename": "linking.38.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 254,
       "filename": "linking.39.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 258,
       "filename": "linking.40.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 262,
       "filename": "linking.41.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 269,
       "name": "Mt",
-      "filename": "linking.42.wasm"
+      "filename": "linking.42.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -623,7 +631,8 @@
       "type": "module",
       "line": 284,
       "name": "Nt",
-      "filename": "linking.43.wasm"
+      "filename": "linking.43.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -952,7 +961,8 @@
       "type": "module",
       "line": 326,
       "name": "Ot",
-      "filename": "linking.44.wasm"
+      "filename": "linking.44.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1352,13 +1362,15 @@
     {
       "type": "module",
       "line": 364,
-      "filename": "linking.45.wasm"
+      "filename": "linking.45.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 370,
       "name": "G1",
-      "filename": "linking.46.wasm"
+      "filename": "linking.46.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1370,7 +1382,8 @@
       "type": "module",
       "line": 372,
       "name": "G2",
-      "filename": "linking.47.wasm"
+      "filename": "linking.47.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1391,15 +1404,15 @@
       "type": "assert_uninstantiable",
       "line": 379,
       "filename": "linking.48.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_unlinkable",
       "line": 388,
       "filename": "linking.49.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_trap",
@@ -1421,8 +1434,8 @@
       "type": "assert_uninstantiable",
       "line": 402,
       "filename": "linking.50.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_return",
@@ -1465,8 +1478,8 @@
       "type": "assert_uninstantiable",
       "line": 414,
       "filename": "linking.51.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_return",
@@ -1493,7 +1506,8 @@
       "type": "module",
       "line": 426,
       "name": "Mtable_ex",
-      "filename": "linking.52.wasm"
+      "filename": "linking.52.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1504,55 +1518,57 @@
     {
       "type": "module",
       "line": 434,
-      "filename": "linking.53.wasm"
+      "filename": "linking.53.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 442,
       "filename": "linking.54.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 446,
       "filename": "linking.55.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 451,
       "filename": "linking.56.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 455,
       "filename": "linking.57.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 460,
       "filename": "linking.58.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 464,
       "filename": "linking.59.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 471,
       "name": "Mm",
-      "filename": "linking.60.wasm"
+      "filename": "linking.60.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1564,7 +1580,8 @@
       "type": "module",
       "line": 481,
       "name": "Nm",
-      "filename": "linking.61.wasm"
+      "filename": "linking.61.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1633,7 +1650,8 @@
       "type": "module",
       "line": 497,
       "name": "Om",
-      "filename": "linking.62.wasm"
+      "filename": "linking.62.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1722,20 +1740,22 @@
     {
       "type": "module",
       "line": 511,
-      "filename": "linking.63.wasm"
+      "filename": "linking.63.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_uninstantiable",
       "line": 517,
       "filename": "linking.64.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "module",
       "line": 524,
       "name": "Pm",
-      "filename": "linking.65.wasm"
+      "filename": "linking.65.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1909,8 +1929,8 @@
       "type": "assert_unlinkable",
       "line": 542,
       "filename": "linking.66.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_return",
@@ -1937,8 +1957,8 @@
       "type": "assert_uninstantiable",
       "line": 555,
       "filename": "linking.67.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_return",
@@ -1986,8 +2006,8 @@
       "type": "assert_uninstantiable",
       "line": 567,
       "filename": "linking.68.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_return",
@@ -2014,7 +2034,8 @@
       "type": "module",
       "line": 579,
       "name": "Ms",
-      "filename": "linking.69.wasm"
+      "filename": "linking.69.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -2026,8 +2047,8 @@
       "type": "assert_uninstantiable",
       "line": 593,
       "filename": "linking.70.wasm",
-      "text": "unreachable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unreachable"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/gc/local_get.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/local_get.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "local_get.0.wasm"
+      "filename": "local_get.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -397,113 +398,113 @@
       "type": "assert_invalid",
       "line": 149,
       "filename": "local_get.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 153,
       "filename": "local_get.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 157,
       "filename": "local_get.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 165,
       "filename": "local_get.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 169,
       "filename": "local_get.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 173,
       "filename": "local_get.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 181,
       "filename": "local_get.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 185,
       "filename": "local_get.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 189,
       "filename": "local_get.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 193,
       "filename": "local_get.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 201,
       "filename": "local_get.11.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 205,
       "filename": "local_get.12.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 210,
       "filename": "local_get.13.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 214,
       "filename": "local_get.14.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 219,
       "filename": "local_get.15.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 223,
       "filename": "local_get.16.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/local_init.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/local_init.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "local_init.0.wasm"
+      "filename": "local_init.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -70,34 +71,35 @@
       "type": "assert_invalid",
       "line": 26,
       "filename": "local_init.1.wasm",
-      "text": "uninitialized local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "uninitialized local"
     },
     {
       "type": "assert_invalid",
       "line": 30,
       "filename": "local_init.2.wasm",
-      "text": "uninitialized local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "uninitialized local"
     },
     {
       "type": "assert_invalid",
       "line": 40,
       "filename": "local_init.3.wasm",
-      "text": "uninitialized local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "uninitialized local"
     },
     {
       "type": "assert_invalid",
       "line": 53,
       "filename": "local_init.4.wasm",
-      "text": "uninitialized local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "uninitialized local"
     },
     {
       "type": "module",
       "line": 66,
-      "filename": "local_init.5.wasm"
+      "filename": "local_init.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/gc/local_tee.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/local_tee.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "local_tee.0.wasm"
+      "filename": "local_tee.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1091,295 +1092,295 @@
       "type": "assert_invalid",
       "line": 371,
       "filename": "local_tee.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 375,
       "filename": "local_tee.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 379,
       "filename": "local_tee.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 384,
       "filename": "local_tee.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 388,
       "filename": "local_tee.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 392,
       "filename": "local_tee.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 396,
       "filename": "local_tee.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 404,
       "filename": "local_tee.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 408,
       "filename": "local_tee.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 412,
       "filename": "local_tee.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 417,
       "filename": "local_tee.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 421,
       "filename": "local_tee.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 425,
       "filename": "local_tee.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 429,
       "filename": "local_tee.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 434,
       "filename": "local_tee.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 442,
       "filename": "local_tee.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 451,
       "filename": "local_tee.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 460,
       "filename": "local_tee.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 469,
       "filename": "local_tee.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 478,
       "filename": "local_tee.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 487,
       "filename": "local_tee.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 496,
       "filename": "local_tee.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 505,
       "filename": "local_tee.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 513,
       "filename": "local_tee.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 521,
       "filename": "local_tee.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 530,
       "filename": "local_tee.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 546,
       "filename": "local_tee.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 554,
       "filename": "local_tee.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 562,
       "filename": "local_tee.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 571,
       "filename": "local_tee.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 580,
       "filename": "local_tee.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 589,
       "filename": "local_tee.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 599,
       "filename": "local_tee.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 603,
       "filename": "local_tee.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 607,
       "filename": "local_tee.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 613,
       "filename": "local_tee.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 630,
       "filename": "local_tee.37.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 634,
       "filename": "local_tee.38.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 639,
       "filename": "local_tee.39.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 643,
       "filename": "local_tee.40.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 648,
       "filename": "local_tee.41.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 652,
       "filename": "local_tee.42.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/ref.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/ref.wast.json
@@ -4,91 +4,92 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "ref.0.wasm"
+      "filename": "ref.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 28,
       "filename": "ref.1.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 32,
       "filename": "ref.2.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 37,
       "filename": "ref.3.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 42,
       "filename": "ref.4.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 47,
       "filename": "ref.5.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 52,
       "filename": "ref.6.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 56,
       "filename": "ref.7.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 60,
       "filename": "ref.8.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 65,
       "filename": "ref.9.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 69,
       "filename": "ref.10.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 73,
       "filename": "ref.11.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 78,
       "filename": "ref.12.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/ref_as_non_null.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/ref_as_non_null.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "ref_as_non_null.0.wasm"
+      "filename": "ref_as_non_null.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -60,13 +61,14 @@
       "type": "assert_invalid",
       "line": 32,
       "filename": "ref_as_non_null.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 41,
-      "filename": "ref_as_non_null.2.wasm"
+      "filename": "ref_as_non_null.2.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/ref_cast.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/ref_cast.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "ref_cast.0.wasm"
+      "filename": "ref_cast.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -623,7 +624,8 @@
     {
       "type": "module",
       "line": 99,
-      "filename": "ref_cast.1.wasm"
+      "filename": "ref_cast.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",

--- a/tests/snapshots/testsuite/proposals/gc/ref_eq.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/ref_eq.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "ref_eq.0.wasm"
+      "filename": "ref_eq.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -1963,43 +1964,43 @@
       "type": "assert_invalid",
       "line": 122,
       "filename": "ref_eq.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 130,
       "filename": "ref_eq.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 138,
       "filename": "ref_eq.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 146,
       "filename": "ref_eq.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 154,
       "filename": "ref_eq.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 162,
       "filename": "ref_eq.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/ref_is_null.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/ref_is_null.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "ref_is_null.0.wasm"
+      "filename": "ref_is_null.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -347,21 +348,22 @@
     {
       "type": "module",
       "line": 71,
-      "filename": "ref_is_null.1.wasm"
+      "filename": "ref_is_null.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 79,
       "filename": "ref_is_null.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 83,
       "filename": "ref_is_null.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/ref_null.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/ref_null.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "ref_null.0.wasm"
+      "filename": "ref_null.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -53,7 +54,8 @@
     {
       "type": "module",
       "line": 17,
-      "filename": "ref_null.1.wasm"
+      "filename": "ref_null.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/gc/ref_test.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/ref_test.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "ref_test.0.wasm"
+      "filename": "ref_test.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -1343,7 +1344,8 @@
     {
       "type": "module",
       "line": 182,
-      "filename": "ref_test.1.wasm"
+      "filename": "ref_test.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/gc/return_call.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/return_call.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "return_call.0.wasm"
+      "filename": "return_call.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -586,88 +587,90 @@
       "type": "assert_invalid",
       "line": 124,
       "filename": "return_call.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 131,
       "filename": "return_call.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 139,
       "filename": "return_call.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 146,
       "filename": "return_call.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 153,
-      "filename": "return_call.5.wasm"
+      "filename": "return_call.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 158,
-      "filename": "return_call.6.wasm"
+      "filename": "return_call.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 164,
       "filename": "return_call.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 171,
       "filename": "return_call.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 178,
       "filename": "return_call.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 185,
       "filename": "return_call.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 192,
       "filename": "return_call.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 204,
       "filename": "return_call.12.wasm",
-      "text": "unknown function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function"
     },
     {
       "type": "assert_invalid",
       "line": 208,
       "filename": "return_call.13.wasm",
-      "text": "unknown function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/return_call_indirect.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/return_call_indirect.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "return_call_indirect.0.wasm"
+      "filename": "return_call_indirect.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -886,193 +887,195 @@
       "type": "assert_malformed",
       "line": 273,
       "filename": "return_call_indirect.1.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 285,
       "filename": "return_call_indirect.2.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 297,
       "filename": "return_call_indirect.3.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 309,
       "filename": "return_call_indirect.4.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 321,
       "filename": "return_call_indirect.5.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 333,
       "filename": "return_call_indirect.6.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 345,
       "filename": "return_call_indirect.7.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 352,
       "filename": "return_call_indirect.8.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 362,
       "filename": "return_call_indirect.9.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 372,
       "filename": "return_call_indirect.10.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 384,
       "filename": "return_call_indirect.11.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_invalid",
       "line": 399,
       "filename": "return_call_indirect.12.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 407,
       "filename": "return_call_indirect.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 415,
       "filename": "return_call_indirect.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 424,
       "filename": "return_call_indirect.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 432,
       "filename": "return_call_indirect.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 440,
-      "filename": "return_call_indirect.17.wasm"
+      "filename": "return_call_indirect.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 446,
-      "filename": "return_call_indirect.18.wasm"
+      "filename": "return_call_indirect.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 455,
       "filename": "return_call_indirect.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 463,
       "filename": "return_call_indirect.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 472,
       "filename": "return_call_indirect.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 482,
       "filename": "return_call_indirect.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 492,
       "filename": "return_call_indirect.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 502,
       "filename": "return_call_indirect.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 512,
       "filename": "return_call_indirect.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 526,
       "filename": "return_call_indirect.26.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 533,
       "filename": "return_call_indirect.27.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 544,
       "filename": "return_call_indirect.28.wasm",
-      "text": "unknown function 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function 0"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/return_call_ref.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/return_call_ref.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "return_call_ref.0.wasm"
+      "filename": "return_call_ref.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -595,54 +596,56 @@
     {
       "type": "module",
       "line": 213,
-      "filename": "return_call_ref.1.wasm"
+      "filename": "return_call_ref.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 232,
       "filename": "return_call_ref.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 243,
       "filename": "return_call_ref.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 254,
       "filename": "return_call_ref.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 265,
       "filename": "return_call_ref.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 276,
       "filename": "return_call_ref.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 287,
       "filename": "return_call_ref.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 299,
-      "filename": "return_call_ref.8.wasm"
+      "filename": "return_call_ref.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -657,7 +660,8 @@
     {
       "type": "module",
       "line": 308,
-      "filename": "return_call_ref.9.wasm"
+      "filename": "return_call_ref.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -672,7 +676,8 @@
     {
       "type": "module",
       "line": 321,
-      "filename": "return_call_ref.10.wasm"
+      "filename": "return_call_ref.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -688,36 +693,36 @@
       "type": "assert_invalid",
       "line": 337,
       "filename": "return_call_ref.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 353,
       "filename": "return_call_ref.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 369,
       "filename": "return_call_ref.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 379,
       "filename": "return_call_ref.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 389,
       "filename": "return_call_ref.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/select.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/select.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "select.0.wasm"
+      "filename": "select.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2834,221 +2835,223 @@
       "type": "assert_invalid",
       "line": 364,
       "filename": "select.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 368,
       "filename": "select.2.wasm",
-      "text": "invalid result arity",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid result arity"
     },
     {
       "type": "assert_invalid",
       "line": 372,
       "filename": "select.3.wasm",
-      "text": "invalid result arity",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid result arity"
     },
     {
       "type": "assert_invalid",
       "line": 384,
       "filename": "select.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 392,
       "filename": "select.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 398,
       "filename": "select.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 403,
-      "filename": "select.7.wasm"
+      "filename": "select.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 408,
       "filename": "select.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 414,
       "filename": "select.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 420,
       "filename": "select.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 427,
       "filename": "select.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 431,
       "filename": "select.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 435,
       "filename": "select.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 439,
       "filename": "select.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 443,
       "filename": "select.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 449,
       "filename": "select.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 457,
       "filename": "select.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 465,
       "filename": "select.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 473,
       "filename": "select.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 482,
       "filename": "select.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 491,
       "filename": "select.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 500,
       "filename": "select.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 509,
       "filename": "select.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 518,
       "filename": "select.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 527,
       "filename": "select.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 536,
       "filename": "select.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 545,
       "filename": "select.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 557,
       "filename": "select.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 561,
       "filename": "select.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 565,
       "filename": "select.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 572,
       "filename": "select.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 579,
-      "filename": "select.32.wasm"
+      "filename": "select.32.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/struct.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/struct.wast.json
@@ -4,50 +4,54 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "struct.0.wasm"
+      "filename": "struct.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 16,
       "filename": "struct.1.wat",
-      "text": "duplicate field",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate field"
     },
     {
       "type": "module",
       "line": 25,
-      "filename": "struct.2.wasm"
+      "filename": "struct.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 37,
       "filename": "struct.3.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 41,
       "filename": "struct.4.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "module",
       "line": 48,
-      "filename": "struct.5.wasm"
+      "filename": "struct.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 59,
       "filename": "struct.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 70,
-      "filename": "struct.7.wasm"
+      "filename": "struct.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -167,13 +171,14 @@
       "type": "assert_invalid",
       "line": 133,
       "filename": "struct.8.wasm",
-      "text": "field is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "field is immutable"
     },
     {
       "type": "module",
       "line": 145,
-      "filename": "struct.9.wasm"
+      "filename": "struct.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -198,7 +203,8 @@
     {
       "type": "module",
       "line": 160,
-      "filename": "struct.10.wasm"
+      "filename": "struct.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/gc/table-sub.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/table-sub.wast.json
@@ -4,21 +4,22 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "table-sub.0.wasm"
+      "filename": "table-sub.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 13,
       "filename": "table-sub.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 24,
       "filename": "table-sub.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/table.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/table.wast.json
@@ -4,180 +4,196 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "table.0.wasm"
+      "filename": "table.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 4,
-      "filename": "table.1.wasm"
+      "filename": "table.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 5,
-      "filename": "table.2.wasm"
+      "filename": "table.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 6,
-      "filename": "table.3.wasm"
+      "filename": "table.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 7,
-      "filename": "table.4.wasm"
+      "filename": "table.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 8,
-      "filename": "table.5.wasm"
+      "filename": "table.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 9,
-      "filename": "table.6.wasm"
+      "filename": "table.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 11,
-      "filename": "table.7.wasm"
+      "filename": "table.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 12,
-      "filename": "table.8.wasm"
+      "filename": "table.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 13,
-      "filename": "table.9.wasm"
+      "filename": "table.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 15,
-      "filename": "table.10.wasm"
+      "filename": "table.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 16,
-      "filename": "table.11.wasm"
+      "filename": "table.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 18,
-      "filename": "table.12.wasm"
+      "filename": "table.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 19,
-      "filename": "table.13.wasm"
+      "filename": "table.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 20,
-      "filename": "table.14.wasm"
+      "filename": "table.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 22,
       "filename": "table.15.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 23,
       "filename": "table.16.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 27,
       "filename": "table.17.wasm",
-      "text": "size minimum must not be greater than maximum",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "size minimum must not be greater than maximum"
     },
     {
       "type": "assert_invalid",
       "line": 31,
       "filename": "table.18.wasm",
-      "text": "size minimum must not be greater than maximum",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "size minimum must not be greater than maximum"
     },
     {
       "type": "assert_malformed",
       "line": 36,
       "filename": "table.19.wat",
-      "text": "i32 constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "i32 constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 40,
       "filename": "table.20.wat",
-      "text": "i32 constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "i32 constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 44,
       "filename": "table.21.wat",
-      "text": "i32 constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "i32 constant out of range"
     },
     {
       "type": "assert_invalid",
       "line": 49,
       "filename": "table.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 53,
       "filename": "table.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 57,
       "filename": "table.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 61,
       "filename": "table.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 65,
       "filename": "table.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 69,
       "filename": "table.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 73,
       "filename": "table.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 80,
-      "filename": "table.29.wasm"
+      "filename": "table.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -187,7 +203,8 @@
     {
       "type": "module",
       "line": 87,
-      "filename": "table.30.wasm"
+      "filename": "table.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -263,43 +280,43 @@
       "type": "assert_invalid",
       "line": 114,
       "filename": "table.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 122,
       "filename": "table.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 130,
       "filename": "table.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 141,
       "filename": "table.34.wat",
-      "text": "duplicate table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate table"
     },
     {
       "type": "assert_malformed",
       "line": 148,
       "filename": "table.35.wat",
-      "text": "duplicate table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate table"
     },
     {
       "type": "assert_malformed",
       "line": 155,
       "filename": "table.36.wat",
-      "text": "duplicate table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate table"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/type-canon.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/type-canon.wast.json
@@ -4,12 +4,14 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "type-canon.0.wasm"
+      "filename": "type-canon.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 9,
-      "filename": "type-canon.1.wasm"
+      "filename": "type-canon.1.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/type-equivalence.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/type-equivalence.wast.json
@@ -4,39 +4,45 @@
     {
       "type": "module",
       "line": 5,
-      "filename": "type-equivalence.0.wasm"
+      "filename": "type-equivalence.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 16,
-      "filename": "type-equivalence.1.wasm"
+      "filename": "type-equivalence.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 30,
-      "filename": "type-equivalence.2.wasm"
+      "filename": "type-equivalence.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 38,
-      "filename": "type-equivalence.3.wasm"
+      "filename": "type-equivalence.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 49,
-      "filename": "type-equivalence.4.wasm"
+      "filename": "type-equivalence.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 77,
       "filename": "type-equivalence.5.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "module",
       "line": 89,
-      "filename": "type-equivalence.6.wasm"
+      "filename": "type-equivalence.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -51,7 +57,8 @@
     {
       "type": "module",
       "line": 107,
-      "filename": "type-equivalence.7.wasm"
+      "filename": "type-equivalence.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -66,7 +73,8 @@
     {
       "type": "module",
       "line": 136,
-      "filename": "type-equivalence.8.wasm"
+      "filename": "type-equivalence.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -81,7 +89,8 @@
     {
       "type": "module",
       "line": 161,
-      "filename": "type-equivalence.9.wasm"
+      "filename": "type-equivalence.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -96,7 +105,8 @@
     {
       "type": "module",
       "line": 195,
-      "filename": "type-equivalence.10.wasm"
+      "filename": "type-equivalence.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -106,12 +116,14 @@
     {
       "type": "module",
       "line": 200,
-      "filename": "type-equivalence.11.wasm"
+      "filename": "type-equivalence.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 208,
-      "filename": "type-equivalence.12.wasm"
+      "filename": "type-equivalence.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -121,12 +133,14 @@
     {
       "type": "module",
       "line": 218,
-      "filename": "type-equivalence.13.wasm"
+      "filename": "type-equivalence.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 233,
-      "filename": "type-equivalence.14.wasm"
+      "filename": "type-equivalence.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -136,12 +150,14 @@
     {
       "type": "module",
       "line": 238,
-      "filename": "type-equivalence.15.wasm"
+      "filename": "type-equivalence.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 246,
-      "filename": "type-equivalence.16.wasm"
+      "filename": "type-equivalence.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -151,12 +167,14 @@
     {
       "type": "module",
       "line": 257,
-      "filename": "type-equivalence.17.wasm"
+      "filename": "type-equivalence.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 268,
-      "filename": "type-equivalence.18.wasm"
+      "filename": "type-equivalence.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -166,12 +184,14 @@
     {
       "type": "module",
       "line": 279,
-      "filename": "type-equivalence.19.wasm"
+      "filename": "type-equivalence.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 290,
-      "filename": "type-equivalence.20.wasm"
+      "filename": "type-equivalence.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -181,7 +201,8 @@
     {
       "type": "module",
       "line": 308,
-      "filename": "type-equivalence.21.wasm"
+      "filename": "type-equivalence.21.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/type-rec.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/type-rec.wast.json
@@ -4,46 +4,49 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "type-rec.0.wasm"
+      "filename": "type-rec.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 10,
-      "filename": "type-rec.1.wasm"
+      "filename": "type-rec.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 26,
       "filename": "type-rec.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 36,
       "filename": "type-rec.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 47,
       "filename": "type-rec.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 57,
       "filename": "type-rec.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 69,
       "name": "M",
-      "filename": "type-rec.6.wasm"
+      "filename": "type-rec.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -54,26 +57,28 @@
     {
       "type": "module",
       "line": 75,
-      "filename": "type-rec.7.wasm"
+      "filename": "type-rec.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 81,
       "filename": "type-rec.8.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 89,
       "filename": "type-rec.9.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 99,
-      "filename": "type-rec.10.wasm"
+      "filename": "type-rec.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -88,7 +93,8 @@
     {
       "type": "module",
       "line": 108,
-      "filename": "type-rec.11.wasm"
+      "filename": "type-rec.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -103,7 +109,8 @@
     {
       "type": "module",
       "line": 117,
-      "filename": "type-rec.12.wasm"
+      "filename": "type-rec.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -118,21 +125,22 @@
     {
       "type": "module",
       "line": 129,
-      "filename": "type-rec.13.wasm"
+      "filename": "type-rec.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 137,
       "filename": "type-rec.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 149,
       "filename": "type-rec.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/type-subtyping.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/type-subtyping.wast.json
@@ -4,98 +4,113 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "type-subtyping.0.wasm"
+      "filename": "type-subtyping.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 15,
-      "filename": "type-subtyping.1.wasm"
+      "filename": "type-subtyping.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 24,
-      "filename": "type-subtyping.2.wasm"
+      "filename": "type-subtyping.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 37,
-      "filename": "type-subtyping.3.wasm"
+      "filename": "type-subtyping.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 43,
-      "filename": "type-subtyping.4.wasm"
+      "filename": "type-subtyping.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 53,
-      "filename": "type-subtyping.5.wasm"
+      "filename": "type-subtyping.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 68,
-      "filename": "type-subtyping.6.wasm"
+      "filename": "type-subtyping.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 89,
-      "filename": "type-subtyping.7.wasm"
+      "filename": "type-subtyping.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 115,
-      "filename": "type-subtyping.8.wasm"
+      "filename": "type-subtyping.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 124,
-      "filename": "type-subtyping.9.wasm"
+      "filename": "type-subtyping.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 140,
       "filename": "type-subtyping.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 151,
-      "filename": "type-subtyping.11.wasm"
+      "filename": "type-subtyping.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 159,
-      "filename": "type-subtyping.12.wasm"
+      "filename": "type-subtyping.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 177,
-      "filename": "type-subtyping.13.wasm"
+      "filename": "type-subtyping.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 188,
-      "filename": "type-subtyping.14.wasm"
+      "filename": "type-subtyping.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 206,
       "filename": "type-subtyping.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 216,
       "filename": "type-subtyping.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 229,
-      "filename": "type-subtyping.17.wasm"
+      "filename": "type-subtyping.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -170,7 +185,8 @@
     {
       "type": "module",
       "line": 290,
-      "filename": "type-subtyping.18.wasm"
+      "filename": "type-subtyping.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -215,7 +231,8 @@
     {
       "type": "module",
       "line": 319,
-      "filename": "type-subtyping.19.wasm"
+      "filename": "type-subtyping.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -250,7 +267,8 @@
     {
       "type": "module",
       "line": 348,
-      "filename": "type-subtyping.20.wasm"
+      "filename": "type-subtyping.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -270,7 +288,8 @@
     {
       "type": "module",
       "line": 360,
-      "filename": "type-subtyping.21.wasm"
+      "filename": "type-subtyping.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -290,7 +309,8 @@
     {
       "type": "module",
       "line": 378,
-      "filename": "type-subtyping.22.wasm"
+      "filename": "type-subtyping.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -310,7 +330,8 @@
     {
       "type": "module",
       "line": 390,
-      "filename": "type-subtyping.23.wasm"
+      "filename": "type-subtyping.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -330,7 +351,8 @@
     {
       "type": "module",
       "line": 401,
-      "filename": "type-subtyping.24.wasm"
+      "filename": "type-subtyping.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -354,7 +376,8 @@
     {
       "type": "module",
       "line": 422,
-      "filename": "type-subtyping.25.wasm"
+      "filename": "type-subtyping.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -386,7 +409,8 @@
     {
       "type": "module",
       "line": 438,
-      "filename": "type-subtyping.26.wasm"
+      "filename": "type-subtyping.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -434,7 +458,8 @@
     {
       "type": "module",
       "line": 461,
-      "filename": "type-subtyping.27.wasm"
+      "filename": "type-subtyping.27.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -454,7 +479,8 @@
     {
       "type": "module",
       "line": 471,
-      "filename": "type-subtyping.28.wasm"
+      "filename": "type-subtyping.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -474,7 +500,8 @@
     {
       "type": "module",
       "line": 486,
-      "filename": "type-subtyping.29.wasm"
+      "filename": "type-subtyping.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -484,33 +511,35 @@
     {
       "type": "module",
       "line": 497,
-      "filename": "type-subtyping.30.wasm"
+      "filename": "type-subtyping.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 511,
       "filename": "type-subtyping.31.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 521,
       "filename": "type-subtyping.32.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 531,
       "filename": "type-subtyping.33.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 540,
-      "filename": "type-subtyping.34.wasm"
+      "filename": "type-subtyping.34.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -521,20 +550,21 @@
       "type": "assert_unlinkable",
       "line": 549,
       "filename": "type-subtyping.35.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 557,
       "filename": "type-subtyping.36.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 566,
-      "filename": "type-subtyping.37.wasm"
+      "filename": "type-subtyping.37.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -544,12 +574,14 @@
     {
       "type": "module",
       "line": 572,
-      "filename": "type-subtyping.38.wasm"
+      "filename": "type-subtyping.38.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 578,
-      "filename": "type-subtyping.39.wasm"
+      "filename": "type-subtyping.39.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -559,12 +591,14 @@
     {
       "type": "module",
       "line": 588,
-      "filename": "type-subtyping.40.wasm"
+      "filename": "type-subtyping.40.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 598,
-      "filename": "type-subtyping.41.wasm"
+      "filename": "type-subtyping.41.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -575,13 +609,14 @@
       "type": "assert_unlinkable",
       "line": 606,
       "filename": "type-subtyping.42.wasm",
-      "text": "incompatible import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import"
     },
     {
       "type": "module",
       "line": 614,
-      "filename": "type-subtyping.43.wasm"
+      "filename": "type-subtyping.43.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -591,12 +626,14 @@
     {
       "type": "module",
       "line": 621,
-      "filename": "type-subtyping.44.wasm"
+      "filename": "type-subtyping.44.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 628,
-      "filename": "type-subtyping.45.wasm"
+      "filename": "type-subtyping.45.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -606,12 +643,14 @@
     {
       "type": "module",
       "line": 639,
-      "filename": "type-subtyping.46.wasm"
+      "filename": "type-subtyping.46.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 652,
-      "filename": "type-subtyping.47.wasm"
+      "filename": "type-subtyping.47.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -621,12 +660,14 @@
     {
       "type": "module",
       "line": 659,
-      "filename": "type-subtyping.48.wasm"
+      "filename": "type-subtyping.48.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 668,
-      "filename": "type-subtyping.49.wasm"
+      "filename": "type-subtyping.49.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -636,12 +677,14 @@
     {
       "type": "module",
       "line": 677,
-      "filename": "type-subtyping.50.wasm"
+      "filename": "type-subtyping.50.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 692,
-      "filename": "type-subtyping.51.wasm"
+      "filename": "type-subtyping.51.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -652,13 +695,14 @@
       "type": "assert_unlinkable",
       "line": 699,
       "filename": "type-subtyping.52.wasm",
-      "text": "incompatible import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import"
     },
     {
       "type": "module",
       "line": 706,
-      "filename": "type-subtyping.53.wasm"
+      "filename": "type-subtyping.53.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -669,99 +713,99 @@
       "type": "assert_unlinkable",
       "line": 714,
       "filename": "type-subtyping.54.wasm",
-      "text": "incompatible import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import"
     },
     {
       "type": "assert_invalid",
       "line": 727,
       "filename": "type-subtyping.55.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 735,
       "filename": "type-subtyping.56.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 743,
       "filename": "type-subtyping.57.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 751,
       "filename": "type-subtyping.58.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 764,
       "filename": "type-subtyping.59.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 772,
       "filename": "type-subtyping.60.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 780,
       "filename": "type-subtyping.61.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 788,
       "filename": "type-subtyping.62.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 796,
       "filename": "type-subtyping.63.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 804,
       "filename": "type-subtyping.64.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 812,
       "filename": "type-subtyping.65.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 820,
       "filename": "type-subtyping.66.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 828,
       "filename": "type-subtyping.67.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/unreached-invalid.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/unreached-invalid.wast.json
@@ -5,848 +5,848 @@
       "type": "assert_invalid",
       "line": 4,
       "filename": "unreached-invalid.0.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 8,
       "filename": "unreached-invalid.1.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 12,
       "filename": "unreached-invalid.2.wasm",
-      "text": "unknown function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function"
     },
     {
       "type": "assert_invalid",
       "line": 16,
       "filename": "unreached-invalid.3.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 21,
       "filename": "unreached-invalid.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 27,
       "filename": "unreached-invalid.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 33,
       "filename": "unreached-invalid.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 42,
       "filename": "unreached-invalid.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 46,
       "filename": "unreached-invalid.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 50,
       "filename": "unreached-invalid.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 56,
       "filename": "unreached-invalid.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 60,
       "filename": "unreached-invalid.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 64,
       "filename": "unreached-invalid.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 71,
       "filename": "unreached-invalid.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 77,
       "filename": "unreached-invalid.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 83,
       "filename": "unreached-invalid.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 89,
       "filename": "unreached-invalid.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 95,
       "filename": "unreached-invalid.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 101,
       "filename": "unreached-invalid.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 107,
       "filename": "unreached-invalid.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 113,
       "filename": "unreached-invalid.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 119,
       "filename": "unreached-invalid.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 125,
       "filename": "unreached-invalid.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 132,
       "filename": "unreached-invalid.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 138,
       "filename": "unreached-invalid.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 144,
       "filename": "unreached-invalid.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 150,
       "filename": "unreached-invalid.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 156,
       "filename": "unreached-invalid.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 162,
       "filename": "unreached-invalid.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 168,
       "filename": "unreached-invalid.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 174,
       "filename": "unreached-invalid.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 180,
       "filename": "unreached-invalid.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 186,
       "filename": "unreached-invalid.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 193,
       "filename": "unreached-invalid.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 199,
       "filename": "unreached-invalid.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 205,
       "filename": "unreached-invalid.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 211,
       "filename": "unreached-invalid.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 217,
       "filename": "unreached-invalid.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 223,
       "filename": "unreached-invalid.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 229,
       "filename": "unreached-invalid.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 235,
       "filename": "unreached-invalid.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 241,
       "filename": "unreached-invalid.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 247,
       "filename": "unreached-invalid.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 253,
       "filename": "unreached-invalid.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 259,
       "filename": "unreached-invalid.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 265,
       "filename": "unreached-invalid.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 271,
       "filename": "unreached-invalid.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 277,
       "filename": "unreached-invalid.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 284,
       "filename": "unreached-invalid.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 290,
       "filename": "unreached-invalid.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 296,
       "filename": "unreached-invalid.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 302,
       "filename": "unreached-invalid.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 308,
       "filename": "unreached-invalid.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 314,
       "filename": "unreached-invalid.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 321,
       "filename": "unreached-invalid.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 327,
       "filename": "unreached-invalid.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 334,
       "filename": "unreached-invalid.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 340,
       "filename": "unreached-invalid.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 348,
       "filename": "unreached-invalid.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 354,
       "filename": "unreached-invalid.59.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 360,
       "filename": "unreached-invalid.60.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 366,
       "filename": "unreached-invalid.61.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 372,
       "filename": "unreached-invalid.62.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 378,
       "filename": "unreached-invalid.63.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 384,
       "filename": "unreached-invalid.64.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 390,
       "filename": "unreached-invalid.65.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 396,
       "filename": "unreached-invalid.66.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 402,
       "filename": "unreached-invalid.67.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 409,
       "filename": "unreached-invalid.68.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 415,
       "filename": "unreached-invalid.69.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 421,
       "filename": "unreached-invalid.70.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 427,
       "filename": "unreached-invalid.71.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 433,
       "filename": "unreached-invalid.72.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 439,
       "filename": "unreached-invalid.73.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 445,
       "filename": "unreached-invalid.74.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 451,
       "filename": "unreached-invalid.75.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 457,
       "filename": "unreached-invalid.76.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 463,
       "filename": "unreached-invalid.77.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 470,
       "filename": "unreached-invalid.78.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 477,
       "filename": "unreached-invalid.79.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 484,
       "filename": "unreached-invalid.80.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 490,
       "filename": "unreached-invalid.81.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 498,
       "filename": "unreached-invalid.82.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 507,
       "filename": "unreached-invalid.83.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 515,
       "filename": "unreached-invalid.84.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 521,
       "filename": "unreached-invalid.85.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 527,
       "filename": "unreached-invalid.86.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 540,
       "filename": "unreached-invalid.87.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 546,
       "filename": "unreached-invalid.88.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 552,
       "filename": "unreached-invalid.89.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 558,
       "filename": "unreached-invalid.90.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 565,
       "filename": "unreached-invalid.91.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 571,
       "filename": "unreached-invalid.92.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 577,
       "filename": "unreached-invalid.93.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 584,
       "filename": "unreached-invalid.94.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 590,
       "filename": "unreached-invalid.95.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 596,
       "filename": "unreached-invalid.96.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 604,
       "filename": "unreached-invalid.97.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 611,
       "filename": "unreached-invalid.98.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 617,
       "filename": "unreached-invalid.99.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 623,
       "filename": "unreached-invalid.100.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 629,
       "filename": "unreached-invalid.101.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 637,
       "filename": "unreached-invalid.102.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 643,
       "filename": "unreached-invalid.103.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 649,
       "filename": "unreached-invalid.104.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 656,
       "filename": "unreached-invalid.105.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 662,
       "filename": "unreached-invalid.106.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 669,
       "filename": "unreached-invalid.107.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 676,
       "filename": "unreached-invalid.108.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 687,
       "filename": "unreached-invalid.109.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 698,
       "filename": "unreached-invalid.110.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 710,
       "filename": "unreached-invalid.111.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 715,
       "filename": "unreached-invalid.112.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 721,
       "filename": "unreached-invalid.113.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 726,
       "filename": "unreached-invalid.114.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 731,
       "filename": "unreached-invalid.115.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 737,
       "filename": "unreached-invalid.116.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 744,
       "filename": "unreached-invalid.117.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 749,
       "filename": "unreached-invalid.118.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 764,
       "filename": "unreached-invalid.119.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 774,
       "filename": "unreached-invalid.120.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/gc/unreached-valid.wast.json
+++ b/tests/snapshots/testsuite/proposals/gc/unreached-valid.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "unreached-valid.0.wasm"
+      "filename": "unreached-valid.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -119,7 +120,8 @@
     {
       "type": "module",
       "line": 63,
-      "filename": "unreached-valid.1.wasm"
+      "filename": "unreached-valid.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -134,7 +136,8 @@
     {
       "type": "module",
       "line": 82,
-      "filename": "unreached-valid.2.wasm"
+      "filename": "unreached-valid.2.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/address.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/address.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "address.0.wasm"
+      "filename": "address.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1745,13 +1746,15 @@
       "type": "assert_invalid",
       "line": 214,
       "filename": "address.1.wat",
-      "text": "offset out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "binary_filename": "address.1.wasm",
+      "text": "offset out of range"
     },
     {
       "type": "module",
       "line": 223,
-      "filename": "address.2.wasm"
+      "filename": "address.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4166,7 +4169,8 @@
     {
       "type": "module",
       "line": 514,
-      "filename": "address.3.wasm"
+      "filename": "address.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4526,7 +4530,8 @@
     {
       "type": "module",
       "line": 564,
-      "filename": "address.4.wasm"
+      "filename": "address.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/address0.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/address0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "address0.0.wasm"
+      "filename": "address0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/address1.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/address1.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "address1.0.wasm"
+      "filename": "address1.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/address64.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/address64.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "address64.0.wasm"
+      "filename": "address64.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1654,7 +1655,8 @@
     {
       "type": "module",
       "line": 209,
-      "filename": "address64.1.wasm"
+      "filename": "address64.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3964,7 +3966,8 @@
     {
       "type": "module",
       "line": 492,
-      "filename": "address64.2.wasm"
+      "filename": "address64.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4294,7 +4297,8 @@
     {
       "type": "module",
       "line": 539,
-      "filename": "address64.3.wasm"
+      "filename": "address64.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/align.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/align.wast.json
@@ -4,703 +4,727 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "align.0.wasm"
+      "filename": "align.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 4,
-      "filename": "align.1.wasm"
+      "filename": "align.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 5,
-      "filename": "align.2.wasm"
+      "filename": "align.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 6,
-      "filename": "align.3.wasm"
+      "filename": "align.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 7,
-      "filename": "align.4.wasm"
+      "filename": "align.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 8,
-      "filename": "align.5.wasm"
+      "filename": "align.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 9,
-      "filename": "align.6.wasm"
+      "filename": "align.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 10,
-      "filename": "align.7.wasm"
+      "filename": "align.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 11,
-      "filename": "align.8.wasm"
+      "filename": "align.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 12,
-      "filename": "align.9.wasm"
+      "filename": "align.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 13,
-      "filename": "align.10.wasm"
+      "filename": "align.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 14,
-      "filename": "align.11.wasm"
+      "filename": "align.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 15,
-      "filename": "align.12.wasm"
+      "filename": "align.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 16,
-      "filename": "align.13.wasm"
+      "filename": "align.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 17,
-      "filename": "align.14.wasm"
+      "filename": "align.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 18,
-      "filename": "align.15.wasm"
+      "filename": "align.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 19,
-      "filename": "align.16.wasm"
+      "filename": "align.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 20,
-      "filename": "align.17.wasm"
+      "filename": "align.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 21,
-      "filename": "align.18.wasm"
+      "filename": "align.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 22,
-      "filename": "align.19.wasm"
+      "filename": "align.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 23,
-      "filename": "align.20.wasm"
+      "filename": "align.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 24,
-      "filename": "align.21.wasm"
+      "filename": "align.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 25,
-      "filename": "align.22.wasm"
+      "filename": "align.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 28,
       "filename": "align.23.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 34,
       "filename": "align.24.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 40,
       "filename": "align.25.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 46,
       "filename": "align.26.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 52,
       "filename": "align.27.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 58,
       "filename": "align.28.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 64,
       "filename": "align.29.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 70,
       "filename": "align.30.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 76,
       "filename": "align.31.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 82,
       "filename": "align.32.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 88,
       "filename": "align.33.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 94,
       "filename": "align.34.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 100,
       "filename": "align.35.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 106,
       "filename": "align.36.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 112,
       "filename": "align.37.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 118,
       "filename": "align.38.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 124,
       "filename": "align.39.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 130,
       "filename": "align.40.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 136,
       "filename": "align.41.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 142,
       "filename": "align.42.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 148,
       "filename": "align.43.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 154,
       "filename": "align.44.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 160,
       "filename": "align.45.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 166,
       "filename": "align.46.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 172,
       "filename": "align.47.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 178,
       "filename": "align.48.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 184,
       "filename": "align.49.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 190,
       "filename": "align.50.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 197,
       "filename": "align.51.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 203,
       "filename": "align.52.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 209,
       "filename": "align.53.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 215,
       "filename": "align.54.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 221,
       "filename": "align.55.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 227,
       "filename": "align.56.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 233,
       "filename": "align.57.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 239,
       "filename": "align.58.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 245,
       "filename": "align.59.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 251,
       "filename": "align.60.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 257,
       "filename": "align.61.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 263,
       "filename": "align.62.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 269,
       "filename": "align.63.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 275,
       "filename": "align.64.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 281,
       "filename": "align.65.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 287,
       "filename": "align.66.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 293,
       "filename": "align.67.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 299,
       "filename": "align.68.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_invalid",
       "line": 306,
       "filename": "align.69.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 310,
       "filename": "align.70.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 314,
       "filename": "align.71.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 318,
       "filename": "align.72.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 322,
       "filename": "align.73.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 326,
       "filename": "align.74.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 330,
       "filename": "align.75.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 334,
       "filename": "align.76.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 338,
       "filename": "align.77.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 342,
       "filename": "align.78.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 346,
       "filename": "align.79.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 350,
       "filename": "align.80.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 354,
       "filename": "align.81.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 358,
       "filename": "align.82.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 363,
       "filename": "align.83.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 367,
       "filename": "align.84.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 371,
       "filename": "align.85.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 375,
       "filename": "align.86.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 379,
       "filename": "align.87.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 383,
       "filename": "align.88.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 387,
       "filename": "align.89.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 391,
       "filename": "align.90.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 395,
       "filename": "align.91.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 399,
       "filename": "align.92.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 403,
       "filename": "align.93.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 407,
       "filename": "align.94.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 411,
       "filename": "align.95.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 415,
       "filename": "align.96.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 420,
       "filename": "align.97.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 424,
       "filename": "align.98.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 428,
       "filename": "align.99.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 432,
       "filename": "align.100.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 436,
       "filename": "align.101.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 440,
       "filename": "align.102.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 444,
       "filename": "align.103.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 448,
       "filename": "align.104.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 452,
       "filename": "align.105.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "module",
       "line": 458,
-      "filename": "align.106.wasm"
+      "filename": "align.106.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1773,7 +1797,8 @@
     {
       "type": "module",
       "line": 854,
-      "filename": "align.107.wasm"
+      "filename": "align.107.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -1818,43 +1843,43 @@
       "type": "assert_invalid",
       "line": 873,
       "filename": "align.108.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_malformed",
       "line": 892,
       "filename": "align.109.wasm",
-      "text": "malformed memop alignment",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed memop alignment"
     },
     {
       "type": "assert_malformed",
       "line": 911,
       "filename": "align.110.wasm",
-      "text": "malformed memop alignment",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed memop alignment"
     },
     {
       "type": "assert_malformed",
       "line": 930,
       "filename": "align.111.wasm",
-      "text": "malformed memop alignment",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed memop alignment"
     },
     {
       "type": "assert_invalid",
       "line": 949,
       "filename": "align.112.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 968,
       "filename": "align.113.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/align0.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/align0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "align0.0.wasm"
+      "filename": "align0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/align64.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/align64.wast.json
@@ -4,703 +4,727 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "align64.0.wasm"
+      "filename": "align64.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 4,
-      "filename": "align64.1.wasm"
+      "filename": "align64.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 5,
-      "filename": "align64.2.wasm"
+      "filename": "align64.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 6,
-      "filename": "align64.3.wasm"
+      "filename": "align64.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 7,
-      "filename": "align64.4.wasm"
+      "filename": "align64.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 8,
-      "filename": "align64.5.wasm"
+      "filename": "align64.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 9,
-      "filename": "align64.6.wasm"
+      "filename": "align64.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 10,
-      "filename": "align64.7.wasm"
+      "filename": "align64.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 11,
-      "filename": "align64.8.wasm"
+      "filename": "align64.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 12,
-      "filename": "align64.9.wasm"
+      "filename": "align64.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 13,
-      "filename": "align64.10.wasm"
+      "filename": "align64.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 14,
-      "filename": "align64.11.wasm"
+      "filename": "align64.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 15,
-      "filename": "align64.12.wasm"
+      "filename": "align64.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 16,
-      "filename": "align64.13.wasm"
+      "filename": "align64.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 17,
-      "filename": "align64.14.wasm"
+      "filename": "align64.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 18,
-      "filename": "align64.15.wasm"
+      "filename": "align64.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 19,
-      "filename": "align64.16.wasm"
+      "filename": "align64.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 20,
-      "filename": "align64.17.wasm"
+      "filename": "align64.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 21,
-      "filename": "align64.18.wasm"
+      "filename": "align64.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 22,
-      "filename": "align64.19.wasm"
+      "filename": "align64.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 23,
-      "filename": "align64.20.wasm"
+      "filename": "align64.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 24,
-      "filename": "align64.21.wasm"
+      "filename": "align64.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 25,
-      "filename": "align64.22.wasm"
+      "filename": "align64.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 28,
       "filename": "align64.23.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 34,
       "filename": "align64.24.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 40,
       "filename": "align64.25.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 46,
       "filename": "align64.26.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 52,
       "filename": "align64.27.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 58,
       "filename": "align64.28.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 64,
       "filename": "align64.29.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 70,
       "filename": "align64.30.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 76,
       "filename": "align64.31.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 82,
       "filename": "align64.32.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 88,
       "filename": "align64.33.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 94,
       "filename": "align64.34.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 100,
       "filename": "align64.35.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 106,
       "filename": "align64.36.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 112,
       "filename": "align64.37.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 118,
       "filename": "align64.38.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 124,
       "filename": "align64.39.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 130,
       "filename": "align64.40.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 136,
       "filename": "align64.41.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 142,
       "filename": "align64.42.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 148,
       "filename": "align64.43.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 154,
       "filename": "align64.44.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 160,
       "filename": "align64.45.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 166,
       "filename": "align64.46.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 172,
       "filename": "align64.47.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 178,
       "filename": "align64.48.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 184,
       "filename": "align64.49.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 190,
       "filename": "align64.50.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 197,
       "filename": "align64.51.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 203,
       "filename": "align64.52.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 209,
       "filename": "align64.53.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 215,
       "filename": "align64.54.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 221,
       "filename": "align64.55.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 227,
       "filename": "align64.56.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 233,
       "filename": "align64.57.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 239,
       "filename": "align64.58.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 245,
       "filename": "align64.59.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 251,
       "filename": "align64.60.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 257,
       "filename": "align64.61.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 263,
       "filename": "align64.62.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 269,
       "filename": "align64.63.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 275,
       "filename": "align64.64.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 281,
       "filename": "align64.65.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 287,
       "filename": "align64.66.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 293,
       "filename": "align64.67.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_malformed",
       "line": 299,
       "filename": "align64.68.wat",
-      "text": "alignment",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment"
     },
     {
       "type": "assert_invalid",
       "line": 306,
       "filename": "align64.69.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 310,
       "filename": "align64.70.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 314,
       "filename": "align64.71.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 318,
       "filename": "align64.72.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 322,
       "filename": "align64.73.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 326,
       "filename": "align64.74.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 330,
       "filename": "align64.75.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 334,
       "filename": "align64.76.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 338,
       "filename": "align64.77.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 342,
       "filename": "align64.78.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 346,
       "filename": "align64.79.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 350,
       "filename": "align64.80.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 354,
       "filename": "align64.81.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 358,
       "filename": "align64.82.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 363,
       "filename": "align64.83.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 367,
       "filename": "align64.84.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 371,
       "filename": "align64.85.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 375,
       "filename": "align64.86.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 379,
       "filename": "align64.87.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 383,
       "filename": "align64.88.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 387,
       "filename": "align64.89.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 391,
       "filename": "align64.90.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 395,
       "filename": "align64.91.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 399,
       "filename": "align64.92.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 403,
       "filename": "align64.93.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 407,
       "filename": "align64.94.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 411,
       "filename": "align64.95.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 415,
       "filename": "align64.96.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 420,
       "filename": "align64.97.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 424,
       "filename": "align64.98.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 428,
       "filename": "align64.99.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 432,
       "filename": "align64.100.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 436,
       "filename": "align64.101.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 440,
       "filename": "align64.102.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 444,
       "filename": "align64.103.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 448,
       "filename": "align64.104.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 452,
       "filename": "align64.105.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "module",
       "line": 458,
-      "filename": "align64.106.wasm"
+      "filename": "align64.106.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1773,7 +1797,8 @@
     {
       "type": "module",
       "line": 854,
-      "filename": "align64.107.wasm"
+      "filename": "align64.107.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",

--- a/tests/snapshots/testsuite/proposals/memory64/annotations.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/annotations.wast.json
@@ -4,503 +4,519 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "annotations.0.wasm"
+      "filename": "annotations.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 23,
       "filename": "annotations.1.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 24,
       "filename": "annotations.2.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 25,
       "filename": "annotations.3.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 26,
       "filename": "annotations.4.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 27,
       "filename": "annotations.5.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 28,
       "filename": "annotations.6.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 29,
       "filename": "annotations.7.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 30,
       "filename": "annotations.8.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 31,
       "filename": "annotations.9.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "module",
       "line": 32,
-      "filename": "annotations.10.wat"
+      "filename": "annotations.10.wat",
+      "module_type": "text",
+      "binary_filename": "annotations.10.wasm"
     },
     {
       "type": "module",
       "line": 33,
-      "filename": "annotations.11.wat"
+      "filename": "annotations.11.wat",
+      "module_type": "text",
+      "binary_filename": "annotations.11.wasm"
     },
     {
       "type": "assert_malformed",
       "line": 34,
       "filename": "annotations.12.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 35,
       "filename": "annotations.13.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "module",
       "line": 36,
-      "filename": "annotations.14.wat"
+      "filename": "annotations.14.wat",
+      "module_type": "text",
+      "binary_filename": "annotations.14.wasm"
     },
     {
       "type": "assert_malformed",
       "line": 37,
       "filename": "annotations.15.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 38,
       "filename": "annotations.16.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 39,
       "filename": "annotations.17.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 40,
       "filename": "annotations.18.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 41,
       "filename": "annotations.19.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 42,
       "filename": "annotations.20.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 43,
       "filename": "annotations.21.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 44,
       "filename": "annotations.22.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 45,
       "filename": "annotations.23.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 46,
       "filename": "annotations.24.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 47,
       "filename": "annotations.25.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 48,
       "filename": "annotations.26.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 49,
       "filename": "annotations.27.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 50,
       "filename": "annotations.28.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 51,
       "filename": "annotations.29.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 52,
       "filename": "annotations.30.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 53,
       "filename": "annotations.31.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 54,
       "filename": "annotations.32.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "module",
       "line": 55,
-      "filename": "annotations.33.wat"
+      "filename": "annotations.33.wat",
+      "module_type": "text",
+      "binary_filename": "annotations.33.wasm"
     },
     {
       "type": "assert_malformed",
       "line": 56,
       "filename": "annotations.34.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 57,
       "filename": "annotations.35.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 58,
       "filename": "annotations.36.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 59,
       "filename": "annotations.37.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 60,
       "filename": "annotations.38.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 61,
       "filename": "annotations.39.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 62,
       "filename": "annotations.40.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 63,
       "filename": "annotations.41.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 64,
       "filename": "annotations.42.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 65,
       "filename": "annotations.43.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 66,
       "filename": "annotations.44.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 67,
       "filename": "annotations.45.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 68,
       "filename": "annotations.46.wat",
-      "text": "illegal character",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "illegal character"
     },
     {
       "type": "assert_malformed",
       "line": 70,
       "filename": "annotations.47.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 72,
       "filename": "annotations.48.wat",
-      "text": "empty annotation id",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty annotation id"
     },
     {
       "type": "assert_malformed",
       "line": 73,
       "filename": "annotations.49.wat",
-      "text": "empty annotation id",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty annotation id"
     },
     {
       "type": "assert_malformed",
       "line": 74,
       "filename": "annotations.50.wat",
-      "text": "empty annotation id",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty annotation id"
     },
     {
       "type": "assert_malformed",
       "line": 75,
       "filename": "annotations.51.wat",
-      "text": "empty annotation id",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty annotation id"
     },
     {
       "type": "assert_malformed",
       "line": 76,
       "filename": "annotations.52.wat",
-      "text": "empty annotation id",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty annotation id"
     },
     {
       "type": "assert_malformed",
       "line": 77,
       "filename": "annotations.53.wat",
-      "text": "empty annotation id",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty annotation id"
     },
     {
       "type": "assert_malformed",
       "line": 78,
       "filename": "annotations.54.wat",
-      "text": "empty annotation id",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty annotation id"
     },
     {
       "type": "assert_malformed",
       "line": 79,
       "filename": "annotations.55.wat",
-      "text": "malformed UTF-8",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8"
     },
     {
       "type": "assert_malformed",
       "line": 81,
       "filename": "annotations.56.wat",
-      "text": "unclosed annotation",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unclosed annotation"
     },
     {
       "type": "assert_malformed",
       "line": 82,
       "filename": "annotations.57.wat",
-      "text": "unclosed annotation",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unclosed annotation"
     },
     {
       "type": "assert_malformed",
       "line": 83,
       "filename": "annotations.58.wat",
-      "text": "unclosed annotation",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unclosed annotation"
     },
     {
       "type": "assert_malformed",
       "line": 84,
       "filename": "annotations.59.wat",
-      "text": "unclosed annotation",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unclosed annotation"
     },
     {
       "type": "assert_malformed",
       "line": 86,
       "filename": "annotations.60.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 87,
       "filename": "annotations.61.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 88,
       "filename": "annotations.62.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 89,
       "filename": "annotations.63.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 91,
       "filename": "annotations.64.wat",
-      "text": "unclosed string",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unclosed string"
     },
     {
       "type": "assert_malformed",
       "line": 92,
       "filename": "annotations.65.wat",
-      "text": "unclosed string",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unclosed string"
     },
     {
       "type": "assert_malformed",
       "line": 94,
       "filename": "annotations.66.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 95,
       "filename": "annotations.67.wat",
-      "text": "empty identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty identifier"
     },
     {
       "type": "assert_malformed",
       "line": 96,
       "filename": "annotations.68.wat",
-      "text": "empty identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty identifier"
     },
     {
       "type": "module",
       "line": 98,
       "name": "m",
-      "filename": "annotations.69.wasm"
+      "filename": "annotations.69.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 129,
       "name": "m1",
-      "filename": "annotations.70.wasm"
+      "filename": "annotations.70.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 154,
       "name": "m2",
-      "filename": "annotations.71.wasm"
+      "filename": "annotations.71.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 206,
-      "filename": "annotations.72.wat"
+      "filename": "annotations.72.wat",
+      "module_type": "text",
+      "binary_filename": "annotations.72.wasm"
     },
     {
       "type": "module",
       "line": 207,
-      "filename": "annotations.73.wat"
+      "filename": "annotations.73.wat",
+      "module_type": "text",
+      "binary_filename": "annotations.73.wasm"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/array.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/array.wast.json
@@ -4,38 +4,41 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "array.0.wasm"
+      "filename": "array.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 28,
       "filename": "array.1.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "module",
       "line": 37,
-      "filename": "array.2.wasm"
+      "filename": "array.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 49,
       "filename": "array.3.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 53,
       "filename": "array.4.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "module",
       "line": 60,
-      "filename": "array.5.wasm"
+      "filename": "array.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -161,7 +164,8 @@
     {
       "type": "module",
       "line": 106,
-      "filename": "array.6.wasm"
+      "filename": "array.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -287,7 +291,8 @@
     {
       "type": "module",
       "line": 151,
-      "filename": "array.7.wasm"
+      "filename": "array.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -448,7 +453,8 @@
     {
       "type": "module",
       "line": 205,
-      "filename": "array.8.wasm"
+      "filename": "array.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -615,27 +621,28 @@
       "type": "assert_invalid",
       "line": 265,
       "filename": "array.9.wasm",
-      "text": "array is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array is immutable"
     },
     {
       "type": "assert_invalid",
       "line": 275,
       "filename": "array.10.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 288,
       "filename": "array.11.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "module",
       "line": 304,
-      "filename": "array.12.wasm"
+      "filename": "array.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",

--- a/tests/snapshots/testsuite/proposals/memory64/array_copy.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/array_copy.wast.json
@@ -5,34 +5,35 @@
       "type": "assert_invalid",
       "line": 6,
       "filename": "array_copy.0.wasm",
-      "text": "array is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array is immutable"
     },
     {
       "type": "assert_invalid",
       "line": 18,
       "filename": "array_copy.1.wasm",
-      "text": "array types do not match",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array types do not match"
     },
     {
       "type": "assert_invalid",
       "line": 30,
       "filename": "array_copy.2.wasm",
-      "text": "array types do not match",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array types do not match"
     },
     {
       "type": "assert_invalid",
       "line": 42,
       "filename": "array_copy.3.wasm",
-      "text": "array types do not match",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array types do not match"
     },
     {
       "type": "module",
       "line": 54,
-      "filename": "array_copy.4.wasm"
+      "filename": "array_copy.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",

--- a/tests/snapshots/testsuite/proposals/memory64/array_fill.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/array_fill.wast.json
@@ -5,27 +5,28 @@
       "type": "assert_invalid",
       "line": 6,
       "filename": "array_fill.0.wasm",
-      "text": "array is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array is immutable"
     },
     {
       "type": "assert_invalid",
       "line": 17,
       "filename": "array_fill.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 28,
       "filename": "array_fill.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 38,
-      "filename": "array_fill.3.wasm"
+      "filename": "array_fill.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",

--- a/tests/snapshots/testsuite/proposals/memory64/array_init_data.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/array_init_data.wast.json
@@ -5,20 +5,21 @@
       "type": "assert_invalid",
       "line": 6,
       "filename": "array_init_data.0.wasm",
-      "text": "array is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array is immutable"
     },
     {
       "type": "assert_invalid",
       "line": 19,
       "filename": "array_init_data.1.wasm",
-      "text": "array type is not numeric or vector",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array type is not numeric or vector"
     },
     {
       "type": "module",
       "line": 31,
-      "filename": "array_init_data.2.wasm"
+      "filename": "array_init_data.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",

--- a/tests/snapshots/testsuite/proposals/memory64/array_init_elem.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/array_init_elem.wast.json
@@ -5,27 +5,28 @@
       "type": "assert_invalid",
       "line": 6,
       "filename": "array_init_elem.0.wasm",
-      "text": "array is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "array is immutable"
     },
     {
       "type": "assert_invalid",
       "line": 19,
       "filename": "array_init_elem.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 32,
       "filename": "array_init_elem.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 44,
-      "filename": "array_init_elem.3.wasm"
+      "filename": "array_init_elem.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",

--- a/tests/snapshots/testsuite/proposals/memory64/binary-gc.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/binary-gc.wast.json
@@ -5,8 +5,8 @@
       "type": "assert_malformed",
       "line": 2,
       "filename": "binary-gc.0.wasm",
-      "text": "malformed mutability",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed mutability"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/binary-leb128.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/binary-leb128.wast.json
@@ -4,585 +4,619 @@
     {
       "type": "module",
       "line": 2,
-      "filename": "binary-leb128.0.wasm"
+      "filename": "binary-leb128.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 7,
-      "filename": "binary-leb128.1.wasm"
+      "filename": "binary-leb128.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 12,
-      "filename": "binary-leb128.2.wasm"
+      "filename": "binary-leb128.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 18,
-      "filename": "binary-leb128.3.wasm"
+      "filename": "binary-leb128.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 24,
-      "filename": "binary-leb128.4.wasm"
+      "filename": "binary-leb128.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 32,
-      "filename": "binary-leb128.5.wasm"
+      "filename": "binary-leb128.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 41,
-      "filename": "binary-leb128.6.wasm"
+      "filename": "binary-leb128.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 49,
-      "filename": "binary-leb128.7.wasm"
+      "filename": "binary-leb128.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 57,
-      "filename": "binary-leb128.8.wasm"
+      "filename": "binary-leb128.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 66,
-      "filename": "binary-leb128.9.wasm"
+      "filename": "binary-leb128.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 75,
-      "filename": "binary-leb128.10.wasm"
+      "filename": "binary-leb128.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 87,
-      "filename": "binary-leb128.11.wasm"
+      "filename": "binary-leb128.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 99,
-      "filename": "binary-leb128.12.wasm"
+      "filename": "binary-leb128.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 111,
-      "filename": "binary-leb128.13.wasm"
+      "filename": "binary-leb128.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 120,
-      "filename": "binary-leb128.14.wasm"
+      "filename": "binary-leb128.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 133,
-      "filename": "binary-leb128.15.wasm"
+      "filename": "binary-leb128.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 146,
-      "filename": "binary-leb128.16.wasm"
+      "filename": "binary-leb128.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 158,
-      "filename": "binary-leb128.17.wasm"
+      "filename": "binary-leb128.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 165,
-      "filename": "binary-leb128.18.wasm"
+      "filename": "binary-leb128.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 172,
-      "filename": "binary-leb128.19.wasm"
+      "filename": "binary-leb128.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 179,
-      "filename": "binary-leb128.20.wasm"
+      "filename": "binary-leb128.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 187,
-      "filename": "binary-leb128.21.wasm"
+      "filename": "binary-leb128.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 194,
-      "filename": "binary-leb128.22.wasm"
+      "filename": "binary-leb128.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 201,
-      "filename": "binary-leb128.23.wasm"
+      "filename": "binary-leb128.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 208,
-      "filename": "binary-leb128.24.wasm"
+      "filename": "binary-leb128.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 218,
       "filename": "binary-leb128.25.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 226,
       "filename": "binary-leb128.26.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 235,
       "filename": "binary-leb128.27.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 246,
       "filename": "binary-leb128.28.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 257,
       "filename": "binary-leb128.29.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 268,
       "filename": "binary-leb128.30.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 279,
       "filename": "binary-leb128.31.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 291,
       "filename": "binary-leb128.32.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 303,
       "filename": "binary-leb128.33.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 318,
       "filename": "binary-leb128.34.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 333,
       "filename": "binary-leb128.35.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 348,
       "filename": "binary-leb128.36.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 360,
       "filename": "binary-leb128.37.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 376,
       "filename": "binary-leb128.38.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 392,
       "filename": "binary-leb128.39.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 405,
       "filename": "binary-leb128.40.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 424,
       "filename": "binary-leb128.41.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 443,
       "filename": "binary-leb128.42.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 462,
       "filename": "binary-leb128.43.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 483,
       "filename": "binary-leb128.44.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 493,
       "filename": "binary-leb128.45.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 504,
       "filename": "binary-leb128.46.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 514,
       "filename": "binary-leb128.47.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 526,
       "filename": "binary-leb128.48.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 534,
       "filename": "binary-leb128.49.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 542,
       "filename": "binary-leb128.50.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 551,
       "filename": "binary-leb128.51.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 560,
       "filename": "binary-leb128.52.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 571,
       "filename": "binary-leb128.53.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 582,
       "filename": "binary-leb128.54.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 593,
       "filename": "binary-leb128.55.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 604,
       "filename": "binary-leb128.56.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 616,
       "filename": "binary-leb128.57.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 628,
       "filename": "binary-leb128.58.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 643,
       "filename": "binary-leb128.59.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 658,
       "filename": "binary-leb128.60.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 673,
       "filename": "binary-leb128.61.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 686,
       "filename": "binary-leb128.62.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 702,
       "filename": "binary-leb128.63.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 718,
       "filename": "binary-leb128.64.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 731,
       "filename": "binary-leb128.65.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 750,
       "filename": "binary-leb128.66.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 769,
       "filename": "binary-leb128.67.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 787,
       "filename": "binary-leb128.68.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 806,
       "filename": "binary-leb128.69.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 825,
       "filename": "binary-leb128.70.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 844,
       "filename": "binary-leb128.71.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 863,
       "filename": "binary-leb128.72.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "module",
       "line": 881,
-      "filename": "binary-leb128.73.wasm"
+      "filename": "binary-leb128.73.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 897,
       "filename": "binary-leb128.74.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 917,
       "filename": "binary-leb128.75.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 927,
       "filename": "binary-leb128.76.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 937,
       "filename": "binary-leb128.77.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 947,
       "filename": "binary-leb128.78.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 958,
       "filename": "binary-leb128.79.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 968,
       "filename": "binary-leb128.80.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 978,
       "filename": "binary-leb128.81.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 988,
       "filename": "binary-leb128.82.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "module",
       "line": 998,
-      "filename": "binary-leb128.83.wasm"
+      "filename": "binary-leb128.83.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 1019,
       "filename": "binary-leb128.84.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "module",
       "line": 1036,
-      "filename": "binary-leb128.85.wasm"
+      "filename": "binary-leb128.85.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 1044,
-      "filename": "binary-leb128.86.wasm"
+      "filename": "binary-leb128.86.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 1053,
-      "filename": "binary-leb128.87.wasm"
+      "filename": "binary-leb128.87.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 1064,
-      "filename": "binary-leb128.88.wasm"
+      "filename": "binary-leb128.88.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 1072,
-      "filename": "binary-leb128.89.wasm"
+      "filename": "binary-leb128.89.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 1081,
-      "filename": "binary-leb128.90.wasm"
+      "filename": "binary-leb128.90.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 1090,
-      "filename": "binary-leb128.91.wasm"
+      "filename": "binary-leb128.91.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 1102,
       "filename": "binary-leb128.92.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/binary.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/binary.wast.json
@@ -4,834 +4,853 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "binary.0.wasm"
+      "filename": "binary.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 2,
-      "filename": "binary.1.wasm"
+      "filename": "binary.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 3,
       "name": "M1",
-      "filename": "binary.2.wasm"
+      "filename": "binary.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 4,
       "name": "M2",
-      "filename": "binary.3.wasm"
+      "filename": "binary.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 6,
       "filename": "binary.4.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 7,
       "filename": "binary.5.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 8,
       "filename": "binary.6.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 9,
       "filename": "binary.7.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 10,
       "filename": "binary.8.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 11,
       "filename": "binary.9.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 12,
       "filename": "binary.10.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 13,
       "filename": "binary.11.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 14,
       "filename": "binary.12.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 15,
       "filename": "binary.13.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 16,
       "filename": "binary.14.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 17,
       "filename": "binary.15.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 18,
       "filename": "binary.16.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 21,
       "filename": "binary.17.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 24,
       "filename": "binary.18.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 25,
       "filename": "binary.19.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 28,
       "filename": "binary.20.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 31,
       "filename": "binary.21.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 34,
       "filename": "binary.22.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 37,
       "filename": "binary.23.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 38,
       "filename": "binary.24.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 39,
       "filename": "binary.25.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 40,
       "filename": "binary.26.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 41,
       "filename": "binary.27.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 42,
       "filename": "binary.28.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 43,
       "filename": "binary.29.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 44,
       "filename": "binary.30.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 45,
       "filename": "binary.31.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 48,
       "filename": "binary.32.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 49,
       "filename": "binary.33.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 50,
       "filename": "binary.34.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 51,
       "filename": "binary.35.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 52,
       "filename": "binary.36.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 56,
       "filename": "binary.37.wasm",
-      "text": "END opcode expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "END opcode expected"
     },
     {
       "type": "assert_malformed",
       "line": 77,
       "filename": "binary.38.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 93,
       "filename": "binary.39.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 113,
       "filename": "binary.40.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 126,
       "filename": "binary.41.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 143,
       "filename": "binary.42.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 160,
       "filename": "binary.43.wasm",
-      "text": "too many locals",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "too many locals"
     },
     {
       "type": "assert_malformed",
       "line": 176,
       "filename": "binary.44.wasm",
-      "text": "too many locals",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "too many locals"
     },
     {
       "type": "module",
       "line": 194,
-      "filename": "binary.45.wasm"
+      "filename": "binary.45.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 210,
       "filename": "binary.46.wasm",
-      "text": "function and code section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function and code section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 220,
       "filename": "binary.47.wasm",
-      "text": "function and code section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function and code section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 229,
       "filename": "binary.48.wasm",
-      "text": "function and code section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function and code section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 240,
       "filename": "binary.49.wasm",
-      "text": "function and code section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function and code section have inconsistent lengths"
     },
     {
       "type": "module",
       "line": 250,
-      "filename": "binary.50.wasm"
+      "filename": "binary.50.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 256,
-      "filename": "binary.51.wasm"
+      "filename": "binary.51.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 263,
       "filename": "binary.52.wasm",
-      "text": "data count and data section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "data count and data section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 273,
       "filename": "binary.53.wasm",
-      "text": "data count and data section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "data count and data section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 283,
       "filename": "binary.54.wasm",
-      "text": "data count section required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "data count section required"
     },
     {
       "type": "assert_malformed",
       "line": 305,
       "filename": "binary.55.wasm",
-      "text": "data count section required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "data count section required"
     },
     {
       "type": "assert_malformed",
       "line": 324,
       "filename": "binary.56.wasm",
-      "text": "illegal opcode",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "illegal opcode"
     },
     {
       "type": "assert_malformed",
       "line": 350,
       "filename": "binary.57.wasm",
-      "text": "malformed reference type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed reference type"
     },
     {
       "type": "module",
       "line": 375,
-      "filename": "binary.58.wasm"
+      "filename": "binary.58.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 399,
-      "filename": "binary.59.wasm"
+      "filename": "binary.59.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 424,
-      "filename": "binary.60.wasm"
+      "filename": "binary.60.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 431,
       "filename": "binary.61.wasm",
-      "text": "length out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "length out of bounds"
     },
     {
       "type": "assert_malformed",
       "line": 442,
       "filename": "binary.62.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 452,
-      "filename": "binary.63.wasm"
+      "filename": "binary.63.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 461,
       "filename": "binary.64.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 471,
       "filename": "binary.65.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 482,
       "filename": "binary.66.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 492,
       "filename": "binary.67.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 503,
       "filename": "binary.68.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 513,
       "filename": "binary.69.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 526,
       "filename": "binary.70.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 545,
       "filename": "binary.71.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 569,
-      "filename": "binary.72.wasm"
+      "filename": "binary.72.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 576,
       "filename": "binary.73.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 586,
       "filename": "binary.74.wasm",
-      "text": "malformed limits flags",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed limits flags"
     },
     {
       "type": "assert_malformed",
       "line": 595,
       "filename": "binary.75.wasm",
-      "text": "malformed limits flags",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed limits flags"
     },
     {
       "type": "assert_malformed",
       "line": 605,
       "filename": "binary.76.wasm",
-      "text": "malformed limits flags",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed limits flags"
     },
     {
       "type": "module",
       "line": 616,
-      "filename": "binary.77.wasm"
+      "filename": "binary.77.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 623,
       "filename": "binary.78.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 633,
       "filename": "binary.79.wasm",
-      "text": "malformed limits flags",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed limits flags"
     },
     {
       "type": "assert_malformed",
       "line": 641,
       "filename": "binary.80.wasm",
-      "text": "malformed limits flags",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed limits flags"
     },
     {
       "type": "assert_malformed",
       "line": 650,
       "filename": "binary.81.wasm",
-      "text": "malformed limits flags",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed limits flags"
     },
     {
       "type": "assert_malformed",
       "line": 659,
       "filename": "binary.82.wasm",
-      "text": "malformed limits flags",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed limits flags"
     },
     {
       "type": "module",
       "line": 669,
-      "filename": "binary.83.wasm"
+      "filename": "binary.83.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 676,
       "filename": "binary.84.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 687,
       "filename": "binary.85.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 697,
-      "filename": "binary.86.wasm"
+      "filename": "binary.86.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 710,
       "filename": "binary.87.wasm",
-      "text": "length out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "length out of bounds"
     },
     {
       "type": "assert_malformed",
       "line": 731,
       "filename": "binary.88.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 751,
-      "filename": "binary.89.wasm"
+      "filename": "binary.89.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 765,
       "filename": "binary.90.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 781,
       "filename": "binary.91.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 798,
       "filename": "binary.92.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 815,
-      "filename": "binary.93.wasm"
+      "filename": "binary.93.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 824,
       "filename": "binary.94.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 837,
       "filename": "binary.95.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 850,
       "filename": "binary.96.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 864,
       "filename": "binary.97.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 877,
-      "filename": "binary.98.wasm"
+      "filename": "binary.98.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 895,
       "filename": "binary.99.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "module",
       "line": 928,
-      "filename": "binary.100.wasm"
+      "filename": "binary.100.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 942,
       "filename": "binary.101.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 959,
       "filename": "binary.102.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 971,
       "filename": "binary.103.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 983,
       "filename": "binary.104.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 993,
       "filename": "binary.105.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1003,
       "filename": "binary.106.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1013,
       "filename": "binary.107.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1023,
       "filename": "binary.108.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1033,
       "filename": "binary.109.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1043,
       "filename": "binary.110.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1053,
       "filename": "binary.111.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1063,
       "filename": "binary.112.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1073,
       "filename": "binary.113.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1083,
       "filename": "binary.114.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1093,
       "filename": "binary.115.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1103,
       "filename": "binary.116.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1113,
       "filename": "binary.117.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1123,
       "filename": "binary.118.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1133,
       "filename": "binary.119.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1144,
       "filename": "binary.120.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1155,
       "filename": "binary.121.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1165,
       "filename": "binary.122.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1175,
       "filename": "binary.123.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/binary0.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/binary0.wast.json
@@ -4,41 +4,46 @@
     {
       "type": "module",
       "line": 2,
-      "filename": "binary0.0.wasm"
+      "filename": "binary0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 8,
-      "filename": "binary0.1.wasm"
+      "filename": "binary0.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 16,
-      "filename": "binary0.2.wasm"
+      "filename": "binary0.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 26,
-      "filename": "binary0.3.wasm"
+      "filename": "binary0.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 36,
-      "filename": "binary0.4.wasm"
+      "filename": "binary0.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 48,
       "filename": "binary0.5.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 59,
       "filename": "binary0.6.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/br_if.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/br_if.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "br_if.0.wasm"
+      "filename": "br_if.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1532,211 +1533,211 @@
       "type": "assert_invalid",
       "line": 481,
       "filename": "br_if.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 485,
       "filename": "br_if.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 489,
       "filename": "br_if.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 493,
       "filename": "br_if.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 498,
       "filename": "br_if.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 502,
       "filename": "br_if.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 506,
       "filename": "br_if.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 510,
       "filename": "br_if.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 515,
       "filename": "br_if.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 521,
       "filename": "br_if.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 527,
       "filename": "br_if.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 533,
       "filename": "br_if.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 540,
       "filename": "br_if.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 546,
       "filename": "br_if.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 552,
       "filename": "br_if.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 560,
       "filename": "br_if.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 569,
       "filename": "br_if.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 575,
       "filename": "br_if.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 581,
       "filename": "br_if.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 587,
       "filename": "br_if.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 593,
       "filename": "br_if.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 599,
       "filename": "br_if.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 606,
       "filename": "br_if.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 618,
       "filename": "br_if.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 630,
       "filename": "br_if.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 641,
       "filename": "br_if.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 654,
       "filename": "br_if.27.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 658,
       "filename": "br_if.28.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 662,
       "filename": "br_if.29.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 668,
       "filename": "br_if.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/br_on_cast.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/br_on_cast.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "br_on_cast.0.wasm"
+      "filename": "br_on_cast.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -523,7 +524,8 @@
     {
       "type": "module",
       "line": 104,
-      "filename": "br_on_cast.1.wasm"
+      "filename": "br_on_cast.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -546,49 +548,50 @@
     {
       "type": "module",
       "line": 211,
-      "filename": "br_on_cast.2.wasm"
+      "filename": "br_on_cast.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 226,
       "filename": "br_on_cast.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 235,
       "filename": "br_on_cast.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 244,
       "filename": "br_on_cast.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 253,
       "filename": "br_on_cast.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 261,
       "filename": "br_on_cast.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 272,
       "filename": "br_on_cast.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/br_on_cast_fail.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/br_on_cast_fail.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "br_on_cast_fail.0.wasm"
+      "filename": "br_on_cast_fail.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -523,7 +524,8 @@
     {
       "type": "module",
       "line": 104,
-      "filename": "br_on_cast_fail.1.wasm"
+      "filename": "br_on_cast_fail.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -546,49 +548,50 @@
     {
       "type": "module",
       "line": 226,
-      "filename": "br_on_cast_fail.2.wasm"
+      "filename": "br_on_cast_fail.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 241,
       "filename": "br_on_cast_fail.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 250,
       "filename": "br_on_cast_fail.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 259,
       "filename": "br_on_cast_fail.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 268,
       "filename": "br_on_cast_fail.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 276,
       "filename": "br_on_cast_fail.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 287,
       "filename": "br_on_cast_fail.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/br_on_non_null.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/br_on_non_null.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "br_on_non_null.0.wasm"
+      "filename": "br_on_non_null.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -64,12 +65,14 @@
     {
       "type": "module",
       "line": 43,
-      "filename": "br_on_non_null.1.wasm"
+      "filename": "br_on_non_null.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 51,
-      "filename": "br_on_non_null.2.wasm"
+      "filename": "br_on_non_null.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -115,8 +118,8 @@
       "type": "assert_invalid",
       "line": 78,
       "filename": "br_on_non_null.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/br_on_null.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/br_on_null.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "br_on_null.0.wasm"
+      "filename": "br_on_null.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -64,12 +65,14 @@
     {
       "type": "module",
       "line": 38,
-      "filename": "br_on_null.1.wasm"
+      "filename": "br_on_null.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 46,
-      "filename": "br_on_null.2.wasm"
+      "filename": "br_on_null.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -115,8 +118,8 @@
       "type": "assert_invalid",
       "line": 82,
       "filename": "br_on_null.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/br_table.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/br_table.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "br_table.0.wasm"
+      "filename": "br_table.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2972,169 +2973,169 @@
       "type": "assert_invalid",
       "line": 1267,
       "filename": "br_table.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1274,
       "filename": "br_table.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1281,
       "filename": "br_table.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1287,
       "filename": "br_table.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1295,
       "filename": "br_table.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1306,
       "filename": "br_table.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1317,
       "filename": "br_table.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1323,
       "filename": "br_table.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1329,
       "filename": "br_table.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1335,
       "filename": "br_table.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1341,
       "filename": "br_table.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1350,
       "filename": "br_table.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1357,
       "filename": "br_table.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1369,
       "filename": "br_table.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1381,
       "filename": "br_table.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1392,
       "filename": "br_table.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1404,
       "filename": "br_table.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1416,
       "filename": "br_table.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1430,
       "filename": "br_table.19.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 1436,
       "filename": "br_table.20.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 1442,
       "filename": "br_table.21.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 1449,
       "filename": "br_table.22.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 1455,
       "filename": "br_table.23.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 1461,
       "filename": "br_table.24.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/call_indirect.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/call_indirect.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "call_indirect.0.wasm"
+      "filename": "call_indirect.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2210,7 +2211,8 @@
     {
       "type": "module",
       "line": 633,
-      "filename": "call_indirect.1.wasm"
+      "filename": "call_indirect.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2527,237 +2529,238 @@
       "type": "assert_malformed",
       "line": 679,
       "filename": "call_indirect.2.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 691,
       "filename": "call_indirect.3.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 703,
       "filename": "call_indirect.4.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 715,
       "filename": "call_indirect.5.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 727,
       "filename": "call_indirect.6.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 739,
       "filename": "call_indirect.7.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 749,
       "filename": "call_indirect.8.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 756,
       "filename": "call_indirect.9.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 766,
       "filename": "call_indirect.10.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 776,
       "filename": "call_indirect.11.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 786,
       "filename": "call_indirect.12.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_invalid",
       "line": 801,
       "filename": "call_indirect.13.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 809,
       "filename": "call_indirect.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 817,
       "filename": "call_indirect.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 826,
       "filename": "call_indirect.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 834,
       "filename": "call_indirect.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 842,
       "filename": "call_indirect.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 850,
       "filename": "call_indirect.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 861,
       "filename": "call_indirect.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 869,
       "filename": "call_indirect.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 878,
       "filename": "call_indirect.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 888,
       "filename": "call_indirect.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 898,
       "filename": "call_indirect.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 908,
       "filename": "call_indirect.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 919,
       "filename": "call_indirect.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 932,
       "filename": "call_indirect.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 945,
       "filename": "call_indirect.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 958,
       "filename": "call_indirect.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 971,
       "filename": "call_indirect.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 987,
       "filename": "call_indirect.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1007,
       "filename": "call_indirect.32.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 1014,
       "filename": "call_indirect.33.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 1025,
       "filename": "call_indirect.34.wasm",
-      "text": "unknown function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function"
     },
     {
       "type": "module",
       "line": 1034,
-      "filename": "call_indirect.35.wasm"
+      "filename": "call_indirect.35.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/call_ref.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/call_ref.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "call_ref.0.wasm"
+      "filename": "call_ref.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -495,7 +496,8 @@
     {
       "type": "module",
       "line": 129,
-      "filename": "call_ref.1.wasm"
+      "filename": "call_ref.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -510,7 +512,8 @@
     {
       "type": "module",
       "line": 138,
-      "filename": "call_ref.2.wasm"
+      "filename": "call_ref.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -525,7 +528,8 @@
     {
       "type": "module",
       "line": 151,
-      "filename": "call_ref.3.wasm"
+      "filename": "call_ref.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -541,29 +545,29 @@
       "type": "assert_invalid",
       "line": 168,
       "filename": "call_ref.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 184,
       "filename": "call_ref.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 201,
       "filename": "call_ref.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 211,
       "filename": "call_ref.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/data.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/data.wast.json
@@ -4,395 +4,426 @@
     {
       "type": "module",
       "line": 5,
-      "filename": "data.0.wasm"
+      "filename": "data.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 36,
-      "filename": "data.1.wasm"
+      "filename": "data.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 40,
-      "filename": "data.2.wasm"
+      "filename": "data.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 45,
-      "filename": "data.3.wasm"
+      "filename": "data.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 53,
-      "filename": "data.4.wasm"
+      "filename": "data.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 63,
-      "filename": "data.5.wasm"
+      "filename": "data.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 68,
-      "filename": "data.6.wasm"
+      "filename": "data.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 74,
-      "filename": "data.7.wasm"
+      "filename": "data.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 79,
-      "filename": "data.8.wasm"
+      "filename": "data.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 85,
-      "filename": "data.9.wasm"
+      "filename": "data.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 86,
-      "filename": "data.10.wasm"
+      "filename": "data.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 91,
-      "filename": "data.11.wasm"
+      "filename": "data.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 96,
-      "filename": "data.12.wasm"
+      "filename": "data.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 102,
-      "filename": "data.13.wasm"
+      "filename": "data.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 107,
-      "filename": "data.14.wasm"
+      "filename": "data.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 111,
-      "filename": "data.15.wasm"
+      "filename": "data.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 116,
-      "filename": "data.16.wasm"
+      "filename": "data.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 121,
-      "filename": "data.17.wasm"
+      "filename": "data.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 126,
-      "filename": "data.18.wasm"
+      "filename": "data.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 130,
-      "filename": "data.19.wasm"
+      "filename": "data.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 135,
-      "filename": "data.20.wasm"
+      "filename": "data.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 140,
-      "filename": "data.21.wasm"
+      "filename": "data.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 145,
-      "filename": "data.22.wasm"
+      "filename": "data.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 150,
-      "filename": "data.23.wasm"
+      "filename": "data.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 156,
-      "filename": "data.24.wasm"
+      "filename": "data.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 162,
-      "filename": "data.25.wasm"
+      "filename": "data.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 167,
-      "filename": "data.26.wasm"
+      "filename": "data.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 174,
-      "filename": "data.27.wasm"
+      "filename": "data.27.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 179,
-      "filename": "data.28.wasm"
+      "filename": "data.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 184,
-      "filename": "data.29.wasm"
+      "filename": "data.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 191,
-      "filename": "data.30.wasm"
+      "filename": "data.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_uninstantiable",
       "line": 207,
       "filename": "data.31.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 215,
       "filename": "data.32.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 223,
       "filename": "data.33.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 230,
       "filename": "data.34.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 237,
       "filename": "data.35.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 254,
       "filename": "data.36.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 263,
       "filename": "data.37.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 270,
       "filename": "data.38.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 278,
       "filename": "data.39.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 286,
       "filename": "data.40.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 294,
       "filename": "data.41.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 301,
       "filename": "data.42.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 309,
       "filename": "data.43.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 316,
       "filename": "data.44.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_invalid",
       "line": 326,
       "filename": "data.45.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 334,
       "filename": "data.46.wasm",
-      "text": "unknown memory 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 1"
     },
     {
       "type": "assert_invalid",
       "line": 347,
       "filename": "data.47.wasm",
-      "text": "unknown memory 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 0"
     },
     {
       "type": "assert_invalid",
       "line": 358,
       "filename": "data.48.wasm",
-      "text": "unknown memory 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 1"
     },
     {
       "type": "assert_invalid",
       "line": 370,
       "filename": "data.49.wasm",
-      "text": "unknown memory 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 1"
     },
     {
       "type": "assert_invalid",
       "line": 392,
       "filename": "data.50.wasm",
-      "text": "unknown memory 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 1"
     },
     {
       "type": "assert_invalid",
       "line": 411,
       "filename": "data.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 419,
       "filename": "data.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 427,
       "filename": "data.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 435,
       "filename": "data.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 443,
       "filename": "data.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 452,
       "filename": "data.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 461,
       "filename": "data.57.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 469,
       "filename": "data.58.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 477,
       "filename": "data.59.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 485,
       "filename": "data.60.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 493,
       "filename": "data.61.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 502,
       "filename": "data.62.wasm",
-      "text": "unknown global 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global 0"
     },
     {
       "type": "assert_invalid",
       "line": 510,
       "filename": "data.63.wasm",
-      "text": "unknown global 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global 1"
     },
     {
       "type": "assert_invalid",
       "line": 519,
       "filename": "data.64.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/data0.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/data0.wast.json
@@ -4,37 +4,44 @@
     {
       "type": "module",
       "line": 5,
-      "filename": "data0.0.wasm"
+      "filename": "data0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 39,
-      "filename": "data0.1.wasm"
+      "filename": "data0.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 43,
-      "filename": "data0.2.wasm"
+      "filename": "data0.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 52,
-      "filename": "data0.3.wasm"
+      "filename": "data0.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 57,
-      "filename": "data0.4.wasm"
+      "filename": "data0.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 63,
-      "filename": "data0.5.wasm"
+      "filename": "data0.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 68,
-      "filename": "data0.6.wasm"
+      "filename": "data0.6.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/data1.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/data1.wast.json
@@ -5,99 +5,99 @@
       "type": "assert_uninstantiable",
       "line": 4,
       "filename": "data1.0.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 14,
       "filename": "data1.1.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 24,
       "filename": "data1.2.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 33,
       "filename": "data1.3.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 42,
       "filename": "data1.4.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 61,
       "filename": "data1.5.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 72,
       "filename": "data1.6.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 81,
       "filename": "data1.7.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 89,
       "filename": "data1.8.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 99,
       "filename": "data1.9.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 109,
       "filename": "data1.10.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 118,
       "filename": "data1.11.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 128,
       "filename": "data1.12.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 137,
       "filename": "data1.13.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/data_drop0.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/data_drop0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 2,
-      "filename": "data_drop0.0.wasm"
+      "filename": "data_drop0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",

--- a/tests/snapshots/testsuite/proposals/memory64/elem.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/elem.wast.json
@@ -4,52 +4,62 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "elem.0.wasm"
+      "filename": "elem.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 80,
-      "filename": "elem.1.wasm"
+      "filename": "elem.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 87,
-      "filename": "elem.2.wasm"
+      "filename": "elem.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 98,
-      "filename": "elem.3.wasm"
+      "filename": "elem.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 103,
-      "filename": "elem.4.wasm"
+      "filename": "elem.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 109,
-      "filename": "elem.5.wasm"
+      "filename": "elem.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 118,
-      "filename": "elem.6.wasm"
+      "filename": "elem.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 128,
-      "filename": "elem.7.wasm"
+      "filename": "elem.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 135,
-      "filename": "elem.8.wasm"
+      "filename": "elem.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 142,
-      "filename": "elem.9.wasm"
+      "filename": "elem.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -84,7 +94,8 @@
     {
       "type": "module",
       "line": 161,
-      "filename": "elem.10.wasm"
+      "filename": "elem.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -119,355 +130,406 @@
     {
       "type": "module",
       "line": 178,
-      "filename": "elem.11.wasm"
+      "filename": "elem.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 182,
-      "filename": "elem.12.wasm"
+      "filename": "elem.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 190,
-      "filename": "elem.13.wasm"
+      "filename": "elem.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 195,
-      "filename": "elem.14.wasm"
+      "filename": "elem.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 201,
-      "filename": "elem.15.wasm"
+      "filename": "elem.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 205,
-      "filename": "elem.16.wasm"
+      "filename": "elem.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 210,
-      "filename": "elem.17.wasm"
+      "filename": "elem.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 215,
-      "filename": "elem.18.wasm"
+      "filename": "elem.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 220,
-      "filename": "elem.19.wasm"
+      "filename": "elem.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 226,
-      "filename": "elem.20.wasm"
+      "filename": "elem.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 232,
-      "filename": "elem.21.wasm"
+      "filename": "elem.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 238,
-      "filename": "elem.22.wasm"
+      "filename": "elem.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 247,
-      "filename": "elem.23.wasm"
+      "filename": "elem.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 252,
-      "filename": "elem.24.wasm"
+      "filename": "elem.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 264,
-      "filename": "elem.25.wasm"
+      "filename": "elem.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 269,
-      "filename": "elem.26.wasm"
+      "filename": "elem.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 281,
-      "filename": "elem.27.wasm"
+      "filename": "elem.27.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 286,
-      "filename": "elem.28.wasm"
+      "filename": "elem.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 298,
-      "filename": "elem.29.wasm"
+      "filename": "elem.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 303,
-      "filename": "elem.30.wasm"
+      "filename": "elem.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 315,
-      "filename": "elem.31.wasm"
+      "filename": "elem.31.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 320,
-      "filename": "elem.32.wasm"
+      "filename": "elem.32.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 331,
-      "filename": "elem.33.wasm"
+      "filename": "elem.33.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 336,
-      "filename": "elem.34.wasm"
+      "filename": "elem.34.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 348,
-      "filename": "elem.35.wasm"
+      "filename": "elem.35.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 353,
-      "filename": "elem.36.wasm"
+      "filename": "elem.36.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 364,
-      "filename": "elem.37.wasm"
+      "filename": "elem.37.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 369,
-      "filename": "elem.38.wasm"
+      "filename": "elem.38.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 381,
-      "filename": "elem.39.wasm"
+      "filename": "elem.39.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 386,
-      "filename": "elem.40.wasm"
+      "filename": "elem.40.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 397,
-      "filename": "elem.41.wasm"
+      "filename": "elem.41.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 402,
-      "filename": "elem.42.wasm"
+      "filename": "elem.42.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 414,
-      "filename": "elem.43.wasm"
+      "filename": "elem.43.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 419,
-      "filename": "elem.44.wasm"
+      "filename": "elem.44.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 430,
-      "filename": "elem.45.wasm"
+      "filename": "elem.45.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 435,
-      "filename": "elem.46.wasm"
+      "filename": "elem.46.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 448,
-      "filename": "elem.47.wasm"
+      "filename": "elem.47.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 453,
-      "filename": "elem.48.wasm"
+      "filename": "elem.48.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 465,
-      "filename": "elem.49.wasm"
+      "filename": "elem.49.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 470,
-      "filename": "elem.50.wasm"
+      "filename": "elem.50.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 482,
-      "filename": "elem.51.wasm"
+      "filename": "elem.51.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 487,
-      "filename": "elem.52.wasm"
+      "filename": "elem.52.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 499,
-      "filename": "elem.53.wasm"
+      "filename": "elem.53.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 504,
-      "filename": "elem.54.wasm"
+      "filename": "elem.54.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 517,
       "filename": "elem.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 525,
       "filename": "elem.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 539,
-      "filename": "elem.57.wasm"
+      "filename": "elem.57.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 544,
-      "filename": "elem.58.wasm"
+      "filename": "elem.58.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 556,
-      "filename": "elem.59.wasm"
+      "filename": "elem.59.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 561,
-      "filename": "elem.60.wasm"
+      "filename": "elem.60.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 573,
-      "filename": "elem.61.wasm"
+      "filename": "elem.61.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 578,
-      "filename": "elem.62.wasm"
+      "filename": "elem.62.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_uninstantiable",
       "line": 594,
       "filename": "elem.63.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 603,
       "filename": "elem.64.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 612,
       "filename": "elem.65.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 621,
       "filename": "elem.66.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 628,
       "filename": "elem.67.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 636,
       "filename": "elem.68.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 645,
       "filename": "elem.69.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 653,
       "filename": "elem.70.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 662,
       "filename": "elem.71.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 670,
       "filename": "elem.72.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 679,
       "filename": "elem.73.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 687,
       "filename": "elem.74.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "module",
       "line": 698,
-      "filename": "elem.75.wasm"
+      "filename": "elem.75.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -482,7 +544,8 @@
     {
       "type": "module",
       "line": 708,
-      "filename": "elem.76.wasm"
+      "filename": "elem.76.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -498,146 +561,147 @@
       "type": "assert_invalid",
       "line": 722,
       "filename": "elem.77.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 733,
       "filename": "elem.78.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 741,
       "filename": "elem.79.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 749,
       "filename": "elem.80.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 757,
       "filename": "elem.81.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 765,
       "filename": "elem.82.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 774,
       "filename": "elem.83.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 784,
       "filename": "elem.84.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 792,
       "filename": "elem.85.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 800,
       "filename": "elem.86.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 808,
       "filename": "elem.87.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 816,
       "filename": "elem.88.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 825,
       "filename": "elem.89.wasm",
-      "text": "unknown global 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global 0"
     },
     {
       "type": "assert_invalid",
       "line": 833,
       "filename": "elem.90.wasm",
-      "text": "unknown global 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global 1"
     },
     {
       "type": "assert_invalid",
       "line": 842,
       "filename": "elem.91.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 854,
       "filename": "elem.92.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 862,
       "filename": "elem.93.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 870,
       "filename": "elem.94.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 878,
       "filename": "elem.95.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 886,
       "filename": "elem.96.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "module",
       "line": 897,
-      "filename": "elem.97.wasm"
+      "filename": "elem.97.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -657,7 +721,8 @@
     {
       "type": "module",
       "line": 910,
-      "filename": "elem.98.wasm"
+      "filename": "elem.98.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -678,7 +743,8 @@
       "type": "module",
       "line": 926,
       "name": "module1",
-      "filename": "elem.99.wasm"
+      "filename": "elem.99.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -733,7 +799,8 @@
       "type": "module",
       "line": 950,
       "name": "module2",
-      "filename": "elem.100.wasm"
+      "filename": "elem.100.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -787,7 +854,8 @@
       "type": "module",
       "line": 963,
       "name": "module3",
-      "filename": "elem.101.wasm"
+      "filename": "elem.101.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -841,35 +909,36 @@
       "type": "assert_invalid",
       "line": 979,
       "filename": "elem.102.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 984,
       "filename": "elem.103.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 989,
       "filename": "elem.104.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 998,
       "filename": "elem.105.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 1007,
       "name": "m",
-      "filename": "elem.106.wasm"
+      "filename": "elem.106.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1004,7 +1073,8 @@
     {
       "type": "module",
       "line": 1025,
-      "filename": "elem.107.wasm"
+      "filename": "elem.107.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1052,7 +1122,8 @@
       "type": "module",
       "line": 1034,
       "name": "module4",
-      "filename": "elem.108.wasm"
+      "filename": "elem.108.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1063,7 +1134,8 @@
     {
       "type": "module",
       "line": 1043,
-      "filename": "elem.109.wasm"
+      "filename": "elem.109.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1083,7 +1155,8 @@
     {
       "type": "module",
       "line": 1057,
-      "filename": "elem.110.wasm"
+      "filename": "elem.110.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1123,7 +1196,8 @@
     {
       "type": "module",
       "line": 1068,
-      "filename": "elem.111.wasm"
+      "filename": "elem.111.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1163,7 +1237,8 @@
     {
       "type": "module",
       "line": 1079,
-      "filename": "elem.112.wasm"
+      "filename": "elem.112.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1203,7 +1278,8 @@
     {
       "type": "module",
       "line": 1092,
-      "filename": "elem.113.wasm"
+      "filename": "elem.113.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/endianness64.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/endianness64.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "endianness64.0.wasm"
+      "filename": "endianness64.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/exports.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/exports.wast.json
@@ -4,63 +4,75 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "exports.0.wasm"
+      "filename": "exports.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 4,
-      "filename": "exports.1.wasm"
+      "filename": "exports.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 5,
-      "filename": "exports.2.wasm"
+      "filename": "exports.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 7,
-      "filename": "exports.3.wasm"
+      "filename": "exports.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 8,
-      "filename": "exports.4.wasm"
+      "filename": "exports.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 9,
-      "filename": "exports.5.wasm"
+      "filename": "exports.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 10,
-      "filename": "exports.6.wasm"
+      "filename": "exports.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 11,
-      "filename": "exports.7.wasm"
+      "filename": "exports.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 12,
-      "filename": "exports.8.wasm"
+      "filename": "exports.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 13,
-      "filename": "exports.9.wasm"
+      "filename": "exports.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 14,
-      "filename": "exports.10.wasm"
+      "filename": "exports.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 16,
       "name": "Func",
-      "filename": "exports.11.wasm"
+      "filename": "exports.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -106,13 +118,15 @@
     {
       "type": "module",
       "line": 24,
-      "filename": "exports.12.wasm"
+      "filename": "exports.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 25,
       "name": "Other1",
-      "filename": "exports.13.wasm"
+      "filename": "exports.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -138,7 +152,8 @@
     {
       "type": "module",
       "line": 28,
-      "filename": "exports.14.wasm"
+      "filename": "exports.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -189,115 +204,125 @@
       "type": "assert_invalid",
       "line": 39,
       "filename": "exports.15.wasm",
-      "text": "unknown function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function"
     },
     {
       "type": "assert_invalid",
       "line": 43,
       "filename": "exports.16.wasm",
-      "text": "unknown function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function"
     },
     {
       "type": "assert_invalid",
       "line": 47,
       "filename": "exports.17.wasm",
-      "text": "unknown function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function"
     },
     {
       "type": "assert_invalid",
       "line": 51,
       "filename": "exports.18.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 55,
       "filename": "exports.19.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 59,
       "filename": "exports.20.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 63,
       "filename": "exports.21.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 67,
       "filename": "exports.22.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 71,
       "filename": "exports.23.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "module",
       "line": 78,
-      "filename": "exports.24.wasm"
+      "filename": "exports.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 79,
-      "filename": "exports.25.wasm"
+      "filename": "exports.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 80,
-      "filename": "exports.26.wasm"
+      "filename": "exports.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 82,
-      "filename": "exports.27.wasm"
+      "filename": "exports.27.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 83,
-      "filename": "exports.28.wasm"
+      "filename": "exports.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 84,
-      "filename": "exports.29.wasm"
+      "filename": "exports.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 85,
-      "filename": "exports.30.wasm"
+      "filename": "exports.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 86,
-      "filename": "exports.31.wasm"
+      "filename": "exports.31.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 87,
-      "filename": "exports.32.wasm"
+      "filename": "exports.32.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 89,
       "name": "Global",
-      "filename": "exports.33.wasm"
+      "filename": "exports.33.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -331,13 +356,15 @@
     {
       "type": "module",
       "line": 95,
-      "filename": "exports.34.wasm"
+      "filename": "exports.34.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 96,
       "name": "Other2",
-      "filename": "exports.35.wasm"
+      "filename": "exports.35.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -358,307 +385,336 @@
       "type": "assert_invalid",
       "line": 100,
       "filename": "exports.36.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 104,
       "filename": "exports.37.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 108,
       "filename": "exports.38.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 112,
       "filename": "exports.39.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 116,
       "filename": "exports.40.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 120,
       "filename": "exports.41.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 124,
       "filename": "exports.42.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 128,
       "filename": "exports.43.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "module",
       "line": 135,
-      "filename": "exports.44.wasm"
+      "filename": "exports.44.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 136,
-      "filename": "exports.45.wasm"
+      "filename": "exports.45.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 137,
-      "filename": "exports.46.wasm"
+      "filename": "exports.46.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 139,
-      "filename": "exports.47.wasm"
+      "filename": "exports.47.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 140,
-      "filename": "exports.48.wasm"
+      "filename": "exports.48.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 141,
-      "filename": "exports.49.wasm"
+      "filename": "exports.49.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 142,
-      "filename": "exports.50.wasm"
+      "filename": "exports.50.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 143,
-      "filename": "exports.51.wasm"
+      "filename": "exports.51.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 144,
-      "filename": "exports.52.wasm"
+      "filename": "exports.52.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 145,
-      "filename": "exports.53.wasm"
+      "filename": "exports.53.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 146,
-      "filename": "exports.54.wasm"
+      "filename": "exports.54.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 147,
-      "filename": "exports.55.wasm"
+      "filename": "exports.55.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 148,
-      "filename": "exports.56.wasm"
+      "filename": "exports.56.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 149,
-      "filename": "exports.57.wasm"
+      "filename": "exports.57.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 150,
-      "filename": "exports.58.wasm"
+      "filename": "exports.58.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 155,
       "filename": "exports.59.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 159,
       "filename": "exports.60.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 163,
       "filename": "exports.61.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 167,
       "filename": "exports.62.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 171,
       "filename": "exports.63.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 175,
       "filename": "exports.64.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 179,
       "filename": "exports.65.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 183,
       "filename": "exports.66.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "module",
       "line": 190,
-      "filename": "exports.67.wasm"
+      "filename": "exports.67.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 191,
-      "filename": "exports.68.wasm"
+      "filename": "exports.68.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 195,
-      "filename": "exports.69.wasm"
+      "filename": "exports.69.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 196,
-      "filename": "exports.70.wasm"
+      "filename": "exports.70.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 197,
-      "filename": "exports.71.wasm"
+      "filename": "exports.71.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 198,
-      "filename": "exports.72.wasm"
+      "filename": "exports.72.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 199,
-      "filename": "exports.73.wasm"
+      "filename": "exports.73.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 200,
-      "filename": "exports.74.wasm"
+      "filename": "exports.74.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 201,
-      "filename": "exports.75.wasm"
+      "filename": "exports.75.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 202,
-      "filename": "exports.76.wasm"
+      "filename": "exports.76.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 203,
-      "filename": "exports.77.wasm"
+      "filename": "exports.77.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 204,
-      "filename": "exports.78.wasm"
+      "filename": "exports.78.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 205,
-      "filename": "exports.79.wasm"
+      "filename": "exports.79.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 206,
-      "filename": "exports.80.wasm"
+      "filename": "exports.80.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 211,
       "filename": "exports.81.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 215,
       "filename": "exports.82.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 219,
       "filename": "exports.83.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 223,
       "filename": "exports.84.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 232,
       "filename": "exports.85.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 236,
       "filename": "exports.86.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 240,
       "filename": "exports.87.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/exports0.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/exports0.wast.json
@@ -4,42 +4,50 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "exports0.0.wasm"
+      "filename": "exports0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 4,
-      "filename": "exports0.1.wasm"
+      "filename": "exports0.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 5,
-      "filename": "exports0.2.wasm"
+      "filename": "exports0.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 6,
-      "filename": "exports0.3.wasm"
+      "filename": "exports0.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 32,
-      "filename": "exports0.4.wasm"
+      "filename": "exports0.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 40,
-      "filename": "exports0.5.wasm"
+      "filename": "exports0.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 49,
-      "filename": "exports0.6.wasm"
+      "filename": "exports0.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 50,
-      "filename": "exports0.7.wasm"
+      "filename": "exports0.7.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/extern.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/extern.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "extern.0.wasm"
+      "filename": "extern.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",

--- a/tests/snapshots/testsuite/proposals/memory64/float_exprs0.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/float_exprs0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "float_exprs0.0.wasm"
+      "filename": "float_exprs0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",

--- a/tests/snapshots/testsuite/proposals/memory64/float_exprs1.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/float_exprs1.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "float_exprs1.0.wasm"
+      "filename": "float_exprs1.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/float_memory0.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/float_memory0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 5,
-      "filename": "float_memory0.0.wasm"
+      "filename": "float_memory0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -195,7 +196,8 @@
     {
       "type": "module",
       "line": 35,
-      "filename": "float_memory0.1.wasm"
+      "filename": "float_memory0.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/float_memory64.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/float_memory64.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 5,
-      "filename": "float_memory64.0.wasm"
+      "filename": "float_memory64.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -195,7 +196,8 @@
     {
       "type": "module",
       "line": 30,
-      "filename": "float_memory64.1.wasm"
+      "filename": "float_memory64.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -386,7 +388,8 @@
     {
       "type": "module",
       "line": 57,
-      "filename": "float_memory64.2.wasm"
+      "filename": "float_memory64.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -577,7 +580,8 @@
     {
       "type": "module",
       "line": 82,
-      "filename": "float_memory64.3.wasm"
+      "filename": "float_memory64.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -768,7 +772,8 @@
     {
       "type": "module",
       "line": 109,
-      "filename": "float_memory64.4.wasm"
+      "filename": "float_memory64.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -959,7 +964,8 @@
     {
       "type": "module",
       "line": 134,
-      "filename": "float_memory64.5.wasm"
+      "filename": "float_memory64.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/func.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/func.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "func.0.wasm"
+      "filename": "func.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1754,26 +1755,28 @@
     {
       "type": "module",
       "line": 422,
-      "filename": "func.1.wasm"
+      "filename": "func.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 436,
       "filename": "func.2.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_malformed",
       "line": 448,
       "filename": "func.3.wat",
-      "text": "unknown type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown type"
     },
     {
       "type": "module",
       "line": 459,
-      "filename": "func.4.wasm"
+      "filename": "func.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1833,7 +1836,8 @@
     {
       "type": "module",
       "line": 488,
-      "filename": "func.5.wasm"
+      "filename": "func.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1879,512 +1883,512 @@
       "type": "assert_malformed",
       "line": 560,
       "filename": "func.6.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 567,
       "filename": "func.7.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 574,
       "filename": "func.8.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 581,
       "filename": "func.9.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 588,
       "filename": "func.10.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 595,
       "filename": "func.11.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 602,
       "filename": "func.12.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 609,
       "filename": "func.13.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 616,
       "filename": "func.14.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 623,
       "filename": "func.15.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_invalid",
       "line": 631,
       "filename": "func.16.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 635,
       "filename": "func.17.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 647,
       "filename": "func.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 651,
       "filename": "func.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 655,
       "filename": "func.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 660,
       "filename": "func.21.wasm",
-      "text": "uninitialized local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "uninitialized local"
     },
     {
       "type": "assert_invalid",
       "line": 671,
       "filename": "func.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 675,
       "filename": "func.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 679,
       "filename": "func.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 687,
       "filename": "func.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 691,
       "filename": "func.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 695,
       "filename": "func.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 699,
       "filename": "func.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 703,
       "filename": "func.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 708,
       "filename": "func.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 714,
       "filename": "func.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 720,
       "filename": "func.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 726,
       "filename": "func.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 732,
       "filename": "func.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 738,
       "filename": "func.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 744,
       "filename": "func.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 751,
       "filename": "func.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 757,
       "filename": "func.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 763,
       "filename": "func.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 769,
       "filename": "func.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 775,
       "filename": "func.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 781,
       "filename": "func.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 788,
       "filename": "func.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 794,
       "filename": "func.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 800,
       "filename": "func.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 806,
       "filename": "func.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 812,
       "filename": "func.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 818,
       "filename": "func.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 824,
       "filename": "func.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 830,
       "filename": "func.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 836,
       "filename": "func.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 843,
       "filename": "func.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 849,
       "filename": "func.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 855,
       "filename": "func.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 861,
       "filename": "func.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 867,
       "filename": "func.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 873,
       "filename": "func.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 879,
       "filename": "func.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 885,
       "filename": "func.59.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 891,
       "filename": "func.60.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 898,
       "filename": "func.61.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 904,
       "filename": "func.62.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 910,
       "filename": "func.63.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 916,
       "filename": "func.64.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 922,
       "filename": "func.65.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 928,
       "filename": "func.66.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 938,
       "filename": "func.67.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 942,
       "filename": "func.68.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 946,
       "filename": "func.69.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 950,
       "filename": "func.70.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 954,
       "filename": "func.71.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 958,
       "filename": "func.72.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 965,
       "filename": "func.73.wat",
-      "text": "duplicate func",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate func"
     },
     {
       "type": "assert_malformed",
       "line": 969,
       "filename": "func.74.wat",
-      "text": "duplicate func",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate func"
     },
     {
       "type": "assert_malformed",
       "line": 973,
       "filename": "func.75.wat",
-      "text": "duplicate func",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate func"
     },
     {
       "type": "assert_malformed",
       "line": 978,
       "filename": "func.76.wat",
-      "text": "duplicate local",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate local"
     },
     {
       "type": "assert_malformed",
       "line": 982,
       "filename": "func.77.wat",
-      "text": "duplicate local",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate local"
     },
     {
       "type": "assert_malformed",
       "line": 986,
       "filename": "func.78.wat",
-      "text": "duplicate local",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate local"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/global.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/global.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "global.0.wasm"
+      "filename": "global.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -930,330 +931,337 @@
       "type": "assert_invalid",
       "line": 285,
       "filename": "global.1.wasm",
-      "text": "immutable global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "immutable global"
     },
     {
       "type": "assert_invalid",
       "line": 290,
       "filename": "global.2.wasm",
-      "text": "immutable global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "immutable global"
     },
     {
       "type": "module",
       "line": 295,
-      "filename": "global.3.wasm"
+      "filename": "global.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 296,
-      "filename": "global.4.wasm"
+      "filename": "global.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 299,
       "filename": "global.5.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 304,
       "filename": "global.6.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 309,
       "filename": "global.7.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 314,
       "filename": "global.8.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 319,
       "filename": "global.9.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 324,
       "filename": "global.10.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 329,
       "filename": "global.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 334,
       "filename": "global.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 339,
       "filename": "global.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 344,
       "filename": "global.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 349,
       "filename": "global.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 354,
       "filename": "global.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 359,
       "filename": "global.17.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 364,
       "filename": "global.18.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 369,
       "filename": "global.19.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "module",
       "line": 373,
-      "filename": "global.20.wasm"
+      "filename": "global.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 374,
-      "filename": "global.21.wasm"
+      "filename": "global.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 377,
       "filename": "global.22.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "module",
       "line": 381,
-      "filename": "global.23.wasm"
+      "filename": "global.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 385,
       "filename": "global.24.wasm",
-      "text": "malformed mutability",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed mutability"
     },
     {
       "type": "assert_malformed",
       "line": 398,
       "filename": "global.25.wasm",
-      "text": "malformed mutability",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed mutability"
     },
     {
       "type": "module",
       "line": 411,
-      "filename": "global.26.wasm"
+      "filename": "global.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 415,
       "filename": "global.27.wasm",
-      "text": "malformed mutability",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed mutability"
     },
     {
       "type": "assert_malformed",
       "line": 427,
       "filename": "global.28.wasm",
-      "text": "malformed mutability",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed mutability"
     },
     {
       "type": "assert_invalid",
       "line": 441,
       "filename": "global.29.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 446,
       "filename": "global.30.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 454,
       "filename": "global.31.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 462,
       "filename": "global.32.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 472,
       "filename": "global.33.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 477,
       "filename": "global.34.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 485,
       "filename": "global.35.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 493,
       "filename": "global.36.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 503,
       "filename": "global.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 512,
       "filename": "global.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 522,
       "filename": "global.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 532,
       "filename": "global.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 542,
       "filename": "global.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 552,
       "filename": "global.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 562,
       "filename": "global.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 572,
       "filename": "global.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 582,
       "filename": "global.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 591,
       "filename": "global.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 600,
       "filename": "global.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 610,
       "filename": "global.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 629,
-      "filename": "global.49.wasm"
+      "filename": "global.49.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1263,7 +1271,8 @@
     {
       "type": "module",
       "line": 634,
-      "filename": "global.50.wasm"
+      "filename": "global.50.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1366,36 +1375,36 @@
       "type": "assert_invalid",
       "line": 667,
       "filename": "global.51.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 675,
       "filename": "global.52.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_malformed",
       "line": 686,
       "filename": "global.53.wat",
-      "text": "duplicate global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate global"
     },
     {
       "type": "assert_malformed",
       "line": 693,
       "filename": "global.54.wat",
-      "text": "duplicate global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate global"
     },
     {
       "type": "assert_malformed",
       "line": 700,
       "filename": "global.55.wat",
-      "text": "duplicate global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate global"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/i31.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/i31.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "i31.0.wasm"
+      "filename": "i31.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -421,7 +422,8 @@
       "type": "module",
       "line": 61,
       "name": "tables_of_i31ref",
-      "filename": "i31.1.wasm"
+      "filename": "i31.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -787,7 +789,8 @@
       "type": "module",
       "line": 123,
       "name": "env",
-      "filename": "i31.2.wasm"
+      "filename": "i31.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -798,7 +801,8 @@
       "type": "module",
       "line": 128,
       "name": "i31ref_of_global_table_initializer",
-      "filename": "i31.3.wasm"
+      "filename": "i31.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -864,7 +868,8 @@
       "type": "module",
       "line": 140,
       "name": "i31ref_of_global_global_initializer",
-      "filename": "i31.4.wasm"
+      "filename": "i31.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -885,7 +890,8 @@
       "type": "module",
       "line": 150,
       "name": "anyref_global_of_i31ref",
-      "filename": "i31.5.wasm"
+      "filename": "i31.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -943,7 +949,8 @@
       "type": "module",
       "line": 168,
       "name": "anyref_table_of_i31ref",
-      "filename": "i31.6.wasm"
+      "filename": "i31.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/id.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/id.wast.json
@@ -4,49 +4,50 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "id.0.wasm"
+      "filename": "id.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 26,
       "filename": "id.1.wat",
-      "text": "empty identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty identifier"
     },
     {
       "type": "assert_malformed",
       "line": 27,
       "filename": "id.2.wat",
-      "text": "empty identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty identifier"
     },
     {
       "type": "assert_malformed",
       "line": 28,
       "filename": "id.3.wat",
-      "text": "empty identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty identifier"
     },
     {
       "type": "assert_malformed",
       "line": 29,
       "filename": "id.4.wat",
-      "text": "empty identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty identifier"
     },
     {
       "type": "assert_malformed",
       "line": 30,
       "filename": "id.5.wat",
-      "text": "empty identifier",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "empty identifier"
     },
     {
       "type": "assert_malformed",
       "line": 31,
       "filename": "id.6.wat",
-      "text": "malformed UTF-8",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/if.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/if.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "if.0.wasm"
+      "filename": "if.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2626,813 +2627,813 @@
       "type": "assert_malformed",
       "line": 736,
       "filename": "if.1.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 745,
       "filename": "if.2.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 754,
       "filename": "if.3.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 763,
       "filename": "if.4.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 772,
       "filename": "if.5.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 781,
       "filename": "if.6.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 788,
       "filename": "if.7.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 796,
       "filename": "if.8.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 806,
       "filename": "if.9.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 816,
       "filename": "if.10.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 826,
       "filename": "if.11.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_invalid",
       "line": 836,
       "filename": "if.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 844,
       "filename": "if.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 848,
       "filename": "if.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 852,
       "filename": "if.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 856,
       "filename": "if.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 861,
       "filename": "if.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 865,
       "filename": "if.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 869,
       "filename": "if.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 873,
       "filename": "if.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 878,
       "filename": "if.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 884,
       "filename": "if.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 890,
       "filename": "if.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 896,
       "filename": "if.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 903,
       "filename": "if.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 909,
       "filename": "if.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 915,
       "filename": "if.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 921,
       "filename": "if.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 928,
       "filename": "if.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 934,
       "filename": "if.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 940,
       "filename": "if.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 947,
       "filename": "if.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 953,
       "filename": "if.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 959,
       "filename": "if.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 966,
       "filename": "if.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 972,
       "filename": "if.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 979,
       "filename": "if.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 985,
       "filename": "if.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 991,
       "filename": "if.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 998,
       "filename": "if.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1004,
       "filename": "if.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1010,
       "filename": "if.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1017,
       "filename": "if.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1023,
       "filename": "if.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1029,
       "filename": "if.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1036,
       "filename": "if.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1042,
       "filename": "if.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1048,
       "filename": "if.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1055,
       "filename": "if.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1062,
       "filename": "if.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1069,
       "filename": "if.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1077,
       "filename": "if.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1083,
       "filename": "if.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1089,
       "filename": "if.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1096,
       "filename": "if.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1102,
       "filename": "if.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1109,
       "filename": "if.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1119,
       "filename": "if.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1129,
       "filename": "if.59.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1140,
       "filename": "if.60.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1146,
       "filename": "if.61.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1152,
       "filename": "if.62.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1158,
       "filename": "if.63.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1165,
       "filename": "if.64.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1174,
       "filename": "if.65.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1183,
       "filename": "if.66.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1192,
       "filename": "if.67.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1202,
       "filename": "if.68.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1211,
       "filename": "if.69.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1220,
       "filename": "if.70.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1229,
       "filename": "if.71.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1239,
       "filename": "if.72.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1248,
       "filename": "if.73.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1257,
       "filename": "if.74.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1266,
       "filename": "if.75.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1275,
       "filename": "if.76.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1285,
       "filename": "if.77.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1296,
       "filename": "if.78.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1304,
       "filename": "if.79.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1313,
       "filename": "if.80.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1322,
       "filename": "if.81.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1331,
       "filename": "if.82.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1341,
       "filename": "if.83.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1350,
       "filename": "if.84.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1359,
       "filename": "if.85.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1368,
       "filename": "if.86.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1376,
       "filename": "if.87.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1384,
       "filename": "if.88.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1393,
       "filename": "if.89.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1409,
       "filename": "if.90.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1418,
       "filename": "if.91.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1427,
       "filename": "if.92.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1436,
       "filename": "if.93.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1445,
       "filename": "if.94.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1454,
       "filename": "if.95.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1464,
       "filename": "if.96.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1470,
       "filename": "if.97.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1476,
       "filename": "if.98.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1482,
       "filename": "if.99.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1488,
       "filename": "if.100.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1494,
       "filename": "if.101.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1500,
       "filename": "if.102.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1506,
       "filename": "if.103.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1513,
       "filename": "if.104.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1517,
       "filename": "if.105.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1522,
       "filename": "if.106.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1526,
       "filename": "if.107.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1530,
       "filename": "if.108.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1534,
       "filename": "if.109.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1538,
       "filename": "if.110.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1542,
       "filename": "if.111.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1546,
       "filename": "if.112.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1550,
       "filename": "if.113.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1554,
       "filename": "if.114.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1558,
       "filename": "if.115.wat",
-      "text": "mismatching label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "mismatching label"
     },
     {
       "type": "assert_malformed",
       "line": 1562,
       "filename": "if.116.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/imports.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/imports.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "imports.0.wasm"
+      "filename": "imports.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -14,7 +15,8 @@
     {
       "type": "module",
       "line": 30,
-      "filename": "imports.1.wasm"
+      "filename": "imports.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -50,13 +52,14 @@
       "type": "assert_invalid",
       "line": 96,
       "filename": "imports.2.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "module",
       "line": 104,
-      "filename": "imports.3.wasm"
+      "filename": "imports.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -76,7 +79,8 @@
     {
       "type": "module",
       "line": 114,
-      "filename": "imports.4.wasm"
+      "filename": "imports.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -105,252 +109,260 @@
     {
       "type": "module",
       "line": 123,
-      "filename": "imports.5.wasm"
+      "filename": "imports.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 124,
-      "filename": "imports.6.wasm"
+      "filename": "imports.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 125,
-      "filename": "imports.7.wasm"
+      "filename": "imports.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 126,
-      "filename": "imports.8.wasm"
+      "filename": "imports.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 127,
-      "filename": "imports.9.wasm"
+      "filename": "imports.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 128,
-      "filename": "imports.10.wasm"
+      "filename": "imports.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 129,
-      "filename": "imports.11.wasm"
+      "filename": "imports.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 132,
       "filename": "imports.12.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 136,
       "filename": "imports.13.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 141,
       "filename": "imports.14.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 145,
       "filename": "imports.15.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 149,
       "filename": "imports.16.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 153,
       "filename": "imports.17.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 157,
       "filename": "imports.18.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 161,
       "filename": "imports.19.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 165,
       "filename": "imports.20.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 169,
       "filename": "imports.21.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 173,
       "filename": "imports.22.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 177,
       "filename": "imports.23.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 181,
       "filename": "imports.24.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 185,
       "filename": "imports.25.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 189,
       "filename": "imports.26.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 193,
       "filename": "imports.27.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 197,
       "filename": "imports.28.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 201,
       "filename": "imports.29.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 206,
       "filename": "imports.30.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 210,
       "filename": "imports.31.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 214,
       "filename": "imports.32.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 218,
       "filename": "imports.33.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 222,
       "filename": "imports.34.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 226,
       "filename": "imports.35.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 230,
       "filename": "imports.36.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 235,
       "filename": "imports.37.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 239,
       "filename": "imports.38.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 243,
       "filename": "imports.39.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 247,
       "filename": "imports.40.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 251,
       "filename": "imports.41.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 258,
-      "filename": "imports.42.wasm"
+      "filename": "imports.42.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -460,162 +472,166 @@
     {
       "type": "module",
       "line": 286,
-      "filename": "imports.43.wasm"
+      "filename": "imports.43.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 287,
-      "filename": "imports.44.wasm"
+      "filename": "imports.44.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 288,
-      "filename": "imports.45.wasm"
+      "filename": "imports.45.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 291,
       "filename": "imports.46.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 295,
       "filename": "imports.47.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 300,
       "filename": "imports.48.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 304,
       "filename": "imports.49.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 308,
       "filename": "imports.50.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 312,
       "filename": "imports.51.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 316,
       "filename": "imports.52.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 320,
       "filename": "imports.53.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 324,
       "filename": "imports.54.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 328,
       "filename": "imports.55.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 332,
       "filename": "imports.56.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 336,
       "filename": "imports.57.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 340,
       "filename": "imports.58.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 344,
       "filename": "imports.59.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 349,
       "filename": "imports.60.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 353,
       "filename": "imports.61.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 357,
       "filename": "imports.62.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 361,
       "filename": "imports.63.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 365,
       "filename": "imports.64.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 369,
       "filename": "imports.65.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 376,
-      "filename": "imports.66.wasm"
+      "filename": "imports.66.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -705,7 +721,8 @@
     {
       "type": "module",
       "line": 395,
-      "filename": "imports.67.wasm"
+      "filename": "imports.67.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -795,196 +812,218 @@
     {
       "type": "module",
       "line": 414,
-      "filename": "imports.68.wasm"
+      "filename": "imports.68.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 421,
-      "filename": "imports.69.wasm"
+      "filename": "imports.69.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 422,
-      "filename": "imports.70.wasm"
+      "filename": "imports.70.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 423,
-      "filename": "imports.71.wasm"
+      "filename": "imports.71.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 424,
-      "filename": "imports.72.wasm"
+      "filename": "imports.72.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 425,
-      "filename": "imports.73.wasm"
+      "filename": "imports.73.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 426,
-      "filename": "imports.74.wasm"
+      "filename": "imports.74.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 427,
-      "filename": "imports.75.wasm"
+      "filename": "imports.75.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 428,
-      "filename": "imports.76.wasm"
+      "filename": "imports.76.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 429,
-      "filename": "imports.77.wasm"
+      "filename": "imports.77.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 430,
-      "filename": "imports.78.wasm"
+      "filename": "imports.78.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 431,
-      "filename": "imports.79.wasm"
+      "filename": "imports.79.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 432,
-      "filename": "imports.80.wasm"
+      "filename": "imports.80.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 433,
-      "filename": "imports.81.wasm"
+      "filename": "imports.81.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 434,
-      "filename": "imports.82.wasm"
+      "filename": "imports.82.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 435,
-      "filename": "imports.83.wasm"
+      "filename": "imports.83.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 436,
-      "filename": "imports.84.wasm"
+      "filename": "imports.84.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 437,
-      "filename": "imports.85.wasm"
+      "filename": "imports.85.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 438,
-      "filename": "imports.86.wasm"
+      "filename": "imports.86.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 439,
-      "filename": "imports.87.wasm"
+      "filename": "imports.87.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 440,
-      "filename": "imports.88.wasm"
+      "filename": "imports.88.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 443,
       "filename": "imports.89.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 447,
       "filename": "imports.90.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 452,
       "filename": "imports.91.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 456,
       "filename": "imports.92.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 460,
       "filename": "imports.93.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 464,
       "filename": "imports.94.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 468,
       "filename": "imports.95.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 472,
       "filename": "imports.96.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 477,
       "filename": "imports.97.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 481,
       "filename": "imports.98.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 485,
       "filename": "imports.99.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 489,
       "filename": "imports.100.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 497,
-      "filename": "imports.101.wasm"
+      "filename": "imports.101.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1064,7 +1103,8 @@
     {
       "type": "module",
       "line": 509,
-      "filename": "imports.102.wasm"
+      "filename": "imports.102.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1144,150 +1184,160 @@
     {
       "type": "module",
       "line": 520,
-      "filename": "imports.103.wasm"
+      "filename": "imports.103.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 521,
-      "filename": "imports.104.wasm"
+      "filename": "imports.104.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 522,
-      "filename": "imports.105.wasm"
+      "filename": "imports.105.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 523,
-      "filename": "imports.106.wasm"
+      "filename": "imports.106.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 524,
-      "filename": "imports.107.wasm"
+      "filename": "imports.107.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 525,
-      "filename": "imports.108.wasm"
+      "filename": "imports.108.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 526,
-      "filename": "imports.109.wasm"
+      "filename": "imports.109.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 527,
-      "filename": "imports.110.wasm"
+      "filename": "imports.110.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 528,
-      "filename": "imports.111.wasm"
+      "filename": "imports.111.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 531,
       "filename": "imports.112.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 535,
       "filename": "imports.113.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 540,
       "filename": "imports.114.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 544,
       "filename": "imports.115.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 548,
       "filename": "imports.116.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 552,
       "filename": "imports.117.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 557,
       "filename": "imports.118.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 561,
       "filename": "imports.119.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 565,
       "filename": "imports.120.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 569,
       "filename": "imports.121.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 573,
       "filename": "imports.122.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 577,
       "filename": "imports.123.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 582,
       "filename": "imports.124.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 586,
       "filename": "imports.125.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 590,
-      "filename": "imports.126.wasm"
+      "filename": "imports.126.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1393,7 +1443,8 @@
       "type": "module",
       "line": 600,
       "name": "Mgm",
-      "filename": "imports.127.wasm"
+      "filename": "imports.127.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1421,7 +1472,8 @@
       "type": "module",
       "line": 606,
       "name": "Mgim1",
-      "filename": "imports.128.wasm"
+      "filename": "imports.128.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1449,7 +1501,8 @@
       "type": "module",
       "line": 613,
       "name": "Mgim2",
-      "filename": "imports.129.wasm"
+      "filename": "imports.129.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1471,118 +1524,119 @@
       "type": "assert_malformed",
       "line": 624,
       "filename": "imports.130.wat",
-      "text": "import after function",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after function"
     },
     {
       "type": "assert_malformed",
       "line": 628,
       "filename": "imports.131.wat",
-      "text": "import after function",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after function"
     },
     {
       "type": "assert_malformed",
       "line": 632,
       "filename": "imports.132.wat",
-      "text": "import after function",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after function"
     },
     {
       "type": "assert_malformed",
       "line": 636,
       "filename": "imports.133.wat",
-      "text": "import after function",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after function"
     },
     {
       "type": "assert_malformed",
       "line": 641,
       "filename": "imports.134.wat",
-      "text": "import after global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after global"
     },
     {
       "type": "assert_malformed",
       "line": 645,
       "filename": "imports.135.wat",
-      "text": "import after global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after global"
     },
     {
       "type": "assert_malformed",
       "line": 649,
       "filename": "imports.136.wat",
-      "text": "import after global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after global"
     },
     {
       "type": "assert_malformed",
       "line": 653,
       "filename": "imports.137.wat",
-      "text": "import after global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after global"
     },
     {
       "type": "assert_malformed",
       "line": 658,
       "filename": "imports.138.wat",
-      "text": "import after table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after table"
     },
     {
       "type": "assert_malformed",
       "line": 662,
       "filename": "imports.139.wat",
-      "text": "import after table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after table"
     },
     {
       "type": "assert_malformed",
       "line": 666,
       "filename": "imports.140.wat",
-      "text": "import after table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after table"
     },
     {
       "type": "assert_malformed",
       "line": 670,
       "filename": "imports.141.wat",
-      "text": "import after table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after table"
     },
     {
       "type": "assert_malformed",
       "line": 675,
       "filename": "imports.142.wat",
-      "text": "import after memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after memory"
     },
     {
       "type": "assert_malformed",
       "line": 679,
       "filename": "imports.143.wat",
-      "text": "import after memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after memory"
     },
     {
       "type": "assert_malformed",
       "line": 683,
       "filename": "imports.144.wat",
-      "text": "import after memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after memory"
     },
     {
       "type": "assert_malformed",
       "line": 687,
       "filename": "imports.145.wat",
-      "text": "import after memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after memory"
     },
     {
       "type": "module",
       "line": 694,
-      "filename": "imports.146.wasm"
+      "filename": "imports.146.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1593,8 +1647,8 @@
       "type": "assert_unlinkable",
       "line": 697,
       "filename": "imports.147.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/imports0.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/imports0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "imports0.0.wasm"
+      "filename": "imports0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -15,43 +16,43 @@
       "type": "assert_unlinkable",
       "line": 21,
       "filename": "imports0.1.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 25,
       "filename": "imports0.2.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 30,
       "filename": "imports0.3.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 34,
       "filename": "imports0.4.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 39,
       "filename": "imports0.5.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 43,
       "filename": "imports0.6.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/imports1.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/imports1.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "imports1.0.wasm"
+      "filename": "imports1.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/imports2.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/imports2.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "imports2.0.wasm"
+      "filename": "imports2.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -14,7 +15,8 @@
     {
       "type": "module",
       "line": 9,
-      "filename": "imports2.1.wasm"
+      "filename": "imports2.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -94,7 +96,8 @@
     {
       "type": "module",
       "line": 22,
-      "filename": "imports2.2.wasm"
+      "filename": "imports2.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -174,54 +177,56 @@
     {
       "type": "module",
       "line": 33,
-      "filename": "imports2.3.wasm"
+      "filename": "imports2.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 39,
-      "filename": "imports2.4.wasm"
+      "filename": "imports2.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 49,
       "filename": "imports2.5.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 53,
       "filename": "imports2.6.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 58,
       "filename": "imports2.7.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 62,
       "filename": "imports2.8.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 66,
       "filename": "imports2.9.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 70,
       "filename": "imports2.10.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/imports3.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/imports3.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "imports3.0.wasm"
+      "filename": "imports3.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -15,57 +16,57 @@
       "type": "assert_unlinkable",
       "line": 20,
       "filename": "imports3.1.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 27,
       "filename": "imports3.2.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 34,
       "filename": "imports3.3.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 41,
       "filename": "imports3.4.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 48,
       "filename": "imports3.5.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 55,
       "filename": "imports3.6.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 63,
       "filename": "imports3.7.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 70,
       "filename": "imports3.8.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/imports4.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/imports4.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "imports4.0.wasm"
+      "filename": "imports4.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -14,7 +15,8 @@
     {
       "type": "module",
       "line": 8,
-      "filename": "imports4.1.wasm"
+      "filename": "imports4.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -120,7 +122,8 @@
       "type": "module",
       "line": 19,
       "name": "Mgm",
-      "filename": "imports4.2.wasm"
+      "filename": "imports4.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -148,7 +151,8 @@
       "type": "module",
       "line": 28,
       "name": "Mgim1",
-      "filename": "imports4.3.wasm"
+      "filename": "imports4.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -176,7 +180,8 @@
       "type": "module",
       "line": 39,
       "name": "Mgim2",
-      "filename": "imports4.4.wasm"
+      "filename": "imports4.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/linking.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/linking.wast.json
@@ -5,7 +5,8 @@
       "type": "module",
       "line": 3,
       "name": "Mf",
-      "filename": "linking.0.wasm"
+      "filename": "linking.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -17,7 +18,8 @@
       "type": "module",
       "line": 9,
       "name": "Nf",
-      "filename": "linking.1.wasm"
+      "filename": "linking.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -86,7 +88,8 @@
     {
       "type": "module",
       "line": 22,
-      "filename": "linking.2.wasm"
+      "filename": "linking.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -97,21 +100,22 @@
       "type": "assert_unlinkable",
       "line": 28,
       "filename": "linking.3.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 32,
       "filename": "linking.4.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 39,
       "name": "Mg",
-      "filename": "linking.5.wasm"
+      "filename": "linking.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -123,7 +127,8 @@
       "type": "module",
       "line": 50,
       "name": "Ng",
-      "filename": "linking.6.wasm"
+      "filename": "linking.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -362,21 +367,22 @@
       "type": "assert_unlinkable",
       "line": 87,
       "filename": "linking.7.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 91,
       "filename": "linking.8.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 96,
       "name": "Mref_ex",
-      "filename": "linking.9.wasm"
+      "filename": "linking.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -388,230 +394,232 @@
       "type": "module",
       "line": 112,
       "name": "Mref_im",
-      "filename": "linking.10.wasm"
+      "filename": "linking.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 133,
       "filename": "linking.11.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 138,
       "filename": "linking.12.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 142,
       "filename": "linking.13.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 146,
       "filename": "linking.14.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 151,
       "filename": "linking.15.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 155,
       "filename": "linking.16.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 159,
       "filename": "linking.17.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 164,
       "filename": "linking.18.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 168,
       "filename": "linking.19.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 172,
       "filename": "linking.20.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 176,
       "filename": "linking.21.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 182,
       "filename": "linking.22.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 186,
       "filename": "linking.23.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 190,
       "filename": "linking.24.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 194,
       "filename": "linking.25.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 199,
       "filename": "linking.26.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 203,
       "filename": "linking.27.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 207,
       "filename": "linking.28.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 211,
       "filename": "linking.29.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 216,
       "filename": "linking.30.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 220,
       "filename": "linking.31.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 224,
       "filename": "linking.32.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 228,
       "filename": "linking.33.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 233,
       "filename": "linking.34.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 237,
       "filename": "linking.35.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 241,
       "filename": "linking.36.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 245,
       "filename": "linking.37.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 250,
       "filename": "linking.38.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 254,
       "filename": "linking.39.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 258,
       "filename": "linking.40.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 262,
       "filename": "linking.41.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 269,
       "name": "Mt",
-      "filename": "linking.42.wasm"
+      "filename": "linking.42.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -623,7 +631,8 @@
       "type": "module",
       "line": 284,
       "name": "Nt",
-      "filename": "linking.43.wasm"
+      "filename": "linking.43.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -952,7 +961,8 @@
       "type": "module",
       "line": 326,
       "name": "Ot",
-      "filename": "linking.44.wasm"
+      "filename": "linking.44.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1352,13 +1362,15 @@
     {
       "type": "module",
       "line": 364,
-      "filename": "linking.45.wasm"
+      "filename": "linking.45.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 370,
       "name": "G1",
-      "filename": "linking.46.wasm"
+      "filename": "linking.46.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1370,7 +1382,8 @@
       "type": "module",
       "line": 372,
       "name": "G2",
-      "filename": "linking.47.wasm"
+      "filename": "linking.47.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1391,15 +1404,15 @@
       "type": "assert_uninstantiable",
       "line": 379,
       "filename": "linking.48.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_unlinkable",
       "line": 388,
       "filename": "linking.49.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_trap",
@@ -1421,8 +1434,8 @@
       "type": "assert_uninstantiable",
       "line": 402,
       "filename": "linking.50.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_return",
@@ -1465,8 +1478,8 @@
       "type": "assert_uninstantiable",
       "line": 414,
       "filename": "linking.51.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_return",
@@ -1493,7 +1506,8 @@
       "type": "module",
       "line": 426,
       "name": "Mtable_ex",
-      "filename": "linking.52.wasm"
+      "filename": "linking.52.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1504,55 +1518,57 @@
     {
       "type": "module",
       "line": 434,
-      "filename": "linking.53.wasm"
+      "filename": "linking.53.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 442,
       "filename": "linking.54.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 446,
       "filename": "linking.55.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 451,
       "filename": "linking.56.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 455,
       "filename": "linking.57.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 460,
       "filename": "linking.58.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 464,
       "filename": "linking.59.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 471,
       "name": "Mm",
-      "filename": "linking.60.wasm"
+      "filename": "linking.60.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1564,7 +1580,8 @@
       "type": "module",
       "line": 481,
       "name": "Nm",
-      "filename": "linking.61.wasm"
+      "filename": "linking.61.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1633,7 +1650,8 @@
       "type": "module",
       "line": 497,
       "name": "Om",
-      "filename": "linking.62.wasm"
+      "filename": "linking.62.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1722,20 +1740,22 @@
     {
       "type": "module",
       "line": 511,
-      "filename": "linking.63.wasm"
+      "filename": "linking.63.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_uninstantiable",
       "line": 517,
       "filename": "linking.64.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "module",
       "line": 524,
       "name": "Pm",
-      "filename": "linking.65.wasm"
+      "filename": "linking.65.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1909,8 +1929,8 @@
       "type": "assert_unlinkable",
       "line": 542,
       "filename": "linking.66.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_return",
@@ -1937,8 +1957,8 @@
       "type": "assert_uninstantiable",
       "line": 555,
       "filename": "linking.67.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_return",
@@ -1986,8 +2006,8 @@
       "type": "assert_uninstantiable",
       "line": 567,
       "filename": "linking.68.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_return",
@@ -2014,7 +2034,8 @@
       "type": "module",
       "line": 579,
       "name": "Ms",
-      "filename": "linking.69.wasm"
+      "filename": "linking.69.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -2026,8 +2047,8 @@
       "type": "assert_uninstantiable",
       "line": 593,
       "filename": "linking.70.wasm",
-      "text": "unreachable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unreachable"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/linking0.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/linking0.wast.json
@@ -5,7 +5,8 @@
       "type": "module",
       "line": 1,
       "name": "Mt",
-      "filename": "linking0.0.wasm"
+      "filename": "linking0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -17,8 +18,8 @@
       "type": "assert_unlinkable",
       "line": 17,
       "filename": "linking0.1.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_trap",
@@ -40,8 +41,8 @@
       "type": "assert_uninstantiable",
       "line": 31,
       "filename": "linking0.2.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/linking1.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/linking1.wast.json
@@ -5,7 +5,8 @@
       "type": "module",
       "line": 1,
       "name": "Mm",
-      "filename": "linking1.0.wasm"
+      "filename": "linking1.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -17,7 +18,8 @@
       "type": "module",
       "line": 14,
       "name": "Nm",
-      "filename": "linking1.1.wasm"
+      "filename": "linking1.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -86,7 +88,8 @@
       "type": "module",
       "line": 31,
       "name": "Om",
-      "filename": "linking1.2.wasm"
+      "filename": "linking1.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -175,21 +178,22 @@
     {
       "type": "module",
       "line": 45,
-      "filename": "linking1.3.wasm"
+      "filename": "linking1.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_uninstantiable",
       "line": 51,
       "filename": "linking1.4.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 59,
       "filename": "linking1.5.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/linking2.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/linking2.wast.json
@@ -5,7 +5,8 @@
       "type": "module",
       "line": 1,
       "name": "Mm",
-      "filename": "linking2.0.wasm"
+      "filename": "linking2.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -17,7 +18,8 @@
       "type": "module",
       "line": 14,
       "name": "Pm",
-      "filename": "linking2.1.wasm"
+      "filename": "linking2.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/linking3.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/linking3.wast.json
@@ -5,7 +5,8 @@
       "type": "module",
       "line": 1,
       "name": "Mm",
-      "filename": "linking3.0.wasm"
+      "filename": "linking3.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -17,8 +18,8 @@
       "type": "assert_unlinkable",
       "line": 15,
       "filename": "linking3.1.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_return",
@@ -45,8 +46,8 @@
       "type": "assert_uninstantiable",
       "line": 28,
       "filename": "linking3.2.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_return",
@@ -94,8 +95,8 @@
       "type": "assert_uninstantiable",
       "line": 40,
       "filename": "linking3.3.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_return",
@@ -122,7 +123,8 @@
       "type": "module",
       "line": 52,
       "name": "Ms",
-      "filename": "linking3.4.wasm"
+      "filename": "linking3.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -134,8 +136,8 @@
       "type": "assert_uninstantiable",
       "line": 66,
       "filename": "linking3.5.wasm",
-      "text": "unreachable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unreachable"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/load.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/load.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "load.0.wasm"
+      "filename": "load.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -50,7 +51,8 @@
       "type": "module",
       "line": 22,
       "name": "M",
-      "filename": "load.1.wasm"
+      "filename": "load.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -60,7 +62,8 @@
     {
       "type": "module",
       "line": 31,
-      "filename": "load.2.wasm"
+      "filename": "load.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -370,7 +373,8 @@
     {
       "type": "module",
       "line": 67,
-      "filename": "load.3.wasm"
+      "filename": "load.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -909,414 +913,414 @@
       "type": "assert_malformed",
       "line": 278,
       "filename": "load.4.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 285,
       "filename": "load.5.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 292,
       "filename": "load.6.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 299,
       "filename": "load.7.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 306,
       "filename": "load.8.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 313,
       "filename": "load.9.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 321,
       "filename": "load.10.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 328,
       "filename": "load.11.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 335,
       "filename": "load.12.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 343,
       "filename": "load.13.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 350,
       "filename": "load.14.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 358,
       "filename": "load.15.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 365,
       "filename": "load.16.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_invalid",
       "line": 376,
       "filename": "load.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 380,
       "filename": "load.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 384,
       "filename": "load.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 388,
       "filename": "load.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 392,
       "filename": "load.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 396,
       "filename": "load.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 400,
       "filename": "load.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 404,
       "filename": "load.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 408,
       "filename": "load.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 412,
       "filename": "load.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 416,
       "filename": "load.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 420,
       "filename": "load.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 424,
       "filename": "load.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 428,
       "filename": "load.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 435,
       "filename": "load.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 436,
       "filename": "load.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 437,
       "filename": "load.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 438,
       "filename": "load.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 439,
       "filename": "load.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 440,
       "filename": "load.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 441,
       "filename": "load.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 442,
       "filename": "load.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 443,
       "filename": "load.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 444,
       "filename": "load.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 445,
       "filename": "load.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 446,
       "filename": "load.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 447,
       "filename": "load.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 448,
       "filename": "load.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 452,
       "filename": "load.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 461,
       "filename": "load.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 471,
       "filename": "load.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 481,
       "filename": "load.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 491,
       "filename": "load.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 501,
       "filename": "load.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 511,
       "filename": "load.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 521,
       "filename": "load.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 531,
       "filename": "load.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 540,
       "filename": "load.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 549,
       "filename": "load.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 559,
       "filename": "load.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 576,
       "filename": "load.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 586,
       "filename": "load.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 596,
       "filename": "load.59.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 606,
       "filename": "load.60.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 615,
       "filename": "load.61.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 624,
       "filename": "load.62.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/load0.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/load0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "load0.0.wasm"
+      "filename": "load0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/load1.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/load1.wast.json
@@ -5,7 +5,8 @@
       "type": "module",
       "line": 1,
       "name": "M",
-      "filename": "load1.0.wasm"
+      "filename": "load1.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -15,7 +16,8 @@
     {
       "type": "module",
       "line": 10,
-      "filename": "load1.1.wasm"
+      "filename": "load1.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/load2.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/load2.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "load2.0.wasm"
+      "filename": "load2.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/load64.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/load64.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "load64.0.wasm"
+      "filename": "load64.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -543,414 +544,414 @@
       "type": "assert_malformed",
       "line": 214,
       "filename": "load64.1.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 221,
       "filename": "load64.2.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 228,
       "filename": "load64.3.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 235,
       "filename": "load64.4.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 242,
       "filename": "load64.5.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 249,
       "filename": "load64.6.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 257,
       "filename": "load64.7.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 264,
       "filename": "load64.8.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 271,
       "filename": "load64.9.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 279,
       "filename": "load64.10.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 286,
       "filename": "load64.11.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 294,
       "filename": "load64.12.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 301,
       "filename": "load64.13.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_invalid",
       "line": 312,
       "filename": "load64.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 316,
       "filename": "load64.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 320,
       "filename": "load64.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 324,
       "filename": "load64.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 328,
       "filename": "load64.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 332,
       "filename": "load64.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 336,
       "filename": "load64.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 340,
       "filename": "load64.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 344,
       "filename": "load64.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 348,
       "filename": "load64.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 352,
       "filename": "load64.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 356,
       "filename": "load64.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 360,
       "filename": "load64.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 364,
       "filename": "load64.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 371,
       "filename": "load64.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 372,
       "filename": "load64.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 373,
       "filename": "load64.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 374,
       "filename": "load64.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 375,
       "filename": "load64.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 376,
       "filename": "load64.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 377,
       "filename": "load64.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 378,
       "filename": "load64.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 379,
       "filename": "load64.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 380,
       "filename": "load64.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 381,
       "filename": "load64.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 382,
       "filename": "load64.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 383,
       "filename": "load64.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 384,
       "filename": "load64.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 388,
       "filename": "load64.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 397,
       "filename": "load64.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 407,
       "filename": "load64.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 417,
       "filename": "load64.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 427,
       "filename": "load64.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 437,
       "filename": "load64.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 447,
       "filename": "load64.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 457,
       "filename": "load64.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 467,
       "filename": "load64.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 476,
       "filename": "load64.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 485,
       "filename": "load64.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 495,
       "filename": "load64.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 512,
       "filename": "load64.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 522,
       "filename": "load64.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 532,
       "filename": "load64.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 542,
       "filename": "load64.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 551,
       "filename": "load64.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 560,
       "filename": "load64.59.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/local_get.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/local_get.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "local_get.0.wasm"
+      "filename": "local_get.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -397,113 +398,113 @@
       "type": "assert_invalid",
       "line": 149,
       "filename": "local_get.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 153,
       "filename": "local_get.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 157,
       "filename": "local_get.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 165,
       "filename": "local_get.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 169,
       "filename": "local_get.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 173,
       "filename": "local_get.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 181,
       "filename": "local_get.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 185,
       "filename": "local_get.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 189,
       "filename": "local_get.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 193,
       "filename": "local_get.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 201,
       "filename": "local_get.11.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 205,
       "filename": "local_get.12.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 210,
       "filename": "local_get.13.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 214,
       "filename": "local_get.14.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 219,
       "filename": "local_get.15.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 223,
       "filename": "local_get.16.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/local_init.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/local_init.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "local_init.0.wasm"
+      "filename": "local_init.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -70,34 +71,35 @@
       "type": "assert_invalid",
       "line": 26,
       "filename": "local_init.1.wasm",
-      "text": "uninitialized local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "uninitialized local"
     },
     {
       "type": "assert_invalid",
       "line": 30,
       "filename": "local_init.2.wasm",
-      "text": "uninitialized local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "uninitialized local"
     },
     {
       "type": "assert_invalid",
       "line": 40,
       "filename": "local_init.3.wasm",
-      "text": "uninitialized local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "uninitialized local"
     },
     {
       "type": "assert_invalid",
       "line": 53,
       "filename": "local_init.4.wasm",
-      "text": "uninitialized local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "uninitialized local"
     },
     {
       "type": "module",
       "line": 66,
-      "filename": "local_init.5.wasm"
+      "filename": "local_init.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/local_tee.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/local_tee.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "local_tee.0.wasm"
+      "filename": "local_tee.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1091,295 +1092,295 @@
       "type": "assert_invalid",
       "line": 371,
       "filename": "local_tee.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 375,
       "filename": "local_tee.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 379,
       "filename": "local_tee.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 384,
       "filename": "local_tee.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 388,
       "filename": "local_tee.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 392,
       "filename": "local_tee.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 396,
       "filename": "local_tee.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 404,
       "filename": "local_tee.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 408,
       "filename": "local_tee.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 412,
       "filename": "local_tee.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 417,
       "filename": "local_tee.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 421,
       "filename": "local_tee.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 425,
       "filename": "local_tee.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 429,
       "filename": "local_tee.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 434,
       "filename": "local_tee.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 442,
       "filename": "local_tee.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 451,
       "filename": "local_tee.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 460,
       "filename": "local_tee.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 469,
       "filename": "local_tee.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 478,
       "filename": "local_tee.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 487,
       "filename": "local_tee.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 496,
       "filename": "local_tee.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 505,
       "filename": "local_tee.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 513,
       "filename": "local_tee.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 521,
       "filename": "local_tee.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 530,
       "filename": "local_tee.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 546,
       "filename": "local_tee.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 554,
       "filename": "local_tee.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 562,
       "filename": "local_tee.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 571,
       "filename": "local_tee.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 580,
       "filename": "local_tee.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 589,
       "filename": "local_tee.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 599,
       "filename": "local_tee.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 603,
       "filename": "local_tee.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 607,
       "filename": "local_tee.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 613,
       "filename": "local_tee.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 630,
       "filename": "local_tee.37.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 634,
       "filename": "local_tee.38.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 639,
       "filename": "local_tee.39.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 643,
       "filename": "local_tee.40.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 648,
       "filename": "local_tee.41.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 652,
       "filename": "local_tee.42.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/memory-multi.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/memory-multi.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 5,
-      "filename": "memory-multi.0.wasm"
+      "filename": "memory-multi.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -39,7 +40,8 @@
     {
       "type": "module",
       "line": 26,
-      "filename": "memory-multi.1.wasm"
+      "filename": "memory-multi.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/memory.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/memory.wast.json
@@ -4,37 +4,44 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "memory.0.wasm"
+      "filename": "memory.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 4,
-      "filename": "memory.1.wasm"
+      "filename": "memory.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 5,
-      "filename": "memory.2.wasm"
+      "filename": "memory.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 6,
-      "filename": "memory.3.wasm"
+      "filename": "memory.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 7,
-      "filename": "memory.4.wasm"
+      "filename": "memory.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 8,
-      "filename": "memory.5.wasm"
+      "filename": "memory.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 10,
-      "filename": "memory.6.wasm"
+      "filename": "memory.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -54,7 +61,8 @@
     {
       "type": "module",
       "line": 12,
-      "filename": "memory.7.wasm"
+      "filename": "memory.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -74,7 +82,8 @@
     {
       "type": "module",
       "line": 14,
-      "filename": "memory.8.wasm"
+      "filename": "memory.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -95,139 +104,140 @@
       "type": "assert_invalid",
       "line": 17,
       "filename": "memory.9.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 18,
       "filename": "memory.10.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 19,
       "filename": "memory.11.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 22,
       "filename": "memory.12.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 26,
       "filename": "memory.13.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 30,
       "filename": "memory.14.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 34,
       "filename": "memory.15.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 38,
       "filename": "memory.16.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 42,
       "filename": "memory.17.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 48,
       "filename": "memory.18.wasm",
-      "text": "size minimum must not be greater than maximum",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "size minimum must not be greater than maximum"
     },
     {
       "type": "assert_invalid",
       "line": 52,
       "filename": "memory.19.wasm",
-      "text": "memory size must be at most 65536 pages (4GiB)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
       "type": "assert_invalid",
       "line": 56,
       "filename": "memory.20.wasm",
-      "text": "memory size must be at most 65536 pages (4GiB)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
       "type": "assert_invalid",
       "line": 60,
       "filename": "memory.21.wasm",
-      "text": "memory size must be at most 65536 pages (4GiB)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
       "type": "assert_invalid",
       "line": 64,
       "filename": "memory.22.wasm",
-      "text": "memory size must be at most 65536 pages (4GiB)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
       "type": "assert_invalid",
       "line": 68,
       "filename": "memory.23.wasm",
-      "text": "memory size must be at most 65536 pages (4GiB)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
       "type": "assert_invalid",
       "line": 72,
       "filename": "memory.24.wasm",
-      "text": "memory size must be at most 65536 pages (4GiB)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
       "type": "assert_invalid",
       "line": 77,
       "filename": "memory.25.wat",
-      "text": "memory size must be at most 65536 pages (4GiB)",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
       "type": "assert_invalid",
       "line": 81,
       "filename": "memory.26.wat",
-      "text": "memory size must be at most 65536 pages (4GiB)",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
       "type": "assert_invalid",
       "line": 85,
       "filename": "memory.27.wat",
-      "text": "memory size must be at most 65536 pages (4GiB)",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
       "type": "module",
       "line": 89,
-      "filename": "memory.28.wasm"
+      "filename": "memory.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1063,27 +1073,28 @@
       "type": "assert_malformed",
       "line": 228,
       "filename": "memory.29.wat",
-      "text": "duplicate memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate memory"
     },
     {
       "type": "assert_malformed",
       "line": 232,
       "filename": "memory.30.wat",
-      "text": "duplicate memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate memory"
     },
     {
       "type": "assert_malformed",
       "line": 236,
       "filename": "memory.31.wat",
-      "text": "duplicate memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate memory"
     },
     {
       "type": "module",
       "line": 243,
-      "filename": "memory.32.wasm"
+      "filename": "memory.32.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/memory64.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/memory64.wast.json
@@ -4,27 +4,32 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "memory64.0.wasm"
+      "filename": "memory64.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 5,
-      "filename": "memory64.1.wasm"
+      "filename": "memory64.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 6,
-      "filename": "memory64.2.wasm"
+      "filename": "memory64.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 7,
-      "filename": "memory64.3.wasm"
+      "filename": "memory64.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 9,
-      "filename": "memory64.4.wasm"
+      "filename": "memory64.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -44,7 +49,8 @@
     {
       "type": "module",
       "line": 11,
-      "filename": "memory64.5.wasm"
+      "filename": "memory64.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -64,7 +70,8 @@
     {
       "type": "module",
       "line": 13,
-      "filename": "memory64.6.wasm"
+      "filename": "memory64.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -85,76 +92,77 @@
       "type": "assert_invalid",
       "line": 16,
       "filename": "memory64.7.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 17,
       "filename": "memory64.8.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 18,
       "filename": "memory64.9.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 21,
       "filename": "memory64.10.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 25,
       "filename": "memory64.11.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 29,
       "filename": "memory64.12.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 33,
       "filename": "memory64.13.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 37,
       "filename": "memory64.14.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 41,
       "filename": "memory64.15.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 47,
       "filename": "memory64.16.wasm",
-      "text": "size minimum must not be greater than maximum",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "size minimum must not be greater than maximum"
     },
     {
       "type": "module",
       "line": 51,
-      "filename": "memory64.17.wasm"
+      "filename": "memory64.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/memory_copy.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/memory_copy.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 6,
-      "filename": "memory_copy.0.wasm"
+      "filename": "memory_copy.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -618,7 +619,8 @@
     {
       "type": "module",
       "line": 48,
-      "filename": "memory_copy.1.wasm"
+      "filename": "memory_copy.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -1232,7 +1234,8 @@
     {
       "type": "module",
       "line": 90,
-      "filename": "memory_copy.2.wasm"
+      "filename": "memory_copy.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -1846,7 +1849,8 @@
     {
       "type": "module",
       "line": 132,
-      "filename": "memory_copy.3.wasm"
+      "filename": "memory_copy.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -2460,7 +2464,8 @@
     {
       "type": "module",
       "line": 174,
-      "filename": "memory_copy.4.wasm"
+      "filename": "memory_copy.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -3074,7 +3079,8 @@
     {
       "type": "module",
       "line": 216,
-      "filename": "memory_copy.5.wasm"
+      "filename": "memory_copy.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -3688,7 +3694,8 @@
     {
       "type": "module",
       "line": 258,
-      "filename": "memory_copy.6.wasm"
+      "filename": "memory_copy.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -4302,7 +4309,8 @@
     {
       "type": "module",
       "line": 300,
-      "filename": "memory_copy.7.wasm"
+      "filename": "memory_copy.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -4916,7 +4924,8 @@
     {
       "type": "module",
       "line": 342,
-      "filename": "memory_copy.8.wasm"
+      "filename": "memory_copy.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -11924,7 +11933,8 @@
     {
       "type": "module",
       "line": 703,
-      "filename": "memory_copy.9.wasm"
+      "filename": "memory_copy.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18952,7 +18962,8 @@
     {
       "type": "module",
       "line": 1065,
-      "filename": "memory_copy.10.wasm"
+      "filename": "memory_copy.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -25960,7 +25971,8 @@
     {
       "type": "module",
       "line": 1426,
-      "filename": "memory_copy.11.wasm"
+      "filename": "memory_copy.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -32988,7 +33000,8 @@
     {
       "type": "module",
       "line": 1788,
-      "filename": "memory_copy.12.wasm"
+      "filename": "memory_copy.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -39996,7 +40009,8 @@
     {
       "type": "module",
       "line": 2149,
-      "filename": "memory_copy.13.wasm"
+      "filename": "memory_copy.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -47004,7 +47018,8 @@
     {
       "type": "module",
       "line": 2510,
-      "filename": "memory_copy.14.wasm"
+      "filename": "memory_copy.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -54012,7 +54027,8 @@
     {
       "type": "module",
       "line": 2871,
-      "filename": "memory_copy.15.wasm"
+      "filename": "memory_copy.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -61020,7 +61036,8 @@
     {
       "type": "module",
       "line": 3232,
-      "filename": "memory_copy.16.wasm"
+      "filename": "memory_copy.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -68028,7 +68045,8 @@
     {
       "type": "module",
       "line": 3593,
-      "filename": "memory_copy.17.wasm"
+      "filename": "memory_copy.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -75036,7 +75054,8 @@
     {
       "type": "module",
       "line": 3954,
-      "filename": "memory_copy.18.wasm"
+      "filename": "memory_copy.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -82045,454 +82064,455 @@
       "type": "assert_invalid",
       "line": 4316,
       "filename": "memory_copy.19.wasm",
-      "text": "unknown memory 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 0"
     },
     {
       "type": "assert_invalid",
       "line": 4322,
       "filename": "memory_copy.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4329,
       "filename": "memory_copy.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4336,
       "filename": "memory_copy.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4343,
       "filename": "memory_copy.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4350,
       "filename": "memory_copy.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4357,
       "filename": "memory_copy.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4364,
       "filename": "memory_copy.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4371,
       "filename": "memory_copy.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4378,
       "filename": "memory_copy.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4385,
       "filename": "memory_copy.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4392,
       "filename": "memory_copy.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4399,
       "filename": "memory_copy.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4406,
       "filename": "memory_copy.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4413,
       "filename": "memory_copy.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4420,
       "filename": "memory_copy.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4427,
       "filename": "memory_copy.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4434,
       "filename": "memory_copy.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4441,
       "filename": "memory_copy.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4448,
       "filename": "memory_copy.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4455,
       "filename": "memory_copy.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4462,
       "filename": "memory_copy.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4469,
       "filename": "memory_copy.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4476,
       "filename": "memory_copy.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4483,
       "filename": "memory_copy.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4490,
       "filename": "memory_copy.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4497,
       "filename": "memory_copy.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4504,
       "filename": "memory_copy.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4511,
       "filename": "memory_copy.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4518,
       "filename": "memory_copy.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4525,
       "filename": "memory_copy.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4532,
       "filename": "memory_copy.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4539,
       "filename": "memory_copy.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4546,
       "filename": "memory_copy.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4553,
       "filename": "memory_copy.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4560,
       "filename": "memory_copy.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4567,
       "filename": "memory_copy.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4574,
       "filename": "memory_copy.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4581,
       "filename": "memory_copy.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4588,
       "filename": "memory_copy.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4595,
       "filename": "memory_copy.59.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4602,
       "filename": "memory_copy.60.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4609,
       "filename": "memory_copy.61.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4616,
       "filename": "memory_copy.62.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4623,
       "filename": "memory_copy.63.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4630,
       "filename": "memory_copy.64.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4637,
       "filename": "memory_copy.65.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4644,
       "filename": "memory_copy.66.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4651,
       "filename": "memory_copy.67.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4658,
       "filename": "memory_copy.68.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4665,
       "filename": "memory_copy.69.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4672,
       "filename": "memory_copy.70.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4679,
       "filename": "memory_copy.71.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4686,
       "filename": "memory_copy.72.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4693,
       "filename": "memory_copy.73.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4700,
       "filename": "memory_copy.74.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4707,
       "filename": "memory_copy.75.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4714,
       "filename": "memory_copy.76.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4721,
       "filename": "memory_copy.77.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4728,
       "filename": "memory_copy.78.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4735,
       "filename": "memory_copy.79.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4742,
       "filename": "memory_copy.80.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4749,
       "filename": "memory_copy.81.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 4756,
       "filename": "memory_copy.82.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 4763,
-      "filename": "memory_copy.83.wasm"
+      "filename": "memory_copy.83.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -82590,7 +82610,8 @@
     {
       "type": "module",
       "line": 4789,
-      "filename": "memory_copy.84.wasm"
+      "filename": "memory_copy.84.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -82688,7 +82709,8 @@
     {
       "type": "module",
       "line": 4815,
-      "filename": "memory_copy.85.wasm"
+      "filename": "memory_copy.85.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -82703,7 +82725,8 @@
     {
       "type": "module",
       "line": 4821,
-      "filename": "memory_copy.86.wasm"
+      "filename": "memory_copy.86.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -82718,7 +82741,8 @@
     {
       "type": "module",
       "line": 4827,
-      "filename": "memory_copy.87.wasm"
+      "filename": "memory_copy.87.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -82733,7 +82757,8 @@
     {
       "type": "module",
       "line": 4833,
-      "filename": "memory_copy.88.wasm"
+      "filename": "memory_copy.88.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -82748,7 +82773,8 @@
     {
       "type": "module",
       "line": 4839,
-      "filename": "memory_copy.89.wasm"
+      "filename": "memory_copy.89.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -82818,7 +82844,8 @@
     {
       "type": "module",
       "line": 4863,
-      "filename": "memory_copy.90.wasm"
+      "filename": "memory_copy.90.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -82832,7 +82859,8 @@
     {
       "type": "module",
       "line": 4869,
-      "filename": "memory_copy.91.wasm"
+      "filename": "memory_copy.91.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -82847,7 +82875,8 @@
     {
       "type": "module",
       "line": 4875,
-      "filename": "memory_copy.92.wasm"
+      "filename": "memory_copy.92.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -82861,7 +82890,8 @@
     {
       "type": "module",
       "line": 4881,
-      "filename": "memory_copy.93.wasm"
+      "filename": "memory_copy.93.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -82876,7 +82906,8 @@
     {
       "type": "module",
       "line": 4887,
-      "filename": "memory_copy.94.wasm"
+      "filename": "memory_copy.94.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -82890,7 +82921,8 @@
     {
       "type": "module",
       "line": 4893,
-      "filename": "memory_copy.95.wasm"
+      "filename": "memory_copy.95.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -82905,7 +82937,8 @@
     {
       "type": "module",
       "line": 4899,
-      "filename": "memory_copy.96.wasm"
+      "filename": "memory_copy.96.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -89387,7 +89420,8 @@
     {
       "type": "module",
       "line": 5580,
-      "filename": "memory_copy.97.wasm"
+      "filename": "memory_copy.97.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -90001,7 +90035,8 @@
     {
       "type": "module",
       "line": 5622,
-      "filename": "memory_copy.98.wasm"
+      "filename": "memory_copy.98.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -90615,7 +90650,8 @@
     {
       "type": "module",
       "line": 5664,
-      "filename": "memory_copy.99.wasm"
+      "filename": "memory_copy.99.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -91229,7 +91265,8 @@
     {
       "type": "module",
       "line": 5706,
-      "filename": "memory_copy.100.wasm"
+      "filename": "memory_copy.100.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -91843,7 +91880,8 @@
     {
       "type": "module",
       "line": 5748,
-      "filename": "memory_copy.101.wasm"
+      "filename": "memory_copy.101.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -92457,7 +92495,8 @@
     {
       "type": "module",
       "line": 5790,
-      "filename": "memory_copy.102.wasm"
+      "filename": "memory_copy.102.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -93071,7 +93110,8 @@
     {
       "type": "module",
       "line": 5832,
-      "filename": "memory_copy.103.wasm"
+      "filename": "memory_copy.103.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -93685,7 +93725,8 @@
     {
       "type": "module",
       "line": 5874,
-      "filename": "memory_copy.104.wasm"
+      "filename": "memory_copy.104.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -94299,7 +94340,8 @@
     {
       "type": "module",
       "line": 5916,
-      "filename": "memory_copy.105.wasm"
+      "filename": "memory_copy.105.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -101307,7 +101349,8 @@
     {
       "type": "module",
       "line": 6277,
-      "filename": "memory_copy.106.wasm"
+      "filename": "memory_copy.106.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -108335,7 +108378,8 @@
     {
       "type": "module",
       "line": 6639,
-      "filename": "memory_copy.107.wasm"
+      "filename": "memory_copy.107.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -115343,7 +115387,8 @@
     {
       "type": "module",
       "line": 7000,
-      "filename": "memory_copy.108.wasm"
+      "filename": "memory_copy.108.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -122371,7 +122416,8 @@
     {
       "type": "module",
       "line": 7362,
-      "filename": "memory_copy.109.wasm"
+      "filename": "memory_copy.109.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -129379,7 +129425,8 @@
     {
       "type": "module",
       "line": 7723,
-      "filename": "memory_copy.110.wasm"
+      "filename": "memory_copy.110.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -136387,7 +136434,8 @@
     {
       "type": "module",
       "line": 8084,
-      "filename": "memory_copy.111.wasm"
+      "filename": "memory_copy.111.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -143395,7 +143443,8 @@
     {
       "type": "module",
       "line": 8445,
-      "filename": "memory_copy.112.wasm"
+      "filename": "memory_copy.112.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -150403,7 +150452,8 @@
     {
       "type": "module",
       "line": 8806,
-      "filename": "memory_copy.113.wasm"
+      "filename": "memory_copy.113.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -157411,7 +157461,8 @@
     {
       "type": "module",
       "line": 9167,
-      "filename": "memory_copy.114.wasm"
+      "filename": "memory_copy.114.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -164419,7 +164470,8 @@
     {
       "type": "module",
       "line": 9528,
-      "filename": "memory_copy.115.wasm"
+      "filename": "memory_copy.115.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -171428,454 +171480,455 @@
       "type": "assert_invalid",
       "line": 9890,
       "filename": "memory_copy.116.wasm",
-      "text": "unknown memory 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 0"
     },
     {
       "type": "assert_invalid",
       "line": 9896,
       "filename": "memory_copy.117.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 9903,
       "filename": "memory_copy.118.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 9910,
       "filename": "memory_copy.119.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 9917,
       "filename": "memory_copy.120.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 9924,
       "filename": "memory_copy.121.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 9931,
       "filename": "memory_copy.122.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 9938,
       "filename": "memory_copy.123.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 9945,
       "filename": "memory_copy.124.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 9952,
       "filename": "memory_copy.125.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 9959,
       "filename": "memory_copy.126.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 9966,
       "filename": "memory_copy.127.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 9973,
       "filename": "memory_copy.128.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 9980,
       "filename": "memory_copy.129.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 9987,
       "filename": "memory_copy.130.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 9994,
       "filename": "memory_copy.131.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10001,
       "filename": "memory_copy.132.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10008,
       "filename": "memory_copy.133.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10015,
       "filename": "memory_copy.134.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10022,
       "filename": "memory_copy.135.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10029,
       "filename": "memory_copy.136.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10036,
       "filename": "memory_copy.137.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10043,
       "filename": "memory_copy.138.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10050,
       "filename": "memory_copy.139.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10057,
       "filename": "memory_copy.140.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10064,
       "filename": "memory_copy.141.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10071,
       "filename": "memory_copy.142.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10078,
       "filename": "memory_copy.143.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10085,
       "filename": "memory_copy.144.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10092,
       "filename": "memory_copy.145.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10099,
       "filename": "memory_copy.146.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10106,
       "filename": "memory_copy.147.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10113,
       "filename": "memory_copy.148.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10120,
       "filename": "memory_copy.149.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10127,
       "filename": "memory_copy.150.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10134,
       "filename": "memory_copy.151.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10141,
       "filename": "memory_copy.152.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10148,
       "filename": "memory_copy.153.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10155,
       "filename": "memory_copy.154.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10162,
       "filename": "memory_copy.155.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10169,
       "filename": "memory_copy.156.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10176,
       "filename": "memory_copy.157.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10183,
       "filename": "memory_copy.158.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10190,
       "filename": "memory_copy.159.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10197,
       "filename": "memory_copy.160.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10204,
       "filename": "memory_copy.161.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10211,
       "filename": "memory_copy.162.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10218,
       "filename": "memory_copy.163.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10225,
       "filename": "memory_copy.164.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10232,
       "filename": "memory_copy.165.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10239,
       "filename": "memory_copy.166.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10246,
       "filename": "memory_copy.167.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10253,
       "filename": "memory_copy.168.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10260,
       "filename": "memory_copy.169.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10267,
       "filename": "memory_copy.170.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10274,
       "filename": "memory_copy.171.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10281,
       "filename": "memory_copy.172.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10288,
       "filename": "memory_copy.173.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10295,
       "filename": "memory_copy.174.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10302,
       "filename": "memory_copy.175.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10309,
       "filename": "memory_copy.176.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10316,
       "filename": "memory_copy.177.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10323,
       "filename": "memory_copy.178.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 10330,
       "filename": "memory_copy.179.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 10337,
-      "filename": "memory_copy.180.wasm"
+      "filename": "memory_copy.180.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -171973,7 +172026,8 @@
     {
       "type": "module",
       "line": 10363,
-      "filename": "memory_copy.181.wasm"
+      "filename": "memory_copy.181.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -172071,7 +172125,8 @@
     {
       "type": "module",
       "line": 10389,
-      "filename": "memory_copy.182.wasm"
+      "filename": "memory_copy.182.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -172086,7 +172141,8 @@
     {
       "type": "module",
       "line": 10395,
-      "filename": "memory_copy.183.wasm"
+      "filename": "memory_copy.183.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -172101,7 +172157,8 @@
     {
       "type": "module",
       "line": 10401,
-      "filename": "memory_copy.184.wasm"
+      "filename": "memory_copy.184.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -172116,7 +172173,8 @@
     {
       "type": "module",
       "line": 10407,
-      "filename": "memory_copy.185.wasm"
+      "filename": "memory_copy.185.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -172131,7 +172189,8 @@
     {
       "type": "module",
       "line": 10413,
-      "filename": "memory_copy.186.wasm"
+      "filename": "memory_copy.186.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -172201,7 +172260,8 @@
     {
       "type": "module",
       "line": 10437,
-      "filename": "memory_copy.187.wasm"
+      "filename": "memory_copy.187.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -172215,7 +172275,8 @@
     {
       "type": "module",
       "line": 10443,
-      "filename": "memory_copy.188.wasm"
+      "filename": "memory_copy.188.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -172230,7 +172291,8 @@
     {
       "type": "module",
       "line": 10449,
-      "filename": "memory_copy.189.wasm"
+      "filename": "memory_copy.189.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -172244,7 +172306,8 @@
     {
       "type": "module",
       "line": 10455,
-      "filename": "memory_copy.190.wasm"
+      "filename": "memory_copy.190.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -172259,7 +172322,8 @@
     {
       "type": "module",
       "line": 10461,
-      "filename": "memory_copy.191.wasm"
+      "filename": "memory_copy.191.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -172273,7 +172337,8 @@
     {
       "type": "module",
       "line": 10467,
-      "filename": "memory_copy.192.wasm"
+      "filename": "memory_copy.192.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -172288,7 +172353,8 @@
     {
       "type": "module",
       "line": 10473,
-      "filename": "memory_copy.193.wasm"
+      "filename": "memory_copy.193.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",

--- a/tests/snapshots/testsuite/proposals/memory64/memory_copy0.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/memory_copy0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 2,
-      "filename": "memory_copy0.0.wasm"
+      "filename": "memory_copy0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",

--- a/tests/snapshots/testsuite/proposals/memory64/memory_copy1.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/memory_copy1.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 2,
-      "filename": "memory_copy1.0.wasm"
+      "filename": "memory_copy1.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",

--- a/tests/snapshots/testsuite/proposals/memory64/memory_fill.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/memory_fill.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 6,
-      "filename": "memory_fill.0.wasm"
+      "filename": "memory_fill.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -74,7 +75,8 @@
     {
       "type": "module",
       "line": 28,
-      "filename": "memory_fill.1.wasm"
+      "filename": "memory_fill.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -89,7 +91,8 @@
     {
       "type": "module",
       "line": 46,
-      "filename": "memory_fill.2.wasm"
+      "filename": "memory_fill.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -104,7 +107,8 @@
     {
       "type": "module",
       "line": 64,
-      "filename": "memory_fill.3.wasm"
+      "filename": "memory_fill.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -146,7 +150,8 @@
     {
       "type": "module",
       "line": 84,
-      "filename": "memory_fill.4.wasm"
+      "filename": "memory_fill.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -160,7 +165,8 @@
     {
       "type": "module",
       "line": 102,
-      "filename": "memory_fill.5.wasm"
+      "filename": "memory_fill.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -175,7 +181,8 @@
     {
       "type": "module",
       "line": 120,
-      "filename": "memory_fill.6.wasm"
+      "filename": "memory_fill.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -273,7 +280,8 @@
     {
       "type": "module",
       "line": 145,
-      "filename": "memory_fill.7.wasm"
+      "filename": "memory_fill.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -428,454 +436,455 @@
       "type": "assert_invalid",
       "line": 175,
       "filename": "memory_fill.8.wasm",
-      "text": "unknown memory 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 0"
     },
     {
       "type": "assert_invalid",
       "line": 181,
       "filename": "memory_fill.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 188,
       "filename": "memory_fill.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 195,
       "filename": "memory_fill.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 202,
       "filename": "memory_fill.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 209,
       "filename": "memory_fill.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 216,
       "filename": "memory_fill.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 223,
       "filename": "memory_fill.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 230,
       "filename": "memory_fill.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 237,
       "filename": "memory_fill.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 244,
       "filename": "memory_fill.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 251,
       "filename": "memory_fill.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 258,
       "filename": "memory_fill.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 265,
       "filename": "memory_fill.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 272,
       "filename": "memory_fill.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 279,
       "filename": "memory_fill.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 286,
       "filename": "memory_fill.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 293,
       "filename": "memory_fill.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 300,
       "filename": "memory_fill.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 307,
       "filename": "memory_fill.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 314,
       "filename": "memory_fill.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 321,
       "filename": "memory_fill.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 328,
       "filename": "memory_fill.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 335,
       "filename": "memory_fill.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 342,
       "filename": "memory_fill.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 349,
       "filename": "memory_fill.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 356,
       "filename": "memory_fill.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 363,
       "filename": "memory_fill.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 370,
       "filename": "memory_fill.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 377,
       "filename": "memory_fill.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 384,
       "filename": "memory_fill.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 391,
       "filename": "memory_fill.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 398,
       "filename": "memory_fill.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 405,
       "filename": "memory_fill.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 412,
       "filename": "memory_fill.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 419,
       "filename": "memory_fill.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 426,
       "filename": "memory_fill.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 433,
       "filename": "memory_fill.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 440,
       "filename": "memory_fill.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 447,
       "filename": "memory_fill.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 454,
       "filename": "memory_fill.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 461,
       "filename": "memory_fill.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 468,
       "filename": "memory_fill.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 475,
       "filename": "memory_fill.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 482,
       "filename": "memory_fill.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 489,
       "filename": "memory_fill.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 496,
       "filename": "memory_fill.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 503,
       "filename": "memory_fill.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 510,
       "filename": "memory_fill.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 517,
       "filename": "memory_fill.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 524,
       "filename": "memory_fill.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 531,
       "filename": "memory_fill.59.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 538,
       "filename": "memory_fill.60.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 545,
       "filename": "memory_fill.61.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 552,
       "filename": "memory_fill.62.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 559,
       "filename": "memory_fill.63.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 566,
       "filename": "memory_fill.64.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 573,
       "filename": "memory_fill.65.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 580,
       "filename": "memory_fill.66.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 587,
       "filename": "memory_fill.67.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 594,
       "filename": "memory_fill.68.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 601,
       "filename": "memory_fill.69.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 608,
       "filename": "memory_fill.70.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 615,
       "filename": "memory_fill.71.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 621,
-      "filename": "memory_fill.72.wasm"
+      "filename": "memory_fill.72.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -931,7 +940,8 @@
     {
       "type": "module",
       "line": 643,
-      "filename": "memory_fill.73.wasm"
+      "filename": "memory_fill.73.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -987,7 +997,8 @@
     {
       "type": "module",
       "line": 665,
-      "filename": "memory_fill.74.wasm"
+      "filename": "memory_fill.74.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -1043,7 +1054,8 @@
     {
       "type": "module",
       "line": 688,
-      "filename": "memory_fill.75.wasm"
+      "filename": "memory_fill.75.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -1113,7 +1125,8 @@
     {
       "type": "module",
       "line": 710,
-      "filename": "memory_fill.76.wasm"
+      "filename": "memory_fill.76.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -1128,7 +1141,8 @@
     {
       "type": "module",
       "line": 728,
-      "filename": "memory_fill.77.wasm"
+      "filename": "memory_fill.77.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -1143,7 +1157,8 @@
     {
       "type": "module",
       "line": 746,
-      "filename": "memory_fill.78.wasm"
+      "filename": "memory_fill.78.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -1185,7 +1200,8 @@
     {
       "type": "module",
       "line": 766,
-      "filename": "memory_fill.79.wasm"
+      "filename": "memory_fill.79.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -1199,7 +1215,8 @@
     {
       "type": "module",
       "line": 784,
-      "filename": "memory_fill.80.wasm"
+      "filename": "memory_fill.80.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -1214,7 +1231,8 @@
     {
       "type": "module",
       "line": 802,
-      "filename": "memory_fill.81.wasm"
+      "filename": "memory_fill.81.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -1312,7 +1330,8 @@
     {
       "type": "module",
       "line": 827,
-      "filename": "memory_fill.82.wasm"
+      "filename": "memory_fill.82.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -1467,454 +1486,455 @@
       "type": "assert_invalid",
       "line": 857,
       "filename": "memory_fill.83.wasm",
-      "text": "unknown memory 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 0"
     },
     {
       "type": "assert_invalid",
       "line": 863,
       "filename": "memory_fill.84.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 870,
       "filename": "memory_fill.85.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 877,
       "filename": "memory_fill.86.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 884,
       "filename": "memory_fill.87.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 891,
       "filename": "memory_fill.88.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 898,
       "filename": "memory_fill.89.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 905,
       "filename": "memory_fill.90.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 912,
       "filename": "memory_fill.91.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 919,
       "filename": "memory_fill.92.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 926,
       "filename": "memory_fill.93.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 933,
       "filename": "memory_fill.94.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 940,
       "filename": "memory_fill.95.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 947,
       "filename": "memory_fill.96.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 954,
       "filename": "memory_fill.97.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 961,
       "filename": "memory_fill.98.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 968,
       "filename": "memory_fill.99.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 975,
       "filename": "memory_fill.100.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 982,
       "filename": "memory_fill.101.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 989,
       "filename": "memory_fill.102.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 996,
       "filename": "memory_fill.103.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1003,
       "filename": "memory_fill.104.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1010,
       "filename": "memory_fill.105.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1017,
       "filename": "memory_fill.106.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1024,
       "filename": "memory_fill.107.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1031,
       "filename": "memory_fill.108.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1038,
       "filename": "memory_fill.109.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1045,
       "filename": "memory_fill.110.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1052,
       "filename": "memory_fill.111.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1059,
       "filename": "memory_fill.112.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1066,
       "filename": "memory_fill.113.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1073,
       "filename": "memory_fill.114.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1080,
       "filename": "memory_fill.115.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1087,
       "filename": "memory_fill.116.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1094,
       "filename": "memory_fill.117.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1101,
       "filename": "memory_fill.118.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1108,
       "filename": "memory_fill.119.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1115,
       "filename": "memory_fill.120.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1122,
       "filename": "memory_fill.121.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1129,
       "filename": "memory_fill.122.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1136,
       "filename": "memory_fill.123.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1143,
       "filename": "memory_fill.124.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1150,
       "filename": "memory_fill.125.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1157,
       "filename": "memory_fill.126.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1164,
       "filename": "memory_fill.127.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1171,
       "filename": "memory_fill.128.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1178,
       "filename": "memory_fill.129.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1185,
       "filename": "memory_fill.130.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1192,
       "filename": "memory_fill.131.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1199,
       "filename": "memory_fill.132.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1206,
       "filename": "memory_fill.133.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1213,
       "filename": "memory_fill.134.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1220,
       "filename": "memory_fill.135.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1227,
       "filename": "memory_fill.136.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1234,
       "filename": "memory_fill.137.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1241,
       "filename": "memory_fill.138.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1248,
       "filename": "memory_fill.139.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1255,
       "filename": "memory_fill.140.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1262,
       "filename": "memory_fill.141.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1269,
       "filename": "memory_fill.142.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1276,
       "filename": "memory_fill.143.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1283,
       "filename": "memory_fill.144.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1290,
       "filename": "memory_fill.145.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1297,
       "filename": "memory_fill.146.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 1303,
-      "filename": "memory_fill.147.wasm"
+      "filename": "memory_fill.147.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -1970,7 +1990,8 @@
     {
       "type": "module",
       "line": 1325,
-      "filename": "memory_fill.148.wasm"
+      "filename": "memory_fill.148.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -2026,7 +2047,8 @@
     {
       "type": "module",
       "line": 1347,
-      "filename": "memory_fill.149.wasm"
+      "filename": "memory_fill.149.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",

--- a/tests/snapshots/testsuite/proposals/memory64/memory_fill0.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/memory_fill0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 2,
-      "filename": "memory_fill0.0.wasm"
+      "filename": "memory_fill0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",

--- a/tests/snapshots/testsuite/proposals/memory64/memory_grow.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/memory_grow.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "memory_grow.0.wasm"
+      "filename": "memory_grow.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -169,7 +170,8 @@
     {
       "type": "module",
       "line": 15,
-      "filename": "memory_grow.1.wasm"
+      "filename": "memory_grow.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -334,7 +336,8 @@
     {
       "type": "module",
       "line": 32,
-      "filename": "memory_grow.2.wasm"
+      "filename": "memory_grow.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -583,7 +586,8 @@
     {
       "type": "module",
       "line": 68,
-      "filename": "memory_grow.3.wasm"
+      "filename": "memory_grow.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -853,7 +857,8 @@
     {
       "type": "module",
       "line": 109,
-      "filename": "memory_grow.4.wasm"
+      "filename": "memory_grow.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -863,7 +868,8 @@
     {
       "type": "module",
       "line": 115,
-      "filename": "memory_grow.5.wasm"
+      "filename": "memory_grow.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1508,7 +1514,8 @@
     {
       "type": "module",
       "line": 191,
-      "filename": "memory_grow.6.wasm"
+      "filename": "memory_grow.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2041,7 +2048,8 @@
     {
       "type": "module",
       "line": 404,
-      "filename": "memory_grow.7.wasm"
+      "filename": "memory_grow.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2177,64 +2185,64 @@
       "type": "assert_invalid",
       "line": 431,
       "filename": "memory_grow.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 440,
       "filename": "memory_grow.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 449,
       "filename": "memory_grow.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 459,
       "filename": "memory_grow.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 469,
       "filename": "memory_grow.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 480,
       "filename": "memory_grow.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 489,
       "filename": "memory_grow.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 499,
       "filename": "memory_grow.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 508,
       "filename": "memory_grow.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/memory_grow64.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/memory_grow64.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "memory_grow64.0.wasm"
+      "filename": "memory_grow64.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -274,7 +275,8 @@
     {
       "type": "module",
       "line": 36,
-      "filename": "memory_grow64.1.wasm"
+      "filename": "memory_grow64.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -399,7 +401,8 @@
     {
       "type": "module",
       "line": 48,
-      "filename": "memory_grow64.2.wasm"
+      "filename": "memory_grow64.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -564,7 +567,8 @@
     {
       "type": "module",
       "line": 64,
-      "filename": "memory_grow64.3.wasm"
+      "filename": "memory_grow64.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/memory_init.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/memory_init.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 6,
-      "filename": "memory_init.0.wasm"
+      "filename": "memory_init.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -618,7 +619,8 @@
     {
       "type": "module",
       "line": 50,
-      "filename": "memory_init.1.wasm"
+      "filename": "memory_init.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -1232,7 +1234,8 @@
     {
       "type": "module",
       "line": 94,
-      "filename": "memory_init.2.wasm"
+      "filename": "memory_init.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -1846,7 +1849,8 @@
     {
       "type": "module",
       "line": 138,
-      "filename": "memory_init.3.wasm"
+      "filename": "memory_init.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -2461,20 +2465,21 @@
       "type": "assert_invalid",
       "line": 190,
       "filename": "memory_init.4.wasm",
-      "text": "unknown data segment",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown data segment"
     },
     {
       "type": "assert_invalid",
       "line": 196,
       "filename": "memory_init.5.wasm",
-      "text": "unknown data segment",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown data segment"
     },
     {
       "type": "module",
       "line": 203,
-      "filename": "memory_init.6.wasm"
+      "filename": "memory_init.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -2488,7 +2493,8 @@
     {
       "type": "module",
       "line": 211,
-      "filename": "memory_init.7.wasm"
+      "filename": "memory_init.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -2503,7 +2509,8 @@
     {
       "type": "module",
       "line": 219,
-      "filename": "memory_init.8.wasm"
+      "filename": "memory_init.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -2519,20 +2526,21 @@
       "type": "assert_invalid",
       "line": 227,
       "filename": "memory_init.9.wasm",
-      "text": "unknown memory 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 0"
     },
     {
       "type": "assert_invalid",
       "line": 233,
       "filename": "memory_init.10.wasm",
-      "text": "unknown data segment 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown data segment 1"
     },
     {
       "type": "module",
       "line": 240,
-      "filename": "memory_init.11.wasm"
+      "filename": "memory_init.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -2546,7 +2554,8 @@
     {
       "type": "module",
       "line": 248,
-      "filename": "memory_init.12.wasm"
+      "filename": "memory_init.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -2561,7 +2570,8 @@
     {
       "type": "module",
       "line": 255,
-      "filename": "memory_init.13.wasm"
+      "filename": "memory_init.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -2576,7 +2586,8 @@
     {
       "type": "module",
       "line": 262,
-      "filename": "memory_init.14.wasm"
+      "filename": "memory_init.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -2591,7 +2602,8 @@
     {
       "type": "module",
       "line": 269,
-      "filename": "memory_init.15.wasm"
+      "filename": "memory_init.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -2606,7 +2618,8 @@
     {
       "type": "module",
       "line": 276,
-      "filename": "memory_init.16.wasm"
+      "filename": "memory_init.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -2620,7 +2633,8 @@
     {
       "type": "module",
       "line": 283,
-      "filename": "memory_init.17.wasm"
+      "filename": "memory_init.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -2635,7 +2649,8 @@
     {
       "type": "module",
       "line": 290,
-      "filename": "memory_init.18.wasm"
+      "filename": "memory_init.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -2649,7 +2664,8 @@
     {
       "type": "module",
       "line": 297,
-      "filename": "memory_init.19.wasm"
+      "filename": "memory_init.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -2663,7 +2679,8 @@
     {
       "type": "module",
       "line": 304,
-      "filename": "memory_init.20.wasm"
+      "filename": "memory_init.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -2679,447 +2696,448 @@
       "type": "assert_invalid",
       "line": 312,
       "filename": "memory_init.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 320,
       "filename": "memory_init.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 328,
       "filename": "memory_init.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 336,
       "filename": "memory_init.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 344,
       "filename": "memory_init.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 352,
       "filename": "memory_init.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 360,
       "filename": "memory_init.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 368,
       "filename": "memory_init.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 376,
       "filename": "memory_init.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 384,
       "filename": "memory_init.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 392,
       "filename": "memory_init.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 400,
       "filename": "memory_init.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 408,
       "filename": "memory_init.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 416,
       "filename": "memory_init.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 424,
       "filename": "memory_init.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 432,
       "filename": "memory_init.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 440,
       "filename": "memory_init.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 448,
       "filename": "memory_init.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 456,
       "filename": "memory_init.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 464,
       "filename": "memory_init.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 472,
       "filename": "memory_init.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 480,
       "filename": "memory_init.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 488,
       "filename": "memory_init.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 496,
       "filename": "memory_init.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 504,
       "filename": "memory_init.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 512,
       "filename": "memory_init.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 520,
       "filename": "memory_init.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 528,
       "filename": "memory_init.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 536,
       "filename": "memory_init.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 544,
       "filename": "memory_init.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 552,
       "filename": "memory_init.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 560,
       "filename": "memory_init.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 568,
       "filename": "memory_init.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 576,
       "filename": "memory_init.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 584,
       "filename": "memory_init.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 592,
       "filename": "memory_init.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 600,
       "filename": "memory_init.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 608,
       "filename": "memory_init.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 616,
       "filename": "memory_init.59.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 624,
       "filename": "memory_init.60.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 632,
       "filename": "memory_init.61.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 640,
       "filename": "memory_init.62.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 648,
       "filename": "memory_init.63.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 656,
       "filename": "memory_init.64.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 664,
       "filename": "memory_init.65.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 672,
       "filename": "memory_init.66.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 680,
       "filename": "memory_init.67.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 688,
       "filename": "memory_init.68.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 696,
       "filename": "memory_init.69.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 704,
       "filename": "memory_init.70.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 712,
       "filename": "memory_init.71.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 720,
       "filename": "memory_init.72.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 728,
       "filename": "memory_init.73.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 736,
       "filename": "memory_init.74.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 744,
       "filename": "memory_init.75.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 752,
       "filename": "memory_init.76.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 760,
       "filename": "memory_init.77.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 768,
       "filename": "memory_init.78.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 776,
       "filename": "memory_init.79.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 784,
       "filename": "memory_init.80.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 792,
       "filename": "memory_init.81.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 800,
       "filename": "memory_init.82.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 808,
       "filename": "memory_init.83.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 815,
-      "filename": "memory_init.84.wasm"
+      "filename": "memory_init.84.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -3171,7 +3189,8 @@
     {
       "type": "module",
       "line": 838,
-      "filename": "memory_init.85.wasm"
+      "filename": "memory_init.85.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -3223,7 +3242,8 @@
     {
       "type": "module",
       "line": 861,
-      "filename": "memory_init.86.wasm"
+      "filename": "memory_init.86.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -3275,7 +3295,8 @@
     {
       "type": "module",
       "line": 884,
-      "filename": "memory_init.87.wasm"
+      "filename": "memory_init.87.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -3327,7 +3348,8 @@
     {
       "type": "module",
       "line": 907,
-      "filename": "memory_init.88.wasm"
+      "filename": "memory_init.88.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -3379,7 +3401,8 @@
     {
       "type": "module",
       "line": 930,
-      "filename": "memory_init.89.wasm"
+      "filename": "memory_init.89.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -3431,12 +3454,14 @@
     {
       "type": "module",
       "line": 954,
-      "filename": "memory_init.90.wasm"
+      "filename": "memory_init.90.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 969,
-      "filename": "memory_init.91.wasm"
+      "filename": "memory_init.91.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -4050,7 +4075,8 @@
     {
       "type": "module",
       "line": 1013,
-      "filename": "memory_init.92.wasm"
+      "filename": "memory_init.92.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -4664,7 +4690,8 @@
     {
       "type": "module",
       "line": 1057,
-      "filename": "memory_init.93.wasm"
+      "filename": "memory_init.93.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -5278,7 +5305,8 @@
     {
       "type": "module",
       "line": 1101,
-      "filename": "memory_init.94.wasm"
+      "filename": "memory_init.94.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -5893,20 +5921,21 @@
       "type": "assert_invalid",
       "line": 1153,
       "filename": "memory_init.95.wasm",
-      "text": "unknown data segment",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown data segment"
     },
     {
       "type": "assert_invalid",
       "line": 1159,
       "filename": "memory_init.96.wasm",
-      "text": "unknown data segment",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown data segment"
     },
     {
       "type": "module",
       "line": 1166,
-      "filename": "memory_init.97.wasm"
+      "filename": "memory_init.97.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -5920,7 +5949,8 @@
     {
       "type": "module",
       "line": 1174,
-      "filename": "memory_init.98.wasm"
+      "filename": "memory_init.98.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -5935,7 +5965,8 @@
     {
       "type": "module",
       "line": 1182,
-      "filename": "memory_init.99.wasm"
+      "filename": "memory_init.99.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -5951,20 +5982,21 @@
       "type": "assert_invalid",
       "line": 1190,
       "filename": "memory_init.100.wasm",
-      "text": "unknown memory 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 0"
     },
     {
       "type": "assert_invalid",
       "line": 1196,
       "filename": "memory_init.101.wasm",
-      "text": "unknown data segment 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown data segment 1"
     },
     {
       "type": "module",
       "line": 1203,
-      "filename": "memory_init.102.wasm"
+      "filename": "memory_init.102.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -5978,7 +6010,8 @@
     {
       "type": "module",
       "line": 1211,
-      "filename": "memory_init.103.wasm"
+      "filename": "memory_init.103.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -5993,7 +6026,8 @@
     {
       "type": "module",
       "line": 1218,
-      "filename": "memory_init.104.wasm"
+      "filename": "memory_init.104.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -6008,7 +6042,8 @@
     {
       "type": "module",
       "line": 1225,
-      "filename": "memory_init.105.wasm"
+      "filename": "memory_init.105.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -6023,7 +6058,8 @@
     {
       "type": "module",
       "line": 1232,
-      "filename": "memory_init.106.wasm"
+      "filename": "memory_init.106.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -6038,7 +6074,8 @@
     {
       "type": "module",
       "line": 1239,
-      "filename": "memory_init.107.wasm"
+      "filename": "memory_init.107.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -6052,7 +6089,8 @@
     {
       "type": "module",
       "line": 1246,
-      "filename": "memory_init.108.wasm"
+      "filename": "memory_init.108.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -6067,7 +6105,8 @@
     {
       "type": "module",
       "line": 1253,
-      "filename": "memory_init.109.wasm"
+      "filename": "memory_init.109.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -6081,7 +6120,8 @@
     {
       "type": "module",
       "line": 1260,
-      "filename": "memory_init.110.wasm"
+      "filename": "memory_init.110.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -6095,7 +6135,8 @@
     {
       "type": "module",
       "line": 1267,
-      "filename": "memory_init.111.wasm"
+      "filename": "memory_init.111.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -6111,447 +6152,448 @@
       "type": "assert_invalid",
       "line": 1275,
       "filename": "memory_init.112.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1283,
       "filename": "memory_init.113.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1291,
       "filename": "memory_init.114.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1299,
       "filename": "memory_init.115.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1307,
       "filename": "memory_init.116.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1315,
       "filename": "memory_init.117.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1323,
       "filename": "memory_init.118.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1331,
       "filename": "memory_init.119.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1339,
       "filename": "memory_init.120.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1347,
       "filename": "memory_init.121.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1355,
       "filename": "memory_init.122.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1363,
       "filename": "memory_init.123.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1371,
       "filename": "memory_init.124.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1379,
       "filename": "memory_init.125.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1387,
       "filename": "memory_init.126.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1395,
       "filename": "memory_init.127.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1403,
       "filename": "memory_init.128.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1411,
       "filename": "memory_init.129.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1419,
       "filename": "memory_init.130.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1427,
       "filename": "memory_init.131.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1435,
       "filename": "memory_init.132.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1443,
       "filename": "memory_init.133.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1451,
       "filename": "memory_init.134.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1459,
       "filename": "memory_init.135.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1467,
       "filename": "memory_init.136.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1475,
       "filename": "memory_init.137.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1483,
       "filename": "memory_init.138.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1491,
       "filename": "memory_init.139.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1499,
       "filename": "memory_init.140.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1507,
       "filename": "memory_init.141.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1515,
       "filename": "memory_init.142.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1523,
       "filename": "memory_init.143.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1531,
       "filename": "memory_init.144.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1539,
       "filename": "memory_init.145.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1547,
       "filename": "memory_init.146.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1555,
       "filename": "memory_init.147.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1563,
       "filename": "memory_init.148.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1571,
       "filename": "memory_init.149.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1579,
       "filename": "memory_init.150.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1587,
       "filename": "memory_init.151.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1595,
       "filename": "memory_init.152.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1603,
       "filename": "memory_init.153.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1611,
       "filename": "memory_init.154.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1619,
       "filename": "memory_init.155.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1627,
       "filename": "memory_init.156.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1635,
       "filename": "memory_init.157.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1643,
       "filename": "memory_init.158.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1651,
       "filename": "memory_init.159.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1659,
       "filename": "memory_init.160.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1667,
       "filename": "memory_init.161.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1675,
       "filename": "memory_init.162.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1683,
       "filename": "memory_init.163.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1691,
       "filename": "memory_init.164.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1699,
       "filename": "memory_init.165.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1707,
       "filename": "memory_init.166.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1715,
       "filename": "memory_init.167.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1723,
       "filename": "memory_init.168.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1731,
       "filename": "memory_init.169.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1739,
       "filename": "memory_init.170.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1747,
       "filename": "memory_init.171.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1755,
       "filename": "memory_init.172.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1763,
       "filename": "memory_init.173.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1771,
       "filename": "memory_init.174.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 1778,
-      "filename": "memory_init.175.wasm"
+      "filename": "memory_init.175.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -6603,7 +6645,8 @@
     {
       "type": "module",
       "line": 1801,
-      "filename": "memory_init.176.wasm"
+      "filename": "memory_init.176.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -6655,7 +6698,8 @@
     {
       "type": "module",
       "line": 1824,
-      "filename": "memory_init.177.wasm"
+      "filename": "memory_init.177.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -6707,7 +6751,8 @@
     {
       "type": "module",
       "line": 1847,
-      "filename": "memory_init.178.wasm"
+      "filename": "memory_init.178.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -6759,7 +6804,8 @@
     {
       "type": "module",
       "line": 1870,
-      "filename": "memory_init.179.wasm"
+      "filename": "memory_init.179.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -6811,7 +6857,8 @@
     {
       "type": "module",
       "line": 1893,
-      "filename": "memory_init.180.wasm"
+      "filename": "memory_init.180.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -6863,7 +6910,8 @@
     {
       "type": "module",
       "line": 1917,
-      "filename": "memory_init.181.wasm"
+      "filename": "memory_init.181.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/memory_init0.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/memory_init0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 2,
-      "filename": "memory_init0.0.wasm"
+      "filename": "memory_init0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",

--- a/tests/snapshots/testsuite/proposals/memory64/memory_redundancy64.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/memory_redundancy64.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 5,
-      "filename": "memory_redundancy64.0.wasm"
+      "filename": "memory_redundancy64.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/memory_size.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/memory_size.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "memory_size.0.wasm"
+      "filename": "memory_size.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -114,7 +115,8 @@
     {
       "type": "module",
       "line": 15,
-      "filename": "memory_size.1.wasm"
+      "filename": "memory_size.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -224,7 +226,8 @@
     {
       "type": "module",
       "line": 29,
-      "filename": "memory_size.2.wasm"
+      "filename": "memory_size.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -394,7 +397,8 @@
     {
       "type": "module",
       "line": 47,
-      "filename": "memory_size.3.wasm"
+      "filename": "memory_size.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -564,7 +568,8 @@
     {
       "type": "module",
       "line": 68,
-      "filename": "memory_size.4.wasm"
+      "filename": "memory_size.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -574,7 +579,8 @@
     {
       "type": "module",
       "line": 74,
-      "filename": "memory_size.5.wasm"
+      "filename": "memory_size.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -640,15 +646,15 @@
       "type": "assert_invalid",
       "line": 95,
       "filename": "memory_size.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 104,
       "filename": "memory_size.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/memory_size0.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/memory_size0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "memory_size0.0.wasm"
+      "filename": "memory_size0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/memory_size1.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/memory_size1.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "memory_size1.0.wasm"
+      "filename": "memory_size1.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/memory_size2.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/memory_size2.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "memory_size2.0.wasm"
+      "filename": "memory_size2.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/memory_size3.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/memory_size3.wast.json
@@ -5,15 +5,15 @@
       "type": "assert_invalid",
       "line": 4,
       "filename": "memory_size3.0.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 15,
       "filename": "memory_size3.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/memory_trap0.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/memory_trap0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "memory_trap0.0.wasm"
+      "filename": "memory_trap0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/memory_trap1.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/memory_trap1.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "memory_trap1.0.wasm"
+      "filename": "memory_trap1.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",

--- a/tests/snapshots/testsuite/proposals/memory64/memory_trap64.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/memory_trap64.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "memory_trap64.0.wasm"
+      "filename": "memory_trap64.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -218,7 +219,8 @@
     {
       "type": "module",
       "line": 34,
-      "filename": "memory_trap64.1.wasm"
+      "filename": "memory_trap64.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",

--- a/tests/snapshots/testsuite/proposals/memory64/ref.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/ref.wast.json
@@ -4,91 +4,92 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "ref.0.wasm"
+      "filename": "ref.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 28,
       "filename": "ref.1.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 32,
       "filename": "ref.2.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 37,
       "filename": "ref.3.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 42,
       "filename": "ref.4.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 47,
       "filename": "ref.5.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 52,
       "filename": "ref.6.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 56,
       "filename": "ref.7.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 60,
       "filename": "ref.8.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 65,
       "filename": "ref.9.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 69,
       "filename": "ref.10.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 73,
       "filename": "ref.11.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 78,
       "filename": "ref.12.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/ref_as_non_null.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/ref_as_non_null.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "ref_as_non_null.0.wasm"
+      "filename": "ref_as_non_null.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -60,13 +61,14 @@
       "type": "assert_invalid",
       "line": 32,
       "filename": "ref_as_non_null.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 41,
-      "filename": "ref_as_non_null.2.wasm"
+      "filename": "ref_as_non_null.2.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/ref_cast.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/ref_cast.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "ref_cast.0.wasm"
+      "filename": "ref_cast.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -623,7 +624,8 @@
     {
       "type": "module",
       "line": 99,
-      "filename": "ref_cast.1.wasm"
+      "filename": "ref_cast.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",

--- a/tests/snapshots/testsuite/proposals/memory64/ref_eq.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/ref_eq.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "ref_eq.0.wasm"
+      "filename": "ref_eq.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -1963,43 +1964,43 @@
       "type": "assert_invalid",
       "line": 122,
       "filename": "ref_eq.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 130,
       "filename": "ref_eq.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 138,
       "filename": "ref_eq.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 146,
       "filename": "ref_eq.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 154,
       "filename": "ref_eq.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 162,
       "filename": "ref_eq.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/ref_is_null.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/ref_is_null.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "ref_is_null.0.wasm"
+      "filename": "ref_is_null.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -347,21 +348,22 @@
     {
       "type": "module",
       "line": 71,
-      "filename": "ref_is_null.1.wasm"
+      "filename": "ref_is_null.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 79,
       "filename": "ref_is_null.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 83,
       "filename": "ref_is_null.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/ref_null.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/ref_null.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "ref_null.0.wasm"
+      "filename": "ref_null.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -83,7 +84,8 @@
     {
       "type": "module",
       "line": 23,
-      "filename": "ref_null.1.wasm"
+      "filename": "ref_null.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/ref_test.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/ref_test.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "ref_test.0.wasm"
+      "filename": "ref_test.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -1343,7 +1344,8 @@
     {
       "type": "module",
       "line": 182,
-      "filename": "ref_test.1.wasm"
+      "filename": "ref_test.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/return_call.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/return_call.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "return_call.0.wasm"
+      "filename": "return_call.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -586,88 +587,90 @@
       "type": "assert_invalid",
       "line": 124,
       "filename": "return_call.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 131,
       "filename": "return_call.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 139,
       "filename": "return_call.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 146,
       "filename": "return_call.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 153,
-      "filename": "return_call.5.wasm"
+      "filename": "return_call.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 158,
-      "filename": "return_call.6.wasm"
+      "filename": "return_call.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 164,
       "filename": "return_call.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 171,
       "filename": "return_call.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 178,
       "filename": "return_call.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 185,
       "filename": "return_call.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 192,
       "filename": "return_call.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 204,
       "filename": "return_call.12.wasm",
-      "text": "unknown function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function"
     },
     {
       "type": "assert_invalid",
       "line": 208,
       "filename": "return_call.13.wasm",
-      "text": "unknown function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/return_call_indirect.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/return_call_indirect.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "return_call_indirect.0.wasm"
+      "filename": "return_call_indirect.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -886,193 +887,195 @@
       "type": "assert_malformed",
       "line": 273,
       "filename": "return_call_indirect.1.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 285,
       "filename": "return_call_indirect.2.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 297,
       "filename": "return_call_indirect.3.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 309,
       "filename": "return_call_indirect.4.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 321,
       "filename": "return_call_indirect.5.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 333,
       "filename": "return_call_indirect.6.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 345,
       "filename": "return_call_indirect.7.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 352,
       "filename": "return_call_indirect.8.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 362,
       "filename": "return_call_indirect.9.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 372,
       "filename": "return_call_indirect.10.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 384,
       "filename": "return_call_indirect.11.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_invalid",
       "line": 399,
       "filename": "return_call_indirect.12.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 407,
       "filename": "return_call_indirect.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 415,
       "filename": "return_call_indirect.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 424,
       "filename": "return_call_indirect.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 432,
       "filename": "return_call_indirect.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 440,
-      "filename": "return_call_indirect.17.wasm"
+      "filename": "return_call_indirect.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 446,
-      "filename": "return_call_indirect.18.wasm"
+      "filename": "return_call_indirect.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 455,
       "filename": "return_call_indirect.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 463,
       "filename": "return_call_indirect.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 472,
       "filename": "return_call_indirect.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 482,
       "filename": "return_call_indirect.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 492,
       "filename": "return_call_indirect.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 502,
       "filename": "return_call_indirect.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 512,
       "filename": "return_call_indirect.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 526,
       "filename": "return_call_indirect.26.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 533,
       "filename": "return_call_indirect.27.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 544,
       "filename": "return_call_indirect.28.wasm",
-      "text": "unknown function 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function 0"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/return_call_ref.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/return_call_ref.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "return_call_ref.0.wasm"
+      "filename": "return_call_ref.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -595,54 +596,56 @@
     {
       "type": "module",
       "line": 213,
-      "filename": "return_call_ref.1.wasm"
+      "filename": "return_call_ref.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 232,
       "filename": "return_call_ref.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 243,
       "filename": "return_call_ref.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 254,
       "filename": "return_call_ref.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 265,
       "filename": "return_call_ref.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 276,
       "filename": "return_call_ref.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 287,
       "filename": "return_call_ref.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 299,
-      "filename": "return_call_ref.8.wasm"
+      "filename": "return_call_ref.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -657,7 +660,8 @@
     {
       "type": "module",
       "line": 308,
-      "filename": "return_call_ref.9.wasm"
+      "filename": "return_call_ref.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -672,7 +676,8 @@
     {
       "type": "module",
       "line": 321,
-      "filename": "return_call_ref.10.wasm"
+      "filename": "return_call_ref.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -688,36 +693,36 @@
       "type": "assert_invalid",
       "line": 337,
       "filename": "return_call_ref.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 353,
       "filename": "return_call_ref.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 369,
       "filename": "return_call_ref.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 379,
       "filename": "return_call_ref.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 389,
       "filename": "return_call_ref.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/select.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/select.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "select.0.wasm"
+      "filename": "select.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2834,221 +2835,223 @@
       "type": "assert_invalid",
       "line": 364,
       "filename": "select.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 368,
       "filename": "select.2.wasm",
-      "text": "invalid result arity",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid result arity"
     },
     {
       "type": "assert_invalid",
       "line": 372,
       "filename": "select.3.wasm",
-      "text": "invalid result arity",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid result arity"
     },
     {
       "type": "assert_invalid",
       "line": 384,
       "filename": "select.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 392,
       "filename": "select.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 398,
       "filename": "select.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 403,
-      "filename": "select.7.wasm"
+      "filename": "select.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 408,
       "filename": "select.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 414,
       "filename": "select.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 420,
       "filename": "select.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 427,
       "filename": "select.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 431,
       "filename": "select.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 435,
       "filename": "select.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 439,
       "filename": "select.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 443,
       "filename": "select.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 449,
       "filename": "select.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 457,
       "filename": "select.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 465,
       "filename": "select.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 473,
       "filename": "select.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 482,
       "filename": "select.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 491,
       "filename": "select.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 500,
       "filename": "select.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 509,
       "filename": "select.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 518,
       "filename": "select.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 527,
       "filename": "select.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 536,
       "filename": "select.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 545,
       "filename": "select.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 557,
       "filename": "select.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 561,
       "filename": "select.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 565,
       "filename": "select.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 572,
       "filename": "select.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 579,
-      "filename": "select.32.wasm"
+      "filename": "select.32.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/simd_address.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/simd_address.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "simd_address.0.wasm"
+      "filename": "simd_address.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1151,7 +1152,8 @@
     {
       "type": "module",
       "line": 104,
-      "filename": "simd_address.1.wasm"
+      "filename": "simd_address.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -1167,13 +1169,14 @@
       "type": "assert_malformed",
       "line": 113,
       "filename": "simd_address.2.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 122,
-      "filename": "simd_address.3.wasm"
+      "filename": "simd_address.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -1189,22 +1192,24 @@
       "type": "assert_malformed",
       "line": 131,
       "filename": "simd_address.4.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_invalid",
       "line": 144,
       "filename": "simd_address.5.wat",
-      "text": "offset out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "binary_filename": "simd_address.5.wasm",
+      "text": "offset out of range"
     },
     {
       "type": "assert_invalid",
       "line": 152,
       "filename": "simd_address.6.wat",
-      "text": "offset out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "binary_filename": "simd_address.6.wasm",
+      "text": "offset out of range"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/simd_lane.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/simd_lane.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_lane.0.wasm"
+      "filename": "simd_lane.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -8068,958 +8069,959 @@
       "type": "assert_malformed",
       "line": 398,
       "filename": "simd_lane.1.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 399,
       "filename": "simd_lane.2.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 400,
       "filename": "simd_lane.3.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 401,
       "filename": "simd_lane.4.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 402,
       "filename": "simd_lane.5.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 403,
       "filename": "simd_lane.6.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 404,
       "filename": "simd_lane.7.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 405,
       "filename": "simd_lane.8.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 406,
       "filename": "simd_lane.9.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 407,
       "filename": "simd_lane.10.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 408,
       "filename": "simd_lane.11.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 409,
       "filename": "simd_lane.12.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 410,
       "filename": "simd_lane.13.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 411,
       "filename": "simd_lane.14.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 415,
       "filename": "simd_lane.15.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 416,
       "filename": "simd_lane.16.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 417,
       "filename": "simd_lane.17.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 418,
       "filename": "simd_lane.18.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 419,
       "filename": "simd_lane.19.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 420,
       "filename": "simd_lane.20.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 421,
       "filename": "simd_lane.21.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 422,
       "filename": "simd_lane.22.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 423,
       "filename": "simd_lane.23.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 424,
       "filename": "simd_lane.24.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 425,
       "filename": "simd_lane.25.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 426,
       "filename": "simd_lane.26.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 427,
       "filename": "simd_lane.27.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 428,
       "filename": "simd_lane.28.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_invalid",
       "line": 432,
       "filename": "simd_lane.29.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 433,
       "filename": "simd_lane.30.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 434,
       "filename": "simd_lane.31.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 435,
       "filename": "simd_lane.32.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 436,
       "filename": "simd_lane.33.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 437,
       "filename": "simd_lane.34.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 438,
       "filename": "simd_lane.35.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 439,
       "filename": "simd_lane.36.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 440,
       "filename": "simd_lane.37.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 441,
       "filename": "simd_lane.38.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 442,
       "filename": "simd_lane.39.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 443,
       "filename": "simd_lane.40.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 444,
       "filename": "simd_lane.41.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 445,
       "filename": "simd_lane.42.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 446,
       "filename": "simd_lane.43.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 447,
       "filename": "simd_lane.44.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 448,
       "filename": "simd_lane.45.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 449,
       "filename": "simd_lane.46.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 450,
       "filename": "simd_lane.47.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 451,
       "filename": "simd_lane.48.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 452,
       "filename": "simd_lane.49.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 453,
       "filename": "simd_lane.50.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 454,
       "filename": "simd_lane.51.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 455,
       "filename": "simd_lane.52.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 456,
       "filename": "simd_lane.53.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 457,
       "filename": "simd_lane.54.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 458,
       "filename": "simd_lane.55.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 459,
       "filename": "simd_lane.56.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 463,
       "filename": "simd_lane.57.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 464,
       "filename": "simd_lane.58.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 465,
       "filename": "simd_lane.59.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 466,
       "filename": "simd_lane.60.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 467,
       "filename": "simd_lane.61.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 468,
       "filename": "simd_lane.62.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 469,
       "filename": "simd_lane.63.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 470,
       "filename": "simd_lane.64.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 471,
       "filename": "simd_lane.65.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 472,
       "filename": "simd_lane.66.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 473,
       "filename": "simd_lane.67.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 477,
       "filename": "simd_lane.68.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 478,
       "filename": "simd_lane.69.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 479,
       "filename": "simd_lane.70.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 480,
       "filename": "simd_lane.71.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 481,
       "filename": "simd_lane.72.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 482,
       "filename": "simd_lane.73.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 483,
       "filename": "simd_lane.74.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 484,
       "filename": "simd_lane.75.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 485,
       "filename": "simd_lane.76.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 486,
       "filename": "simd_lane.77.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 487,
       "filename": "simd_lane.78.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 488,
       "filename": "simd_lane.79.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 489,
       "filename": "simd_lane.80.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 490,
       "filename": "simd_lane.81.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 494,
       "filename": "simd_lane.82.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 495,
       "filename": "simd_lane.83.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 496,
       "filename": "simd_lane.84.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 497,
       "filename": "simd_lane.85.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 499,
       "filename": "simd_lane.86.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 500,
       "filename": "simd_lane.87.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 503,
       "filename": "simd_lane.88.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 505,
       "filename": "simd_lane.89.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 507,
       "filename": "simd_lane.90.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 510,
       "filename": "simd_lane.91.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 515,
       "filename": "simd_lane.92.wat",
-      "text": "invalid lane length",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "invalid lane length"
     },
     {
       "type": "assert_malformed",
       "line": 518,
       "filename": "simd_lane.93.wat",
-      "text": "invalid lane length",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "invalid lane length"
     },
     {
       "type": "assert_malformed",
       "line": 521,
       "filename": "simd_lane.94.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 525,
       "filename": "simd_lane.95.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_invalid",
       "line": 529,
       "filename": "simd_lane.96.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_malformed",
       "line": 536,
       "filename": "simd_lane.97.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 537,
       "filename": "simd_lane.98.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 538,
       "filename": "simd_lane.99.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 539,
       "filename": "simd_lane.100.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 540,
       "filename": "simd_lane.101.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 541,
       "filename": "simd_lane.102.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 545,
       "filename": "simd_lane.103.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 549,
       "filename": "simd_lane.104.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 555,
       "filename": "simd_lane.105.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 559,
       "filename": "simd_lane.106.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 570,
       "filename": "simd_lane.107.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 571,
       "filename": "simd_lane.108.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 572,
       "filename": "simd_lane.109.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 573,
       "filename": "simd_lane.110.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 574,
       "filename": "simd_lane.111.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 575,
       "filename": "simd_lane.112.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 576,
       "filename": "simd_lane.113.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 577,
       "filename": "simd_lane.114.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 578,
       "filename": "simd_lane.115.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 579,
       "filename": "simd_lane.116.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 581,
       "filename": "simd_lane.117.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 582,
       "filename": "simd_lane.118.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 583,
       "filename": "simd_lane.119.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 584,
       "filename": "simd_lane.120.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 588,
       "filename": "simd_lane.121.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 589,
       "filename": "simd_lane.122.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 590,
       "filename": "simd_lane.123.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 591,
       "filename": "simd_lane.124.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 592,
       "filename": "simd_lane.125.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 593,
       "filename": "simd_lane.126.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 594,
       "filename": "simd_lane.127.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 595,
       "filename": "simd_lane.128.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 596,
       "filename": "simd_lane.129.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 597,
       "filename": "simd_lane.130.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 600,
       "filename": "simd_lane.131.wat",
-      "text": "invalid lane length",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "invalid lane length"
     },
     {
       "type": "assert_malformed",
       "line": 604,
       "filename": "simd_lane.132.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 608,
       "filename": "simd_lane.133.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 612,
       "filename": "simd_lane.134.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 616,
       "filename": "simd_lane.135.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 620,
       "filename": "simd_lane.136.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "module",
       "line": 628,
-      "filename": "simd_lane.137.wasm"
+      "filename": "simd_lane.137.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -9880,7 +9882,8 @@
     {
       "type": "module",
       "line": 703,
-      "filename": "simd_lane.138.wasm"
+      "filename": "simd_lane.138.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -10901,7 +10904,8 @@
     {
       "type": "module",
       "line": 799,
-      "filename": "simd_lane.139.wasm"
+      "filename": "simd_lane.139.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -11146,7 +11150,8 @@
     {
       "type": "module",
       "line": 830,
-      "filename": "simd_lane.140.wasm"
+      "filename": "simd_lane.140.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -11508,407 +11513,414 @@
       "type": "assert_malformed",
       "line": 877,
       "filename": "simd_lane.141.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 878,
       "filename": "simd_lane.142.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 879,
       "filename": "simd_lane.143.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 880,
       "filename": "simd_lane.144.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 881,
       "filename": "simd_lane.145.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 882,
       "filename": "simd_lane.146.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 883,
       "filename": "simd_lane.147.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "module",
       "line": 887,
-      "filename": "simd_lane.148.wasm"
+      "filename": "simd_lane.148.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 888,
-      "filename": "simd_lane.149.wasm"
+      "filename": "simd_lane.149.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 889,
-      "filename": "simd_lane.150.wasm"
+      "filename": "simd_lane.150.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 890,
-      "filename": "simd_lane.151.wasm"
+      "filename": "simd_lane.151.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 891,
-      "filename": "simd_lane.152.wasm"
+      "filename": "simd_lane.152.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 892,
-      "filename": "simd_lane.153.wasm"
+      "filename": "simd_lane.153.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 893,
-      "filename": "simd_lane.154.wasm"
+      "filename": "simd_lane.154.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 897,
       "filename": "simd_lane.155.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 902,
       "filename": "simd_lane.156.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 910,
       "filename": "simd_lane.157.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 918,
       "filename": "simd_lane.158.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 926,
       "filename": "simd_lane.159.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 934,
       "filename": "simd_lane.160.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 942,
       "filename": "simd_lane.161.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 950,
       "filename": "simd_lane.162.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 958,
       "filename": "simd_lane.163.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 966,
       "filename": "simd_lane.164.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 974,
       "filename": "simd_lane.165.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 982,
       "filename": "simd_lane.166.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 990,
       "filename": "simd_lane.167.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 998,
       "filename": "simd_lane.168.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 1006,
       "filename": "simd_lane.169.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1014,
       "filename": "simd_lane.170.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1022,
       "filename": "simd_lane.171.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 1030,
       "filename": "simd_lane.172.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1038,
       "filename": "simd_lane.173.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1046,
       "filename": "simd_lane.174.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 1054,
       "filename": "simd_lane.175.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1062,
       "filename": "simd_lane.176.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1070,
       "filename": "simd_lane.177.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1078,
       "filename": "simd_lane.178.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 1086,
       "filename": "simd_lane.179.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1094,
       "filename": "simd_lane.180.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1102,
       "filename": "simd_lane.181.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1110,
       "filename": "simd_lane.182.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 1118,
       "filename": "simd_lane.183.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1126,
       "filename": "simd_lane.184.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1134,
       "filename": "simd_lane.185.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1142,
       "filename": "simd_lane.186.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 1150,
       "filename": "simd_lane.187.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1158,
       "filename": "simd_lane.188.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1166,
       "filename": "simd_lane.189.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1174,
       "filename": "simd_lane.190.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 1182,
       "filename": "simd_lane.191.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1190,
       "filename": "simd_lane.192.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1198,
       "filename": "simd_lane.193.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1206,
       "filename": "simd_lane.194.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 1214,
       "filename": "simd_lane.195.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1222,
       "filename": "simd_lane.196.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1230,
       "filename": "simd_lane.197.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1238,
       "filename": "simd_lane.198.wat",
-      "text": "invalid lane length",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "invalid lane length"
     },
     {
       "type": "assert_invalid",
       "line": 1249,
       "filename": "simd_lane.199.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1259,
       "filename": "simd_lane.200.wat",
-      "text": "invalid lane length",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "invalid lane length"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/simd_memory-multi.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/simd_memory-multi.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 5,
-      "filename": "simd_memory-multi.0.wasm"
+      "filename": "simd_memory-multi.0.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/start0.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/start0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "start0.0.wasm"
+      "filename": "start0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/store.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/store.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "store.0.wasm"
+      "filename": "store.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -86,7 +87,8 @@
       "type": "module",
       "line": 28,
       "name": "M1",
-      "filename": "store.1.wasm"
+      "filename": "store.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -97,7 +99,8 @@
       "type": "module",
       "line": 40,
       "name": "M2",
-      "filename": "store.2.wasm"
+      "filename": "store.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -187,7 +190,8 @@
     {
       "type": "module",
       "line": 57,
-      "filename": "store.3.wasm"
+      "filename": "store.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -268,7 +272,8 @@
     {
       "type": "module",
       "line": 82,
-      "filename": "store.4.wasm"
+      "filename": "store.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -278,7 +283,8 @@
     {
       "type": "module",
       "line": 87,
-      "filename": "store.5.wasm"
+      "filename": "store.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -701,7 +707,8 @@
     {
       "type": "module",
       "line": 151,
-      "filename": "store.6.wasm"
+      "filename": "store.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -797,407 +804,407 @@
       "type": "assert_malformed",
       "line": 206,
       "filename": "store.7.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 213,
       "filename": "store.8.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 221,
       "filename": "store.9.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 229,
       "filename": "store.10.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 236,
       "filename": "store.11.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 244,
       "filename": "store.12.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 251,
       "filename": "store.13.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_invalid",
       "line": 260,
       "filename": "store.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 264,
       "filename": "store.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 268,
       "filename": "store.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 272,
       "filename": "store.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 276,
       "filename": "store.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 280,
       "filename": "store.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 284,
       "filename": "store.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 288,
       "filename": "store.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 292,
       "filename": "store.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 298,
       "filename": "store.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 307,
       "filename": "store.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 316,
       "filename": "store.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 326,
       "filename": "store.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 336,
       "filename": "store.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 346,
       "filename": "store.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 356,
       "filename": "store.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 366,
       "filename": "store.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 376,
       "filename": "store.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 386,
       "filename": "store.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 396,
       "filename": "store.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 406,
       "filename": "store.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 416,
       "filename": "store.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 426,
       "filename": "store.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 436,
       "filename": "store.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 446,
       "filename": "store.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 456,
       "filename": "store.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 465,
       "filename": "store.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 474,
       "filename": "store.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 483,
       "filename": "store.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 492,
       "filename": "store.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 502,
       "filename": "store.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 512,
       "filename": "store.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 528,
       "filename": "store.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 547,
       "filename": "store.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 548,
       "filename": "store.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 549,
       "filename": "store.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 550,
       "filename": "store.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 551,
       "filename": "store.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 552,
       "filename": "store.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 553,
       "filename": "store.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 554,
       "filename": "store.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 555,
       "filename": "store.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 557,
       "filename": "store.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 558,
       "filename": "store.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 559,
       "filename": "store.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 560,
       "filename": "store.59.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 561,
       "filename": "store.60.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 562,
       "filename": "store.61.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 563,
       "filename": "store.62.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 564,
       "filename": "store.63.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 565,
       "filename": "store.64.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/store0.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/store0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "store0.0.wasm"
+      "filename": "store0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",

--- a/tests/snapshots/testsuite/proposals/memory64/store1.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/store1.wast.json
@@ -5,7 +5,8 @@
       "type": "module",
       "line": 1,
       "name": "M1",
-      "filename": "store1.0.wasm"
+      "filename": "store1.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -16,7 +17,8 @@
       "type": "module",
       "line": 13,
       "name": "M2",
-      "filename": "store1.1.wasm"
+      "filename": "store1.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -106,7 +108,8 @@
     {
       "type": "module",
       "line": 30,
-      "filename": "store1.2.wasm"
+      "filename": "store1.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",

--- a/tests/snapshots/testsuite/proposals/memory64/struct.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/struct.wast.json
@@ -4,50 +4,54 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "struct.0.wasm"
+      "filename": "struct.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 16,
       "filename": "struct.1.wat",
-      "text": "duplicate field",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate field"
     },
     {
       "type": "module",
       "line": 25,
-      "filename": "struct.2.wasm"
+      "filename": "struct.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 37,
       "filename": "struct.3.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 41,
       "filename": "struct.4.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "module",
       "line": 48,
-      "filename": "struct.5.wasm"
+      "filename": "struct.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 59,
       "filename": "struct.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 70,
-      "filename": "struct.7.wasm"
+      "filename": "struct.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -167,13 +171,14 @@
       "type": "assert_invalid",
       "line": 133,
       "filename": "struct.8.wasm",
-      "text": "field is immutable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "field is immutable"
     },
     {
       "type": "module",
       "line": 145,
-      "filename": "struct.9.wasm"
+      "filename": "struct.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -198,7 +203,8 @@
     {
       "type": "module",
       "line": 160,
-      "filename": "struct.10.wasm"
+      "filename": "struct.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/memory64/table-sub.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/table-sub.wast.json
@@ -4,21 +4,22 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "table-sub.0.wasm"
+      "filename": "table-sub.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 13,
       "filename": "table-sub.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 24,
       "filename": "table-sub.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/table.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/table.wast.json
@@ -4,253 +4,278 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "table.0.wasm"
+      "filename": "table.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 4,
-      "filename": "table.1.wasm"
+      "filename": "table.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 5,
-      "filename": "table.2.wasm"
+      "filename": "table.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 6,
-      "filename": "table.3.wasm"
+      "filename": "table.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 7,
-      "filename": "table.4.wasm"
+      "filename": "table.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 8,
-      "filename": "table.5.wasm"
+      "filename": "table.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 9,
-      "filename": "table.6.wasm"
+      "filename": "table.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 11,
-      "filename": "table.7.wasm"
+      "filename": "table.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 12,
-      "filename": "table.8.wasm"
+      "filename": "table.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 13,
-      "filename": "table.9.wasm"
+      "filename": "table.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 15,
-      "filename": "table.10.wasm"
+      "filename": "table.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 16,
-      "filename": "table.11.wasm"
+      "filename": "table.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 18,
-      "filename": "table.12.wasm"
+      "filename": "table.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 19,
-      "filename": "table.13.wasm"
+      "filename": "table.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 20,
-      "filename": "table.14.wasm"
+      "filename": "table.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 22,
       "filename": "table.15.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 23,
       "filename": "table.16.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 26,
       "filename": "table.17.wasm",
-      "text": "size minimum must not be greater than maximum",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "size minimum must not be greater than maximum"
     },
     {
       "type": "assert_invalid",
       "line": 30,
       "filename": "table.18.wasm",
-      "text": "size minimum must not be greater than maximum",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "size minimum must not be greater than maximum"
     },
     {
       "type": "assert_invalid",
       "line": 35,
       "filename": "table.19.wat",
-      "text": "table size must be at most 2^32-1",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "table size must be at most 2^32-1"
     },
     {
       "type": "assert_invalid",
       "line": 39,
       "filename": "table.20.wat",
-      "text": "table size must be at most 2^32-1",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "table size must be at most 2^32-1"
     },
     {
       "type": "assert_invalid",
       "line": 43,
       "filename": "table.21.wat",
-      "text": "table size must be at most 2^32-1",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "table size must be at most 2^32-1"
     },
     {
       "type": "module",
       "line": 49,
-      "filename": "table.22.wasm"
+      "filename": "table.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 50,
-      "filename": "table.23.wasm"
+      "filename": "table.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 51,
-      "filename": "table.24.wasm"
+      "filename": "table.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 52,
-      "filename": "table.25.wasm"
+      "filename": "table.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 53,
-      "filename": "table.26.wasm"
+      "filename": "table.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 54,
-      "filename": "table.27.wasm"
+      "filename": "table.27.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 55,
-      "filename": "table.28.wasm"
+      "filename": "table.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 57,
-      "filename": "table.29.wasm"
+      "filename": "table.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 58,
-      "filename": "table.30.wasm"
+      "filename": "table.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 61,
       "filename": "table.31.wasm",
-      "text": "size minimum must not be greater than maximum",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "size minimum must not be greater than maximum"
     },
     {
       "type": "assert_invalid",
       "line": 65,
       "filename": "table.32.wasm",
-      "text": "size minimum must not be greater than maximum",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "size minimum must not be greater than maximum"
     },
     {
       "type": "assert_invalid",
       "line": 71,
       "filename": "table.33.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 72,
       "filename": "table.34.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 75,
       "filename": "table.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 79,
       "filename": "table.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 83,
       "filename": "table.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 87,
       "filename": "table.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 91,
       "filename": "table.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 95,
       "filename": "table.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 99,
       "filename": "table.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 106,
-      "filename": "table.42.wasm"
+      "filename": "table.42.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -260,7 +285,8 @@
     {
       "type": "module",
       "line": 113,
-      "filename": "table.43.wasm"
+      "filename": "table.43.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -336,43 +362,43 @@
       "type": "assert_invalid",
       "line": 140,
       "filename": "table.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 148,
       "filename": "table.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 156,
       "filename": "table.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 167,
       "filename": "table.47.wat",
-      "text": "duplicate table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate table"
     },
     {
       "type": "assert_malformed",
       "line": 174,
       "filename": "table.48.wat",
-      "text": "duplicate table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate table"
     },
     {
       "type": "assert_malformed",
       "line": 181,
       "filename": "table.49.wat",
-      "text": "duplicate table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate table"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/table_copy.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/table_copy.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 6,
-      "filename": "table_copy.0.wasm"
+      "filename": "table_copy.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -14,7 +15,8 @@
     {
       "type": "module",
       "line": 15,
-      "filename": "table_copy.1.wasm"
+      "filename": "table_copy.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -1018,7 +1020,8 @@
     {
       "type": "module",
       "line": 107,
-      "filename": "table_copy.2.wasm"
+      "filename": "table_copy.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -2022,7 +2025,8 @@
     {
       "type": "module",
       "line": 199,
-      "filename": "table_copy.3.wasm"
+      "filename": "table_copy.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -3036,7 +3040,8 @@
     {
       "type": "module",
       "line": 291,
-      "filename": "table_copy.4.wasm"
+      "filename": "table_copy.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -4025,7 +4030,8 @@
     {
       "type": "module",
       "line": 383,
-      "filename": "table_copy.5.wasm"
+      "filename": "table_copy.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -5029,7 +5035,8 @@
     {
       "type": "module",
       "line": 475,
-      "filename": "table_copy.6.wasm"
+      "filename": "table_copy.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -6043,7 +6050,8 @@
     {
       "type": "module",
       "line": 567,
-      "filename": "table_copy.7.wasm"
+      "filename": "table_copy.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -7047,7 +7055,8 @@
     {
       "type": "module",
       "line": 659,
-      "filename": "table_copy.8.wasm"
+      "filename": "table_copy.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -8051,7 +8060,8 @@
     {
       "type": "module",
       "line": 751,
-      "filename": "table_copy.9.wasm"
+      "filename": "table_copy.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -9075,7 +9085,8 @@
     {
       "type": "module",
       "line": 843,
-      "filename": "table_copy.10.wasm"
+      "filename": "table_copy.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -10079,7 +10090,8 @@
     {
       "type": "module",
       "line": 935,
-      "filename": "table_copy.11.wasm"
+      "filename": "table_copy.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -11083,7 +11095,8 @@
     {
       "type": "module",
       "line": 1027,
-      "filename": "table_copy.12.wasm"
+      "filename": "table_copy.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -12097,7 +12110,8 @@
     {
       "type": "module",
       "line": 1119,
-      "filename": "table_copy.13.wasm"
+      "filename": "table_copy.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -13086,7 +13100,8 @@
     {
       "type": "module",
       "line": 1211,
-      "filename": "table_copy.14.wasm"
+      "filename": "table_copy.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -14090,7 +14105,8 @@
     {
       "type": "module",
       "line": 1303,
-      "filename": "table_copy.15.wasm"
+      "filename": "table_copy.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -15104,7 +15120,8 @@
     {
       "type": "module",
       "line": 1395,
-      "filename": "table_copy.16.wasm"
+      "filename": "table_copy.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -16108,7 +16125,8 @@
     {
       "type": "module",
       "line": 1487,
-      "filename": "table_copy.17.wasm"
+      "filename": "table_copy.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -17112,7 +17130,8 @@
     {
       "type": "module",
       "line": 1579,
-      "filename": "table_copy.18.wasm"
+      "filename": "table_copy.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -18136,7 +18155,8 @@
     {
       "type": "module",
       "line": 1671,
-      "filename": "table_copy.19.wasm"
+      "filename": "table_copy.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18151,7 +18171,8 @@
     {
       "type": "module",
       "line": 1696,
-      "filename": "table_copy.20.wasm"
+      "filename": "table_copy.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18166,7 +18187,8 @@
     {
       "type": "module",
       "line": 1721,
-      "filename": "table_copy.21.wasm"
+      "filename": "table_copy.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18181,7 +18203,8 @@
     {
       "type": "module",
       "line": 1746,
-      "filename": "table_copy.22.wasm"
+      "filename": "table_copy.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18196,7 +18219,8 @@
     {
       "type": "module",
       "line": 1771,
-      "filename": "table_copy.23.wasm"
+      "filename": "table_copy.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -18210,7 +18234,8 @@
     {
       "type": "module",
       "line": 1796,
-      "filename": "table_copy.24.wasm"
+      "filename": "table_copy.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -18224,7 +18249,8 @@
     {
       "type": "module",
       "line": 1821,
-      "filename": "table_copy.25.wasm"
+      "filename": "table_copy.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18239,7 +18265,8 @@
     {
       "type": "module",
       "line": 1846,
-      "filename": "table_copy.26.wasm"
+      "filename": "table_copy.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -18253,7 +18280,8 @@
     {
       "type": "module",
       "line": 1871,
-      "filename": "table_copy.27.wasm"
+      "filename": "table_copy.27.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18268,7 +18296,8 @@
     {
       "type": "module",
       "line": 1896,
-      "filename": "table_copy.28.wasm"
+      "filename": "table_copy.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -18282,7 +18311,8 @@
     {
       "type": "module",
       "line": 1921,
-      "filename": "table_copy.29.wasm"
+      "filename": "table_copy.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18297,7 +18327,8 @@
     {
       "type": "module",
       "line": 1946,
-      "filename": "table_copy.30.wasm"
+      "filename": "table_copy.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18312,7 +18343,8 @@
     {
       "type": "module",
       "line": 1971,
-      "filename": "table_copy.31.wasm"
+      "filename": "table_copy.31.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18327,7 +18359,8 @@
     {
       "type": "module",
       "line": 1996,
-      "filename": "table_copy.32.wasm"
+      "filename": "table_copy.32.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18342,7 +18375,8 @@
     {
       "type": "module",
       "line": 2021,
-      "filename": "table_copy.33.wasm"
+      "filename": "table_copy.33.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18357,7 +18391,8 @@
     {
       "type": "module",
       "line": 2046,
-      "filename": "table_copy.34.wasm"
+      "filename": "table_copy.34.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -18371,7 +18406,8 @@
     {
       "type": "module",
       "line": 2071,
-      "filename": "table_copy.35.wasm"
+      "filename": "table_copy.35.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -18385,7 +18421,8 @@
     {
       "type": "module",
       "line": 2096,
-      "filename": "table_copy.36.wasm"
+      "filename": "table_copy.36.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18400,7 +18437,8 @@
     {
       "type": "module",
       "line": 2121,
-      "filename": "table_copy.37.wasm"
+      "filename": "table_copy.37.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -18414,7 +18452,8 @@
     {
       "type": "module",
       "line": 2146,
-      "filename": "table_copy.38.wasm"
+      "filename": "table_copy.38.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18429,7 +18468,8 @@
     {
       "type": "module",
       "line": 2171,
-      "filename": "table_copy.39.wasm"
+      "filename": "table_copy.39.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -18443,7 +18483,8 @@
     {
       "type": "module",
       "line": 2196,
-      "filename": "table_copy.40.wasm"
+      "filename": "table_copy.40.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18458,7 +18499,8 @@
     {
       "type": "module",
       "line": 2221,
-      "filename": "table_copy.41.wasm"
+      "filename": "table_copy.41.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18473,7 +18515,8 @@
     {
       "type": "module",
       "line": 2246,
-      "filename": "table_copy.42.wasm"
+      "filename": "table_copy.42.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18488,7 +18531,8 @@
     {
       "type": "module",
       "line": 2271,
-      "filename": "table_copy.43.wasm"
+      "filename": "table_copy.43.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18503,7 +18547,8 @@
     {
       "type": "module",
       "line": 2296,
-      "filename": "table_copy.44.wasm"
+      "filename": "table_copy.44.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18518,7 +18563,8 @@
     {
       "type": "module",
       "line": 2321,
-      "filename": "table_copy.45.wasm"
+      "filename": "table_copy.45.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -18532,7 +18578,8 @@
     {
       "type": "module",
       "line": 2346,
-      "filename": "table_copy.46.wasm"
+      "filename": "table_copy.46.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -18546,7 +18593,8 @@
     {
       "type": "module",
       "line": 2371,
-      "filename": "table_copy.47.wasm"
+      "filename": "table_copy.47.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18561,7 +18609,8 @@
     {
       "type": "module",
       "line": 2396,
-      "filename": "table_copy.48.wasm"
+      "filename": "table_copy.48.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -18575,7 +18624,8 @@
     {
       "type": "module",
       "line": 2421,
-      "filename": "table_copy.49.wasm"
+      "filename": "table_copy.49.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18590,7 +18640,8 @@
     {
       "type": "module",
       "line": 2446,
-      "filename": "table_copy.50.wasm"
+      "filename": "table_copy.50.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -18604,7 +18655,8 @@
     {
       "type": "module",
       "line": 2471,
-      "filename": "table_copy.51.wasm"
+      "filename": "table_copy.51.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18619,7 +18671,8 @@
     {
       "type": "module",
       "line": 2496,
-      "filename": "table_copy.52.wasm"
+      "filename": "table_copy.52.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18634,7 +18687,8 @@
     {
       "type": "module",
       "line": 2521,
-      "filename": "table_copy.53.wasm"
+      "filename": "table_copy.53.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18649,7 +18703,8 @@
     {
       "type": "module",
       "line": 2546,
-      "filename": "table_copy.54.wasm"
+      "filename": "table_copy.54.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18664,7 +18719,8 @@
     {
       "type": "module",
       "line": 2571,
-      "filename": "table_copy.55.wasm"
+      "filename": "table_copy.55.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18679,7 +18735,8 @@
     {
       "type": "module",
       "line": 2596,
-      "filename": "table_copy.56.wasm"
+      "filename": "table_copy.56.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -18693,7 +18750,8 @@
     {
       "type": "module",
       "line": 2621,
-      "filename": "table_copy.57.wasm"
+      "filename": "table_copy.57.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -18707,7 +18765,8 @@
     {
       "type": "module",
       "line": 2646,
-      "filename": "table_copy.58.wasm"
+      "filename": "table_copy.58.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18722,7 +18781,8 @@
     {
       "type": "module",
       "line": 2671,
-      "filename": "table_copy.59.wasm"
+      "filename": "table_copy.59.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -18736,7 +18796,8 @@
     {
       "type": "module",
       "line": 2696,
-      "filename": "table_copy.60.wasm"
+      "filename": "table_copy.60.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18751,7 +18812,8 @@
     {
       "type": "module",
       "line": 2721,
-      "filename": "table_copy.61.wasm"
+      "filename": "table_copy.61.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -18765,7 +18827,8 @@
     {
       "type": "module",
       "line": 2746,
-      "filename": "table_copy.62.wasm"
+      "filename": "table_copy.62.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18780,7 +18843,8 @@
     {
       "type": "module",
       "line": 2771,
-      "filename": "table_copy.63.wasm"
+      "filename": "table_copy.63.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -19328,7 +19392,8 @@
     {
       "type": "module",
       "line": 2832,
-      "filename": "table_copy.64.wasm"
+      "filename": "table_copy.64.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -19881,7 +19946,8 @@
     {
       "type": "module",
       "line": 2893,
-      "filename": "table_copy.65.wasm"
+      "filename": "table_copy.65.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -20429,7 +20495,8 @@
     {
       "type": "module",
       "line": 2954,
-      "filename": "table_copy.66.wasm"
+      "filename": "table_copy.66.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -20982,7 +21049,8 @@
     {
       "type": "module",
       "line": 3015,
-      "filename": "table_copy.67.wasm"
+      "filename": "table_copy.67.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -21530,7 +21598,8 @@
     {
       "type": "module",
       "line": 3076,
-      "filename": "table_copy.68.wasm"
+      "filename": "table_copy.68.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -22078,7 +22147,8 @@
     {
       "type": "module",
       "line": 3137,
-      "filename": "table_copy.69.wasm"
+      "filename": "table_copy.69.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -22626,7 +22696,8 @@
     {
       "type": "module",
       "line": 3198,
-      "filename": "table_copy.70.wasm"
+      "filename": "table_copy.70.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -23174,7 +23245,8 @@
     {
       "type": "module",
       "line": 3259,
-      "filename": "table_copy.71.wasm"
+      "filename": "table_copy.71.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -23737,7 +23809,8 @@
     {
       "type": "module",
       "line": 3320,
-      "filename": "table_copy.72.wasm"
+      "filename": "table_copy.72.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -25765,7 +25838,8 @@
     {
       "type": "module",
       "line": 3477,
-      "filename": "table_copy.73.wasm"
+      "filename": "table_copy.73.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",

--- a/tests/snapshots/testsuite/proposals/memory64/table_copy_mixed.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/table_copy_mixed.wast.json
@@ -4,28 +4,29 @@
     {
       "type": "module",
       "line": 2,
-      "filename": "table_copy_mixed.0.wasm"
+      "filename": "table_copy_mixed.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 20,
       "filename": "table_copy_mixed.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 30,
       "filename": "table_copy_mixed.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 40,
       "filename": "table_copy_mixed.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/table_fill.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/table_fill.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "table_fill.0.wasm"
+      "filename": "table_fill.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1464,64 +1465,64 @@
       "type": "assert_invalid",
       "line": 140,
       "filename": "table_fill.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 149,
       "filename": "table_fill.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 158,
       "filename": "table_fill.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 167,
       "filename": "table_fill.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 176,
       "filename": "table_fill.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 185,
       "filename": "table_fill.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 194,
       "filename": "table_fill.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 204,
       "filename": "table_fill.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 215,
       "filename": "table_fill.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/table_get.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/table_get.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "table_get.0.wasm"
+      "filename": "table_get.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -204,36 +205,36 @@
       "type": "assert_invalid",
       "line": 47,
       "filename": "table_get.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 56,
       "filename": "table_get.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 66,
       "filename": "table_get.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 75,
       "filename": "table_get.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 85,
       "filename": "table_get.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/table_grow.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/table_grow.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "table_grow.0.wasm"
+      "filename": "table_grow.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -793,7 +794,8 @@
     {
       "type": "module",
       "line": 75,
-      "filename": "table_grow.1.wasm"
+      "filename": "table_grow.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -813,7 +815,8 @@
     {
       "type": "module",
       "line": 86,
-      "filename": "table_grow.2.wasm"
+      "filename": "table_grow.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -918,7 +921,8 @@
     {
       "type": "module",
       "line": 100,
-      "filename": "table_grow.3.wasm"
+      "filename": "table_grow.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1083,7 +1087,8 @@
     {
       "type": "module",
       "line": 117,
-      "filename": "table_grow.4.wasm"
+      "filename": "table_grow.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1157,50 +1162,50 @@
       "type": "assert_invalid",
       "line": 147,
       "filename": "table_grow.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 156,
       "filename": "table_grow.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 165,
       "filename": "table_grow.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 174,
       "filename": "table_grow.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 183,
       "filename": "table_grow.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 193,
       "filename": "table_grow.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 202,
       "filename": "table_grow.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/table_init.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/table_init.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 6,
-      "filename": "table_init.0.wasm"
+      "filename": "table_init.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -14,7 +15,8 @@
     {
       "type": "module",
       "line": 15,
-      "filename": "table_init.1.wasm"
+      "filename": "table_init.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -543,7 +545,8 @@
     {
       "type": "module",
       "line": 74,
-      "filename": "table_init.2.wasm"
+      "filename": "table_init.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -1057,7 +1060,8 @@
     {
       "type": "module",
       "line": 133,
-      "filename": "table_init.3.wasm"
+      "filename": "table_init.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -1606,7 +1610,8 @@
     {
       "type": "module",
       "line": 200,
-      "filename": "table_init.4.wasm"
+      "filename": "table_init.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -2135,7 +2140,8 @@
     {
       "type": "module",
       "line": 259,
-      "filename": "table_init.5.wasm"
+      "filename": "table_init.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -2649,7 +2655,8 @@
     {
       "type": "module",
       "line": 318,
-      "filename": "table_init.6.wasm"
+      "filename": "table_init.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -3198,7 +3205,8 @@
     {
       "type": "module",
       "line": 385,
-      "filename": "table_init.7.wasm"
+      "filename": "table_init.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -3727,7 +3735,8 @@
     {
       "type": "module",
       "line": 444,
-      "filename": "table_init.8.wasm"
+      "filename": "table_init.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -4241,7 +4250,8 @@
     {
       "type": "module",
       "line": 503,
-      "filename": "table_init.9.wasm"
+      "filename": "table_init.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -4791,34 +4801,35 @@
       "type": "assert_invalid",
       "line": 570,
       "filename": "table_init.10.wasm",
-      "text": "unknown elem segment 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown elem segment 0"
     },
     {
       "type": "assert_invalid",
       "line": 576,
       "filename": "table_init.11.wasm",
-      "text": "unknown table 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table 0"
     },
     {
       "type": "assert_invalid",
       "line": 582,
       "filename": "table_init.12.wasm",
-      "text": "unknown elem segment 4",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown elem segment 4"
     },
     {
       "type": "assert_invalid",
       "line": 590,
       "filename": "table_init.13.wasm",
-      "text": "unknown table 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table 0"
     },
     {
       "type": "module",
       "line": 598,
-      "filename": "table_init.14.wasm"
+      "filename": "table_init.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -4832,7 +4843,8 @@
     {
       "type": "module",
       "line": 622,
-      "filename": "table_init.15.wasm"
+      "filename": "table_init.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -4847,7 +4859,8 @@
     {
       "type": "module",
       "line": 646,
-      "filename": "table_init.16.wasm"
+      "filename": "table_init.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -4861,7 +4874,8 @@
     {
       "type": "module",
       "line": 670,
-      "filename": "table_init.17.wasm"
+      "filename": "table_init.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -4875,7 +4889,8 @@
     {
       "type": "module",
       "line": 694,
-      "filename": "table_init.18.wasm"
+      "filename": "table_init.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -4890,7 +4905,8 @@
     {
       "type": "module",
       "line": 718,
-      "filename": "table_init.19.wasm"
+      "filename": "table_init.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -4905,7 +4921,8 @@
     {
       "type": "module",
       "line": 742,
-      "filename": "table_init.20.wasm"
+      "filename": "table_init.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -4920,7 +4937,8 @@
     {
       "type": "module",
       "line": 766,
-      "filename": "table_init.21.wasm"
+      "filename": "table_init.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -4935,7 +4953,8 @@
     {
       "type": "module",
       "line": 790,
-      "filename": "table_init.22.wasm"
+      "filename": "table_init.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -4949,7 +4968,8 @@
     {
       "type": "module",
       "line": 814,
-      "filename": "table_init.23.wasm"
+      "filename": "table_init.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -4964,7 +4984,8 @@
     {
       "type": "module",
       "line": 838,
-      "filename": "table_init.24.wasm"
+      "filename": "table_init.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -4978,7 +4999,8 @@
     {
       "type": "module",
       "line": 862,
-      "filename": "table_init.25.wasm"
+      "filename": "table_init.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -4993,7 +5015,8 @@
     {
       "type": "module",
       "line": 886,
-      "filename": "table_init.26.wasm"
+      "filename": "table_init.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -5007,7 +5030,8 @@
     {
       "type": "module",
       "line": 910,
-      "filename": "table_init.27.wasm"
+      "filename": "table_init.27.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -5022,7 +5046,8 @@
     {
       "type": "module",
       "line": 934,
-      "filename": "table_init.28.wasm"
+      "filename": "table_init.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -5037,7 +5062,8 @@
     {
       "type": "module",
       "line": 958,
-      "filename": "table_init.29.wasm"
+      "filename": "table_init.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -5051,7 +5077,8 @@
     {
       "type": "module",
       "line": 982,
-      "filename": "table_init.30.wasm"
+      "filename": "table_init.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -5066,7 +5093,8 @@
     {
       "type": "module",
       "line": 1006,
-      "filename": "table_init.31.wasm"
+      "filename": "table_init.31.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -5080,7 +5108,8 @@
     {
       "type": "module",
       "line": 1030,
-      "filename": "table_init.32.wasm"
+      "filename": "table_init.32.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -5095,7 +5124,8 @@
     {
       "type": "module",
       "line": 1054,
-      "filename": "table_init.33.wasm"
+      "filename": "table_init.33.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -5109,7 +5139,8 @@
     {
       "type": "module",
       "line": 1078,
-      "filename": "table_init.34.wasm"
+      "filename": "table_init.34.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -5125,447 +5156,448 @@
       "type": "assert_invalid",
       "line": 1103,
       "filename": "table_init.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1112,
       "filename": "table_init.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1121,
       "filename": "table_init.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1130,
       "filename": "table_init.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1139,
       "filename": "table_init.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1148,
       "filename": "table_init.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1157,
       "filename": "table_init.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1166,
       "filename": "table_init.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1175,
       "filename": "table_init.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1184,
       "filename": "table_init.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1193,
       "filename": "table_init.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1202,
       "filename": "table_init.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1211,
       "filename": "table_init.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1220,
       "filename": "table_init.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1229,
       "filename": "table_init.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1238,
       "filename": "table_init.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1247,
       "filename": "table_init.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1256,
       "filename": "table_init.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1265,
       "filename": "table_init.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1274,
       "filename": "table_init.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1283,
       "filename": "table_init.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1292,
       "filename": "table_init.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1301,
       "filename": "table_init.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1310,
       "filename": "table_init.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1319,
       "filename": "table_init.59.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1328,
       "filename": "table_init.60.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1337,
       "filename": "table_init.61.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1346,
       "filename": "table_init.62.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1355,
       "filename": "table_init.63.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1364,
       "filename": "table_init.64.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1373,
       "filename": "table_init.65.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1382,
       "filename": "table_init.66.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1391,
       "filename": "table_init.67.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1400,
       "filename": "table_init.68.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1409,
       "filename": "table_init.69.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1418,
       "filename": "table_init.70.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1427,
       "filename": "table_init.71.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1436,
       "filename": "table_init.72.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1445,
       "filename": "table_init.73.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1454,
       "filename": "table_init.74.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1463,
       "filename": "table_init.75.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1472,
       "filename": "table_init.76.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1481,
       "filename": "table_init.77.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1490,
       "filename": "table_init.78.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1499,
       "filename": "table_init.79.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1508,
       "filename": "table_init.80.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1517,
       "filename": "table_init.81.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1526,
       "filename": "table_init.82.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1535,
       "filename": "table_init.83.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1544,
       "filename": "table_init.84.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1553,
       "filename": "table_init.85.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1562,
       "filename": "table_init.86.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1571,
       "filename": "table_init.87.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1580,
       "filename": "table_init.88.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1589,
       "filename": "table_init.89.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1598,
       "filename": "table_init.90.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1607,
       "filename": "table_init.91.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1616,
       "filename": "table_init.92.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1625,
       "filename": "table_init.93.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1634,
       "filename": "table_init.94.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1643,
       "filename": "table_init.95.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1652,
       "filename": "table_init.96.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1661,
       "filename": "table_init.97.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 1669,
-      "filename": "table_init.98.wasm"
+      "filename": "table_init.98.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -6069,7 +6101,8 @@
     {
       "type": "module",
       "line": 1731,
-      "filename": "table_init.99.wasm"
+      "filename": "table_init.99.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -6573,7 +6606,8 @@
     {
       "type": "module",
       "line": 1793,
-      "filename": "table_init.100.wasm"
+      "filename": "table_init.100.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -8997,7 +9031,8 @@
     {
       "type": "module",
       "line": 1983,
-      "filename": "table_init.101.wasm"
+      "filename": "table_init.101.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -11421,7 +11456,8 @@
     {
       "type": "module",
       "line": 2173,
-      "filename": "table_init.102.wasm"
+      "filename": "table_init.102.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -12405,7 +12441,8 @@
     {
       "type": "module",
       "line": 2267,
-      "filename": "table_init.103.wasm"
+      "filename": "table_init.103.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -12669,7 +12706,8 @@
     {
       "type": "module",
       "line": 2313,
-      "filename": "table_init.104.wasm"
+      "filename": "table_init.104.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/table_set.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/table_set.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "table_set.0.wasm"
+      "filename": "table_set.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -397,50 +398,50 @@
       "type": "assert_invalid",
       "line": 65,
       "filename": "table_set.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 74,
       "filename": "table_set.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 83,
       "filename": "table_set.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 92,
       "filename": "table_set.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 101,
       "filename": "table_set.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 111,
       "filename": "table_set.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 122,
       "filename": "table_set.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/table_size.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/table_size.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "table_size.0.wasm"
+      "filename": "table_size.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -565,15 +566,15 @@
       "type": "assert_invalid",
       "line": 73,
       "filename": "table_size.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 82,
       "filename": "table_size.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/tag.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/tag.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "tag.0.wasm"
+      "filename": "tag.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -14,19 +15,21 @@
     {
       "type": "module",
       "line": 13,
-      "filename": "tag.1.wasm"
+      "filename": "tag.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 19,
       "filename": "tag.2.wasm",
-      "text": "non-empty tag result type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "non-empty tag result type"
     },
     {
       "type": "module",
       "line": 26,
-      "filename": "tag.3.wasm"
+      "filename": "tag.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -36,21 +39,22 @@
     {
       "type": "module",
       "line": 36,
-      "filename": "tag.4.wasm"
+      "filename": "tag.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 45,
       "filename": "tag.5.wasm",
-      "text": "incompatible import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import"
     },
     {
       "type": "assert_unlinkable",
       "line": 56,
       "filename": "tag.6.wasm",
-      "text": "incompatible import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/throw.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/throw.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "throw.0.wasm"
+      "filename": "throw.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -128,22 +129,22 @@
       "type": "assert_invalid",
       "line": 51,
       "filename": "throw.1.wasm",
-      "text": "unknown tag 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown tag 0"
     },
     {
       "type": "assert_invalid",
       "line": 52,
       "filename": "throw.2.wasm",
-      "text": "type mismatch: instruction requires [i32] but stack has []",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch: instruction requires [i32] but stack has []"
     },
     {
       "type": "assert_invalid",
       "line": 54,
       "filename": "throw.3.wasm",
-      "text": "type mismatch: instruction requires [i32] but stack has [i64]",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch: instruction requires [i32] but stack has [i64]"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/throw_ref.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/throw_ref.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "throw_ref.0.wasm"
+      "filename": "throw_ref.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_exception",
@@ -193,15 +194,15 @@
       "type": "assert_invalid",
       "line": 117,
       "filename": "throw_ref.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 118,
       "filename": "throw_ref.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/token.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/token.wast.json
@@ -5,358 +5,393 @@
       "type": "assert_malformed",
       "line": 4,
       "filename": "token.0.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 8,
       "filename": "token.1.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 15,
-      "filename": "token.2.wasm"
+      "filename": "token.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 18,
-      "filename": "token.3.wasm"
+      "filename": "token.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 21,
-      "filename": "token.4.wasm"
+      "filename": "token.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 24,
-      "filename": "token.5.wasm"
+      "filename": "token.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 27,
-      "filename": "token.6.wasm"
+      "filename": "token.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 30,
-      "filename": "token.7.wasm"
+      "filename": "token.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 33,
-      "filename": "token.8.wasm"
+      "filename": "token.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 38,
-      "filename": "token.9.wasm"
+      "filename": "token.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 43,
-      "filename": "token.10.wasm"
+      "filename": "token.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 47,
-      "filename": "token.11.wasm"
+      "filename": "token.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 54,
-      "filename": "token.12.wasm"
+      "filename": "token.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 58,
-      "filename": "token.13.wasm"
+      "filename": "token.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 62,
-      "filename": "token.14.wasm"
+      "filename": "token.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 66,
-      "filename": "token.15.wasm"
+      "filename": "token.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 70,
-      "filename": "token.16.wasm"
+      "filename": "token.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 74,
-      "filename": "token.17.wasm"
+      "filename": "token.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 82,
-      "filename": "token.18.wasm"
+      "filename": "token.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 86,
       "filename": "token.19.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 92,
       "filename": "token.20.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 98,
-      "filename": "token.21.wasm"
+      "filename": "token.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 102,
       "filename": "token.22.wat",
-      "text": "unknown label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown label"
     },
     {
       "type": "assert_malformed",
       "line": 108,
       "filename": "token.23.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 114,
-      "filename": "token.24.wasm"
+      "filename": "token.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 118,
       "filename": "token.25.wat",
-      "text": "unknown label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown label"
     },
     {
       "type": "assert_malformed",
       "line": 124,
       "filename": "token.26.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 130,
-      "filename": "token.27.wasm"
+      "filename": "token.27.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 133,
-      "filename": "token.28.wasm"
+      "filename": "token.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 140,
-      "filename": "token.29.wasm"
+      "filename": "token.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 144,
       "filename": "token.30.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 150,
-      "filename": "token.31.wasm"
+      "filename": "token.31.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 154,
       "filename": "token.32.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 160,
-      "filename": "token.33.wasm"
+      "filename": "token.33.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 164,
       "filename": "token.34.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 170,
-      "filename": "token.35.wasm"
+      "filename": "token.35.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 174,
       "filename": "token.36.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 180,
-      "filename": "token.37.wasm"
+      "filename": "token.37.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 184,
       "filename": "token.38.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 190,
-      "filename": "token.39.wasm"
+      "filename": "token.39.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 194,
       "filename": "token.40.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 200,
-      "filename": "token.41.wasm"
+      "filename": "token.41.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 204,
       "filename": "token.42.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 210,
-      "filename": "token.43.wasm"
+      "filename": "token.43.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 214,
       "filename": "token.44.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 220,
-      "filename": "token.45.wasm"
+      "filename": "token.45.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 224,
       "filename": "token.46.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 230,
-      "filename": "token.47.wasm"
+      "filename": "token.47.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 234,
       "filename": "token.48.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 240,
-      "filename": "token.49.wasm"
+      "filename": "token.49.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 244,
       "filename": "token.50.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 250,
-      "filename": "token.51.wasm"
+      "filename": "token.51.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 254,
       "filename": "token.52.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 260,
-      "filename": "token.53.wasm"
+      "filename": "token.53.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 264,
       "filename": "token.54.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 270,
-      "filename": "token.55.wasm"
+      "filename": "token.55.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 274,
       "filename": "token.56.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 282,
       "filename": "token.57.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 288,
       "filename": "token.58.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 294,
       "filename": "token.59.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 300,
       "filename": "token.60.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/traps0.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/traps0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "traps0.0.wasm"
+      "filename": "traps0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",

--- a/tests/snapshots/testsuite/proposals/memory64/try_table.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/try_table.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "try_table.0.wasm"
+      "filename": "try_table.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -14,7 +15,8 @@
     {
       "type": "module",
       "line": 10,
-      "filename": "try_table.1.wasm"
+      "filename": "try_table.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -723,7 +725,8 @@
     {
       "type": "module",
       "line": 303,
-      "filename": "try_table.2.wasm"
+      "filename": "try_table.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -744,74 +747,76 @@
       "type": "assert_malformed",
       "line": 328,
       "filename": "try_table.3.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 333,
       "filename": "try_table.4.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "module",
       "line": 337,
-      "filename": "try_table.5.wasm"
+      "filename": "try_table.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 348,
       "filename": "try_table.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 352,
       "filename": "try_table.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 357,
       "filename": "try_table.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 361,
       "filename": "try_table.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 365,
       "filename": "try_table.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 369,
       "filename": "try_table.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 373,
       "filename": "try_table.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 381,
-      "filename": "try_table.13.wasm"
+      "filename": "try_table.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -879,15 +884,15 @@
       "type": "assert_invalid",
       "line": 432,
       "filename": "try_table.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 445,
       "filename": "try_table.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/type-canon.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/type-canon.wast.json
@@ -4,12 +4,14 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "type-canon.0.wasm"
+      "filename": "type-canon.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 9,
-      "filename": "type-canon.1.wasm"
+      "filename": "type-canon.1.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/type-equivalence.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/type-equivalence.wast.json
@@ -4,39 +4,45 @@
     {
       "type": "module",
       "line": 5,
-      "filename": "type-equivalence.0.wasm"
+      "filename": "type-equivalence.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 16,
-      "filename": "type-equivalence.1.wasm"
+      "filename": "type-equivalence.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 30,
-      "filename": "type-equivalence.2.wasm"
+      "filename": "type-equivalence.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 38,
-      "filename": "type-equivalence.3.wasm"
+      "filename": "type-equivalence.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 49,
-      "filename": "type-equivalence.4.wasm"
+      "filename": "type-equivalence.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 77,
       "filename": "type-equivalence.5.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "module",
       "line": 89,
-      "filename": "type-equivalence.6.wasm"
+      "filename": "type-equivalence.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -51,7 +57,8 @@
     {
       "type": "module",
       "line": 107,
-      "filename": "type-equivalence.7.wasm"
+      "filename": "type-equivalence.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -66,7 +73,8 @@
     {
       "type": "module",
       "line": 136,
-      "filename": "type-equivalence.8.wasm"
+      "filename": "type-equivalence.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -81,7 +89,8 @@
     {
       "type": "module",
       "line": 161,
-      "filename": "type-equivalence.9.wasm"
+      "filename": "type-equivalence.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -96,7 +105,8 @@
     {
       "type": "module",
       "line": 195,
-      "filename": "type-equivalence.10.wasm"
+      "filename": "type-equivalence.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -106,12 +116,14 @@
     {
       "type": "module",
       "line": 200,
-      "filename": "type-equivalence.11.wasm"
+      "filename": "type-equivalence.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 208,
-      "filename": "type-equivalence.12.wasm"
+      "filename": "type-equivalence.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -121,12 +133,14 @@
     {
       "type": "module",
       "line": 218,
-      "filename": "type-equivalence.13.wasm"
+      "filename": "type-equivalence.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 233,
-      "filename": "type-equivalence.14.wasm"
+      "filename": "type-equivalence.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -136,12 +150,14 @@
     {
       "type": "module",
       "line": 238,
-      "filename": "type-equivalence.15.wasm"
+      "filename": "type-equivalence.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 246,
-      "filename": "type-equivalence.16.wasm"
+      "filename": "type-equivalence.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -151,12 +167,14 @@
     {
       "type": "module",
       "line": 257,
-      "filename": "type-equivalence.17.wasm"
+      "filename": "type-equivalence.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 268,
-      "filename": "type-equivalence.18.wasm"
+      "filename": "type-equivalence.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -166,12 +184,14 @@
     {
       "type": "module",
       "line": 279,
-      "filename": "type-equivalence.19.wasm"
+      "filename": "type-equivalence.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 290,
-      "filename": "type-equivalence.20.wasm"
+      "filename": "type-equivalence.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -181,7 +201,8 @@
     {
       "type": "module",
       "line": 308,
-      "filename": "type-equivalence.21.wasm"
+      "filename": "type-equivalence.21.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/type-rec.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/type-rec.wast.json
@@ -4,46 +4,49 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "type-rec.0.wasm"
+      "filename": "type-rec.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 10,
-      "filename": "type-rec.1.wasm"
+      "filename": "type-rec.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 26,
       "filename": "type-rec.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 36,
       "filename": "type-rec.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 47,
       "filename": "type-rec.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 57,
       "filename": "type-rec.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 69,
       "name": "M",
-      "filename": "type-rec.6.wasm"
+      "filename": "type-rec.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -54,26 +57,28 @@
     {
       "type": "module",
       "line": 75,
-      "filename": "type-rec.7.wasm"
+      "filename": "type-rec.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 81,
       "filename": "type-rec.8.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 89,
       "filename": "type-rec.9.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 99,
-      "filename": "type-rec.10.wasm"
+      "filename": "type-rec.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -88,7 +93,8 @@
     {
       "type": "module",
       "line": 108,
-      "filename": "type-rec.11.wasm"
+      "filename": "type-rec.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -103,7 +109,8 @@
     {
       "type": "module",
       "line": 117,
-      "filename": "type-rec.12.wasm"
+      "filename": "type-rec.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -118,21 +125,22 @@
     {
       "type": "module",
       "line": 129,
-      "filename": "type-rec.13.wasm"
+      "filename": "type-rec.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 137,
       "filename": "type-rec.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 149,
       "filename": "type-rec.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/type-subtyping.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/type-subtyping.wast.json
@@ -4,98 +4,113 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "type-subtyping.0.wasm"
+      "filename": "type-subtyping.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 15,
-      "filename": "type-subtyping.1.wasm"
+      "filename": "type-subtyping.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 24,
-      "filename": "type-subtyping.2.wasm"
+      "filename": "type-subtyping.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 37,
-      "filename": "type-subtyping.3.wasm"
+      "filename": "type-subtyping.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 43,
-      "filename": "type-subtyping.4.wasm"
+      "filename": "type-subtyping.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 53,
-      "filename": "type-subtyping.5.wasm"
+      "filename": "type-subtyping.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 68,
-      "filename": "type-subtyping.6.wasm"
+      "filename": "type-subtyping.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 89,
-      "filename": "type-subtyping.7.wasm"
+      "filename": "type-subtyping.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 115,
-      "filename": "type-subtyping.8.wasm"
+      "filename": "type-subtyping.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 124,
-      "filename": "type-subtyping.9.wasm"
+      "filename": "type-subtyping.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 140,
       "filename": "type-subtyping.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 151,
-      "filename": "type-subtyping.11.wasm"
+      "filename": "type-subtyping.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 159,
-      "filename": "type-subtyping.12.wasm"
+      "filename": "type-subtyping.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 177,
-      "filename": "type-subtyping.13.wasm"
+      "filename": "type-subtyping.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 188,
-      "filename": "type-subtyping.14.wasm"
+      "filename": "type-subtyping.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 206,
       "filename": "type-subtyping.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 216,
       "filename": "type-subtyping.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 229,
-      "filename": "type-subtyping.17.wasm"
+      "filename": "type-subtyping.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -170,7 +185,8 @@
     {
       "type": "module",
       "line": 290,
-      "filename": "type-subtyping.18.wasm"
+      "filename": "type-subtyping.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -215,7 +231,8 @@
     {
       "type": "module",
       "line": 319,
-      "filename": "type-subtyping.19.wasm"
+      "filename": "type-subtyping.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -250,7 +267,8 @@
     {
       "type": "module",
       "line": 348,
-      "filename": "type-subtyping.20.wasm"
+      "filename": "type-subtyping.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -270,7 +288,8 @@
     {
       "type": "module",
       "line": 360,
-      "filename": "type-subtyping.21.wasm"
+      "filename": "type-subtyping.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -290,7 +309,8 @@
     {
       "type": "module",
       "line": 378,
-      "filename": "type-subtyping.22.wasm"
+      "filename": "type-subtyping.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -310,7 +330,8 @@
     {
       "type": "module",
       "line": 390,
-      "filename": "type-subtyping.23.wasm"
+      "filename": "type-subtyping.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -330,7 +351,8 @@
     {
       "type": "module",
       "line": 401,
-      "filename": "type-subtyping.24.wasm"
+      "filename": "type-subtyping.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -354,7 +376,8 @@
     {
       "type": "module",
       "line": 422,
-      "filename": "type-subtyping.25.wasm"
+      "filename": "type-subtyping.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -386,7 +409,8 @@
     {
       "type": "module",
       "line": 438,
-      "filename": "type-subtyping.26.wasm"
+      "filename": "type-subtyping.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -434,7 +458,8 @@
     {
       "type": "module",
       "line": 461,
-      "filename": "type-subtyping.27.wasm"
+      "filename": "type-subtyping.27.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -454,7 +479,8 @@
     {
       "type": "module",
       "line": 471,
-      "filename": "type-subtyping.28.wasm"
+      "filename": "type-subtyping.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -474,7 +500,8 @@
     {
       "type": "module",
       "line": 486,
-      "filename": "type-subtyping.29.wasm"
+      "filename": "type-subtyping.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -484,33 +511,35 @@
     {
       "type": "module",
       "line": 497,
-      "filename": "type-subtyping.30.wasm"
+      "filename": "type-subtyping.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 511,
       "filename": "type-subtyping.31.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 521,
       "filename": "type-subtyping.32.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 531,
       "filename": "type-subtyping.33.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 540,
-      "filename": "type-subtyping.34.wasm"
+      "filename": "type-subtyping.34.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -521,20 +550,21 @@
       "type": "assert_unlinkable",
       "line": 549,
       "filename": "type-subtyping.35.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 557,
       "filename": "type-subtyping.36.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 566,
-      "filename": "type-subtyping.37.wasm"
+      "filename": "type-subtyping.37.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -544,12 +574,14 @@
     {
       "type": "module",
       "line": 572,
-      "filename": "type-subtyping.38.wasm"
+      "filename": "type-subtyping.38.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 578,
-      "filename": "type-subtyping.39.wasm"
+      "filename": "type-subtyping.39.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -559,12 +591,14 @@
     {
       "type": "module",
       "line": 588,
-      "filename": "type-subtyping.40.wasm"
+      "filename": "type-subtyping.40.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 598,
-      "filename": "type-subtyping.41.wasm"
+      "filename": "type-subtyping.41.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -575,13 +609,14 @@
       "type": "assert_unlinkable",
       "line": 606,
       "filename": "type-subtyping.42.wasm",
-      "text": "incompatible import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import"
     },
     {
       "type": "module",
       "line": 614,
-      "filename": "type-subtyping.43.wasm"
+      "filename": "type-subtyping.43.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -591,12 +626,14 @@
     {
       "type": "module",
       "line": 621,
-      "filename": "type-subtyping.44.wasm"
+      "filename": "type-subtyping.44.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 628,
-      "filename": "type-subtyping.45.wasm"
+      "filename": "type-subtyping.45.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -606,12 +643,14 @@
     {
       "type": "module",
       "line": 639,
-      "filename": "type-subtyping.46.wasm"
+      "filename": "type-subtyping.46.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 652,
-      "filename": "type-subtyping.47.wasm"
+      "filename": "type-subtyping.47.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -621,12 +660,14 @@
     {
       "type": "module",
       "line": 659,
-      "filename": "type-subtyping.48.wasm"
+      "filename": "type-subtyping.48.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 668,
-      "filename": "type-subtyping.49.wasm"
+      "filename": "type-subtyping.49.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -636,12 +677,14 @@
     {
       "type": "module",
       "line": 677,
-      "filename": "type-subtyping.50.wasm"
+      "filename": "type-subtyping.50.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 692,
-      "filename": "type-subtyping.51.wasm"
+      "filename": "type-subtyping.51.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -652,13 +695,14 @@
       "type": "assert_unlinkable",
       "line": 699,
       "filename": "type-subtyping.52.wasm",
-      "text": "incompatible import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import"
     },
     {
       "type": "module",
       "line": 706,
-      "filename": "type-subtyping.53.wasm"
+      "filename": "type-subtyping.53.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -669,99 +713,99 @@
       "type": "assert_unlinkable",
       "line": 714,
       "filename": "type-subtyping.54.wasm",
-      "text": "incompatible import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import"
     },
     {
       "type": "assert_invalid",
       "line": 727,
       "filename": "type-subtyping.55.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 735,
       "filename": "type-subtyping.56.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 743,
       "filename": "type-subtyping.57.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 751,
       "filename": "type-subtyping.58.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 764,
       "filename": "type-subtyping.59.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 772,
       "filename": "type-subtyping.60.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 780,
       "filename": "type-subtyping.61.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 788,
       "filename": "type-subtyping.62.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 796,
       "filename": "type-subtyping.63.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 804,
       "filename": "type-subtyping.64.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 812,
       "filename": "type-subtyping.65.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 820,
       "filename": "type-subtyping.66.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     },
     {
       "type": "assert_invalid",
       "line": 828,
       "filename": "type-subtyping.67.wasm",
-      "text": "sub type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "sub type"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/unreached-invalid.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/unreached-invalid.wast.json
@@ -5,848 +5,848 @@
       "type": "assert_invalid",
       "line": 4,
       "filename": "unreached-invalid.0.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 8,
       "filename": "unreached-invalid.1.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 12,
       "filename": "unreached-invalid.2.wasm",
-      "text": "unknown function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function"
     },
     {
       "type": "assert_invalid",
       "line": 16,
       "filename": "unreached-invalid.3.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 21,
       "filename": "unreached-invalid.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 27,
       "filename": "unreached-invalid.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 33,
       "filename": "unreached-invalid.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 42,
       "filename": "unreached-invalid.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 46,
       "filename": "unreached-invalid.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 50,
       "filename": "unreached-invalid.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 56,
       "filename": "unreached-invalid.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 60,
       "filename": "unreached-invalid.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 64,
       "filename": "unreached-invalid.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 71,
       "filename": "unreached-invalid.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 77,
       "filename": "unreached-invalid.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 83,
       "filename": "unreached-invalid.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 89,
       "filename": "unreached-invalid.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 95,
       "filename": "unreached-invalid.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 101,
       "filename": "unreached-invalid.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 107,
       "filename": "unreached-invalid.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 113,
       "filename": "unreached-invalid.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 119,
       "filename": "unreached-invalid.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 125,
       "filename": "unreached-invalid.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 132,
       "filename": "unreached-invalid.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 138,
       "filename": "unreached-invalid.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 144,
       "filename": "unreached-invalid.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 150,
       "filename": "unreached-invalid.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 156,
       "filename": "unreached-invalid.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 162,
       "filename": "unreached-invalid.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 168,
       "filename": "unreached-invalid.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 174,
       "filename": "unreached-invalid.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 180,
       "filename": "unreached-invalid.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 186,
       "filename": "unreached-invalid.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 193,
       "filename": "unreached-invalid.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 199,
       "filename": "unreached-invalid.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 205,
       "filename": "unreached-invalid.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 211,
       "filename": "unreached-invalid.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 217,
       "filename": "unreached-invalid.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 223,
       "filename": "unreached-invalid.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 229,
       "filename": "unreached-invalid.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 235,
       "filename": "unreached-invalid.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 241,
       "filename": "unreached-invalid.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 247,
       "filename": "unreached-invalid.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 253,
       "filename": "unreached-invalid.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 259,
       "filename": "unreached-invalid.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 265,
       "filename": "unreached-invalid.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 271,
       "filename": "unreached-invalid.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 277,
       "filename": "unreached-invalid.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 284,
       "filename": "unreached-invalid.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 290,
       "filename": "unreached-invalid.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 296,
       "filename": "unreached-invalid.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 302,
       "filename": "unreached-invalid.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 308,
       "filename": "unreached-invalid.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 314,
       "filename": "unreached-invalid.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 321,
       "filename": "unreached-invalid.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 327,
       "filename": "unreached-invalid.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 334,
       "filename": "unreached-invalid.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 340,
       "filename": "unreached-invalid.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 348,
       "filename": "unreached-invalid.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 354,
       "filename": "unreached-invalid.59.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 360,
       "filename": "unreached-invalid.60.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 366,
       "filename": "unreached-invalid.61.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 372,
       "filename": "unreached-invalid.62.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 378,
       "filename": "unreached-invalid.63.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 384,
       "filename": "unreached-invalid.64.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 390,
       "filename": "unreached-invalid.65.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 396,
       "filename": "unreached-invalid.66.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 402,
       "filename": "unreached-invalid.67.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 409,
       "filename": "unreached-invalid.68.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 415,
       "filename": "unreached-invalid.69.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 421,
       "filename": "unreached-invalid.70.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 427,
       "filename": "unreached-invalid.71.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 433,
       "filename": "unreached-invalid.72.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 439,
       "filename": "unreached-invalid.73.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 445,
       "filename": "unreached-invalid.74.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 451,
       "filename": "unreached-invalid.75.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 457,
       "filename": "unreached-invalid.76.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 463,
       "filename": "unreached-invalid.77.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 470,
       "filename": "unreached-invalid.78.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 477,
       "filename": "unreached-invalid.79.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 484,
       "filename": "unreached-invalid.80.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 490,
       "filename": "unreached-invalid.81.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 498,
       "filename": "unreached-invalid.82.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 507,
       "filename": "unreached-invalid.83.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 515,
       "filename": "unreached-invalid.84.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 521,
       "filename": "unreached-invalid.85.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 527,
       "filename": "unreached-invalid.86.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 540,
       "filename": "unreached-invalid.87.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 546,
       "filename": "unreached-invalid.88.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 552,
       "filename": "unreached-invalid.89.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 558,
       "filename": "unreached-invalid.90.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 565,
       "filename": "unreached-invalid.91.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 571,
       "filename": "unreached-invalid.92.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 577,
       "filename": "unreached-invalid.93.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 584,
       "filename": "unreached-invalid.94.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 590,
       "filename": "unreached-invalid.95.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 596,
       "filename": "unreached-invalid.96.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 604,
       "filename": "unreached-invalid.97.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 611,
       "filename": "unreached-invalid.98.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 617,
       "filename": "unreached-invalid.99.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 623,
       "filename": "unreached-invalid.100.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 629,
       "filename": "unreached-invalid.101.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 637,
       "filename": "unreached-invalid.102.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 643,
       "filename": "unreached-invalid.103.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 649,
       "filename": "unreached-invalid.104.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 656,
       "filename": "unreached-invalid.105.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 662,
       "filename": "unreached-invalid.106.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 669,
       "filename": "unreached-invalid.107.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 676,
       "filename": "unreached-invalid.108.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 687,
       "filename": "unreached-invalid.109.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 698,
       "filename": "unreached-invalid.110.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 710,
       "filename": "unreached-invalid.111.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 715,
       "filename": "unreached-invalid.112.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 721,
       "filename": "unreached-invalid.113.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 726,
       "filename": "unreached-invalid.114.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 731,
       "filename": "unreached-invalid.115.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 737,
       "filename": "unreached-invalid.116.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 744,
       "filename": "unreached-invalid.117.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 749,
       "filename": "unreached-invalid.118.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 764,
       "filename": "unreached-invalid.119.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 774,
       "filename": "unreached-invalid.120.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/memory64/unreached-valid.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/unreached-valid.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "unreached-valid.0.wasm"
+      "filename": "unreached-valid.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -119,7 +120,8 @@
     {
       "type": "module",
       "line": 63,
-      "filename": "unreached-valid.1.wasm"
+      "filename": "unreached-valid.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -134,7 +136,8 @@
     {
       "type": "module",
       "line": 82,
-      "filename": "unreached-valid.2.wasm"
+      "filename": "unreached-valid.2.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/multi-memory/address0.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/address0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "address0.0.wasm"
+      "filename": "address0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/multi-memory/address1.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/address1.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "address1.0.wasm"
+      "filename": "address1.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/multi-memory/align0.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/align0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "align0.0.wasm"
+      "filename": "align0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/multi-memory/binary.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/binary.wast.json
@@ -4,834 +4,853 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "binary.0.wasm"
+      "filename": "binary.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 2,
-      "filename": "binary.1.wasm"
+      "filename": "binary.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 3,
       "name": "M1",
-      "filename": "binary.2.wasm"
+      "filename": "binary.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 4,
       "name": "M2",
-      "filename": "binary.3.wasm"
+      "filename": "binary.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 6,
       "filename": "binary.4.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 7,
       "filename": "binary.5.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 8,
       "filename": "binary.6.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 9,
       "filename": "binary.7.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 10,
       "filename": "binary.8.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 11,
       "filename": "binary.9.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 12,
       "filename": "binary.10.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 13,
       "filename": "binary.11.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 14,
       "filename": "binary.12.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 15,
       "filename": "binary.13.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 16,
       "filename": "binary.14.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 17,
       "filename": "binary.15.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 18,
       "filename": "binary.16.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 21,
       "filename": "binary.17.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 24,
       "filename": "binary.18.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 25,
       "filename": "binary.19.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 28,
       "filename": "binary.20.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 31,
       "filename": "binary.21.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 34,
       "filename": "binary.22.wasm",
-      "text": "magic header not detected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "magic header not detected"
     },
     {
       "type": "assert_malformed",
       "line": 37,
       "filename": "binary.23.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 38,
       "filename": "binary.24.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 39,
       "filename": "binary.25.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 40,
       "filename": "binary.26.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 41,
       "filename": "binary.27.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 42,
       "filename": "binary.28.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 43,
       "filename": "binary.29.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 44,
       "filename": "binary.30.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 45,
       "filename": "binary.31.wasm",
-      "text": "unknown binary version",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown binary version"
     },
     {
       "type": "assert_malformed",
       "line": 48,
       "filename": "binary.32.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 49,
       "filename": "binary.33.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 50,
       "filename": "binary.34.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 51,
       "filename": "binary.35.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 52,
       "filename": "binary.36.wasm",
-      "text": "malformed section id",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed section id"
     },
     {
       "type": "assert_malformed",
       "line": 56,
       "filename": "binary.37.wasm",
-      "text": "END opcode expected",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "END opcode expected"
     },
     {
       "type": "assert_malformed",
       "line": 77,
       "filename": "binary.38.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 93,
       "filename": "binary.39.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 113,
       "filename": "binary.40.wasm",
-      "text": "illegal opcode",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "illegal opcode"
     },
     {
       "type": "assert_malformed",
       "line": 126,
       "filename": "binary.41.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 143,
       "filename": "binary.42.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 160,
       "filename": "binary.43.wasm",
-      "text": "too many locals",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "too many locals"
     },
     {
       "type": "assert_malformed",
       "line": 176,
       "filename": "binary.44.wasm",
-      "text": "too many locals",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "too many locals"
     },
     {
       "type": "module",
       "line": 194,
-      "filename": "binary.45.wasm"
+      "filename": "binary.45.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 210,
       "filename": "binary.46.wasm",
-      "text": "function and code section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function and code section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 220,
       "filename": "binary.47.wasm",
-      "text": "function and code section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function and code section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 229,
       "filename": "binary.48.wasm",
-      "text": "function and code section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function and code section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 240,
       "filename": "binary.49.wasm",
-      "text": "function and code section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "function and code section have inconsistent lengths"
     },
     {
       "type": "module",
       "line": 250,
-      "filename": "binary.50.wasm"
+      "filename": "binary.50.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 256,
-      "filename": "binary.51.wasm"
+      "filename": "binary.51.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 263,
       "filename": "binary.52.wasm",
-      "text": "data count and data section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "data count and data section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 273,
       "filename": "binary.53.wasm",
-      "text": "data count and data section have inconsistent lengths",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "data count and data section have inconsistent lengths"
     },
     {
       "type": "assert_malformed",
       "line": 283,
       "filename": "binary.54.wasm",
-      "text": "data count section required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "data count section required"
     },
     {
       "type": "assert_malformed",
       "line": 305,
       "filename": "binary.55.wasm",
-      "text": "data count section required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "data count section required"
     },
     {
       "type": "assert_malformed",
       "line": 324,
       "filename": "binary.56.wasm",
-      "text": "illegal opcode",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "illegal opcode"
     },
     {
       "type": "assert_malformed",
       "line": 350,
       "filename": "binary.57.wasm",
-      "text": "malformed reference type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed reference type"
     },
     {
       "type": "module",
       "line": 375,
-      "filename": "binary.58.wasm"
+      "filename": "binary.58.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 399,
-      "filename": "binary.59.wasm"
+      "filename": "binary.59.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 424,
-      "filename": "binary.60.wasm"
+      "filename": "binary.60.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 431,
       "filename": "binary.61.wasm",
-      "text": "length out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "length out of bounds"
     },
     {
       "type": "assert_malformed",
       "line": 442,
       "filename": "binary.62.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 452,
-      "filename": "binary.63.wasm"
+      "filename": "binary.63.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 461,
       "filename": "binary.64.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 471,
       "filename": "binary.65.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 482,
       "filename": "binary.66.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 492,
       "filename": "binary.67.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 503,
       "filename": "binary.68.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 513,
       "filename": "binary.69.wasm",
-      "text": "malformed import kind",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed import kind"
     },
     {
       "type": "assert_malformed",
       "line": 526,
       "filename": "binary.70.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 545,
       "filename": "binary.71.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 569,
-      "filename": "binary.72.wasm"
+      "filename": "binary.72.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 576,
       "filename": "binary.73.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 586,
       "filename": "binary.74.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 595,
       "filename": "binary.75.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 605,
       "filename": "binary.76.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "module",
       "line": 616,
-      "filename": "binary.77.wasm"
+      "filename": "binary.77.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 623,
       "filename": "binary.78.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 633,
       "filename": "binary.79.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 641,
       "filename": "binary.80.wasm",
-      "text": "integer too large",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer too large"
     },
     {
       "type": "assert_malformed",
       "line": 650,
       "filename": "binary.81.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 659,
       "filename": "binary.82.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "module",
       "line": 669,
-      "filename": "binary.83.wasm"
+      "filename": "binary.83.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 676,
       "filename": "binary.84.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 687,
       "filename": "binary.85.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 697,
-      "filename": "binary.86.wasm"
+      "filename": "binary.86.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 710,
       "filename": "binary.87.wasm",
-      "text": "length out of bounds",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "length out of bounds"
     },
     {
       "type": "assert_malformed",
       "line": 731,
       "filename": "binary.88.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 751,
-      "filename": "binary.89.wasm"
+      "filename": "binary.89.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 765,
       "filename": "binary.90.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 781,
       "filename": "binary.91.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "assert_malformed",
       "line": 798,
       "filename": "binary.92.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 815,
-      "filename": "binary.93.wasm"
+      "filename": "binary.93.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 824,
       "filename": "binary.94.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 837,
       "filename": "binary.95.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 850,
       "filename": "binary.96.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     },
     {
       "type": "assert_malformed",
       "line": 864,
       "filename": "binary.97.wasm",
-      "text": "section size mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "section size mismatch"
     },
     {
       "type": "module",
       "line": 877,
-      "filename": "binary.98.wasm"
+      "filename": "binary.98.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 895,
       "filename": "binary.99.wasm",
-      "text": "unexpected end",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end"
     },
     {
       "type": "module",
       "line": 928,
-      "filename": "binary.100.wasm"
+      "filename": "binary.100.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 942,
       "filename": "binary.101.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 959,
       "filename": "binary.102.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 971,
       "filename": "binary.103.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 983,
       "filename": "binary.104.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 993,
       "filename": "binary.105.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1003,
       "filename": "binary.106.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1013,
       "filename": "binary.107.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1023,
       "filename": "binary.108.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1033,
       "filename": "binary.109.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1043,
       "filename": "binary.110.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1053,
       "filename": "binary.111.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1063,
       "filename": "binary.112.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1073,
       "filename": "binary.113.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1083,
       "filename": "binary.114.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1093,
       "filename": "binary.115.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1103,
       "filename": "binary.116.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1113,
       "filename": "binary.117.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1123,
       "filename": "binary.118.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1133,
       "filename": "binary.119.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1144,
       "filename": "binary.120.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1155,
       "filename": "binary.121.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1165,
       "filename": "binary.122.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     },
     {
       "type": "assert_malformed",
       "line": 1175,
       "filename": "binary.123.wasm",
-      "text": "unexpected content after last section",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected content after last section"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/multi-memory/binary0.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/binary0.wast.json
@@ -4,41 +4,46 @@
     {
       "type": "module",
       "line": 2,
-      "filename": "binary0.0.wasm"
+      "filename": "binary0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 8,
-      "filename": "binary0.1.wasm"
+      "filename": "binary0.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 16,
-      "filename": "binary0.2.wasm"
+      "filename": "binary0.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 26,
-      "filename": "binary0.3.wasm"
+      "filename": "binary0.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 36,
-      "filename": "binary0.4.wasm"
+      "filename": "binary0.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 48,
       "filename": "binary0.5.wasm",
-      "text": "integer representation too long",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "integer representation too long"
     },
     {
       "type": "assert_malformed",
       "line": 59,
       "filename": "binary0.6.wasm",
-      "text": "unexpected end of section or function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unexpected end of section or function"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/multi-memory/data.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/data.wast.json
@@ -4,379 +4,404 @@
     {
       "type": "module",
       "line": 5,
-      "filename": "data.0.wasm"
+      "filename": "data.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 36,
-      "filename": "data.1.wasm"
+      "filename": "data.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 40,
-      "filename": "data.2.wasm"
+      "filename": "data.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 45,
-      "filename": "data.3.wasm"
+      "filename": "data.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 53,
-      "filename": "data.4.wasm"
+      "filename": "data.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 63,
-      "filename": "data.5.wasm"
+      "filename": "data.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 68,
-      "filename": "data.6.wasm"
+      "filename": "data.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 74,
-      "filename": "data.7.wasm"
+      "filename": "data.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 79,
-      "filename": "data.8.wasm"
+      "filename": "data.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 86,
       "filename": "data.9.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 90,
       "filename": "data.10.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "module",
       "line": 97,
-      "filename": "data.11.wasm"
+      "filename": "data.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 102,
-      "filename": "data.12.wasm"
+      "filename": "data.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 108,
-      "filename": "data.13.wasm"
+      "filename": "data.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 113,
-      "filename": "data.14.wasm"
+      "filename": "data.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 117,
-      "filename": "data.15.wasm"
+      "filename": "data.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 122,
-      "filename": "data.16.wasm"
+      "filename": "data.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 127,
-      "filename": "data.17.wasm"
+      "filename": "data.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 132,
-      "filename": "data.18.wasm"
+      "filename": "data.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 136,
-      "filename": "data.19.wasm"
+      "filename": "data.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 141,
-      "filename": "data.20.wasm"
+      "filename": "data.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 146,
-      "filename": "data.21.wasm"
+      "filename": "data.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 151,
-      "filename": "data.22.wasm"
+      "filename": "data.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 156,
-      "filename": "data.23.wasm"
+      "filename": "data.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 162,
-      "filename": "data.24.wasm"
+      "filename": "data.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 168,
-      "filename": "data.25.wasm"
+      "filename": "data.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 173,
-      "filename": "data.26.wasm"
+      "filename": "data.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_uninstantiable",
       "line": 181,
       "filename": "data.27.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 189,
       "filename": "data.28.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 197,
       "filename": "data.29.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 204,
       "filename": "data.30.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 211,
       "filename": "data.31.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 228,
       "filename": "data.32.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 237,
       "filename": "data.33.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 244,
       "filename": "data.34.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 252,
       "filename": "data.35.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 260,
       "filename": "data.36.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 268,
       "filename": "data.37.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 275,
       "filename": "data.38.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 283,
       "filename": "data.39.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 290,
       "filename": "data.40.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_invalid",
       "line": 300,
       "filename": "data.41.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 308,
       "filename": "data.42.wasm",
-      "text": "unknown memory 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 1"
     },
     {
       "type": "assert_invalid",
       "line": 321,
       "filename": "data.43.wasm",
-      "text": "unknown memory 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 0"
     },
     {
       "type": "assert_invalid",
       "line": 332,
       "filename": "data.44.wasm",
-      "text": "unknown memory 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 1"
     },
     {
       "type": "assert_invalid",
       "line": 344,
       "filename": "data.45.wasm",
-      "text": "unknown memory 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 1"
     },
     {
       "type": "assert_invalid",
       "line": 366,
       "filename": "data.46.wasm",
-      "text": "unknown memory 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory 1"
     },
     {
       "type": "assert_invalid",
       "line": 385,
       "filename": "data.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 393,
       "filename": "data.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 401,
       "filename": "data.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 409,
       "filename": "data.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 417,
       "filename": "data.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 426,
       "filename": "data.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 435,
       "filename": "data.53.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 443,
       "filename": "data.54.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 451,
       "filename": "data.55.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 459,
       "filename": "data.56.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 467,
       "filename": "data.57.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     },
     {
       "type": "assert_invalid",
       "line": 476,
       "filename": "data.58.wasm",
-      "text": "unknown global 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global 0"
     },
     {
       "type": "assert_invalid",
       "line": 484,
       "filename": "data.59.wasm",
-      "text": "unknown global 1",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global 1"
     },
     {
       "type": "assert_invalid",
       "line": 493,
       "filename": "data.60.wasm",
-      "text": "constant expression required",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "constant expression required"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/multi-memory/data0.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/data0.wast.json
@@ -4,37 +4,44 @@
     {
       "type": "module",
       "line": 5,
-      "filename": "data0.0.wasm"
+      "filename": "data0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 39,
-      "filename": "data0.1.wasm"
+      "filename": "data0.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 43,
-      "filename": "data0.2.wasm"
+      "filename": "data0.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 52,
-      "filename": "data0.3.wasm"
+      "filename": "data0.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 57,
-      "filename": "data0.4.wasm"
+      "filename": "data0.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 63,
-      "filename": "data0.5.wasm"
+      "filename": "data0.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 68,
-      "filename": "data0.6.wasm"
+      "filename": "data0.6.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/multi-memory/data1.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/data1.wast.json
@@ -5,99 +5,99 @@
       "type": "assert_uninstantiable",
       "line": 4,
       "filename": "data1.0.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 14,
       "filename": "data1.1.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 24,
       "filename": "data1.2.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 33,
       "filename": "data1.3.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 42,
       "filename": "data1.4.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 61,
       "filename": "data1.5.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 72,
       "filename": "data1.6.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 81,
       "filename": "data1.7.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 89,
       "filename": "data1.8.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 99,
       "filename": "data1.9.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 109,
       "filename": "data1.10.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 118,
       "filename": "data1.11.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 128,
       "filename": "data1.12.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 137,
       "filename": "data1.13.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/multi-memory/data_drop0.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/data_drop0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 2,
-      "filename": "data_drop0.0.wasm"
+      "filename": "data_drop0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",

--- a/tests/snapshots/testsuite/proposals/multi-memory/exports0.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/exports0.wast.json
@@ -4,42 +4,50 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "exports0.0.wasm"
+      "filename": "exports0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 4,
-      "filename": "exports0.1.wasm"
+      "filename": "exports0.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 5,
-      "filename": "exports0.2.wasm"
+      "filename": "exports0.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 6,
-      "filename": "exports0.3.wasm"
+      "filename": "exports0.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 32,
-      "filename": "exports0.4.wasm"
+      "filename": "exports0.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 40,
-      "filename": "exports0.5.wasm"
+      "filename": "exports0.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 49,
-      "filename": "exports0.6.wasm"
+      "filename": "exports0.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 50,
-      "filename": "exports0.7.wasm"
+      "filename": "exports0.7.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/multi-memory/float_exprs0.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/float_exprs0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "float_exprs0.0.wasm"
+      "filename": "float_exprs0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",

--- a/tests/snapshots/testsuite/proposals/multi-memory/float_exprs1.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/float_exprs1.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "float_exprs1.0.wasm"
+      "filename": "float_exprs1.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/multi-memory/float_memory0.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/float_memory0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 5,
-      "filename": "float_memory0.0.wasm"
+      "filename": "float_memory0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -195,7 +196,8 @@
     {
       "type": "module",
       "line": 35,
-      "filename": "float_memory0.1.wasm"
+      "filename": "float_memory0.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/multi-memory/imports.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/imports.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "imports.0.wasm"
+      "filename": "imports.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -14,7 +15,8 @@
     {
       "type": "module",
       "line": 26,
-      "filename": "imports.1.wasm"
+      "filename": "imports.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -50,13 +52,14 @@
       "type": "assert_invalid",
       "line": 89,
       "filename": "imports.2.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "module",
       "line": 97,
-      "filename": "imports.3.wasm"
+      "filename": "imports.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -76,7 +79,8 @@
     {
       "type": "module",
       "line": 107,
-      "filename": "imports.4.wasm"
+      "filename": "imports.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -105,210 +109,218 @@
     {
       "type": "module",
       "line": 116,
-      "filename": "imports.5.wasm"
+      "filename": "imports.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 117,
-      "filename": "imports.6.wasm"
+      "filename": "imports.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 118,
-      "filename": "imports.7.wasm"
+      "filename": "imports.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 119,
-      "filename": "imports.8.wasm"
+      "filename": "imports.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 120,
-      "filename": "imports.9.wasm"
+      "filename": "imports.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 121,
-      "filename": "imports.10.wasm"
+      "filename": "imports.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 122,
-      "filename": "imports.11.wasm"
+      "filename": "imports.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 125,
       "filename": "imports.12.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 129,
       "filename": "imports.13.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 134,
       "filename": "imports.14.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 138,
       "filename": "imports.15.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 142,
       "filename": "imports.16.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 146,
       "filename": "imports.17.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 150,
       "filename": "imports.18.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 154,
       "filename": "imports.19.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 158,
       "filename": "imports.20.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 162,
       "filename": "imports.21.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 166,
       "filename": "imports.22.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 170,
       "filename": "imports.23.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 174,
       "filename": "imports.24.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 178,
       "filename": "imports.25.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 182,
       "filename": "imports.26.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 186,
       "filename": "imports.27.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 190,
       "filename": "imports.28.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 194,
       "filename": "imports.29.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 199,
       "filename": "imports.30.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 203,
       "filename": "imports.31.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 207,
       "filename": "imports.32.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 211,
       "filename": "imports.33.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 215,
       "filename": "imports.34.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 219,
       "filename": "imports.35.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 226,
-      "filename": "imports.36.wasm"
+      "filename": "imports.36.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -418,162 +430,166 @@
     {
       "type": "module",
       "line": 254,
-      "filename": "imports.37.wasm"
+      "filename": "imports.37.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 255,
-      "filename": "imports.38.wasm"
+      "filename": "imports.38.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 256,
-      "filename": "imports.39.wasm"
+      "filename": "imports.39.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 259,
       "filename": "imports.40.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 263,
       "filename": "imports.41.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 268,
       "filename": "imports.42.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 272,
       "filename": "imports.43.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 276,
       "filename": "imports.44.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 280,
       "filename": "imports.45.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 284,
       "filename": "imports.46.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 288,
       "filename": "imports.47.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 292,
       "filename": "imports.48.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 296,
       "filename": "imports.49.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 300,
       "filename": "imports.50.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 304,
       "filename": "imports.51.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 308,
       "filename": "imports.52.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 312,
       "filename": "imports.53.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 317,
       "filename": "imports.54.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 321,
       "filename": "imports.55.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 325,
       "filename": "imports.56.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 329,
       "filename": "imports.57.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 333,
       "filename": "imports.58.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 337,
       "filename": "imports.59.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 344,
-      "filename": "imports.60.wasm"
+      "filename": "imports.60.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -663,7 +679,8 @@
     {
       "type": "module",
       "line": 363,
-      "filename": "imports.61.wasm"
+      "filename": "imports.61.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -753,196 +770,218 @@
     {
       "type": "module",
       "line": 382,
-      "filename": "imports.62.wasm"
+      "filename": "imports.62.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 389,
-      "filename": "imports.63.wasm"
+      "filename": "imports.63.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 390,
-      "filename": "imports.64.wasm"
+      "filename": "imports.64.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 391,
-      "filename": "imports.65.wasm"
+      "filename": "imports.65.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 392,
-      "filename": "imports.66.wasm"
+      "filename": "imports.66.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 393,
-      "filename": "imports.67.wasm"
+      "filename": "imports.67.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 394,
-      "filename": "imports.68.wasm"
+      "filename": "imports.68.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 395,
-      "filename": "imports.69.wasm"
+      "filename": "imports.69.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 396,
-      "filename": "imports.70.wasm"
+      "filename": "imports.70.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 397,
-      "filename": "imports.71.wasm"
+      "filename": "imports.71.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 398,
-      "filename": "imports.72.wasm"
+      "filename": "imports.72.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 399,
-      "filename": "imports.73.wasm"
+      "filename": "imports.73.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 400,
-      "filename": "imports.74.wasm"
+      "filename": "imports.74.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 401,
-      "filename": "imports.75.wasm"
+      "filename": "imports.75.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 402,
-      "filename": "imports.76.wasm"
+      "filename": "imports.76.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 403,
-      "filename": "imports.77.wasm"
+      "filename": "imports.77.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 404,
-      "filename": "imports.78.wasm"
+      "filename": "imports.78.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 405,
-      "filename": "imports.79.wasm"
+      "filename": "imports.79.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 406,
-      "filename": "imports.80.wasm"
+      "filename": "imports.80.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 407,
-      "filename": "imports.81.wasm"
+      "filename": "imports.81.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 408,
-      "filename": "imports.82.wasm"
+      "filename": "imports.82.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 411,
       "filename": "imports.83.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 415,
       "filename": "imports.84.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 420,
       "filename": "imports.85.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 424,
       "filename": "imports.86.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 428,
       "filename": "imports.87.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 432,
       "filename": "imports.88.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 436,
       "filename": "imports.89.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 440,
       "filename": "imports.90.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 445,
       "filename": "imports.91.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 449,
       "filename": "imports.92.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 453,
       "filename": "imports.93.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 457,
       "filename": "imports.94.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 465,
-      "filename": "imports.95.wasm"
+      "filename": "imports.95.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1022,7 +1061,8 @@
     {
       "type": "module",
       "line": 477,
-      "filename": "imports.96.wasm"
+      "filename": "imports.96.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1102,150 +1142,160 @@
     {
       "type": "module",
       "line": 488,
-      "filename": "imports.97.wasm"
+      "filename": "imports.97.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 489,
-      "filename": "imports.98.wasm"
+      "filename": "imports.98.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 490,
-      "filename": "imports.99.wasm"
+      "filename": "imports.99.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 491,
-      "filename": "imports.100.wasm"
+      "filename": "imports.100.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 492,
-      "filename": "imports.101.wasm"
+      "filename": "imports.101.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 493,
-      "filename": "imports.102.wasm"
+      "filename": "imports.102.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 494,
-      "filename": "imports.103.wasm"
+      "filename": "imports.103.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 495,
-      "filename": "imports.104.wasm"
+      "filename": "imports.104.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 496,
-      "filename": "imports.105.wasm"
+      "filename": "imports.105.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 499,
       "filename": "imports.106.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 503,
       "filename": "imports.107.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 508,
       "filename": "imports.108.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 512,
       "filename": "imports.109.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 516,
       "filename": "imports.110.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 520,
       "filename": "imports.111.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 525,
       "filename": "imports.112.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 529,
       "filename": "imports.113.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 533,
       "filename": "imports.114.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 537,
       "filename": "imports.115.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 541,
       "filename": "imports.116.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 545,
       "filename": "imports.117.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 550,
       "filename": "imports.118.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 554,
       "filename": "imports.119.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 558,
-      "filename": "imports.120.wasm"
+      "filename": "imports.120.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1351,7 +1401,8 @@
       "type": "module",
       "line": 568,
       "name": "Mgm",
-      "filename": "imports.121.wasm"
+      "filename": "imports.121.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1379,7 +1430,8 @@
       "type": "module",
       "line": 574,
       "name": "Mgim1",
-      "filename": "imports.122.wasm"
+      "filename": "imports.122.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1407,7 +1459,8 @@
       "type": "module",
       "line": 581,
       "name": "Mgim2",
-      "filename": "imports.123.wasm"
+      "filename": "imports.123.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1429,118 +1482,119 @@
       "type": "assert_malformed",
       "line": 592,
       "filename": "imports.124.wat",
-      "text": "import after function",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after function"
     },
     {
       "type": "assert_malformed",
       "line": 596,
       "filename": "imports.125.wat",
-      "text": "import after function",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after function"
     },
     {
       "type": "assert_malformed",
       "line": 600,
       "filename": "imports.126.wat",
-      "text": "import after function",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after function"
     },
     {
       "type": "assert_malformed",
       "line": 604,
       "filename": "imports.127.wat",
-      "text": "import after function",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after function"
     },
     {
       "type": "assert_malformed",
       "line": 609,
       "filename": "imports.128.wat",
-      "text": "import after global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after global"
     },
     {
       "type": "assert_malformed",
       "line": 613,
       "filename": "imports.129.wat",
-      "text": "import after global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after global"
     },
     {
       "type": "assert_malformed",
       "line": 617,
       "filename": "imports.130.wat",
-      "text": "import after global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after global"
     },
     {
       "type": "assert_malformed",
       "line": 621,
       "filename": "imports.131.wat",
-      "text": "import after global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after global"
     },
     {
       "type": "assert_malformed",
       "line": 626,
       "filename": "imports.132.wat",
-      "text": "import after table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after table"
     },
     {
       "type": "assert_malformed",
       "line": 630,
       "filename": "imports.133.wat",
-      "text": "import after table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after table"
     },
     {
       "type": "assert_malformed",
       "line": 634,
       "filename": "imports.134.wat",
-      "text": "import after table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after table"
     },
     {
       "type": "assert_malformed",
       "line": 638,
       "filename": "imports.135.wat",
-      "text": "import after table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after table"
     },
     {
       "type": "assert_malformed",
       "line": 643,
       "filename": "imports.136.wat",
-      "text": "import after memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after memory"
     },
     {
       "type": "assert_malformed",
       "line": 647,
       "filename": "imports.137.wat",
-      "text": "import after memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after memory"
     },
     {
       "type": "assert_malformed",
       "line": 651,
       "filename": "imports.138.wat",
-      "text": "import after memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after memory"
     },
     {
       "type": "assert_malformed",
       "line": 655,
       "filename": "imports.139.wat",
-      "text": "import after memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after memory"
     },
     {
       "type": "module",
       "line": 662,
-      "filename": "imports.140.wasm"
+      "filename": "imports.140.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1551,8 +1605,8 @@
       "type": "assert_unlinkable",
       "line": 665,
       "filename": "imports.141.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/multi-memory/imports0.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/imports0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "imports0.0.wasm"
+      "filename": "imports0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -15,43 +16,43 @@
       "type": "assert_unlinkable",
       "line": 21,
       "filename": "imports0.1.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 25,
       "filename": "imports0.2.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 30,
       "filename": "imports0.3.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 34,
       "filename": "imports0.4.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 39,
       "filename": "imports0.5.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 43,
       "filename": "imports0.6.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/multi-memory/imports1.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/imports1.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "imports1.0.wasm"
+      "filename": "imports1.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/multi-memory/imports2.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/imports2.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "imports2.0.wasm"
+      "filename": "imports2.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -14,7 +15,8 @@
     {
       "type": "module",
       "line": 9,
-      "filename": "imports2.1.wasm"
+      "filename": "imports2.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -94,7 +96,8 @@
     {
       "type": "module",
       "line": 22,
-      "filename": "imports2.2.wasm"
+      "filename": "imports2.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -174,54 +177,56 @@
     {
       "type": "module",
       "line": 33,
-      "filename": "imports2.3.wasm"
+      "filename": "imports2.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 39,
-      "filename": "imports2.4.wasm"
+      "filename": "imports2.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 49,
       "filename": "imports2.5.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 53,
       "filename": "imports2.6.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 58,
       "filename": "imports2.7.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 62,
       "filename": "imports2.8.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 66,
       "filename": "imports2.9.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 70,
       "filename": "imports2.10.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/multi-memory/imports3.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/imports3.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "imports3.0.wasm"
+      "filename": "imports3.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -15,57 +16,57 @@
       "type": "assert_unlinkable",
       "line": 20,
       "filename": "imports3.1.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 27,
       "filename": "imports3.2.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 34,
       "filename": "imports3.3.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 41,
       "filename": "imports3.4.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 48,
       "filename": "imports3.5.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 55,
       "filename": "imports3.6.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 63,
       "filename": "imports3.7.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 70,
       "filename": "imports3.8.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/multi-memory/imports4.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/imports4.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "imports4.0.wasm"
+      "filename": "imports4.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -14,7 +15,8 @@
     {
       "type": "module",
       "line": 8,
-      "filename": "imports4.1.wasm"
+      "filename": "imports4.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -120,7 +122,8 @@
       "type": "module",
       "line": 19,
       "name": "Mgm",
-      "filename": "imports4.2.wasm"
+      "filename": "imports4.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -148,7 +151,8 @@
       "type": "module",
       "line": 28,
       "name": "Mgim1",
-      "filename": "imports4.3.wasm"
+      "filename": "imports4.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -176,7 +180,8 @@
       "type": "module",
       "line": 39,
       "name": "Mgim2",
-      "filename": "imports4.4.wasm"
+      "filename": "imports4.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/multi-memory/linking0.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/linking0.wast.json
@@ -5,7 +5,8 @@
       "type": "module",
       "line": 1,
       "name": "Mt",
-      "filename": "linking0.0.wasm"
+      "filename": "linking0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -17,8 +18,8 @@
       "type": "assert_unlinkable",
       "line": 17,
       "filename": "linking0.1.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_trap",
@@ -40,8 +41,8 @@
       "type": "assert_uninstantiable",
       "line": 31,
       "filename": "linking0.2.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/multi-memory/linking1.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/linking1.wast.json
@@ -5,7 +5,8 @@
       "type": "module",
       "line": 1,
       "name": "Mm",
-      "filename": "linking1.0.wasm"
+      "filename": "linking1.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -17,7 +18,8 @@
       "type": "module",
       "line": 14,
       "name": "Nm",
-      "filename": "linking1.1.wasm"
+      "filename": "linking1.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -86,7 +88,8 @@
       "type": "module",
       "line": 31,
       "name": "Om",
-      "filename": "linking1.2.wasm"
+      "filename": "linking1.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -175,21 +178,22 @@
     {
       "type": "module",
       "line": 45,
-      "filename": "linking1.3.wasm"
+      "filename": "linking1.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_uninstantiable",
       "line": 51,
       "filename": "linking1.4.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_uninstantiable",
       "line": 59,
       "filename": "linking1.5.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/multi-memory/linking2.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/linking2.wast.json
@@ -5,7 +5,8 @@
       "type": "module",
       "line": 1,
       "name": "Mm",
-      "filename": "linking2.0.wasm"
+      "filename": "linking2.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -17,7 +18,8 @@
       "type": "module",
       "line": 14,
       "name": "Pm",
-      "filename": "linking2.1.wasm"
+      "filename": "linking2.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/multi-memory/linking3.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/linking3.wast.json
@@ -5,7 +5,8 @@
       "type": "module",
       "line": 1,
       "name": "Mm",
-      "filename": "linking3.0.wasm"
+      "filename": "linking3.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -17,8 +18,8 @@
       "type": "assert_unlinkable",
       "line": 15,
       "filename": "linking3.1.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_return",
@@ -45,8 +46,8 @@
       "type": "assert_uninstantiable",
       "line": 28,
       "filename": "linking3.2.wasm",
-      "text": "out of bounds memory access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds memory access"
     },
     {
       "type": "assert_return",
@@ -94,8 +95,8 @@
       "type": "assert_uninstantiable",
       "line": 40,
       "filename": "linking3.3.wasm",
-      "text": "out of bounds table access",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "out of bounds table access"
     },
     {
       "type": "assert_return",
@@ -122,7 +123,8 @@
       "type": "module",
       "line": 52,
       "name": "Ms",
-      "filename": "linking3.4.wasm"
+      "filename": "linking3.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -134,8 +136,8 @@
       "type": "assert_uninstantiable",
       "line": 66,
       "filename": "linking3.5.wasm",
-      "text": "unreachable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unreachable"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/multi-memory/load.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/load.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "load.0.wasm"
+      "filename": "load.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -50,7 +51,8 @@
       "type": "module",
       "line": 22,
       "name": "M",
-      "filename": "load.1.wasm"
+      "filename": "load.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -60,7 +62,8 @@
     {
       "type": "module",
       "line": 31,
-      "filename": "load.2.wasm"
+      "filename": "load.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -370,7 +373,8 @@
     {
       "type": "module",
       "line": 67,
-      "filename": "load.3.wasm"
+      "filename": "load.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -909,414 +913,414 @@
       "type": "assert_malformed",
       "line": 278,
       "filename": "load.4.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 285,
       "filename": "load.5.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 292,
       "filename": "load.6.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 299,
       "filename": "load.7.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 306,
       "filename": "load.8.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 313,
       "filename": "load.9.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 321,
       "filename": "load.10.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 328,
       "filename": "load.11.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 335,
       "filename": "load.12.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 343,
       "filename": "load.13.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 350,
       "filename": "load.14.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 358,
       "filename": "load.15.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 365,
       "filename": "load.16.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_invalid",
       "line": 376,
       "filename": "load.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 380,
       "filename": "load.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 384,
       "filename": "load.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 388,
       "filename": "load.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 392,
       "filename": "load.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 396,
       "filename": "load.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 400,
       "filename": "load.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 404,
       "filename": "load.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 408,
       "filename": "load.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 412,
       "filename": "load.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 416,
       "filename": "load.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 420,
       "filename": "load.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 424,
       "filename": "load.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 428,
       "filename": "load.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 435,
       "filename": "load.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 436,
       "filename": "load.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 437,
       "filename": "load.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 438,
       "filename": "load.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 439,
       "filename": "load.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 440,
       "filename": "load.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 441,
       "filename": "load.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 442,
       "filename": "load.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 443,
       "filename": "load.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 444,
       "filename": "load.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 445,
       "filename": "load.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 446,
       "filename": "load.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 447,
       "filename": "load.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 448,
       "filename": "load.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 452,
       "filename": "load.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 461,
       "filename": "load.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 471,
       "filename": "load.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 481,
       "filename": "load.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 491,
       "filename": "load.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 501,
       "filename": "load.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 511,
       "filename": "load.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 521,
       "filename": "load.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 531,
       "filename": "load.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 540,
       "filename": "load.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 549,
       "filename": "load.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 559,
       "filename": "load.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 576,
       "filename": "load.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 586,
       "filename": "load.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 596,
       "filename": "load.59.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 606,
       "filename": "load.60.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 615,
       "filename": "load.61.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 624,
       "filename": "load.62.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/multi-memory/load0.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/load0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "load0.0.wasm"
+      "filename": "load0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/multi-memory/load1.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/load1.wast.json
@@ -5,7 +5,8 @@
       "type": "module",
       "line": 1,
       "name": "M",
-      "filename": "load1.0.wasm"
+      "filename": "load1.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -15,7 +16,8 @@
     {
       "type": "module",
       "line": 10,
-      "filename": "load1.1.wasm"
+      "filename": "load1.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/multi-memory/load2.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/load2.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "load2.0.wasm"
+      "filename": "load2.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/multi-memory/memory-multi.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/memory-multi.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 5,
-      "filename": "memory-multi.0.wasm"
+      "filename": "memory-multi.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -39,7 +40,8 @@
     {
       "type": "module",
       "line": 26,
-      "filename": "memory-multi.1.wasm"
+      "filename": "memory-multi.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/multi-memory/memory.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/memory.wast.json
@@ -4,37 +4,44 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "memory.0.wasm"
+      "filename": "memory.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 4,
-      "filename": "memory.1.wasm"
+      "filename": "memory.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 5,
-      "filename": "memory.2.wasm"
+      "filename": "memory.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 6,
-      "filename": "memory.3.wasm"
+      "filename": "memory.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 7,
-      "filename": "memory.4.wasm"
+      "filename": "memory.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 8,
-      "filename": "memory.5.wasm"
+      "filename": "memory.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 10,
-      "filename": "memory.6.wasm"
+      "filename": "memory.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -54,7 +61,8 @@
     {
       "type": "module",
       "line": 12,
-      "filename": "memory.7.wasm"
+      "filename": "memory.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -74,7 +82,8 @@
     {
       "type": "module",
       "line": 14,
-      "filename": "memory.8.wasm"
+      "filename": "memory.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -95,139 +104,140 @@
       "type": "assert_invalid",
       "line": 17,
       "filename": "memory.9.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 18,
       "filename": "memory.10.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 19,
       "filename": "memory.11.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 22,
       "filename": "memory.12.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 26,
       "filename": "memory.13.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 30,
       "filename": "memory.14.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 34,
       "filename": "memory.15.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 38,
       "filename": "memory.16.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 42,
       "filename": "memory.17.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 48,
       "filename": "memory.18.wasm",
-      "text": "size minimum must not be greater than maximum",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "size minimum must not be greater than maximum"
     },
     {
       "type": "assert_invalid",
       "line": 52,
       "filename": "memory.19.wasm",
-      "text": "memory size must be at most 65536 pages (4GiB)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
       "type": "assert_invalid",
       "line": 56,
       "filename": "memory.20.wasm",
-      "text": "memory size must be at most 65536 pages (4GiB)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
       "type": "assert_invalid",
       "line": 60,
       "filename": "memory.21.wasm",
-      "text": "memory size must be at most 65536 pages (4GiB)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
       "type": "assert_invalid",
       "line": 64,
       "filename": "memory.22.wasm",
-      "text": "memory size must be at most 65536 pages (4GiB)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
       "type": "assert_invalid",
       "line": 68,
       "filename": "memory.23.wasm",
-      "text": "memory size must be at most 65536 pages (4GiB)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
       "type": "assert_invalid",
       "line": 72,
       "filename": "memory.24.wasm",
-      "text": "memory size must be at most 65536 pages (4GiB)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
       "type": "assert_malformed",
       "line": 77,
       "filename": "memory.25.wat",
-      "text": "i32 constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "i32 constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 81,
       "filename": "memory.26.wat",
-      "text": "i32 constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "i32 constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 85,
       "filename": "memory.27.wat",
-      "text": "i32 constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "i32 constant out of range"
     },
     {
       "type": "module",
       "line": 89,
-      "filename": "memory.28.wasm"
+      "filename": "memory.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1063,27 +1073,28 @@
       "type": "assert_malformed",
       "line": 228,
       "filename": "memory.29.wat",
-      "text": "duplicate memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate memory"
     },
     {
       "type": "assert_malformed",
       "line": 232,
       "filename": "memory.30.wat",
-      "text": "duplicate memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate memory"
     },
     {
       "type": "assert_malformed",
       "line": 236,
       "filename": "memory.31.wat",
-      "text": "duplicate memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate memory"
     },
     {
       "type": "module",
       "line": 243,
-      "filename": "memory.32.wasm"
+      "filename": "memory.32.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/multi-memory/memory_copy0.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/memory_copy0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 2,
-      "filename": "memory_copy0.0.wasm"
+      "filename": "memory_copy0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",

--- a/tests/snapshots/testsuite/proposals/multi-memory/memory_copy1.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/memory_copy1.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 2,
-      "filename": "memory_copy1.0.wasm"
+      "filename": "memory_copy1.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",

--- a/tests/snapshots/testsuite/proposals/multi-memory/memory_fill0.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/memory_fill0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 2,
-      "filename": "memory_fill0.0.wasm"
+      "filename": "memory_fill0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",

--- a/tests/snapshots/testsuite/proposals/multi-memory/memory_grow.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/memory_grow.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "memory_grow.0.wasm"
+      "filename": "memory_grow.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -169,7 +170,8 @@
     {
       "type": "module",
       "line": 15,
-      "filename": "memory_grow.1.wasm"
+      "filename": "memory_grow.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -334,7 +336,8 @@
     {
       "type": "module",
       "line": 32,
-      "filename": "memory_grow.2.wasm"
+      "filename": "memory_grow.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -583,7 +586,8 @@
     {
       "type": "module",
       "line": 68,
-      "filename": "memory_grow.3.wasm"
+      "filename": "memory_grow.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -853,7 +857,8 @@
     {
       "type": "module",
       "line": 109,
-      "filename": "memory_grow.4.wasm"
+      "filename": "memory_grow.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -863,7 +868,8 @@
     {
       "type": "module",
       "line": 115,
-      "filename": "memory_grow.5.wasm"
+      "filename": "memory_grow.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1508,7 +1514,8 @@
     {
       "type": "module",
       "line": 191,
-      "filename": "memory_grow.6.wasm"
+      "filename": "memory_grow.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2041,7 +2048,8 @@
     {
       "type": "module",
       "line": 404,
-      "filename": "memory_grow.7.wasm"
+      "filename": "memory_grow.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2177,64 +2185,64 @@
       "type": "assert_invalid",
       "line": 431,
       "filename": "memory_grow.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 440,
       "filename": "memory_grow.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 449,
       "filename": "memory_grow.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 459,
       "filename": "memory_grow.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 469,
       "filename": "memory_grow.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 480,
       "filename": "memory_grow.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 489,
       "filename": "memory_grow.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 499,
       "filename": "memory_grow.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 508,
       "filename": "memory_grow.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/multi-memory/memory_init0.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/memory_init0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 2,
-      "filename": "memory_init0.0.wasm"
+      "filename": "memory_init0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",

--- a/tests/snapshots/testsuite/proposals/multi-memory/memory_size.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/memory_size.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "memory_size.0.wasm"
+      "filename": "memory_size.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -114,7 +115,8 @@
     {
       "type": "module",
       "line": 15,
-      "filename": "memory_size.1.wasm"
+      "filename": "memory_size.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -224,7 +226,8 @@
     {
       "type": "module",
       "line": 29,
-      "filename": "memory_size.2.wasm"
+      "filename": "memory_size.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -394,7 +397,8 @@
     {
       "type": "module",
       "line": 47,
-      "filename": "memory_size.3.wasm"
+      "filename": "memory_size.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -564,7 +568,8 @@
     {
       "type": "module",
       "line": 68,
-      "filename": "memory_size.4.wasm"
+      "filename": "memory_size.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -574,7 +579,8 @@
     {
       "type": "module",
       "line": 74,
-      "filename": "memory_size.5.wasm"
+      "filename": "memory_size.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -640,15 +646,15 @@
       "type": "assert_invalid",
       "line": 95,
       "filename": "memory_size.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 104,
       "filename": "memory_size.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/multi-memory/memory_size0.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/memory_size0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "memory_size0.0.wasm"
+      "filename": "memory_size0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/multi-memory/memory_size1.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/memory_size1.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "memory_size1.0.wasm"
+      "filename": "memory_size1.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/multi-memory/memory_size2.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/memory_size2.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "memory_size2.0.wasm"
+      "filename": "memory_size2.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/multi-memory/memory_size3.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/memory_size3.wast.json
@@ -5,15 +5,15 @@
       "type": "assert_invalid",
       "line": 4,
       "filename": "memory_size3.0.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 15,
       "filename": "memory_size3.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/multi-memory/memory_trap0.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/memory_trap0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "memory_trap0.0.wasm"
+      "filename": "memory_trap0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/multi-memory/memory_trap1.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/memory_trap1.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "memory_trap1.0.wasm"
+      "filename": "memory_trap1.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",

--- a/tests/snapshots/testsuite/proposals/multi-memory/simd_memory-multi.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/simd_memory-multi.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 5,
-      "filename": "simd_memory-multi.0.wasm"
+      "filename": "simd_memory-multi.0.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/multi-memory/start0.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/start0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "start0.0.wasm"
+      "filename": "start0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/multi-memory/store.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/store.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "store.0.wasm"
+      "filename": "store.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -86,7 +87,8 @@
       "type": "module",
       "line": 28,
       "name": "M1",
-      "filename": "store.1.wasm"
+      "filename": "store.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -97,7 +99,8 @@
       "type": "module",
       "line": 40,
       "name": "M2",
-      "filename": "store.2.wasm"
+      "filename": "store.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -187,7 +190,8 @@
     {
       "type": "module",
       "line": 57,
-      "filename": "store.3.wasm"
+      "filename": "store.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -268,7 +272,8 @@
     {
       "type": "module",
       "line": 82,
-      "filename": "store.4.wasm"
+      "filename": "store.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -278,7 +283,8 @@
     {
       "type": "module",
       "line": 87,
-      "filename": "store.5.wasm"
+      "filename": "store.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -701,7 +707,8 @@
     {
       "type": "module",
       "line": 151,
-      "filename": "store.6.wasm"
+      "filename": "store.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -797,407 +804,407 @@
       "type": "assert_malformed",
       "line": 206,
       "filename": "store.7.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 213,
       "filename": "store.8.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 221,
       "filename": "store.9.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 229,
       "filename": "store.10.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 236,
       "filename": "store.11.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 244,
       "filename": "store.12.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 251,
       "filename": "store.13.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_invalid",
       "line": 260,
       "filename": "store.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 264,
       "filename": "store.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 268,
       "filename": "store.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 272,
       "filename": "store.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 276,
       "filename": "store.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 280,
       "filename": "store.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 284,
       "filename": "store.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 288,
       "filename": "store.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 292,
       "filename": "store.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 298,
       "filename": "store.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 307,
       "filename": "store.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 316,
       "filename": "store.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 326,
       "filename": "store.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 336,
       "filename": "store.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 346,
       "filename": "store.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 356,
       "filename": "store.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 366,
       "filename": "store.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 376,
       "filename": "store.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 386,
       "filename": "store.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 396,
       "filename": "store.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 406,
       "filename": "store.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 416,
       "filename": "store.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 426,
       "filename": "store.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 436,
       "filename": "store.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 446,
       "filename": "store.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 456,
       "filename": "store.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 465,
       "filename": "store.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 474,
       "filename": "store.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 483,
       "filename": "store.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 492,
       "filename": "store.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 502,
       "filename": "store.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 512,
       "filename": "store.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 528,
       "filename": "store.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 547,
       "filename": "store.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 548,
       "filename": "store.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 549,
       "filename": "store.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 550,
       "filename": "store.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 551,
       "filename": "store.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 552,
       "filename": "store.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 553,
       "filename": "store.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 554,
       "filename": "store.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 555,
       "filename": "store.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 557,
       "filename": "store.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 558,
       "filename": "store.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 559,
       "filename": "store.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 560,
       "filename": "store.59.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 561,
       "filename": "store.60.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 562,
       "filename": "store.61.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 563,
       "filename": "store.62.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 564,
       "filename": "store.63.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 565,
       "filename": "store.64.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/multi-memory/store0.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/store0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "store0.0.wasm"
+      "filename": "store0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",

--- a/tests/snapshots/testsuite/proposals/multi-memory/store1.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/store1.wast.json
@@ -5,7 +5,8 @@
       "type": "module",
       "line": 1,
       "name": "M1",
-      "filename": "store1.0.wasm"
+      "filename": "store1.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -16,7 +17,8 @@
       "type": "module",
       "line": 13,
       "name": "M2",
-      "filename": "store1.1.wasm"
+      "filename": "store1.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -106,7 +108,8 @@
     {
       "type": "module",
       "line": 30,
-      "filename": "store1.2.wasm"
+      "filename": "store1.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",

--- a/tests/snapshots/testsuite/proposals/multi-memory/traps0.wast.json
+++ b/tests/snapshots/testsuite/proposals/multi-memory/traps0.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "traps0.0.wasm"
+      "filename": "traps0.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",

--- a/tests/snapshots/testsuite/proposals/relaxed-simd/i16x8_relaxed_q15mulr_s.wast.json
+++ b/tests/snapshots/testsuite/proposals/relaxed-simd/i16x8_relaxed_q15mulr_s.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "i16x8_relaxed_q15mulr_s.0.wasm"
+      "filename": "i16x8_relaxed_q15mulr_s.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/relaxed-simd/i32x4_relaxed_trunc.wast.json
+++ b/tests/snapshots/testsuite/proposals/relaxed-simd/i32x4_relaxed_trunc.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "i32x4_relaxed_trunc.0.wasm"
+      "filename": "i32x4_relaxed_trunc.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/relaxed-simd/i8x16_relaxed_swizzle.wast.json
+++ b/tests/snapshots/testsuite/proposals/relaxed-simd/i8x16_relaxed_swizzle.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "i8x16_relaxed_swizzle.0.wasm"
+      "filename": "i8x16_relaxed_swizzle.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/relaxed-simd/relaxed_dot_product.wast.json
+++ b/tests/snapshots/testsuite/proposals/relaxed-simd/relaxed_dot_product.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "relaxed_dot_product.0.wasm"
+      "filename": "relaxed_dot_product.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/relaxed-simd/relaxed_laneselect.wast.json
+++ b/tests/snapshots/testsuite/proposals/relaxed-simd/relaxed_laneselect.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "relaxed_laneselect.0.wasm"
+      "filename": "relaxed_laneselect.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/relaxed-simd/relaxed_madd_nmadd.wast.json
+++ b/tests/snapshots/testsuite/proposals/relaxed-simd/relaxed_madd_nmadd.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "relaxed_madd_nmadd.0.wasm"
+      "filename": "relaxed_madd_nmadd.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -889,7 +890,8 @@
     {
       "type": "module",
       "line": 208,
-      "filename": "relaxed_madd_nmadd.1.wasm"
+      "filename": "relaxed_madd_nmadd.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/relaxed-simd/relaxed_min_max.wast.json
+++ b/tests/snapshots/testsuite/proposals/relaxed-simd/relaxed_min_max.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "relaxed_min_max.0.wasm"
+      "filename": "relaxed_min_max.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/proposals/tail-call/return_call.wast.json
+++ b/tests/snapshots/testsuite/proposals/tail-call/return_call.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "return_call.0.wasm"
+      "filename": "return_call.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -586,81 +587,83 @@
       "type": "assert_invalid",
       "line": 124,
       "filename": "return_call.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 131,
       "filename": "return_call.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 139,
       "filename": "return_call.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 146,
       "filename": "return_call.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 153,
-      "filename": "return_call.5.wasm"
+      "filename": "return_call.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 158,
-      "filename": "return_call.6.wasm"
+      "filename": "return_call.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 164,
       "filename": "return_call.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 171,
       "filename": "return_call.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 178,
       "filename": "return_call.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 185,
       "filename": "return_call.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 196,
       "filename": "return_call.11.wasm",
-      "text": "unknown function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function"
     },
     {
       "type": "assert_invalid",
       "line": 200,
       "filename": "return_call.12.wasm",
-      "text": "unknown function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/tail-call/return_call_indirect.wast.json
+++ b/tests/snapshots/testsuite/proposals/tail-call/return_call_indirect.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "return_call_indirect.0.wasm"
+      "filename": "return_call_indirect.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -886,186 +887,188 @@
       "type": "assert_malformed",
       "line": 273,
       "filename": "return_call_indirect.1.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 285,
       "filename": "return_call_indirect.2.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 297,
       "filename": "return_call_indirect.3.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 309,
       "filename": "return_call_indirect.4.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 321,
       "filename": "return_call_indirect.5.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 333,
       "filename": "return_call_indirect.6.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 345,
       "filename": "return_call_indirect.7.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 352,
       "filename": "return_call_indirect.8.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 362,
       "filename": "return_call_indirect.9.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 372,
       "filename": "return_call_indirect.10.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_malformed",
       "line": 384,
       "filename": "return_call_indirect.11.wat",
-      "text": "inline function type",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "inline function type"
     },
     {
       "type": "assert_invalid",
       "line": 399,
       "filename": "return_call_indirect.12.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 407,
       "filename": "return_call_indirect.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 415,
       "filename": "return_call_indirect.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 424,
       "filename": "return_call_indirect.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 432,
       "filename": "return_call_indirect.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 440,
-      "filename": "return_call_indirect.17.wasm"
+      "filename": "return_call_indirect.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 446,
-      "filename": "return_call_indirect.18.wasm"
+      "filename": "return_call_indirect.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 455,
       "filename": "return_call_indirect.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 463,
       "filename": "return_call_indirect.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 472,
       "filename": "return_call_indirect.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 482,
       "filename": "return_call_indirect.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 492,
       "filename": "return_call_indirect.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 502,
       "filename": "return_call_indirect.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 516,
       "filename": "return_call_indirect.25.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 523,
       "filename": "return_call_indirect.26.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "assert_invalid",
       "line": 534,
       "filename": "return_call_indirect.27.wasm",
-      "text": "unknown function 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function 0"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/threads/atomic.wast.json
+++ b/tests/snapshots/testsuite/proposals/threads/atomic.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "atomic.0.wasm"
+      "filename": "atomic.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -4729,7 +4730,8 @@
     {
       "type": "module",
       "line": 420,
-      "filename": "atomic.1.wasm"
+      "filename": "atomic.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -4828,343 +4830,344 @@
     {
       "type": "module",
       "line": 439,
-      "filename": "atomic.2.wasm"
+      "filename": "atomic.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 492,
       "filename": "atomic.3.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 493,
       "filename": "atomic.4.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 494,
       "filename": "atomic.5.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 495,
       "filename": "atomic.6.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 496,
       "filename": "atomic.7.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 497,
       "filename": "atomic.8.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 498,
       "filename": "atomic.9.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 499,
       "filename": "atomic.10.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 500,
       "filename": "atomic.11.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 501,
       "filename": "atomic.12.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 502,
       "filename": "atomic.13.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 503,
       "filename": "atomic.14.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 504,
       "filename": "atomic.15.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 505,
       "filename": "atomic.16.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 506,
       "filename": "atomic.17.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 507,
       "filename": "atomic.18.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 508,
       "filename": "atomic.19.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 509,
       "filename": "atomic.20.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 510,
       "filename": "atomic.21.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 511,
       "filename": "atomic.22.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 512,
       "filename": "atomic.23.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 513,
       "filename": "atomic.24.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 514,
       "filename": "atomic.25.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 515,
       "filename": "atomic.26.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 516,
       "filename": "atomic.27.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 517,
       "filename": "atomic.28.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 518,
       "filename": "atomic.29.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 519,
       "filename": "atomic.30.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 520,
       "filename": "atomic.31.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 521,
       "filename": "atomic.32.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 522,
       "filename": "atomic.33.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 523,
       "filename": "atomic.34.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 524,
       "filename": "atomic.35.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 525,
       "filename": "atomic.36.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 526,
       "filename": "atomic.37.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 527,
       "filename": "atomic.38.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 528,
       "filename": "atomic.39.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 529,
       "filename": "atomic.40.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 530,
       "filename": "atomic.41.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 531,
       "filename": "atomic.42.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 532,
       "filename": "atomic.43.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 533,
       "filename": "atomic.44.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 534,
       "filename": "atomic.45.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 535,
       "filename": "atomic.46.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 536,
       "filename": "atomic.47.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 537,
       "filename": "atomic.48.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 538,
       "filename": "atomic.49.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 539,
       "filename": "atomic.50.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/threads/exports.wast.json
+++ b/tests/snapshots/testsuite/proposals/threads/exports.wast.json
@@ -4,63 +4,75 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "exports.0.wasm"
+      "filename": "exports.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 4,
-      "filename": "exports.1.wasm"
+      "filename": "exports.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 5,
-      "filename": "exports.2.wasm"
+      "filename": "exports.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 7,
-      "filename": "exports.3.wasm"
+      "filename": "exports.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 8,
-      "filename": "exports.4.wasm"
+      "filename": "exports.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 9,
-      "filename": "exports.5.wasm"
+      "filename": "exports.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 10,
-      "filename": "exports.6.wasm"
+      "filename": "exports.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 11,
-      "filename": "exports.7.wasm"
+      "filename": "exports.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 12,
-      "filename": "exports.8.wasm"
+      "filename": "exports.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 13,
-      "filename": "exports.9.wasm"
+      "filename": "exports.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 14,
-      "filename": "exports.10.wasm"
+      "filename": "exports.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 16,
       "name": "Func",
-      "filename": "exports.11.wasm"
+      "filename": "exports.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -106,13 +118,15 @@
     {
       "type": "module",
       "line": 24,
-      "filename": "exports.12.wasm"
+      "filename": "exports.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 25,
       "name": "Other1",
-      "filename": "exports.13.wasm"
+      "filename": "exports.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -139,94 +153,104 @@
       "type": "assert_invalid",
       "line": 29,
       "filename": "exports.14.wasm",
-      "text": "unknown function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function"
     },
     {
       "type": "assert_invalid",
       "line": 33,
       "filename": "exports.15.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 37,
       "filename": "exports.16.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 41,
       "filename": "exports.17.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 45,
       "filename": "exports.18.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 49,
       "filename": "exports.19.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "module",
       "line": 56,
-      "filename": "exports.20.wasm"
+      "filename": "exports.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 57,
-      "filename": "exports.21.wasm"
+      "filename": "exports.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 58,
-      "filename": "exports.22.wasm"
+      "filename": "exports.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 60,
-      "filename": "exports.23.wasm"
+      "filename": "exports.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 61,
-      "filename": "exports.24.wasm"
+      "filename": "exports.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 62,
-      "filename": "exports.25.wasm"
+      "filename": "exports.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 63,
-      "filename": "exports.26.wasm"
+      "filename": "exports.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 64,
-      "filename": "exports.27.wasm"
+      "filename": "exports.27.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 65,
-      "filename": "exports.28.wasm"
+      "filename": "exports.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 67,
       "name": "Global",
-      "filename": "exports.29.wasm"
+      "filename": "exports.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -260,13 +284,15 @@
     {
       "type": "module",
       "line": 73,
-      "filename": "exports.30.wasm"
+      "filename": "exports.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 74,
       "name": "Other2",
-      "filename": "exports.31.wasm"
+      "filename": "exports.31.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -287,283 +313,317 @@
       "type": "assert_invalid",
       "line": 78,
       "filename": "exports.32.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 82,
       "filename": "exports.33.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 86,
       "filename": "exports.34.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 90,
       "filename": "exports.35.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 94,
       "filename": "exports.36.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 98,
       "filename": "exports.37.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "module",
       "line": 105,
-      "filename": "exports.38.wasm"
+      "filename": "exports.38.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 106,
-      "filename": "exports.39.wasm"
+      "filename": "exports.39.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 110,
-      "filename": "exports.40.wasm"
+      "filename": "exports.40.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 111,
-      "filename": "exports.41.wasm"
+      "filename": "exports.41.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 112,
-      "filename": "exports.42.wasm"
+      "filename": "exports.42.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 113,
-      "filename": "exports.43.wasm"
+      "filename": "exports.43.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 114,
-      "filename": "exports.44.wasm"
+      "filename": "exports.44.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 115,
-      "filename": "exports.45.wasm"
+      "filename": "exports.45.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 116,
-      "filename": "exports.46.wasm"
+      "filename": "exports.46.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 117,
-      "filename": "exports.47.wasm"
+      "filename": "exports.47.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 118,
-      "filename": "exports.48.wasm"
+      "filename": "exports.48.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 119,
-      "filename": "exports.49.wasm"
+      "filename": "exports.49.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 120,
-      "filename": "exports.50.wasm"
+      "filename": "exports.50.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 121,
-      "filename": "exports.51.wasm"
+      "filename": "exports.51.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 126,
       "filename": "exports.52.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 130,
       "filename": "exports.53.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 139,
       "filename": "exports.54.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 143,
       "filename": "exports.55.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 147,
       "filename": "exports.56.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "module",
       "line": 154,
-      "filename": "exports.57.wasm"
+      "filename": "exports.57.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 155,
-      "filename": "exports.58.wasm"
+      "filename": "exports.58.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 159,
-      "filename": "exports.59.wasm"
+      "filename": "exports.59.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 160,
-      "filename": "exports.60.wasm"
+      "filename": "exports.60.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 161,
-      "filename": "exports.61.wasm"
+      "filename": "exports.61.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 162,
-      "filename": "exports.62.wasm"
+      "filename": "exports.62.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 163,
-      "filename": "exports.63.wasm"
+      "filename": "exports.63.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 164,
-      "filename": "exports.64.wasm"
+      "filename": "exports.64.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 165,
-      "filename": "exports.65.wasm"
+      "filename": "exports.65.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 166,
-      "filename": "exports.66.wasm"
+      "filename": "exports.66.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 167,
-      "filename": "exports.67.wasm"
+      "filename": "exports.67.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 168,
-      "filename": "exports.68.wasm"
+      "filename": "exports.68.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 169,
-      "filename": "exports.69.wasm"
+      "filename": "exports.69.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 170,
-      "filename": "exports.70.wasm"
+      "filename": "exports.70.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 172,
-      "filename": "exports.71.wasm"
+      "filename": "exports.71.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 173,
-      "filename": "exports.72.wasm"
+      "filename": "exports.72.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 174,
-      "filename": "exports.73.wasm"
+      "filename": "exports.73.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 175,
-      "filename": "exports.74.wasm"
+      "filename": "exports.74.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 176,
-      "filename": "exports.75.wasm"
+      "filename": "exports.75.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 177,
-      "filename": "exports.76.wasm"
+      "filename": "exports.76.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 182,
       "filename": "exports.77.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 186,
       "filename": "exports.78.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 195,
       "filename": "exports.79.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 199,
       "filename": "exports.80.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     },
     {
       "type": "assert_invalid",
       "line": 203,
       "filename": "exports.81.wasm",
-      "text": "duplicate export name",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "duplicate export name"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/threads/imports.wast.json
+++ b/tests/snapshots/testsuite/proposals/threads/imports.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "imports.0.wasm"
+      "filename": "imports.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -14,7 +15,8 @@
     {
       "type": "module",
       "line": 24,
-      "filename": "imports.1.wasm"
+      "filename": "imports.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -50,216 +52,224 @@
       "type": "assert_invalid",
       "line": 91,
       "filename": "imports.2.wasm",
-      "text": "unknown type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown type"
     },
     {
       "type": "module",
       "line": 98,
-      "filename": "imports.3.wasm"
+      "filename": "imports.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 99,
-      "filename": "imports.4.wasm"
+      "filename": "imports.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 100,
-      "filename": "imports.5.wasm"
+      "filename": "imports.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 101,
-      "filename": "imports.6.wasm"
+      "filename": "imports.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 102,
-      "filename": "imports.7.wasm"
+      "filename": "imports.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 103,
-      "filename": "imports.8.wasm"
+      "filename": "imports.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 104,
-      "filename": "imports.9.wasm"
+      "filename": "imports.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 107,
       "filename": "imports.10.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 111,
       "filename": "imports.11.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 116,
       "filename": "imports.12.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 120,
       "filename": "imports.13.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 124,
       "filename": "imports.14.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 128,
       "filename": "imports.15.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 132,
       "filename": "imports.16.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 136,
       "filename": "imports.17.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 140,
       "filename": "imports.18.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 144,
       "filename": "imports.19.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 148,
       "filename": "imports.20.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 152,
       "filename": "imports.21.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 156,
       "filename": "imports.22.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 160,
       "filename": "imports.23.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 164,
       "filename": "imports.24.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 168,
       "filename": "imports.25.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 172,
       "filename": "imports.26.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 176,
       "filename": "imports.27.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 181,
       "filename": "imports.28.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 185,
       "filename": "imports.29.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 189,
       "filename": "imports.30.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 193,
       "filename": "imports.31.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 197,
       "filename": "imports.32.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 201,
       "filename": "imports.33.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 208,
-      "filename": "imports.34.wasm"
+      "filename": "imports.34.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -324,73 +334,76 @@
     {
       "type": "module",
       "line": 231,
-      "filename": "imports.35.wasm"
+      "filename": "imports.35.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 232,
-      "filename": "imports.36.wasm"
+      "filename": "imports.36.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 235,
       "filename": "imports.37.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 239,
       "filename": "imports.38.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 244,
       "filename": "imports.39.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 248,
       "filename": "imports.40.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 252,
       "filename": "imports.41.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 256,
       "filename": "imports.42.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 260,
       "filename": "imports.43.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 264,
       "filename": "imports.44.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 271,
-      "filename": "imports.45.wasm"
+      "filename": "imports.45.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -480,7 +493,8 @@
     {
       "type": "module",
       "line": 290,
-      "filename": "imports.46.wasm"
+      "filename": "imports.46.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -571,152 +585,164 @@
       "type": "assert_invalid",
       "line": 310,
       "filename": "imports.47.wasm",
-      "text": "multiple tables",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "multiple tables"
     },
     {
       "type": "assert_invalid",
       "line": 314,
       "filename": "imports.48.wasm",
-      "text": "multiple tables",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "multiple tables"
     },
     {
       "type": "assert_invalid",
       "line": 318,
       "filename": "imports.49.wasm",
-      "text": "multiple tables",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "multiple tables"
     },
     {
       "type": "module",
       "line": 322,
-      "filename": "imports.50.wasm"
+      "filename": "imports.50.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 323,
-      "filename": "imports.51.wasm"
+      "filename": "imports.51.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 324,
-      "filename": "imports.52.wasm"
+      "filename": "imports.52.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 325,
-      "filename": "imports.53.wasm"
+      "filename": "imports.53.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 326,
-      "filename": "imports.54.wasm"
+      "filename": "imports.54.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 327,
-      "filename": "imports.55.wasm"
+      "filename": "imports.55.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 328,
-      "filename": "imports.56.wasm"
+      "filename": "imports.56.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 329,
-      "filename": "imports.57.wasm"
+      "filename": "imports.57.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 330,
-      "filename": "imports.58.wasm"
+      "filename": "imports.58.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 331,
-      "filename": "imports.59.wasm"
+      "filename": "imports.59.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 332,
-      "filename": "imports.60.wasm"
+      "filename": "imports.60.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 335,
       "filename": "imports.61.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 339,
       "filename": "imports.62.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 344,
       "filename": "imports.63.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 348,
       "filename": "imports.64.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 352,
       "filename": "imports.65.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 356,
       "filename": "imports.66.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 361,
       "filename": "imports.67.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 365,
       "filename": "imports.68.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 369,
       "filename": "imports.69.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 373,
       "filename": "imports.70.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 381,
-      "filename": "imports.71.wasm"
+      "filename": "imports.71.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -796,7 +822,8 @@
     {
       "type": "module",
       "line": 393,
-      "filename": "imports.72.wasm"
+      "filename": "imports.72.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -877,170 +904,180 @@
       "type": "assert_invalid",
       "line": 405,
       "filename": "imports.73.wasm",
-      "text": "multiple memories",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "multiple memories"
     },
     {
       "type": "assert_invalid",
       "line": 409,
       "filename": "imports.74.wasm",
-      "text": "multiple memories",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "multiple memories"
     },
     {
       "type": "assert_invalid",
       "line": 413,
       "filename": "imports.75.wasm",
-      "text": "multiple memories",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "multiple memories"
     },
     {
       "type": "module",
       "line": 417,
-      "filename": "imports.76.wasm"
+      "filename": "imports.76.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 418,
-      "filename": "imports.77.wasm"
+      "filename": "imports.77.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 419,
-      "filename": "imports.78.wasm"
+      "filename": "imports.78.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 420,
-      "filename": "imports.79.wasm"
+      "filename": "imports.79.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 421,
-      "filename": "imports.80.wasm"
+      "filename": "imports.80.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 422,
-      "filename": "imports.81.wasm"
+      "filename": "imports.81.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 423,
-      "filename": "imports.82.wasm"
+      "filename": "imports.82.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 424,
-      "filename": "imports.83.wasm"
+      "filename": "imports.83.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 425,
-      "filename": "imports.84.wasm"
+      "filename": "imports.84.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 428,
       "filename": "imports.85.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 432,
       "filename": "imports.86.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     },
     {
       "type": "assert_unlinkable",
       "line": 437,
       "filename": "imports.87.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 441,
       "filename": "imports.88.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 445,
       "filename": "imports.89.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 449,
       "filename": "imports.90.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 454,
       "filename": "imports.91.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 458,
       "filename": "imports.92.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 462,
       "filename": "imports.93.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 466,
       "filename": "imports.94.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 470,
       "filename": "imports.95.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 474,
       "filename": "imports.96.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 479,
       "filename": "imports.97.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 483,
       "filename": "imports.98.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "module",
       "line": 487,
-      "filename": "imports.99.wasm"
+      "filename": "imports.99.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1145,138 +1182,140 @@
     {
       "type": "module",
       "line": 499,
-      "filename": "imports.100.wasm"
+      "filename": "imports.100.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_unlinkable",
       "line": 502,
       "filename": "imports.101.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_unlinkable",
       "line": 506,
       "filename": "imports.102.wasm",
-      "text": "incompatible import type",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "incompatible import type"
     },
     {
       "type": "assert_malformed",
       "line": 513,
       "filename": "imports.103.wat",
-      "text": "import after function",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after function"
     },
     {
       "type": "assert_malformed",
       "line": 517,
       "filename": "imports.104.wat",
-      "text": "import after function",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after function"
     },
     {
       "type": "assert_malformed",
       "line": 521,
       "filename": "imports.105.wat",
-      "text": "import after function",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after function"
     },
     {
       "type": "assert_malformed",
       "line": 525,
       "filename": "imports.106.wat",
-      "text": "import after function",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after function"
     },
     {
       "type": "assert_malformed",
       "line": 530,
       "filename": "imports.107.wat",
-      "text": "import after global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after global"
     },
     {
       "type": "assert_malformed",
       "line": 534,
       "filename": "imports.108.wat",
-      "text": "import after global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after global"
     },
     {
       "type": "assert_malformed",
       "line": 538,
       "filename": "imports.109.wat",
-      "text": "import after global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after global"
     },
     {
       "type": "assert_malformed",
       "line": 542,
       "filename": "imports.110.wat",
-      "text": "import after global",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after global"
     },
     {
       "type": "assert_malformed",
       "line": 547,
       "filename": "imports.111.wat",
-      "text": "import after table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after table"
     },
     {
       "type": "assert_malformed",
       "line": 551,
       "filename": "imports.112.wat",
-      "text": "import after table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after table"
     },
     {
       "type": "assert_malformed",
       "line": 555,
       "filename": "imports.113.wat",
-      "text": "import after table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after table"
     },
     {
       "type": "assert_malformed",
       "line": 559,
       "filename": "imports.114.wat",
-      "text": "import after table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after table"
     },
     {
       "type": "assert_malformed",
       "line": 564,
       "filename": "imports.115.wat",
-      "text": "import after memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after memory"
     },
     {
       "type": "assert_malformed",
       "line": 568,
       "filename": "imports.116.wat",
-      "text": "import after memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after memory"
     },
     {
       "type": "assert_malformed",
       "line": 572,
       "filename": "imports.117.wat",
-      "text": "import after memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after memory"
     },
     {
       "type": "assert_malformed",
       "line": 576,
       "filename": "imports.118.wat",
-      "text": "import after memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "import after memory"
     },
     {
       "type": "module",
       "line": 583,
-      "filename": "imports.119.wasm"
+      "filename": "imports.119.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -1287,8 +1326,8 @@
       "type": "assert_unlinkable",
       "line": 586,
       "filename": "imports.120.wasm",
-      "text": "unknown import",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown import"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/threads/memory.wast.json
+++ b/tests/snapshots/testsuite/proposals/threads/memory.wast.json
@@ -4,68 +4,77 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "memory.0.wasm"
+      "filename": "memory.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 4,
-      "filename": "memory.1.wasm"
+      "filename": "memory.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 5,
-      "filename": "memory.2.wasm"
+      "filename": "memory.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 6,
-      "filename": "memory.3.wasm"
+      "filename": "memory.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 7,
-      "filename": "memory.4.wasm"
+      "filename": "memory.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 8,
-      "filename": "memory.5.wasm"
+      "filename": "memory.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 9,
-      "filename": "memory.6.wasm"
+      "filename": "memory.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 10,
-      "filename": "memory.7.wasm"
+      "filename": "memory.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 12,
       "filename": "memory.8.wasm",
-      "text": "shared memory must have maximum",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "shared memory must have maximum"
     },
     {
       "type": "assert_invalid",
       "line": 14,
       "filename": "memory.9.wasm",
-      "text": "multiple memories",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "multiple memories"
     },
     {
       "type": "assert_invalid",
       "line": 15,
       "filename": "memory.10.wasm",
-      "text": "multiple memories",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "multiple memories"
     },
     {
       "type": "module",
       "line": 17,
-      "filename": "memory.11.wasm"
+      "filename": "memory.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -85,7 +94,8 @@
     {
       "type": "module",
       "line": 19,
-      "filename": "memory.12.wasm"
+      "filename": "memory.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -105,7 +115,8 @@
     {
       "type": "module",
       "line": 21,
-      "filename": "memory.13.wasm"
+      "filename": "memory.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -126,139 +137,140 @@
       "type": "assert_invalid",
       "line": 24,
       "filename": "memory.14.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 25,
       "filename": "memory.15.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 26,
       "filename": "memory.16.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 29,
       "filename": "memory.17.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 33,
       "filename": "memory.18.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 37,
       "filename": "memory.19.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 41,
       "filename": "memory.20.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 45,
       "filename": "memory.21.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 49,
       "filename": "memory.22.wasm",
-      "text": "unknown memory",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown memory"
     },
     {
       "type": "assert_invalid",
       "line": 55,
       "filename": "memory.23.wasm",
-      "text": "size minimum must not be greater than maximum",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "size minimum must not be greater than maximum"
     },
     {
       "type": "assert_invalid",
       "line": 59,
       "filename": "memory.24.wasm",
-      "text": "memory size must be at most 65536 pages (4GiB)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
       "type": "assert_invalid",
       "line": 63,
       "filename": "memory.25.wasm",
-      "text": "memory size must be at most 65536 pages (4GiB)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
       "type": "assert_invalid",
       "line": 67,
       "filename": "memory.26.wasm",
-      "text": "memory size must be at most 65536 pages (4GiB)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
       "type": "assert_invalid",
       "line": 71,
       "filename": "memory.27.wasm",
-      "text": "memory size must be at most 65536 pages (4GiB)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
       "type": "assert_invalid",
       "line": 75,
       "filename": "memory.28.wasm",
-      "text": "memory size must be at most 65536 pages (4GiB)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
       "type": "assert_invalid",
       "line": 79,
       "filename": "memory.29.wasm",
-      "text": "memory size must be at most 65536 pages (4GiB)",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
       "type": "assert_malformed",
       "line": 84,
       "filename": "memory.30.wat",
-      "text": "i32 constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "i32 constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 88,
       "filename": "memory.31.wat",
-      "text": "i32 constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "i32 constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 92,
       "filename": "memory.32.wat",
-      "text": "i32 constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "i32 constant out of range"
     },
     {
       "type": "module",
       "line": 96,
-      "filename": "memory.33.wasm"
+      "filename": "memory.33.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1094,22 +1106,22 @@
       "type": "assert_malformed",
       "line": 235,
       "filename": "memory.34.wat",
-      "text": "duplicate memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate memory"
     },
     {
       "type": "assert_malformed",
       "line": 239,
       "filename": "memory.35.wat",
-      "text": "duplicate memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate memory"
     },
     {
       "type": "assert_malformed",
       "line": 243,
       "filename": "memory.36.wat",
-      "text": "duplicate memory",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate memory"
     }
   ]
 }

--- a/tests/snapshots/testsuite/ref_func.wast.json
+++ b/tests/snapshots/testsuite/ref_func.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "ref_func.0.wasm"
+      "filename": "ref_func.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -14,7 +15,8 @@
     {
       "type": "module",
       "line": 6,
-      "filename": "ref_func.1.wasm"
+      "filename": "ref_func.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -183,27 +185,28 @@
       "type": "assert_invalid",
       "line": 69,
       "filename": "ref_func.2.wasm",
-      "text": "unknown function 7",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function 7"
     },
     {
       "type": "module",
       "line": 80,
-      "filename": "ref_func.3.wasm"
+      "filename": "ref_func.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 109,
       "filename": "ref_func.4.wasm",
-      "text": "undeclared function reference",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "undeclared function reference"
     },
     {
       "type": "assert_invalid",
       "line": 113,
       "filename": "ref_func.5.wasm",
-      "text": "undeclared function reference",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "undeclared function reference"
     }
   ]
 }

--- a/tests/snapshots/testsuite/ref_is_null.wast.json
+++ b/tests/snapshots/testsuite/ref_is_null.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "ref_is_null.0.wasm"
+      "filename": "ref_is_null.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -253,15 +254,15 @@
       "type": "assert_invalid",
       "line": 52,
       "filename": "ref_is_null.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 56,
       "filename": "ref_is_null.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/ref_null.wast.json
+++ b/tests/snapshots/testsuite/ref_null.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "ref_null.0.wasm"
+      "filename": "ref_null.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/return.wast.json
+++ b/tests/snapshots/testsuite/return.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "return.0.wasm"
+      "filename": "return.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -977,141 +978,141 @@
       "type": "assert_invalid",
       "line": 311,
       "filename": "return.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 315,
       "filename": "return.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 324,
       "filename": "return.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 333,
       "filename": "return.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 342,
       "filename": "return.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 351,
       "filename": "return.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 360,
       "filename": "return.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 369,
       "filename": "return.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 378,
       "filename": "return.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 386,
       "filename": "return.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 394,
       "filename": "return.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 403,
       "filename": "return.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 418,
       "filename": "return.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 427,
       "filename": "return.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 436,
       "filename": "return.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 445,
       "filename": "return.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 454,
       "filename": "return.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 463,
       "filename": "return.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 472,
       "filename": "return.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 476,
       "filename": "return.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/select.wast.json
+++ b/tests/snapshots/testsuite/select.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "select.0.wasm"
+      "filename": "select.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2736,202 +2737,203 @@
       "type": "assert_invalid",
       "line": 320,
       "filename": "select.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 324,
       "filename": "select.2.wasm",
-      "text": "invalid result arity",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid result arity"
     },
     {
       "type": "assert_invalid",
       "line": 328,
       "filename": "select.3.wasm",
-      "text": "invalid result arity",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid result arity"
     },
     {
       "type": "assert_invalid",
       "line": 340,
       "filename": "select.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 347,
       "filename": "select.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 353,
       "filename": "select.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 359,
       "filename": "select.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 366,
       "filename": "select.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 370,
       "filename": "select.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 374,
       "filename": "select.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 378,
       "filename": "select.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 382,
       "filename": "select.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 388,
       "filename": "select.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 396,
       "filename": "select.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 404,
       "filename": "select.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 412,
       "filename": "select.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 421,
       "filename": "select.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 430,
       "filename": "select.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 439,
       "filename": "select.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 448,
       "filename": "select.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 457,
       "filename": "select.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 466,
       "filename": "select.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 475,
       "filename": "select.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 484,
       "filename": "select.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 496,
       "filename": "select.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 500,
       "filename": "select.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 504,
       "filename": "select.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 511,
       "filename": "select.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 518,
-      "filename": "select.29.wasm"
+      "filename": "select.29.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_address.wast.json
+++ b/tests/snapshots/testsuite/simd_address.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "simd_address.0.wasm"
+      "filename": "simd_address.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1151,7 +1152,8 @@
     {
       "type": "module",
       "line": 104,
-      "filename": "simd_address.1.wasm"
+      "filename": "simd_address.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -1167,13 +1169,14 @@
       "type": "assert_malformed",
       "line": 113,
       "filename": "simd_address.2.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 122,
-      "filename": "simd_address.3.wasm"
+      "filename": "simd_address.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -1189,22 +1192,22 @@
       "type": "assert_malformed",
       "line": 131,
       "filename": "simd_address.4.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 144,
       "filename": "simd_address.5.wat",
-      "text": "i32 constant",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "i32 constant"
     },
     {
       "type": "assert_malformed",
       "line": 152,
       "filename": "simd_address.6.wat",
-      "text": "i32 constant",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "i32 constant"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_align.wast.json
+++ b/tests/snapshots/testsuite/simd_align.wast.json
@@ -4,549 +4,594 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "simd_align.0.wasm"
+      "filename": "simd_align.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_align.1.wasm"
+      "filename": "simd_align.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 5,
-      "filename": "simd_align.2.wasm"
+      "filename": "simd_align.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 6,
-      "filename": "simd_align.3.wasm"
+      "filename": "simd_align.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 7,
-      "filename": "simd_align.4.wasm"
+      "filename": "simd_align.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 9,
-      "filename": "simd_align.5.wasm"
+      "filename": "simd_align.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 10,
-      "filename": "simd_align.6.wasm"
+      "filename": "simd_align.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 11,
-      "filename": "simd_align.7.wasm"
+      "filename": "simd_align.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 12,
-      "filename": "simd_align.8.wasm"
+      "filename": "simd_align.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 13,
-      "filename": "simd_align.9.wasm"
+      "filename": "simd_align.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 15,
-      "filename": "simd_align.10.wasm"
+      "filename": "simd_align.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 16,
-      "filename": "simd_align.11.wasm"
+      "filename": "simd_align.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 17,
-      "filename": "simd_align.12.wasm"
+      "filename": "simd_align.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 18,
-      "filename": "simd_align.13.wasm"
+      "filename": "simd_align.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 19,
-      "filename": "simd_align.14.wasm"
+      "filename": "simd_align.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 20,
-      "filename": "simd_align.15.wasm"
+      "filename": "simd_align.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 21,
-      "filename": "simd_align.16.wasm"
+      "filename": "simd_align.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 22,
-      "filename": "simd_align.17.wasm"
+      "filename": "simd_align.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 23,
-      "filename": "simd_align.18.wasm"
+      "filename": "simd_align.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 24,
-      "filename": "simd_align.19.wasm"
+      "filename": "simd_align.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 25,
-      "filename": "simd_align.20.wasm"
+      "filename": "simd_align.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 26,
-      "filename": "simd_align.21.wasm"
+      "filename": "simd_align.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 27,
-      "filename": "simd_align.22.wasm"
+      "filename": "simd_align.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 28,
-      "filename": "simd_align.23.wasm"
+      "filename": "simd_align.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 29,
-      "filename": "simd_align.24.wasm"
+      "filename": "simd_align.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 30,
-      "filename": "simd_align.25.wasm"
+      "filename": "simd_align.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 31,
-      "filename": "simd_align.26.wasm"
+      "filename": "simd_align.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 32,
-      "filename": "simd_align.27.wasm"
+      "filename": "simd_align.27.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 33,
-      "filename": "simd_align.28.wasm"
+      "filename": "simd_align.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 34,
-      "filename": "simd_align.29.wasm"
+      "filename": "simd_align.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 35,
-      "filename": "simd_align.30.wasm"
+      "filename": "simd_align.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 36,
-      "filename": "simd_align.31.wasm"
+      "filename": "simd_align.31.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 37,
-      "filename": "simd_align.32.wasm"
+      "filename": "simd_align.32.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 38,
-      "filename": "simd_align.33.wasm"
+      "filename": "simd_align.33.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 40,
-      "filename": "simd_align.34.wasm"
+      "filename": "simd_align.34.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 41,
-      "filename": "simd_align.35.wasm"
+      "filename": "simd_align.35.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 42,
-      "filename": "simd_align.36.wasm"
+      "filename": "simd_align.36.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 43,
-      "filename": "simd_align.37.wasm"
+      "filename": "simd_align.37.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 44,
-      "filename": "simd_align.38.wasm"
+      "filename": "simd_align.38.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 45,
-      "filename": "simd_align.39.wasm"
+      "filename": "simd_align.39.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 46,
-      "filename": "simd_align.40.wasm"
+      "filename": "simd_align.40.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 47,
-      "filename": "simd_align.41.wasm"
+      "filename": "simd_align.41.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 48,
-      "filename": "simd_align.42.wasm"
+      "filename": "simd_align.42.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 49,
-      "filename": "simd_align.43.wasm"
+      "filename": "simd_align.43.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 54,
       "filename": "simd_align.44.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 58,
       "filename": "simd_align.45.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 62,
       "filename": "simd_align.46.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 66,
       "filename": "simd_align.47.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 70,
       "filename": "simd_align.48.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 74,
       "filename": "simd_align.49.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 78,
       "filename": "simd_align.50.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 82,
       "filename": "simd_align.51.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 86,
       "filename": "simd_align.52.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 90,
       "filename": "simd_align.53.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 94,
       "filename": "simd_align.54.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_invalid",
       "line": 98,
       "filename": "simd_align.55.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     },
     {
       "type": "assert_malformed",
       "line": 105,
       "filename": "simd_align.56.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 111,
       "filename": "simd_align.57.wat",
-      "text": "alignment must be a power of two",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment must be a power of two"
     },
     {
       "type": "assert_malformed",
       "line": 117,
       "filename": "simd_align.58.wat",
-      "text": "alignment must be a power of two",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment must be a power of two"
     },
     {
       "type": "assert_malformed",
       "line": 123,
       "filename": "simd_align.59.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 129,
       "filename": "simd_align.60.wat",
-      "text": "alignment must be a power of two",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment must be a power of two"
     },
     {
       "type": "assert_malformed",
       "line": 135,
       "filename": "simd_align.61.wat",
-      "text": "alignment must be a power of two",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment must be a power of two"
     },
     {
       "type": "assert_malformed",
       "line": 141,
       "filename": "simd_align.62.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 147,
       "filename": "simd_align.63.wat",
-      "text": "alignment must be a power of two",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment must be a power of two"
     },
     {
       "type": "assert_malformed",
       "line": 153,
       "filename": "simd_align.64.wat",
-      "text": "alignment must be a power of two",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment must be a power of two"
     },
     {
       "type": "assert_malformed",
       "line": 159,
       "filename": "simd_align.65.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 165,
       "filename": "simd_align.66.wat",
-      "text": "alignment must be a power of two",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment must be a power of two"
     },
     {
       "type": "assert_malformed",
       "line": 171,
       "filename": "simd_align.67.wat",
-      "text": "alignment must be a power of two",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment must be a power of two"
     },
     {
       "type": "assert_malformed",
       "line": 177,
       "filename": "simd_align.68.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 183,
       "filename": "simd_align.69.wat",
-      "text": "alignment must be a power of two",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment must be a power of two"
     },
     {
       "type": "assert_malformed",
       "line": 189,
       "filename": "simd_align.70.wat",
-      "text": "alignment must be a power of two",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment must be a power of two"
     },
     {
       "type": "assert_malformed",
       "line": 195,
       "filename": "simd_align.71.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 201,
       "filename": "simd_align.72.wat",
-      "text": "alignment must be a power of two",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment must be a power of two"
     },
     {
       "type": "assert_malformed",
       "line": 207,
       "filename": "simd_align.73.wat",
-      "text": "alignment must be a power of two",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment must be a power of two"
     },
     {
       "type": "assert_malformed",
       "line": 213,
       "filename": "simd_align.74.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 219,
       "filename": "simd_align.75.wat",
-      "text": "alignment must be a power of two",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment must be a power of two"
     },
     {
       "type": "assert_malformed",
       "line": 225,
       "filename": "simd_align.76.wat",
-      "text": "alignment must be a power of two",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment must be a power of two"
     },
     {
       "type": "assert_malformed",
       "line": 231,
       "filename": "simd_align.77.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 237,
       "filename": "simd_align.78.wat",
-      "text": "alignment must be a power of two",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment must be a power of two"
     },
     {
       "type": "assert_malformed",
       "line": 243,
       "filename": "simd_align.79.wat",
-      "text": "alignment must be a power of two",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment must be a power of two"
     },
     {
       "type": "assert_malformed",
       "line": 249,
       "filename": "simd_align.80.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 255,
       "filename": "simd_align.81.wat",
-      "text": "alignment must be a power of two",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment must be a power of two"
     },
     {
       "type": "assert_malformed",
       "line": 261,
       "filename": "simd_align.82.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 267,
       "filename": "simd_align.83.wat",
-      "text": "alignment must be a power of two",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment must be a power of two"
     },
     {
       "type": "assert_malformed",
       "line": 273,
       "filename": "simd_align.84.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 279,
       "filename": "simd_align.85.wat",
-      "text": "alignment must be a power of two",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment must be a power of two"
     },
     {
       "type": "assert_malformed",
       "line": 285,
       "filename": "simd_align.86.wat",
-      "text": "alignment must be a power of two",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment must be a power of two"
     },
     {
       "type": "assert_malformed",
       "line": 291,
       "filename": "simd_align.87.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 297,
       "filename": "simd_align.88.wat",
-      "text": "alignment must be a power of two",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment must be a power of two"
     },
     {
       "type": "assert_malformed",
       "line": 303,
       "filename": "simd_align.89.wat",
-      "text": "alignment must be a power of two",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "alignment must be a power of two"
     },
     {
       "type": "module",
       "line": 311,
-      "filename": "simd_align.90.wasm"
+      "filename": "simd_align.90.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -678,7 +723,8 @@
     {
       "type": "module",
       "line": 328,
-      "filename": "simd_align.91.wasm"
+      "filename": "simd_align.91.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/simd_bit_shift.wast.json
+++ b/tests/snapshots/testsuite/simd_bit_shift.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "simd_bit_shift.0.wasm"
+      "filename": "simd_bit_shift.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -7973,7 +7974,8 @@
     {
       "type": "module",
       "line": 658,
-      "filename": "simd_bit_shift.1.wasm"
+      "filename": "simd_bit_shift.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -8219,274 +8221,274 @@
       "type": "assert_invalid",
       "line": 976,
       "filename": "simd_bit_shift.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 977,
       "filename": "simd_bit_shift.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 978,
       "filename": "simd_bit_shift.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 979,
       "filename": "simd_bit_shift.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 980,
       "filename": "simd_bit_shift.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 981,
       "filename": "simd_bit_shift.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 982,
       "filename": "simd_bit_shift.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 983,
       "filename": "simd_bit_shift.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 984,
       "filename": "simd_bit_shift.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 985,
       "filename": "simd_bit_shift.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 986,
       "filename": "simd_bit_shift.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 987,
       "filename": "simd_bit_shift.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 991,
       "filename": "simd_bit_shift.14.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 992,
       "filename": "simd_bit_shift.15.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 993,
       "filename": "simd_bit_shift.16.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 994,
       "filename": "simd_bit_shift.17.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 995,
       "filename": "simd_bit_shift.18.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 996,
       "filename": "simd_bit_shift.19.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 997,
       "filename": "simd_bit_shift.20.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 998,
       "filename": "simd_bit_shift.21.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 999,
       "filename": "simd_bit_shift.22.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1000,
       "filename": "simd_bit_shift.23.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1001,
       "filename": "simd_bit_shift.24.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1002,
       "filename": "simd_bit_shift.25.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1003,
       "filename": "simd_bit_shift.26.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1004,
       "filename": "simd_bit_shift.27.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1005,
       "filename": "simd_bit_shift.28.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_invalid",
       "line": 1010,
       "filename": "simd_bit_shift.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1018,
       "filename": "simd_bit_shift.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1026,
       "filename": "simd_bit_shift.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1034,
       "filename": "simd_bit_shift.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1042,
       "filename": "simd_bit_shift.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1050,
       "filename": "simd_bit_shift.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1058,
       "filename": "simd_bit_shift.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1066,
       "filename": "simd_bit_shift.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1074,
       "filename": "simd_bit_shift.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1082,
       "filename": "simd_bit_shift.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1090,
       "filename": "simd_bit_shift.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1098,
       "filename": "simd_bit_shift.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_bitwise.wast.json
+++ b/tests/snapshots/testsuite/simd_bitwise.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "simd_bitwise.0.wasm"
+      "filename": "simd_bitwise.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5362,118 +5363,119 @@
       "type": "assert_invalid",
       "line": 405,
       "filename": "simd_bitwise.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 407,
       "filename": "simd_bitwise.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 408,
       "filename": "simd_bitwise.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 409,
       "filename": "simd_bitwise.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 411,
       "filename": "simd_bitwise.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 412,
       "filename": "simd_bitwise.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 413,
       "filename": "simd_bitwise.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 415,
       "filename": "simd_bitwise.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 416,
       "filename": "simd_bitwise.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 417,
       "filename": "simd_bitwise.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 419,
       "filename": "simd_bitwise.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 420,
       "filename": "simd_bitwise.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 421,
       "filename": "simd_bitwise.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 423,
       "filename": "simd_bitwise.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 424,
       "filename": "simd_bitwise.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 425,
       "filename": "simd_bitwise.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 429,
-      "filename": "simd_bitwise.17.wasm"
+      "filename": "simd_bitwise.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5609,85 +5611,85 @@
       "type": "assert_invalid",
       "line": 718,
       "filename": "simd_bitwise.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 726,
       "filename": "simd_bitwise.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 734,
       "filename": "simd_bitwise.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 742,
       "filename": "simd_bitwise.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 750,
       "filename": "simd_bitwise.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 758,
       "filename": "simd_bitwise.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 766,
       "filename": "simd_bitwise.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 774,
       "filename": "simd_bitwise.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 782,
       "filename": "simd_bitwise.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 790,
       "filename": "simd_bitwise.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 798,
       "filename": "simd_bitwise.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 806,
       "filename": "simd_bitwise.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_boolean.wast.json
+++ b/tests/snapshots/testsuite/simd_boolean.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "simd_boolean.0.wasm"
+      "filename": "simd_boolean.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2377,7 +2378,8 @@
     {
       "type": "module",
       "line": 188,
-      "filename": "simd_boolean.1.wasm"
+      "filename": "simd_boolean.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -10047,113 +10049,113 @@
       "type": "assert_invalid",
       "line": 995,
       "filename": "simd_boolean.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 996,
       "filename": "simd_boolean.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 997,
       "filename": "simd_boolean.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 998,
       "filename": "simd_boolean.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 999,
       "filename": "simd_boolean.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1000,
       "filename": "simd_boolean.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1004,
       "filename": "simd_boolean.8.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1005,
       "filename": "simd_boolean.9.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1006,
       "filename": "simd_boolean.10.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1007,
       "filename": "simd_boolean.11.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_invalid",
       "line": 1012,
       "filename": "simd_boolean.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1020,
       "filename": "simd_boolean.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1028,
       "filename": "simd_boolean.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1036,
       "filename": "simd_boolean.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1044,
       "filename": "simd_boolean.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1052,
       "filename": "simd_boolean.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_const.wast.json
+++ b/tests/snapshots/testsuite/simd_const.wast.json
@@ -4,1160 +4,1274 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "simd_const.0.wasm"
+      "filename": "simd_const.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_const.1.wasm"
+      "filename": "simd_const.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 5,
-      "filename": "simd_const.2.wasm"
+      "filename": "simd_const.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 6,
-      "filename": "simd_const.3.wasm"
+      "filename": "simd_const.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 7,
-      "filename": "simd_const.4.wasm"
+      "filename": "simd_const.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 8,
-      "filename": "simd_const.5.wasm"
+      "filename": "simd_const.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 9,
-      "filename": "simd_const.6.wasm"
+      "filename": "simd_const.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 10,
-      "filename": "simd_const.7.wasm"
+      "filename": "simd_const.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 11,
-      "filename": "simd_const.8.wasm"
+      "filename": "simd_const.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 12,
-      "filename": "simd_const.9.wasm"
+      "filename": "simd_const.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 13,
-      "filename": "simd_const.10.wasm"
+      "filename": "simd_const.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 14,
-      "filename": "simd_const.11.wasm"
+      "filename": "simd_const.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 15,
-      "filename": "simd_const.12.wasm"
+      "filename": "simd_const.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 16,
-      "filename": "simd_const.13.wasm"
+      "filename": "simd_const.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 17,
-      "filename": "simd_const.14.wasm"
+      "filename": "simd_const.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 18,
-      "filename": "simd_const.15.wasm"
+      "filename": "simd_const.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 19,
-      "filename": "simd_const.16.wasm"
+      "filename": "simd_const.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 20,
-      "filename": "simd_const.17.wasm"
+      "filename": "simd_const.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 21,
-      "filename": "simd_const.18.wasm"
+      "filename": "simd_const.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 22,
-      "filename": "simd_const.19.wasm"
+      "filename": "simd_const.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 23,
-      "filename": "simd_const.20.wasm"
+      "filename": "simd_const.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 24,
-      "filename": "simd_const.21.wasm"
+      "filename": "simd_const.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 25,
-      "filename": "simd_const.22.wasm"
+      "filename": "simd_const.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 26,
-      "filename": "simd_const.23.wasm"
+      "filename": "simd_const.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 27,
-      "filename": "simd_const.24.wasm"
+      "filename": "simd_const.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 28,
-      "filename": "simd_const.25.wasm"
+      "filename": "simd_const.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 29,
-      "filename": "simd_const.26.wasm"
+      "filename": "simd_const.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 30,
-      "filename": "simd_const.27.wasm"
+      "filename": "simd_const.27.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 31,
-      "filename": "simd_const.28.wasm"
+      "filename": "simd_const.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 32,
-      "filename": "simd_const.29.wasm"
+      "filename": "simd_const.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 33,
-      "filename": "simd_const.30.wasm"
+      "filename": "simd_const.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 34,
-      "filename": "simd_const.31.wasm"
+      "filename": "simd_const.31.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 35,
-      "filename": "simd_const.32.wasm"
+      "filename": "simd_const.32.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 36,
-      "filename": "simd_const.33.wasm"
+      "filename": "simd_const.33.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 37,
-      "filename": "simd_const.34.wasm"
+      "filename": "simd_const.34.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 38,
-      "filename": "simd_const.35.wasm"
+      "filename": "simd_const.35.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 39,
-      "filename": "simd_const.36.wasm"
+      "filename": "simd_const.36.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 41,
-      "filename": "simd_const.37.wasm"
+      "filename": "simd_const.37.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 43,
-      "filename": "simd_const.38.wasm"
+      "filename": "simd_const.38.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 44,
-      "filename": "simd_const.39.wasm"
+      "filename": "simd_const.39.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 45,
-      "filename": "simd_const.40.wasm"
+      "filename": "simd_const.40.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 46,
-      "filename": "simd_const.41.wasm"
+      "filename": "simd_const.41.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 47,
-      "filename": "simd_const.42.wasm"
+      "filename": "simd_const.42.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 48,
-      "filename": "simd_const.43.wasm"
+      "filename": "simd_const.43.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 49,
-      "filename": "simd_const.44.wasm"
+      "filename": "simd_const.44.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 50,
-      "filename": "simd_const.45.wasm"
+      "filename": "simd_const.45.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 51,
-      "filename": "simd_const.46.wasm"
+      "filename": "simd_const.46.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 52,
-      "filename": "simd_const.47.wasm"
+      "filename": "simd_const.47.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 53,
-      "filename": "simd_const.48.wasm"
+      "filename": "simd_const.48.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 54,
-      "filename": "simd_const.49.wasm"
+      "filename": "simd_const.49.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 55,
-      "filename": "simd_const.50.wasm"
+      "filename": "simd_const.50.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 56,
-      "filename": "simd_const.51.wasm"
+      "filename": "simd_const.51.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 57,
-      "filename": "simd_const.52.wasm"
+      "filename": "simd_const.52.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 58,
-      "filename": "simd_const.53.wasm"
+      "filename": "simd_const.53.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 59,
-      "filename": "simd_const.54.wasm"
+      "filename": "simd_const.54.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 60,
-      "filename": "simd_const.55.wasm"
+      "filename": "simd_const.55.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 61,
-      "filename": "simd_const.56.wasm"
+      "filename": "simd_const.56.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 62,
-      "filename": "simd_const.57.wasm"
+      "filename": "simd_const.57.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 63,
-      "filename": "simd_const.58.wasm"
+      "filename": "simd_const.58.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 64,
-      "filename": "simd_const.59.wasm"
+      "filename": "simd_const.59.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 65,
-      "filename": "simd_const.60.wasm"
+      "filename": "simd_const.60.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 66,
-      "filename": "simd_const.61.wasm"
+      "filename": "simd_const.61.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 67,
-      "filename": "simd_const.62.wasm"
+      "filename": "simd_const.62.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 68,
-      "filename": "simd_const.63.wasm"
+      "filename": "simd_const.63.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 69,
-      "filename": "simd_const.64.wasm"
+      "filename": "simd_const.64.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 70,
-      "filename": "simd_const.65.wasm"
+      "filename": "simd_const.65.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 71,
-      "filename": "simd_const.66.wasm"
+      "filename": "simd_const.66.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 72,
-      "filename": "simd_const.67.wasm"
+      "filename": "simd_const.67.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 73,
-      "filename": "simd_const.68.wasm"
+      "filename": "simd_const.68.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 75,
-      "filename": "simd_const.69.wasm"
+      "filename": "simd_const.69.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 77,
-      "filename": "simd_const.70.wasm"
+      "filename": "simd_const.70.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 78,
-      "filename": "simd_const.71.wasm"
+      "filename": "simd_const.71.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 79,
-      "filename": "simd_const.72.wasm"
+      "filename": "simd_const.72.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 80,
-      "filename": "simd_const.73.wasm"
+      "filename": "simd_const.73.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 81,
-      "filename": "simd_const.74.wasm"
+      "filename": "simd_const.74.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 82,
-      "filename": "simd_const.75.wasm"
+      "filename": "simd_const.75.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 83,
-      "filename": "simd_const.76.wasm"
+      "filename": "simd_const.76.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 84,
-      "filename": "simd_const.77.wasm"
+      "filename": "simd_const.77.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 85,
-      "filename": "simd_const.78.wasm"
+      "filename": "simd_const.78.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 86,
-      "filename": "simd_const.79.wasm"
+      "filename": "simd_const.79.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 87,
-      "filename": "simd_const.80.wasm"
+      "filename": "simd_const.80.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 88,
-      "filename": "simd_const.81.wasm"
+      "filename": "simd_const.81.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 89,
-      "filename": "simd_const.82.wasm"
+      "filename": "simd_const.82.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 90,
-      "filename": "simd_const.83.wasm"
+      "filename": "simd_const.83.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 91,
-      "filename": "simd_const.84.wasm"
+      "filename": "simd_const.84.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 92,
-      "filename": "simd_const.85.wasm"
+      "filename": "simd_const.85.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 93,
-      "filename": "simd_const.86.wasm"
+      "filename": "simd_const.86.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 94,
-      "filename": "simd_const.87.wasm"
+      "filename": "simd_const.87.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 95,
-      "filename": "simd_const.88.wasm"
+      "filename": "simd_const.88.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 96,
-      "filename": "simd_const.89.wasm"
+      "filename": "simd_const.89.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 97,
-      "filename": "simd_const.90.wasm"
+      "filename": "simd_const.90.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 98,
-      "filename": "simd_const.91.wasm"
+      "filename": "simd_const.91.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 99,
-      "filename": "simd_const.92.wasm"
+      "filename": "simd_const.92.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 100,
-      "filename": "simd_const.93.wasm"
+      "filename": "simd_const.93.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 101,
-      "filename": "simd_const.94.wasm"
+      "filename": "simd_const.94.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 102,
-      "filename": "simd_const.95.wasm"
+      "filename": "simd_const.95.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 106,
-      "filename": "simd_const.96.wasm"
+      "filename": "simd_const.96.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 108,
-      "filename": "simd_const.97.wasm"
+      "filename": "simd_const.97.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 110,
-      "filename": "simd_const.98.wasm"
+      "filename": "simd_const.98.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 112,
-      "filename": "simd_const.99.wasm"
+      "filename": "simd_const.99.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 113,
-      "filename": "simd_const.100.wasm"
+      "filename": "simd_const.100.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 114,
-      "filename": "simd_const.101.wasm"
+      "filename": "simd_const.101.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 115,
-      "filename": "simd_const.102.wasm"
+      "filename": "simd_const.102.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 116,
-      "filename": "simd_const.103.wasm"
+      "filename": "simd_const.103.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 117,
-      "filename": "simd_const.104.wasm"
+      "filename": "simd_const.104.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 118,
-      "filename": "simd_const.105.wasm"
+      "filename": "simd_const.105.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 119,
-      "filename": "simd_const.106.wasm"
+      "filename": "simd_const.106.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 120,
-      "filename": "simd_const.107.wasm"
+      "filename": "simd_const.107.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 121,
-      "filename": "simd_const.108.wasm"
+      "filename": "simd_const.108.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 122,
-      "filename": "simd_const.109.wasm"
+      "filename": "simd_const.109.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 123,
-      "filename": "simd_const.110.wasm"
+      "filename": "simd_const.110.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 124,
-      "filename": "simd_const.111.wasm"
+      "filename": "simd_const.111.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 128,
-      "filename": "simd_const.112.wasm"
+      "filename": "simd_const.112.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 130,
       "filename": "simd_const.113.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 134,
       "filename": "simd_const.114.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 138,
       "filename": "simd_const.115.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 142,
       "filename": "simd_const.116.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 146,
       "filename": "simd_const.117.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 150,
       "filename": "simd_const.118.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 154,
       "filename": "simd_const.119.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 158,
       "filename": "simd_const.120.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 162,
       "filename": "simd_const.121.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 166,
       "filename": "simd_const.122.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 170,
       "filename": "simd_const.123.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 174,
       "filename": "simd_const.124.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 178,
       "filename": "simd_const.125.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 182,
       "filename": "simd_const.126.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 186,
       "filename": "simd_const.127.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 190,
       "filename": "simd_const.128.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 194,
       "filename": "simd_const.129.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 199,
       "filename": "simd_const.130.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 205,
       "filename": "simd_const.131.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 210,
       "filename": "simd_const.132.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 215,
       "filename": "simd_const.133.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 221,
       "filename": "simd_const.134.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 227,
       "filename": "simd_const.135.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 232,
       "filename": "simd_const.136.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 236,
       "filename": "simd_const.137.wat",
-      "text": "wrong number of lane literals",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "wrong number of lane literals"
     },
     {
       "type": "assert_malformed",
       "line": 240,
       "filename": "simd_const.138.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 244,
       "filename": "simd_const.139.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 248,
       "filename": "simd_const.140.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 253,
       "filename": "simd_const.141.wat",
-      "text": "wrong number of lane literals",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "wrong number of lane literals"
     },
     {
       "type": "assert_malformed",
       "line": 257,
       "filename": "simd_const.142.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 261,
       "filename": "simd_const.143.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 265,
       "filename": "simd_const.144.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 270,
       "filename": "simd_const.145.wat",
-      "text": "wrong number of lane literals",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "wrong number of lane literals"
     },
     {
       "type": "assert_malformed",
       "line": 274,
       "filename": "simd_const.146.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 278,
       "filename": "simd_const.147.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 282,
       "filename": "simd_const.148.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 287,
       "filename": "simd_const.149.wat",
-      "text": "wrong number of lane literals",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "wrong number of lane literals"
     },
     {
       "type": "assert_malformed",
       "line": 291,
       "filename": "simd_const.150.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 295,
       "filename": "simd_const.151.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 299,
       "filename": "simd_const.152.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 304,
       "filename": "simd_const.153.wat",
-      "text": "wrong number of lane literals",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "wrong number of lane literals"
     },
     {
       "type": "assert_malformed",
       "line": 308,
       "filename": "simd_const.154.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 312,
       "filename": "simd_const.155.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 316,
       "filename": "simd_const.156.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 320,
       "filename": "simd_const.157.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 324,
       "filename": "simd_const.158.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 328,
       "filename": "simd_const.159.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 332,
       "filename": "simd_const.160.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 336,
       "filename": "simd_const.161.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 340,
       "filename": "simd_const.162.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 344,
       "filename": "simd_const.163.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 348,
       "filename": "simd_const.164.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 352,
       "filename": "simd_const.165.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 356,
       "filename": "simd_const.166.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 360,
       "filename": "simd_const.167.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 364,
       "filename": "simd_const.168.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 368,
       "filename": "simd_const.169.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 372,
       "filename": "simd_const.170.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 376,
       "filename": "simd_const.171.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 380,
       "filename": "simd_const.172.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 384,
       "filename": "simd_const.173.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 389,
       "filename": "simd_const.174.wat",
-      "text": "wrong number of lane literals",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "wrong number of lane literals"
     },
     {
       "type": "assert_malformed",
       "line": 393,
       "filename": "simd_const.175.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 397,
       "filename": "simd_const.176.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 401,
       "filename": "simd_const.177.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 405,
       "filename": "simd_const.178.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 409,
       "filename": "simd_const.179.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 413,
       "filename": "simd_const.180.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 417,
       "filename": "simd_const.181.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 421,
       "filename": "simd_const.182.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 425,
       "filename": "simd_const.183.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 429,
       "filename": "simd_const.184.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 433,
       "filename": "simd_const.185.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 437,
       "filename": "simd_const.186.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 441,
       "filename": "simd_const.187.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 445,
       "filename": "simd_const.188.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 449,
       "filename": "simd_const.189.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 453,
       "filename": "simd_const.190.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 457,
       "filename": "simd_const.191.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 461,
       "filename": "simd_const.192.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 465,
       "filename": "simd_const.193.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 469,
       "filename": "simd_const.194.wat",
-      "text": "constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 476,
       "filename": "simd_const.195.wat",
-      "text": "wrong number of lane literals",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "wrong number of lane literals"
     },
     {
       "type": "assert_malformed",
       "line": 482,
       "filename": "simd_const.196.wat",
-      "text": "wrong number of lane literals",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "wrong number of lane literals"
     },
     {
       "type": "module",
       "line": 489,
-      "filename": "simd_const.197.wasm"
+      "filename": "simd_const.197.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1183,7 +1297,8 @@
     {
       "type": "module",
       "line": 491,
-      "filename": "simd_const.198.wasm"
+      "filename": "simd_const.198.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1209,7 +1324,8 @@
     {
       "type": "module",
       "line": 493,
-      "filename": "simd_const.199.wasm"
+      "filename": "simd_const.199.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1235,7 +1351,8 @@
     {
       "type": "module",
       "line": 495,
-      "filename": "simd_const.200.wasm"
+      "filename": "simd_const.200.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1261,7 +1378,8 @@
     {
       "type": "module",
       "line": 498,
-      "filename": "simd_const.201.wasm"
+      "filename": "simd_const.201.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1287,7 +1405,8 @@
     {
       "type": "module",
       "line": 500,
-      "filename": "simd_const.202.wasm"
+      "filename": "simd_const.202.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1313,7 +1432,8 @@
     {
       "type": "module",
       "line": 502,
-      "filename": "simd_const.203.wasm"
+      "filename": "simd_const.203.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1339,7 +1459,8 @@
     {
       "type": "module",
       "line": 504,
-      "filename": "simd_const.204.wasm"
+      "filename": "simd_const.204.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1365,7 +1486,8 @@
     {
       "type": "module",
       "line": 507,
-      "filename": "simd_const.205.wasm"
+      "filename": "simd_const.205.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1391,7 +1513,8 @@
     {
       "type": "module",
       "line": 509,
-      "filename": "simd_const.206.wasm"
+      "filename": "simd_const.206.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1417,7 +1540,8 @@
     {
       "type": "module",
       "line": 511,
-      "filename": "simd_const.207.wasm"
+      "filename": "simd_const.207.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1443,7 +1567,8 @@
     {
       "type": "module",
       "line": 513,
-      "filename": "simd_const.208.wasm"
+      "filename": "simd_const.208.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1469,7 +1594,8 @@
     {
       "type": "module",
       "line": 517,
-      "filename": "simd_const.209.wasm"
+      "filename": "simd_const.209.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1495,7 +1621,8 @@
     {
       "type": "module",
       "line": 519,
-      "filename": "simd_const.210.wasm"
+      "filename": "simd_const.210.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1521,7 +1648,8 @@
     {
       "type": "module",
       "line": 521,
-      "filename": "simd_const.211.wasm"
+      "filename": "simd_const.211.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1547,7 +1675,8 @@
     {
       "type": "module",
       "line": 523,
-      "filename": "simd_const.212.wasm"
+      "filename": "simd_const.212.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1573,7 +1702,8 @@
     {
       "type": "module",
       "line": 526,
-      "filename": "simd_const.213.wasm"
+      "filename": "simd_const.213.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1599,7 +1729,8 @@
     {
       "type": "module",
       "line": 528,
-      "filename": "simd_const.214.wasm"
+      "filename": "simd_const.214.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1625,7 +1756,8 @@
     {
       "type": "module",
       "line": 530,
-      "filename": "simd_const.215.wasm"
+      "filename": "simd_const.215.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1651,7 +1783,8 @@
     {
       "type": "module",
       "line": 532,
-      "filename": "simd_const.216.wasm"
+      "filename": "simd_const.216.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1677,7 +1810,8 @@
     {
       "type": "module",
       "line": 535,
-      "filename": "simd_const.217.wasm"
+      "filename": "simd_const.217.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1703,7 +1837,8 @@
     {
       "type": "module",
       "line": 537,
-      "filename": "simd_const.218.wasm"
+      "filename": "simd_const.218.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1729,7 +1864,8 @@
     {
       "type": "module",
       "line": 539,
-      "filename": "simd_const.219.wasm"
+      "filename": "simd_const.219.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1755,7 +1891,8 @@
     {
       "type": "module",
       "line": 541,
-      "filename": "simd_const.220.wasm"
+      "filename": "simd_const.220.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1781,7 +1918,8 @@
     {
       "type": "module",
       "line": 545,
-      "filename": "simd_const.221.wasm"
+      "filename": "simd_const.221.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1807,7 +1945,8 @@
     {
       "type": "module",
       "line": 547,
-      "filename": "simd_const.222.wasm"
+      "filename": "simd_const.222.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1833,7 +1972,8 @@
     {
       "type": "module",
       "line": 549,
-      "filename": "simd_const.223.wasm"
+      "filename": "simd_const.223.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1859,7 +1999,8 @@
     {
       "type": "module",
       "line": 551,
-      "filename": "simd_const.224.wasm"
+      "filename": "simd_const.224.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1885,7 +2026,8 @@
     {
       "type": "module",
       "line": 555,
-      "filename": "simd_const.225.wasm"
+      "filename": "simd_const.225.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1911,7 +2053,8 @@
     {
       "type": "module",
       "line": 557,
-      "filename": "simd_const.226.wasm"
+      "filename": "simd_const.226.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1937,7 +2080,8 @@
     {
       "type": "module",
       "line": 559,
-      "filename": "simd_const.227.wasm"
+      "filename": "simd_const.227.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1963,7 +2107,8 @@
     {
       "type": "module",
       "line": 561,
-      "filename": "simd_const.228.wasm"
+      "filename": "simd_const.228.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1989,7 +2134,8 @@
     {
       "type": "module",
       "line": 565,
-      "filename": "simd_const.229.wasm"
+      "filename": "simd_const.229.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2009,7 +2155,8 @@
     {
       "type": "module",
       "line": 567,
-      "filename": "simd_const.230.wasm"
+      "filename": "simd_const.230.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2029,7 +2176,8 @@
     {
       "type": "module",
       "line": 569,
-      "filename": "simd_const.231.wasm"
+      "filename": "simd_const.231.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2049,7 +2197,8 @@
     {
       "type": "module",
       "line": 571,
-      "filename": "simd_const.232.wasm"
+      "filename": "simd_const.232.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2069,7 +2218,8 @@
     {
       "type": "module",
       "line": 573,
-      "filename": "simd_const.233.wasm"
+      "filename": "simd_const.233.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2089,7 +2239,8 @@
     {
       "type": "module",
       "line": 575,
-      "filename": "simd_const.234.wasm"
+      "filename": "simd_const.234.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2109,7 +2260,8 @@
     {
       "type": "module",
       "line": 577,
-      "filename": "simd_const.235.wasm"
+      "filename": "simd_const.235.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2129,7 +2281,8 @@
     {
       "type": "module",
       "line": 579,
-      "filename": "simd_const.236.wasm"
+      "filename": "simd_const.236.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2149,7 +2302,8 @@
     {
       "type": "module",
       "line": 581,
-      "filename": "simd_const.237.wasm"
+      "filename": "simd_const.237.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2169,7 +2323,8 @@
     {
       "type": "module",
       "line": 583,
-      "filename": "simd_const.238.wasm"
+      "filename": "simd_const.238.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2189,7 +2344,8 @@
     {
       "type": "module",
       "line": 585,
-      "filename": "simd_const.239.wasm"
+      "filename": "simd_const.239.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2209,7 +2365,8 @@
     {
       "type": "module",
       "line": 587,
-      "filename": "simd_const.240.wasm"
+      "filename": "simd_const.240.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2229,7 +2386,8 @@
     {
       "type": "module",
       "line": 589,
-      "filename": "simd_const.241.wasm"
+      "filename": "simd_const.241.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2249,7 +2407,8 @@
     {
       "type": "module",
       "line": 591,
-      "filename": "simd_const.242.wasm"
+      "filename": "simd_const.242.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2269,7 +2428,8 @@
     {
       "type": "module",
       "line": 593,
-      "filename": "simd_const.243.wasm"
+      "filename": "simd_const.243.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2289,7 +2449,8 @@
     {
       "type": "module",
       "line": 595,
-      "filename": "simd_const.244.wasm"
+      "filename": "simd_const.244.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2309,7 +2470,8 @@
     {
       "type": "module",
       "line": 597,
-      "filename": "simd_const.245.wasm"
+      "filename": "simd_const.245.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2329,7 +2491,8 @@
     {
       "type": "module",
       "line": 599,
-      "filename": "simd_const.246.wasm"
+      "filename": "simd_const.246.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2349,7 +2512,8 @@
     {
       "type": "module",
       "line": 601,
-      "filename": "simd_const.247.wasm"
+      "filename": "simd_const.247.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2369,7 +2533,8 @@
     {
       "type": "module",
       "line": 603,
-      "filename": "simd_const.248.wasm"
+      "filename": "simd_const.248.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2389,7 +2554,8 @@
     {
       "type": "module",
       "line": 605,
-      "filename": "simd_const.249.wasm"
+      "filename": "simd_const.249.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2409,7 +2575,8 @@
     {
       "type": "module",
       "line": 607,
-      "filename": "simd_const.250.wasm"
+      "filename": "simd_const.250.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2429,7 +2596,8 @@
     {
       "type": "module",
       "line": 609,
-      "filename": "simd_const.251.wasm"
+      "filename": "simd_const.251.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2449,7 +2617,8 @@
     {
       "type": "module",
       "line": 611,
-      "filename": "simd_const.252.wasm"
+      "filename": "simd_const.252.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2469,7 +2638,8 @@
     {
       "type": "module",
       "line": 613,
-      "filename": "simd_const.253.wasm"
+      "filename": "simd_const.253.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2489,7 +2659,8 @@
     {
       "type": "module",
       "line": 615,
-      "filename": "simd_const.254.wasm"
+      "filename": "simd_const.254.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2509,7 +2680,8 @@
     {
       "type": "module",
       "line": 617,
-      "filename": "simd_const.255.wasm"
+      "filename": "simd_const.255.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2529,7 +2701,8 @@
     {
       "type": "module",
       "line": 619,
-      "filename": "simd_const.256.wasm"
+      "filename": "simd_const.256.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2549,7 +2722,8 @@
     {
       "type": "module",
       "line": 621,
-      "filename": "simd_const.257.wasm"
+      "filename": "simd_const.257.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2569,7 +2743,8 @@
     {
       "type": "module",
       "line": 623,
-      "filename": "simd_const.258.wasm"
+      "filename": "simd_const.258.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2589,7 +2764,8 @@
     {
       "type": "module",
       "line": 625,
-      "filename": "simd_const.259.wasm"
+      "filename": "simd_const.259.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2609,7 +2785,8 @@
     {
       "type": "module",
       "line": 627,
-      "filename": "simd_const.260.wasm"
+      "filename": "simd_const.260.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2629,7 +2806,8 @@
     {
       "type": "module",
       "line": 629,
-      "filename": "simd_const.261.wasm"
+      "filename": "simd_const.261.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2649,7 +2827,8 @@
     {
       "type": "module",
       "line": 631,
-      "filename": "simd_const.262.wasm"
+      "filename": "simd_const.262.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2669,7 +2848,8 @@
     {
       "type": "module",
       "line": 633,
-      "filename": "simd_const.263.wasm"
+      "filename": "simd_const.263.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2689,7 +2869,8 @@
     {
       "type": "module",
       "line": 635,
-      "filename": "simd_const.264.wasm"
+      "filename": "simd_const.264.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2709,7 +2890,8 @@
     {
       "type": "module",
       "line": 637,
-      "filename": "simd_const.265.wasm"
+      "filename": "simd_const.265.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2729,7 +2911,8 @@
     {
       "type": "module",
       "line": 639,
-      "filename": "simd_const.266.wasm"
+      "filename": "simd_const.266.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2749,7 +2932,8 @@
     {
       "type": "module",
       "line": 641,
-      "filename": "simd_const.267.wasm"
+      "filename": "simd_const.267.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2769,7 +2953,8 @@
     {
       "type": "module",
       "line": 643,
-      "filename": "simd_const.268.wasm"
+      "filename": "simd_const.268.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2789,7 +2974,8 @@
     {
       "type": "module",
       "line": 645,
-      "filename": "simd_const.269.wasm"
+      "filename": "simd_const.269.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2809,7 +2995,8 @@
     {
       "type": "module",
       "line": 647,
-      "filename": "simd_const.270.wasm"
+      "filename": "simd_const.270.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2829,7 +3016,8 @@
     {
       "type": "module",
       "line": 649,
-      "filename": "simd_const.271.wasm"
+      "filename": "simd_const.271.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2849,7 +3037,8 @@
     {
       "type": "module",
       "line": 651,
-      "filename": "simd_const.272.wasm"
+      "filename": "simd_const.272.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2869,7 +3058,8 @@
     {
       "type": "module",
       "line": 653,
-      "filename": "simd_const.273.wasm"
+      "filename": "simd_const.273.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2889,7 +3079,8 @@
     {
       "type": "module",
       "line": 655,
-      "filename": "simd_const.274.wasm"
+      "filename": "simd_const.274.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2909,7 +3100,8 @@
     {
       "type": "module",
       "line": 657,
-      "filename": "simd_const.275.wasm"
+      "filename": "simd_const.275.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2929,7 +3121,8 @@
     {
       "type": "module",
       "line": 659,
-      "filename": "simd_const.276.wasm"
+      "filename": "simd_const.276.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2949,7 +3142,8 @@
     {
       "type": "module",
       "line": 661,
-      "filename": "simd_const.277.wasm"
+      "filename": "simd_const.277.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2969,7 +3163,8 @@
     {
       "type": "module",
       "line": 663,
-      "filename": "simd_const.278.wasm"
+      "filename": "simd_const.278.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2989,7 +3184,8 @@
     {
       "type": "module",
       "line": 665,
-      "filename": "simd_const.279.wasm"
+      "filename": "simd_const.279.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3009,7 +3205,8 @@
     {
       "type": "module",
       "line": 667,
-      "filename": "simd_const.280.wasm"
+      "filename": "simd_const.280.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3029,7 +3226,8 @@
     {
       "type": "module",
       "line": 669,
-      "filename": "simd_const.281.wasm"
+      "filename": "simd_const.281.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3049,7 +3247,8 @@
     {
       "type": "module",
       "line": 671,
-      "filename": "simd_const.282.wasm"
+      "filename": "simd_const.282.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3069,7 +3268,8 @@
     {
       "type": "module",
       "line": 673,
-      "filename": "simd_const.283.wasm"
+      "filename": "simd_const.283.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3089,7 +3289,8 @@
     {
       "type": "module",
       "line": 675,
-      "filename": "simd_const.284.wasm"
+      "filename": "simd_const.284.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3109,7 +3310,8 @@
     {
       "type": "module",
       "line": 677,
-      "filename": "simd_const.285.wasm"
+      "filename": "simd_const.285.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3129,7 +3331,8 @@
     {
       "type": "module",
       "line": 679,
-      "filename": "simd_const.286.wasm"
+      "filename": "simd_const.286.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3149,7 +3352,8 @@
     {
       "type": "module",
       "line": 681,
-      "filename": "simd_const.287.wasm"
+      "filename": "simd_const.287.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3169,7 +3373,8 @@
     {
       "type": "module",
       "line": 683,
-      "filename": "simd_const.288.wasm"
+      "filename": "simd_const.288.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3189,7 +3394,8 @@
     {
       "type": "module",
       "line": 687,
-      "filename": "simd_const.289.wasm"
+      "filename": "simd_const.289.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3213,7 +3419,8 @@
     {
       "type": "module",
       "line": 689,
-      "filename": "simd_const.290.wasm"
+      "filename": "simd_const.290.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3237,7 +3444,8 @@
     {
       "type": "module",
       "line": 691,
-      "filename": "simd_const.291.wasm"
+      "filename": "simd_const.291.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3261,7 +3469,8 @@
     {
       "type": "module",
       "line": 693,
-      "filename": "simd_const.292.wasm"
+      "filename": "simd_const.292.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3285,7 +3494,8 @@
     {
       "type": "module",
       "line": 695,
-      "filename": "simd_const.293.wasm"
+      "filename": "simd_const.293.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3309,7 +3519,8 @@
     {
       "type": "module",
       "line": 697,
-      "filename": "simd_const.294.wasm"
+      "filename": "simd_const.294.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3333,7 +3544,8 @@
     {
       "type": "module",
       "line": 699,
-      "filename": "simd_const.295.wasm"
+      "filename": "simd_const.295.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3357,7 +3569,8 @@
     {
       "type": "module",
       "line": 701,
-      "filename": "simd_const.296.wasm"
+      "filename": "simd_const.296.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3381,7 +3594,8 @@
     {
       "type": "module",
       "line": 703,
-      "filename": "simd_const.297.wasm"
+      "filename": "simd_const.297.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3405,7 +3619,8 @@
     {
       "type": "module",
       "line": 705,
-      "filename": "simd_const.298.wasm"
+      "filename": "simd_const.298.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3429,7 +3644,8 @@
     {
       "type": "module",
       "line": 707,
-      "filename": "simd_const.299.wasm"
+      "filename": "simd_const.299.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3453,7 +3669,8 @@
     {
       "type": "module",
       "line": 709,
-      "filename": "simd_const.300.wasm"
+      "filename": "simd_const.300.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3477,7 +3694,8 @@
     {
       "type": "module",
       "line": 711,
-      "filename": "simd_const.301.wasm"
+      "filename": "simd_const.301.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3501,7 +3719,8 @@
     {
       "type": "module",
       "line": 713,
-      "filename": "simd_const.302.wasm"
+      "filename": "simd_const.302.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3525,7 +3744,8 @@
     {
       "type": "module",
       "line": 715,
-      "filename": "simd_const.303.wasm"
+      "filename": "simd_const.303.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3549,7 +3769,8 @@
     {
       "type": "module",
       "line": 717,
-      "filename": "simd_const.304.wasm"
+      "filename": "simd_const.304.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3573,7 +3794,8 @@
     {
       "type": "module",
       "line": 719,
-      "filename": "simd_const.305.wasm"
+      "filename": "simd_const.305.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3597,7 +3819,8 @@
     {
       "type": "module",
       "line": 721,
-      "filename": "simd_const.306.wasm"
+      "filename": "simd_const.306.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3621,7 +3844,8 @@
     {
       "type": "module",
       "line": 723,
-      "filename": "simd_const.307.wasm"
+      "filename": "simd_const.307.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3645,7 +3869,8 @@
     {
       "type": "module",
       "line": 725,
-      "filename": "simd_const.308.wasm"
+      "filename": "simd_const.308.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3669,7 +3894,8 @@
     {
       "type": "module",
       "line": 727,
-      "filename": "simd_const.309.wasm"
+      "filename": "simd_const.309.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3693,7 +3919,8 @@
     {
       "type": "module",
       "line": 729,
-      "filename": "simd_const.310.wasm"
+      "filename": "simd_const.310.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3717,7 +3944,8 @@
     {
       "type": "module",
       "line": 731,
-      "filename": "simd_const.311.wasm"
+      "filename": "simd_const.311.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3741,7 +3969,8 @@
     {
       "type": "module",
       "line": 733,
-      "filename": "simd_const.312.wasm"
+      "filename": "simd_const.312.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3765,7 +3994,8 @@
     {
       "type": "module",
       "line": 735,
-      "filename": "simd_const.313.wasm"
+      "filename": "simd_const.313.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3789,7 +4019,8 @@
     {
       "type": "module",
       "line": 737,
-      "filename": "simd_const.314.wasm"
+      "filename": "simd_const.314.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3813,7 +4044,8 @@
     {
       "type": "module",
       "line": 739,
-      "filename": "simd_const.315.wasm"
+      "filename": "simd_const.315.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3837,7 +4069,8 @@
     {
       "type": "module",
       "line": 741,
-      "filename": "simd_const.316.wasm"
+      "filename": "simd_const.316.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3861,7 +4094,8 @@
     {
       "type": "module",
       "line": 743,
-      "filename": "simd_const.317.wasm"
+      "filename": "simd_const.317.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3885,7 +4119,8 @@
     {
       "type": "module",
       "line": 745,
-      "filename": "simd_const.318.wasm"
+      "filename": "simd_const.318.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3909,7 +4144,8 @@
     {
       "type": "module",
       "line": 747,
-      "filename": "simd_const.319.wasm"
+      "filename": "simd_const.319.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3933,7 +4169,8 @@
     {
       "type": "module",
       "line": 749,
-      "filename": "simd_const.320.wasm"
+      "filename": "simd_const.320.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3957,7 +4194,8 @@
     {
       "type": "module",
       "line": 751,
-      "filename": "simd_const.321.wasm"
+      "filename": "simd_const.321.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3981,7 +4219,8 @@
     {
       "type": "module",
       "line": 753,
-      "filename": "simd_const.322.wasm"
+      "filename": "simd_const.322.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4005,7 +4244,8 @@
     {
       "type": "module",
       "line": 755,
-      "filename": "simd_const.323.wasm"
+      "filename": "simd_const.323.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4029,7 +4269,8 @@
     {
       "type": "module",
       "line": 757,
-      "filename": "simd_const.324.wasm"
+      "filename": "simd_const.324.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4053,7 +4294,8 @@
     {
       "type": "module",
       "line": 759,
-      "filename": "simd_const.325.wasm"
+      "filename": "simd_const.325.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4077,7 +4319,8 @@
     {
       "type": "module",
       "line": 761,
-      "filename": "simd_const.326.wasm"
+      "filename": "simd_const.326.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4101,7 +4344,8 @@
     {
       "type": "module",
       "line": 763,
-      "filename": "simd_const.327.wasm"
+      "filename": "simd_const.327.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4125,7 +4369,8 @@
     {
       "type": "module",
       "line": 765,
-      "filename": "simd_const.328.wasm"
+      "filename": "simd_const.328.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4149,7 +4394,8 @@
     {
       "type": "module",
       "line": 767,
-      "filename": "simd_const.329.wasm"
+      "filename": "simd_const.329.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4173,7 +4419,8 @@
     {
       "type": "module",
       "line": 769,
-      "filename": "simd_const.330.wasm"
+      "filename": "simd_const.330.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4197,7 +4444,8 @@
     {
       "type": "module",
       "line": 771,
-      "filename": "simd_const.331.wasm"
+      "filename": "simd_const.331.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4221,7 +4469,8 @@
     {
       "type": "module",
       "line": 773,
-      "filename": "simd_const.332.wasm"
+      "filename": "simd_const.332.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4245,7 +4494,8 @@
     {
       "type": "module",
       "line": 775,
-      "filename": "simd_const.333.wasm"
+      "filename": "simd_const.333.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4269,7 +4519,8 @@
     {
       "type": "module",
       "line": 777,
-      "filename": "simd_const.334.wasm"
+      "filename": "simd_const.334.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4293,7 +4544,8 @@
     {
       "type": "module",
       "line": 779,
-      "filename": "simd_const.335.wasm"
+      "filename": "simd_const.335.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4317,7 +4569,8 @@
     {
       "type": "module",
       "line": 781,
-      "filename": "simd_const.336.wasm"
+      "filename": "simd_const.336.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4341,7 +4594,8 @@
     {
       "type": "module",
       "line": 783,
-      "filename": "simd_const.337.wasm"
+      "filename": "simd_const.337.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4365,7 +4619,8 @@
     {
       "type": "module",
       "line": 785,
-      "filename": "simd_const.338.wasm"
+      "filename": "simd_const.338.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4389,7 +4644,8 @@
     {
       "type": "module",
       "line": 787,
-      "filename": "simd_const.339.wasm"
+      "filename": "simd_const.339.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4413,7 +4669,8 @@
     {
       "type": "module",
       "line": 789,
-      "filename": "simd_const.340.wasm"
+      "filename": "simd_const.340.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4437,7 +4694,8 @@
     {
       "type": "module",
       "line": 791,
-      "filename": "simd_const.341.wasm"
+      "filename": "simd_const.341.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4461,7 +4719,8 @@
     {
       "type": "module",
       "line": 793,
-      "filename": "simd_const.342.wasm"
+      "filename": "simd_const.342.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4485,7 +4744,8 @@
     {
       "type": "module",
       "line": 795,
-      "filename": "simd_const.343.wasm"
+      "filename": "simd_const.343.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4509,7 +4769,8 @@
     {
       "type": "module",
       "line": 797,
-      "filename": "simd_const.344.wasm"
+      "filename": "simd_const.344.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4533,7 +4794,8 @@
     {
       "type": "module",
       "line": 799,
-      "filename": "simd_const.345.wasm"
+      "filename": "simd_const.345.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4557,7 +4819,8 @@
     {
       "type": "module",
       "line": 801,
-      "filename": "simd_const.346.wasm"
+      "filename": "simd_const.346.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4581,7 +4844,8 @@
     {
       "type": "module",
       "line": 803,
-      "filename": "simd_const.347.wasm"
+      "filename": "simd_const.347.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4605,7 +4869,8 @@
     {
       "type": "module",
       "line": 805,
-      "filename": "simd_const.348.wasm"
+      "filename": "simd_const.348.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4629,7 +4894,8 @@
     {
       "type": "module",
       "line": 807,
-      "filename": "simd_const.349.wasm"
+      "filename": "simd_const.349.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4653,7 +4919,8 @@
     {
       "type": "module",
       "line": 809,
-      "filename": "simd_const.350.wasm"
+      "filename": "simd_const.350.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4677,7 +4944,8 @@
     {
       "type": "module",
       "line": 811,
-      "filename": "simd_const.351.wasm"
+      "filename": "simd_const.351.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4701,7 +4969,8 @@
     {
       "type": "module",
       "line": 813,
-      "filename": "simd_const.352.wasm"
+      "filename": "simd_const.352.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4725,7 +4994,8 @@
     {
       "type": "module",
       "line": 817,
-      "filename": "simd_const.353.wasm"
+      "filename": "simd_const.353.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4749,7 +5019,8 @@
     {
       "type": "module",
       "line": 819,
-      "filename": "simd_const.354.wasm"
+      "filename": "simd_const.354.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4773,7 +5044,8 @@
     {
       "type": "module",
       "line": 821,
-      "filename": "simd_const.355.wasm"
+      "filename": "simd_const.355.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4797,7 +5069,8 @@
     {
       "type": "module",
       "line": 823,
-      "filename": "simd_const.356.wasm"
+      "filename": "simd_const.356.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4821,7 +5094,8 @@
     {
       "type": "module",
       "line": 825,
-      "filename": "simd_const.357.wasm"
+      "filename": "simd_const.357.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4845,7 +5119,8 @@
     {
       "type": "module",
       "line": 827,
-      "filename": "simd_const.358.wasm"
+      "filename": "simd_const.358.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4869,7 +5144,8 @@
     {
       "type": "module",
       "line": 829,
-      "filename": "simd_const.359.wasm"
+      "filename": "simd_const.359.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4893,7 +5169,8 @@
     {
       "type": "module",
       "line": 831,
-      "filename": "simd_const.360.wasm"
+      "filename": "simd_const.360.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4917,7 +5194,8 @@
     {
       "type": "module",
       "line": 833,
-      "filename": "simd_const.361.wasm"
+      "filename": "simd_const.361.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4941,7 +5219,8 @@
     {
       "type": "module",
       "line": 835,
-      "filename": "simd_const.362.wasm"
+      "filename": "simd_const.362.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4965,7 +5244,8 @@
     {
       "type": "module",
       "line": 837,
-      "filename": "simd_const.363.wasm"
+      "filename": "simd_const.363.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4989,7 +5269,8 @@
     {
       "type": "module",
       "line": 839,
-      "filename": "simd_const.364.wasm"
+      "filename": "simd_const.364.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5013,7 +5294,8 @@
     {
       "type": "module",
       "line": 841,
-      "filename": "simd_const.365.wasm"
+      "filename": "simd_const.365.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5037,7 +5319,8 @@
     {
       "type": "module",
       "line": 843,
-      "filename": "simd_const.366.wasm"
+      "filename": "simd_const.366.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5061,7 +5344,8 @@
     {
       "type": "module",
       "line": 845,
-      "filename": "simd_const.367.wasm"
+      "filename": "simd_const.367.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5085,7 +5369,8 @@
     {
       "type": "module",
       "line": 847,
-      "filename": "simd_const.368.wasm"
+      "filename": "simd_const.368.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5109,7 +5394,8 @@
     {
       "type": "module",
       "line": 849,
-      "filename": "simd_const.369.wasm"
+      "filename": "simd_const.369.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5133,7 +5419,8 @@
     {
       "type": "module",
       "line": 851,
-      "filename": "simd_const.370.wasm"
+      "filename": "simd_const.370.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5157,7 +5444,8 @@
     {
       "type": "module",
       "line": 853,
-      "filename": "simd_const.371.wasm"
+      "filename": "simd_const.371.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5181,7 +5469,8 @@
     {
       "type": "module",
       "line": 855,
-      "filename": "simd_const.372.wasm"
+      "filename": "simd_const.372.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5205,7 +5494,8 @@
     {
       "type": "module",
       "line": 857,
-      "filename": "simd_const.373.wasm"
+      "filename": "simd_const.373.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5229,7 +5519,8 @@
     {
       "type": "module",
       "line": 859,
-      "filename": "simd_const.374.wasm"
+      "filename": "simd_const.374.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5253,7 +5544,8 @@
     {
       "type": "module",
       "line": 861,
-      "filename": "simd_const.375.wasm"
+      "filename": "simd_const.375.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5277,7 +5569,8 @@
     {
       "type": "module",
       "line": 863,
-      "filename": "simd_const.376.wasm"
+      "filename": "simd_const.376.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5301,7 +5594,8 @@
     {
       "type": "module",
       "line": 865,
-      "filename": "simd_const.377.wasm"
+      "filename": "simd_const.377.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5325,7 +5619,8 @@
     {
       "type": "module",
       "line": 867,
-      "filename": "simd_const.378.wasm"
+      "filename": "simd_const.378.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5349,7 +5644,8 @@
     {
       "type": "module",
       "line": 869,
-      "filename": "simd_const.379.wasm"
+      "filename": "simd_const.379.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5373,7 +5669,8 @@
     {
       "type": "module",
       "line": 871,
-      "filename": "simd_const.380.wasm"
+      "filename": "simd_const.380.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5397,7 +5694,8 @@
     {
       "type": "module",
       "line": 875,
-      "filename": "simd_const.381.wasm"
+      "filename": "simd_const.381.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5421,7 +5719,8 @@
     {
       "type": "module",
       "line": 877,
-      "filename": "simd_const.382.wasm"
+      "filename": "simd_const.382.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5445,7 +5744,8 @@
     {
       "type": "module",
       "line": 879,
-      "filename": "simd_const.383.wasm"
+      "filename": "simd_const.383.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5469,7 +5769,8 @@
     {
       "type": "module",
       "line": 881,
-      "filename": "simd_const.384.wasm"
+      "filename": "simd_const.384.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5493,7 +5794,8 @@
     {
       "type": "module",
       "line": 886,
-      "filename": "simd_const.385.wasm"
+      "filename": "simd_const.385.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5878,7 +6180,8 @@
     {
       "type": "module",
       "line": 995,
-      "filename": "simd_const.386.wasm"
+      "filename": "simd_const.386.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6000,7 +6303,8 @@
     {
       "type": "module",
       "line": 1031,
-      "filename": "simd_const.387.wasm"
+      "filename": "simd_const.387.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6140,7 +6444,8 @@
     {
       "type": "module",
       "line": 1076,
-      "filename": "simd_const.388.wasm"
+      "filename": "simd_const.388.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6586,146 +6891,147 @@
       "type": "assert_malformed",
       "line": 1131,
       "filename": "simd_const.389.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1135,
       "filename": "simd_const.390.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1139,
       "filename": "simd_const.391.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1143,
       "filename": "simd_const.392.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1147,
       "filename": "simd_const.393.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1151,
       "filename": "simd_const.394.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1155,
       "filename": "simd_const.395.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1159,
       "filename": "simd_const.396.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1163,
       "filename": "simd_const.397.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1167,
       "filename": "simd_const.398.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1172,
       "filename": "simd_const.399.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1176,
       "filename": "simd_const.400.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1180,
       "filename": "simd_const.401.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1184,
       "filename": "simd_const.402.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1188,
       "filename": "simd_const.403.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1192,
       "filename": "simd_const.404.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1196,
       "filename": "simd_const.405.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1200,
       "filename": "simd_const.406.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1204,
       "filename": "simd_const.407.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1208,
       "filename": "simd_const.408.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 1214,
-      "filename": "simd_const.409.wasm"
+      "filename": "simd_const.409.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -7131,538 +7437,539 @@
       "type": "assert_malformed",
       "line": 1259,
       "filename": "simd_const.410.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1263,
       "filename": "simd_const.411.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1267,
       "filename": "simd_const.412.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1271,
       "filename": "simd_const.413.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1275,
       "filename": "simd_const.414.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1279,
       "filename": "simd_const.415.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1283,
       "filename": "simd_const.416.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1287,
       "filename": "simd_const.417.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1291,
       "filename": "simd_const.418.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1295,
       "filename": "simd_const.419.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1299,
       "filename": "simd_const.420.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1303,
       "filename": "simd_const.421.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1307,
       "filename": "simd_const.422.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1311,
       "filename": "simd_const.423.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1315,
       "filename": "simd_const.424.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1319,
       "filename": "simd_const.425.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1323,
       "filename": "simd_const.426.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1327,
       "filename": "simd_const.427.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1331,
       "filename": "simd_const.428.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1335,
       "filename": "simd_const.429.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1339,
       "filename": "simd_const.430.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1343,
       "filename": "simd_const.431.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1347,
       "filename": "simd_const.432.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1351,
       "filename": "simd_const.433.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1355,
       "filename": "simd_const.434.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1359,
       "filename": "simd_const.435.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1363,
       "filename": "simd_const.436.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1367,
       "filename": "simd_const.437.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1371,
       "filename": "simd_const.438.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1375,
       "filename": "simd_const.439.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1379,
       "filename": "simd_const.440.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1383,
       "filename": "simd_const.441.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1387,
       "filename": "simd_const.442.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1391,
       "filename": "simd_const.443.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1395,
       "filename": "simd_const.444.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1399,
       "filename": "simd_const.445.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1403,
       "filename": "simd_const.446.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1407,
       "filename": "simd_const.447.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1412,
       "filename": "simd_const.448.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1416,
       "filename": "simd_const.449.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1420,
       "filename": "simd_const.450.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1424,
       "filename": "simd_const.451.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1428,
       "filename": "simd_const.452.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1432,
       "filename": "simd_const.453.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1436,
       "filename": "simd_const.454.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1440,
       "filename": "simd_const.455.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1444,
       "filename": "simd_const.456.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1448,
       "filename": "simd_const.457.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1452,
       "filename": "simd_const.458.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1456,
       "filename": "simd_const.459.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1460,
       "filename": "simd_const.460.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1464,
       "filename": "simd_const.461.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1468,
       "filename": "simd_const.462.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1472,
       "filename": "simd_const.463.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1476,
       "filename": "simd_const.464.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1480,
       "filename": "simd_const.465.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1484,
       "filename": "simd_const.466.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1488,
       "filename": "simd_const.467.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1492,
       "filename": "simd_const.468.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1496,
       "filename": "simd_const.469.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1500,
       "filename": "simd_const.470.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1504,
       "filename": "simd_const.471.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1508,
       "filename": "simd_const.472.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1512,
       "filename": "simd_const.473.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1516,
       "filename": "simd_const.474.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1520,
       "filename": "simd_const.475.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1524,
       "filename": "simd_const.476.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1528,
       "filename": "simd_const.477.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1532,
       "filename": "simd_const.478.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1536,
       "filename": "simd_const.479.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1540,
       "filename": "simd_const.480.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1544,
       "filename": "simd_const.481.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1548,
       "filename": "simd_const.482.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1552,
       "filename": "simd_const.483.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1556,
       "filename": "simd_const.484.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1560,
       "filename": "simd_const.485.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 1566,
-      "filename": "simd_const.486.wasm"
+      "filename": "simd_const.486.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -7700,7 +8007,8 @@
     {
       "type": "module",
       "line": 1583,
-      "filename": "simd_const.487.wasm"
+      "filename": "simd_const.487.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -7730,7 +8038,8 @@
     {
       "type": "module",
       "line": 1600,
-      "filename": "simd_const.488.wasm"
+      "filename": "simd_const.488.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -7756,7 +8065,8 @@
     {
       "type": "module",
       "line": 1617,
-      "filename": "simd_const.489.wasm"
+      "filename": "simd_const.489.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -7780,7 +8090,8 @@
     {
       "type": "module",
       "line": 1634,
-      "filename": "simd_const.490.wasm"
+      "filename": "simd_const.490.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -7806,7 +8117,8 @@
     {
       "type": "module",
       "line": 1651,
-      "filename": "simd_const.491.wasm"
+      "filename": "simd_const.491.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/simd_conversions.wast.json
+++ b/tests/snapshots/testsuite/simd_conversions.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "simd_conversions.0.wasm"
+      "filename": "simd_conversions.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -9004,272 +9005,273 @@
       "type": "assert_malformed",
       "line": 605,
       "filename": "simd_conversions.1.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 608,
       "filename": "simd_conversions.2.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 611,
       "filename": "simd_conversions.3.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 614,
       "filename": "simd_conversions.4.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 617,
       "filename": "simd_conversions.5.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 620,
       "filename": "simd_conversions.6.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 624,
       "filename": "simd_conversions.7.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 627,
       "filename": "simd_conversions.8.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 630,
       "filename": "simd_conversions.9.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 633,
       "filename": "simd_conversions.10.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 637,
       "filename": "simd_conversions.11.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 640,
       "filename": "simd_conversions.12.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 643,
       "filename": "simd_conversions.13.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 646,
       "filename": "simd_conversions.14.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 649,
       "filename": "simd_conversions.15.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 652,
       "filename": "simd_conversions.16.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 655,
       "filename": "simd_conversions.17.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 658,
       "filename": "simd_conversions.18.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 662,
       "filename": "simd_conversions.19.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 665,
       "filename": "simd_conversions.20.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 668,
       "filename": "simd_conversions.21.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 671,
       "filename": "simd_conversions.22.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 674,
       "filename": "simd_conversions.23.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 677,
       "filename": "simd_conversions.24.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 680,
       "filename": "simd_conversions.25.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 683,
       "filename": "simd_conversions.26.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 686,
       "filename": "simd_conversions.27.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 689,
       "filename": "simd_conversions.28.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 692,
       "filename": "simd_conversions.29.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 695,
       "filename": "simd_conversions.30.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_invalid",
       "line": 702,
       "filename": "simd_conversions.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 703,
       "filename": "simd_conversions.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 704,
       "filename": "simd_conversions.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 705,
       "filename": "simd_conversions.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 707,
       "filename": "simd_conversions.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 708,
       "filename": "simd_conversions.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 709,
       "filename": "simd_conversions.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 710,
       "filename": "simd_conversions.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 715,
-      "filename": "simd_conversions.39.wasm"
+      "filename": "simd_conversions.39.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -10169,71 +10171,71 @@
       "type": "assert_invalid",
       "line": 821,
       "filename": "simd_conversions.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 829,
       "filename": "simd_conversions.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 837,
       "filename": "simd_conversions.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 845,
       "filename": "simd_conversions.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 853,
       "filename": "simd_conversions.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 861,
       "filename": "simd_conversions.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 869,
       "filename": "simd_conversions.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 877,
       "filename": "simd_conversions.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 885,
       "filename": "simd_conversions.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 893,
       "filename": "simd_conversions.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_f32x4.wast.json
+++ b/tests/snapshots/testsuite/simd_f32x4.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_f32x4.0.wasm"
+      "filename": "simd_f32x4.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -31787,118 +31788,119 @@
       "type": "assert_malformed",
       "line": 2325,
       "filename": "simd_f32x4.1.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 2326,
       "filename": "simd_f32x4.2.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 2327,
       "filename": "simd_f32x4.3.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 2328,
       "filename": "simd_f32x4.4.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 2329,
       "filename": "simd_f32x4.5.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 2330,
       "filename": "simd_f32x4.6.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 2331,
       "filename": "simd_f32x4.7.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 2332,
       "filename": "simd_f32x4.8.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_invalid",
       "line": 2335,
       "filename": "simd_f32x4.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2336,
       "filename": "simd_f32x4.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2337,
       "filename": "simd_f32x4.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2342,
       "filename": "simd_f32x4.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2350,
       "filename": "simd_f32x4.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2358,
       "filename": "simd_f32x4.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2366,
       "filename": "simd_f32x4.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2374,
       "filename": "simd_f32x4.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 2383,
-      "filename": "simd_f32x4.17.wasm"
+      "filename": "simd_f32x4.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/simd_f32x4_arith.wast.json
+++ b/tests/snapshots/testsuite/simd_f32x4_arith.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_f32x4_arith.0.wasm"
+      "filename": "simd_f32x4_arith.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -74057,7 +74058,8 @@
     {
       "type": "module",
       "line": 5280,
-      "filename": "simd_f32x4_arith.1.wasm"
+      "filename": "simd_f32x4_arith.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -74126,118 +74128,119 @@
       "type": "assert_invalid",
       "line": 5295,
       "filename": "simd_f32x4_arith.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5296,
       "filename": "simd_f32x4_arith.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5297,
       "filename": "simd_f32x4_arith.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5298,
       "filename": "simd_f32x4_arith.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5299,
       "filename": "simd_f32x4_arith.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5300,
       "filename": "simd_f32x4_arith.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5305,
       "filename": "simd_f32x4_arith.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5313,
       "filename": "simd_f32x4_arith.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5321,
       "filename": "simd_f32x4_arith.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5329,
       "filename": "simd_f32x4_arith.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5337,
       "filename": "simd_f32x4_arith.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5345,
       "filename": "simd_f32x4_arith.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5353,
       "filename": "simd_f32x4_arith.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5361,
       "filename": "simd_f32x4_arith.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5369,
       "filename": "simd_f32x4_arith.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5377,
       "filename": "simd_f32x4_arith.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 5386,
-      "filename": "simd_f32x4_arith.18.wasm"
+      "filename": "simd_f32x4_arith.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/simd_f32x4_cmp.wast.json
+++ b/tests/snapshots/testsuite/simd_f32x4_cmp.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "simd_f32x4_cmp.0.wasm"
+      "filename": "simd_f32x4_cmp.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -107962,90 +107963,91 @@
       "type": "assert_invalid",
       "line": 7779,
       "filename": "simd_f32x4_cmp.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 7780,
       "filename": "simd_f32x4_cmp.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 7781,
       "filename": "simd_f32x4_cmp.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 7782,
       "filename": "simd_f32x4_cmp.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 7783,
       "filename": "simd_f32x4_cmp.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 7784,
       "filename": "simd_f32x4_cmp.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 7789,
       "filename": "simd_f32x4_cmp.7.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 7790,
       "filename": "simd_f32x4_cmp.8.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 7791,
       "filename": "simd_f32x4_cmp.9.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 7792,
       "filename": "simd_f32x4_cmp.10.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 7793,
       "filename": "simd_f32x4_cmp.11.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 7794,
       "filename": "simd_f32x4_cmp.12.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 7799,
-      "filename": "simd_f32x4_cmp.13.wasm"
+      "filename": "simd_f32x4_cmp.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -108181,85 +108183,85 @@
       "type": "assert_invalid",
       "line": 8073,
       "filename": "simd_f32x4_cmp.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 8081,
       "filename": "simd_f32x4_cmp.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 8089,
       "filename": "simd_f32x4_cmp.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 8097,
       "filename": "simd_f32x4_cmp.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 8105,
       "filename": "simd_f32x4_cmp.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 8113,
       "filename": "simd_f32x4_cmp.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 8121,
       "filename": "simd_f32x4_cmp.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 8129,
       "filename": "simd_f32x4_cmp.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 8137,
       "filename": "simd_f32x4_cmp.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 8145,
       "filename": "simd_f32x4_cmp.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 8153,
       "filename": "simd_f32x4_cmp.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 8161,
       "filename": "simd_f32x4_cmp.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_f32x4_pmin_pmax.wast.json
+++ b/tests/snapshots/testsuite/simd_f32x4_pmin_pmax.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_f32x4_pmin_pmax.0.wasm"
+      "filename": "simd_f32x4_pmin_pmax.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -162634,99 +162635,99 @@
       "type": "assert_malformed",
       "line": 11629,
       "filename": "simd_f32x4_pmin_pmax.1.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 11630,
       "filename": "simd_f32x4_pmin_pmax.2.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 11631,
       "filename": "simd_f32x4_pmin_pmax.3.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 11632,
       "filename": "simd_f32x4_pmin_pmax.4.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 11633,
       "filename": "simd_f32x4_pmin_pmax.5.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 11634,
       "filename": "simd_f32x4_pmin_pmax.6.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 11635,
       "filename": "simd_f32x4_pmin_pmax.7.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 11636,
       "filename": "simd_f32x4_pmin_pmax.8.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_invalid",
       "line": 11639,
       "filename": "simd_f32x4_pmin_pmax.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 11640,
       "filename": "simd_f32x4_pmin_pmax.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 11645,
       "filename": "simd_f32x4_pmin_pmax.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 11653,
       "filename": "simd_f32x4_pmin_pmax.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 11661,
       "filename": "simd_f32x4_pmin_pmax.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 11669,
       "filename": "simd_f32x4_pmin_pmax.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_f32x4_rounding.wast.json
+++ b/tests/snapshots/testsuite/simd_f32x4_rounding.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_f32x4_rounding.0.wasm"
+      "filename": "simd_f32x4_rounding.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5642,169 +5643,169 @@
       "type": "assert_malformed",
       "line": 367,
       "filename": "simd_f32x4_rounding.1.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 368,
       "filename": "simd_f32x4_rounding.2.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 369,
       "filename": "simd_f32x4_rounding.3.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 370,
       "filename": "simd_f32x4_rounding.4.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 371,
       "filename": "simd_f32x4_rounding.5.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 372,
       "filename": "simd_f32x4_rounding.6.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 373,
       "filename": "simd_f32x4_rounding.7.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 374,
       "filename": "simd_f32x4_rounding.8.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 375,
       "filename": "simd_f32x4_rounding.9.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 376,
       "filename": "simd_f32x4_rounding.10.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 377,
       "filename": "simd_f32x4_rounding.11.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 378,
       "filename": "simd_f32x4_rounding.12.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 379,
       "filename": "simd_f32x4_rounding.13.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 380,
       "filename": "simd_f32x4_rounding.14.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 381,
       "filename": "simd_f32x4_rounding.15.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 382,
       "filename": "simd_f32x4_rounding.16.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_invalid",
       "line": 385,
       "filename": "simd_f32x4_rounding.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 386,
       "filename": "simd_f32x4_rounding.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 387,
       "filename": "simd_f32x4_rounding.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 388,
       "filename": "simd_f32x4_rounding.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 393,
       "filename": "simd_f32x4_rounding.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 401,
       "filename": "simd_f32x4_rounding.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 409,
       "filename": "simd_f32x4_rounding.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 417,
       "filename": "simd_f32x4_rounding.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_f64x2.wast.json
+++ b/tests/snapshots/testsuite/simd_f64x2.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_f64x2.0.wasm"
+      "filename": "simd_f64x2.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -27812,62 +27813,63 @@
       "type": "assert_invalid",
       "line": 2387,
       "filename": "simd_f64x2.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2388,
       "filename": "simd_f64x2.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2389,
       "filename": "simd_f64x2.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2394,
       "filename": "simd_f64x2.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2402,
       "filename": "simd_f64x2.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2410,
       "filename": "simd_f64x2.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2418,
       "filename": "simd_f64x2.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 2426,
       "filename": "simd_f64x2.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 2435,
-      "filename": "simd_f64x2.9.wasm"
+      "filename": "simd_f64x2.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/simd_f64x2_arith.wast.json
+++ b/tests/snapshots/testsuite/simd_f64x2_arith.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_f64x2_arith.0.wasm"
+      "filename": "simd_f64x2_arith.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -63529,7 +63530,8 @@
     {
       "type": "module",
       "line": 5279,
-      "filename": "simd_f64x2_arith.1.wasm"
+      "filename": "simd_f64x2_arith.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -63649,118 +63651,119 @@
       "type": "assert_invalid",
       "line": 5302,
       "filename": "simd_f64x2_arith.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5303,
       "filename": "simd_f64x2_arith.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5304,
       "filename": "simd_f64x2_arith.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5305,
       "filename": "simd_f64x2_arith.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5306,
       "filename": "simd_f64x2_arith.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5307,
       "filename": "simd_f64x2_arith.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5312,
       "filename": "simd_f64x2_arith.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5320,
       "filename": "simd_f64x2_arith.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5328,
       "filename": "simd_f64x2_arith.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5336,
       "filename": "simd_f64x2_arith.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5344,
       "filename": "simd_f64x2_arith.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5352,
       "filename": "simd_f64x2_arith.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5360,
       "filename": "simd_f64x2_arith.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5368,
       "filename": "simd_f64x2_arith.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5376,
       "filename": "simd_f64x2_arith.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 5384,
       "filename": "simd_f64x2_arith.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 5393,
-      "filename": "simd_f64x2_arith.18.wasm"
+      "filename": "simd_f64x2_arith.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/simd_f64x2_cmp.wast.json
+++ b/tests/snapshots/testsuite/simd_f64x2_cmp.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_f64x2_cmp.0.wasm"
+      "filename": "simd_f64x2_cmp.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -95266,174 +95267,175 @@
       "type": "assert_malformed",
       "line": 7954,
       "filename": "simd_f64x2_cmp.1.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 7955,
       "filename": "simd_f64x2_cmp.2.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 7956,
       "filename": "simd_f64x2_cmp.3.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 7957,
       "filename": "simd_f64x2_cmp.4.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 7958,
       "filename": "simd_f64x2_cmp.5.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 7959,
       "filename": "simd_f64x2_cmp.6.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_invalid",
       "line": 7962,
       "filename": "simd_f64x2_cmp.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 7963,
       "filename": "simd_f64x2_cmp.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 7964,
       "filename": "simd_f64x2_cmp.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 7965,
       "filename": "simd_f64x2_cmp.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 7966,
       "filename": "simd_f64x2_cmp.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 7967,
       "filename": "simd_f64x2_cmp.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 7972,
       "filename": "simd_f64x2_cmp.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 7980,
       "filename": "simd_f64x2_cmp.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 7988,
       "filename": "simd_f64x2_cmp.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 7996,
       "filename": "simd_f64x2_cmp.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 8004,
       "filename": "simd_f64x2_cmp.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 8012,
       "filename": "simd_f64x2_cmp.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 8020,
       "filename": "simd_f64x2_cmp.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 8028,
       "filename": "simd_f64x2_cmp.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 8036,
       "filename": "simd_f64x2_cmp.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 8044,
       "filename": "simd_f64x2_cmp.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 8052,
       "filename": "simd_f64x2_cmp.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 8060,
       "filename": "simd_f64x2_cmp.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 8069,
-      "filename": "simd_f64x2_cmp.25.wasm"
+      "filename": "simd_f64x2_cmp.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/simd_f64x2_pmin_pmax.wast.json
+++ b/tests/snapshots/testsuite/simd_f64x2_pmin_pmax.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_f64x2_pmin_pmax.0.wasm"
+      "filename": "simd_f64x2_pmin_pmax.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -139402,99 +139403,99 @@
       "type": "assert_malformed",
       "line": 11629,
       "filename": "simd_f64x2_pmin_pmax.1.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 11630,
       "filename": "simd_f64x2_pmin_pmax.2.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 11631,
       "filename": "simd_f64x2_pmin_pmax.3.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 11632,
       "filename": "simd_f64x2_pmin_pmax.4.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 11633,
       "filename": "simd_f64x2_pmin_pmax.5.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 11634,
       "filename": "simd_f64x2_pmin_pmax.6.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 11635,
       "filename": "simd_f64x2_pmin_pmax.7.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 11636,
       "filename": "simd_f64x2_pmin_pmax.8.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_invalid",
       "line": 11639,
       "filename": "simd_f64x2_pmin_pmax.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 11640,
       "filename": "simd_f64x2_pmin_pmax.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 11645,
       "filename": "simd_f64x2_pmin_pmax.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 11653,
       "filename": "simd_f64x2_pmin_pmax.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 11661,
       "filename": "simd_f64x2_pmin_pmax.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 11669,
       "filename": "simd_f64x2_pmin_pmax.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_f64x2_rounding.wast.json
+++ b/tests/snapshots/testsuite/simd_f64x2_rounding.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_f64x2_rounding.0.wasm"
+      "filename": "simd_f64x2_rounding.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4938,169 +4939,169 @@
       "type": "assert_malformed",
       "line": 367,
       "filename": "simd_f64x2_rounding.1.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 368,
       "filename": "simd_f64x2_rounding.2.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 369,
       "filename": "simd_f64x2_rounding.3.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 370,
       "filename": "simd_f64x2_rounding.4.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 371,
       "filename": "simd_f64x2_rounding.5.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 372,
       "filename": "simd_f64x2_rounding.6.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 373,
       "filename": "simd_f64x2_rounding.7.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 374,
       "filename": "simd_f64x2_rounding.8.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 375,
       "filename": "simd_f64x2_rounding.9.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 376,
       "filename": "simd_f64x2_rounding.10.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 377,
       "filename": "simd_f64x2_rounding.11.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 378,
       "filename": "simd_f64x2_rounding.12.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 379,
       "filename": "simd_f64x2_rounding.13.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 380,
       "filename": "simd_f64x2_rounding.14.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 381,
       "filename": "simd_f64x2_rounding.15.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 382,
       "filename": "simd_f64x2_rounding.16.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_invalid",
       "line": 385,
       "filename": "simd_f64x2_rounding.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 386,
       "filename": "simd_f64x2_rounding.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 387,
       "filename": "simd_f64x2_rounding.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 388,
       "filename": "simd_f64x2_rounding.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 393,
       "filename": "simd_f64x2_rounding.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 401,
       "filename": "simd_f64x2_rounding.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 409,
       "filename": "simd_f64x2_rounding.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 417,
       "filename": "simd_f64x2_rounding.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_i16x8_arith.wast.json
+++ b/tests/snapshots/testsuite/simd_i16x8_arith.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_i16x8_arith.0.wasm"
+      "filename": "simd_i16x8_arith.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -9136,83 +9137,84 @@
       "type": "assert_invalid",
       "line": 528,
       "filename": "simd_i16x8_arith.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 529,
       "filename": "simd_i16x8_arith.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 530,
       "filename": "simd_i16x8_arith.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 531,
       "filename": "simd_i16x8_arith.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 536,
       "filename": "simd_i16x8_arith.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 544,
       "filename": "simd_i16x8_arith.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 552,
       "filename": "simd_i16x8_arith.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 560,
       "filename": "simd_i16x8_arith.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 568,
       "filename": "simd_i16x8_arith.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 576,
       "filename": "simd_i16x8_arith.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 584,
       "filename": "simd_i16x8_arith.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 593,
-      "filename": "simd_i16x8_arith.12.wasm"
+      "filename": "simd_i16x8_arith.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/simd_i16x8_arith2.wast.json
+++ b/tests/snapshots/testsuite/simd_i16x8_arith2.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "simd_i16x8_arith2.0.wasm"
+      "filename": "simd_i16x8_arith2.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5495,139 +5496,140 @@
       "type": "assert_malformed",
       "line": 337,
       "filename": "simd_i16x8_arith2.1.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 338,
       "filename": "simd_i16x8_arith2.2.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_invalid",
       "line": 341,
       "filename": "simd_i16x8_arith2.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 342,
       "filename": "simd_i16x8_arith2.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 343,
       "filename": "simd_i16x8_arith2.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 344,
       "filename": "simd_i16x8_arith2.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 345,
       "filename": "simd_i16x8_arith2.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 346,
       "filename": "simd_i16x8_arith2.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 351,
       "filename": "simd_i16x8_arith2.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 359,
       "filename": "simd_i16x8_arith2.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 367,
       "filename": "simd_i16x8_arith2.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 375,
       "filename": "simd_i16x8_arith2.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 383,
       "filename": "simd_i16x8_arith2.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 391,
       "filename": "simd_i16x8_arith2.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 399,
       "filename": "simd_i16x8_arith2.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 407,
       "filename": "simd_i16x8_arith2.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 415,
       "filename": "simd_i16x8_arith2.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 423,
       "filename": "simd_i16x8_arith2.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 431,
       "filename": "simd_i16x8_arith2.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 440,
-      "filename": "simd_i16x8_arith2.20.wasm"
+      "filename": "simd_i16x8_arith2.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/simd_i16x8_cmp.wast.json
+++ b/tests/snapshots/testsuite/simd_i16x8_cmp.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_i16x8_cmp.0.wasm"
+      "filename": "simd_i16x8_cmp.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -22890,76 +22891,77 @@
       "type": "assert_invalid",
       "line": 1455,
       "filename": "simd_i16x8_cmp.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1456,
       "filename": "simd_i16x8_cmp.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1457,
       "filename": "simd_i16x8_cmp.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1458,
       "filename": "simd_i16x8_cmp.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1459,
       "filename": "simd_i16x8_cmp.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1460,
       "filename": "simd_i16x8_cmp.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1461,
       "filename": "simd_i16x8_cmp.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1462,
       "filename": "simd_i16x8_cmp.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1463,
       "filename": "simd_i16x8_cmp.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1464,
       "filename": "simd_i16x8_cmp.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 1469,
-      "filename": "simd_i16x8_cmp.11.wasm"
+      "filename": "simd_i16x8_cmp.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -23095,141 +23097,141 @@
       "type": "assert_invalid",
       "line": 1743,
       "filename": "simd_i16x8_cmp.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1751,
       "filename": "simd_i16x8_cmp.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1759,
       "filename": "simd_i16x8_cmp.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1767,
       "filename": "simd_i16x8_cmp.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1775,
       "filename": "simd_i16x8_cmp.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1783,
       "filename": "simd_i16x8_cmp.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1791,
       "filename": "simd_i16x8_cmp.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1799,
       "filename": "simd_i16x8_cmp.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1807,
       "filename": "simd_i16x8_cmp.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1815,
       "filename": "simd_i16x8_cmp.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1823,
       "filename": "simd_i16x8_cmp.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1831,
       "filename": "simd_i16x8_cmp.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1839,
       "filename": "simd_i16x8_cmp.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1847,
       "filename": "simd_i16x8_cmp.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1855,
       "filename": "simd_i16x8_cmp.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1863,
       "filename": "simd_i16x8_cmp.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1871,
       "filename": "simd_i16x8_cmp.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1879,
       "filename": "simd_i16x8_cmp.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1887,
       "filename": "simd_i16x8_cmp.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1895,
       "filename": "simd_i16x8_cmp.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_i16x8_extadd_pairwise_i8x16.wast.json
+++ b/tests/snapshots/testsuite/simd_i16x8_extadd_pairwise_i8x16.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_i16x8_extadd_pairwise_i8x16.0.wasm"
+      "filename": "simd_i16x8_extadd_pairwise_i8x16.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -778,29 +779,29 @@
       "type": "assert_invalid",
       "line": 47,
       "filename": "simd_i16x8_extadd_pairwise_i8x16.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 48,
       "filename": "simd_i16x8_extadd_pairwise_i8x16.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 53,
       "filename": "simd_i16x8_extadd_pairwise_i8x16.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 61,
       "filename": "simd_i16x8_extadd_pairwise_i8x16.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_i16x8_extmul_i8x16.wast.json
+++ b/tests/snapshots/testsuite/simd_i16x8_extmul_i8x16.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_i16x8_extmul_i8x16.0.wasm"
+      "filename": "simd_i16x8_extmul_i8x16.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -7290,85 +7291,85 @@
       "type": "assert_invalid",
       "line": 333,
       "filename": "simd_i16x8_extmul_i8x16.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 334,
       "filename": "simd_i16x8_extmul_i8x16.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 335,
       "filename": "simd_i16x8_extmul_i8x16.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 336,
       "filename": "simd_i16x8_extmul_i8x16.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 341,
       "filename": "simd_i16x8_extmul_i8x16.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 349,
       "filename": "simd_i16x8_extmul_i8x16.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 357,
       "filename": "simd_i16x8_extmul_i8x16.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 365,
       "filename": "simd_i16x8_extmul_i8x16.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 373,
       "filename": "simd_i16x8_extmul_i8x16.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 381,
       "filename": "simd_i16x8_extmul_i8x16.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 389,
       "filename": "simd_i16x8_extmul_i8x16.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 397,
       "filename": "simd_i16x8_extmul_i8x16.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_i16x8_q15mulr_sat_s.wast.json
+++ b/tests/snapshots/testsuite/simd_i16x8_q15mulr_sat_s.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_i16x8_q15mulr_sat_s.0.wasm"
+      "filename": "simd_i16x8_q15mulr_sat_s.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1414,22 +1415,22 @@
       "type": "assert_invalid",
       "line": 90,
       "filename": "simd_i16x8_q15mulr_sat_s.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 95,
       "filename": "simd_i16x8_q15mulr_sat_s.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 103,
       "filename": "simd_i16x8_q15mulr_sat_s.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_i16x8_sat_arith.wast.json
+++ b/tests/snapshots/testsuite/simd_i16x8_sat_arith.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_i16x8_sat_arith.0.wasm"
+      "filename": "simd_i16x8_sat_arith.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -10514,118 +10515,119 @@
       "type": "assert_malformed",
       "line": 609,
       "filename": "simd_i16x8_sat_arith.1.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 612,
       "filename": "simd_i16x8_sat_arith.2.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 615,
       "filename": "simd_i16x8_sat_arith.3.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 618,
       "filename": "simd_i16x8_sat_arith.4.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_invalid",
       "line": 623,
       "filename": "simd_i16x8_sat_arith.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 624,
       "filename": "simd_i16x8_sat_arith.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 625,
       "filename": "simd_i16x8_sat_arith.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 626,
       "filename": "simd_i16x8_sat_arith.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 631,
       "filename": "simd_i16x8_sat_arith.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 639,
       "filename": "simd_i16x8_sat_arith.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 647,
       "filename": "simd_i16x8_sat_arith.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 655,
       "filename": "simd_i16x8_sat_arith.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 663,
       "filename": "simd_i16x8_sat_arith.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 671,
       "filename": "simd_i16x8_sat_arith.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 679,
       "filename": "simd_i16x8_sat_arith.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 687,
       "filename": "simd_i16x8_sat_arith.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 696,
-      "filename": "simd_i16x8_sat_arith.17.wasm"
+      "filename": "simd_i16x8_sat_arith.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/simd_i32x4_arith.wast.json
+++ b/tests/snapshots/testsuite/simd_i32x4_arith.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_i32x4_arith.0.wasm"
+      "filename": "simd_i32x4_arith.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -7264,83 +7265,84 @@
       "type": "assert_invalid",
       "line": 528,
       "filename": "simd_i32x4_arith.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 529,
       "filename": "simd_i32x4_arith.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 530,
       "filename": "simd_i32x4_arith.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 531,
       "filename": "simd_i32x4_arith.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 536,
       "filename": "simd_i32x4_arith.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 544,
       "filename": "simd_i32x4_arith.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 552,
       "filename": "simd_i32x4_arith.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 560,
       "filename": "simd_i32x4_arith.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 568,
       "filename": "simd_i32x4_arith.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 576,
       "filename": "simd_i32x4_arith.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 584,
       "filename": "simd_i32x4_arith.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 593,
-      "filename": "simd_i32x4_arith.12.wasm"
+      "filename": "simd_i32x4_arith.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/simd_i32x4_arith2.wast.json
+++ b/tests/snapshots/testsuite/simd_i32x4_arith2.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "simd_i32x4_arith2.0.wasm"
+      "filename": "simd_i32x4_arith2.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3583,188 +3584,189 @@
       "type": "assert_malformed",
       "line": 281,
       "filename": "simd_i32x4_arith2.1.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 282,
       "filename": "simd_i32x4_arith2.2.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 283,
       "filename": "simd_i32x4_arith2.3.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 284,
       "filename": "simd_i32x4_arith2.4.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 285,
       "filename": "simd_i32x4_arith2.5.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 286,
       "filename": "simd_i32x4_arith2.6.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 287,
       "filename": "simd_i32x4_arith2.7.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 288,
       "filename": "simd_i32x4_arith2.8.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 289,
       "filename": "simd_i32x4_arith2.9.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 290,
       "filename": "simd_i32x4_arith2.10.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 291,
       "filename": "simd_i32x4_arith2.11.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 292,
       "filename": "simd_i32x4_arith2.12.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_invalid",
       "line": 295,
       "filename": "simd_i32x4_arith2.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 296,
       "filename": "simd_i32x4_arith2.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 297,
       "filename": "simd_i32x4_arith2.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 298,
       "filename": "simd_i32x4_arith2.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 299,
       "filename": "simd_i32x4_arith2.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 304,
       "filename": "simd_i32x4_arith2.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 312,
       "filename": "simd_i32x4_arith2.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 320,
       "filename": "simd_i32x4_arith2.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 328,
       "filename": "simd_i32x4_arith2.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 336,
       "filename": "simd_i32x4_arith2.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 344,
       "filename": "simd_i32x4_arith2.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 352,
       "filename": "simd_i32x4_arith2.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 360,
       "filename": "simd_i32x4_arith2.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 368,
       "filename": "simd_i32x4_arith2.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 377,
-      "filename": "simd_i32x4_arith2.27.wasm"
+      "filename": "simd_i32x4_arith2.27.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/simd_i32x4_cmp.wast.json
+++ b/tests/snapshots/testsuite/simd_i32x4_cmp.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_i32x4_cmp.0.wasm"
+      "filename": "simd_i32x4_cmp.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -18770,76 +18771,77 @@
       "type": "assert_invalid",
       "line": 1461,
       "filename": "simd_i32x4_cmp.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1462,
       "filename": "simd_i32x4_cmp.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1463,
       "filename": "simd_i32x4_cmp.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1464,
       "filename": "simd_i32x4_cmp.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1465,
       "filename": "simd_i32x4_cmp.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1466,
       "filename": "simd_i32x4_cmp.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1467,
       "filename": "simd_i32x4_cmp.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1468,
       "filename": "simd_i32x4_cmp.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1469,
       "filename": "simd_i32x4_cmp.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1470,
       "filename": "simd_i32x4_cmp.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 1475,
-      "filename": "simd_i32x4_cmp.11.wasm"
+      "filename": "simd_i32x4_cmp.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -18975,211 +18977,211 @@
       "type": "assert_invalid",
       "line": 1749,
       "filename": "simd_i32x4_cmp.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1757,
       "filename": "simd_i32x4_cmp.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1765,
       "filename": "simd_i32x4_cmp.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1773,
       "filename": "simd_i32x4_cmp.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1781,
       "filename": "simd_i32x4_cmp.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1789,
       "filename": "simd_i32x4_cmp.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1797,
       "filename": "simd_i32x4_cmp.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1805,
       "filename": "simd_i32x4_cmp.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1813,
       "filename": "simd_i32x4_cmp.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1821,
       "filename": "simd_i32x4_cmp.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1829,
       "filename": "simd_i32x4_cmp.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1837,
       "filename": "simd_i32x4_cmp.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1845,
       "filename": "simd_i32x4_cmp.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1853,
       "filename": "simd_i32x4_cmp.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1861,
       "filename": "simd_i32x4_cmp.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1869,
       "filename": "simd_i32x4_cmp.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1877,
       "filename": "simd_i32x4_cmp.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1885,
       "filename": "simd_i32x4_cmp.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1893,
       "filename": "simd_i32x4_cmp.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1901,
       "filename": "simd_i32x4_cmp.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1910,
       "filename": "simd_i32x4_cmp.32.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1911,
       "filename": "simd_i32x4_cmp.33.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1912,
       "filename": "simd_i32x4_cmp.34.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1913,
       "filename": "simd_i32x4_cmp.35.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1914,
       "filename": "simd_i32x4_cmp.36.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1915,
       "filename": "simd_i32x4_cmp.37.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1916,
       "filename": "simd_i32x4_cmp.38.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1917,
       "filename": "simd_i32x4_cmp.39.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1918,
       "filename": "simd_i32x4_cmp.40.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 1919,
       "filename": "simd_i32x4_cmp.41.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_i32x4_dot_i16x8.wast.json
+++ b/tests/snapshots/testsuite/simd_i32x4_dot_i16x8.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_i32x4_dot_i16x8.0.wasm"
+      "filename": "simd_i32x4_dot_i16x8.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1310,22 +1311,22 @@
       "type": "assert_invalid",
       "line": 90,
       "filename": "simd_i32x4_dot_i16x8.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 95,
       "filename": "simd_i32x4_dot_i16x8.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 103,
       "filename": "simd_i32x4_dot_i16x8.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_i32x4_extadd_pairwise_i16x8.wast.json
+++ b/tests/snapshots/testsuite/simd_i32x4_extadd_pairwise_i16x8.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_i32x4_extadd_pairwise_i16x8.0.wasm"
+      "filename": "simd_i32x4_extadd_pairwise_i16x8.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -586,29 +587,29 @@
       "type": "assert_invalid",
       "line": 47,
       "filename": "simd_i32x4_extadd_pairwise_i16x8.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 48,
       "filename": "simd_i32x4_extadd_pairwise_i16x8.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 53,
       "filename": "simd_i32x4_extadd_pairwise_i16x8.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 61,
       "filename": "simd_i32x4_extadd_pairwise_i16x8.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_i32x4_extmul_i16x8.wast.json
+++ b/tests/snapshots/testsuite/simd_i32x4_extmul_i16x8.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_i32x4_extmul_i16x8.0.wasm"
+      "filename": "simd_i32x4_extmul_i16x8.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -5210,85 +5211,85 @@
       "type": "assert_invalid",
       "line": 333,
       "filename": "simd_i32x4_extmul_i16x8.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 334,
       "filename": "simd_i32x4_extmul_i16x8.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 335,
       "filename": "simd_i32x4_extmul_i16x8.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 336,
       "filename": "simd_i32x4_extmul_i16x8.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 341,
       "filename": "simd_i32x4_extmul_i16x8.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 349,
       "filename": "simd_i32x4_extmul_i16x8.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 357,
       "filename": "simd_i32x4_extmul_i16x8.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 365,
       "filename": "simd_i32x4_extmul_i16x8.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 373,
       "filename": "simd_i32x4_extmul_i16x8.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 381,
       "filename": "simd_i32x4_extmul_i16x8.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 389,
       "filename": "simd_i32x4_extmul_i16x8.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 397,
       "filename": "simd_i32x4_extmul_i16x8.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_i32x4_trunc_sat_f32x4.wast.json
+++ b/tests/snapshots/testsuite/simd_i32x4_trunc_sat_f32x4.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "simd_i32x4_trunc_sat_f32x4.0.wasm"
+      "filename": "simd_i32x4_trunc_sat_f32x4.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3274,29 +3275,29 @@
       "type": "assert_invalid",
       "line": 218,
       "filename": "simd_i32x4_trunc_sat_f32x4.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 219,
       "filename": "simd_i32x4_trunc_sat_f32x4.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 224,
       "filename": "simd_i32x4_trunc_sat_f32x4.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 232,
       "filename": "simd_i32x4_trunc_sat_f32x4.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_i32x4_trunc_sat_f64x2.wast.json
+++ b/tests/snapshots/testsuite/simd_i32x4_trunc_sat_f64x2.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "simd_i32x4_trunc_sat_f64x2.0.wasm"
+      "filename": "simd_i32x4_trunc_sat_f64x2.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3070,29 +3071,29 @@
       "type": "assert_invalid",
       "line": 218,
       "filename": "simd_i32x4_trunc_sat_f64x2.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 219,
       "filename": "simd_i32x4_trunc_sat_f64x2.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 224,
       "filename": "simd_i32x4_trunc_sat_f64x2.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 232,
       "filename": "simd_i32x4_trunc_sat_f64x2.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_i64x2_arith.wast.json
+++ b/tests/snapshots/testsuite/simd_i64x2_arith.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_i64x2_arith.0.wasm"
+      "filename": "simd_i64x2_arith.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -6502,83 +6503,84 @@
       "type": "assert_invalid",
       "line": 546,
       "filename": "simd_i64x2_arith.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 547,
       "filename": "simd_i64x2_arith.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 548,
       "filename": "simd_i64x2_arith.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 549,
       "filename": "simd_i64x2_arith.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 554,
       "filename": "simd_i64x2_arith.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 562,
       "filename": "simd_i64x2_arith.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 570,
       "filename": "simd_i64x2_arith.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 578,
       "filename": "simd_i64x2_arith.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 586,
       "filename": "simd_i64x2_arith.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 594,
       "filename": "simd_i64x2_arith.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 602,
       "filename": "simd_i64x2_arith.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 611,
-      "filename": "simd_i64x2_arith.12.wasm"
+      "filename": "simd_i64x2_arith.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/simd_i64x2_arith2.wast.json
+++ b/tests/snapshots/testsuite/simd_i64x2_arith2.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "simd_i64x2_arith2.0.wasm"
+      "filename": "simd_i64x2_arith2.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -561,20 +562,21 @@
       "type": "assert_invalid",
       "line": 59,
       "filename": "simd_i64x2_arith2.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 64,
       "filename": "simd_i64x2_arith2.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 73,
-      "filename": "simd_i64x2_arith2.3.wasm"
+      "filename": "simd_i64x2_arith2.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/simd_i64x2_cmp.wast.json
+++ b/tests/snapshots/testsuite/simd_i64x2_cmp.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_i64x2_cmp.0.wasm"
+      "filename": "simd_i64x2_cmp.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3682,71 +3683,71 @@
       "type": "assert_invalid",
       "line": 380,
       "filename": "simd_i64x2_cmp.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 381,
       "filename": "simd_i64x2_cmp.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 382,
       "filename": "simd_i64x2_cmp.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 383,
       "filename": "simd_i64x2_cmp.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 384,
       "filename": "simd_i64x2_cmp.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 385,
       "filename": "simd_i64x2_cmp.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 390,
       "filename": "simd_i64x2_cmp.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 398,
       "filename": "simd_i64x2_cmp.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 406,
       "filename": "simd_i64x2_cmp.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 414,
       "filename": "simd_i64x2_cmp.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_i64x2_extmul_i32x4.wast.json
+++ b/tests/snapshots/testsuite/simd_i64x2_extmul_i32x4.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_i64x2_extmul_i32x4.0.wasm"
+      "filename": "simd_i64x2_extmul_i32x4.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4170,85 +4171,85 @@
       "type": "assert_invalid",
       "line": 333,
       "filename": "simd_i64x2_extmul_i32x4.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 334,
       "filename": "simd_i64x2_extmul_i32x4.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 335,
       "filename": "simd_i64x2_extmul_i32x4.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 336,
       "filename": "simd_i64x2_extmul_i32x4.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 341,
       "filename": "simd_i64x2_extmul_i32x4.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 349,
       "filename": "simd_i64x2_extmul_i32x4.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 357,
       "filename": "simd_i64x2_extmul_i32x4.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 365,
       "filename": "simd_i64x2_extmul_i32x4.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 373,
       "filename": "simd_i64x2_extmul_i32x4.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 381,
       "filename": "simd_i64x2_extmul_i32x4.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 389,
       "filename": "simd_i64x2_extmul_i32x4.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 397,
       "filename": "simd_i64x2_extmul_i32x4.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_i8x16_arith.wast.json
+++ b/tests/snapshots/testsuite/simd_i8x16_arith.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_i8x16_arith.0.wasm"
+      "filename": "simd_i8x16_arith.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -8558,62 +8559,63 @@
       "type": "assert_invalid",
       "line": 354,
       "filename": "simd_i8x16_arith.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 355,
       "filename": "simd_i8x16_arith.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 356,
       "filename": "simd_i8x16_arith.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 361,
       "filename": "simd_i8x16_arith.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 369,
       "filename": "simd_i8x16_arith.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 377,
       "filename": "simd_i8x16_arith.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 385,
       "filename": "simd_i8x16_arith.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 393,
       "filename": "simd_i8x16_arith.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 402,
-      "filename": "simd_i8x16_arith.9.wasm"
+      "filename": "simd_i8x16_arith.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/simd_i8x16_arith2.wast.json
+++ b/tests/snapshots/testsuite/simd_i8x16_arith2.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "simd_i8x16_arith2.0.wasm"
+      "filename": "simd_i8x16_arith2.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -8944,181 +8945,182 @@
       "type": "assert_malformed",
       "line": 378,
       "filename": "simd_i8x16_arith2.1.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 379,
       "filename": "simd_i8x16_arith2.2.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 380,
       "filename": "simd_i8x16_arith2.3.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 381,
       "filename": "simd_i8x16_arith2.4.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 382,
       "filename": "simd_i8x16_arith2.5.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 383,
       "filename": "simd_i8x16_arith2.6.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_invalid",
       "line": 386,
       "filename": "simd_i8x16_arith2.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 387,
       "filename": "simd_i8x16_arith2.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 388,
       "filename": "simd_i8x16_arith2.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 389,
       "filename": "simd_i8x16_arith2.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 390,
       "filename": "simd_i8x16_arith2.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 391,
       "filename": "simd_i8x16_arith2.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 392,
       "filename": "simd_i8x16_arith2.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 397,
       "filename": "simd_i8x16_arith2.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 405,
       "filename": "simd_i8x16_arith2.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 413,
       "filename": "simd_i8x16_arith2.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 421,
       "filename": "simd_i8x16_arith2.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 429,
       "filename": "simd_i8x16_arith2.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 437,
       "filename": "simd_i8x16_arith2.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 445,
       "filename": "simd_i8x16_arith2.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 453,
       "filename": "simd_i8x16_arith2.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 461,
       "filename": "simd_i8x16_arith2.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 469,
       "filename": "simd_i8x16_arith2.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 477,
       "filename": "simd_i8x16_arith2.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 485,
       "filename": "simd_i8x16_arith2.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 494,
-      "filename": "simd_i8x16_arith2.26.wasm"
+      "filename": "simd_i8x16_arith2.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/simd_i8x16_cmp.wast.json
+++ b/tests/snapshots/testsuite/simd_i8x16_cmp.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_i8x16_cmp.0.wasm"
+      "filename": "simd_i8x16_cmp.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -29570,76 +29571,77 @@
       "type": "assert_invalid",
       "line": 1401,
       "filename": "simd_i8x16_cmp.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1402,
       "filename": "simd_i8x16_cmp.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1403,
       "filename": "simd_i8x16_cmp.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1404,
       "filename": "simd_i8x16_cmp.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1405,
       "filename": "simd_i8x16_cmp.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1406,
       "filename": "simd_i8x16_cmp.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1407,
       "filename": "simd_i8x16_cmp.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1408,
       "filename": "simd_i8x16_cmp.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1409,
       "filename": "simd_i8x16_cmp.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1410,
       "filename": "simd_i8x16_cmp.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 1415,
-      "filename": "simd_i8x16_cmp.11.wasm"
+      "filename": "simd_i8x16_cmp.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -29775,141 +29777,141 @@
       "type": "assert_invalid",
       "line": 1689,
       "filename": "simd_i8x16_cmp.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1697,
       "filename": "simd_i8x16_cmp.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1705,
       "filename": "simd_i8x16_cmp.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1713,
       "filename": "simd_i8x16_cmp.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1721,
       "filename": "simd_i8x16_cmp.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1729,
       "filename": "simd_i8x16_cmp.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1737,
       "filename": "simd_i8x16_cmp.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1745,
       "filename": "simd_i8x16_cmp.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1753,
       "filename": "simd_i8x16_cmp.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1761,
       "filename": "simd_i8x16_cmp.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1769,
       "filename": "simd_i8x16_cmp.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1777,
       "filename": "simd_i8x16_cmp.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1785,
       "filename": "simd_i8x16_cmp.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1793,
       "filename": "simd_i8x16_cmp.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1801,
       "filename": "simd_i8x16_cmp.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1809,
       "filename": "simd_i8x16_cmp.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1817,
       "filename": "simd_i8x16_cmp.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1825,
       "filename": "simd_i8x16_cmp.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1833,
       "filename": "simd_i8x16_cmp.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1841,
       "filename": "simd_i8x16_cmp.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_i8x16_sat_arith.wast.json
+++ b/tests/snapshots/testsuite/simd_i8x16_sat_arith.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_i8x16_sat_arith.0.wasm"
+      "filename": "simd_i8x16_sat_arith.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -13810,174 +13811,175 @@
       "type": "assert_malformed",
       "line": 561,
       "filename": "simd_i8x16_sat_arith.1.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 564,
       "filename": "simd_i8x16_sat_arith.2.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 567,
       "filename": "simd_i8x16_sat_arith.3.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 570,
       "filename": "simd_i8x16_sat_arith.4.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 573,
       "filename": "simd_i8x16_sat_arith.5.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 576,
       "filename": "simd_i8x16_sat_arith.6.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 579,
       "filename": "simd_i8x16_sat_arith.7.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 582,
       "filename": "simd_i8x16_sat_arith.8.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 585,
       "filename": "simd_i8x16_sat_arith.9.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 588,
       "filename": "simd_i8x16_sat_arith.10.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 591,
       "filename": "simd_i8x16_sat_arith.11.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 594,
       "filename": "simd_i8x16_sat_arith.12.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_invalid",
       "line": 599,
       "filename": "simd_i8x16_sat_arith.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 600,
       "filename": "simd_i8x16_sat_arith.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 601,
       "filename": "simd_i8x16_sat_arith.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 602,
       "filename": "simd_i8x16_sat_arith.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 607,
       "filename": "simd_i8x16_sat_arith.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 615,
       "filename": "simd_i8x16_sat_arith.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 623,
       "filename": "simd_i8x16_sat_arith.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 631,
       "filename": "simd_i8x16_sat_arith.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 639,
       "filename": "simd_i8x16_sat_arith.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 647,
       "filename": "simd_i8x16_sat_arith.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 655,
       "filename": "simd_i8x16_sat_arith.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 663,
       "filename": "simd_i8x16_sat_arith.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 672,
-      "filename": "simd_i8x16_sat_arith.25.wasm"
+      "filename": "simd_i8x16_sat_arith.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/simd_int_to_int_extend.wast.json
+++ b/tests/snapshots/testsuite/simd_int_to_int_extend.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "simd_int_to_int_extend.0.wasm"
+      "filename": "simd_int_to_int_extend.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -8674,169 +8675,169 @@
       "type": "assert_invalid",
       "line": 488,
       "filename": "simd_int_to_int_extend.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 489,
       "filename": "simd_int_to_int_extend.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 490,
       "filename": "simd_int_to_int_extend.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 491,
       "filename": "simd_int_to_int_extend.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 492,
       "filename": "simd_int_to_int_extend.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 493,
       "filename": "simd_int_to_int_extend.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 494,
       "filename": "simd_int_to_int_extend.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 495,
       "filename": "simd_int_to_int_extend.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 496,
       "filename": "simd_int_to_int_extend.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 497,
       "filename": "simd_int_to_int_extend.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 498,
       "filename": "simd_int_to_int_extend.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 499,
       "filename": "simd_int_to_int_extend.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 504,
       "filename": "simd_int_to_int_extend.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 512,
       "filename": "simd_int_to_int_extend.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 520,
       "filename": "simd_int_to_int_extend.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 528,
       "filename": "simd_int_to_int_extend.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 536,
       "filename": "simd_int_to_int_extend.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 544,
       "filename": "simd_int_to_int_extend.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 552,
       "filename": "simd_int_to_int_extend.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 560,
       "filename": "simd_int_to_int_extend.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 568,
       "filename": "simd_int_to_int_extend.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 576,
       "filename": "simd_int_to_int_extend.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 584,
       "filename": "simd_int_to_int_extend.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 592,
       "filename": "simd_int_to_int_extend.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_lane.wast.json
+++ b/tests/snapshots/testsuite/simd_lane.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_lane.0.wasm"
+      "filename": "simd_lane.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -8068,958 +8069,959 @@
       "type": "assert_malformed",
       "line": 398,
       "filename": "simd_lane.1.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 399,
       "filename": "simd_lane.2.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 400,
       "filename": "simd_lane.3.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 401,
       "filename": "simd_lane.4.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 402,
       "filename": "simd_lane.5.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 403,
       "filename": "simd_lane.6.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 404,
       "filename": "simd_lane.7.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 405,
       "filename": "simd_lane.8.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 406,
       "filename": "simd_lane.9.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 407,
       "filename": "simd_lane.10.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 408,
       "filename": "simd_lane.11.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 409,
       "filename": "simd_lane.12.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 410,
       "filename": "simd_lane.13.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 411,
       "filename": "simd_lane.14.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 415,
       "filename": "simd_lane.15.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 416,
       "filename": "simd_lane.16.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 417,
       "filename": "simd_lane.17.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 418,
       "filename": "simd_lane.18.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 419,
       "filename": "simd_lane.19.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 420,
       "filename": "simd_lane.20.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 421,
       "filename": "simd_lane.21.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 422,
       "filename": "simd_lane.22.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 423,
       "filename": "simd_lane.23.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 424,
       "filename": "simd_lane.24.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 425,
       "filename": "simd_lane.25.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 426,
       "filename": "simd_lane.26.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 427,
       "filename": "simd_lane.27.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 428,
       "filename": "simd_lane.28.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_invalid",
       "line": 432,
       "filename": "simd_lane.29.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 433,
       "filename": "simd_lane.30.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 434,
       "filename": "simd_lane.31.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 435,
       "filename": "simd_lane.32.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 436,
       "filename": "simd_lane.33.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 437,
       "filename": "simd_lane.34.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 438,
       "filename": "simd_lane.35.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 439,
       "filename": "simd_lane.36.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 440,
       "filename": "simd_lane.37.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 441,
       "filename": "simd_lane.38.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 442,
       "filename": "simd_lane.39.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 443,
       "filename": "simd_lane.40.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 444,
       "filename": "simd_lane.41.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 445,
       "filename": "simd_lane.42.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 446,
       "filename": "simd_lane.43.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 447,
       "filename": "simd_lane.44.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 448,
       "filename": "simd_lane.45.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 449,
       "filename": "simd_lane.46.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 450,
       "filename": "simd_lane.47.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 451,
       "filename": "simd_lane.48.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 452,
       "filename": "simd_lane.49.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 453,
       "filename": "simd_lane.50.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 454,
       "filename": "simd_lane.51.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 455,
       "filename": "simd_lane.52.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 456,
       "filename": "simd_lane.53.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 457,
       "filename": "simd_lane.54.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 458,
       "filename": "simd_lane.55.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 459,
       "filename": "simd_lane.56.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 463,
       "filename": "simd_lane.57.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 464,
       "filename": "simd_lane.58.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 465,
       "filename": "simd_lane.59.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 466,
       "filename": "simd_lane.60.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 467,
       "filename": "simd_lane.61.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 468,
       "filename": "simd_lane.62.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 469,
       "filename": "simd_lane.63.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 470,
       "filename": "simd_lane.64.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 471,
       "filename": "simd_lane.65.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 472,
       "filename": "simd_lane.66.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 473,
       "filename": "simd_lane.67.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 477,
       "filename": "simd_lane.68.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 478,
       "filename": "simd_lane.69.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 479,
       "filename": "simd_lane.70.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 480,
       "filename": "simd_lane.71.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 481,
       "filename": "simd_lane.72.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 482,
       "filename": "simd_lane.73.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 483,
       "filename": "simd_lane.74.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 484,
       "filename": "simd_lane.75.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 485,
       "filename": "simd_lane.76.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 486,
       "filename": "simd_lane.77.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 487,
       "filename": "simd_lane.78.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 488,
       "filename": "simd_lane.79.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 489,
       "filename": "simd_lane.80.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 490,
       "filename": "simd_lane.81.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 494,
       "filename": "simd_lane.82.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 495,
       "filename": "simd_lane.83.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 496,
       "filename": "simd_lane.84.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 497,
       "filename": "simd_lane.85.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 499,
       "filename": "simd_lane.86.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 500,
       "filename": "simd_lane.87.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 503,
       "filename": "simd_lane.88.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 505,
       "filename": "simd_lane.89.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 507,
       "filename": "simd_lane.90.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 510,
       "filename": "simd_lane.91.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 515,
       "filename": "simd_lane.92.wat",
-      "text": "invalid lane length",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "invalid lane length"
     },
     {
       "type": "assert_malformed",
       "line": 518,
       "filename": "simd_lane.93.wat",
-      "text": "invalid lane length",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "invalid lane length"
     },
     {
       "type": "assert_malformed",
       "line": 521,
       "filename": "simd_lane.94.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 525,
       "filename": "simd_lane.95.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_invalid",
       "line": 529,
       "filename": "simd_lane.96.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_malformed",
       "line": 536,
       "filename": "simd_lane.97.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 537,
       "filename": "simd_lane.98.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 538,
       "filename": "simd_lane.99.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 539,
       "filename": "simd_lane.100.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 540,
       "filename": "simd_lane.101.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 541,
       "filename": "simd_lane.102.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 545,
       "filename": "simd_lane.103.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 549,
       "filename": "simd_lane.104.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 555,
       "filename": "simd_lane.105.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 559,
       "filename": "simd_lane.106.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 570,
       "filename": "simd_lane.107.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 571,
       "filename": "simd_lane.108.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 572,
       "filename": "simd_lane.109.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 573,
       "filename": "simd_lane.110.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 574,
       "filename": "simd_lane.111.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 575,
       "filename": "simd_lane.112.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 576,
       "filename": "simd_lane.113.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 577,
       "filename": "simd_lane.114.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 578,
       "filename": "simd_lane.115.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 579,
       "filename": "simd_lane.116.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 581,
       "filename": "simd_lane.117.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 582,
       "filename": "simd_lane.118.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 583,
       "filename": "simd_lane.119.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 584,
       "filename": "simd_lane.120.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 588,
       "filename": "simd_lane.121.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 589,
       "filename": "simd_lane.122.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 590,
       "filename": "simd_lane.123.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 591,
       "filename": "simd_lane.124.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 592,
       "filename": "simd_lane.125.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 593,
       "filename": "simd_lane.126.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 594,
       "filename": "simd_lane.127.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 595,
       "filename": "simd_lane.128.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 596,
       "filename": "simd_lane.129.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 597,
       "filename": "simd_lane.130.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 600,
       "filename": "simd_lane.131.wat",
-      "text": "invalid lane length",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "invalid lane length"
     },
     {
       "type": "assert_malformed",
       "line": 604,
       "filename": "simd_lane.132.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 608,
       "filename": "simd_lane.133.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 612,
       "filename": "simd_lane.134.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 616,
       "filename": "simd_lane.135.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "assert_malformed",
       "line": 620,
       "filename": "simd_lane.136.wat",
-      "text": "malformed lane index",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed lane index"
     },
     {
       "type": "module",
       "line": 628,
-      "filename": "simd_lane.137.wasm"
+      "filename": "simd_lane.137.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -9880,7 +9882,8 @@
     {
       "type": "module",
       "line": 703,
-      "filename": "simd_lane.138.wasm"
+      "filename": "simd_lane.138.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -10901,7 +10904,8 @@
     {
       "type": "module",
       "line": 799,
-      "filename": "simd_lane.139.wasm"
+      "filename": "simd_lane.139.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -11146,7 +11150,8 @@
     {
       "type": "module",
       "line": 830,
-      "filename": "simd_lane.140.wasm"
+      "filename": "simd_lane.140.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -11508,407 +11513,414 @@
       "type": "assert_malformed",
       "line": 877,
       "filename": "simd_lane.141.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 878,
       "filename": "simd_lane.142.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 879,
       "filename": "simd_lane.143.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 880,
       "filename": "simd_lane.144.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 881,
       "filename": "simd_lane.145.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 882,
       "filename": "simd_lane.146.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 883,
       "filename": "simd_lane.147.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "module",
       "line": 887,
-      "filename": "simd_lane.148.wasm"
+      "filename": "simd_lane.148.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 888,
-      "filename": "simd_lane.149.wasm"
+      "filename": "simd_lane.149.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 889,
-      "filename": "simd_lane.150.wasm"
+      "filename": "simd_lane.150.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 890,
-      "filename": "simd_lane.151.wasm"
+      "filename": "simd_lane.151.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 891,
-      "filename": "simd_lane.152.wasm"
+      "filename": "simd_lane.152.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 892,
-      "filename": "simd_lane.153.wasm"
+      "filename": "simd_lane.153.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 893,
-      "filename": "simd_lane.154.wasm"
+      "filename": "simd_lane.154.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 897,
       "filename": "simd_lane.155.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 902,
       "filename": "simd_lane.156.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 910,
       "filename": "simd_lane.157.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 918,
       "filename": "simd_lane.158.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 926,
       "filename": "simd_lane.159.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 934,
       "filename": "simd_lane.160.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 942,
       "filename": "simd_lane.161.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 950,
       "filename": "simd_lane.162.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 958,
       "filename": "simd_lane.163.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 966,
       "filename": "simd_lane.164.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 974,
       "filename": "simd_lane.165.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 982,
       "filename": "simd_lane.166.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 990,
       "filename": "simd_lane.167.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 998,
       "filename": "simd_lane.168.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 1006,
       "filename": "simd_lane.169.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1014,
       "filename": "simd_lane.170.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1022,
       "filename": "simd_lane.171.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 1030,
       "filename": "simd_lane.172.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1038,
       "filename": "simd_lane.173.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1046,
       "filename": "simd_lane.174.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 1054,
       "filename": "simd_lane.175.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1062,
       "filename": "simd_lane.176.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1070,
       "filename": "simd_lane.177.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1078,
       "filename": "simd_lane.178.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 1086,
       "filename": "simd_lane.179.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1094,
       "filename": "simd_lane.180.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1102,
       "filename": "simd_lane.181.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1110,
       "filename": "simd_lane.182.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 1118,
       "filename": "simd_lane.183.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1126,
       "filename": "simd_lane.184.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1134,
       "filename": "simd_lane.185.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1142,
       "filename": "simd_lane.186.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 1150,
       "filename": "simd_lane.187.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1158,
       "filename": "simd_lane.188.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1166,
       "filename": "simd_lane.189.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1174,
       "filename": "simd_lane.190.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 1182,
       "filename": "simd_lane.191.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1190,
       "filename": "simd_lane.192.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1198,
       "filename": "simd_lane.193.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1206,
       "filename": "simd_lane.194.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_invalid",
       "line": 1214,
       "filename": "simd_lane.195.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1222,
       "filename": "simd_lane.196.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1230,
       "filename": "simd_lane.197.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 1238,
       "filename": "simd_lane.198.wat",
-      "text": "invalid lane length",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "invalid lane length"
     },
     {
       "type": "assert_invalid",
       "line": 1249,
       "filename": "simd_lane.199.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 1259,
       "filename": "simd_lane.200.wat",
-      "text": "invalid lane length",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "invalid lane length"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_linking.wast.json
+++ b/tests/snapshots/testsuite/simd_linking.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "simd_linking.0.wasm"
+      "filename": "simd_linking.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -14,7 +15,8 @@
     {
       "type": "module",
       "line": 7,
-      "filename": "simd_linking.1.wasm"
+      "filename": "simd_linking.1.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_load.wast.json
+++ b/tests/snapshots/testsuite/simd_load.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "simd_load.0.wasm"
+      "filename": "simd_load.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -88,7 +89,8 @@
     {
       "type": "module",
       "line": 18,
-      "filename": "simd_load.1.wasm"
+      "filename": "simd_load.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -108,7 +110,8 @@
     {
       "type": "module",
       "line": 26,
-      "filename": "simd_load.2.wasm"
+      "filename": "simd_load.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -134,7 +137,8 @@
     {
       "type": "module",
       "line": 34,
-      "filename": "simd_load.3.wasm"
+      "filename": "simd_load.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -175,7 +179,8 @@
     {
       "type": "module",
       "line": 46,
-      "filename": "simd_load.4.wasm"
+      "filename": "simd_load.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -201,7 +206,8 @@
     {
       "type": "module",
       "line": 56,
-      "filename": "simd_load.5.wasm"
+      "filename": "simd_load.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -227,7 +233,8 @@
     {
       "type": "module",
       "line": 64,
-      "filename": "simd_load.6.wasm"
+      "filename": "simd_load.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -253,7 +260,8 @@
     {
       "type": "module",
       "line": 78,
-      "filename": "simd_load.7.wasm"
+      "filename": "simd_load.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -279,7 +287,8 @@
     {
       "type": "module",
       "line": 87,
-      "filename": "simd_load.8.wasm"
+      "filename": "simd_load.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -305,7 +314,8 @@
     {
       "type": "module",
       "line": 95,
-      "filename": "simd_load.9.wasm"
+      "filename": "simd_load.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -331,7 +341,8 @@
     {
       "type": "module",
       "line": 104,
-      "filename": "simd_load.10.wasm"
+      "filename": "simd_load.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -357,7 +368,8 @@
     {
       "type": "module",
       "line": 112,
-      "filename": "simd_load.11.wasm"
+      "filename": "simd_load.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -383,7 +395,8 @@
     {
       "type": "module",
       "line": 120,
-      "filename": "simd_load.12.wasm"
+      "filename": "simd_load.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -421,7 +434,8 @@
     {
       "type": "module",
       "line": 129,
-      "filename": "simd_load.13.wasm"
+      "filename": "simd_load.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -448,57 +462,57 @@
       "type": "assert_malformed",
       "line": 141,
       "filename": "simd_load.14.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 148,
       "filename": "simd_load.15.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 155,
       "filename": "simd_load.16.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_invalid",
       "line": 166,
       "filename": "simd_load.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 170,
       "filename": "simd_load.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 174,
       "filename": "simd_load.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 182,
       "filename": "simd_load.20.wasm",
-      "text": "unknown local 2",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local 2"
     },
     {
       "type": "assert_invalid",
       "line": 186,
       "filename": "simd_load.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_load16_lane.wast.json
+++ b/tests/snapshots/testsuite/simd_load16_lane.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_load16_lane.0.wasm"
+      "filename": "simd_load16_lane.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1386,22 +1387,22 @@
       "type": "assert_invalid",
       "line": 195,
       "filename": "simd_load16_lane.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 201,
       "filename": "simd_load16_lane.2.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 208,
       "filename": "simd_load16_lane.3.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_load32_lane.wast.json
+++ b/tests/snapshots/testsuite/simd_load32_lane.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_load32_lane.0.wasm"
+      "filename": "simd_load32_lane.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -714,22 +715,22 @@
       "type": "assert_invalid",
       "line": 127,
       "filename": "simd_load32_lane.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 133,
       "filename": "simd_load32_lane.2.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 140,
       "filename": "simd_load32_lane.3.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_load64_lane.wast.json
+++ b/tests/snapshots/testsuite/simd_load64_lane.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_load64_lane.0.wasm"
+      "filename": "simd_load64_lane.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -386,22 +387,22 @@
       "type": "assert_invalid",
       "line": 81,
       "filename": "simd_load64_lane.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 87,
       "filename": "simd_load64_lane.2.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 94,
       "filename": "simd_load64_lane.3.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_load8_lane.wast.json
+++ b/tests/snapshots/testsuite/simd_load8_lane.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_load8_lane.0.wasm"
+      "filename": "simd_load8_lane.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2826,22 +2827,22 @@
       "type": "assert_invalid",
       "line": 283,
       "filename": "simd_load8_lane.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 289,
       "filename": "simd_load8_lane.2.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 296,
       "filename": "simd_load8_lane.3.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_load_extend.wast.json
+++ b/tests/snapshots/testsuite/simd_load_extend.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "simd_load_extend.0.wasm"
+      "filename": "simd_load_extend.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1600,132 +1601,133 @@
       "type": "assert_invalid",
       "line": 241,
       "filename": "simd_load_extend.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 242,
       "filename": "simd_load_extend.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 243,
       "filename": "simd_load_extend.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 244,
       "filename": "simd_load_extend.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 245,
       "filename": "simd_load_extend.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 246,
       "filename": "simd_load_extend.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 251,
       "filename": "simd_load_extend.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 259,
       "filename": "simd_load_extend.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 267,
       "filename": "simd_load_extend.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 275,
       "filename": "simd_load_extend.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 283,
       "filename": "simd_load_extend.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 291,
       "filename": "simd_load_extend.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 301,
       "filename": "simd_load_extend.13.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 302,
       "filename": "simd_load_extend.14.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 303,
       "filename": "simd_load_extend.15.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 304,
       "filename": "simd_load_extend.16.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 305,
       "filename": "simd_load_extend.17.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 306,
       "filename": "simd_load_extend.18.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 309,
-      "filename": "simd_load_extend.19.wasm"
+      "filename": "simd_load_extend.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/simd_load_splat.wast.json
+++ b/tests/snapshots/testsuite/simd_load_splat.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "simd_load_splat.0.wasm"
+      "filename": "simd_load_splat.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2495,7 +2496,8 @@
     {
       "type": "module",
       "line": 158,
-      "filename": "simd_load_splat.1.wasm"
+      "filename": "simd_load_splat.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2757,85 +2759,85 @@
       "type": "assert_invalid",
       "line": 214,
       "filename": "simd_load_splat.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 215,
       "filename": "simd_load_splat.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 216,
       "filename": "simd_load_splat.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 217,
       "filename": "simd_load_splat.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 222,
       "filename": "simd_load_splat.6.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 223,
       "filename": "simd_load_splat.7.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 224,
       "filename": "simd_load_splat.8.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 225,
       "filename": "simd_load_splat.9.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_invalid",
       "line": 231,
       "filename": "simd_load_splat.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 239,
       "filename": "simd_load_splat.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 247,
       "filename": "simd_load_splat.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 255,
       "filename": "simd_load_splat.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_load_zero.wast.json
+++ b/tests/snapshots/testsuite/simd_load_zero.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "simd_load_zero.0.wasm"
+      "filename": "simd_load_zero.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -484,76 +485,77 @@
       "type": "assert_invalid",
       "line": 95,
       "filename": "simd_load_zero.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 96,
       "filename": "simd_load_zero.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 101,
       "filename": "simd_load_zero.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 109,
       "filename": "simd_load_zero.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_malformed",
       "line": 119,
       "filename": "simd_load_zero.5.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 120,
       "filename": "simd_load_zero.6.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 121,
       "filename": "simd_load_zero.7.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 122,
       "filename": "simd_load_zero.8.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 123,
       "filename": "simd_load_zero.9.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 124,
       "filename": "simd_load_zero.10.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 127,
-      "filename": "simd_load_zero.11.wasm"
+      "filename": "simd_load_zero.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",

--- a/tests/snapshots/testsuite/simd_splat.wast.json
+++ b/tests/snapshots/testsuite/simd_splat.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "simd_splat.0.wasm"
+      "filename": "simd_splat.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -2758,125 +2759,126 @@
       "type": "assert_malformed",
       "line": 122,
       "filename": "simd_splat.1.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_invalid",
       "line": 127,
       "filename": "simd_splat.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 128,
       "filename": "simd_splat.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 129,
       "filename": "simd_splat.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 130,
       "filename": "simd_splat.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 131,
       "filename": "simd_splat.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 132,
       "filename": "simd_splat.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 133,
       "filename": "simd_splat.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 134,
       "filename": "simd_splat.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 135,
       "filename": "simd_splat.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 136,
       "filename": "simd_splat.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 137,
       "filename": "simd_splat.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 138,
       "filename": "simd_splat.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 139,
       "filename": "simd_splat.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 140,
       "filename": "simd_splat.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 141,
       "filename": "simd_splat.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 142,
       "filename": "simd_splat.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 148,
-      "filename": "simd_splat.18.wasm"
+      "filename": "simd_splat.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -3023,7 +3025,8 @@
     {
       "type": "module",
       "line": 172,
-      "filename": "simd_splat.19.wasm"
+      "filename": "simd_splat.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4282,7 +4285,8 @@
     {
       "type": "module",
       "line": 347,
-      "filename": "simd_splat.20.wasm"
+      "filename": "simd_splat.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -4504,43 +4508,43 @@
       "type": "assert_invalid",
       "line": 384,
       "filename": "simd_splat.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 392,
       "filename": "simd_splat.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 400,
       "filename": "simd_splat.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 408,
       "filename": "simd_splat.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 416,
       "filename": "simd_splat.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 424,
       "filename": "simd_splat.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_store.wast.json
+++ b/tests/snapshots/testsuite/simd_store.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "simd_store.0.wasm"
+      "filename": "simd_store.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -201,7 +202,8 @@
     {
       "type": "module",
       "line": 52,
-      "filename": "simd_store.1.wasm"
+      "filename": "simd_store.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -297,64 +299,64 @@
       "type": "assert_malformed",
       "line": 103,
       "filename": "simd_store.2.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 110,
       "filename": "simd_store.3.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 117,
       "filename": "simd_store.4.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_invalid",
       "line": 128,
       "filename": "simd_store.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 132,
       "filename": "simd_store.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 136,
       "filename": "simd_store.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 144,
       "filename": "simd_store.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 152,
       "filename": "simd_store.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 160,
       "filename": "simd_store.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_store16_lane.wast.json
+++ b/tests/snapshots/testsuite/simd_store16_lane.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_store16_lane.0.wasm"
+      "filename": "simd_store16_lane.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1066,22 +1067,22 @@
       "type": "assert_invalid",
       "line": 283,
       "filename": "simd_store16_lane.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 289,
       "filename": "simd_store16_lane.2.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 296,
       "filename": "simd_store16_lane.3.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_store32_lane.wast.json
+++ b/tests/snapshots/testsuite/simd_store32_lane.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_store32_lane.0.wasm"
+      "filename": "simd_store32_lane.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -594,22 +595,22 @@
       "type": "assert_invalid",
       "line": 183,
       "filename": "simd_store32_lane.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 189,
       "filename": "simd_store32_lane.2.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 196,
       "filename": "simd_store32_lane.3.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_store64_lane.wast.json
+++ b/tests/snapshots/testsuite/simd_store64_lane.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_store64_lane.0.wasm"
+      "filename": "simd_store64_lane.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -338,22 +339,22 @@
       "type": "assert_invalid",
       "line": 115,
       "filename": "simd_store64_lane.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 121,
       "filename": "simd_store64_lane.2.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 128,
       "filename": "simd_store64_lane.3.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     }
   ]
 }

--- a/tests/snapshots/testsuite/simd_store8_lane.wast.json
+++ b/tests/snapshots/testsuite/simd_store8_lane.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 4,
-      "filename": "simd_store8_lane.0.wasm"
+      "filename": "simd_store8_lane.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -1962,22 +1963,22 @@
       "type": "assert_invalid",
       "line": 411,
       "filename": "simd_store8_lane.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 417,
       "filename": "simd_store8_lane.2.wasm",
-      "text": "invalid lane index",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "invalid lane index"
     },
     {
       "type": "assert_invalid",
       "line": 424,
       "filename": "simd_store8_lane.3.wasm",
-      "text": "alignment must not be larger than natural",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     }
   ]
 }

--- a/tests/snapshots/testsuite/skip-stack-guard-page.wast.json
+++ b/tests/snapshots/testsuite/skip-stack-guard-page.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 2,
-      "filename": "skip-stack-guard-page.0.wasm"
+      "filename": "skip-stack-guard-page.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_exhaustion",

--- a/tests/snapshots/testsuite/stack.wast.json
+++ b/tests/snapshots/testsuite/stack.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "stack.0.wasm"
+      "filename": "stack.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -99,7 +100,8 @@
     {
       "type": "module",
       "line": 156,
-      "filename": "stack.1.wasm"
+      "filename": "stack.1.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/start.wast.json
+++ b/tests/snapshots/testsuite/start.wast.json
@@ -5,27 +5,28 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "start.0.wasm",
-      "text": "unknown function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function"
     },
     {
       "type": "assert_invalid",
       "line": 7,
       "filename": "start.1.wasm",
-      "text": "start function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "start function"
     },
     {
       "type": "assert_invalid",
       "line": 14,
       "filename": "start.2.wasm",
-      "text": "start function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "start function"
     },
     {
       "type": "module",
       "line": 21,
-      "filename": "start.3.wasm"
+      "filename": "start.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -93,7 +94,8 @@
     {
       "type": "module",
       "line": 51,
-      "filename": "start.4.wasm"
+      "filename": "start.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -161,31 +163,34 @@
     {
       "type": "module",
       "line": 80,
-      "filename": "start.5.wasm"
+      "filename": "start.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 86,
-      "filename": "start.6.wasm"
+      "filename": "start.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 92,
-      "filename": "start.7.wasm"
+      "filename": "start.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_uninstantiable",
       "line": 98,
       "filename": "start.8.wasm",
-      "text": "unreachable",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unreachable"
     },
     {
       "type": "assert_malformed",
       "line": 103,
       "filename": "start.9.wat",
-      "text": "multiple start sections",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "multiple start sections"
     }
   ]
 }

--- a/tests/snapshots/testsuite/store.wast.json
+++ b/tests/snapshots/testsuite/store.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "store.0.wasm"
+      "filename": "store.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -100,407 +101,407 @@
       "type": "assert_malformed",
       "line": 58,
       "filename": "store.1.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 65,
       "filename": "store.2.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 73,
       "filename": "store.3.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 81,
       "filename": "store.4.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 88,
       "filename": "store.5.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 96,
       "filename": "store.6.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 103,
       "filename": "store.7.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_invalid",
       "line": 112,
       "filename": "store.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 116,
       "filename": "store.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 120,
       "filename": "store.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 124,
       "filename": "store.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 128,
       "filename": "store.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 132,
       "filename": "store.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 136,
       "filename": "store.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 140,
       "filename": "store.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 144,
       "filename": "store.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 150,
       "filename": "store.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 159,
       "filename": "store.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 168,
       "filename": "store.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 178,
       "filename": "store.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 188,
       "filename": "store.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 198,
       "filename": "store.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 208,
       "filename": "store.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 218,
       "filename": "store.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 228,
       "filename": "store.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 238,
       "filename": "store.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 248,
       "filename": "store.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 258,
       "filename": "store.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 268,
       "filename": "store.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 278,
       "filename": "store.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 288,
       "filename": "store.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 298,
       "filename": "store.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 308,
       "filename": "store.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 317,
       "filename": "store.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 326,
       "filename": "store.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 335,
       "filename": "store.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 344,
       "filename": "store.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 354,
       "filename": "store.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 364,
       "filename": "store.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 380,
       "filename": "store.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 399,
       "filename": "store.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 400,
       "filename": "store.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 401,
       "filename": "store.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 402,
       "filename": "store.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 403,
       "filename": "store.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 404,
       "filename": "store.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 405,
       "filename": "store.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 406,
       "filename": "store.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 407,
       "filename": "store.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 409,
       "filename": "store.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 410,
       "filename": "store.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 411,
       "filename": "store.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 412,
       "filename": "store.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 413,
       "filename": "store.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 414,
       "filename": "store.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 415,
       "filename": "store.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 416,
       "filename": "store.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 417,
       "filename": "store.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/switch.wast.json
+++ b/tests/snapshots/testsuite/switch.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "switch.0.wasm"
+      "filename": "switch.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -525,8 +526,8 @@
       "type": "assert_invalid",
       "line": 150,
       "filename": "switch.1.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     }
   ]
 }

--- a/tests/snapshots/testsuite/table-sub.wast.json
+++ b/tests/snapshots/testsuite/table-sub.wast.json
@@ -5,15 +5,15 @@
       "type": "assert_invalid",
       "line": 2,
       "filename": "table-sub.0.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 13,
       "filename": "table-sub.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/table.wast.json
+++ b/tests/snapshots/testsuite/table.wast.json
@@ -4,117 +4,126 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "table.0.wasm"
+      "filename": "table.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 4,
-      "filename": "table.1.wasm"
+      "filename": "table.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 5,
-      "filename": "table.2.wasm"
+      "filename": "table.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 6,
-      "filename": "table.3.wasm"
+      "filename": "table.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 7,
-      "filename": "table.4.wasm"
+      "filename": "table.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 8,
-      "filename": "table.5.wasm"
+      "filename": "table.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 9,
-      "filename": "table.6.wasm"
+      "filename": "table.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 11,
-      "filename": "table.7.wasm"
+      "filename": "table.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 12,
-      "filename": "table.8.wasm"
+      "filename": "table.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
       "line": 14,
       "filename": "table.9.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 15,
       "filename": "table.10.wasm",
-      "text": "unknown table",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table"
     },
     {
       "type": "assert_invalid",
       "line": 19,
       "filename": "table.11.wasm",
-      "text": "size minimum must not be greater than maximum",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "size minimum must not be greater than maximum"
     },
     {
       "type": "assert_invalid",
       "line": 23,
       "filename": "table.12.wasm",
-      "text": "size minimum must not be greater than maximum",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "size minimum must not be greater than maximum"
     },
     {
       "type": "assert_malformed",
       "line": 28,
       "filename": "table.13.wat",
-      "text": "i32 constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "i32 constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 32,
       "filename": "table.14.wat",
-      "text": "i32 constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "i32 constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 36,
       "filename": "table.15.wat",
-      "text": "i32 constant out of range",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "i32 constant out of range"
     },
     {
       "type": "assert_malformed",
       "line": 43,
       "filename": "table.16.wat",
-      "text": "duplicate table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate table"
     },
     {
       "type": "assert_malformed",
       "line": 47,
       "filename": "table.17.wat",
-      "text": "duplicate table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate table"
     },
     {
       "type": "assert_malformed",
       "line": 51,
       "filename": "table.18.wat",
-      "text": "duplicate table",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "duplicate table"
     }
   ]
 }

--- a/tests/snapshots/testsuite/table_copy.wast.json
+++ b/tests/snapshots/testsuite/table_copy.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 6,
-      "filename": "table_copy.0.wasm"
+      "filename": "table_copy.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -14,7 +15,8 @@
     {
       "type": "module",
       "line": 15,
-      "filename": "table_copy.1.wasm"
+      "filename": "table_copy.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -1018,7 +1020,8 @@
     {
       "type": "module",
       "line": 107,
-      "filename": "table_copy.2.wasm"
+      "filename": "table_copy.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -2022,7 +2025,8 @@
     {
       "type": "module",
       "line": 199,
-      "filename": "table_copy.3.wasm"
+      "filename": "table_copy.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -3036,7 +3040,8 @@
     {
       "type": "module",
       "line": 291,
-      "filename": "table_copy.4.wasm"
+      "filename": "table_copy.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -4025,7 +4030,8 @@
     {
       "type": "module",
       "line": 383,
-      "filename": "table_copy.5.wasm"
+      "filename": "table_copy.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -5029,7 +5035,8 @@
     {
       "type": "module",
       "line": 475,
-      "filename": "table_copy.6.wasm"
+      "filename": "table_copy.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -6043,7 +6050,8 @@
     {
       "type": "module",
       "line": 567,
-      "filename": "table_copy.7.wasm"
+      "filename": "table_copy.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -7047,7 +7055,8 @@
     {
       "type": "module",
       "line": 659,
-      "filename": "table_copy.8.wasm"
+      "filename": "table_copy.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -8051,7 +8060,8 @@
     {
       "type": "module",
       "line": 751,
-      "filename": "table_copy.9.wasm"
+      "filename": "table_copy.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -9075,7 +9085,8 @@
     {
       "type": "module",
       "line": 843,
-      "filename": "table_copy.10.wasm"
+      "filename": "table_copy.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -10079,7 +10090,8 @@
     {
       "type": "module",
       "line": 935,
-      "filename": "table_copy.11.wasm"
+      "filename": "table_copy.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -11083,7 +11095,8 @@
     {
       "type": "module",
       "line": 1027,
-      "filename": "table_copy.12.wasm"
+      "filename": "table_copy.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -12097,7 +12110,8 @@
     {
       "type": "module",
       "line": 1119,
-      "filename": "table_copy.13.wasm"
+      "filename": "table_copy.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -13086,7 +13100,8 @@
     {
       "type": "module",
       "line": 1211,
-      "filename": "table_copy.14.wasm"
+      "filename": "table_copy.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -14090,7 +14105,8 @@
     {
       "type": "module",
       "line": 1303,
-      "filename": "table_copy.15.wasm"
+      "filename": "table_copy.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -15104,7 +15120,8 @@
     {
       "type": "module",
       "line": 1395,
-      "filename": "table_copy.16.wasm"
+      "filename": "table_copy.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -16108,7 +16125,8 @@
     {
       "type": "module",
       "line": 1487,
-      "filename": "table_copy.17.wasm"
+      "filename": "table_copy.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -17112,7 +17130,8 @@
     {
       "type": "module",
       "line": 1579,
-      "filename": "table_copy.18.wasm"
+      "filename": "table_copy.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -18136,7 +18155,8 @@
     {
       "type": "module",
       "line": 1671,
-      "filename": "table_copy.19.wasm"
+      "filename": "table_copy.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18151,7 +18171,8 @@
     {
       "type": "module",
       "line": 1696,
-      "filename": "table_copy.20.wasm"
+      "filename": "table_copy.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18166,7 +18187,8 @@
     {
       "type": "module",
       "line": 1721,
-      "filename": "table_copy.21.wasm"
+      "filename": "table_copy.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18181,7 +18203,8 @@
     {
       "type": "module",
       "line": 1746,
-      "filename": "table_copy.22.wasm"
+      "filename": "table_copy.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18196,7 +18219,8 @@
     {
       "type": "module",
       "line": 1771,
-      "filename": "table_copy.23.wasm"
+      "filename": "table_copy.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -18210,7 +18234,8 @@
     {
       "type": "module",
       "line": 1796,
-      "filename": "table_copy.24.wasm"
+      "filename": "table_copy.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -18224,7 +18249,8 @@
     {
       "type": "module",
       "line": 1821,
-      "filename": "table_copy.25.wasm"
+      "filename": "table_copy.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18239,7 +18265,8 @@
     {
       "type": "module",
       "line": 1846,
-      "filename": "table_copy.26.wasm"
+      "filename": "table_copy.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -18253,7 +18280,8 @@
     {
       "type": "module",
       "line": 1871,
-      "filename": "table_copy.27.wasm"
+      "filename": "table_copy.27.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18268,7 +18296,8 @@
     {
       "type": "module",
       "line": 1896,
-      "filename": "table_copy.28.wasm"
+      "filename": "table_copy.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -18282,7 +18311,8 @@
     {
       "type": "module",
       "line": 1921,
-      "filename": "table_copy.29.wasm"
+      "filename": "table_copy.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18297,7 +18327,8 @@
     {
       "type": "module",
       "line": 1946,
-      "filename": "table_copy.30.wasm"
+      "filename": "table_copy.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18312,7 +18343,8 @@
     {
       "type": "module",
       "line": 1971,
-      "filename": "table_copy.31.wasm"
+      "filename": "table_copy.31.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18327,7 +18359,8 @@
     {
       "type": "module",
       "line": 1996,
-      "filename": "table_copy.32.wasm"
+      "filename": "table_copy.32.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18342,7 +18375,8 @@
     {
       "type": "module",
       "line": 2021,
-      "filename": "table_copy.33.wasm"
+      "filename": "table_copy.33.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18357,7 +18391,8 @@
     {
       "type": "module",
       "line": 2046,
-      "filename": "table_copy.34.wasm"
+      "filename": "table_copy.34.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -18371,7 +18406,8 @@
     {
       "type": "module",
       "line": 2071,
-      "filename": "table_copy.35.wasm"
+      "filename": "table_copy.35.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -18385,7 +18421,8 @@
     {
       "type": "module",
       "line": 2096,
-      "filename": "table_copy.36.wasm"
+      "filename": "table_copy.36.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18400,7 +18437,8 @@
     {
       "type": "module",
       "line": 2121,
-      "filename": "table_copy.37.wasm"
+      "filename": "table_copy.37.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -18414,7 +18452,8 @@
     {
       "type": "module",
       "line": 2146,
-      "filename": "table_copy.38.wasm"
+      "filename": "table_copy.38.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18429,7 +18468,8 @@
     {
       "type": "module",
       "line": 2171,
-      "filename": "table_copy.39.wasm"
+      "filename": "table_copy.39.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -18443,7 +18483,8 @@
     {
       "type": "module",
       "line": 2196,
-      "filename": "table_copy.40.wasm"
+      "filename": "table_copy.40.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -18458,7 +18499,8 @@
     {
       "type": "module",
       "line": 2221,
-      "filename": "table_copy.41.wasm"
+      "filename": "table_copy.41.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -19006,7 +19048,8 @@
     {
       "type": "module",
       "line": 2282,
-      "filename": "table_copy.42.wasm"
+      "filename": "table_copy.42.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -19559,7 +19602,8 @@
     {
       "type": "module",
       "line": 2343,
-      "filename": "table_copy.43.wasm"
+      "filename": "table_copy.43.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -20107,7 +20151,8 @@
     {
       "type": "module",
       "line": 2404,
-      "filename": "table_copy.44.wasm"
+      "filename": "table_copy.44.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -20660,7 +20705,8 @@
     {
       "type": "module",
       "line": 2465,
-      "filename": "table_copy.45.wasm"
+      "filename": "table_copy.45.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -21208,7 +21254,8 @@
     {
       "type": "module",
       "line": 2526,
-      "filename": "table_copy.46.wasm"
+      "filename": "table_copy.46.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -21756,7 +21803,8 @@
     {
       "type": "module",
       "line": 2587,
-      "filename": "table_copy.47.wasm"
+      "filename": "table_copy.47.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -22304,7 +22352,8 @@
     {
       "type": "module",
       "line": 2648,
-      "filename": "table_copy.48.wasm"
+      "filename": "table_copy.48.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -22852,7 +22901,8 @@
     {
       "type": "module",
       "line": 2709,
-      "filename": "table_copy.49.wasm"
+      "filename": "table_copy.49.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -23415,7 +23465,8 @@
     {
       "type": "module",
       "line": 2770,
-      "filename": "table_copy.50.wasm"
+      "filename": "table_copy.50.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -25443,7 +25494,8 @@
     {
       "type": "module",
       "line": 2927,
-      "filename": "table_copy.51.wasm"
+      "filename": "table_copy.51.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",

--- a/tests/snapshots/testsuite/table_fill.wast.json
+++ b/tests/snapshots/testsuite/table_fill.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "table_fill.0.wasm"
+      "filename": "table_fill.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -737,64 +738,64 @@
       "type": "assert_invalid",
       "line": 75,
       "filename": "table_fill.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 84,
       "filename": "table_fill.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 93,
       "filename": "table_fill.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 102,
       "filename": "table_fill.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 111,
       "filename": "table_fill.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 120,
       "filename": "table_fill.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 129,
       "filename": "table_fill.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 139,
       "filename": "table_fill.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 150,
       "filename": "table_fill.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/table_get.wast.json
+++ b/tests/snapshots/testsuite/table_get.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "table_get.0.wasm"
+      "filename": "table_get.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -184,36 +185,36 @@
       "type": "assert_invalid",
       "line": 42,
       "filename": "table_get.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 51,
       "filename": "table_get.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 61,
       "filename": "table_get.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 70,
       "filename": "table_get.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 80,
       "filename": "table_get.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/table_grow.wast.json
+++ b/tests/snapshots/testsuite/table_grow.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "table_grow.0.wasm"
+      "filename": "table_grow.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -401,7 +402,8 @@
     {
       "type": "module",
       "line": 42,
-      "filename": "table_grow.1.wasm"
+      "filename": "table_grow.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -421,7 +423,8 @@
     {
       "type": "module",
       "line": 53,
-      "filename": "table_grow.2.wasm"
+      "filename": "table_grow.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -526,7 +529,8 @@
     {
       "type": "module",
       "line": 67,
-      "filename": "table_grow.3.wasm"
+      "filename": "table_grow.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -691,7 +695,8 @@
     {
       "type": "module",
       "line": 84,
-      "filename": "table_grow.4.wasm"
+      "filename": "table_grow.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -765,7 +770,8 @@
       "type": "module",
       "line": 111,
       "name": "Tgt",
-      "filename": "table_grow.5.wasm"
+      "filename": "table_grow.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -793,7 +799,8 @@
       "type": "module",
       "line": 117,
       "name": "Tgit1",
-      "filename": "table_grow.6.wasm"
+      "filename": "table_grow.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -821,7 +828,8 @@
       "type": "module",
       "line": 124,
       "name": "Tgit2",
-      "filename": "table_grow.7.wasm"
+      "filename": "table_grow.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -843,50 +851,50 @@
       "type": "assert_invalid",
       "line": 135,
       "filename": "table_grow.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 144,
       "filename": "table_grow.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 153,
       "filename": "table_grow.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 162,
       "filename": "table_grow.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 171,
       "filename": "table_grow.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 181,
       "filename": "table_grow.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 190,
       "filename": "table_grow.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/table_init.wast.json
+++ b/tests/snapshots/testsuite/table_init.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 6,
-      "filename": "table_init.0.wasm"
+      "filename": "table_init.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "register",
@@ -14,7 +15,8 @@
     {
       "type": "module",
       "line": 15,
-      "filename": "table_init.1.wasm"
+      "filename": "table_init.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -543,7 +545,8 @@
     {
       "type": "module",
       "line": 73,
-      "filename": "table_init.2.wasm"
+      "filename": "table_init.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -1057,7 +1060,8 @@
     {
       "type": "module",
       "line": 131,
-      "filename": "table_init.3.wasm"
+      "filename": "table_init.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -1606,7 +1610,8 @@
     {
       "type": "module",
       "line": 197,
-      "filename": "table_init.4.wasm"
+      "filename": "table_init.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -2135,7 +2140,8 @@
     {
       "type": "module",
       "line": 255,
-      "filename": "table_init.5.wasm"
+      "filename": "table_init.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -2649,7 +2655,8 @@
     {
       "type": "module",
       "line": 313,
-      "filename": "table_init.6.wasm"
+      "filename": "table_init.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -3199,34 +3206,35 @@
       "type": "assert_invalid",
       "line": 379,
       "filename": "table_init.7.wasm",
-      "text": "unknown elem segment 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown elem segment 0"
     },
     {
       "type": "assert_invalid",
       "line": 385,
       "filename": "table_init.8.wasm",
-      "text": "unknown table 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table 0"
     },
     {
       "type": "assert_invalid",
       "line": 391,
       "filename": "table_init.9.wasm",
-      "text": "unknown elem segment 4",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown elem segment 4"
     },
     {
       "type": "assert_invalid",
       "line": 399,
       "filename": "table_init.10.wasm",
-      "text": "unknown table 0",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown table 0"
     },
     {
       "type": "module",
       "line": 407,
-      "filename": "table_init.11.wasm"
+      "filename": "table_init.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -3240,7 +3248,8 @@
     {
       "type": "module",
       "line": 431,
-      "filename": "table_init.12.wasm"
+      "filename": "table_init.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -3255,7 +3264,8 @@
     {
       "type": "module",
       "line": 455,
-      "filename": "table_init.13.wasm"
+      "filename": "table_init.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -3269,7 +3279,8 @@
     {
       "type": "module",
       "line": 479,
-      "filename": "table_init.14.wasm"
+      "filename": "table_init.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -3283,7 +3294,8 @@
     {
       "type": "module",
       "line": 503,
-      "filename": "table_init.15.wasm"
+      "filename": "table_init.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -3298,7 +3310,8 @@
     {
       "type": "module",
       "line": 527,
-      "filename": "table_init.16.wasm"
+      "filename": "table_init.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -3313,7 +3326,8 @@
     {
       "type": "module",
       "line": 551,
-      "filename": "table_init.17.wasm"
+      "filename": "table_init.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -3328,7 +3342,8 @@
     {
       "type": "module",
       "line": 575,
-      "filename": "table_init.18.wasm"
+      "filename": "table_init.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -3343,7 +3358,8 @@
     {
       "type": "module",
       "line": 599,
-      "filename": "table_init.19.wasm"
+      "filename": "table_init.19.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -3357,7 +3373,8 @@
     {
       "type": "module",
       "line": 623,
-      "filename": "table_init.20.wasm"
+      "filename": "table_init.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -3372,7 +3389,8 @@
     {
       "type": "module",
       "line": 647,
-      "filename": "table_init.21.wasm"
+      "filename": "table_init.21.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -3386,7 +3404,8 @@
     {
       "type": "module",
       "line": 671,
-      "filename": "table_init.22.wasm"
+      "filename": "table_init.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -3401,7 +3420,8 @@
     {
       "type": "module",
       "line": 695,
-      "filename": "table_init.23.wasm"
+      "filename": "table_init.23.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -3415,7 +3435,8 @@
     {
       "type": "module",
       "line": 719,
-      "filename": "table_init.24.wasm"
+      "filename": "table_init.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -3430,7 +3451,8 @@
     {
       "type": "module",
       "line": 743,
-      "filename": "table_init.25.wasm"
+      "filename": "table_init.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -3445,7 +3467,8 @@
     {
       "type": "module",
       "line": 767,
-      "filename": "table_init.26.wasm"
+      "filename": "table_init.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -3459,7 +3482,8 @@
     {
       "type": "module",
       "line": 791,
-      "filename": "table_init.27.wasm"
+      "filename": "table_init.27.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -3474,7 +3498,8 @@
     {
       "type": "module",
       "line": 815,
-      "filename": "table_init.28.wasm"
+      "filename": "table_init.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -3488,7 +3513,8 @@
     {
       "type": "module",
       "line": 839,
-      "filename": "table_init.29.wasm"
+      "filename": "table_init.29.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -3503,7 +3529,8 @@
     {
       "type": "module",
       "line": 863,
-      "filename": "table_init.30.wasm"
+      "filename": "table_init.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "action",
@@ -3517,7 +3544,8 @@
     {
       "type": "module",
       "line": 887,
-      "filename": "table_init.31.wasm"
+      "filename": "table_init.31.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -3533,447 +3561,448 @@
       "type": "assert_invalid",
       "line": 912,
       "filename": "table_init.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 921,
       "filename": "table_init.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 930,
       "filename": "table_init.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 939,
       "filename": "table_init.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 948,
       "filename": "table_init.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 957,
       "filename": "table_init.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 966,
       "filename": "table_init.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 975,
       "filename": "table_init.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 984,
       "filename": "table_init.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 993,
       "filename": "table_init.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1002,
       "filename": "table_init.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1011,
       "filename": "table_init.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1020,
       "filename": "table_init.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1029,
       "filename": "table_init.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1038,
       "filename": "table_init.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1047,
       "filename": "table_init.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1056,
       "filename": "table_init.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1065,
       "filename": "table_init.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1074,
       "filename": "table_init.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1083,
       "filename": "table_init.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1092,
       "filename": "table_init.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1101,
       "filename": "table_init.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1110,
       "filename": "table_init.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1119,
       "filename": "table_init.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1128,
       "filename": "table_init.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1137,
       "filename": "table_init.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1146,
       "filename": "table_init.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1155,
       "filename": "table_init.59.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1164,
       "filename": "table_init.60.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1173,
       "filename": "table_init.61.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1182,
       "filename": "table_init.62.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1191,
       "filename": "table_init.63.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1200,
       "filename": "table_init.64.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1209,
       "filename": "table_init.65.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1218,
       "filename": "table_init.66.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1227,
       "filename": "table_init.67.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1236,
       "filename": "table_init.68.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1245,
       "filename": "table_init.69.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1254,
       "filename": "table_init.70.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1263,
       "filename": "table_init.71.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1272,
       "filename": "table_init.72.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1281,
       "filename": "table_init.73.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1290,
       "filename": "table_init.74.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1299,
       "filename": "table_init.75.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1308,
       "filename": "table_init.76.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1317,
       "filename": "table_init.77.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1326,
       "filename": "table_init.78.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1335,
       "filename": "table_init.79.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1344,
       "filename": "table_init.80.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1353,
       "filename": "table_init.81.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1362,
       "filename": "table_init.82.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1371,
       "filename": "table_init.83.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1380,
       "filename": "table_init.84.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1389,
       "filename": "table_init.85.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1398,
       "filename": "table_init.86.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1407,
       "filename": "table_init.87.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1416,
       "filename": "table_init.88.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1425,
       "filename": "table_init.89.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1434,
       "filename": "table_init.90.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1443,
       "filename": "table_init.91.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1452,
       "filename": "table_init.92.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1461,
       "filename": "table_init.93.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 1470,
       "filename": "table_init.94.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "module",
       "line": 1478,
-      "filename": "table_init.95.wasm"
+      "filename": "table_init.95.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -4477,7 +4506,8 @@
     {
       "type": "module",
       "line": 1540,
-      "filename": "table_init.96.wasm"
+      "filename": "table_init.96.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -4981,7 +5011,8 @@
     {
       "type": "module",
       "line": 1602,
-      "filename": "table_init.97.wasm"
+      "filename": "table_init.97.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -7405,7 +7436,8 @@
     {
       "type": "module",
       "line": 1792,
-      "filename": "table_init.98.wasm"
+      "filename": "table_init.98.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -9829,7 +9861,8 @@
     {
       "type": "module",
       "line": 1982,
-      "filename": "table_init.99.wasm"
+      "filename": "table_init.99.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -10813,7 +10846,8 @@
     {
       "type": "module",
       "line": 2076,
-      "filename": "table_init.100.wasm"
+      "filename": "table_init.100.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -11077,7 +11111,8 @@
     {
       "type": "module",
       "line": 2122,
-      "filename": "table_init.101.wasm"
+      "filename": "table_init.101.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/testsuite/table_set.wast.json
+++ b/tests/snapshots/testsuite/table_set.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "table_set.0.wasm"
+      "filename": "table_set.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -358,50 +359,50 @@
       "type": "assert_invalid",
       "line": 55,
       "filename": "table_set.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 64,
       "filename": "table_set.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 73,
       "filename": "table_set.3.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 82,
       "filename": "table_set.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 91,
       "filename": "table_set.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 101,
       "filename": "table_set.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 112,
       "filename": "table_set.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/table_size.wast.json
+++ b/tests/snapshots/testsuite/table_size.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "table_size.0.wasm"
+      "filename": "table_size.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_return",
@@ -550,15 +551,15 @@
       "type": "assert_invalid",
       "line": 70,
       "filename": "table_size.1.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 79,
       "filename": "table_size.2.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/token.wast.json
+++ b/tests/snapshots/testsuite/token.wast.json
@@ -5,337 +5,372 @@
       "type": "assert_malformed",
       "line": 4,
       "filename": "token.0.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 8,
       "filename": "token.1.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 15,
-      "filename": "token.2.wasm"
+      "filename": "token.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 18,
-      "filename": "token.3.wasm"
+      "filename": "token.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 21,
-      "filename": "token.4.wasm"
+      "filename": "token.4.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 24,
-      "filename": "token.5.wasm"
+      "filename": "token.5.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 27,
-      "filename": "token.6.wasm"
+      "filename": "token.6.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 30,
-      "filename": "token.7.wasm"
+      "filename": "token.7.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 33,
-      "filename": "token.8.wasm"
+      "filename": "token.8.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 38,
-      "filename": "token.9.wasm"
+      "filename": "token.9.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 43,
-      "filename": "token.10.wasm"
+      "filename": "token.10.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 47,
-      "filename": "token.11.wasm"
+      "filename": "token.11.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 54,
-      "filename": "token.12.wasm"
+      "filename": "token.12.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 58,
-      "filename": "token.13.wasm"
+      "filename": "token.13.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 62,
-      "filename": "token.14.wasm"
+      "filename": "token.14.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 66,
-      "filename": "token.15.wasm"
+      "filename": "token.15.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 70,
-      "filename": "token.16.wasm"
+      "filename": "token.16.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 74,
-      "filename": "token.17.wasm"
+      "filename": "token.17.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 82,
-      "filename": "token.18.wasm"
+      "filename": "token.18.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 86,
       "filename": "token.19.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 92,
-      "filename": "token.20.wasm"
+      "filename": "token.20.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 96,
       "filename": "token.21.wat",
-      "text": "unknown label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown label"
     },
     {
       "type": "module",
       "line": 102,
-      "filename": "token.22.wasm"
+      "filename": "token.22.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 106,
       "filename": "token.23.wat",
-      "text": "unknown label",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown label"
     },
     {
       "type": "module",
       "line": 112,
-      "filename": "token.24.wasm"
+      "filename": "token.24.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 115,
-      "filename": "token.25.wasm"
+      "filename": "token.25.wasm",
+      "module_type": "binary"
     },
     {
       "type": "module",
       "line": 122,
-      "filename": "token.26.wasm"
+      "filename": "token.26.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 126,
       "filename": "token.27.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 132,
-      "filename": "token.28.wasm"
+      "filename": "token.28.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 136,
       "filename": "token.29.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 142,
-      "filename": "token.30.wasm"
+      "filename": "token.30.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 146,
       "filename": "token.31.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 152,
-      "filename": "token.32.wasm"
+      "filename": "token.32.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 156,
       "filename": "token.33.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 162,
-      "filename": "token.34.wasm"
+      "filename": "token.34.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 166,
       "filename": "token.35.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 172,
-      "filename": "token.36.wasm"
+      "filename": "token.36.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 176,
       "filename": "token.37.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 182,
-      "filename": "token.38.wasm"
+      "filename": "token.38.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 186,
       "filename": "token.39.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 192,
-      "filename": "token.40.wasm"
+      "filename": "token.40.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 196,
       "filename": "token.41.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 202,
-      "filename": "token.42.wasm"
+      "filename": "token.42.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 206,
       "filename": "token.43.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 212,
-      "filename": "token.44.wasm"
+      "filename": "token.44.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 216,
       "filename": "token.45.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 222,
-      "filename": "token.46.wasm"
+      "filename": "token.46.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 226,
       "filename": "token.47.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 232,
-      "filename": "token.48.wasm"
+      "filename": "token.48.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 236,
       "filename": "token.49.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 242,
-      "filename": "token.50.wasm"
+      "filename": "token.50.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 246,
       "filename": "token.51.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "module",
       "line": 252,
-      "filename": "token.52.wasm"
+      "filename": "token.52.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 256,
       "filename": "token.53.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 264,
       "filename": "token.54.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 270,
       "filename": "token.55.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 276,
       "filename": "token.56.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     },
     {
       "type": "assert_malformed",
       "line": 282,
       "filename": "token.57.wat",
-      "text": "unknown operator",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unknown operator"
     }
   ]
 }

--- a/tests/snapshots/testsuite/traps.wast.json
+++ b/tests/snapshots/testsuite/traps.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 5,
-      "filename": "traps.0.wasm"
+      "filename": "traps.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -123,7 +124,8 @@
     {
       "type": "module",
       "line": 23,
-      "filename": "traps.1.wasm"
+      "filename": "traps.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -204,7 +206,8 @@
     {
       "type": "module",
       "line": 39,
-      "filename": "traps.2.wasm"
+      "filename": "traps.2.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -329,7 +332,8 @@
     {
       "type": "module",
       "line": 59,
-      "filename": "traps.3.wasm"
+      "filename": "traps.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",

--- a/tests/snapshots/testsuite/type.wast.json
+++ b/tests/snapshots/testsuite/type.wast.json
@@ -4,21 +4,22 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "type.0.wasm"
+      "filename": "type.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_malformed",
       "line": 44,
       "filename": "type.1.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     },
     {
       "type": "assert_malformed",
       "line": 48,
       "filename": "type.2.wat",
-      "text": "unexpected token",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "unexpected token"
     }
   ]
 }

--- a/tests/snapshots/testsuite/unreachable.wast.json
+++ b/tests/snapshots/testsuite/unreachable.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "unreachable.0.wasm"
+      "filename": "unreachable.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",

--- a/tests/snapshots/testsuite/unreached-invalid.wast.json
+++ b/tests/snapshots/testsuite/unreached-invalid.wast.json
@@ -5,827 +5,827 @@
       "type": "assert_invalid",
       "line": 4,
       "filename": "unreached-invalid.0.wasm",
-      "text": "unknown local",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown local"
     },
     {
       "type": "assert_invalid",
       "line": 8,
       "filename": "unreached-invalid.1.wasm",
-      "text": "unknown global",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown global"
     },
     {
       "type": "assert_invalid",
       "line": 12,
       "filename": "unreached-invalid.2.wasm",
-      "text": "unknown function",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown function"
     },
     {
       "type": "assert_invalid",
       "line": 16,
       "filename": "unreached-invalid.3.wasm",
-      "text": "unknown label",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "unknown label"
     },
     {
       "type": "assert_invalid",
       "line": 21,
       "filename": "unreached-invalid.4.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 27,
       "filename": "unreached-invalid.5.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 33,
       "filename": "unreached-invalid.6.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 42,
       "filename": "unreached-invalid.7.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 46,
       "filename": "unreached-invalid.8.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 50,
       "filename": "unreached-invalid.9.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 56,
       "filename": "unreached-invalid.10.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 60,
       "filename": "unreached-invalid.11.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 64,
       "filename": "unreached-invalid.12.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 71,
       "filename": "unreached-invalid.13.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 77,
       "filename": "unreached-invalid.14.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 83,
       "filename": "unreached-invalid.15.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 89,
       "filename": "unreached-invalid.16.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 95,
       "filename": "unreached-invalid.17.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 101,
       "filename": "unreached-invalid.18.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 107,
       "filename": "unreached-invalid.19.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 113,
       "filename": "unreached-invalid.20.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 119,
       "filename": "unreached-invalid.21.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 125,
       "filename": "unreached-invalid.22.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 132,
       "filename": "unreached-invalid.23.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 138,
       "filename": "unreached-invalid.24.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 144,
       "filename": "unreached-invalid.25.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 150,
       "filename": "unreached-invalid.26.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 156,
       "filename": "unreached-invalid.27.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 162,
       "filename": "unreached-invalid.28.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 168,
       "filename": "unreached-invalid.29.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 174,
       "filename": "unreached-invalid.30.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 180,
       "filename": "unreached-invalid.31.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 186,
       "filename": "unreached-invalid.32.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 193,
       "filename": "unreached-invalid.33.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 199,
       "filename": "unreached-invalid.34.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 205,
       "filename": "unreached-invalid.35.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 211,
       "filename": "unreached-invalid.36.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 217,
       "filename": "unreached-invalid.37.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 223,
       "filename": "unreached-invalid.38.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 229,
       "filename": "unreached-invalid.39.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 235,
       "filename": "unreached-invalid.40.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 241,
       "filename": "unreached-invalid.41.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 247,
       "filename": "unreached-invalid.42.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 253,
       "filename": "unreached-invalid.43.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 259,
       "filename": "unreached-invalid.44.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 265,
       "filename": "unreached-invalid.45.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 271,
       "filename": "unreached-invalid.46.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 277,
       "filename": "unreached-invalid.47.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 284,
       "filename": "unreached-invalid.48.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 290,
       "filename": "unreached-invalid.49.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 296,
       "filename": "unreached-invalid.50.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 302,
       "filename": "unreached-invalid.51.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 308,
       "filename": "unreached-invalid.52.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 314,
       "filename": "unreached-invalid.53.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 321,
       "filename": "unreached-invalid.54.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 327,
       "filename": "unreached-invalid.55.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 334,
       "filename": "unreached-invalid.56.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 340,
       "filename": "unreached-invalid.57.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 348,
       "filename": "unreached-invalid.58.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 354,
       "filename": "unreached-invalid.59.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 360,
       "filename": "unreached-invalid.60.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 366,
       "filename": "unreached-invalid.61.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 372,
       "filename": "unreached-invalid.62.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 378,
       "filename": "unreached-invalid.63.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 384,
       "filename": "unreached-invalid.64.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 390,
       "filename": "unreached-invalid.65.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 396,
       "filename": "unreached-invalid.66.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 402,
       "filename": "unreached-invalid.67.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 409,
       "filename": "unreached-invalid.68.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 415,
       "filename": "unreached-invalid.69.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 421,
       "filename": "unreached-invalid.70.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 427,
       "filename": "unreached-invalid.71.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 433,
       "filename": "unreached-invalid.72.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 439,
       "filename": "unreached-invalid.73.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 445,
       "filename": "unreached-invalid.74.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 451,
       "filename": "unreached-invalid.75.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 457,
       "filename": "unreached-invalid.76.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 463,
       "filename": "unreached-invalid.77.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 470,
       "filename": "unreached-invalid.78.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 477,
       "filename": "unreached-invalid.79.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 484,
       "filename": "unreached-invalid.80.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 490,
       "filename": "unreached-invalid.81.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 498,
       "filename": "unreached-invalid.82.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 507,
       "filename": "unreached-invalid.83.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 515,
       "filename": "unreached-invalid.84.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 521,
       "filename": "unreached-invalid.85.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 527,
       "filename": "unreached-invalid.86.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 540,
       "filename": "unreached-invalid.87.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 546,
       "filename": "unreached-invalid.88.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 552,
       "filename": "unreached-invalid.89.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 558,
       "filename": "unreached-invalid.90.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 565,
       "filename": "unreached-invalid.91.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 571,
       "filename": "unreached-invalid.92.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 577,
       "filename": "unreached-invalid.93.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 584,
       "filename": "unreached-invalid.94.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 590,
       "filename": "unreached-invalid.95.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 596,
       "filename": "unreached-invalid.96.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 604,
       "filename": "unreached-invalid.97.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 611,
       "filename": "unreached-invalid.98.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 617,
       "filename": "unreached-invalid.99.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 623,
       "filename": "unreached-invalid.100.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 629,
       "filename": "unreached-invalid.101.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 637,
       "filename": "unreached-invalid.102.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 643,
       "filename": "unreached-invalid.103.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 649,
       "filename": "unreached-invalid.104.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 656,
       "filename": "unreached-invalid.105.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 662,
       "filename": "unreached-invalid.106.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 669,
       "filename": "unreached-invalid.107.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 676,
       "filename": "unreached-invalid.108.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 687,
       "filename": "unreached-invalid.109.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 699,
       "filename": "unreached-invalid.110.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 704,
       "filename": "unreached-invalid.111.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 710,
       "filename": "unreached-invalid.112.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 715,
       "filename": "unreached-invalid.113.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 720,
       "filename": "unreached-invalid.114.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 726,
       "filename": "unreached-invalid.115.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 733,
       "filename": "unreached-invalid.116.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     },
     {
       "type": "assert_invalid",
       "line": 738,
       "filename": "unreached-invalid.117.wasm",
-      "text": "type mismatch",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "type mismatch"
     }
   ]
 }

--- a/tests/snapshots/testsuite/unreached-valid.wast.json
+++ b/tests/snapshots/testsuite/unreached-valid.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 1,
-      "filename": "unreached-valid.0.wasm"
+      "filename": "unreached-valid.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",
@@ -69,7 +70,8 @@
     {
       "type": "module",
       "line": 49,
-      "filename": "unreached-valid.1.wasm"
+      "filename": "unreached-valid.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",

--- a/tests/snapshots/testsuite/unwind.wast.json
+++ b/tests/snapshots/testsuite/unwind.wast.json
@@ -4,7 +4,8 @@
     {
       "type": "module",
       "line": 3,
-      "filename": "unwind.0.wasm"
+      "filename": "unwind.0.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_trap",

--- a/tests/snapshots/testsuite/utf8-custom-section-id.wast.json
+++ b/tests/snapshots/testsuite/utf8-custom-section-id.wast.json
@@ -5,1233 +5,1233 @@
       "type": "assert_malformed",
       "line": 7,
       "filename": "utf8-custom-section-id.0.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 17,
       "filename": "utf8-custom-section-id.1.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 27,
       "filename": "utf8-custom-section-id.2.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 37,
       "filename": "utf8-custom-section-id.3.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 47,
       "filename": "utf8-custom-section-id.4.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 57,
       "filename": "utf8-custom-section-id.5.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 69,
       "filename": "utf8-custom-section-id.6.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 79,
       "filename": "utf8-custom-section-id.7.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 89,
       "filename": "utf8-custom-section-id.8.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 101,
       "filename": "utf8-custom-section-id.9.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 111,
       "filename": "utf8-custom-section-id.10.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 121,
       "filename": "utf8-custom-section-id.11.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 131,
       "filename": "utf8-custom-section-id.12.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 141,
       "filename": "utf8-custom-section-id.13.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 151,
       "filename": "utf8-custom-section-id.14.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 161,
       "filename": "utf8-custom-section-id.15.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 171,
       "filename": "utf8-custom-section-id.16.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 181,
       "filename": "utf8-custom-section-id.17.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 191,
       "filename": "utf8-custom-section-id.18.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 201,
       "filename": "utf8-custom-section-id.19.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 211,
       "filename": "utf8-custom-section-id.20.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 223,
       "filename": "utf8-custom-section-id.21.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 233,
       "filename": "utf8-custom-section-id.22.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 243,
       "filename": "utf8-custom-section-id.23.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 253,
       "filename": "utf8-custom-section-id.24.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 263,
       "filename": "utf8-custom-section-id.25.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 275,
       "filename": "utf8-custom-section-id.26.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 285,
       "filename": "utf8-custom-section-id.27.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 295,
       "filename": "utf8-custom-section-id.28.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 305,
       "filename": "utf8-custom-section-id.29.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 315,
       "filename": "utf8-custom-section-id.30.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 325,
       "filename": "utf8-custom-section-id.31.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 335,
       "filename": "utf8-custom-section-id.32.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 345,
       "filename": "utf8-custom-section-id.33.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 355,
       "filename": "utf8-custom-section-id.34.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 365,
       "filename": "utf8-custom-section-id.35.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 375,
       "filename": "utf8-custom-section-id.36.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 385,
       "filename": "utf8-custom-section-id.37.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 395,
       "filename": "utf8-custom-section-id.38.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 405,
       "filename": "utf8-custom-section-id.39.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 415,
       "filename": "utf8-custom-section-id.40.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 425,
       "filename": "utf8-custom-section-id.41.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 435,
       "filename": "utf8-custom-section-id.42.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 445,
       "filename": "utf8-custom-section-id.43.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 455,
       "filename": "utf8-custom-section-id.44.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 465,
       "filename": "utf8-custom-section-id.45.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 475,
       "filename": "utf8-custom-section-id.46.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 485,
       "filename": "utf8-custom-section-id.47.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 495,
       "filename": "utf8-custom-section-id.48.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 505,
       "filename": "utf8-custom-section-id.49.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 515,
       "filename": "utf8-custom-section-id.50.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 525,
       "filename": "utf8-custom-section-id.51.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 535,
       "filename": "utf8-custom-section-id.52.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 545,
       "filename": "utf8-custom-section-id.53.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 555,
       "filename": "utf8-custom-section-id.54.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 565,
       "filename": "utf8-custom-section-id.55.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 575,
       "filename": "utf8-custom-section-id.56.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 585,
       "filename": "utf8-custom-section-id.57.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 597,
       "filename": "utf8-custom-section-id.58.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 607,
       "filename": "utf8-custom-section-id.59.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 617,
       "filename": "utf8-custom-section-id.60.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 627,
       "filename": "utf8-custom-section-id.61.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 637,
       "filename": "utf8-custom-section-id.62.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 647,
       "filename": "utf8-custom-section-id.63.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 657,
       "filename": "utf8-custom-section-id.64.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 667,
       "filename": "utf8-custom-section-id.65.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 677,
       "filename": "utf8-custom-section-id.66.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 687,
       "filename": "utf8-custom-section-id.67.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 697,
       "filename": "utf8-custom-section-id.68.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 707,
       "filename": "utf8-custom-section-id.69.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 717,
       "filename": "utf8-custom-section-id.70.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 727,
       "filename": "utf8-custom-section-id.71.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 737,
       "filename": "utf8-custom-section-id.72.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 747,
       "filename": "utf8-custom-section-id.73.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 757,
       "filename": "utf8-custom-section-id.74.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 767,
       "filename": "utf8-custom-section-id.75.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 777,
       "filename": "utf8-custom-section-id.76.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 787,
       "filename": "utf8-custom-section-id.77.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 797,
       "filename": "utf8-custom-section-id.78.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 807,
       "filename": "utf8-custom-section-id.79.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 817,
       "filename": "utf8-custom-section-id.80.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 827,
       "filename": "utf8-custom-section-id.81.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 839,
       "filename": "utf8-custom-section-id.82.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 849,
       "filename": "utf8-custom-section-id.83.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 859,
       "filename": "utf8-custom-section-id.84.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 869,
       "filename": "utf8-custom-section-id.85.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 879,
       "filename": "utf8-custom-section-id.86.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 889,
       "filename": "utf8-custom-section-id.87.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 899,
       "filename": "utf8-custom-section-id.88.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 911,
       "filename": "utf8-custom-section-id.89.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 921,
       "filename": "utf8-custom-section-id.90.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 931,
       "filename": "utf8-custom-section-id.91.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 941,
       "filename": "utf8-custom-section-id.92.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 951,
       "filename": "utf8-custom-section-id.93.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 961,
       "filename": "utf8-custom-section-id.94.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 971,
       "filename": "utf8-custom-section-id.95.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 981,
       "filename": "utf8-custom-section-id.96.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 991,
       "filename": "utf8-custom-section-id.97.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1001,
       "filename": "utf8-custom-section-id.98.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1011,
       "filename": "utf8-custom-section-id.99.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1021,
       "filename": "utf8-custom-section-id.100.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1031,
       "filename": "utf8-custom-section-id.101.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1041,
       "filename": "utf8-custom-section-id.102.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1051,
       "filename": "utf8-custom-section-id.103.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1061,
       "filename": "utf8-custom-section-id.104.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1071,
       "filename": "utf8-custom-section-id.105.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1081,
       "filename": "utf8-custom-section-id.106.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1091,
       "filename": "utf8-custom-section-id.107.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1101,
       "filename": "utf8-custom-section-id.108.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1111,
       "filename": "utf8-custom-section-id.109.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1121,
       "filename": "utf8-custom-section-id.110.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1131,
       "filename": "utf8-custom-section-id.111.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1141,
       "filename": "utf8-custom-section-id.112.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1151,
       "filename": "utf8-custom-section-id.113.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1163,
       "filename": "utf8-custom-section-id.114.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1173,
       "filename": "utf8-custom-section-id.115.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1183,
       "filename": "utf8-custom-section-id.116.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1193,
       "filename": "utf8-custom-section-id.117.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1203,
       "filename": "utf8-custom-section-id.118.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1213,
       "filename": "utf8-custom-section-id.119.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1223,
       "filename": "utf8-custom-section-id.120.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1233,
       "filename": "utf8-custom-section-id.121.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1243,
       "filename": "utf8-custom-section-id.122.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1253,
       "filename": "utf8-custom-section-id.123.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1263,
       "filename": "utf8-custom-section-id.124.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1273,
       "filename": "utf8-custom-section-id.125.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1283,
       "filename": "utf8-custom-section-id.126.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1293,
       "filename": "utf8-custom-section-id.127.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1303,
       "filename": "utf8-custom-section-id.128.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1313,
       "filename": "utf8-custom-section-id.129.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1325,
       "filename": "utf8-custom-section-id.130.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1335,
       "filename": "utf8-custom-section-id.131.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1345,
       "filename": "utf8-custom-section-id.132.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1355,
       "filename": "utf8-custom-section-id.133.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1365,
       "filename": "utf8-custom-section-id.134.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1375,
       "filename": "utf8-custom-section-id.135.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1385,
       "filename": "utf8-custom-section-id.136.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1395,
       "filename": "utf8-custom-section-id.137.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1405,
       "filename": "utf8-custom-section-id.138.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1415,
       "filename": "utf8-custom-section-id.139.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1425,
       "filename": "utf8-custom-section-id.140.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1435,
       "filename": "utf8-custom-section-id.141.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1445,
       "filename": "utf8-custom-section-id.142.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1455,
       "filename": "utf8-custom-section-id.143.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1465,
       "filename": "utf8-custom-section-id.144.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1475,
       "filename": "utf8-custom-section-id.145.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1487,
       "filename": "utf8-custom-section-id.146.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1497,
       "filename": "utf8-custom-section-id.147.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1507,
       "filename": "utf8-custom-section-id.148.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1517,
       "filename": "utf8-custom-section-id.149.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1527,
       "filename": "utf8-custom-section-id.150.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1537,
       "filename": "utf8-custom-section-id.151.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1547,
       "filename": "utf8-custom-section-id.152.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1557,
       "filename": "utf8-custom-section-id.153.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1567,
       "filename": "utf8-custom-section-id.154.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1579,
       "filename": "utf8-custom-section-id.155.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1589,
       "filename": "utf8-custom-section-id.156.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1601,
       "filename": "utf8-custom-section-id.157.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1611,
       "filename": "utf8-custom-section-id.158.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1621,
       "filename": "utf8-custom-section-id.159.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1631,
       "filename": "utf8-custom-section-id.160.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1641,
       "filename": "utf8-custom-section-id.161.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1651,
       "filename": "utf8-custom-section-id.162.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1661,
       "filename": "utf8-custom-section-id.163.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1671,
       "filename": "utf8-custom-section-id.164.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1681,
       "filename": "utf8-custom-section-id.165.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1691,
       "filename": "utf8-custom-section-id.166.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1701,
       "filename": "utf8-custom-section-id.167.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1713,
       "filename": "utf8-custom-section-id.168.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1723,
       "filename": "utf8-custom-section-id.169.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1735,
       "filename": "utf8-custom-section-id.170.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1745,
       "filename": "utf8-custom-section-id.171.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1755,
       "filename": "utf8-custom-section-id.172.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1765,
       "filename": "utf8-custom-section-id.173.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1775,
       "filename": "utf8-custom-section-id.174.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1785,
       "filename": "utf8-custom-section-id.175.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     }
   ]
 }

--- a/tests/snapshots/testsuite/utf8-import-field.wast.json
+++ b/tests/snapshots/testsuite/utf8-import-field.wast.json
@@ -5,1233 +5,1233 @@
       "type": "assert_malformed",
       "line": 7,
       "filename": "utf8-import-field.0.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 22,
       "filename": "utf8-import-field.1.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 37,
       "filename": "utf8-import-field.2.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 52,
       "filename": "utf8-import-field.3.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 67,
       "filename": "utf8-import-field.4.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 82,
       "filename": "utf8-import-field.5.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 99,
       "filename": "utf8-import-field.6.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 114,
       "filename": "utf8-import-field.7.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 129,
       "filename": "utf8-import-field.8.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 146,
       "filename": "utf8-import-field.9.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 161,
       "filename": "utf8-import-field.10.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 176,
       "filename": "utf8-import-field.11.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 191,
       "filename": "utf8-import-field.12.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 206,
       "filename": "utf8-import-field.13.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 221,
       "filename": "utf8-import-field.14.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 236,
       "filename": "utf8-import-field.15.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 251,
       "filename": "utf8-import-field.16.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 266,
       "filename": "utf8-import-field.17.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 281,
       "filename": "utf8-import-field.18.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 296,
       "filename": "utf8-import-field.19.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 311,
       "filename": "utf8-import-field.20.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 328,
       "filename": "utf8-import-field.21.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 343,
       "filename": "utf8-import-field.22.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 358,
       "filename": "utf8-import-field.23.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 373,
       "filename": "utf8-import-field.24.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 388,
       "filename": "utf8-import-field.25.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 405,
       "filename": "utf8-import-field.26.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 420,
       "filename": "utf8-import-field.27.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 435,
       "filename": "utf8-import-field.28.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 450,
       "filename": "utf8-import-field.29.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 465,
       "filename": "utf8-import-field.30.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 480,
       "filename": "utf8-import-field.31.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 495,
       "filename": "utf8-import-field.32.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 510,
       "filename": "utf8-import-field.33.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 525,
       "filename": "utf8-import-field.34.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 540,
       "filename": "utf8-import-field.35.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 555,
       "filename": "utf8-import-field.36.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 570,
       "filename": "utf8-import-field.37.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 585,
       "filename": "utf8-import-field.38.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 600,
       "filename": "utf8-import-field.39.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 615,
       "filename": "utf8-import-field.40.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 630,
       "filename": "utf8-import-field.41.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 645,
       "filename": "utf8-import-field.42.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 660,
       "filename": "utf8-import-field.43.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 675,
       "filename": "utf8-import-field.44.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 690,
       "filename": "utf8-import-field.45.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 705,
       "filename": "utf8-import-field.46.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 720,
       "filename": "utf8-import-field.47.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 735,
       "filename": "utf8-import-field.48.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 750,
       "filename": "utf8-import-field.49.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 765,
       "filename": "utf8-import-field.50.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 780,
       "filename": "utf8-import-field.51.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 795,
       "filename": "utf8-import-field.52.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 810,
       "filename": "utf8-import-field.53.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 825,
       "filename": "utf8-import-field.54.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 840,
       "filename": "utf8-import-field.55.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 855,
       "filename": "utf8-import-field.56.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 870,
       "filename": "utf8-import-field.57.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 887,
       "filename": "utf8-import-field.58.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 902,
       "filename": "utf8-import-field.59.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 917,
       "filename": "utf8-import-field.60.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 932,
       "filename": "utf8-import-field.61.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 947,
       "filename": "utf8-import-field.62.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 962,
       "filename": "utf8-import-field.63.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 977,
       "filename": "utf8-import-field.64.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 992,
       "filename": "utf8-import-field.65.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1007,
       "filename": "utf8-import-field.66.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1022,
       "filename": "utf8-import-field.67.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1037,
       "filename": "utf8-import-field.68.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1052,
       "filename": "utf8-import-field.69.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1067,
       "filename": "utf8-import-field.70.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1082,
       "filename": "utf8-import-field.71.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1097,
       "filename": "utf8-import-field.72.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1112,
       "filename": "utf8-import-field.73.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1127,
       "filename": "utf8-import-field.74.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1142,
       "filename": "utf8-import-field.75.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1157,
       "filename": "utf8-import-field.76.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1172,
       "filename": "utf8-import-field.77.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1187,
       "filename": "utf8-import-field.78.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1202,
       "filename": "utf8-import-field.79.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1217,
       "filename": "utf8-import-field.80.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1232,
       "filename": "utf8-import-field.81.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1249,
       "filename": "utf8-import-field.82.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1264,
       "filename": "utf8-import-field.83.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1279,
       "filename": "utf8-import-field.84.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1294,
       "filename": "utf8-import-field.85.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1309,
       "filename": "utf8-import-field.86.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1324,
       "filename": "utf8-import-field.87.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1339,
       "filename": "utf8-import-field.88.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1356,
       "filename": "utf8-import-field.89.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1371,
       "filename": "utf8-import-field.90.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1386,
       "filename": "utf8-import-field.91.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1401,
       "filename": "utf8-import-field.92.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1416,
       "filename": "utf8-import-field.93.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1431,
       "filename": "utf8-import-field.94.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1446,
       "filename": "utf8-import-field.95.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1461,
       "filename": "utf8-import-field.96.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1476,
       "filename": "utf8-import-field.97.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1491,
       "filename": "utf8-import-field.98.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1506,
       "filename": "utf8-import-field.99.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1521,
       "filename": "utf8-import-field.100.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1536,
       "filename": "utf8-import-field.101.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1551,
       "filename": "utf8-import-field.102.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1566,
       "filename": "utf8-import-field.103.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1581,
       "filename": "utf8-import-field.104.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1596,
       "filename": "utf8-import-field.105.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1611,
       "filename": "utf8-import-field.106.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1626,
       "filename": "utf8-import-field.107.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1641,
       "filename": "utf8-import-field.108.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1656,
       "filename": "utf8-import-field.109.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1671,
       "filename": "utf8-import-field.110.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1686,
       "filename": "utf8-import-field.111.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1701,
       "filename": "utf8-import-field.112.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1716,
       "filename": "utf8-import-field.113.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1733,
       "filename": "utf8-import-field.114.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1748,
       "filename": "utf8-import-field.115.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1763,
       "filename": "utf8-import-field.116.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1778,
       "filename": "utf8-import-field.117.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1793,
       "filename": "utf8-import-field.118.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1808,
       "filename": "utf8-import-field.119.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1823,
       "filename": "utf8-import-field.120.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1838,
       "filename": "utf8-import-field.121.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1853,
       "filename": "utf8-import-field.122.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1868,
       "filename": "utf8-import-field.123.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1883,
       "filename": "utf8-import-field.124.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1898,
       "filename": "utf8-import-field.125.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1913,
       "filename": "utf8-import-field.126.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1928,
       "filename": "utf8-import-field.127.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1943,
       "filename": "utf8-import-field.128.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1958,
       "filename": "utf8-import-field.129.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1975,
       "filename": "utf8-import-field.130.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1990,
       "filename": "utf8-import-field.131.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2005,
       "filename": "utf8-import-field.132.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2020,
       "filename": "utf8-import-field.133.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2035,
       "filename": "utf8-import-field.134.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2050,
       "filename": "utf8-import-field.135.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2065,
       "filename": "utf8-import-field.136.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2080,
       "filename": "utf8-import-field.137.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2095,
       "filename": "utf8-import-field.138.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2110,
       "filename": "utf8-import-field.139.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2125,
       "filename": "utf8-import-field.140.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2140,
       "filename": "utf8-import-field.141.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2155,
       "filename": "utf8-import-field.142.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2170,
       "filename": "utf8-import-field.143.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2185,
       "filename": "utf8-import-field.144.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2200,
       "filename": "utf8-import-field.145.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2217,
       "filename": "utf8-import-field.146.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2232,
       "filename": "utf8-import-field.147.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2247,
       "filename": "utf8-import-field.148.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2262,
       "filename": "utf8-import-field.149.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2277,
       "filename": "utf8-import-field.150.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2292,
       "filename": "utf8-import-field.151.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2307,
       "filename": "utf8-import-field.152.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2322,
       "filename": "utf8-import-field.153.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2337,
       "filename": "utf8-import-field.154.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2354,
       "filename": "utf8-import-field.155.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2369,
       "filename": "utf8-import-field.156.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2386,
       "filename": "utf8-import-field.157.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2401,
       "filename": "utf8-import-field.158.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2416,
       "filename": "utf8-import-field.159.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2431,
       "filename": "utf8-import-field.160.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2446,
       "filename": "utf8-import-field.161.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2461,
       "filename": "utf8-import-field.162.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2476,
       "filename": "utf8-import-field.163.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2491,
       "filename": "utf8-import-field.164.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2506,
       "filename": "utf8-import-field.165.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2521,
       "filename": "utf8-import-field.166.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2536,
       "filename": "utf8-import-field.167.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2553,
       "filename": "utf8-import-field.168.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2568,
       "filename": "utf8-import-field.169.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2585,
       "filename": "utf8-import-field.170.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2600,
       "filename": "utf8-import-field.171.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2615,
       "filename": "utf8-import-field.172.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2630,
       "filename": "utf8-import-field.173.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2645,
       "filename": "utf8-import-field.174.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2660,
       "filename": "utf8-import-field.175.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     }
   ]
 }

--- a/tests/snapshots/testsuite/utf8-import-module.wast.json
+++ b/tests/snapshots/testsuite/utf8-import-module.wast.json
@@ -5,1233 +5,1233 @@
       "type": "assert_malformed",
       "line": 7,
       "filename": "utf8-import-module.0.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 22,
       "filename": "utf8-import-module.1.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 37,
       "filename": "utf8-import-module.2.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 52,
       "filename": "utf8-import-module.3.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 67,
       "filename": "utf8-import-module.4.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 82,
       "filename": "utf8-import-module.5.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 99,
       "filename": "utf8-import-module.6.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 114,
       "filename": "utf8-import-module.7.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 129,
       "filename": "utf8-import-module.8.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 146,
       "filename": "utf8-import-module.9.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 161,
       "filename": "utf8-import-module.10.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 176,
       "filename": "utf8-import-module.11.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 191,
       "filename": "utf8-import-module.12.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 206,
       "filename": "utf8-import-module.13.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 221,
       "filename": "utf8-import-module.14.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 236,
       "filename": "utf8-import-module.15.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 251,
       "filename": "utf8-import-module.16.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 266,
       "filename": "utf8-import-module.17.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 281,
       "filename": "utf8-import-module.18.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 296,
       "filename": "utf8-import-module.19.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 311,
       "filename": "utf8-import-module.20.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 328,
       "filename": "utf8-import-module.21.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 343,
       "filename": "utf8-import-module.22.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 358,
       "filename": "utf8-import-module.23.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 373,
       "filename": "utf8-import-module.24.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 388,
       "filename": "utf8-import-module.25.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 405,
       "filename": "utf8-import-module.26.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 420,
       "filename": "utf8-import-module.27.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 435,
       "filename": "utf8-import-module.28.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 450,
       "filename": "utf8-import-module.29.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 465,
       "filename": "utf8-import-module.30.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 480,
       "filename": "utf8-import-module.31.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 495,
       "filename": "utf8-import-module.32.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 510,
       "filename": "utf8-import-module.33.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 525,
       "filename": "utf8-import-module.34.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 540,
       "filename": "utf8-import-module.35.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 555,
       "filename": "utf8-import-module.36.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 570,
       "filename": "utf8-import-module.37.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 585,
       "filename": "utf8-import-module.38.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 600,
       "filename": "utf8-import-module.39.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 615,
       "filename": "utf8-import-module.40.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 630,
       "filename": "utf8-import-module.41.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 645,
       "filename": "utf8-import-module.42.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 660,
       "filename": "utf8-import-module.43.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 675,
       "filename": "utf8-import-module.44.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 690,
       "filename": "utf8-import-module.45.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 705,
       "filename": "utf8-import-module.46.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 720,
       "filename": "utf8-import-module.47.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 735,
       "filename": "utf8-import-module.48.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 750,
       "filename": "utf8-import-module.49.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 765,
       "filename": "utf8-import-module.50.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 780,
       "filename": "utf8-import-module.51.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 795,
       "filename": "utf8-import-module.52.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 810,
       "filename": "utf8-import-module.53.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 825,
       "filename": "utf8-import-module.54.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 840,
       "filename": "utf8-import-module.55.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 855,
       "filename": "utf8-import-module.56.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 870,
       "filename": "utf8-import-module.57.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 887,
       "filename": "utf8-import-module.58.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 902,
       "filename": "utf8-import-module.59.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 917,
       "filename": "utf8-import-module.60.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 932,
       "filename": "utf8-import-module.61.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 947,
       "filename": "utf8-import-module.62.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 962,
       "filename": "utf8-import-module.63.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 977,
       "filename": "utf8-import-module.64.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 992,
       "filename": "utf8-import-module.65.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1007,
       "filename": "utf8-import-module.66.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1022,
       "filename": "utf8-import-module.67.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1037,
       "filename": "utf8-import-module.68.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1052,
       "filename": "utf8-import-module.69.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1067,
       "filename": "utf8-import-module.70.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1082,
       "filename": "utf8-import-module.71.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1097,
       "filename": "utf8-import-module.72.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1112,
       "filename": "utf8-import-module.73.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1127,
       "filename": "utf8-import-module.74.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1142,
       "filename": "utf8-import-module.75.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1157,
       "filename": "utf8-import-module.76.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1172,
       "filename": "utf8-import-module.77.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1187,
       "filename": "utf8-import-module.78.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1202,
       "filename": "utf8-import-module.79.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1217,
       "filename": "utf8-import-module.80.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1232,
       "filename": "utf8-import-module.81.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1249,
       "filename": "utf8-import-module.82.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1264,
       "filename": "utf8-import-module.83.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1279,
       "filename": "utf8-import-module.84.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1294,
       "filename": "utf8-import-module.85.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1309,
       "filename": "utf8-import-module.86.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1324,
       "filename": "utf8-import-module.87.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1339,
       "filename": "utf8-import-module.88.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1356,
       "filename": "utf8-import-module.89.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1371,
       "filename": "utf8-import-module.90.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1386,
       "filename": "utf8-import-module.91.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1401,
       "filename": "utf8-import-module.92.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1416,
       "filename": "utf8-import-module.93.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1431,
       "filename": "utf8-import-module.94.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1446,
       "filename": "utf8-import-module.95.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1461,
       "filename": "utf8-import-module.96.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1476,
       "filename": "utf8-import-module.97.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1491,
       "filename": "utf8-import-module.98.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1506,
       "filename": "utf8-import-module.99.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1521,
       "filename": "utf8-import-module.100.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1536,
       "filename": "utf8-import-module.101.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1551,
       "filename": "utf8-import-module.102.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1566,
       "filename": "utf8-import-module.103.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1581,
       "filename": "utf8-import-module.104.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1596,
       "filename": "utf8-import-module.105.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1611,
       "filename": "utf8-import-module.106.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1626,
       "filename": "utf8-import-module.107.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1641,
       "filename": "utf8-import-module.108.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1656,
       "filename": "utf8-import-module.109.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1671,
       "filename": "utf8-import-module.110.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1686,
       "filename": "utf8-import-module.111.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1701,
       "filename": "utf8-import-module.112.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1716,
       "filename": "utf8-import-module.113.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1733,
       "filename": "utf8-import-module.114.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1748,
       "filename": "utf8-import-module.115.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1763,
       "filename": "utf8-import-module.116.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1778,
       "filename": "utf8-import-module.117.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1793,
       "filename": "utf8-import-module.118.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1808,
       "filename": "utf8-import-module.119.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1823,
       "filename": "utf8-import-module.120.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1838,
       "filename": "utf8-import-module.121.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1853,
       "filename": "utf8-import-module.122.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1868,
       "filename": "utf8-import-module.123.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1883,
       "filename": "utf8-import-module.124.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1898,
       "filename": "utf8-import-module.125.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1913,
       "filename": "utf8-import-module.126.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1928,
       "filename": "utf8-import-module.127.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1943,
       "filename": "utf8-import-module.128.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1958,
       "filename": "utf8-import-module.129.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1975,
       "filename": "utf8-import-module.130.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 1990,
       "filename": "utf8-import-module.131.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2005,
       "filename": "utf8-import-module.132.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2020,
       "filename": "utf8-import-module.133.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2035,
       "filename": "utf8-import-module.134.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2050,
       "filename": "utf8-import-module.135.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2065,
       "filename": "utf8-import-module.136.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2080,
       "filename": "utf8-import-module.137.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2095,
       "filename": "utf8-import-module.138.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2110,
       "filename": "utf8-import-module.139.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2125,
       "filename": "utf8-import-module.140.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2140,
       "filename": "utf8-import-module.141.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2155,
       "filename": "utf8-import-module.142.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2170,
       "filename": "utf8-import-module.143.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2185,
       "filename": "utf8-import-module.144.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2200,
       "filename": "utf8-import-module.145.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2217,
       "filename": "utf8-import-module.146.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2232,
       "filename": "utf8-import-module.147.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2247,
       "filename": "utf8-import-module.148.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2262,
       "filename": "utf8-import-module.149.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2277,
       "filename": "utf8-import-module.150.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2292,
       "filename": "utf8-import-module.151.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2307,
       "filename": "utf8-import-module.152.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2322,
       "filename": "utf8-import-module.153.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2337,
       "filename": "utf8-import-module.154.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2354,
       "filename": "utf8-import-module.155.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2369,
       "filename": "utf8-import-module.156.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2386,
       "filename": "utf8-import-module.157.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2401,
       "filename": "utf8-import-module.158.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2416,
       "filename": "utf8-import-module.159.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2431,
       "filename": "utf8-import-module.160.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2446,
       "filename": "utf8-import-module.161.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2461,
       "filename": "utf8-import-module.162.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2476,
       "filename": "utf8-import-module.163.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2491,
       "filename": "utf8-import-module.164.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2506,
       "filename": "utf8-import-module.165.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2521,
       "filename": "utf8-import-module.166.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2536,
       "filename": "utf8-import-module.167.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2553,
       "filename": "utf8-import-module.168.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2568,
       "filename": "utf8-import-module.169.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2585,
       "filename": "utf8-import-module.170.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2600,
       "filename": "utf8-import-module.171.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2615,
       "filename": "utf8-import-module.172.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2630,
       "filename": "utf8-import-module.173.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2645,
       "filename": "utf8-import-module.174.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2660,
       "filename": "utf8-import-module.175.wasm",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "binary"
+      "module_type": "binary",
+      "text": "malformed UTF-8 encoding"
     }
   ]
 }

--- a/tests/snapshots/testsuite/utf8-invalid-encoding.wast.json
+++ b/tests/snapshots/testsuite/utf8-invalid-encoding.wast.json
@@ -5,1233 +5,1233 @@
       "type": "assert_malformed",
       "line": 1,
       "filename": "utf8-invalid-encoding.0.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 2,
       "filename": "utf8-invalid-encoding.1.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 3,
       "filename": "utf8-invalid-encoding.2.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 4,
       "filename": "utf8-invalid-encoding.3.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 5,
       "filename": "utf8-invalid-encoding.4.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 6,
       "filename": "utf8-invalid-encoding.5.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 7,
       "filename": "utf8-invalid-encoding.6.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 8,
       "filename": "utf8-invalid-encoding.7.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 9,
       "filename": "utf8-invalid-encoding.8.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 10,
       "filename": "utf8-invalid-encoding.9.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 11,
       "filename": "utf8-invalid-encoding.10.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 12,
       "filename": "utf8-invalid-encoding.11.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 13,
       "filename": "utf8-invalid-encoding.12.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 14,
       "filename": "utf8-invalid-encoding.13.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 15,
       "filename": "utf8-invalid-encoding.14.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 16,
       "filename": "utf8-invalid-encoding.15.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 17,
       "filename": "utf8-invalid-encoding.16.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 18,
       "filename": "utf8-invalid-encoding.17.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 19,
       "filename": "utf8-invalid-encoding.18.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 20,
       "filename": "utf8-invalid-encoding.19.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 21,
       "filename": "utf8-invalid-encoding.20.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 22,
       "filename": "utf8-invalid-encoding.21.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 23,
       "filename": "utf8-invalid-encoding.22.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 24,
       "filename": "utf8-invalid-encoding.23.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 25,
       "filename": "utf8-invalid-encoding.24.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 26,
       "filename": "utf8-invalid-encoding.25.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 27,
       "filename": "utf8-invalid-encoding.26.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 28,
       "filename": "utf8-invalid-encoding.27.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 29,
       "filename": "utf8-invalid-encoding.28.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 30,
       "filename": "utf8-invalid-encoding.29.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 31,
       "filename": "utf8-invalid-encoding.30.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 32,
       "filename": "utf8-invalid-encoding.31.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 33,
       "filename": "utf8-invalid-encoding.32.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 34,
       "filename": "utf8-invalid-encoding.33.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 35,
       "filename": "utf8-invalid-encoding.34.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 36,
       "filename": "utf8-invalid-encoding.35.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 37,
       "filename": "utf8-invalid-encoding.36.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 38,
       "filename": "utf8-invalid-encoding.37.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 39,
       "filename": "utf8-invalid-encoding.38.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 40,
       "filename": "utf8-invalid-encoding.39.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 41,
       "filename": "utf8-invalid-encoding.40.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 42,
       "filename": "utf8-invalid-encoding.41.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 43,
       "filename": "utf8-invalid-encoding.42.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 44,
       "filename": "utf8-invalid-encoding.43.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 45,
       "filename": "utf8-invalid-encoding.44.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 46,
       "filename": "utf8-invalid-encoding.45.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 47,
       "filename": "utf8-invalid-encoding.46.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 48,
       "filename": "utf8-invalid-encoding.47.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 49,
       "filename": "utf8-invalid-encoding.48.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 50,
       "filename": "utf8-invalid-encoding.49.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 51,
       "filename": "utf8-invalid-encoding.50.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 52,
       "filename": "utf8-invalid-encoding.51.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 53,
       "filename": "utf8-invalid-encoding.52.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 54,
       "filename": "utf8-invalid-encoding.53.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 55,
       "filename": "utf8-invalid-encoding.54.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 56,
       "filename": "utf8-invalid-encoding.55.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 57,
       "filename": "utf8-invalid-encoding.56.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 58,
       "filename": "utf8-invalid-encoding.57.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 59,
       "filename": "utf8-invalid-encoding.58.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 60,
       "filename": "utf8-invalid-encoding.59.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 61,
       "filename": "utf8-invalid-encoding.60.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 62,
       "filename": "utf8-invalid-encoding.61.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 63,
       "filename": "utf8-invalid-encoding.62.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 64,
       "filename": "utf8-invalid-encoding.63.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 65,
       "filename": "utf8-invalid-encoding.64.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 66,
       "filename": "utf8-invalid-encoding.65.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 67,
       "filename": "utf8-invalid-encoding.66.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 68,
       "filename": "utf8-invalid-encoding.67.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 69,
       "filename": "utf8-invalid-encoding.68.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 70,
       "filename": "utf8-invalid-encoding.69.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 71,
       "filename": "utf8-invalid-encoding.70.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 72,
       "filename": "utf8-invalid-encoding.71.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 73,
       "filename": "utf8-invalid-encoding.72.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 74,
       "filename": "utf8-invalid-encoding.73.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 75,
       "filename": "utf8-invalid-encoding.74.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 76,
       "filename": "utf8-invalid-encoding.75.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 77,
       "filename": "utf8-invalid-encoding.76.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 78,
       "filename": "utf8-invalid-encoding.77.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 79,
       "filename": "utf8-invalid-encoding.78.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 80,
       "filename": "utf8-invalid-encoding.79.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 81,
       "filename": "utf8-invalid-encoding.80.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 82,
       "filename": "utf8-invalid-encoding.81.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 83,
       "filename": "utf8-invalid-encoding.82.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 84,
       "filename": "utf8-invalid-encoding.83.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 85,
       "filename": "utf8-invalid-encoding.84.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 86,
       "filename": "utf8-invalid-encoding.85.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 87,
       "filename": "utf8-invalid-encoding.86.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 88,
       "filename": "utf8-invalid-encoding.87.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 89,
       "filename": "utf8-invalid-encoding.88.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 90,
       "filename": "utf8-invalid-encoding.89.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 91,
       "filename": "utf8-invalid-encoding.90.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 92,
       "filename": "utf8-invalid-encoding.91.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 93,
       "filename": "utf8-invalid-encoding.92.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 94,
       "filename": "utf8-invalid-encoding.93.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 95,
       "filename": "utf8-invalid-encoding.94.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 96,
       "filename": "utf8-invalid-encoding.95.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 97,
       "filename": "utf8-invalid-encoding.96.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 98,
       "filename": "utf8-invalid-encoding.97.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 99,
       "filename": "utf8-invalid-encoding.98.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 100,
       "filename": "utf8-invalid-encoding.99.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 101,
       "filename": "utf8-invalid-encoding.100.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 102,
       "filename": "utf8-invalid-encoding.101.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 103,
       "filename": "utf8-invalid-encoding.102.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 104,
       "filename": "utf8-invalid-encoding.103.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 105,
       "filename": "utf8-invalid-encoding.104.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 106,
       "filename": "utf8-invalid-encoding.105.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 107,
       "filename": "utf8-invalid-encoding.106.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 108,
       "filename": "utf8-invalid-encoding.107.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 109,
       "filename": "utf8-invalid-encoding.108.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 110,
       "filename": "utf8-invalid-encoding.109.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 111,
       "filename": "utf8-invalid-encoding.110.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 112,
       "filename": "utf8-invalid-encoding.111.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 113,
       "filename": "utf8-invalid-encoding.112.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 114,
       "filename": "utf8-invalid-encoding.113.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 115,
       "filename": "utf8-invalid-encoding.114.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 116,
       "filename": "utf8-invalid-encoding.115.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 117,
       "filename": "utf8-invalid-encoding.116.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 118,
       "filename": "utf8-invalid-encoding.117.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 119,
       "filename": "utf8-invalid-encoding.118.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 120,
       "filename": "utf8-invalid-encoding.119.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 121,
       "filename": "utf8-invalid-encoding.120.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 122,
       "filename": "utf8-invalid-encoding.121.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 123,
       "filename": "utf8-invalid-encoding.122.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 124,
       "filename": "utf8-invalid-encoding.123.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 125,
       "filename": "utf8-invalid-encoding.124.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 126,
       "filename": "utf8-invalid-encoding.125.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 127,
       "filename": "utf8-invalid-encoding.126.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 128,
       "filename": "utf8-invalid-encoding.127.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 129,
       "filename": "utf8-invalid-encoding.128.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 130,
       "filename": "utf8-invalid-encoding.129.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 131,
       "filename": "utf8-invalid-encoding.130.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 132,
       "filename": "utf8-invalid-encoding.131.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 133,
       "filename": "utf8-invalid-encoding.132.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 134,
       "filename": "utf8-invalid-encoding.133.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 135,
       "filename": "utf8-invalid-encoding.134.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 136,
       "filename": "utf8-invalid-encoding.135.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 137,
       "filename": "utf8-invalid-encoding.136.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 138,
       "filename": "utf8-invalid-encoding.137.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 139,
       "filename": "utf8-invalid-encoding.138.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 140,
       "filename": "utf8-invalid-encoding.139.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 141,
       "filename": "utf8-invalid-encoding.140.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 142,
       "filename": "utf8-invalid-encoding.141.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 143,
       "filename": "utf8-invalid-encoding.142.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 144,
       "filename": "utf8-invalid-encoding.143.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 145,
       "filename": "utf8-invalid-encoding.144.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 146,
       "filename": "utf8-invalid-encoding.145.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 147,
       "filename": "utf8-invalid-encoding.146.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 148,
       "filename": "utf8-invalid-encoding.147.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 149,
       "filename": "utf8-invalid-encoding.148.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 150,
       "filename": "utf8-invalid-encoding.149.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 151,
       "filename": "utf8-invalid-encoding.150.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 152,
       "filename": "utf8-invalid-encoding.151.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 153,
       "filename": "utf8-invalid-encoding.152.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 154,
       "filename": "utf8-invalid-encoding.153.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 155,
       "filename": "utf8-invalid-encoding.154.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 156,
       "filename": "utf8-invalid-encoding.155.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 157,
       "filename": "utf8-invalid-encoding.156.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 158,
       "filename": "utf8-invalid-encoding.157.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 159,
       "filename": "utf8-invalid-encoding.158.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 160,
       "filename": "utf8-invalid-encoding.159.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 161,
       "filename": "utf8-invalid-encoding.160.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 162,
       "filename": "utf8-invalid-encoding.161.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 163,
       "filename": "utf8-invalid-encoding.162.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 164,
       "filename": "utf8-invalid-encoding.163.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 165,
       "filename": "utf8-invalid-encoding.164.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 166,
       "filename": "utf8-invalid-encoding.165.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 167,
       "filename": "utf8-invalid-encoding.166.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 168,
       "filename": "utf8-invalid-encoding.167.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 169,
       "filename": "utf8-invalid-encoding.168.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 170,
       "filename": "utf8-invalid-encoding.169.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 171,
       "filename": "utf8-invalid-encoding.170.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 172,
       "filename": "utf8-invalid-encoding.171.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 173,
       "filename": "utf8-invalid-encoding.172.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 174,
       "filename": "utf8-invalid-encoding.173.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 175,
       "filename": "utf8-invalid-encoding.174.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     },
     {
       "type": "assert_malformed",
       "line": 176,
       "filename": "utf8-invalid-encoding.175.wat",
-      "text": "malformed UTF-8 encoding",
-      "module_type": "text"
+      "module_type": "text",
+      "text": "malformed UTF-8 encoding"
     }
   ]
 }


### PR DESCRIPTION
This commit is aimed at addressing #1771 by including a new `binary_filename` field in the JSON which is populated when the test itself is `module quote`, or a textual module, but the module parse successfully. This should help avoid the need for a text parser for external users using the tool while still reflecting the test case itself where it's text-based.

Closes #1771