### PR TITLE
`wasmparser`: Allow to drop hash-based dependencies entirely

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
         name: bins-${{ matrix.build }}
         path: dist
 
-  test-no-hash-maps:
+  test-prefer-btree-collections:
     name: Test (no-hash-maps)
     runs-on: ubuntu-latest
     steps:
@@ -64,8 +64,8 @@ jobs:
         with:
           submodules: true
       - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v20.0.0
-      - name: Test (no-hash-maps)
-        run: cargo test --workspace --locked --features no-hash-maps
+      - name: Test (prefer-btree-collections)
+        run: cargo test --workspace --locked --features prefer-btree-collections
 
   test:
     name: Test
@@ -238,14 +238,14 @@ jobs:
       - run: cargo check --no-default-features -p wasmparser
       - run: cargo check --no-default-features -p wasmparser --target x86_64-unknown-none
       - run: cargo check --no-default-features -p wasmparser --target x86_64-unknown-none --features validate,serde
-      - run: cargo check --no-default-features -p wasmparser --target x86_64-unknown-none --features validate,serde,no-hash-maps
+      - run: cargo check --no-default-features -p wasmparser --target x86_64-unknown-none --features validate,serde,prefer-btree-collections
       - run: cargo check --no-default-features -p wasmparser --features std
       - run: cargo check --no-default-features -p wasmparser --features validate
       - run: cargo check --no-default-features -p wasmparser --features features
       - run: cargo check --no-default-features -p wasmparser --features features,validate
-      - run: cargo check --no-default-features -p wasmparser --features no-hash-maps
+      - run: cargo check --no-default-features -p wasmparser --features prefer-btree-collections
       - run: cargo check --no-default-features -p wasmparser --features serde
-      - run: cargo check --no-default-features -p wasmparser --features serde,no-hash-maps
+      - run: cargo check --no-default-features -p wasmparser --features serde,prefer-btree-collections
       - run: cargo check --no-default-features -p wasmparser --features component-model
       - run: cargo check --no-default-features -p wasmparser --features component-model,validate
       - run: cargo check --no-default-features -p wasmparser --features std,component-model
@@ -315,7 +315,7 @@ jobs:
       - verify-publish
       - test_capi
       - test_extra_features
-      - test-no-hash-maps
+      - test-prefer-btree-collections
       - clippy
     if: always()
 

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -43,7 +43,7 @@ name = "benchmark"
 harness = false
 
 [features]
-default = ['std', 'validate', 'serde', 'features', 'component-model']
+default = ['std', 'validate', 'serde', 'features', 'component-model', 'hash-collections']
 
 # A feature which enables implementations of `std::error::Error` as appropriate
 # along with other convenience APIs. This additionally uses the standard

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -50,21 +50,24 @@ default = ['std', 'validate', 'serde', 'features', 'component-model']
 # library's source of randomness for seeding hash maps.
 std = ['indexmap/std']
 
-# Tells the wasmparser crate to avoid using hash based maps and sets.
-#
-# Some embedded environments cannot provide a random source which is required
-# to properly initialize hashmap based data structures for resilience against
-# malious actors that control their inputs.
-no-hash-maps = []
+# Tells the `wasmparser` crate to provide (and use) hash-based collections internally.
+hash-collections = [
+  'dep:hashbrown',
+  'dep:indexmap',
+  'dep:ahash',
+]
+# Tells the `wasmparser` crate to prefer using its built-in btree-based collections 
+# even if `hash-collections` is enabled.
+prefer-btree-collections = []
 
 # A feature that enables validating WebAssembly files. This is enabled by
 # default but not required if you're only parsing a file, for example, as
 # opposed to validating all of its contents.
 validate = [
-  'dep:indexmap',
+  # 'dep:indexmap',
   'dep:semver',
-  'dep:hashbrown',
-  'dep:ahash',
+  # 'dep:hashbrown',
+  # 'dep:ahash',
 ]
 
 # Enable Serialize/Deserialize implementations for types in

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -51,6 +51,9 @@ default = ['std', 'validate', 'serde', 'features', 'component-model']
 std = ['indexmap/std']
 
 # Tells the `wasmparser` crate to provide (and use) hash-based collections internally.
