### PR TITLE
Deduplicate how many times type-related opcodes are listed

### DIFF
--- a/crates/wasmparser/src/parser.rs
+++ b/crates/wasmparser/src/parser.rs
@@ -1560,11 +1560,10 @@ mod tests {
                 payload: Payload::CodeSectionStart { count: 1, .. },
             }),
         );
-        assert!(p
-            .parse(&[0], false)
-            .unwrap_err()
-            .to_string()
-            .contains("unexpected end-of-file"));
+        assert_eq!(
+            p.parse(&[0], false).unwrap_err().message(),
+            "unexpected end-of-file"
+        );
 
         // section with 2 functions but section is cut off
         let mut p = parser_after_header();
@@ -1583,11 +1582,10 @@ mod tests {
             }),
         );
         assert_matches!(p.parse(&[], false), Ok(Chunk::NeedMoreData(1)));
-        assert!(p
-            .parse(&[0], false)
-            .unwrap_err()
-            .to_string()
-            .contains("unexpected end-of-file"));
+        assert_eq!(
+            p.parse(&[0], false).unwrap_err().message(),
+            "unexpected end-of-file",
+        );
 
         // trailing data is bad
         let mut p = parser_after_header();
@@ -1605,11 +1603,10 @@ mod tests {
                 payload: Payload::CodeSectionEntry(_),
             }),
         );
-        assert!(p
-            .parse(&[0], false)
-            .unwrap_err()
-            .to_string()
-            .contains("trailing bytes at end of section",));
+        assert_eq!(
+            p.parse(&[0], false).unwrap_err().message(),
+            "trailing bytes at end of section",
+        );
     }
 
     #[test]
@@ -1691,10 +1688,9 @@ mod tests {
         // module. This is a custom section, one byte big, with one content byte. The
         // content byte, however, lives outside of the parent's module code
         // section.
-        assert!(sub
-            .parse(&[0, 1, 0], false)
-            .unwrap_err()
-            .to_string()
-            .contains("section too large"));
+        assert_eq!(
+            sub.parse(&[0, 1, 0], false).unwrap_err().message(),
+            "section too large",
+        );
     }
 }

--- a/crates/wasmparser/src/parser.rs
+++ b/crates/wasmparser/src/parser.rs
@@ -1560,10 +1560,11 @@ mod tests {
                 payload: Payload::CodeSectionStart { count: 1, .. },
             }),
         );
-        assert_eq!(
-            p.parse(&[0], false).unwrap_err().message(),
-            "unexpected end-of-file"
-        );
+        assert!(p
+            .parse(&[0], false)
+            .unwrap_err()
+            .to_string()
+            .contains("unexpected end-of-file"));
 
         // section with 2 functions but section is cut off
         let mut p = parser_after_header();
@@ -1582,10 +1583,11 @@ mod tests {
             }),
         );
         assert_matches!(p.parse(&[], false), Ok(Chunk::NeedMoreData(1)));
-        assert_eq!(
-            p.parse(&[0], false).unwrap_err().message(),
-            "unexpected end-of-file",
-        );
+        assert!(p
+            .parse(&[0], false)
+            .unwrap_err()
+            .to_string()
+            .contains("unexpected end-of-file"));
 
         // trailing data is bad
         let mut p = parser_after_header();
@@ -1603,10 +1605,11 @@ mod tests {
                 payload: Payload::CodeSectionEntry(_),
             }),
         );
-        assert_eq!(
-            p.parse(&[0], false).unwrap_err().message(),
-            "trailing bytes at end of section",
-        );
+        assert!(p
+            .parse(&[0], false)
+            .unwrap_err()
+            .to_string()
+            .contains("trailing bytes at end of section",));
     }
 
     #[test]
@@ -1688,9 +1691,10 @@ mod tests {
         // module. This is a custom section, one byte big, with one content byte. The
         // content byte, however, lives outside of the parent's module code
         // section.
-        assert_eq!(
-            sub.parse(&[0, 1, 0], false).unwrap_err().message(),
-            "section too large",
-        );
+        assert!(sub
+            .parse(&[0, 1, 0], false)
+            .unwrap_err()
+            .to_string()
+            .contains("section too large"));
     }
 }

--- a/crates/wasmparser/src/readers/core/types.rs
+++ b/crates/wasmparser/src/readers/core/types.rs
@@ -1715,8 +1715,8 @@ impl<'a> FromReader<'a> for ValType {
                 // that's the "root" of what was being parsed rather than
                 // reference types.
                 let refty = reader.read().map_err(|mut e| {
-                    if let BinaryReaderErrorKind::Invalid(msg) = e.kind_mut() {
-                        *msg = "invalid value type";
+                    if let BinaryReaderErrorKind::Invalid = e.kind() {
+                        e.set_message("invalid value type");
                     }
                     e
                 })?;
@@ -1742,8 +1742,8 @@ impl<'a> FromReader<'a> for RefType {
                 // that's the "root" of what was being parsed rather than
                 // heap types.
                 let hty = reader.read().map_err(|mut e| {
-                    if let BinaryReaderErrorKind::Invalid(msg) = e.kind_mut() {
-                        *msg = "malformed reference type";
+                    if let BinaryReaderErrorKind::Invalid = e.kind() {
+                        e.set_message("malformed reference type");
                     }
                     e
                 })?;
@@ -1788,8 +1788,8 @@ impl<'a> FromReader<'a> for HeapType {
                     // that's the "root" of what was being parsed rather than
                     // abstract heap types.
                     let ty = reader.read().map_err(|mut e| {
-                        if let BinaryReaderErrorKind::Invalid(msg) = e.kind_mut() {
-                            *msg = "invalid heap type";
+                        if let BinaryReaderErrorKind::Invalid = e.kind() {
+                            e.set_message("invalid heap type");
                         }
                         e
                     })?;


### PR DESCRIPTION
This commit refactors the parsing of core types in wasmparser to deduplicate the number of times that opcodes for particular types are listed. Previously each layer of parsing types would check for all valid prefixes and then delegate to a "lower" parser if applicable. This meant though that a type's opcode was listed at each layer it could be parsed, resulting in duplication.

Instead now types only parse what is exclusive to that layer and then a lower layer parses everything else. The only gotcha with this is to preserve reasonable error messages (lest every error become "invalid abstract heap type"). For this a new `BinaryReaderErrorKind` enum (internal) was added which is used to track this and the message is updated as parsing fails and errors progress upwards.