### PR TITLE
wasm-wave logos dependency: require forbid_unsafe feature from 0.14.2

### DIFF
--- a/crates/wasm-wave/Cargo.toml
+++ b/crates/wasm-wave/Cargo.toml
@@ -17,7 +17,7 @@ wit = ["dep:wit-parser"]
 
 [dependencies]
 indexmap.workspace = true
-logos = "0.14.0"
+logos = { version = "0.14.2", features = ["forbid_unsafe"] }
 thiserror = "1.0.48"
 wit-parser = { workspace = true, optional = true }
 


### PR DESCRIPTION
This feature allows us to include wasm-wave in wasmtime's supply chain.

See:
https://github.com/maciejhirsz/logos/issues/398
https://github.com/maciejhirsz/logos/pull/413