+#
+# Disabling this crate feature allows to drop `hashbrown`, `indexmap` and `ahash` dependencies
+# entirely, reducing compilation times and shrink binary sizes.
 hash-collections = [
   'dep:hashbrown',
   'dep:indexmap',

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -63,12 +63,7 @@ prefer-btree-collections = []
 # A feature that enables validating WebAssembly files. This is enabled by
 # default but not required if you're only parsing a file, for example, as
 # opposed to validating all of its contents.
-validate = [
-  # 'dep:indexmap',
-  'dep:semver',
-  # 'dep:hashbrown',
-  # 'dep:ahash',
-]
+validate = ['dep:semver']
 
 # Enable Serialize/Deserialize implementations for types in
 # `wasmparser::collections`

--- a/crates/wasmparser/src/collections/index_map.rs
+++ b/crates/wasmparser/src/collections/index_map.rs
@@ -109,10 +109,7 @@ where
     /// Reserves capacity for at least `additional` more elements to be inserted in the [`IndexMap`].
     #[inline]
     pub fn reserve(&mut self, additional: usize) {
-        #[cfg(not(feature = "no-hash-maps"))]
         self.inner.reserve(additional);
-        #[cfg(feature = "no-hash-maps")]
-        let _ = additional;
     }
 
     /// Returns true if `key` is contains in the [`IndexMap`].

--- a/crates/wasmparser/src/collections/index_map/detail.rs
+++ b/crates/wasmparser/src/collections/index_map/detail.rs
@@ -1,6 +1,6 @@
 //! An ordered map based on a B-Tree that keeps insertion order of elements.
 
-#[cfg(not(feature = "no-hash-maps"))]
+#[cfg(all(feature = "hash-collections", not(feature = "prefer-btree-collections")))]
 mod impls {
     use crate::collections::hash;
     use indexmap::IndexMap;
@@ -17,7 +17,7 @@ mod impls {
     pub type ValuesMutImpl<'a, K, V> = indexmap::map::ValuesMut<'a, K, V>;
 }
 
-#[cfg(feature = "no-hash-maps")]
+#[cfg(any(not(feature = "hash-collections"), feature = "prefer-btree-collections"))]
 mod impls {
     pub type IndexMapImpl<K, V> = super::IndexMap<K, V>;
     pub type EntryImpl<'a, K, V> = super::Entry<'a, K, V>;

--- a/crates/wasmparser/src/collections/index_map/detail.rs
+++ b/crates/wasmparser/src/collections/index_map/detail.rs
@@ -1,6 +1,9 @@
 //! An ordered map based on a B-Tree that keeps insertion order of elements.
 
-#[cfg(all(feature = "hash-collections", not(feature = "prefer-btree-collections")))]
+#[cfg(all(
+    feature = "hash-collections",
+    not(feature = "prefer-btree-collections")
+))]
 mod impls {
     use crate::collections::hash;
     use indexmap::IndexMap;
@@ -17,7 +20,10 @@ mod impls {
     pub type ValuesMutImpl<'a, K, V> = indexmap::map::ValuesMut<'a, K, V>;
 }
 
-#[cfg(any(not(feature = "hash-collections"), feature = "prefer-btree-collections"))]
+#[cfg(any(
+    not(feature = "hash-collections"),
+    feature = "prefer-btree-collections"
+))]
 mod impls {
     pub type IndexMapImpl<K, V> = super::IndexMap<K, V>;
     pub type EntryImpl<'a, K, V> = super::Entry<'a, K, V>;

--- a/crates/wasmparser/src/collections/map.rs
+++ b/crates/wasmparser/src/collections/map.rs
@@ -3,7 +3,10 @@
 use core::fmt::Debug;
 use core::{borrow::Borrow, hash::Hash, iter::FusedIterator, ops::Index};
 
-#[cfg(all(feature = "hash-collections", not(feature = "prefer-btree-collections")))]
+#[cfg(all(
+    feature = "hash-collections",
+    not(feature = "prefer-btree-collections")
+))]
 mod detail {
     use crate::collections::hash;
     use hashbrown::hash_map;
@@ -22,7 +25,10 @@ mod detail {
     pub type IntoValuesImpl<K, V> = hash_map::IntoValues<K, V>;
 }
 
-#[cfg(any(not(feature = "hash-collections"), feature = "prefer-btree-collections"))]
+#[cfg(any(
+    not(feature = "hash-collections"),
+    feature = "prefer-btree-collections"
+))]
 mod detail {
     use alloc::collections::btree_map;
 
@@ -155,9 +161,15 @@ where
     /// Reserves capacity for at least `additional` more elements to be inserted in the [`Map`].
     #[inline]
     pub fn reserve(&mut self, additional: usize) {
-        #[cfg(all(feature = "hash-collections", not(feature = "prefer-btree-collections")))]
+        #[cfg(all(
+            feature = "hash-collections",
+            not(feature = "prefer-btree-collections")
+        ))]
         self.inner.reserve(additional);
