### PR TITLE
`wast`: Add `#[non_exhaustive]` to `WastArg` and `WastRet`

### DIFF
--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -498,6 +498,7 @@ pub enum QuoteWatTest {
 
 #[derive(Debug)]
 #[allow(missing_docs)]
+#[non_exhaustive]
 pub enum WastArg<'a> {
     Core(WastArgCore<'a>),
     // TODO: technically this isn't cargo-compliant since it means that this
@@ -524,6 +525,7 @@ impl<'a> Parse<'a> for WastArg<'a> {
 
 #[derive(Debug)]
 #[allow(missing_docs)]
+#[non_exhaustive]
 pub enum WastRet<'a> {
     Core(WastRetCore<'a>),
     #[cfg(feature = "component-model")]

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -501,10 +501,6 @@ pub enum QuoteWatTest {
 #[non_exhaustive]
 pub enum WastArg<'a> {
     Core(WastArgCore<'a>),
-    // TODO: technically this isn't cargo-compliant since it means that this
-    // isn't and additive feature by defining this conditionally. That being
-    // said this seems unlikely to break many in practice so this isn't a shared
-    // type, so fixing this is left to a future commit.
     #[cfg(feature = "component-model")]
     Component(WastVal<'a>),
 }

--- a/src/bin/wasm-tools/json_from_wast.rs
+++ b/src/bin/wasm-tools/json_from_wast.rs
@@ -362,7 +362,7 @@ impl<'a> JsonBuilder<'a> {
         for arg in args {
             let arg = match arg {
                 WastArg::Core(core) => core,
-                WastArg::Component(_) => bail!("component support not implemented yet"),
+                _ => bail!("encountered unsupported Wast argument: {arg:?}"),
             };
             let val = match arg {
                 I32(i) => json::Const::I32 {
@@ -419,7 +419,7 @@ impl<'a> JsonBuilder<'a> {
         for r in rets {
             let r = match r {
                 WastRet::Core(core) => self.core_ret(core)?,
-                WastRet::Component(_) => bail!("component support not implemented yet"),
+                _ => bail!("encountered unsupported Wast result: {r:?}"),
             };
             ret.push(r);
         }


### PR DESCRIPTION
This attribute is required because depending on `#[cfg(feature = "component-model")]` both `WastArg` and `WastRet` can be `enum`s with a single variant. Since crate features are resolved together this might cause problems in a crate due to feature usage of another crate or dependency, e.g. in the same workspace, with respect to irrefutable patterns.

# Examples

1.

```rust
let arg = WastArg::Core(..);
let WastArg::Core(arg) = arg; // ok if `component-model` is disabled, error if enabled
```

2.

```rust
let arg = WastArg::Core(..);
let arg = match arg {
    WastArg::Core(arg) = arg,
    _ => panic!(), // ok if `component-model` is enabled, unreachable code warning if enabled
};
```