### PR TITLE
Vendor install-rust CI action from Wasmtime

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -1,0 +1,43 @@
+name: 'Install Rust toolchain'
+description: 'Install a rust toolchain'
+
+inputs:
+  toolchain:
+    description: 'Default toolchan to install'
+    required: false
+    default: 'stable'
+
+runs:
+  using: composite
+  steps:
+    - name: Install Rust
+      shell: bash
+      id: select
+      run: |
+        # Determine MSRV as N in `1.N.0` by looking at the `rust-version`
+        # located in the root `Cargo.toml`.
+        msrv=$(grep 'rust-version.*1' Cargo.toml | sed 's/.*\.\([0-9]*\)\..*/\1/')
+
+        if [ "${{ inputs.toolchain }}" = "msrv" ]; then
+          echo "version=1.$msrv.0" >> "$GITHUB_OUTPUT"
+        else
+          echo "version=${{ inputs.toolchain }}" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Install Rust
+      shell: bash
+      run: |
+        rustup set profile minimal
+        rustup update "${{ steps.select.outputs.version }}" --no-self-update
+        rustup default "${{ steps.select.outputs.version }}"
+
+        # Save disk space by avoiding incremental compilation. Also turn down
+        # debuginfo from 2 to 0 to help save disk space.
+        cat >> "$GITHUB_ENV" <<EOF
+        CARGO_INCREMENTAL=0
+        CARGO_PROFILE_DEV_DEBUG=0
+        CARGO_PROFILE_TEST_DEBUG=0
+        EOF
+
+        # Deny warnings on CI to keep our code warning-free as it lands in-tree.
+        echo RUSTFLAGS="-D warnings" >> "$GITHUB_ENV"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,8 +40,8 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v20.0.0
-    - uses: bytecodealliance/wasmtime/.github/actions/binary-compatible-builds@v20.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v26.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/binary-compatible-builds@v26.0.0
       with:
         name: ${{ matrix.build }}
       if: matrix.build != 'wasm32-wasip1'
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v20.0.0
+      - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v26.0.0
       - name: Test (prefer-btree-collections)
         run: cargo test --workspace --locked --features prefer-btree-collections
 
@@ -103,7 +103,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v20.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v26.0.0
       with:
         toolchain: ${{ matrix.rust }}
     - run: cargo test --locked --all ${{ matrix.flags }}
@@ -115,7 +115,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v20.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v26.0.0
     - run: cargo test --locked -p wasmparser --benches
     - run: cargo test --locked -p wasm-encoder --all-features
     - run: cargo test -p wasm-smith --features wasmparser
@@ -134,7 +134,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v20.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v26.0.0
     - run: cmake -S examples -B examples/build -DCMAKE_BUILD_TYPE=Release
     - run: cmake --build examples/build --config Release
 
@@ -145,7 +145,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v20.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v26.0.0
       with:
         toolchain: 1.79.0
     - run: rustup target add wasm32-wasip1
@@ -162,7 +162,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v20.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v26.0.0
     - run: rustup target add wasm32-wasip1
     - run: |
         tag=v10.0.1
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v20.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v26.0.0
     - run: rustup component add rustfmt
     - run: printf "\n" > playground/component/src/bindings.rs
     # Note that this doesn't use `cargo fmt` because that doesn't format
@@ -198,7 +198,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v20.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v26.0.0
       with:
         toolchain: nightly
     - run: cargo install cargo-fuzz
@@ -209,7 +209,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v20.0.0
+      - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v26.0.0
       - run: rustup target add x86_64-unknown-none
       - run: cargo check --benches -p wasm-smith
       - run: cargo check --no-default-features
@@ -281,7 +281,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v20.0.0
+      - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v26.0.0
       - run: rustup component add clippy
       - run: cargo clippy --workspace --all-targets --exclude dl --exclude component
 
@@ -292,7 +292,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v20.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v26.0.0
     - run: rustc ci/publish.rs
     # Make sure we can bump version numbers for the next release
     - run: ./publish bump

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,8 +40,8 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v26.0.0
-    - uses: bytecodealliance/wasmtime/.github/actions/binary-compatible-builds@v26.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@release-27.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/binary-compatible-builds@release-27.0.0
       with:
         name: ${{ matrix.build }}
       if: matrix.build != 'wasm32-wasip1'
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v26.0.0
+      - uses: bytecodealliance/wasmtime/.github/actions/install-rust@release-27.0.0
       - name: Test (prefer-btree-collections)
         run: cargo test --workspace --locked --features prefer-btree-collections
 