-        #[cfg(any(not(feature = "hash-collections"), feature = "prefer-btree-collections"))]
+        #[cfg(any(
+            not(feature = "hash-collections"),
+            feature = "prefer-btree-collections"
+        ))]
         let _ = additional;
     }
 

--- a/crates/wasmparser/src/collections/map.rs
+++ b/crates/wasmparser/src/collections/map.rs
@@ -3,7 +3,7 @@
 use core::fmt::Debug;
 use core::{borrow::Borrow, hash::Hash, iter::FusedIterator, ops::Index};
 
-#[cfg(not(feature = "no-hash-maps"))]
+#[cfg(all(feature = "hash-collections", not(feature = "prefer-btree-collections")))]
 mod detail {
     use crate::collections::hash;
     use hashbrown::hash_map;
@@ -22,7 +22,7 @@ mod detail {
     pub type IntoValuesImpl<K, V> = hash_map::IntoValues<K, V>;
 }
 
-#[cfg(feature = "no-hash-maps")]
+#[cfg(any(not(feature = "hash-collections"), feature = "prefer-btree-collections"))]
 mod detail {
     use alloc::collections::btree_map;
 
@@ -155,9 +155,9 @@ where
     /// Reserves capacity for at least `additional` more elements to be inserted in the [`Map`].
     #[inline]
     pub fn reserve(&mut self, additional: usize) {
-        #[cfg(not(feature = "no-hash-maps"))]
+        #[cfg(all(feature = "hash-collections", not(feature = "prefer-btree-collections")))]
         self.inner.reserve(additional);
-        #[cfg(feature = "no-hash-maps")]
+        #[cfg(any(not(feature = "hash-collections"), feature = "prefer-btree-collections"))]
         let _ = additional;
     }
 

--- a/crates/wasmparser/src/collections/mod.rs
+++ b/crates/wasmparser/src/collections/mod.rs
@@ -14,6 +14,16 @@
 //! [`BTreeMap`]: alloc::collections::BTreeMap
 //! [`BTreeSet`]: alloc::collections::BTreeSet
 
+// Which collections will be used feature matrix:
+//
+// `hash-collections` | `prefer-btree-collections` |      usage
+// ------------------ | -------------------------- | -------------------
+//            false   |                    false   |      btree
+//             true   |                    false   |      hash
+//            false   |                     true   |      btree
+//             true   |                     true   |      btree
+
+#[cfg(feature = "hash-collections")]
 pub mod hash;
 pub mod index_map;
 pub mod index_set;

--- a/crates/wasmparser/src/collections/set.rs
+++ b/crates/wasmparser/src/collections/set.rs
@@ -8,7 +8,10 @@ use core::{
     ops::{BitAnd, BitOr, BitXor, Sub},
 };
 
-#[cfg(all(feature = "hash-collections", not(feature = "prefer-btree-collections")))]
+#[cfg(all(
+    feature = "hash-collections",
+    not(feature = "prefer-btree-collections")
+))]
 mod detail {
     use crate::collections::hash;
     use hashbrown::hash_set;
@@ -23,7 +26,10 @@ mod detail {
     pub type UnionImpl<'a, T> = hash_set::Union<'a, T, hash::RandomState>;
 }
 
-#[cfg(any(not(feature = "hash-collections"), feature = "prefer-btree-collections"))]
+#[cfg(any(
+    not(feature = "hash-collections"),
+    feature = "prefer-btree-collections"
+))]
 mod detail {
     use alloc::collections::btree_set;
 
@@ -105,9 +111,15 @@ where
     /// Reserves capacity for at least `additional` more elements to be inserted in the [`Set`].
     #[inline]
     pub fn reserve(&mut self, additional: usize) {
-        #[cfg(all(feature = "hash-collections", not(feature = "prefer-btree-collections")))]
+        #[cfg(all(
+            feature = "hash-collections",
+            not(feature = "prefer-btree-collections")
+        ))]
         self.inner.reserve(additional);
