### PR TITLE
Remove a copy being made of wasm modules

### DIFF
--- a/crates/wat/src/lib.rs
+++ b/crates/wat/src/lib.rs
@@ -235,6 +235,12 @@ impl Parser {
             }),
         })?;
         match self.parse_bytes(Some(file), &contents) {
+            // If the result here is borrowed then that means that the input
+            // `&contents` was itself already a wasm module. We've already got
+            // an owned copy of that so return `contents` directly after
+            // double-checking it is indeed the same as the `bytes` return value
+            // here. That helps avoid a copy of `bytes` via something like
+            // `Cow::to_owned` which would otherwise copy the bytes.
             Ok(Cow::Borrowed(bytes)) => {
                 assert_eq!(bytes.len(), contents.len());
                 assert_eq!(bytes.as_ptr(), contents.as_ptr());

--- a/crates/wat/src/lib.rs
+++ b/crates/wat/src/lib.rs
@@ -235,7 +235,12 @@ impl Parser {
             }),
         })?;
         match self.parse_bytes(Some(file), &contents) {
-            Ok(bytes) => Ok(bytes.into_owned()),
+            Ok(Cow::Borrowed(bytes)) => {
+                assert_eq!(bytes.len(), contents.len());
+                assert_eq!(bytes.as_ptr(), contents.as_ptr());
+                Ok(contents)
+            }
+            Ok(Cow::Owned(bytes)) => Ok(bytes),
             Err(mut e) => {
                 e.set_path(file);
                 Err(e)

--- a/src/bin/wasm-tools/validate.rs
+++ b/src/bin/wasm-tools/validate.rs
@@ -66,7 +66,9 @@ impl Opts {
     }
 
     pub fn run(&self) -> Result<()> {
+        let start = Instant::now();
         let wasm = self.io.parse_input_wasm()?;
+        log::info!("read module in {:?}", start.elapsed());
 
         // If validation fails then try to attach extra information to the
         // error based on DWARF information in the input wasm binary. If


### PR DESCRIPTION
This commit removes a copy performed when the input file is WebAssembly when parsing input files on the CLI. This happened due to the implementation of `Cow::to_owned` but isn't necessary since we have the original owned copy around to return that instead.