### PR TITLE
threads: add `rec` group test

### DIFF
--- a/tests/local/shared-everything-threads/rec-groups.wast
+++ b/tests/local/shared-everything-threads/rec-groups.wast
@@ -1,0 +1,19 @@
+(assert_invalid
+  (module
+    (rec
+      (type (; super ;) (sub (func (result (ref null (shared func))))))
+      (type (; sub ;) (sub 0 (func (result (ref null func)))))
+    )
+  )
+  "sub type must match super type"
+)
+
+(assert_invalid
+  (module
+    (rec
+      (type (; super ;) (sub (func (param (ref null (shared func))))))
+      (type (; sub ;) (sub 0 (func (param (ref null 0)))))
+    )
+  )
+  "sub type must match super type"
+)

--- a/tests/snapshots/local/shared-everything-threads/rec-groups.wast.json
+++ b/tests/snapshots/local/shared-everything-threads/rec-groups.wast.json
@@ -1,0 +1,19 @@
+{
+  "source_filename": "tests/local/shared-everything-threads/rec-groups.wast",
+  "commands": [
+    {
+      "type": "assert_invalid",
+      "line": 2,
+      "filename": "rec-groups.0.wasm",
+      "module_type": "binary",
+      "text": "sub type must match super type"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 12,
+      "filename": "rec-groups.1.wasm",
+      "module_type": "binary",
+      "text": "sub type must match super type"
+    }
+  ]
+}


### PR DESCRIPTION
It should be invalid to create a sub-type in a recursive group that does not match the sharedness of the super-type. This test adds a check for this; feel free to suggest further cases.