### PR TITLE
Support `i8x16.shuffle` in `wasm-mutate`

### DIFF
--- a/crates/wasm-mutate/src/mutators/peephole.rs
+++ b/crates/wasm-mutate/src/mutators/peephole.rs
@@ -1595,4 +1595,18 @@ mod tests {
         mutator.rules = Some(rules);
         config.match_mutation(original, mutator, expected);
     }
+
+    #[test]
+    fn i8x16_shuffle_handled() {
+        test_default_peephole_mutator(
+            "(module (func (param v128 v128)
+                local.get 0
+                local.get 1
+                i8x16.shuffle 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+                drop)
+            )",
+            "(module (func (param v128 v128)))",
+            4,
+        );
+    }
 }

--- a/crates/wasm-mutate/src/mutators/peephole/dfg.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/dfg.rs
@@ -3,7 +3,7 @@
 
 use super::eggsy::encoder::rebuild::build_expr;
 use crate::mutators::peephole::{
-    Lang, MemArg, MemArgLane, MemoryCopy, MemoryInit, RefType, TableCopy, TableInit,
+    Lang, MemArg, MemArgLane, MemoryCopy, MemoryInit, RefType, Shuffle, TableCopy, TableInit,
 };
 use crate::mutators::OperatorAndByteOffset;
 use crate::{ModuleInfo, WasmMutate};
@@ -865,6 +865,11 @@ impl<'a> DFGBuilder {
                 }
 
                 Operator::I8x16Swizzle => self.binop(idx, Lang::I8x16Swizzle),
+                Operator::I8x16Shuffle { lanes } => {
+                    let a = Id::from(self.pop_operand(idx, false));
+                    let b = Id::from(self.pop_operand(idx, false));
+                    self.push_node(Lang::I8x16Shuffle(Shuffle { indices: *lanes }, [b, a]), idx);
+                }
                 Operator::I8x16Splat => self.unop(idx, Lang::I8x16Splat),
                 Operator::I16x8Splat => self.unop(idx, Lang::I16x8Splat),
                 Operator::I32x4Splat => self.unop(idx, Lang::I32x4Splat),

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/analysis.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/analysis.rs
@@ -347,6 +347,7 @@ impl PeepholeMutationAnalysis {
             Lang::F64x2ReplaceLane(..) => Ok(PrimitiveTypeInfo::V128),
 
             Lang::I8x16Swizzle(_) => Ok(PrimitiveTypeInfo::V128),
+            Lang::I8x16Shuffle(..) => Ok(PrimitiveTypeInfo::V128),
             Lang::I8x16Splat(_) => Ok(PrimitiveTypeInfo::V128),
             Lang::I16x8Splat(_) => Ok(PrimitiveTypeInfo::V128),
             Lang::I32x4Splat(_) => Ok(PrimitiveTypeInfo::V128),

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder/expr2wasm.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder/expr2wasm.rs
@@ -525,6 +525,9 @@ pub fn expr2wasm(
                     Lang::F64x2ReplaceLane(lane, _) => insn(Instruction::F64x2ReplaceLane(*lane)),
 
                     Lang::I8x16Swizzle(_) => insn(Instruction::I8x16Swizzle),
+                    Lang::I8x16Shuffle(indices, _) => {
+                        insn(Instruction::I8x16Shuffle(indices.indices))
+                    }
                     Lang::I8x16Splat(_) => insn(Instruction::I8x16Splat),
                     Lang::I16x8Splat(_) => insn(Instruction::I16x8Splat),
                     Lang::I32x4Splat(_) => insn(Instruction::I32x4Splat),

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
@@ -714,7 +714,7 @@ lang! {
         F64x2ReplaceLane(u8, [Id; 2]) = "f64x2.replace_lane",
 
         I8x16Swizzle([Id; 2]) = "i8x16.swizzle",
-        I8x16Shuffle(Shuffle, [Id; 2]) = "i8x16.swizzle",
+        I8x16Shuffle(Shuffle, [Id; 2]) = "i8x16.shuffle",
         I8x16Splat([Id; 1]) = "i8x16.splat",
         I16x8Splat([Id; 1]) = "i16x8.splat",
         I32x4Splat([Id; 1]) = "i32x4.splat",

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
@@ -714,6 +714,7 @@ lang! {
         F64x2ReplaceLane(u8, [Id; 2]) = "f64x2.replace_lane",
 
         I8x16Swizzle([Id; 2]) = "i8x16.swizzle",
+        I8x16Shuffle(Shuffle, [Id; 2]) = "i8x16.swizzle",
         I8x16Splat([Id; 1]) = "i8x16.splat",
         I16x8Splat([Id; 1]) = "i16x8.splat",
         I32x4Splat([Id; 1]) = "i32x4.splat",
@@ -1185,6 +1186,40 @@ impl FromStr for MemArgLane {
         }
 
         Ok(MemArgLane { lane, memarg })
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct Shuffle {
+    pub indices: [u8; 16],
+}
+
+impl fmt::Display for Shuffle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (i, idx) in self.indices.iter().enumerate() {
+            if i != 0 {
+                write!(f, ".")?;
+            }
+            write!(f, "{idx}")?;
+        }
+        Ok(())
+    }
+}
+
+impl FromStr for Shuffle {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Shuffle, String> {
+        let indices = s
+            .split('.')
+            .map(|part| part.parse::<u8>())
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|_| format!("failed to parse integer"))?;
+        let indices: &[u8; 16] = indices
+            .as_slice()
+            .try_into()
+            .map_err(|_| format!("wrong number of lanes"))?;
+
+        Ok(Shuffle { indices: *indices })
     }
 }
 


### PR DESCRIPTION
Support another SIMD instruction in `wasm-mutate` to assist with shrinking functions which might contain this instruction.