### PR TITLE
Improve `json-from-wast -h` output

### DIFF
--- a/src/bin/wasm-tools/json_from_wast.rs
+++ b/src/bin/wasm-tools/json_from_wast.rs
@@ -54,7 +54,7 @@ pub struct Opts {
     ///
     /// This is defaulted to `true` to enable parsing all upstream spec tests
     /// but can be disabled if desired too.
-    #[clap(long)]
+    #[clap(long, value_name = "ALLOW")]
     allow_confusing_unicode: Option<bool>,
 }
 

--- a/src/bin/wasm-tools/json_from_wast.rs
+++ b/src/bin/wasm-tools/json_from_wast.rs
@@ -54,7 +54,7 @@ pub struct Opts {
     ///
     /// This is defaulted to `true` to enable parsing all upstream spec tests
     /// but can be disabled if desired too.
-    #[clap(long, value_name = "ALLOW")]
+    #[clap(long, value_name = "true|false")]
     allow_confusing_unicode: Option<bool>,
 }
 


### PR DESCRIPTION
Don't render a long variable name placeholder as
`ALLOW_CONFUSING_UNICODE` and instead render it just as `ALLOW`.