### PR TITLE
Update unicode-width to 0.2.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Many crates in this repository (located in `crates/*`) both have unit tests
 $ cargo test -p wasmparser
 ```
 
-Running all tests can be done by fist ensuring that the spec test suite is
+Running all tests can be done by first ensuring that the spec test suite is
 checked out:
 
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1552,9 +1552,9 @@ checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -21,7 +21,7 @@ workspace = true
 
 [dependencies]
 leb128 = { workspace = true }
-unicode-width = "0.1.9"
+unicode-width = "0.2.0"
 memchr = "2.4.1"
 wasm-encoder = { workspace = true }
 bumpalo = "3.14.0"


### PR DESCRIPTION
This updates the unicode-width crate to 0.2.0. The library now uses different widths for some control characters, but it doesn't look like the changes affect wast.