### PR TITLE
Add a `component-model` feature to wat/wast/wasm-encoder

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -247,6 +247,10 @@ jobs:
       - run: cargo check --no-default-features -p wasmparser --features serde,no-hash-maps
       - run: cargo check --no-default-features -p wast
       - run: cargo check --no-default-features -p wast --features wasm-module
+      - run: cargo check --no-default-features -p wast --features wasm-module,component-model
+      - run: cargo check --no-default-features -p wat
+      - run: cargo check --no-default-features -p wat --features component-model
+      - run: cargo check --no-default-features -p wat --features dwarf
       - run: |
           if cargo tree -p wasm-smith --no-default-features -e no-dev | grep wasmparser; then
             echo wasm-smith without default features should not depend on wasmparser

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -251,6 +251,9 @@ jobs:
       - run: cargo check --no-default-features -p wat
       - run: cargo check --no-default-features -p wat --features component-model
       - run: cargo check --no-default-features -p wat --features dwarf
+      - run: cargo check --no-default-features -p wasm-encoder
+      - run: cargo check --no-default-features -p wasm-encoder --features component-model
+      - run: cargo check --no-default-features -p wasm-encoder --features wasmparser
       - run: |
           if cargo tree -p wasm-smith --no-default-features -e no-dev | grep wasmparser; then
             echo wasm-smith without default features should not depend on wasmparser

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ gimli = "0.30.0"
 id-arena = "2"
 
 wasm-compose = { version = "0.218.0", path = "crates/wasm-compose" }
-wasm-encoder = { version = "0.218.0", path = "crates/wasm-encoder" }
+wasm-encoder = { version = "0.218.0", path = "crates/wasm-encoder", default-features = false }
 wasm-metadata = { version = "0.218.0", path = "crates/wasm-metadata" }
 wasm-mutate = { version = "0.218.0", path = "crates/wasm-mutate" }
 wasm-shrink = { version = "0.218.0", path = "crates/wasm-shrink" }

--- a/crates/wasm-encoder/Cargo.toml
+++ b/crates/wasm-encoder/Cargo.toml
@@ -31,3 +31,10 @@ anyhow = { workspace = true }
 tempfile = "3.2.0"
 wasmparser = { path = "../wasmparser" }
 wasmprinter = { path = "../wasmprinter" }
+
+[features]
+default = ['component-model']
+
+# On-by-default: conditional support for emitting components in addition to
+# core modules.
+component-model = []

--- a/crates/wasm-encoder/src/lib.rs
+++ b/crates/wasm-encoder/src/lib.rs
@@ -71,12 +71,14 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(missing_docs, missing_debug_implementations)]
 
+#[cfg(feature = "component-model")]
 mod component;
 mod core;
 mod raw;
 #[cfg(feature = "wasmparser")]
 pub mod reencode;
 
+#[cfg(feature = "component-model")]
 pub use self::component::*;
 pub use self::core::*;
 pub use self::raw::*;

--- a/crates/wasm-encoder/src/raw.rs
+++ b/crates/wasm-encoder/src/raw.rs
@@ -1,4 +1,4 @@
-use crate::{ComponentSection, Encode, Section};
+use crate::{Encode, Section};
 
 /// A section made up of uninterpreted, raw bytes.
 ///
@@ -23,7 +23,8 @@ impl Section for RawSection<'_> {
     }
 }
 
-impl ComponentSection for RawSection<'_> {
+#[cfg(feature = "component-model")]
+impl crate::ComponentSection for RawSection<'_> {
     fn id(&self) -> u8 {
         self.id
     }

--- a/crates/wasm-encoder/src/reencode.rs
+++ b/crates/wasm-encoder/src/reencode.rs
@@ -6,8 +6,10 @@
 use crate::CoreTypeEncoder;
 use std::convert::Infallible;
 
+#[cfg(feature = "component-model")]
 mod component;
 
+#[cfg(feature = "component-model")]
 pub use self::component::*;
 
 #[allow(missing_docs)] // FIXME

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -35,7 +35,7 @@ wat = { path = "../wat" }
 rand = { workspace = true }
 
 [features]
-default = ['wasm-module']
+default = ['wasm-module', 'component-model']
 
 # Includes default parsing support for `*.wat` and `*.wast` files (wasm
 # modules). This isn't always needed though if you're parsing just an
@@ -49,6 +49,10 @@ wasm-module = []
 # parsed binaries pointing back to source locations in the original `*.wat`
 # source.
 dwarf = ["dep:gimli"]
+
+# On-by-default this builds in support for parsing the text format of
+# components.
+component-model = ['wasm-module']
 
 [[test]]
 name = "parse-fail"

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -52,7 +52,7 @@ dwarf = ["dep:gimli"]
 
 # On-by-default this builds in support for parsing the text format of
 # components.
