### PR TITLE
Update some fuzzing defaults and infrastructure

### DIFF
--- a/crates/fuzz-stats/src/bin/failed-instantiations.rs
+++ b/crates/fuzz-stats/src/bin/failed-instantiations.rs
@@ -99,6 +99,9 @@ impl State {
         let mut config = wasm_smith::Config::arbitrary(&mut u)?;
         config.allow_start_export = false;
 
+        config.exceptions_enabled = false; // Not implemented by Wasmtime
+        config.threads_enabled = false; // not enabled by default in Wasmtime
+
         // NB: just added "table64" support to this and wasmtime doesn't
         // implement that yet
         config.memory64_enabled = false;

--- a/crates/wasm-mutate/src/mutators/peephole.rs
+++ b/crates/wasm-mutate/src/mutators/peephole.rs
@@ -89,7 +89,7 @@ impl PeepholeMutator {
                 }
                 for _ in 0..localsreader.get_count() {
                     let (count, ty) = localsreader.read()?;
-                    let tymapped = PrimitiveTypeInfo::from(ty);
+                    let tymapped = PrimitiveTypeInfo::try_from(ty)?;
                     for _ in 0..count {
                         all_locals.push(tymapped);
                     }

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/analysis.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/analysis.rs
@@ -290,7 +290,7 @@ impl PeepholeMutationAnalysis {
             Lang::TableSet(..) => Ok(PrimitiveTypeInfo::Empty),
             Lang::TableGet(idx, _) => {
                 let ty = self.table_types[*idx as usize];
-                Ok(ty.element_type.into())
+                ty.element_type.try_into()
             }
             Lang::I32UseGlobal(_) => Ok(PrimitiveTypeInfo::I32),
             Lang::I64UseGlobal(_) => Ok(PrimitiveTypeInfo::I64),

--- a/crates/wasm-smith/tests/common/mod.rs
+++ b/crates/wasm-smith/tests/common/mod.rs
@@ -25,6 +25,7 @@ pub fn parser_features_from_config(config: &Config) -> WasmFeatures {
     features.set(WasmFeatures::TAIL_CALL, config.tail_call_enabled);
     features.set(WasmFeatures::FUNCTION_REFERENCES, config.gc_enabled);
     features.set(WasmFeatures::GC, config.gc_enabled);
+    features.set(WasmFeatures::THREADS, config.threads_enabled);
     features.set(
         WasmFeatures::CUSTOM_PAGE_SIZES,
         config.custom_page_sizes_enabled,

--- a/crates/wasm-smith/tests/core.rs
+++ b/crates/wasm-smith/tests/core.rs
@@ -93,6 +93,8 @@ fn smoke_can_smith_valid_webassembly_one_point_oh() {
         cfg.relaxed_simd_enabled = false;
         cfg.exceptions_enabled = false;
         cfg.memory64_enabled = false;
+        cfg.reference_types_enabled = false;
+        cfg.gc_enabled = false;
         cfg.max_memories = 1;
         cfg.max_tables = 1;
         let features = parser_features_from_config(&cfg);

--- a/fuzz/src/mutate.rs
+++ b/fuzz/src/mutate.rs
@@ -11,9 +11,10 @@ pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
 
     let mut seed = 0;
     let mut preserve_semantics = false;
-    let (wasm, _config) = crate::generate_valid_module(u, |config, u| {
-        config.exceptions_enabled = false;
-        config.gc_enabled = false;
+    let (wasm, _config) = crate::generate_valid_module(u, |_config, u| {
+        // NB: wasm-mutate is a general-purpose tool so unsupported proposals by
+        // wasm-mutate are not disabled here. Those must be rejected with a
+        // first-class error in wasm-mutate instead of panicking.
         seed = u.arbitrary()?;
         preserve_semantics = u.arbitrary()?;
         Ok(())


### PR DESCRIPTION
* Update `wasm_smith::Config` to default-enable some stage4+ proposals: `exceptions`, `gc`, `reference_types`, `relaxed_simd`, `simd`, `tail_call`, `threads`. These can still all be disabled via configuration and CLI flags.
* All stage4+ proposals are now swarm-enabled through `Arbitrary for Config`
* Default generation of modules in wasm-tools's own fuzzing no longer special-cases these proposals since they're all already handled.
* The `WasmFeatures` used for validating fuzz-generated modules now starts with a minimal baseline set of features to ensure that all proposals are disabled in the validator if the corresponding wasm-smith configuration flag is disabled.
* The `wasm-mutate` crate was updated to return errors instead of panicking for unsupported wasm proposals. All wasm proposals are now enabled when passing to `wasm-mutate`.

The primary motivation for this commit was this last point where I'm seeing panics on OSS-Fuzz for Wasmtime using `wasm-mutate` as a mutation hook because `wasm-mutate` is panicking on some GC types. When fixing that I noticed other fuzz-related things I wanted to clean up while I was here.