### PR TITLE
wit-encoder: Implement world uses and sort interface and world items, uses

### DIFF
--- a/crates/wit-encoder/tests/deps.rs
+++ b/crates/wit-encoder/tests/deps.rs
@@ -10,7 +10,11 @@ const MAIN_PACKAGE_SOURCE: &str = indoc::indoc! {"
       use foo:dep-a/dep-a-interface-b.{ ra };
     }
 
-    interface main-interface-b {}
+    interface main-interface-b {
+        record mb {
+            x: f32,
+        }
+    }
 
     interface main-interface-c {}
 
@@ -19,14 +23,17 @@ const MAIN_PACKAGE_SOURCE: &str = indoc::indoc! {"
     interface main-interface-e {}
 
     world main-world-a {
+      use foo:dep-c/dep-c-interface-b.{ cb, cb as cbcb };
       import foo:dep-c/dep-c-interface-a;
       export foo:dep-c/dep-c-interface-b;
       include foo:dep-c/dep-c-world-a;
 
+      use foo:dep-b/dep-b-interface-b@1.2.3.{ bb, bb as bbbb };
       import foo:dep-b/dep-b-interface-a@1.2.3;
       export foo:dep-b/dep-b-interface-b@1.2.3;
       include foo:dep-b/dep-b-world-b@1.2.3;
 
+      use main-interface-b.{ mb, mb as mbmb };
       import main-interface-b;
       export main-interface-a;
       include main-world-b;
@@ -45,7 +52,11 @@ const MAIN_PACKAGE_RESOLVED_ENCODED: &str = indoc::indoc! {"
       use foo:dep-a/dep-a-interface-b.{ ra };
     }
 
-    interface main-interface-b {}
+    interface main-interface-b {
+      record mb {
+        x: f32,
+      }
+    }
 
     interface main-interface-c {}
 
@@ -59,16 +70,21 @@ const MAIN_PACKAGE_RESOLVED_ENCODED: &str = indoc::indoc! {"
     }
 
     world main-world-a {
-      import foo:dep-c/dep-c-interface-a;
-      import foo:dep-b/dep-b-interface-a@1.2.3;
-      import main-interface-b;
-      import foo:dep-c/dep-c-interface-c;
-      import main-interface-d;
+      use foo:dep-b/dep-b-interface-b@1.2.3.{ bb, bb as bbbb };
+      use foo:dep-c/dep-c-interface-b.{ cb, cb as cbcb };
+      use main-interface-b.{ mb, mb as mbmb };
       import foo:dep-a/dep-a-interface-b;
-      export foo:dep-c/dep-c-interface-b;
+      import foo:dep-b/dep-b-interface-a@1.2.3;
+      import foo:dep-b/dep-b-interface-b@1.2.3;
+      import foo:dep-c/dep-c-interface-a;
+      import foo:dep-c/dep-c-interface-b;
+      import foo:dep-c/dep-c-interface-c;
+      import main-interface-b;
+      import main-interface-d;
       export foo:dep-b/dep-b-interface-b@1.2.3;
-      export main-interface-a;
+      export foo:dep-c/dep-c-interface-b;
       export foo:dep-c/dep-c-interface-d;
+      export main-interface-a;
       export main-interface-d;
     }
 "};
@@ -96,6 +112,10 @@ const DEP_PACKAGE_B: &str = indoc::indoc! {"
 
     interface dep-b-interface-b {
       use foo:dep-c/dep-c-interface-a.{a};
+
+      record bb {
+        x: f32,
+      }
     }
 
     world dep-b-world-a {
@@ -115,7 +135,11 @@ const DEP_PACKAGE_C: &str = indoc::indoc! {"
       }
     }
 
-    interface dep-c-interface-b {}
+    interface dep-c-interface-b {
+      record cb {
+        x: f32,
+      }
+    }
 
     interface dep-c-interface-c {}
 

--- a/crates/wit-encoder/tests/parse-to-encoder.rs
+++ b/crates/wit-encoder/tests/parse-to-encoder.rs
@@ -20,19 +20,14 @@ interface bar-interface {
 
 interface %interface {
   use bar-interface.{ some-enum, external-type };
-  statndalone-func: func(a: u32, b: s32) -> f32;
-  variant %variant {
-    empty-case,
-    valued-case(u32),
+  resource other-resource {
+    constructor(values: list<u32>);
+    static-method: func(arg: tuple<u32, u32>);
   }
   resource %resource {
     constructor();
     method: func(arg: list<u32>) -> char;
     static-method: static func(arg: tuple<u32, u32>) -> list<u32>;
-  }
-  resource other-resource {
-    constructor(values: list<u32>);
-    static-method: func(arg: tuple<u32, u32>);
   }
   record some-record {
     optinal: option<string>,
@@ -44,6 +39,8 @@ interface %interface {
     result-d: result<f64, f32>,
     result-e: result<string, list<u8>>,
   }
+  type type-handle-borrow = borrow<%resource>;
+  type type-handle-own = %resource;
   type type-list = list<f64>;
   type type-option = option<f64>;
   type type-result-a = result;
@@ -51,34 +48,47 @@ interface %interface {
   type type-result-c = result<_, f64>;
   type type-result-d = result<f64, f32>;
   type type-result-e = result<string, list<u8>>;
-  type type-handle-own = %resource;
-  type type-handle-borrow = borrow<%resource>;
   type type-tuple = tuple<u32, list<u32>, borrow<%resource>>;
+  variant %variant {
+    empty-case,
+    valued-case(u32),
+  }
+  statndalone-func: func(a: u32, b: s32) -> f32;
 }
 
 world my-world {
-  import foo-interface;
-  import bar-interface;
-  import %interface;
   import inline-import: interface {
     do-something: func(a: string) -> string;
   }
-  import import-func: func();
-  export export-func: func(a: u32, b: s32) -> f32;
-  export %interface;
   export inline-export: interface {
     do-nothing: func();
   }
+  import bar-interface;
+  import foo-interface;
+  import %interface;
+  export %interface;
+  import import-func: func();
+  export export-func: func(a: u32, b: s32) -> f32;
 }
 "#;
 
 #[test]
 fn round_trip() {
+    // First round trip
     let mut resolve = wit_parser::Resolve::new();
     resolve.push_str("", WIT).unwrap();
     let packages = packages_from_parsed(&resolve);
 
-    assert!(packages.len() == 1, "Should create exactly one package");
+    assert_eq!(packages.len(), 1, "Should create exactly one package");
+    let package = &packages[0];
+    assert_eq!(WIT, package.to_string());
+
+    // Second round tip
+    let mut resolve = wit_parser::Resolve::new();
+    resolve.push_str("", &package.to_string()).unwrap();
+    let packages = packages_from_parsed(&resolve);
+
+    assert_eq!(packages.len(), 1, "Should create exactly one package");
     let package = &packages[0];
     assert_eq!(WIT, package.to_string());
 }


### PR DESCRIPTION
Wit-encoder changes:
 - implement world uses for exports and imports following the pattern used in interfaces
 - sort output items that are converted from IndexMap parser sources, so the ordering is stable