### PR TITLE
Start requiring f32/f64 in WIT by default

### DIFF
--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -5,7 +5,7 @@ use std::mem;
 use wit_parser::*;
 
 // NB: keep in sync with `crates/wit-parser/src/ast/lex.rs`
-const PRINT_F32_F64_DEFAULT: bool = false;
+const PRINT_F32_F64_DEFAULT: bool = true;
 
 /// A utility for printing WebAssembly interface definitions to a string.
 pub struct WitPrinter {

--- a/crates/wit-parser/src/ast.rs
+++ b/crates/wit-parser/src/ast.rs
@@ -1772,13 +1772,15 @@ impl SourceMap {
             bail!("{msg}")
         }
 
-        if let Some(sort) = err.downcast_ref::<toposort::Error>() {
-            let span = match sort {
-                toposort::Error::NonexistentDep { span, .. }
-                | toposort::Error::Cycle { span, .. } => *span,
-            };
-            let msg = self.highlight_err(span.start, Some(span.end), sort);
-            bail!("{msg}")
+        if let Some(sort) = err.downcast_mut::<toposort::Error>() {
+            if sort.highlighted().is_none() {
+                let span = match sort {
+                    toposort::Error::NonexistentDep { span, .. }
+                    | toposort::Error::Cycle { span, .. } => *span,
+                };
+                let highlighted = self.highlight_err(span.start, Some(span.end), &sort);
+                sort.set_highlighted(highlighted);
+            }
         }
 
         Err(err)

--- a/crates/wit-parser/src/ast/lex.rs
+++ b/crates/wit-parser/src/ast/lex.rs
@@ -116,7 +116,7 @@ pub enum Error {
 }
 
 // NB: keep in sync with `crates/wit-component/src/printing.rs`.
-const REQUIRE_F32_F64_BY_DEFAULT: bool = false;
+const REQUIRE_F32_F64_BY_DEFAULT: bool = true;
 
 impl<'a> Tokenizer<'a> {
     pub fn new(

--- a/crates/wit-parser/tests/ui/parse-fail/old-float-types.wit
+++ b/crates/wit-parser/tests/ui/parse-fail/old-float-types.wit
@@ -1,0 +1,5 @@
+package foo:bar;
+
+interface a {
+  type t1 = float32;
+}

--- a/crates/wit-parser/tests/ui/parse-fail/old-float-types.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/old-float-types.wit.result
@@ -1,0 +1,5 @@
+the `float32` type has been renamed to `f32` and is no longer accepted, but the `WIT_REQUIRE_F32_F64=0` environment variable can be used to temporarily disable this error: type `float32` does not exist
+     --> tests/ui/parse-fail/old-float-types.wit:4:13
+      |
+    4 |   type t1 = float32;
+      |             ^------


### PR DESCRIPTION
This commit continues the transition started in #1364 to rename the `float32 `and `float64` types in WIT to `f32` and `f64`. Now that support has been present for some time to parse `f32` and `f64` this commit flips the WIT parser to requiring it by default. The error message for `float32` and `float64` has additionally been updated to explain a bit more about this transition.