### PR TITLE
Add memory64 feature to "wasm3" group

### DIFF
--- a/crates/wasmparser/src/features.rs
+++ b/crates/wasmparser/src/features.rs
@@ -283,7 +283,8 @@ impl WasmFeatures {
         .union(WasmFeatures::MULTI_MEMORY)
         .union(WasmFeatures::RELAXED_SIMD)
         .union(WasmFeatures::THREADS)
-        .union(WasmFeatures::EXCEPTIONS);
+        .union(WasmFeatures::EXCEPTIONS)
+        .union(WasmFeatures::MEMORY64);
 }
 
 #[cfg(feature = "features")]


### PR DESCRIPTION
The wasm3 specification hasn't been published yet, but it looks like this proposal has been merged, so add it in.