### PR TITLE
Auto-generate release notes for releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,6 +77,7 @@ jobs:
       if: steps.tag.outputs.push_tag == 'yes'
       with:
         files: "dist/*"
+        generate_release_notes: true
         tag_name: v${{ steps.tag.outputs.version }}
 
     - run: |


### PR DESCRIPTION
While #1826 is figured out this is probably better than nothing, so set this flag to get GitHub's auto-generated release notes.