### PR TITLE
Fix a typo about `unbundle` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ that can be use programmatically as well:
 | `wasm-tools component new` | [wit-component] |  | Create a component from a core wasm binary |
 | `wasm-tools component wit` |  |  | Extract a `*.wit` interface from a component |
 | `wasm-tools component embed` |  |  | Embed a `component-type` custom section in a core wasm binary |
+| `wasm-tools component unbundle` |  |  | Extract core wasm modules from a component |
 | `wasm-tools metadata show` |  [wasm-metadata] |  | Show name and producer metadata in a component or module |
 | `wasm-tools metadata add` |  |  | Add name or producer metadata to a component or module |
-| `wasm-tools metadata unbundle` |  |  | Extract core wasm modules from a component |
 | `wasm-tools addr2line` |  |  | Translate wasm offsets to filename/line numbers with DWARF |
 | `wasm-tools completion` |  |  | Generate shell completion scripts for `wasm-tools` |
 | `wasm-tools json-from-wast` |  |  | Convert a `*.wast` file into JSON commands |


### PR DESCRIPTION
My own copy/paste mistake...