### PR TITLE
`wasmparser`: use `semver` dependency only when `component-model` is enabled

### DIFF
--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -64,7 +64,7 @@ prefer-btree-collections = []
 # A feature that enables validating WebAssembly files. This is enabled by
 # default but not required if you're only parsing a file, for example, as
 # opposed to validating all of its contents.
-validate = ['dep:semver']
+validate = []
 
 # Enable Serialize/Deserialize implementations for types in
 # `wasmparser::collections`
@@ -81,4 +81,4 @@ features = []
 # A feature that enables parsing and validating the component-model proposal for
 # WebAssembly. This is enabled by default but if your use case is only
 # interested in working with core modules then this feature can be disabled.
-component-model = []
+component-model = ['dep:semver']


### PR DESCRIPTION
I have looked up where the `semver` dependency is actually used in `wasmparser` and it seems to me that the only location where it actually is used is in the `ComponentNameParser` which is part of the `component-model`.

This helps to reduce compile time further when `component-model` is disabled.