### PR TITLE
Start removing custom translation in wasm-mutate

### DIFF
--- a/crates/wasm-mutate/Cargo.toml
+++ b/crates/wasm-mutate/Cargo.toml
@@ -24,3 +24,4 @@ anyhow = { workspace = true }
 wat = { path = "../wat" }
 wasmprinter = { path = "../wasmprinter" }
 env_logger = { workspace = true }
+wasmparser = { workspace = true, features = ['validate', 'features'] }

--- a/crates/wasm-mutate/src/error.rs
+++ b/crates/wasm-mutate/src/error.rs
@@ -56,6 +56,16 @@ impl From<wasmparser::BinaryReaderError> for Error {
     }
 }
 
+impl From<wasm_encoder::reencode::Error<Error>> for Error {
+    fn from(e: wasm_encoder::reencode::Error<Error>) -> Self {
+        match e {
+            wasm_encoder::reencode::Error::ParseError(e) => Error::parse(e),
+            wasm_encoder::reencode::Error::UserError(e) => e,
+            other => Error::other(other.to_string()),
+        }
+    }
+}
+
 /// The kind of error.
 #[derive(thiserror::Error, Debug)]
 pub enum ErrorKind {

--- a/crates/wasmparser/src/parser.rs
+++ b/crates/wasmparser/src/parser.rs
@@ -407,6 +407,11 @@ impl Parser {
         self.features = features;
     }
 
+    /// Returns the original offset that this parser is currently at.
+    pub fn offset(&self) -> u64 {
+        self.offset
+    }
+
     /// Attempts to parse a chunk of data.
     ///
     /// This method will attempt to parse the next incremental portion of a


### PR DESCRIPTION
Now that `wasm_encoder::reencode` exists that's the better option to use for reencoding modules. This commit removes one of the major users of the equivalent `Translator` trait in `wasm_mutate` to start down the path of removing that trait entirely and instead relying on the support in `wasm_encoder`.