### PR TITLE
Add `simd_visitor` helper methods to `FuncValidator`

### DIFF
--- a/crates/wasmparser/src/validator/func.rs
+++ b/crates/wasmparser/src/validator/func.rs
@@ -177,6 +177,17 @@ impl<T: WasmModuleResources> FuncValidator<T> {
         self.validator.with_resources(&self.resources, offset)
     }
 
+    /// Same as [`FuncValidator::visit`] except that the returned type
+    /// implements the [`VisitSimdOperator`](crate::VisitSimdOperator) trait as
+    /// well.
+    #[cfg(feature = "simd")]
+    pub fn simd_visitor<'this, 'a: 'this>(
+        &'this mut self,
+        offset: usize,
+    ) -> impl crate::VisitSimdOperator<'a, Output = Result<()>> + ModuleArity + 'this {
+        self.validator.with_resources_simd(&self.resources, offset)
+    }
+
     /// Function that must be called after the last opcode has been processed.
     ///
     /// This will validate that the function was properly terminated with the

--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -493,6 +493,25 @@ impl OperatorValidator {
         })
     }
 
+    /// Same as `with_resources` above but guarantees it's able to visit simd
+    /// operators as well.
+    #[cfg(feature = "simd")]
+    pub fn with_resources_simd<'a, 'validator, 'resources, T>(
+        &'validator mut self,
+        resources: &'resources T,
+        offset: usize,
+    ) -> impl VisitSimdOperator<'a, Output = Result<()>> + ModuleArity + 'validator
+    where
+        T: WasmModuleResources,
+        'resources: 'validator,
+    {
+        WasmProposalValidator(OperatorValidatorTemp {
+            offset,
+            inner: self,
+            resources,
+        })
+    }
+
     pub fn finish(&mut self, offset: usize) -> Result<()> {
         if self.control.last().is_some() {
             bail!(


### PR DESCRIPTION
The previous `visitor` return method only return `impl VisitOperator`, so this adds a second method for when the `simd` feature is enabled to return a similar structure which also is guaranteed to implement `VisitSimdOperator`.