### PR TITLE
feature: Output wasm custom section

### DIFF
--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -26,6 +26,7 @@ pub enum Opts {
     Embed(EmbedOpts),
     Targets(TargetsOpts),
     Link(LinkOpts),
+    Section(SectionOpts),
     SemverCheck(SemverCheckOpts),
     Unbundle(UnbundleOpts),
 }
@@ -38,6 +39,7 @@ impl Opts {
             Opts::Embed(embed) => embed.run(),
             Opts::Targets(targets) => targets.run(),
             Opts::Link(link) => link.run(),
+            Opts::Section(section) => section.run(),
             Opts::SemverCheck(s) => s.run(),
             Opts::Unbundle(s) => s.run(),
         }
@@ -50,6 +52,7 @@ impl Opts {
             Opts::Embed(embed) => embed.general_opts(),
             Opts::Targets(targets) => targets.general_opts(),
             Opts::Link(link) => link.general_opts(),
+            Opts::Section(section) => section.general_opts(),
             Opts::SemverCheck(s) => s.general_opts(),
             Opts::Unbundle(s) => s.general_opts(),
         }
@@ -307,12 +310,8 @@ pub struct EmbedOpts {
     dummy_names: Option<Mangling>,
 
     /// Print the output in the WebAssembly text format instead of binary.
-    #[clap(long, short = 't', conflicts_with = "custom")]
+    #[clap(long, short = 't')]
     wat: bool,
-
-    /// Print the output as Web Assembly Custom Section.
-    #[clap(long, short = 'c', conflicts_with = "wat")]
-    custom: bool,
 }
 
 impl EmbedOpts {
@@ -332,18 +331,6 @@ impl EmbedOpts {
             self.io.parse_input_wasm()?
         };
 
-        if self.custom {
-            let encoded = metadata::encode(
-                &resolve,
-                world,
-                self.encoding.unwrap_or(StringEncoding::UTF8),
-                None,
-            )?;
-
-            self.io.output_wasm(&encoded, false)?;
-            return Ok(());
-        }
-
         embed_component_metadata(
             &mut wasm,
             &resolve,
@@ -352,6 +339,67 @@ impl EmbedOpts {
         )?;
 
         self.io.output_wasm(&wasm, self.wat)?;
+
+        Ok(())
+    }
+}
+
+#[derive(Parser)]
+/// Outputs the core wasm section for a given world.
+///
+/// This subcommand produces core wasm sections for a given world, to be used
+/// in language tooling while converting core wasm modules to components.
+///
+/// This metadata describe the imports and exports of a core wasm module with a
+/// WIT package's `world`. The metadata will be used when creating a full
+/// component.
+pub struct SectionOpts {
+    #[clap(flatten)]
+    resolve: WitResolve,
+
+    #[clap(flatten)]
+    io: wasm_tools::InputOutput,
+
+    /// The expected string encoding format for the component.
+    ///
+    /// Supported values are: `utf8` (default), `utf16`, and `compact-utf16`.
+    /// This is only applicable to the `wit` argument to describe the string
+    /// encoding of the functions in that world.
+    #[clap(long, value_name = "ENCODING")]
+    encoding: Option<StringEncoding>,
+
+    /// The world that the component uses.
+    ///
+    /// This is the path, within the `WIT` source provided as a positional
+    /// argument, to the `world` that the core wasm module works with. If this
+    /// option is omitted then the "main package" pointed to by `WIT` must have
+    /// a single world and that's what is used to embed. Otherwise this could be
+    /// a bare string `foo` to point to the `world foo` within the main
+    /// package of WIT. Finally this can be a fully qualified name too such as
+    /// `wasi:http/proxy` which can select a world from a WIT dependency as
+    /// well.
+    #[clap(short, long)]
+    world: Option<String>,
+}
+
+impl SectionOpts {
+    fn general_opts(&self) -> &wasm_tools::GeneralOpts {
+        self.io.general_opts()
+    }
+
+    /// Executes the application.
+    fn run(self) -> Result<()> {
+        let (resolve, pkg_id) = self.resolve.load()?;
+        let world = resolve.select_world(pkg_id, self.world.as_deref())?;
+
+        let encoded = metadata::encode(
+            &resolve,
+            world,
+            self.encoding.unwrap_or(StringEncoding::UTF8),
+            None,
+        )?;
+
+        self.io.output_wasm(&encoded, false)?;
 
         Ok(())
     }

--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -339,7 +339,7 @@ impl EmbedOpts {
                 None,
             )?;
 
-            self.io.output_wasm(&encoded, self.wat)?;
+            self.io.output_wasm(&encoded, false)?;
             return Ok(());
         }
 
