### PR TITLE
[wasm-metadata] remove `wat` dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1679,7 +1679,6 @@ dependencies = [
  "spdx",
  "wasm-encoder 0.221.0",
  "wasmparser 0.221.0",
- "wat",
 ]
 
 [[package]]

--- a/crates/wasm-metadata/Cargo.toml
+++ b/crates/wasm-metadata/Cargo.toml
@@ -20,6 +20,3 @@ serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { version = "1" }
 spdx = "0.10.1"
-
-[dev-dependencies]
-wat = { workspace = true }

--- a/crates/wasm-metadata/src/producers.rs
+++ b/crates/wasm-metadata/src/producers.rs
@@ -191,11 +191,11 @@ impl<'a> ProducersField<'a> {
 mod test {
     use super::*;
     use crate::Metadata;
+    use wasm_encoder::Module;
 
     #[test]
     fn producers_empty_module() {
-        let wat = "(module)";
-        let module = wat::parse_str(wat).unwrap();
+        let module = Module::new().finish();
         let mut producers = Producers::empty();
         producers.add("language", "bar", "");
         producers.add("processed-by", "baz", "1.0");
@@ -221,8 +221,7 @@ mod test {
 
     #[test]
     fn producers_add_another_field() {
-        let wat = "(module)";
-        let module = wat::parse_str(wat).unwrap();
+        let module = Module::new().finish();
         let mut producers = Producers::empty();
         producers.add("language", "bar", "");
         producers.add("processed-by", "baz", "1.0");
@@ -252,8 +251,7 @@ mod test {
 
     #[test]
     fn producers_overwrite_field() {
-        let wat = "(module)";
-        let module = wat::parse_str(wat).unwrap();
+        let module = Module::new().finish();
         let mut producers = Producers::empty();
         producers.add("processed-by", "baz", "1.0");
         let module = producers.add_to_wasm(&module).unwrap();

--- a/crates/wasm-metadata/src/registry.rs
+++ b/crates/wasm-metadata/src/registry.rs
@@ -345,11 +345,11 @@ impl Display for CustomLicense {
 mod test {
     use super::*;
     use crate::Metadata;
+    use wasm_encoder::Module;
 
     #[test]
     fn overwrite_registry_metadata() {
-        let wat = "(module)";
-        let module = wat::parse_str(wat).unwrap();
+        let module = Module::new().finish();
         let registry_metadata = RegistryMetadata {
             authors: Some(vec!["Foo".to_owned()]),
             ..Default::default()

--- a/crates/wasm-metadata/tests/component.rs
+++ b/crates/wasm-metadata/tests/component.rs
@@ -1,11 +1,11 @@
 use std::vec;
 
+use wasm_encoder::{Component, Module};
 use wasm_metadata::*;
 
 #[test]
 fn add_to_empty_component() {
-    let wat = "(component)";
-    let component = wat::parse_str(wat).unwrap();
+    let component = Component::new().finish();
     let add = AddMetadata {
         name: Some("foo".to_owned()),
         language: vec!["bar".to_owned()],
@@ -105,8 +105,7 @@ fn add_to_empty_component() {
 #[test]
 fn add_to_nested_component() {
     // Create the same old module, stick some metadata into it
-    let wat = "(module)";
-    let module = wat::parse_str(wat).unwrap();
+    let module = Module::new().finish();
     let add = AddMetadata {
         name: Some("foo".to_owned()),
         language: vec!["bar".to_owned()],

--- a/crates/wasm-metadata/tests/module.rs
+++ b/crates/wasm-metadata/tests/module.rs
@@ -1,11 +1,11 @@
 use std::vec;
 
+use wasm_encoder::Module;
 use wasm_metadata::*;
 
 #[test]
 fn add_to_empty_module() {
-    let wat = "(module)";
-    let module = wat::parse_str(wat).unwrap();
+    let module = Module::new().finish();
     let add = AddMetadata {
         name: Some("foo".to_owned()),
         language: vec!["bar".to_owned()],


### PR DESCRIPTION
Removes the `wat` dep from `wasm-metadata` in favor of using `wasm-encoder`. Thanks!