### PR TITLE
wit-parser package not found: explain error better

### DIFF
--- a/crates/wit-parser/src/ast.rs
+++ b/crates/wit-parser/src/ast.rs
@@ -1,4 +1,4 @@
-use crate::{Error, UnresolvedPackageGroup};
+use crate::{Error, PackageNotFoundError, UnresolvedPackageGroup};
 use anyhow::{bail, Context, Result};
 use lex::{Span, Token, Tokenizer};
 use semver::Version;
@@ -1756,6 +1756,19 @@ impl SourceMap {
             }
         }
         if let Some(_) = err.downcast_mut::<Error>() {
+            return Err(err);
+        }
+        if let Some(notfound) = err.downcast_mut::<PackageNotFoundError>() {
+            if notfound.highlighted.is_none() {
+                let msg = self.highlight_err(
+                    notfound.span.start,
+                    Some(notfound.span.end),
+                    &format!("{notfound}"),
+                );
+                notfound.highlighted = Some(msg);
+            }
+        }
+        if let Some(_) = err.downcast_mut::<PackageNotFoundError>() {
             return Err(err);
         }
 

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -273,6 +273,52 @@ impl fmt::Display for Error {
 
 impl std::error::Error for Error {}
 
+#[derive(Debug)]
+struct PackageNotFoundError {
+    span: Span,
+    requested: PackageName,
+    known: Vec<PackageName>,
+    highlighted: Option<String>,
+}
+
+impl PackageNotFoundError {
+    pub fn new(span: Span, requested: PackageName, known: Vec<PackageName>) -> Self {
+        Self {
+            span,
+            requested,
+            known,
+            highlighted: None,
+        }
+    }
+}
+
+impl fmt::Display for PackageNotFoundError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(highlighted) = &self.highlighted {
+            return highlighted.fmt(f);
+        }
+        if self.known.is_empty() {
+            write!(
+                f,
+                "package '{}' not found. no known packages.",
+                self.requested
+            )?;
+        } else {
+            write!(
+                f,
+                "package '{}' not found. known packages:\n",
+                self.requested
+            )?;
+            for known in self.known.iter() {
+                write!(f, "    {known}\n")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for PackageNotFoundError {}
+
 impl UnresolvedPackageGroup {
     /// Parses the given string as a wit document.
     ///

--- a/crates/wit-parser/src/resolve.rs
+++ b/crates/wit-parser/src/resolve.rs
@@ -18,9 +18,9 @@ use crate::ast::{parse_use_path, ParsedUsePath};
 use crate::serde_::{serialize_arena, serialize_id_map};
 use crate::{
     AstItem, Docs, Error, Function, FunctionKind, Handle, IncludeName, Interface, InterfaceId,
-    InterfaceSpan, Mangling, PackageName, Results, SourceMap, Stability, Type, TypeDef,
-    TypeDefKind, TypeId, TypeIdVisitor, TypeOwner, UnresolvedPackage, UnresolvedPackageGroup,
-    World, WorldId, WorldItem, WorldKey, WorldSpan,
+    InterfaceSpan, Mangling, PackageName, PackageNotFoundError, Results, SourceMap, Stability,
+    Type, TypeDef, TypeDefKind, TypeId, TypeIdVisitor, TypeOwner, UnresolvedPackage,
+    UnresolvedPackageGroup, World, WorldId, WorldItem, WorldKey, WorldSpan,
 };
 
 mod clone;
@@ -2786,7 +2786,13 @@ impl Remap {
                 .package_names
                 .get(pkg_name)
                 .copied()
-                .ok_or_else(|| Error::new(span, "package not found"))?;
+                .ok_or_else(|| {
+                    PackageNotFoundError::new(
+                        span,
+                        pkg_name.clone(),
+                        resolve.package_names.keys().cloned().collect(),
+                    )
+                })?;
 
             // Functions can't be imported so this should be empty.
             assert!(unresolved_iface.functions.is_empty());

--- a/crates/wit-parser/tests/ui/parse-fail/bad-pkg6.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-pkg6.wit.result
@@ -1,4 +1,6 @@
-failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/bad-pkg6]: package not found
+failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/bad-pkg6]: package 'foo:bar' not found. known packages:
+    foo:baz
+
      --> tests/ui/parse-fail/bad-pkg6/root.wit:3:7
       |
     3 |   use foo:bar/baz.{};

--- a/crates/wit-parser/tests/ui/parse-fail/unresolved-interface4.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/unresolved-interface4.wit.result
@@ -1,4 +1,4 @@
-package not found
+package 'some:dependency' not found. no known packages.
      --> tests/ui/parse-fail/unresolved-interface4.wit:6:10
       |
     6 |   import some:dependency/iface;


### PR DESCRIPTION
Hopefully this helps people understand why a package is not found, e.g. did you mismatch the version string? did you put it in the wrong directory structure so its not found that way?

The downcast rewrite is ugly, perhaps there's a better way to do that but I did it the dumbest way possible. The alternative is to make this a separate constructor of Error.