### PR TITLE
Added a `len` method to `wasm_encoder::Module`

### DIFF
--- a/crates/wasm-encoder/src/core.rs
+++ b/crates/wasm-encoder/src/core.rs
@@ -154,6 +154,11 @@ impl Module {
         &self.bytes
     }
 
+    /// Give the current size of the module in bytes.
+    pub fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
     /// Finish writing this Wasm module and extract ownership of the encoded
     /// bytes.
     pub fn finish(self) -> Vec<u8> {


### PR DESCRIPTION
Hi,

I have a use case where I would require to know the number of bytes of a module that has been encoded so far so I've added an API that does this.