### PR TITLE
`wasmparser`: optimize type section valiadation by specializing over Wasm feature subset

### DIFF
--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -569,7 +569,7 @@ impl Module {
                 offset,
             )?;
         }
-        if !(features.function_references() || features.gc() || features.component_model()) {
+        if !(features.function_references() || features.gc() || features.component_model() || features.stack_switching()) {
             // Without `function-references`, `gc` and the `component-model` proposals
             // we can use a special type validation that is simpler and more efficient.
             if rec_group.is_explicit_rec_group() {

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -571,7 +571,11 @@ impl Module {
         }
         /// The subset of `WasmFeatures` for which we know that the
         /// fast type section validation can be safely applied.
-        const ALLOWED_FEATURES: WasmFeatures = WasmFeatures::WASM2
+        /// 
+        /// Fast type section validation does not have to canonicalize
+        /// (deduplicate) types and does not have to perform sub-typing
+        /// checks.
+        const FAST_VALIDATION_FEATURES: WasmFeatures = WasmFeatures::WASM2
             .union(WasmFeatures::CUSTOM_PAGE_SIZES)
             .union(WasmFeatures::EXTENDED_CONST)
             .union(WasmFeatures::MEMORY64)
@@ -580,9 +584,7 @@ impl Module {
             .union(WasmFeatures::TAIL_CALL)
             .union(WasmFeatures::THREADS)
             .union(WasmFeatures::WIDE_ARITHMETIC);
-        if ALLOWED_FEATURES.contains(*features) {
-            // Note: without the proposals guarded above we can use a special
-            //       type validation that is both simpler and more efficient.
+        if FAST_VALIDATION_FEATURES.contains(*features) {
             if rec_group.is_explicit_rec_group() {
                 bail!(offset, "requires `gc` proposal to be enabled")
             }

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -569,11 +569,18 @@ impl Module {
                 offset,
             )?;
         }
-        if !(features.function_references()
-            || features.gc()
-            || features.component_model()
-            || features.stack_switching())
-        {
+        /// The subset of `WasmFeatures` for which we know that the
+        /// fast type section validation can be safely applied.
+        const ALLOWED_FEATURES: WasmFeatures = WasmFeatures::WASM2
+            .union(WasmFeatures::CUSTOM_PAGE_SIZES)
+            .union(WasmFeatures::EXTENDED_CONST)
+            .union(WasmFeatures::MULTI_MEMORY)
+            .union(WasmFeatures::WIDE_ARITHMETIC)
+            .union(WasmFeatures::MEMORY64)
+            .union(WasmFeatures::TAIL_CALL)
+            .union(WasmFeatures::RELAXED_SIMD)
+            .union(WasmFeatures::THREADS);
+        if ALLOWED_FEATURES.contains(*features) {
             // Note: without the proposals guarded above we can use a special
             //       type validation that is both simpler and more efficient.
             if rec_group.is_explicit_rec_group() {

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -6,7 +6,9 @@ pub(crate) use canonical::InternRecGroup;
 
 use self::arc::MaybeOwned;
 use super::{
-    check_max, combine_type_sizes, operators::{ty_to_str, OperatorValidator, OperatorValidatorAllocations}, types::{CoreTypeId, EntityType, RecGroupId, TypeAlloc, TypeList}
+    check_max, combine_type_sizes,
+    operators::{ty_to_str, OperatorValidator, OperatorValidatorAllocations},
+    types::{CoreTypeId, EntityType, RecGroupId, TypeAlloc, TypeList},
 };
 use crate::{
     limits::*, BinaryReaderError, ConstExpr, Data, DataKind, Element, ElementKind, ExternalKind,
@@ -567,11 +569,7 @@ impl Module {
                 offset,
             )?;
         }
-        if !(
-            features.function_references() ||
-            features.gc() ||
-            features.component_model()
-        ) {
+        if !(features.function_references() || features.gc() || features.component_model()) {
             // Without `function-references`, `gc` and the `component-model` proposals
             // we can use a special type validation that is simpler and more efficient.
             if rec_group.is_explicit_rec_group() {
@@ -582,7 +580,7 @@ impl Module {
                 self.add_type_id(id);
                 self.check_composite_type(&ty.composite_type, features, &types, offset)?;
             }
-            return Ok(())
+            return Ok(());
         }
         self.canonicalize_and_intern_rec_group(features, types, rec_group, offset)
     }

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -574,12 +574,12 @@ impl Module {
         const ALLOWED_FEATURES: WasmFeatures = WasmFeatures::WASM2
             .union(WasmFeatures::CUSTOM_PAGE_SIZES)
             .union(WasmFeatures::EXTENDED_CONST)
-            .union(WasmFeatures::MULTI_MEMORY)
-            .union(WasmFeatures::WIDE_ARITHMETIC)
             .union(WasmFeatures::MEMORY64)
-            .union(WasmFeatures::TAIL_CALL)
+            .union(WasmFeatures::MULTI_MEMORY)
             .union(WasmFeatures::RELAXED_SIMD)
-            .union(WasmFeatures::THREADS);
+            .union(WasmFeatures::TAIL_CALL)
+            .union(WasmFeatures::THREADS)
+            .union(WasmFeatures::WIDE_ARITHMETIC);
         if ALLOWED_FEATURES.contains(*features) {
             // Note: without the proposals guarded above we can use a special
             //       type validation that is both simpler and more efficient.

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -568,9 +568,9 @@ impl Module {
             )?;
         }
         if !(
-            features.contains(WasmFeatures::FUNCTION_REFERENCES) ||
-            features.contains(WasmFeatures::GC) ||
-            features.contains(WasmFeatures::COMPONENT_MODEL)
+            features.function_references() ||
+            features.gc() ||
+            features.component_model()
         ) {
             // Without `function-references`, `gc` and the `component-model` proposals
             // we can use a special type validation that is simpler and more efficient.

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -569,7 +569,11 @@ impl Module {
                 offset,
             )?;
         }
-        if !(features.function_references() || features.gc() || features.component_model() || features.stack_switching()) {
+        if !(features.function_references()
+            || features.gc()
+            || features.component_model()
+            || features.stack_switching())
+        {
             // Without `function-references`, `gc` and the `component-model` proposals
             // we can use a special type validation that is simpler and more efficient.
             if rec_group.is_explicit_rec_group() {

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -576,9 +576,9 @@ impl Module {
                 bail!(offset, "requires `gc` proposal to be enabled")
             }
             for ty in rec_group.types() {
+                self.check_composite_type(&ty.composite_type, features, &types, offset)?;
                 let id = types.push(ty.clone());
                 self.add_type_id(id);
-                self.check_composite_type(&ty.composite_type, features, &types, offset)?;
             }
             return Ok(());
         }

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -574,8 +574,8 @@ impl Module {
             || features.component_model()
             || features.stack_switching())
         {
-            // Without `function-references`, `gc` and the `component-model` proposals
-            // we can use a special type validation that is simpler and more efficient.
+            // Note: without the proposals guarded above we can use a special
+            //       type validation that is both simpler and more efficient.
             if rec_group.is_explicit_rec_group() {
                 bail!(offset, "requires `gc` proposal to be enabled")
             }

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -571,7 +571,7 @@ impl Module {
         }
         /// The subset of `WasmFeatures` for which we know that the
         /// fast type section validation can be safely applied.
-        /// 
+        ///
         /// Fast type section validation does not have to canonicalize
         /// (deduplicate) types and does not have to perform sub-typing
         /// checks.

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -576,9 +576,9 @@ impl Module {
                 bail!(offset, "requires `gc` proposal to be enabled")
             }
             for ty in rec_group.types() {
-                self.check_composite_type(&ty.composite_type, features, &types, offset)?;
                 let id = types.push(ty.clone());
                 self.add_type_id(id);
+                self.check_composite_type(&ty.composite_type, features, &types, offset)?;
             }
             return Ok(());
         }


### PR DESCRIPTION
Closes https://github.com/bytecodealliance/wasm-tools/issues/1701.

cc @alexcrichton : Are there any other Wasm proposals that might conflict?

This implements a lightweight type section validation for a subset of Wasm proposals.

## Benchmarks

I compared `main` against PR and changed the used `WasmFeatures` set for both:

```rust
Validator::new_with_features(
    WasmFeatures::WASM2
        .union(WasmFeatures::CUSTOM_PAGE_SIZES)
        .union(WasmFeatures::EXTENDED_CONST)
        .union(WasmFeatures::MEMORY64)
        .union(WasmFeatures::MULTI_MEMORY)
        .union(WasmFeatures::RELAXED_SIMD)
        .union(WasmFeatures::TAIL_CALL)
        .union(WasmFeatures::THREADS)
        .union(WasmFeatures::WIDE_ARITHMETIC);
)
```

![image](https://github.com/user-attachments/assets/8b21bc2b-9c16-4beb-81b5-761c036de747)