### PR TITLE
optionally allow output world name when importizing

### DIFF
--- a/crates/wit-parser/src/resolve.rs
+++ b/crates/wit-parser/src/resolve.rs
@@ -1021,7 +1021,7 @@ package {name} is defined in two different locations:\n\
     /// bindings in a context that is importing the original world. This
     /// is intended to be used as part of language tooling when depending on
     /// other components.
-    pub fn importize(&mut self, world_id: WorldId) -> Result<()> {
+    pub fn importize(&mut self, world_id: WorldId, out_world_name: Option<String>) -> Result<()> {
         // Rename the world to avoid having it get confused with the original
         // name of the world. Add `-importized` to it for now. Precisely how
         // this new world is created may want to be updated over time if this
@@ -1029,8 +1029,13 @@ package {name} is defined in two different locations:\n\
         let world = &mut self.worlds[world_id];
         let pkg = &mut self.packages[world.package.unwrap()];
         pkg.worlds.shift_remove(&world.name);
-        world.name.push_str("-importized");
-        pkg.worlds.insert(world.name.clone(), world_id);
+        if let Some(name) = out_world_name {
+            world.name = name.clone();
+            pkg.worlds.insert(name, world_id);
+        } else {
+            world.name.push_str("-importized");
+            pkg.worlds.insert(world.name.clone(), world_id);
+        }
 
         // Trim all non-type definitions from imports. Types can be used by
         // exported functions, for example, so they're preserved.

--- a/fuzz/src/roundtrip_wit.rs
+++ b/fuzz/src/roundtrip_wit.rs
@@ -62,7 +62,7 @@ pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
         // valid.
         log::debug!("... importizing this world");
         let mut resolve2 = resolve.clone();
-        let _ = resolve2.importize(id);
+        let _ = resolve2.importize(id, None);
     }
 
     if decoded_bindgens.len() < 2 {

--- a/tests/cli/importize.wit
+++ b/tests/cli/importize.wit
@@ -1,4 +1,5 @@
 // RUN[simple]: component wit --importize-world simple %
+// RUN[simple-rename]: component wit --importize-world simple-rename --importize-out-world-name test-rename  %
 // RUN[simple-component]: component embed --dummy --world simple % | \
 //                        component wit --importize
 // RUN[with-deps]: component wit --importize-world with-deps %
@@ -31,6 +32,10 @@ interface something-else-dep {
 }
 
 world simple {
+    export t;
+}
+
+world simple-rename {
     export t;
 }
 

--- a/tests/cli/importize.wit.simple-rename.stdout
+++ b/tests/cli/importize.wit.simple-rename.stdout
@@ -47,9 +47,6 @@ interface with-dep {
 world simple {
   export t;
 }
-world simple-rename {
-  export t;
-}
 world with-deps {
   import t;
   import bar;
@@ -60,6 +57,18 @@ world simple-toplevel {
   export foo: func();
   export something: interface {
     foo: func();
+  }
+}
+world toplevel-deps {
+  import something-else-dep;
+
+  type s = u32;
+
+  export bar: func() -> s;
+  export something-else: interface {
+    use something-else-dep.{t};
+
+    bar: func() -> t;
   }
 }
 world fail1 {
@@ -83,14 +92,6 @@ world tricky-import {
 
   export f: func() -> t;
 }
-world toplevel-deps-importized {
-  import bar: func() -> s;
-  import something-else-dep;
-  import something-else: interface {
-    use something-else-dep.{t};
-
-    bar: func() -> t;
-  }
-
-  type s = u32;
+world test-rename {
+  import t;
 }

--- a/tests/cli/importize.wit.simple-toplevel.stdout
+++ b/tests/cli/importize.wit.simple-toplevel.stdout
@@ -1,4 +1,5 @@
 /// RUN[simple]: component wit --importize-world simple %
+/// RUN[simple-rename]: component wit --importize-world simple-rename --importize-out-world-name test-rename  %
 /// RUN[simple-component]: component embed --dummy --world simple % | /
 /// component wit --importize
 /// RUN[with-deps]: component wit --importize-world with-deps %
@@ -44,6 +45,9 @@ interface with-dep {
 }
 
 world simple {
+  export t;
+}
+world simple-rename {
   export t;
 }
 world with-deps {

--- a/tests/cli/importize.wit.simple.stdout
+++ b/tests/cli/importize.wit.simple.stdout
@@ -1,4 +1,5 @@
 /// RUN[simple]: component wit --importize-world simple %
+/// RUN[simple-rename]: component wit --importize-world simple-rename --importize-out-world-name test-rename  %
 /// RUN[simple-component]: component embed --dummy --world simple % | /
 /// component wit --importize
 /// RUN[with-deps]: component wit --importize-world with-deps %
@@ -43,6 +44,9 @@ interface with-dep {
   type t = u32;
 }
 
+world simple-rename {
+  export t;
+}
 world with-deps {
   import t;
   import bar;

--- a/tests/cli/importize.wit.tricky-import.stdout
+++ b/tests/cli/importize.wit.tricky-import.stdout
@@ -1,4 +1,5 @@
 /// RUN[simple]: component wit --importize-world simple %
+/// RUN[simple-rename]: component wit --importize-world simple-rename --importize-out-world-name test-rename  %
 /// RUN[simple-component]: component embed --dummy --world simple % | /
 /// component wit --importize
 /// RUN[with-deps]: component wit --importize-world with-deps %
@@ -44,6 +45,9 @@ interface with-dep {
 }
 
 world simple {
+  export t;
+}
+world simple-rename {
   export t;
 }
 world with-deps {

--- a/tests/cli/importize.wit.trim-imports.stdout
+++ b/tests/cli/importize.wit.trim-imports.stdout
@@ -1,4 +1,5 @@
 /// RUN[simple]: component wit --importize-world simple %
+/// RUN[simple-rename]: component wit --importize-world simple-rename --importize-out-world-name test-rename  %
 /// RUN[simple-component]: component embed --dummy --world simple % | /
 /// component wit --importize
 /// RUN[with-deps]: component wit --importize-world with-deps %
@@ -44,6 +45,9 @@ interface with-dep {
 }
 
 world simple {
+  export t;
+}
+world simple-rename {
   export t;
 }
 world with-deps {

--- a/tests/cli/importize.wit.with-deps.stdout
+++ b/tests/cli/importize.wit.with-deps.stdout
@@ -1,4 +1,5 @@
 /// RUN[simple]: component wit --importize-world simple %
+/// RUN[simple-rename]: component wit --importize-world simple-rename --importize-out-world-name test-rename  %
 /// RUN[simple-component]: component embed --dummy --world simple % | /
 /// component wit --importize
 /// RUN[with-deps]: component wit --importize-world with-deps %
@@ -44,6 +45,9 @@ interface with-dep {
 }
 
 world simple {
+  export t;
+}
+world simple-rename {
   export t;
 }
 world simple-toplevel {


### PR DESCRIPTION
Allow specifying output world name when importizing. This would allow multiple importized worlds to be merged. 