### PR TITLE
Gate wasm-smith component support behind a feature

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,6 +119,7 @@ jobs:
     - run: cargo test --locked -p wasmparser --benches
     - run: cargo test --locked -p wasm-encoder --all-features
     - run: cargo test -p wasm-smith --features wasmparser
+    - run: cargo test -p wasm-smith --features component-model
 
   test_capi:
     name: Test the C API
@@ -258,6 +259,10 @@ jobs:
       - run: cargo check --no-default-features -p wasm-encoder
       - run: cargo check --no-default-features -p wasm-encoder --features component-model
       - run: cargo check --no-default-features -p wasm-encoder --features wasmparser
+      - run: cargo check --no-default-features -p wasm-smith
+      - run: cargo check --no-default-features -p wasm-smith --features component-model
+      - run: cargo check --no-default-features -p wasm-smith --features wasmparser
+      - run: cargo check --no-default-features -p wasm-smith --features wasmparser,component-model
       - run: |
           if cargo tree -p wasm-smith --no-default-features -e no-dev | grep wasmparser; then
             echo wasm-smith without default features should not depend on wasmparser

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -12,6 +12,9 @@ version.workspace = true
 exclude = ["/benches/corpus"]
 rust-version.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+
 [[bench]]
 name = "corpus"
 harness = false
@@ -28,7 +31,7 @@ indexmap = { workspace = true }
 leb128 = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
-wasm-encoder = { workspace = true, features = ['component-model'] }
+wasm-encoder = { workspace = true }
 wasmparser = { workspace = true, optional = true, features = ['validate'] }
 wat = { workspace = true, optional = true }
 
@@ -45,3 +48,4 @@ libfuzzer-sys = { workspace = true }
 [features]
 _internal_cli = ["clap", "flagset/serde", "serde", "serde_derive", "wasmparser", "wat"]
 wasmparser = ['dep:wasmparser', 'wasm-encoder/wasmparser']
+component-model = ['wasm-encoder/component-model']

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -278,7 +278,7 @@ pub(crate) struct CompositeType {
 }
 
 impl CompositeType {
-    #[cfg(feature = "component-model")]
+    #[cfg(any(feature = "component-model", feature = "wasmparser"))]
     pub(crate) fn new_func(func: Rc<FuncType>, shared: bool) -> Self {
         Self {
             inner: CompositeInnerType::Func(func),

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -278,6 +278,7 @@ pub(crate) struct CompositeType {
 }
 
 impl CompositeType {
+    #[cfg(feature = "component-model")]
     pub(crate) fn new_func(func: Rc<FuncType>, shared: bool) -> Self {
         Self {
             inner: CompositeInnerType::Func(func),

--- a/crates/wasm-smith/src/lib.rs
+++ b/crates/wasm-smith/src/lib.rs
@@ -50,16 +50,19 @@
 //! The design and implementation strategy of wasm-smith is outlined in
 //! [this article](https://fitzgeraldnick.com/2020/08/24/writing-a-test-case-generator.html).
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(missing_docs, missing_debug_implementations)]
 // Needed for the `instructions!` macro in `src/code_builder.rs`.
 #![recursion_limit = "512"]
 
+#[cfg(feature = "component-model")]
 mod component;
 mod config;
 mod core;
 
 pub use crate::core::{InstructionKind, InstructionKinds, Module};
 use arbitrary::{Result, Unstructured};
+#[cfg(feature = "component-model")]
 pub use component::Component;
 pub use config::{Config, MemoryOffsetChoices};
 use std::{collections::HashSet, fmt::Write, str};
@@ -137,6 +140,7 @@ pub(crate) fn unique_string(
     Ok(name)
 }
 
+#[cfg(feature = "component-model")]
 pub(crate) fn unique_kebab_string(
     max_size: usize,
     names: &mut HashSet<String>,
@@ -185,6 +189,7 @@ pub(crate) fn unique_kebab_string(
     Ok(name)
 }
 
+#[cfg(feature = "component-model")]
 pub(crate) fn unique_url(
     max_size: usize,
     names: &mut HashSet<String>,

--- a/crates/wasm-smith/tests/component.rs
+++ b/crates/wasm-smith/tests/component.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "component-model")]
+
 use arbitrary::{Arbitrary, Unstructured};
 use rand::{rngs::SmallRng, RngCore, SeedableRng};
 use wasm_smith::Component;

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -18,7 +18,7 @@ libfuzzer-sys = { workspace = true }
 log = { workspace = true }
 tempfile = "3.0"
 wasm-mutate = { path = "../crates/wasm-mutate" }
-wasm-smith = { path = "../crates/wasm-smith" }
+wasm-smith = { path = "../crates/wasm-smith", features = ['component-model'] }
 wasmparser = { path = "../crates/wasmparser" }
 wasmprinter = { path = "../crates/wasmprinter" }
 wasmtime = { workspace = true, optional = true }


### PR DESCRIPTION
This feature is additionally off-by-default because the component support of `wasm-smith` has fallen quite far behind where components are at today.