### PR TITLE
Support multiple `-f` flags in `validate`

### DIFF
--- a/tests/cli/validate-multiple-flags.wat
+++ b/tests/cli/validate-multiple-flags.wat
@@ -1,0 +1,5 @@
+;; RUN: validate % -f wasm1 -f simd
+
+(module
+  (import "" "" (global v128))
+)


### PR DESCRIPTION
This commit adds support for multiple `--feature` or `-f` flags in the `wasm-tools validate` subcommand. This behaves the same way as supplying multiple values separated by commas, but it can additionally be used through passing multiple arguments now.