### PR TITLE
Update proposals in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,11 +183,12 @@ Currently implemented proposals in this repository that are stage 4+ are:
 * [x] [annotations](https://github.com/WebAssembly/annotations)
 * [x] [branch-hinting](https://github.com/WebAssembly/branch-hinting)
 * [x] [bulk-memory](https://github.com/WebAssembly/bulk-memory-operations)
+* [x] [component-model](https://github.com/WebAssembly/component-model) (note
+  this is an exception, it's not stage4+ but is on-by-default)
 * [x] [exceptions](https://github.com/WebAssembly/exceptions)
 * [x] [extended-const](https://github.com/WebAssembly/extended-const)
 * [x] [function-references](https://github.com/WebAssembly/function-references)
 * [x] [gc](https://github.com/WebAssembly/gc)
-* [x] [memory64](https://github.com/WebAssembly/memory64)
 * [x] [multi-memory](https://github.com/WebAssembly/multi-memory)
 * [x] [multi-value](https://github.com/WebAssembly/multi-value)
 * [x] [mutable-global](https://github.com/WebAssembly/mutable-global)
@@ -204,11 +205,12 @@ they are disabled by default in validation and their implementation may change
 over time as the proposal evolves. Additionally the proposal may also have
 changed since these proposals were implemented, so there may be a mismatch too.
 
-* [x] [component-model](https://github.com/WebAssembly/component-model)
 * [x] [custom-page-sizes](https://github.com/WebAssembly/custom-page-sizes)
 * [x] [memory-control](https://github.com/WebAssembly/memory-control)
+* [x] [memory64](https://github.com/WebAssembly/memory64)
 * [x] [shared-everything-threads](https://github.com/WebAssembly/shared-everything-threads)
 * [x] [stack-switching](https://github.com/WebAssembly/stack-switching)
+* [x] [wide-arithmetic](https://github.com/WebAssembly/wide-arithmetic)
 
 # Libraries
 


### PR DESCRIPTION
* The `memory64` proposal is disabled-by-default
* The `wide-airthmetic` proposal was just implemented
* The `component-model` proposal is on-by-default despite not being stage4+