### PR TITLE
Prepare to update spec test suite

### DIFF
--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -761,12 +761,6 @@ impl Module {
         }
 
         self.check_limits(ty.initial, ty.maximum, offset)?;
-        if ty.initial > MAX_WASM_TABLE_ENTRIES as u64 {
-            return Err(BinaryReaderError::new(
-                "minimum table size is out of bounds",
-                offset,
-            ));
-        }
 
         if ty.shared {
             if !features.shared_everything_threads() {

--- a/crates/wast/src/core/resolve/deinline_import_export.rs
+++ b/crates/wast/src/core/resolve/deinline_import_export.rs
@@ -48,7 +48,11 @@ pub fn run(fields: &mut Vec<ModuleField>) {
                     }
                     // If data is defined inline insert an explicit `data` module
                     // field here instead, switching this to a `Normal` memory.
-                    MemoryKind::Inline { is64, ref data } => {
+                    MemoryKind::Inline {
+                        is64,
+                        ref data,
+                        page_size_log2,
+                    } => {
                         let len = data.iter().map(|l| l.len()).sum::<usize>() as u64;
                         let pages = (len + default_page_size() - 1) / default_page_size();
                         let kind = MemoryKind::Normal(MemoryType {
@@ -58,7 +62,7 @@ pub fn run(fields: &mut Vec<ModuleField>) {
                                 max: Some(pages),
                             },
                             shared: false,
-                            page_size_log2: None,
+                            page_size_log2,
                         });
                         let data = match mem::replace(&mut m.kind, kind) {
                             MemoryKind::Inline { data, .. } => data,

--- a/crates/wast/src/core/types.rs
+++ b/crates/wast/src/core/types.rs
@@ -613,17 +613,9 @@ impl<'a> Parse<'a> for Limits {
             false
         };
 
-        let parse = || {
-            if is64 {
-                parser.parse::<u64>()
-            } else {
-                parser.parse::<u32>().map(|x| x.into())
-            }
-        };
-
-        let min = parse()?;
+        let min = parser.parse()?;
         let max = if parser.peek::<u64>()? {
-            Some(parse()?)
+            Some(parser.parse()?)
         } else {
             None
         };
@@ -663,8 +655,9 @@ pub struct MemoryType {
     pub page_size_log2: Option<u32>,
 }
 
-fn page_size(parser: Parser<'_>) -> Result<Option<u32>> {
-    if parser.peek::<LParen>()? {
+/// Parse `(pagesize N)` or nothing.
+pub fn page_size(parser: Parser<'_>) -> Result<Option<u32>> {
+    if parser.peek::<LParen>()? && parser.peek2::<kw::pagesize>()? {
         Ok(Some(parser.parens(|parser| {
             parser.parse::<kw::pagesize>()?;
             let span = parser.cur_span();

--- a/tests/local/table-too-big.wast
+++ b/tests/local/table-too-big.wast
@@ -1,5 +1,3 @@
-(assert_invalid
-  (module
-    (table 1_000_000_000 funcref)
-  )
-  "minimum table size is out of bounds")
+(module definition
+  (table 1_000_000_000 funcref)
+)

--- a/tests/snapshots/local/table-too-big.wast.json
+++ b/tests/snapshots/local/table-too-big.wast.json
@@ -2,11 +2,10 @@
   "source_filename": "tests/local/table-too-big.wast",
   "commands": [
     {
-      "type": "assert_invalid",
-      "line": 2,
+      "type": "module_definition",
+      "line": 1,
       "filename": "table-too-big.0.wasm",
-      "module_type": "binary",
-      "text": "minimum table size is out of bounds"
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/table-too-big.wast/0.print
+++ b/tests/snapshots/local/table-too-big.wast/0.print
@@ -1,0 +1,3 @@
+(module
+  (table (;0;) 1000000000 funcref)
+)

--- a/tests/snapshots/testsuite/proposals/memory64/memory.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/memory.wast.json
@@ -217,6 +217,7 @@
       "line": 77,
       "filename": "memory.25.wat",
       "module_type": "text",
+      "binary_filename": "memory.25.wasm",
       "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
@@ -224,6 +225,7 @@
       "line": 81,
       "filename": "memory.26.wat",
       "module_type": "text",
+      "binary_filename": "memory.26.wasm",
       "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {
@@ -231,6 +233,7 @@
       "line": 85,
       "filename": "memory.27.wat",
       "module_type": "text",
+      "binary_filename": "memory.27.wasm",
       "text": "memory size must be at most 65536 pages (4GiB)"
     },
     {

--- a/tests/snapshots/testsuite/proposals/memory64/table.wast.json
+++ b/tests/snapshots/testsuite/proposals/memory64/table.wast.json
@@ -124,6 +124,7 @@
       "line": 35,
       "filename": "table.19.wat",
       "module_type": "text",
+      "binary_filename": "table.19.wasm",
       "text": "table size must be at most 2^32-1"
     },
     {
@@ -131,6 +132,7 @@
       "line": 39,
       "filename": "table.20.wat",
       "module_type": "text",
+      "binary_filename": "table.20.wasm",
       "text": "table size must be at most 2^32-1"
     },
     {
@@ -138,6 +140,7 @@
       "line": 43,
       "filename": "table.21.wat",
       "module_type": "text",
+      "binary_filename": "table.21.wasm",
       "text": "table size must be at most 2^32-1"
     },
     {


### PR DESCRIPTION
Some minor updates in preparation for WebAssembly/testsuite#110:

* Don't limit the size of tables in the validator and instead defer such maximal validation to runtimes themselves.
* Parse the `(pagesize N)` syntax on "inline memories"
* Always parse table/memory limits as 64-bit integers
* Stop matching spec test suite error messages

This last point is something I've tried to hold off on doing for a long time but as the giant `error_matches` function continues to grow and become more unwieldy it has become less and less tenable to do this. Overall it doesn't seem too beneficial to keep maintaining this especially in the face of numerous proposals, so instead basically remove it entirely.