### PR TITLE
`wasmparser`: Update `hashbrown` to `v0.15.1` and use its `default-hasher` to replace `ahash` usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,11 +746,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
 dependencies = [
  "foldhash",
+ "serde",
 ]
 
 [[package]]
@@ -820,7 +821,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.1",
  "serde",
 ]
 
@@ -1068,7 +1069,7 @@ checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "crc32fast",
  "flate2",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.1",
  "indexmap 2.6.0",
  "memchr",
  "ruzstd",
@@ -1876,12 +1877,11 @@ dependencies = [
 name = "wasmparser"
 version = "0.220.0"
 dependencies = [
- "ahash",
  "anyhow",
  "bitflags",
  "criterion",
  "env_logger",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.1",
  "indexmap 2.6.0",
  "log",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ semver = { version = "1.0.0", default-features = false }
 smallvec = "1.11.1"
 libtest-mimic = "0.7.0"
 bitflags = "2.5.0"
-hashbrown = { version = "0.14.3", default-features = false, features = ['ahash'] }
+hashbrown = { version = "0.15.1", default-features = false, features = ['default-hasher'] }
 ahash = { version = "0.8.11", default-features = false }
 termcolor = "1.2.0"
 indoc = "2.0.5"

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -24,7 +24,6 @@ bitflags = "2.4.1"
 indexmap = { workspace = true, optional = true }
 semver = { workspace = true, optional = true }
 hashbrown = { workspace = true, optional = true }
-ahash = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -52,12 +51,11 @@ std = ['indexmap?/std']
 
 # Tells the `wasmparser` crate to provide (and use) hash-based collections internally.
 #
-# Disabling this crate feature allows to drop `hashbrown`, `indexmap` and `ahash` dependencies
+# Disabling this crate feature allows to drop `hashbrown`, `indexmap` dependencies
 # entirely, reducing compilation times and shrink binary sizes.
 hash-collections = [
   'dep:hashbrown',
   'dep:indexmap',
-  'dep:ahash',
 ]
 # Tells the `wasmparser` crate to prefer using its built-in btree-based collections 
 # even if `hash-collections` is enabled.

--- a/crates/wasmparser/src/collections/hash.rs
+++ b/crates/wasmparser/src/collections/hash.rs
@@ -97,24 +97,24 @@ use std::collections::hash_map::RandomState as RandomStateImpl;
 #[derive(Clone, Debug)]
 #[cfg(not(feature = "std"))]
 struct RandomStateImpl {
-    state: ahash::RandomState,
+    state: hashbrown::DefaultHashBuilder,
 }
 
 #[cfg(not(feature = "std"))]
 impl Default for RandomStateImpl {
     fn default() -> RandomStateImpl {
         RandomStateImpl {
-            state: ahash::RandomState::new(),
+            state: hashbrown::DefaultHashBuilder::default(),
         }
     }
 }
 
 #[cfg(not(feature = "std"))]
 impl BuildHasher for RandomStateImpl {
-    type Hasher = ahash::AHasher;
+    type Hasher = <hashbrown::DefaultHashBuilder as BuildHasher>::Hasher;
 
     #[inline]
-    fn build_hasher(&self) -> ahash::AHasher {
+    fn build_hasher(&self) -> Self::Hasher {
         self.state.build_hasher()
     }
 }


### PR DESCRIPTION
- Updates to `hashbrown` v0.15.1.
- Also remove `ahash` and use hashbrown's `default-hasher` crate feature as replacement. This allows to drop yet another `wasmparser` dependency.

### Note

- `hashbrown` started using [`foldhash`](https://github.com/orlp/foldhash) as its default-hasher starting in `v0.15.0`. From what I know it should be an improvement over `ahash`.
- `hashbrown` by default is using `foldhash-f` and not `foldhash-q` where `foldhash-f` is the "fast" version and `foldhash-q` is the hash-DOS resistant version. It seems that `foldhash-f` is more DOS-resistant than `fxhash` but less than both `foldhash-q` and `ahash`. Maybe this is a reason to _not_ use `hashbrown`'s default hasher. For Wasmi my stance is that if you want DOS-resistance, you simply do not use hash-tables at all by disabling `hash-collections` feature.

Q: Are there any other workspace crates that need adjustment?

Background: [I did the same in Wasmi](https://github.com/wasmi-labs/wasmi/pull/1305) and found it to be a good solution so far.