### PR TITLE
Pin nightly versions in CI to insulate from breakage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
           - os: ubuntu-latest
             rust: beta
           - os: ubuntu-latest
-            rust: nightly
+            rust: nightly-2024-09-10
           - os: macos-latest
             rust: default
           - os: windows-latest


### PR DESCRIPTION
This'll in theory get updated occasionally but should protect us from breakage in the meantime.