### PR TITLE
Enable memory64 by default during validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Currently implemented proposals in this repository that are stage 4+ are:
   (note this is not phase 4 but `wast` does not have the concept of features)
 * [x] [function-references](https://github.com/WebAssembly/function-references)
 * [x] [gc](https://github.com/WebAssembly/gc)
+* [x] [memory64](https://github.com/WebAssembly/memory64)
 * [x] [multi-memory](https://github.com/WebAssembly/multi-memory)
 * [x] [multi-value](https://github.com/WebAssembly/multi-value)
 * [x] [mutable-global](https://github.com/WebAssembly/mutable-global)
@@ -211,7 +212,6 @@ changed since these proposals were implemented, so there may be a mismatch too.
 
 * [x] [custom-page-sizes](https://github.com/WebAssembly/custom-page-sizes)
 * [x] [memory-control](https://github.com/WebAssembly/memory-control)
-* [x] [memory64](https://github.com/WebAssembly/memory64)
 * [x] [shared-everything-threads](https://github.com/WebAssembly/shared-everything-threads)
 * [x] [stack-switching](https://github.com/WebAssembly/stack-switching)
 * [x] [wide-arithmetic](https://github.com/WebAssembly/wide-arithmetic)

--- a/crates/wasm-smith/src/config.rs
+++ b/crates/wasm-smith/src/config.rs
@@ -455,10 +455,10 @@ define_config! {
         /// Note that this is irrelevant unless value model support is enabled.
         pub max_values: usize = 10,
 
-        /// Returns whether 64-bit memories are allowed. Defaults to false.
+        /// Returns whether 64-bit memories are allowed. Defaults to true.
         ///
         /// Note that this is the gate for the memory64 proposal to WebAssembly.
-        pub memory64_enabled: bool = false,
+        pub memory64_enabled: bool = true,
 
         /// Whether every Wasm memory must have a maximum size
         /// specified. Defaults to `false`.
@@ -718,6 +718,7 @@ impl<'a> Arbitrary<'a> for Config {
             threads_enabled: u.arbitrary()?,
             tail_call_enabled: u.arbitrary()?,
             gc_enabled: u.arbitrary()?,
+            memory64_enabled: u.arbitrary()?,
             allowed_instructions: {
                 use flagset::Flags;
                 let mut allowed = Vec::new();
@@ -764,7 +765,6 @@ impl<'a> Arbitrary<'a> for Config {
             allow_invalid_funcs: false,
 
             // Proposals that are not stage4+ are disabled by default.
-            memory64_enabled: false,
             custom_page_sizes_enabled: false,
             wide_arithmetic_enabled: false,
             shared_everything_threads_enabled: false,

--- a/crates/wasm-smith/tests/core.rs
+++ b/crates/wasm-smith/tests/core.rs
@@ -16,7 +16,7 @@ fn smoke_test_module() {
         if let Ok(module) = Module::arbitrary_take_rest(u) {
             let wasm_bytes = module.to_bytes();
 
-            let mut validator = Validator::new_with_features(wasm_features());
+            let mut validator = Validator::new_with_features(WasmFeatures::all());
             validate(&mut validator, &wasm_bytes);
         }
     }
@@ -33,7 +33,7 @@ fn smoke_test_ensure_termination() {
             module.ensure_termination(10).unwrap();
             let wasm_bytes = module.to_bytes();
 
-            let mut validator = Validator::new_with_features(wasm_features());
+            let mut validator = Validator::new_with_features(WasmFeatures::all());
             validate(&mut validator, &wasm_bytes);
         }
     }
@@ -50,7 +50,7 @@ fn smoke_test_swarm_config() {
             if let Ok(module) = Module::new(config, &mut u) {
                 let wasm_bytes = module.to_bytes();
 
-                let mut validator = Validator::new_with_features(wasm_features());
+                let mut validator = Validator::new_with_features(WasmFeatures::all());
                 validate(&mut validator, &wasm_bytes);
             }
         }
@@ -68,7 +68,7 @@ fn multi_value_disabled() {
         cfg.multi_value_enabled = false;
         if let Ok(module) = Module::new(cfg, &mut u) {
             let wasm_bytes = module.to_bytes();
-            let mut features = wasm_features();
+            let mut features = WasmFeatures::all();
             features.remove(WasmFeatures::MULTI_VALUE);
             let mut validator = Validator::new_with_features(features);
             validate(&mut validator, &wasm_bytes);
@@ -96,13 +96,15 @@ fn smoke_can_smith_valid_webassembly_one_point_oh() {
         cfg.memory64_enabled = false;
         cfg.reference_types_enabled = false;
         cfg.gc_enabled = false;
+        cfg.extended_const_enabled = false;
+        cfg.tail_call_enabled = false;
+        cfg.threads_enabled = false;
         cfg.max_memories = 1;
         cfg.max_tables = 1;
-        let features = cfg.features();
         if let Ok(module) = Module::new(cfg, &mut u) {
             let wasm_bytes = module.to_bytes();
             // This table should set to `true` only features specified in wasm-core-1 spec.
-            let mut validator = Validator::new_with_features(features);
+            let mut validator = Validator::new_with_features(WasmFeatures::WASM1);
             validate(&mut validator, &wasm_bytes);
         }
     }
@@ -119,7 +121,7 @@ fn smoke_test_no_trapping_mode() {
         cfg.disallow_traps = true;
         if let Ok(module) = Module::new(cfg, &mut u) {
             let wasm_bytes = module.to_bytes();
-            let mut validator = Validator::new_with_features(wasm_features());
+            let mut validator = Validator::new_with_features(WasmFeatures::all());
             validate(&mut validator, &wasm_bytes);
         }
     }
@@ -136,7 +138,7 @@ fn smoke_test_disallow_floats() {
         cfg.allow_floats = false;
         if let Ok(module) = Module::new(cfg, &mut u) {
             let wasm_bytes = module.to_bytes();
-            let mut features = wasm_features();
+            let mut features = WasmFeatures::all();
             features.remove(WasmFeatures::FLOATS);
             let mut validator = Validator::new_with_features(features);
             validate(&mut validator, &wasm_bytes);
@@ -156,7 +158,7 @@ fn smoke_test_reference_types() {
         cfg.max_tables = 1;
         if let Ok(module) = Module::new(cfg, &mut u) {
             let wasm_bytes = module.to_bytes();
-            let mut features = wasm_features();
+            let mut features = WasmFeatures::all();
             features.remove(WasmFeatures::REFERENCE_TYPES);
             let mut validator = Validator::new_with_features(features);
             validate(&mut validator, &wasm_bytes);
@@ -178,7 +180,7 @@ fn smoke_test_wasm_gc() {
         };
         if let Ok(module) = Module::new(config, &mut u) {
             let wasm_bytes = module.to_bytes();
-            let mut validator = Validator::new_with_features(wasm_features());
+            let mut validator = Validator::new_with_features(WasmFeatures::all());
             validate(&mut validator, &wasm_bytes);
         }
     }
@@ -197,12 +199,8 @@ fn smoke_test_wasm_custom_page_sizes() {
         };
         if let Ok(module) = Module::new(config, &mut u) {
             let wasm_bytes = module.to_bytes();
-            let mut validator = Validator::new_with_features(wasm_features());
+            let mut validator = Validator::new_with_features(WasmFeatures::all());
             validate(&mut validator, &wasm_bytes);
         }
     }
-}
-
-fn wasm_features() -> WasmFeatures {
-    WasmFeatures::all()
 }

--- a/crates/wasmparser/src/features.rs
+++ b/crates/wasmparser/src/features.rs
@@ -179,7 +179,7 @@ define_wasm_features! {
         /// The WebAssembly exception handling proposal.
         pub exceptions: EXCEPTIONS(1 << 13) = true;
         /// The WebAssembly memory64 proposal.
-        pub memory64: MEMORY64(1 << 14) = false;
+        pub memory64: MEMORY64(1 << 14) = true;
         /// The WebAssembly extended_const proposal.
         pub extended_const: EXTENDED_CONST(1 << 15) = true;
         /// The WebAssembly component model proposal.

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -23,7 +23,6 @@ pub fn generate_valid_module(
 
     // These are disabled in the swarm config by default, but we want to test
     // them. Use the input data to determine whether these features are enabled.
-    config.memory64_enabled = u.arbitrary()?;
     config.canonicalize_nans = u.arbitrary()?;
     config.custom_page_sizes_enabled = u.arbitrary()?;
     config.wide_arithmetic_enabled = u.arbitrary()?;
@@ -58,7 +57,6 @@ pub fn generate_valid_component(
     // them. Use the input data to determine whether these features are enabled.
     config.simd_enabled = u.arbitrary()?;
     config.relaxed_simd_enabled = config.simd_enabled && u.arbitrary()?;
-    config.memory64_enabled = u.arbitrary()?;
     config.exceptions_enabled = u.arbitrary()?;
     config.canonicalize_nans = u.arbitrary()?;
 


### PR DESCRIPTION
This proposal has now reached phase 4 in the standardization process which is the threshold for enabling it by default in this repository. Fuzzing knobs a have been tuned a bit to take this on-by-default behavior into account.