@@ -103,7 +103,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v26.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@release-27.0.0
       with:
         toolchain: ${{ matrix.rust }}
     - run: cargo test --locked --all ${{ matrix.flags }}
@@ -115,7 +115,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v26.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@release-27.0.0
     - run: cargo test --locked -p wasmparser --benches
     - run: cargo test --locked -p wasm-encoder --all-features
     - run: cargo test -p wasm-smith --features wasmparser
@@ -134,7 +134,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v26.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@release-27.0.0
     - run: cmake -S examples -B examples/build -DCMAKE_BUILD_TYPE=Release
     - run: cmake --build examples/build --config Release
 
@@ -145,7 +145,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v26.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@release-27.0.0
       with:
         toolchain: 1.79.0
     - run: rustup target add wasm32-wasip1
@@ -162,7 +162,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v26.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@release-27.0.0
     - run: rustup target add wasm32-wasip1
     - run: |
         tag=v10.0.1
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v26.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@release-27.0.0
     - run: rustup component add rustfmt
     - run: printf "\n" > playground/component/src/bindings.rs
     # Note that this doesn't use `cargo fmt` because that doesn't format
@@ -198,7 +198,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v26.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@release-27.0.0
       with:
         toolchain: nightly
     - run: cargo install cargo-fuzz
@@ -209,7 +209,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v26.0.0
+      - uses: bytecodealliance/wasmtime/.github/actions/install-rust@release-27.0.0
       - run: rustup target add x86_64-unknown-none
       - run: cargo check --benches -p wasm-smith
       - run: cargo check --no-default-features
@@ -281,7 +281,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v26.0.0
+      - uses: bytecodealliance/wasmtime/.github/actions/install-rust@release-27.0.0
       - run: rustup component add clippy
       - run: cargo clippy --workspace --all-targets --exclude dl --exclude component
 
@@ -292,7 +292,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@v26.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@release-27.0.0
     - run: rustc ci/publish.rs
     # Make sure we can bump version numbers for the next release
     - run: ./publish bump

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,8 +40,8 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@release-27.0.0
-    - uses: bytecodealliance/wasmtime/.github/actions/binary-compatible-builds@release-27.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@main
+    - uses: bytecodealliance/wasmtime/.github/actions/binary-compatible-builds@main
       with:
         name: ${{ matrix.build }}
       if: matrix.build != 'wasm32-wasip1'
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: bytecodealliance/wasmtime/.github/actions/install-rust@release-27.0.0
+      - uses: bytecodealliance/wasmtime/.github/actions/install-rust@main
       - name: Test (prefer-btree-collections)
         run: cargo test --workspace --locked --features prefer-btree-collections
 
@@ -103,7 +103,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@release-27.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@main
       with:
         toolchain: ${{ matrix.rust }}
     - run: cargo test --locked --all ${{ matrix.flags }}
@@ -115,7 +115,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@release-27.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@main
     - run: cargo test --locked -p wasmparser --benches
     - run: cargo test --locked -p wasm-encoder --all-features
     - run: cargo test -p wasm-smith --features wasmparser
@@ -134,7 +134,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@release-27.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@main
     - run: cmake -S examples -B examples/build -DCMAKE_BUILD_TYPE=Release
     - run: cmake --build examples/build --config Release
 
@@ -145,7 +145,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@release-27.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@main
       with:
         toolchain: 1.79.0
     - run: rustup target add wasm32-wasip1
@@ -162,7 +162,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@release-27.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@main
     - run: rustup target add wasm32-wasip1
     - run: |
         tag=v10.0.1
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@release-27.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@main
     - run: rustup component add rustfmt
     - run: printf "\n" > playground/component/src/bindings.rs
     # Note that this doesn't use `cargo fmt` because that doesn't format
@@ -198,7 +198,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@release-27.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@main
       with:
         toolchain: nightly
     - run: cargo install cargo-fuzz
@@ -209,7 +209,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bytecodealliance/wasmtime/.github/actions/install-rust@release-27.0.0
+      - uses: bytecodealliance/wasmtime/.github/actions/install-rust@main
       - run: rustup target add x86_64-unknown-none
       - run: cargo check --benches -p wasm-smith
       - run: cargo check --no-default-features
@@ -281,7 +281,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bytecodealliance/wasmtime/.github/actions/install-rust@release-27.0.0
+      - uses: bytecodealliance/wasmtime/.github/actions/install-rust@main
       - run: rustup component add clippy
       - run: cargo clippy --workspace --all-targets --exclude dl --exclude component
 
