### PR TITLE
[wasm-metadata] parse OCI author custom section

### DIFF
--- a/crates/wasm-metadata/src/lib.rs
+++ b/crates/wasm-metadata/src/lib.rs
@@ -5,6 +5,7 @@
 pub use add_metadata::AddMetadata;
 pub use metadata::Metadata;
 pub use names::{ComponentNames, ModuleNames};
+pub use oci_annotations::Author;
 pub use producers::{Producers, ProducersField};
 pub use registry::{CustomLicense, Link, LinkType, RegistryMetadata};
 
@@ -13,6 +14,7 @@ pub(crate) use rewrite::rewrite_wasm;
 mod add_metadata;
 mod metadata;
 mod names;
+mod oci_annotations;
 mod producers;
 mod registry;
 mod rewrite;

--- a/crates/wasm-metadata/src/oci_annotations/author.rs
+++ b/crates/wasm-metadata/src/oci_annotations/author.rs
@@ -1,0 +1,79 @@
+use std::borrow::Cow;
+use std::fmt::{self, Display};
+
+use anyhow::{ensure, Result};
+use wasm_encoder::{ComponentSection, CustomSection, Encode};
+use wasmparser::CustomSectionReader;
+
+/// Contact details of the people or organization responsible for the image
+/// encoded as a freeform string.
+#[derive(Debug)]
+pub struct Author(CustomSection<'static>);
+
+impl Display for Author {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // NOTE: this will never panic since we always guarantee the data is
+        // encoded as utf8, even if we internally store it as [u8].
+        let data = String::from_utf8(self.0.data.to_vec()).unwrap();
+        write!(f, "{data}")
+    }
+}
+
+impl Author {
+    /// Create a new instance of `Author`.
+    pub fn new<S: Into<Cow<'static, str>>>(s: S) -> Self {
+        Self(CustomSection {
+            name: "author".into(),
+            data: match s.into() {
+                Cow::Borrowed(s) => Cow::Borrowed(s.as_bytes()),
+                Cow::Owned(s) => Cow::Owned(s.into()),
+            },
+        })
+    }
+
+    /// Parse an `author` custom section from a wasm binary.
+    pub fn parse_wasm(reader: CustomSectionReader<'_>) -> Result<Self> {
+        ensure!(
+            dbg!(reader.name()) == "author",
+            "The `author` custom section should have a name of 'author'"
+        );
+        let data = String::from_utf8(reader.data().to_owned())?;
+        Ok(Self::new(data))
+    }
+}
+
+impl ComponentSection for Author {
+    fn id(&self) -> u8 {
+        self.0.id()
+    }
+}
+
+impl Encode for Author {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        self.0.encode(sink);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use wasm_encoder::Component;
+    use wasmparser::Payload;
+
+    #[test]
+    fn roundtrip() {
+        let mut component = Component::new();
+        component.section(&Author::new("Nori Cat"));
+        let component = component.finish();
+
+        let mut parsed = false;
+        for section in wasmparser::Parser::new(0).parse_all(&component) {
+            if let Payload::CustomSection(reader) = section.unwrap() {
+                let author = Author::parse_wasm(reader).unwrap();
+                assert_eq!(author.to_string(), "Nori Cat");
+                parsed = true;
+            }
+        }
+        assert!(parsed);
+    }
+}

--- a/crates/wasm-metadata/src/oci_annotations/mod.rs
+++ b/crates/wasm-metadata/src/oci_annotations/mod.rs
@@ -1,0 +1,20 @@
+//! Annotations following the [OCI Annotations Spec].
+//!
+//! The fields of these annotations are encoded into custom sections of
+//! component binaries, and are explicitly compatible with the OCI Annotations
+//! Spec. That enables Compontents to be encoded to OCI and back without needing
+//! to perform any additional parsing. This greatly simplifies adding metadata to
+//! component registries, since language-native component toolchains can encode them
+//! directly into components. Which in turn can be picked up by Component-to-OCI
+//! tooling to take those annotations and display them in a way that registries can
+//! understand.
+//!
+//! For the files in this submodule that means we want to be explicitly
+//! compatible with the OCI Annotations specification. Any deviation in our
+//! parsing rules from the spec should be considered a bug we have to fix.
+//!
+//! [OCI Annotations Spec]: https://specs.opencontainers.org/image-spec/annotations/
+
+pub use author::Author;
+
+mod author;


### PR DESCRIPTION
This PR adds support for parsing the `author` custom section, implementing parts of #1922. Thanks!

## Draft Notes

I'm filing this PR early and as a draft because I'm not 100% sure I'm following best practices here. It's my first time using `wasmparser` and `wasm-encoder`, and I'm for example not sure whether `parse_wasm` should take a `BinaryReader` or `CustomSectionReader`.

Also: I was looking for something like a `Parse` trait, but I don't think `wasmparser` has one? I quite liked the encoder side of things.

Finally: in this PR I'm basically just wrapping `CustomSection` in a newtype - however that means storing the internal data as a byte array rather than a string. How do we feel about that?

I'm asking these questions since I'm planning to repeat this pattern a number of times for the other custom sections, and it seems worth making sure it's early on. Thanks!