### PR TITLE
Relax semver-checks to compare worlds in packages with different versions

### DIFF
--- a/crates/wit-component/src/semver_check.rs
+++ b/crates/wit-component/src/semver_check.rs
@@ -55,7 +55,7 @@ pub fn semver_check(mut resolve: Resolve, prev: WorldId, new: WorldId) -> Result
         .package
         .context("new world not in named package")?;
     let new_pkg_name = &resolve.packages[new_pkg_id].name;
-    if old_pkg_id != new_pkg_id {
+    if old_pkg_name != new_pkg_name {
         bail!("the old world is in package {old_pkg_name}, which is not the same as the new world, which is in package {new_pkg_name}", )
     }
 

--- a/tests/cli/semver-check-different-package-versions.wit
+++ b/tests/cli/semver-check-different-package-versions.wit
@@ -1,0 +1,14 @@
+// FAIL: component semver-check % --prev a:b/worldly@0.2.0 --new a:b/worldly@0.2.1
+
+package foo:root;
+package a:b@0.2.0 {
+  world worldly {
+    import a: func();
+    import b: interface {}
+  }
+}
+
+package a:b@0.2.1 {
+  world worldly {
+  }
+}

--- a/tests/cli/semver-check-different-package-versions.wit.stderr
+++ b/tests/cli/semver-check-different-package-versions.wit.stderr
@@ -1,0 +1,5 @@
+error: new world is not semver-compatible with the previous world
+
+Caused by:
+    0: type mismatch for import `worldly`
+       missing import named `a` (at offset 0x186)


### PR DESCRIPTION
In wasm-tools component semver-checks, instead of requiring that the old and new world live in packages with the same id, just require that they have the same name. This allows checking for semver compatibility between different versions of a package, for example, this command:

```shell
$ wasm-tools component semver-check --prev wasi:http/proxy@0.2.2 --new wasi:http/proxy@0.2.3 ./wit
```

in a dirctory with `wit/deps/http@0.2.2` contains the current wasi-http wit files, and `wit/deps/http@0.2.3` contains a new set of wit files, checks that the new version is semver-compatible.