-component-model = ['wasm-module']
+component-model = ['wasm-module', 'wasm-encoder/component-model']
 
 [[test]]
 name = "parse-fail"

--- a/crates/wast/src/component/binary.rs
+++ b/crates/wast/src/component/binary.rs
@@ -1,7 +1,7 @@
 use crate::component::*;
 use crate::core;
 use crate::core::EncodeOptions;
-use crate::token::{Id, Index, NameAnnotation};
+use crate::token::{Id, NameAnnotation};
 use wasm_encoder::{
     CanonicalFunctionSection, ComponentAliasSection, ComponentCoreTypeEncoder,
     ComponentDefinedTypeEncoder, ComponentExportSection, ComponentImportSection,
@@ -583,27 +583,6 @@ impl From<&CoreItemRef<'_, core::ExportKind>> for (wasm_encoder::ExportKind, u32
             core::ExportKind::Memory => (wasm_encoder::ExportKind::Memory, item.idx.into()),
             core::ExportKind::Global => (wasm_encoder::ExportKind::Global, item.idx.into()),
             core::ExportKind::Tag => (wasm_encoder::ExportKind::Tag, item.idx.into()),
-        }
-    }
-}
-
-impl From<core::ExportKind> for wasm_encoder::ExportKind {
-    fn from(kind: core::ExportKind) -> Self {
-        match kind {
-            core::ExportKind::Func => Self::Func,
-            core::ExportKind::Table => Self::Table,
-            core::ExportKind::Memory => Self::Memory,
-            core::ExportKind::Global => Self::Global,
-            core::ExportKind::Tag => Self::Tag,
-        }
-    }
-}
-
-impl From<Index<'_>> for u32 {
-    fn from(i: Index<'_>) -> Self {
-        match i {
-            Index::Num(i, _) => i,
-            Index::Id(_) => unreachable!("unresolved index in encoding: {:?}", i),
         }
     }
 }

--- a/crates/wast/src/component/component.rs
+++ b/crates/wast/src/component/component.rs
@@ -8,6 +8,7 @@ use crate::token::{Id, NameAnnotation, Span};
 
 /// A parsed WebAssembly component module.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct Component<'a> {
     /// Where this `component` was defined
     pub span: Span,

--- a/crates/wast/src/component_disabled.rs
+++ b/crates/wast/src/component_disabled.rs
@@ -1,0 +1,30 @@
+//! Disabled support for the component model.
+
+use crate::parser::{Parse, Parser, Result};
+use crate::token::{Id, Span};
+
+#[derive(Debug)]
+enum Uninhabited {}
+
+/// Empty definition of a component that cannot be created.
+#[derive(Debug)]
+pub struct Component<'a> {
+    /// Where this `component` was defined
+    pub span: Span,
+    /// An optional identifier this component is known by
+    pub id: Option<Id<'a>>,
+
+    x: Uninhabited,
+}
+
+impl Component<'_> {
+    pub(crate) fn validate(&self, _parser: Parser<'_>) -> Result<()> {
+        match self.x {}
+    }
+}
+
+impl<'a> Parse<'a> for Component<'a> {
+    fn parse(parser: Parser<'a>) -> Result<Self> {
+        Err(parser.error("support for parsing components disabled at compile time"))
+    }
+}

--- a/crates/wast/src/core/resolve/mod.rs
+++ b/crates/wast/src/core/resolve/mod.rs
@@ -6,6 +6,7 @@ mod deinline_import_export;
 mod names;
 pub(crate) mod types;
 
+#[cfg(feature = "component-model")]
 pub(crate) use names::ResolveCoreType;
 
 #[derive(PartialEq, Eq, Hash, Copy, Clone, Debug)]

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -377,6 +377,10 @@ id! {
     pub mod core;
 
     // Support for component model parsing
+    #[cfg(feature = "component-model")]
+    pub mod component;
+    #[cfg(not(feature = "component-model"))]
+    #[path = "component_disabled.rs"]
     pub mod component;
 }
 

--- a/crates/wat/Cargo.toml
+++ b/crates/wat/Cargo.toml
@@ -23,7 +23,12 @@ workspace = true
 wast = { workspace = true }
 
 [features]
+default = ['component-model']
+
 # Off-by-default feature to support emitting DWARF debugging information in
 # parsed binaries pointing back to source locations in the original `*.wat`
 # source.
 dwarf = ['wast/dwarf']
+
+# On-by-default feature to support parsing the component model text format.
+component-model = []


### PR DESCRIPTION
I case users want to disable the component model proposal this can be useful to cut down on both binary size and compilation time of these crates themselves. Additionally this helps keep component bits more cleanly separable from the rest of the various bits. Note that the component-model features remains on-by-default.