### PR TITLE
Fix some minor issues in WIT world merging

### DIFF
--- a/fuzz/src/roundtrip_wit.rs
+++ b/fuzz/src/roundtrip_wit.rs
@@ -1,6 +1,5 @@
 use arbitrary::{Result, Unstructured};
 use std::path::Path;
-use wasmparser::WasmFeatures;
 use wit_component::*;
 use wit_parser::{PackageId, Resolve};
 
@@ -14,6 +13,7 @@ pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
         DecodedWasm::WitPackage(resolve, pkg) => (resolve, pkg),
         DecodedWasm::Component(..) => unreachable!(),
     };
+    resolve.assert_valid();
 
     roundtrip_through_printing("doc1", &resolve, pkg, &wasm);
 
@@ -21,6 +21,7 @@ pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
         DecodedWasm::WitPackage(resolve, pkgs) => (resolve, pkgs),
         DecodedWasm::Component(..) => unreachable!(),
     };
+    resolve2.assert_valid();
 
     let wasm2 = wit_component::encode(&resolve2, pkg2).expect("failed to encode WIT document");
     write_file("doc2.wasm", &wasm2);
@@ -32,18 +33,13 @@ pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
 
     // If there's hundreds or thousands of worlds only work with the first few
     // to avoid timing out this fuzzer with asan enabled.
-    let mut decoded_worlds = Vec::new();
+    let mut decoded_bindgens = Vec::new();
     for (id, world) in resolve.worlds.iter().take(20) {
         log::debug!("embedding world {} as in a dummy module", world.name);
         let mut dummy = wit_component::dummy_module(&resolve, id);
         wit_component::embed_component_metadata(&mut dummy, &resolve, id, StringEncoding::UTF8)
             .unwrap();
         write_file("dummy.wasm", &dummy);
-
-        // Decode what was just created and record it later for testing merging
-        // worlds together.
-        let (_, decoded) = wit_component::metadata::decode(&dummy).unwrap();
-        decoded_worlds.push(decoded.resolve);
 
         log::debug!("... componentizing the world into a binary component");
         let wasm = wit_component::ComponentEncoder::default()
@@ -52,11 +48,12 @@ pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
             .encode()
             .unwrap();
         write_file("dummy.component.wasm", &wasm);
-        wasmparser::Validator::new_with_features(
-            WasmFeatures::default() | WasmFeatures::COMPONENT_MODEL,
-        )
-        .validate_all(&wasm)
-        .unwrap();
+        wasmparser::Validator::new().validate_all(&wasm).unwrap();
+
+        // Decode what was just created and record it later for testing merging
+        // worlds together.
+        let (_, decoded) = wit_component::metadata::decode(&dummy).unwrap();
+        decoded_bindgens.push((decoded, dummy, world.name.clone()));
 
         log::debug!("... decoding the component itself");
         wit_component::decode(&wasm).unwrap();
@@ -66,19 +63,28 @@ pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
         log::debug!("... importizing this world");
         let mut resolve2 = resolve.clone();
         let _ = resolve2.importize(id);
-        resolve.assert_valid();
     }
 
-    if decoded_worlds.len() < 2 {
+    if decoded_bindgens.len() < 2 {
         return Ok(());
     }
 
-    log::debug!("merging worlds");
-    let w1 = u.choose(&decoded_worlds)?;
-    let w2 = u.choose(&decoded_worlds)?;
-    let mut dst = w1.clone();
-    dst.merge(w2.clone()).unwrap();
-    dst.assert_valid();
+    let i = u.choose_index(decoded_bindgens.len())?;
+    let (mut b1, wasm1, world1) = decoded_bindgens.swap_remove(i);
+    let i = u.choose_index(decoded_bindgens.len())?;
+    let (b2, wasm2, world2) = decoded_bindgens.swap_remove(i);
+
+    log::debug!("merging bindgens world {world1} <- world {world2}");
+
+    write_file("bindgen1.wasm", &wasm1);
+    write_file("bindgen2.wasm", &wasm2);
+
+    // Merging worlds may fail but if successful then a `Resolve` is asserted
+    // to be valid which is what we're interested in here. Note that failure
+    // here can be due to the structure of worlds which aren't reasonable to
+    // control in this generator, so it's just done to see what happens and try
+    // to trigger panics in `Resolve::assert_valid`.
+    let _ = b1.merge(b2);
     Ok(())
 }
 

--- a/tests/cli/fail-merge.wit
+++ b/tests/cli/fail-merge.wit
@@ -8,17 +8,15 @@ interface i1 {
 interface i2 {
   use i1.{t};
 }
-interface i3 {
-  use i2.{t};
-}
 
 world into {
-  export i1;
-  export i2;
+  export x: interface {
+    use i2.{t};
+  }
 }
 
+// `into` has a transitive dep on importing i2 and must then import i1. Means
+// we can't import `i1` when merging this in.
 world %from {
-  export x: interface {
-    use i3.{t};
-  }
+  export i1;
 }

--- a/tests/cli/fail-merge.wit.stderr
+++ b/tests/cli/fail-merge.wit.stderr
@@ -1,0 +1,6 @@
+error: updating metadata for section component-type
+
+Caused by:
+    0: failed to merge worlds from two documents
+    1: failed to add export `a:b/i1`
+    2: export `x` depends on `a:b/i1` previously as an import which will change meaning if `a:b/i1` is added as an export

--- a/tests/cli/merge-fail-to-add-import.wit
+++ b/tests/cli/merge-fail-to-add-import.wit
@@ -1,0 +1,23 @@
+// FAIL: component embed --dummy --world into % | component embed --world %from % | component wit
+
+package a:b;
+
+interface i1 {
+  type t = u32;
+}
+interface i2 {
+  use i1.{t};
+}
+
+world into {
+  export i2;
+}
+
+// This world cannot be merged into `into` because it would change the meaning
+// of `into`. Previously in `into` i2's export of `i2` would refer to the
+// implicit import of `i1`, but here the export of `i2` refers to the export of
+// `i1`.
+world %from {
+  export i1;
+  export i2;
+}

--- a/tests/cli/merge-fail-to-add-import.wit.stderr
+++ b/tests/cli/merge-fail-to-add-import.wit.stderr
@@ -1,0 +1,6 @@
+error: updating metadata for section component-type
+
+Caused by:
+    0: failed to merge worlds from two documents
+    1: failed to add export `a:b/i1`
+    2: export `a:b/i2` depends on `a:b/i1` previously as an import which will change meaning if `a:b/i1` is added as an export

--- a/tests/cli/world-merging-export-semantic-change.wit.stderr
+++ b/tests/cli/world-merging-export-semantic-change.wit.stderr
@@ -2,5 +2,7 @@ error: updating metadata for section component-type
 
 Caused by:
     0: failed to merge worlds from two documents
-    1: failed to add export `a:b/i1`
-    2: export `a:b/i2` has a type `t` which could change meaning if this world export were added
+    1: failed to add export `x`
+    2: failed validating export of `x`
+    3: failed validating transitive import dep `a:b/i3`
+    4: world exports `a:b/i2` but it's also transitively used by an import which means that this is not valid


### PR DESCRIPTION
This commit updates the `roundtrip_wit` fuzzer to test out merging of worlds, not just merging of `Resolve`. This then fixes various bugs that cropped up where `ensure_can_add_world_exports` wasn't ensuring enough.