### PR TITLE
Skip Wasmtime in no_traps for wide-arithmetic

### DIFF
--- a/fuzz/src/no_traps.rs
+++ b/fuzz/src/no_traps.rs
@@ -30,6 +30,10 @@ pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
     if config.custom_page_sizes_enabled {
         return Ok(());
     }
+    // Not implemented in wasmtime at this time.
+    if config.wide_arithmetic_enabled {
+        return Ok(());
+    }
 
     #[cfg(feature = "wasmtime")]
     {


### PR DESCRIPTION
The published version of Wasmtime in use doesn't support wide arithmetic so skip the test execution in Wasmtime in that case.