### PR TITLE
Don't panic on duplicate imports when creating components

### DIFF
--- a/crates/wit-component/src/validation.rs
+++ b/crates/wit-component/src/validation.rs
@@ -174,7 +174,13 @@ pub fn validate_module<'a>(
                                 Entry::Vacant(e) => e.insert(IndexMap::new()),
                             };
 
-                            assert!(map.insert(import.name, ty).is_none());
+                            if map.insert(import.name, ty).is_some() {
+                                bail!(
+                                    "module has duplicate import for `{}::{}`",
+                                    import.module,
+                                    import.name
+                                );
+                            }
                         }
                         _ => bail!("module is only allowed to import functions"),
                     }

--- a/tests/cli/bad-component-new.wat
+++ b/tests/cli/bad-component-new.wat
@@ -1,0 +1,6 @@
+;; FAIL: component new %
+
+(module
+  (import "a" "a" (func))
+  (import "a" "a" (func))
+)

--- a/tests/cli/bad-component-new.wat.stderr
+++ b/tests/cli/bad-component-new.wat.stderr
@@ -1,0 +1,6 @@
+error: failed to encode a component from module
+
+Caused by:
+    0: failed to decode world from module
+    1: module was not valid
+    2: module has duplicate import for `a::a`


### PR DESCRIPTION
Return an error instead since that's more appropriate in this context.

Closes #1786