### PR TITLE
wit-encoder: interface identifier and getter setter fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2321,6 +2321,7 @@ dependencies = [
 name = "wit-encoder"
 version = "0.219.1"
 dependencies = [
+ "anyhow",
  "id-arena",
  "indoc",
  "pretty_assertions",

--- a/crates/wit-encoder/Cargo.toml
+++ b/crates/wit-encoder/Cargo.toml
@@ -33,4 +33,5 @@ wit-parser = { workspace = true, optional = true }
 id-arena = { workspace = true, optional = true }
 
 [dev-dependencies]
+anyhow = { workspace = true }
 indoc = { workspace = true }

--- a/crates/wit-encoder/src/world.rs
+++ b/crates/wit-encoder/src/world.rs
@@ -254,7 +254,20 @@ impl WorldNamedInterface {
             docs: None,
         }
     }
-    pub fn docs(&mut self, docs: Option<impl Into<Docs>>) {
+
+    pub fn set_name(&mut self, name: impl Into<Ident>) {
+        self.name = name.into();
+    }
+
+    pub fn name(&mut self) -> &Ident {
+        &self.name
+    }
+
+    pub fn set_docs(&mut self, docs: Option<impl Into<Docs>>) {
         self.docs = docs.map(|d| d.into());
+    }
+
+    pub fn docs(&self) -> Option<&Docs> {
+        self.docs.as_ref()
     }
 }

--- a/crates/wit-encoder/src/world.rs
+++ b/crates/wit-encoder/src/world.rs
@@ -31,7 +31,7 @@ impl World {
         self.name = name.into();
     }
 
-    pub fn name(&mut self) -> &Ident {
+    pub fn name(&self) -> &Ident {
         &self.name
     }
 
@@ -259,7 +259,7 @@ impl WorldNamedInterface {
         self.name = name.into();
     }
 
-    pub fn name(&mut self) -> &Ident {
+    pub fn name(&self) -> &Ident {
         &self.name
     }
 

--- a/crates/wit-encoder/tests/deps.rs
+++ b/crates/wit-encoder/tests/deps.rs
@@ -1,0 +1,132 @@
+use pretty_assertions::assert_eq;
+use wit_parser::Resolve;
+
+const MAIN_PACKAGE_CASE_1: &str = indoc::indoc! {"
+    package foo:main;
+
+    interface main-interface-a {
+        use foo:dep-a/dep-a-interface-b.{ra};
+    }
+
+    interface main-interface-b {
+    }
+
+    interface main-interface-c {
+    }
+
+    world main-world-a {
+        import foo:dep-c/dep-c-interface-a;
+        export foo:dep-c/dep-c-interface-b;
+        include foo:dep-c/dep-c-world-a;
+
+        import foo:dep-b/dep-b-interface-a@1.2.3;
+        export foo:dep-b/dep-b-interface-b@1.2.3;
+        include foo:dep-b/dep-b-world-b@1.2.3;
+
+        import main-interface-b;
+        export main-interface-a;
+        include main-world-b;
+    }
+
+    world main-world-b {
+    }
+"};
+
+const DEP_PACKAGE_A: &str = indoc::indoc! {"
+    package foo:dep-a;
+
+    interface dep-a-interface-b {
+        use foo:dep-b/dep-b-interface-a@1.2.3.{a};
+        type ra = a;
+    }
+
+    world dep-a-world {
+    }
+"};
+
+const DEP_PACKAGE_B: &str = indoc::indoc! {"
+    package foo:dep-b@1.2.3;
+
+    interface dep-b-interface-a {
+        record a {
+            x: f32,
+            y: f32,
+        }
+    }
+
+    interface dep-b-interface-b {
+        use foo:dep-c/dep-c-interface-a.{a};
+    }
+
+    world dep-b-world-a {
+        export dep-b-interface-a;
+    }
+
+    world dep-b-world-b {
+    }
+"};
+
+const DEP_PACKAGE_C: &str = indoc::indoc! {"
+    package foo:dep-c;
+
+    interface dep-c-interface-a {
+        record a {
+            x: f32,
+            y: f32,
+        }
+    }
+
+    interface dep-c-interface-b {
+    }
+
+    interface dep-c-interface-c {
+    }
+
+    interface dep-c-interface-d {
+    }
+
+    world dep-c-world-a {
+        import dep-c-interface-c;
+        export dep-c-interface-d;
+    }
+"};
+
+#[test]
+fn resolve_encode_resolve_round_trip_with_use_and_include() {
+    let packages = {
+        let mut resolve = Resolve::new();
+        resolve.push_str("dep_c.wit", DEP_PACKAGE_C).unwrap();
+        resolve.push_str("dep_b.wit", DEP_PACKAGE_B).unwrap();
+        resolve.push_str("dep_a.wit", DEP_PACKAGE_A).unwrap();
+        resolve
+            .push_str("main_foo.wit", MAIN_PACKAGE_CASE_1)
+            .unwrap();
+
+        wit_encoder::packages_from_parsed(&resolve)
+    };
+    assert_eq!(packages.len(), 4);
+
+    // The order of converted packages currently follows the order of pushes to the parser's package arena.
+    // If this changes, then explicit sorting or search is required in this test.
+    assert_eq!(packages[0].name().name().raw_name(), "dep-c");
+    assert_eq!(packages[1].name().name().raw_name(), "dep-b");
+    assert_eq!(packages[2].name().name().raw_name(), "dep-a");
+    assert_eq!(packages[3].name().name().raw_name(), "main");
+
+    // Resolve should still work after rendering the encoded packages
+    {
+        let mut resolve = Resolve::new();
+        resolve
+            .push_str("dep_c.wit", &packages[0].to_string())
+            .unwrap();
+        resolve
+            .push_str("dep_b.wit", &packages[1].to_string())
+            .unwrap();
+        resolve
+            .push_str("dep_a.wit", &packages[2].to_string())
+            .unwrap();
+        resolve
+            .push_str("main_foo.wit", &packages[3].to_string())
+            .unwrap();
+    }
+}

--- a/crates/wit-encoder/tests/deps.rs
+++ b/crates/wit-encoder/tests/deps.rs
@@ -163,7 +163,6 @@ fn resolve_encode_resolve_round_trip_with_use_and_include() {
         &["foo:dep-c", "foo:dep-b@1.2.3", "foo:dep-a", "foo:main"],
     );
 
-
     // Check for the encoded main wit
     assert_eq!(MAIN_PACKAGE_RESOLVED_ENCODED, &packages[3].to_string());
 }

--- a/crates/wit-encoder/tests/deps.rs
+++ b/crates/wit-encoder/tests/deps.rs
@@ -3,34 +3,73 @@ use pretty_assertions::assert_eq;
 use wit_encoder::{packages_from_parsed, Package};
 use wit_parser::Resolve;
 
-const MAIN_PACKAGE_CASE_1: &str = indoc::indoc! {"
+const MAIN_PACKAGE_SOURCE: &str = indoc::indoc! {"
     package foo:main;
 
     interface main-interface-a {
-        use foo:dep-a/dep-a-interface-b.{ra};
+      use foo:dep-a/dep-a-interface-b.{ ra };
     }
 
-    interface main-interface-b {
-    }
+    interface main-interface-b {}
 
-    interface main-interface-c {
-    }
+    interface main-interface-c {}
+
+    interface main-interface-d {}
+
+    interface main-interface-e {}
 
     world main-world-a {
-        import foo:dep-c/dep-c-interface-a;
-        export foo:dep-c/dep-c-interface-b;
-        include foo:dep-c/dep-c-world-a;
+      import foo:dep-c/dep-c-interface-a;
+      export foo:dep-c/dep-c-interface-b;
+      include foo:dep-c/dep-c-world-a;
 
-        import foo:dep-b/dep-b-interface-a@1.2.3;
-        export foo:dep-b/dep-b-interface-b@1.2.3;
-        include foo:dep-b/dep-b-world-b@1.2.3;
+      import foo:dep-b/dep-b-interface-a@1.2.3;
+      export foo:dep-b/dep-b-interface-b@1.2.3;
+      include foo:dep-b/dep-b-world-b@1.2.3;
 
-        import main-interface-b;
-        export main-interface-a;
-        include main-world-b;
+      import main-interface-b;
+      export main-interface-a;
+      include main-world-b;
     }
 
     world main-world-b {
+      export main-interface-d;
+      import main-interface-d;
+    }
+"};
+
+const MAIN_PACKAGE_RESOLVED_ENCODED: &str = indoc::indoc! {"
+    package foo:main;
+
+    interface main-interface-a {
+      use foo:dep-a/dep-a-interface-b.{ ra };
+    }
+
+    interface main-interface-b {}
+
+    interface main-interface-c {}
+
+    interface main-interface-d {}
+
+    interface main-interface-e {}
+
+    world main-world-b {
+      import main-interface-d;
+      export main-interface-d;
+    }
+
+    world main-world-a {
+      import foo:dep-c/dep-c-interface-a;
+      import foo:dep-b/dep-b-interface-a@1.2.3;
+      import main-interface-b;
+      import foo:dep-c/dep-c-interface-c;
+      import main-interface-d;
+      import foo:dep-a/dep-a-interface-b;
+      export foo:dep-c/dep-c-interface-b;
+      export foo:dep-b/dep-b-interface-b@1.2.3;
+      export main-interface-a;
+      export foo:dep-c/dep-c-interface-d;
+      export main-interface-d;
     }
 "};
 
@@ -38,58 +77,53 @@ const DEP_PACKAGE_A: &str = indoc::indoc! {"
     package foo:dep-a;
 
     interface dep-a-interface-b {
-        use foo:dep-b/dep-b-interface-a@1.2.3.{a};
-        type ra = a;
+      use foo:dep-b/dep-b-interface-a@1.2.3.{a};
+      type ra = a;
     }
 
-    world dep-a-world {
-    }
+    world dep-a-world {}
 "};
 
 const DEP_PACKAGE_B: &str = indoc::indoc! {"
     package foo:dep-b@1.2.3;
 
     interface dep-b-interface-a {
-        record a {
-            x: f32,
-            y: f32,
-        }
+      record a {
+        x: f32,
+        y: f32,
+      }
     }
 
     interface dep-b-interface-b {
-        use foo:dep-c/dep-c-interface-a.{a};
+      use foo:dep-c/dep-c-interface-a.{a};
     }
 
     world dep-b-world-a {
-        export dep-b-interface-a;
+      export dep-b-interface-a;
     }
 
-    world dep-b-world-b {
-    }
+    world dep-b-world-b {}
 "};
 
 const DEP_PACKAGE_C: &str = indoc::indoc! {"
     package foo:dep-c;
 
     interface dep-c-interface-a {
-        record a {
-            x: f32,
-            y: f32,
-        }
+      record a {
+        x: f32,
+        y: f32,
+      }
     }
 
-    interface dep-c-interface-b {
-    }
+    interface dep-c-interface-b {}
 
-    interface dep-c-interface-c {
-    }
+    interface dep-c-interface-c {}
 
-    interface dep-c-interface-d {
-    }
+    interface dep-c-interface-d {}
 
     world dep-c-world-a {
-        import dep-c-interface-c;
-        export dep-c-interface-d;
+      import dep-c-interface-c;
+      export dep-c-interface-d;
     }
 "};
 
@@ -100,7 +134,7 @@ fn resolve_encode_resolve_round_trip_with_use_and_include() {
             ("dep_c.wit", DEP_PACKAGE_C),
             ("dep_b.wit", DEP_PACKAGE_B),
             ("dep_a.wit", DEP_PACKAGE_A),
-            ("main_foo.wit", MAIN_PACKAGE_CASE_1),
+            ("main_foo.wit", MAIN_PACKAGE_SOURCE),
         ])
         .unwrap(),
     );
@@ -128,6 +162,10 @@ fn resolve_encode_resolve_round_trip_with_use_and_include() {
         &packages,
         &["foo:dep-c", "foo:dep-b@1.2.3", "foo:dep-a", "foo:main"],
     );
+
+
+    // Check for the encoded main wit
+    assert_eq!(MAIN_PACKAGE_RESOLVED_ENCODED, &packages[3].to_string());
 }
 
 fn resolve_packages(packages: &[(&str, &str)]) -> Result<Resolve> {


### PR DESCRIPTION
Changes:
- Add some more missing getters and setters which were left out from https://github.com/bytecodealliance/wasm-tools/pull/1867.
- Interface identifiers were missing the package parts in case they were from another package

