### PR TITLE
`wasmparser`: fix crate feature propagation

### DIFF
--- a/crates/wasm-metadata/Cargo.toml
+++ b/crates/wasm-metadata/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 [dependencies]
 clap = { workspace = true, optional = true }
 anyhow = { workspace = true }
-wasmparser = { workspace = true, features = ['component-model'] }
+wasmparser = { workspace = true, features = ['component-model', 'hash-collections'] }
 wasm-encoder = { workspace = true, features = ['component-model'] }
 indexmap = { workspace = true, features = ["serde"] }
 serde = { workspace = true }

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -48,7 +48,7 @@ default = ['std', 'validate', 'serde', 'features', 'component-model', 'hash-coll
 # A feature which enables implementations of `std::error::Error` as appropriate
 # along with other convenience APIs. This additionally uses the standard
 # library's source of randomness for seeding hash maps.
-std = ['indexmap/std']
+std = ['indexmap?/std']
 
 # Tells the `wasmparser` crate to provide (and use) hash-based collections internally.
 #
@@ -70,7 +70,7 @@ validate = ['dep:semver']
 
 # Enable Serialize/Deserialize implementations for types in
 # `wasmparser::collections`
-serde = ['dep:serde', 'indexmap/serde', 'hashbrown/serde']
+serde = ['dep:serde', 'indexmap?/serde', 'hashbrown?/serde']
 
 # A feature that enables the guts of the `WasmFeatures` type in this crate.
 #


### PR DESCRIPTION
No longer enable `indexmap` and `hashbrown` when `std` feature is enabled without `hash-collections` feature.