### PR TITLE
Enhance `print` and `validate` fuzzers

### DIFF
--- a/crates/wasmprinter/src/lib.rs
+++ b/crates/wasmprinter/src/lib.rs
@@ -48,7 +48,7 @@ pub fn print_bytes(wasm: impl AsRef<[u8]>) -> Result<String> {
 ///
 /// This structure is used to control the overal structure of how wasm binaries
 /// are printed and tweaks various ways that configures the output.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct Config {
     print_offsets: bool,
     print_skeleton: bool,

--- a/fuzz/src/print.rs
+++ b/fuzz/src/print.rs
@@ -1,7 +1,15 @@
 use arbitrary::{Result, Unstructured};
 
 pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
+    let mut cfg = wasmprinter::Config::new();
+    cfg.fold_instructions(u.arbitrary()?);
+    cfg.print_skeleton(u.arbitrary()?);
+    cfg.print_offsets(u.arbitrary()?);
+    cfg.name_unnamed(u.arbitrary()?);
+
     let data = u.bytes(u.len())?;
-    drop(wasmprinter::print_bytes(data));
+    crate::log_wasm(&data, &cfg);
+    let mut dst = String::new();
+    let _ = cfg.print(&data, &mut wasmprinter::PrintFmtWrite(&mut dst));
     Ok(())
 }


### PR DESCRIPTION
This commit updates these two fuzzers, which just have random bytes thrown at them, to additionally fuzz various config options in `wasmprinter`. The `validate` fuzzer in particular is going to be interesting since it creates "halfway invalid" modules where the structure is valid and random bytes may be thrown in a function body. That should stress various bits and pieces of the internals of `wasmprinter` in addition to `wasmparser`.