-        #[cfg(any(not(feature = "hash-collections"), feature = "prefer-btree-collections"))]
+        #[cfg(any(
+            not(feature = "hash-collections"),
+            feature = "prefer-btree-collections"
+        ))]
         let _ = additional;
     }
 

--- a/crates/wasmparser/src/collections/set.rs
+++ b/crates/wasmparser/src/collections/set.rs
@@ -8,7 +8,7 @@ use core::{
     ops::{BitAnd, BitOr, BitXor, Sub},
 };
 
-#[cfg(not(feature = "no-hash-maps"))]
+#[cfg(all(feature = "hash-collections", not(feature = "prefer-btree-collections")))]
 mod detail {
     use crate::collections::hash;
     use hashbrown::hash_set;
@@ -23,7 +23,7 @@ mod detail {
     pub type UnionImpl<'a, T> = hash_set::Union<'a, T, hash::RandomState>;
 }
 
-#[cfg(feature = "no-hash-maps")]
+#[cfg(any(not(feature = "hash-collections"), feature = "prefer-btree-collections"))]
 mod detail {
     use alloc::collections::btree_set;
 
@@ -105,9 +105,9 @@ where
     /// Reserves capacity for at least `additional` more elements to be inserted in the [`Set`].
     #[inline]
     pub fn reserve(&mut self, additional: usize) {
-        #[cfg(not(feature = "no-hash-maps"))]
+        #[cfg(all(feature = "hash-collections", not(feature = "prefer-btree-collections")))]
         self.inner.reserve(additional);
-        #[cfg(feature = "no-hash-maps")]
+        #[cfg(any(not(feature = "hash-collections"), feature = "prefer-btree-collections"))]
         let _ = additional;
     }
 

--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -1697,7 +1697,6 @@ impl ComponentState {
         }
 
         let mut set = Set::default();
-        #[cfg(not(feature = "no-hash-maps"))] // TODO: remove when unified map type is available
         set.reserve(core::cmp::max(ty.params.len(), ty.results.type_count()));
 
         let params = ty


### PR DESCRIPTION
- Adds `hash-collections` crate feature.
- Adds `prefer-btree-collections` crate feature.
- Removes `no-hash-maps` crate feature.

## Advantages

- This allows to get rid of `ahash`, `hashbrown` and `indexmap` dependencies entirely when the `hash-collections` crate feature is disabled to further reduce compilation times and binary sizes. `wasmparser`'s own built-in btree-based collections are used instead.
- This still allows to use btree-collections instead of hash-collections when `prefer-btree-collections` is enabled even if `hash-collections` is enabled as well (higher precedence), similar to `no-hash-maps`.
- The 2 new crate features are additive and are positively named (no negations).

## Compile Times

### Including hash-based collections:

```shell
cargo build --release -p wasmparser --no-default-features --features hash-collections
4.14s user 0.34s system 190% cpu 2.347 total
```

### Excluding hash-based collections:

```shell
cargo build --release -p wasmparser --no-default-features
2.81s user 0.15s system 174% cpu 1.692 total
```

4.14 seconds to 2.81 seconds 🎉 