### PR TITLE
Fix testing for errors during fuzzing

### DIFF
--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -21,7 +21,7 @@ pub use ast::{parse_use_path, ParsedUsePath};
 mod sizealign;
 pub use sizealign::*;
 mod resolve;
-pub use resolve::{Package, PackageId, Remap, Resolve};
+pub use resolve::{InvalidTransitiveDependency, Package, PackageId, Remap, Resolve};
 mod live;
 pub use live::{LiveTypes, TypeIdVisitor};
 

--- a/crates/wit-smith/src/lib.rs
+++ b/crates/wit-smith/src/lib.rs
@@ -6,7 +6,7 @@
 //! type structures.
 
 use arbitrary::{Result, Unstructured};
-use wit_parser::Resolve;
+use wit_parser::{InvalidTransitiveDependency, Resolve};
 
 mod config;
 pub use self::config::Config;
@@ -25,10 +25,7 @@ pub fn smith(config: &Config, u: &mut Unstructured<'_>) -> Result<Vec<u8>> {
         let id = match resolve.push_group(group) {
             Ok(id) => id,
             Err(e) => {
-                if e.to_string().contains(
-                    "interface transitively depends on an interface in \
-                     incompatible ways",
-                ) {
+                if e.is::<InvalidTransitiveDependency>() {
                     return Err(arbitrary::Error::IncorrectFormat);
                 }
                 panic!("bad wit parse: {e:?}")


### PR DESCRIPTION
Create a first-class error instead of testing for error strings to ensure this is more resilient over time.