@@ -358,7 +358,7 @@ impl EmbedOpts {
             self.encoding.unwrap_or(StringEncoding::UTF8),
         )?;
 
-        self.io.output_wasm(&wasm, false)?;
+        self.io.output_wasm(&wasm, self.wat)?;
 
         Ok(())
     }

--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -311,7 +311,12 @@ pub struct EmbedOpts {
     wat: bool,
 
     /// Print the wasm custom section only.
-    #[clap(long, short = 's')]
+    #[clap(
+        long,
+        conflicts_with = "wat",
+        conflicts_with = "dummy",
+        conflicts_with = "dummy_names"
+    )]
     only_custom: bool,
 }
 
@@ -353,7 +358,7 @@ impl EmbedOpts {
             self.encoding.unwrap_or(StringEncoding::UTF8),
         )?;
 
-        self.io.output_wasm(&wasm, self.wat)?;
+        self.io.output_wasm(&wasm, false)?;
 
         Ok(())
     }

--- a/tests/cli/component-embed-only-custom.wit
+++ b/tests/cli/component-embed-only-custom.wit
@@ -1,0 +1,8 @@
+// RUN: component embed --only-custom -w foo % | print
+
+package a:b;
+
+world foo {
+  import x: func();
+  export y: func();
+}

--- a/tests/cli/component-embed-only-custom.wit.stdout
+++ b/tests/cli/component-embed-only-custom.wit.stdout
@@ -1,0 +1,19 @@
+(component
+  (@custom "wit-component-encoding" "/04/00")
+  (type (;0;)
+    (component
+      (type (;0;)
+        (component
+          (type (;0;) (func))
+          (import "x" (func (;0;) (type 0)))
+          (export (;1;) "y" (func (type 0)))
+        )
+      )
+      (export (;0;) "a:b/foo" (component (type 0)))
+    )
+  )
+  (export (;1;) "foo" (type 0))
+  (@producers
+    (processed-by "wit-component" "0.219.1")
+  )
+)


### PR DESCRIPTION
Intended to be used as part of an experiment in [Go bindgen tooling](https://github.com/bytecodealliance/wasm-tools-go)

The current TinyGo experience is as following:
- codegen using wit-bindgen-go ( need wit + target world )
- tinygo build wasm32 module ( also need wit + target world )
  - run `wasm-tools component embed`
  - run `wasm-tools component new`

We are investigating the addition of a language feature ( `//go:wasmsection` ) so TinyGo ( and potentially Big Go ) are not required to know about wit-worlds. The experience would become:
- codegen using wit-bindgen-go ( need wit + target world )
- tinygo build wasm32 module <- no longer needs wit + target world visibility
- User Initiated / Other Tools
  - run `wasm-tools component embed`
  - run `wasm-tools component new`

The following code is analogous to `wasm-tools component embed -w demo -o core_embedded.wasm ./wit core.wasm`

```go
// Creates a custom section 'component-type:demo' with contents from 'demo.bin'
package demo

//go:wasmsection component-type:demo
//go:embed demo.bin
var wasmSection []byte
```

This PR introduces `wasm-tools component section`, which will be responsible for generating the `demo.bin` described above.


During wit-2-go codegen, `wasm-tools` will be executed once per world as needed. Ex for wasi http:
```
wasm-tools component section -w wasi:http/proxy -o http.bin .
```

The contents of `http.bin` will be referenced in `//go:wasmsection component-type:wasi-http http.bin`, resulting in a custom section named `component-type:wasi-http` with content from `http.bin`.

From there, wasm module to component conversion happens as usual with `wasm-tools component new`.

## Alternative
Initially I had this behavior under `wasm-tools component embed --custom` ( flag `--custom` ), which would look like
```
wasm-tools component embed -w example ./wit --dummy  --custom -o /tmp/custom_section.wasm
```
Decided towards another sub-command as the output is significantly different ( a single section vs a whole module ).


cc @ydnar 