### PR TITLE
wit-encoder: Add missing getters and setters

### DIFF
--- a/crates/wit-encoder/src/docs.rs
+++ b/crates/wit-encoder/src/docs.rs
@@ -16,6 +16,14 @@ impl Docs {
             contents: contents.into(),
         }
     }
+
+    pub fn contents(&self) -> &str {
+        self.contents.as_ref()
+    }
+
+    pub fn set_contents(&mut self, contents: impl Into<String>) {
+        self.contents = contents.into();
+    }
 }
 
 impl<S> From<S> for Docs

--- a/crates/wit-encoder/src/enum_.rs
+++ b/crates/wit-encoder/src/enum_.rs
@@ -73,7 +73,7 @@ impl EnumCase {
         self.name = name.into();
     }
 
-    pub fn docs(&mut self) -> &Option<Docs> {
+    pub fn docs(&self) -> &Option<Docs> {
         &self.docs
     }
 

--- a/crates/wit-encoder/src/flags.rs
+++ b/crates/wit-encoder/src/flags.rs
@@ -43,7 +43,7 @@ impl Flag {
         }
     }
 
-    pub fn name(&mut self) -> &Ident {
+    pub fn name(&self) -> &Ident {
         &self.name
     }
 
@@ -51,7 +51,7 @@ impl Flag {
         self.name = name.into();
     }
 
-    pub fn docs(&mut self) -> &Option<Docs> {
+    pub fn docs(&self) -> &Option<Docs> {
         &self.docs
     }
 

--- a/crates/wit-encoder/src/include.rs
+++ b/crates/wit-encoder/src/include.rs
@@ -19,6 +19,22 @@ impl Include {
         }
     }
 
+    pub fn use_path(&self) -> &Ident {
+        &self.use_path
+    }
+
+    pub fn set_use_path(&mut self, use_path: impl Into<Ident>) {
+        self.use_path = use_path.into();
+    }
+
+    pub fn include_names_list(&self) -> &[(String, String)] {
+        &self.include_names_list
+    }
+
+    pub fn include_names_list_mut(&mut self) -> &mut Vec<(String, String)> {
+        &mut self.include_names_list
+    }
+
     pub fn with(&mut self, id: &str, alias: &str) {
         self.include_names_list
             .push((id.to_string(), alias.to_string()));

--- a/crates/wit-encoder/src/interface.rs
+++ b/crates/wit-encoder/src/interface.rs
@@ -30,6 +30,14 @@ impl Interface {
         }
     }
 
+    pub fn name(&self) -> &Ident {
+        &self.name
+    }
+
+    pub fn set_name(&mut self, name: impl Into<Ident>) {
+        self.name = name.into();
+    }
+
     /// Add a `TypeDef` to the interface
     pub fn type_def(&mut self, type_def: TypeDef) {
         self.items.push(InterfaceItem::TypeDef(type_def));
@@ -38,6 +46,14 @@ impl Interface {
     /// Add an `Function` to the interface
     pub fn function(&mut self, function: StandaloneFunc) {
         self.items.push(InterfaceItem::Function(function));
+    }
+
+    pub fn uses(&self) -> &[Use] {
+        &self.uses
+    }
+
+    pub fn uses_mut(&mut self) -> &mut [Use] {
+        &mut self.uses
     }
 
     /// Add a `Use` to the interface

--- a/crates/wit-encoder/src/package.rs
+++ b/crates/wit-encoder/src/package.rs
@@ -29,6 +29,14 @@ impl Package {
         }
     }
 
+    pub fn name(&self) -> &PackageName {
+        &self.name
+    }
+
+    pub fn set_name(&mut self, name: impl Into<PackageName>) {
+        self.name = name.into();
+    }
+
     /// Add an `Interface` to the package
     pub fn interface(&mut self, interface: Interface) {
         self.items.push(PackageItem::Interface(interface))
@@ -124,6 +132,30 @@ impl PackageName {
             name: name.into(),
             version,
         }
+    }
+
+    pub fn namespace(&self) -> &str {
+        &self.namespace
+    }
+
+    pub fn set_namespace(&mut self, namespace: impl Into<String>) {
+        self.namespace = namespace.into();
+    }
+
+    pub fn name(&self) -> &Ident {
+        &self.name
+    }
+
+    pub fn set_name(&mut self, name: impl Into<Ident>) {
+        self.name = name.into()
+    }
+
+    pub fn version(&self) -> Option<&Version> {
+        self.version.as_ref()
+    }
+
+    pub fn set_version(&mut self, version: Option<impl Into<Version>>) {
+        self.version = version.map(|v| v.into())
     }
 }
 

--- a/crates/wit-encoder/src/ty.rs
+++ b/crates/wit-encoder/src/ty.rs
@@ -295,6 +295,10 @@ impl TypeDef {
     pub fn set_docs(&mut self, docs: Option<impl Into<Docs>>) {
         self.docs = docs.map(|d| d.into());
     }
+
+    pub fn docs(&self) -> &Option<Docs> {
+        &self.docs
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/wit-encoder/src/use_.rs
+++ b/crates/wit-encoder/src/use_.rs
@@ -32,6 +32,14 @@ impl Use {
         self.use_names_list
             .push((id.into(), alias.map(|s| s.into())));
     }
+
+    pub fn use_names_list(&self) -> &[(Ident, Option<Ident>)] {
+        &self.use_names_list
+    }
+
+    pub fn use_names_list_mut(&mut self) -> &mut Vec<(Ident, Option<Ident>)> {
+        &mut self.use_names_list
+    }
 }
 
 impl Render for Use {

--- a/crates/wit-encoder/src/world.rs
+++ b/crates/wit-encoder/src/world.rs
@@ -35,6 +35,14 @@ impl World {
         &self.name
     }
 
+    pub fn items(&self) -> &[WorldItem] {
+        &self.items
+    }
+
+    pub fn items_mut(&mut self) -> &mut Vec<WorldItem> {
+        &mut self.items
+    }
+
     /// Add an import or export to the world
     pub fn item(&mut self, item: WorldItem) {
         self.items.push(item);
@@ -63,6 +71,10 @@ impl World {
     }
     pub fn use_(&mut self, use_: Use) {
         self.item(WorldItem::Use(use_));
+    }
+
+    pub fn docs(&self) -> Option<&Docs> {
+        self.docs.as_ref()
     }
 
     /// Set the documentation


### PR DESCRIPTION
Currently traversing and modifying the data structures can be hard, as some getter and setters are missing.

This PR adds these while trying to follow the current conventions.

In case there are reasons for not having these, or there should be a different naming, please let me know.

Thanks in advance.