### PR TITLE
Always implement `Error for BinaryReaderError`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,9 @@ license = "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
 version = "0.221.0"
 # Current policy for wasm-tools is the same as Wasmtime which is that this
 # number can be no larger than the current stable release of Rust minus 2.
+#
+# NB: if this number increases to 1.81-or-later delete the
+# `crates/wasmparser/build.rs` script as it's no longer necessary.
 rust-version = "1.76.0"
 
 [workspace.dependencies]

--- a/crates/wasmparser/build.rs
+++ b/crates/wasmparser/build.rs
@@ -1,0 +1,27 @@
+use std::process::Command;
+use std::str;
+
+fn main() {
+    // Temporary check to see if the rustc version >= 1.81 in which case the
+    // `Error` trait is always available. This is temporary because in the
+    // future the MSRV of this crate will be beyond 1.81 in which case this
+    // build script can be deleted.
+    let minor = rustc_minor_version().unwrap_or(0);
+    if minor >= 81 {
+        println!("cargo:rustc-cfg=core_error");
+    }
+    if minor >= 80 {
+        println!("cargo:rustc-check-cfg=cfg(core_error)");
+    }
+}
+
+fn rustc_minor_version() -> Option<u32> {
+    let rustc = std::env::var("RUSTC").unwrap();
+    let output = Command::new(rustc).arg("--version").output().ok()?;
+    let version = str::from_utf8(&output.stdout).ok()?;
+    let mut pieces = version.split('.');
+    if pieces.next() != Some("rustc 1") {
+        return None;
+    }
+    pieces.next()?.parse().ok()
+}

--- a/crates/wasmparser/src/binary_reader.rs
+++ b/crates/wasmparser/src/binary_reader.rs
@@ -54,6 +54,9 @@ pub type Result<T, E = BinaryReaderError> = core::result::Result<T, E>;
 #[cfg(feature = "std")]
 impl std::error::Error for BinaryReaderError {}
 
+#[cfg(all(not(feature = "std"), core_error))]
+impl core::error::Error for BinaryReaderError {}
+
 impl fmt::Display for BinaryReaderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(


### PR DESCRIPTION
This commit updates the `wasmparser` crate to always implement the `BinaryReaderError` trait even when the `std` feature is disabled. This is done in a way to not increase the MSRV for now and instead leave it at 1.76.