@@ -292,7 +292,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@release-27.0.0
+    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@main
     - run: rustc ci/publish.rs
     # Make sure we can bump version numbers for the next release
     - run: ./publish bump

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@main
+    - uses: ./.github/actions/install-rust
     - uses: bytecodealliance/wasmtime/.github/actions/binary-compatible-builds@main
       with:
         name: ${{ matrix.build }}
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - uses: bytecodealliance/wasmtime/.github/actions/install-rust@main
+      - uses: ./.github/actions/install-rust
       - name: Test (prefer-btree-collections)
         run: cargo test --workspace --locked --features prefer-btree-collections
 
@@ -74,15 +74,15 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            rust: default
+            rust: stable
           - os: ubuntu-latest
             rust: beta
           - os: ubuntu-latest
-            rust: nightly-2024-09-10
+            rust: nightly
           - os: macos-latest
-            rust: default
+            rust: stable
           - os: windows-latest
-            rust: default
+            rust: stable
           - os: ubuntu-latest
             rust: msrv
             # skip testing crates that require wasmtime since wasmtime has a
@@ -95,7 +95,7 @@ jobs:
           # test that if `RUST_BACKTRACE=1` is set in the environment that all
           # tests with blessed error messages still pass.
           - os: ubuntu-latest
-            rust: default
+            rust: stable
             env:
               RUST_BACKTRACE: 1
     env: ${{ matrix.env || fromJSON('{}') }}
@@ -103,7 +103,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@main
+    - uses: ./.github/actions/install-rust
       with:
         toolchain: ${{ matrix.rust }}
     - run: cargo test --locked --all ${{ matrix.flags }}
@@ -115,7 +115,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@main
+    - uses: ./.github/actions/install-rust
     - run: cargo test --locked -p wasmparser --benches
     - run: cargo test --locked -p wasm-encoder --all-features
     - run: cargo test -p wasm-smith --features wasmparser
@@ -134,7 +134,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@main
+    - uses: ./.github/actions/install-rust
     - run: cmake -S examples -B examples/build -DCMAKE_BUILD_TYPE=Release
     - run: cmake --build examples/build --config Release
 
@@ -145,7 +145,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@main
+    - uses: ./.github/actions/install-rust
       with:
         toolchain: 1.79.0
     - run: rustup target add wasm32-wasip1
@@ -162,7 +162,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@main
+    - uses: ./.github/actions/install-rust
     - run: rustup target add wasm32-wasip1
     - run: |
         tag=v10.0.1
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@main
+    - uses: ./.github/actions/install-rust
     - run: rustup component add rustfmt
     - run: printf "\n" > playground/component/src/bindings.rs
     # Note that this doesn't use `cargo fmt` because that doesn't format
@@ -198,7 +198,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@main
+    - uses: ./.github/actions/install-rust
       with:
         toolchain: nightly
     - run: cargo install cargo-fuzz
@@ -209,7 +209,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bytecodealliance/wasmtime/.github/actions/install-rust@main
+      - uses: ./.github/actions/install-rust
       - run: rustup target add x86_64-unknown-none
       - run: cargo check --benches -p wasm-smith
       - run: cargo check --no-default-features
@@ -281,7 +281,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: bytecodealliance/wasmtime/.github/actions/install-rust@main
+      - uses: ./.github/actions/install-rust
       - run: rustup component add clippy
       - run: cargo clippy --workspace --all-targets --exclude dl --exclude component
 
@@ -292,7 +292,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - uses: bytecodealliance/wasmtime/.github/actions/install-rust@main
+    - uses: ./.github/actions/install-rust
     - run: rustc ci/publish.rs
     # Make sure we can bump version numbers for the next release
     - run: ./publish bump


### PR DESCRIPTION
Copy the action over to this repository and edit it to suit this repository's needs such as not installing wasm targets and dealing with MSRV differently. This fixes a CI error from the latest nightly where `wasm32-wasi` isn't available. The Wasmtime version of the action is no longer used since the MSRV in this repository doesn't have `wasm32-wasip1` and otherwise the latest nightly doesn't have `wasm32-wasi`, so it's easier to just edit it here.

This has the additional effect of handling Rust versions in CI slightly different. Previously the Wasmtime behavior of MSRV+2 was chosen for most runs but that was actually 1.78 as opposed to the latest stable 1.82, so the default now is "stable" and only the one builder for "msrv" explicitly reads `Cargo.toml` to run that.

For now this repository has more "floating" CI than the Wasmtime repository where the Rust versions are automatically updated. This will (and has) cause breakage when Rust versions update but otherwise I'm pretty sure I'll always forget to update the CI so it seems like a more reasonable balance for now. If contributions on this repository increase and a disruption of CI is significant it's probably best to fix the Rust versions used in CI