### PR TITLE
Add an assert to wit-parser's `assert_valid`.

### DIFF
--- a/crates/wit-parser/src/resolve.rs
+++ b/crates/wit-parser/src/resolve.rs
@@ -1500,6 +1500,11 @@ package {name} is defined in two different locations:\n\
             let mut worlds = HashSet::new();
             for (name, world) in pkg.worlds.iter() {
                 assert!(worlds.insert(*world));
+                assert_eq!(
+                    pkg.worlds.get_key_value(name),
+                    Some((name, world)),
+                    "`MutableKeys` impl may have been used to change a key's hash or equality"
+                );
                 let world = &self.worlds[*world];
                 assert_eq!(*name, world.name);
                 assert_eq!(world.package.unwrap(), id);


### PR DESCRIPTION
Indexmap's [`MutableKeys` trait] allows one to mutate the keys in an `IndexMap`, however it doesn't prevent bugs where the new keys have different hash values from the old keys. Since I recently made this mistake, add an assert to help catch such bugs. It doesn't always catch the bug, because whether or not the bug is observable depends on hashmap internals, but it's better than nothing.

[`MutableKeys` trait]: https://docs.rs/indexmap/latest/indexmap/map/trait.MutableKeys.html