### PR TITLE
Expose the configured `WasmFeatures` from `FuncValidator`

### DIFF
--- a/crates/wasmparser/src/validator/func.rs
+++ b/crates/wasmparser/src/validator/func.rs
@@ -189,6 +189,11 @@ impl<T: WasmModuleResources> FuncValidator<T> {
         self.validator.finish(offset)
     }
 
+    /// Returns the Wasm features enabled for this validator.
+    pub fn features(&self) -> &WasmFeatures {
+        &self.validator.features
+    }
+
     /// Returns the underlying module resources that this validator is using.
     pub fn resources(&self) -> &T {
         &self.resources


### PR DESCRIPTION
This is useful for Wasmtime to check whether it should emit full subtyping checks on `call_indirect` instructions when the Wasm GC proposal is enabled or just do a strict equality test.