### PR TITLE
Update a few feature-related details

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,8 +104,8 @@ wasm-shrink = { version = "0.218.0", path = "crates/wasm-shrink" }
 wasm-smith = { version = "0.218.0", path = "crates/wasm-smith" }
 wasmparser = { version = "0.218.0", path = "crates/wasmparser", default-features = false, features = ['std'] }
 wasmprinter = { version = "0.218.0", path = "crates/wasmprinter", default-features = false }
-wast = { version = "218.0.0", path = "crates/wast" }
-wat = { version = "1.218.0", path = "crates/wat" }
+wast = { version = "218.0.0", path = "crates/wast", default-features = false }
+wat = { version = "1.218.0", path = "crates/wat", default-features = false }
 wit-component = { version = "0.218.0", path = "crates/wit-component" }
 wit-encoder = { version = "0.218.0", path = "crates/wit-encoder" }
 wit-parser = { version = "0.218.0", path = "crates/wit-parser" }
@@ -118,7 +118,7 @@ log = { workspace = true }
 clap = { workspace = true, features = ['wrap_help'] }
 clap_complete = { workspace = true, optional = true }
 tempfile = "3.2.0"
-wat = { workspace = true, features = ['dwarf'] }
+wat = { workspace = true, features = ['dwarf', 'component-model'] }
 termcolor = { workspace = true }
 
 # Dependencies of `validate`
@@ -175,7 +175,7 @@ is_executable = { version = "1.0.1", optional = true }
 [dev-dependencies]
 serde_json = "1.0"
 tempfile = "3.1"
-wast = { path = 'crates/wast' }
+wast = { workspace = true }
 pretty_assertions = { workspace = true }
 libtest-mimic = { workspace = true }
 indexmap = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ rayon = { workspace = true, optional = true }
 bitflags = { workspace = true, optional = true }
 
 # Dependencies of `print`
-wasmprinter = { workspace = true }
+wasmprinter = { workspace = true, features = ['component-model'] }
 
 # Dependencies of `smith`
 arbitrary = { workspace = true, optional = true }

--- a/crates/wasm-compose/Cargo.toml
+++ b/crates/wasm-compose/Cargo.toml
@@ -16,8 +16,8 @@ workspace = true
 
 [dependencies]
 wat = { workspace = true }
-wasm-encoder = { workspace = true, features = ['wasmparser'] }
-wasmparser = { workspace = true, features = ['validate'] }
+wasm-encoder = { workspace = true, features = ['wasmparser', 'component-model'] }
+wasmparser = { workspace = true, features = ['validate', 'component-model'] }
 indexmap = { workspace = true, features = ["serde"] }
 anyhow = { workspace = true }
 serde = { workspace = true }

--- a/crates/wat/Cargo.toml
+++ b/crates/wat/Cargo.toml
@@ -20,7 +20,7 @@ all-features = true
 workspace = true
 
 [dependencies]
-wast = { workspace = true }
+wast = { workspace = true, features = ['wasm-module'] }
 
 [features]
 default = ['component-model']
@@ -31,4 +31,4 @@ default = ['component-model']
 dwarf = ['wast/dwarf']
 
 # On-by-default feature to support parsing the component model text format.
-component-model = []
+component-model = ['wast/component-model']


### PR DESCRIPTION
* Turn off default-features in the workspace for `wat` and `wast` crates
* Opt-in to `component-model` support on the CLI for some more dependencies 