### PR TITLE
Use `pretty_assertions` instead of `diff` in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1758,7 +1758,6 @@ dependencies = [
  "clap",
  "clap_complete",
  "cpp_demangle",
- "diff",
  "env_logger",
  "gimli 0.30.0",
  "is_executable",
@@ -1903,12 +1902,8 @@ name = "wasmprinter"
 version = "0.217.0"
 dependencies = [
  "anyhow",
- "diff",
- "rayon",
- "tempfile",
  "termcolor",
  "wasmparser 0.217.0",
- "wast",
  "wat",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,7 +175,6 @@ is_executable = { version = "1.0.1", optional = true }
 [dev-dependencies]
 serde_json = "1.0"
 tempfile = "3.1"
-diff = "0.1"
 wast = { path = 'crates/wast' }
 pretty_assertions = { workspace = true }
 libtest-mimic = { workspace = true }

--- a/crates/wasmprinter/Cargo.toml
+++ b/crates/wasmprinter/Cargo.toml
@@ -22,8 +22,4 @@ wasmparser = { workspace = true, features = ['std'] }
 termcolor = { workspace = true }
 
 [dev-dependencies]
-diff = "0.1"
-rayon = { workspace = true }
-tempfile = "3.0"
 wat = { path = "../wat" }
-wast = { path = "../wast" }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -428,27 +428,9 @@ impl TestState {
             // Handle git possibly doing some newline shenanigans on windows.
             let snapshot = snapshot.replace("\r\n", "\n");
             if snapshot != contents {
-                let mut result = String::with_capacity(snapshot.len());
-                for diff in diff::lines(&snapshot, &contents) {
-                    match diff {
-                        diff::Result::Left(s) => {
-                            result.push_str("-");
-                            result.push_str(s);
-                        }
-                        diff::Result::Right(s) => {
-                            result.push_str("+");
-                            result.push_str(s);
-                        }
-                        diff::Result::Both(s, _) => {
-                            result.push_str(" ");
-                            result.push_str(s);
-                        }
-                    }
-                    result.push_str("\n");
-                }
                 anyhow::bail!(
                     "snapshot does not match the expected result, try `env BLESS=1`\n{}",
-                    result
+                    pretty_assertions::StrComparison::new(&snapshot, &contents)
                 );
             }
         }


### PR DESCRIPTION
The very large diffs from errors in development #1775 caused OOMs so I figured now's as good a time as any to switch over to using `pretty_assertions` which other crates in the workspace are already using.