### PR TITLE
[wasm-metadata] warn on missing docs and Debug impls

### DIFF
--- a/crates/wasm-metadata/src/lib.rs
+++ b/crates/wasm-metadata/src/lib.rs
@@ -1,6 +1,6 @@
 //! Read and manipulate WebAssembly metadata
 
-#![warn(missing_debug_implementations)]
+#![warn(missing_debug_implementations, missing_docs)]
 
 pub use add_metadata::AddMetadata;
 pub use metadata::Metadata;

--- a/crates/wasm-metadata/src/lib.rs
+++ b/crates/wasm-metadata/src/lib.rs
@@ -1,5 +1,7 @@
 //! Read and manipulate WebAssembly metadata
 
+#![warn(missing_debug_implementations)]
+
 pub use add_metadata::AddMetadata;
 pub use metadata::Metadata;
 pub use names::{ComponentNames, ModuleNames};

--- a/crates/wasm-metadata/src/names/component.rs
+++ b/crates/wasm-metadata/src/names/component.rs
@@ -1,3 +1,5 @@
+use std::fmt::{self, Debug};
+
 use anyhow::Result;
 use wasm_encoder::Encode;
 use wasmparser::{BinaryReader, ComponentNameSectionReader};
@@ -5,9 +7,18 @@ use wasmparser::{BinaryReader, ComponentNameSectionReader};
 use crate::utils::name_map;
 
 /// Helper for rewriting a component's component-name section with a new component name.
+#[derive(Clone)]
 pub struct ComponentNames<'a> {
     component_name: Option<String>,
     names: Vec<wasmparser::ComponentName<'a>>,
+}
+
+impl<'a> Debug for ComponentNames<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ComponentNames")
+            .field("component_name", &self.component_name)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<'a> ComponentNames<'a> {

--- a/crates/wasm-metadata/src/names/component.rs
+++ b/crates/wasm-metadata/src/names/component.rs
@@ -7,7 +7,6 @@ use wasmparser::{BinaryReader, ComponentNameSectionReader};
 use crate::utils::name_map;
 
 /// Helper for rewriting a component's component-name section with a new component name.
-#[derive(Clone)]
 pub struct ComponentNames<'a> {
     component_name: Option<String>,
     names: Vec<wasmparser::ComponentName<'a>>,

--- a/crates/wasm-metadata/src/names/module.rs
+++ b/crates/wasm-metadata/src/names/module.rs
@@ -1,3 +1,5 @@
+use std::fmt::{self, Debug};
+
 use anyhow::Result;
 use wasm_encoder::Encode;
 use wasmparser::{BinaryReader, NameSectionReader};
@@ -8,6 +10,14 @@ use crate::utils::{indirect_name_map, name_map};
 pub struct ModuleNames<'a> {
     module_name: Option<String>,
     names: Vec<wasmparser::Name<'a>>,
+}
+
+impl<'a> Debug for ModuleNames<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ModuleNames")
+            .field("module_name", &self.module_name)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<'a> ModuleNames<'a> {

--- a/crates/wasm-metadata/src/producers.rs
+++ b/crates/wasm-metadata/src/producers.rs
@@ -174,6 +174,7 @@ impl fmt::Display for Producers {
 }
 
 /// Contents of a producers field
+#[derive(Debug)]
 pub struct ProducersField<'a>(&'a IndexMap<String, String>);
 
 impl<'a> ProducersField<'a> {

--- a/crates/wasm-metadata/src/registry.rs
+++ b/crates/wasm-metadata/src/registry.rs
@@ -7,6 +7,7 @@ use wasmparser::Parser;
 
 use crate::{rewrite_wasm, Producers};
 
+/// Metadata used by a Warg registry
 #[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
 pub struct RegistryMetadata {
     /// List of authors who has created this package.
@@ -46,6 +47,7 @@ impl RegistryMetadata {
         rewrite_wasm(&None, &Producers::empty(), Some(&self), input)
     }
 
+    /// Parse a Wasm binary and extract the `Registry` section, if there is any.
     pub fn from_wasm(bytes: &[u8]) -> Result<Option<Self>> {
         let mut depth = 0;
         for payload in Parser::new(0).parse_all(bytes) {
@@ -70,6 +72,8 @@ impl RegistryMetadata {
         return Ok(registry);
     }
 
+    /// Validate the `RegistryMetadata::license` an
+    /// `RegistryMetadata::CustomLicense` are valid SPDX expressions.
     pub fn validate(&self) -> Result<()> {
         fn validate_expression(expression: &str) -> Result<Vec<String>> {
             let expression = Expression::parse(expression)?;
@@ -257,9 +261,12 @@ impl Display for RegistryMetadata {
     }
 }
 
+/// A link from the registry to an external website
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct Link {
+    /// The type of link
     pub ty: LinkType,
+    /// The address of the link
     pub value: String,
 }
 
@@ -269,12 +276,18 @@ impl Display for Link {
     }
 }
 
+/// What kind of link is this?
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum LinkType {
+    /// Documentation
     Documentation,
+    /// Homepage
     Homepage,
+    /// Code repository
     Repository,
+    /// Funding and donations
     Funding,
+    /// Some other link type
     #[serde(untagged)]
     Custom(String),
 }
@@ -293,6 +306,8 @@ impl Display for LinkType {
     }
 }
 
+/// A human readable short form license identifier for a license not on the SPDX
+/// License List.
 #[derive(Debug, Deserialize, Serialize, Default, Clone, PartialEq)]
 pub struct CustomLicense {
     /// License Identifier


### PR DESCRIPTION
Submitting as a draft since this depends on https://github.com/bytecodealliance/wasm-tools/pull/1917 landing first. This provides some additional tidying up, ensuring everything is documented and we can't accidentally forget any `Debug` impls. Thanks!