### PR TITLE
 Reimplement fast-path validation of MVP types 

### DIFF
--- a/crates/wasmparser/benches/benchmark.rs
+++ b/crates/wasmparser/benches/benchmark.rs
@@ -273,6 +273,9 @@ fn define_benchmarks(c: &mut Criterion) {
     fn validator() -> Validator {
         Validator::new_with_features(WasmFeatures::all())
     }
+    fn old_validator() -> Validator {
+        Validator::new_with_features(WasmFeatures::WASM2)
+    }
 
     let test_inputs = once_cell::unsync::Lazy::new(collect_benchmark_inputs);
 
@@ -330,6 +333,14 @@ fn define_benchmarks(c: &mut Criterion) {
                 validator().validate_all(&wasm).unwrap();
             })
         });
+        if old_validator().validate_all(&wasm).is_ok() {
+            c.bench_function(&format!("validate-old/{name}"), |b| {
+                Lazy::force(&wasm);
+                b.iter(|| {
+                    old_validator().validate_all(&wasm).unwrap();
+                })
+            });
+        }
         c.bench_function(&format!("parse/{name}"), |b| {
             Lazy::force(&wasm);
             b.iter(|| {

--- a/crates/wasmparser/src/features.rs
+++ b/crates/wasmparser/src/features.rs
@@ -306,6 +306,7 @@ impl From<WasmFeatures> for WasmFeaturesInflated {
 impl WasmFeatures {
     /// Returns whether any types considered valid with this set of
     /// `WasmFeatures` requires any type canonicalization/interning internally.
+    #[cfg(feature = "validate")]
     pub(crate) fn needs_type_canonicalization(&self) -> bool {
         #[cfg(feature = "features")]
         {

--- a/crates/wasmparser/src/features.rs
+++ b/crates/wasmparser/src/features.rs
@@ -302,3 +302,40 @@ impl From<WasmFeatures> for WasmFeaturesInflated {
         features.inflate()
     }
 }
+
+impl WasmFeatures {
+    /// Returns whether any types considered valid with this set of
+    /// `WasmFeatures` requires any type canonicalization/interning internally.
+    pub(crate) fn needs_type_canonicalization(&self) -> bool {
+        #[cfg(feature = "features")]
+        {
+            // Types from the function-references proposal and beyond (namely
+            // GC) need type canonicalization for inter-type references and for
+            // rec-groups to work. Prior proposals have no such inter-type
+            // references structurally and as such can hit various fast paths in
+            // the validator to do a bit less work when processing the type
+            // section.
+            //
+            // None of these proposals below support inter-type references. If
+            // `self` contains any proposal outside of this set then it requires
+            // type canonicalization.
+            const FAST_VALIDATION_FEATURES: WasmFeatures = WasmFeatures::WASM2
+                .union(WasmFeatures::CUSTOM_PAGE_SIZES)
+                .union(WasmFeatures::EXTENDED_CONST)
+                .union(WasmFeatures::MEMORY64)
+                .union(WasmFeatures::MULTI_MEMORY)
+                .union(WasmFeatures::RELAXED_SIMD)
+                .union(WasmFeatures::TAIL_CALL)
+                .union(WasmFeatures::THREADS)
+                .union(WasmFeatures::WIDE_ARITHMETIC);
+            !FAST_VALIDATION_FEATURES.contains(*self)
+        }
+        #[cfg(not(feature = "features"))]
+        {
+            // GC/function-references are enabled by default, so
+            // canonicalization is required if feature flags aren't enabled at
+            // runtime.
+            true
+        }
+    }
+}

--- a/crates/wasmparser/src/validator/core.rs
+++ b/crates/wasmparser/src/validator/core.rs
@@ -587,67 +587,7 @@ impl Module {
                 offset,
             )?;
         }
-        if self.try_fast_validation(&rec_group, features, types, offset)? {
-            return Ok(());
-        }
         self.canonicalize_and_intern_rec_group(features, types, rec_group, offset)
-    }
-
-    #[cfg(not(feature = "features"))]
-    fn try_fast_validation(
-        &mut self,
-        _rec_group: &RecGroup,
-        _features: &WasmFeatures,
-        _types: &mut TypeAlloc,
-        _offset: usize,
-    ) -> Result<bool> {
-        Ok(false)
-    }
-
-    /// Performs fast type section validation if possible.
-    ///
-    /// - Returns `Ok(true)` if fast validation was performed, else returns `Ok(false)`.
-    /// - Returns `Err(_)` if a type section validation error was encountered.
-    ///
-    /// # Note
-    ///
-    /// Fast type section validation can only be performed on a
-    /// statically known subset of `WasmFeatures`.
-    #[cfg(feature = "features")]
-    fn try_fast_validation(
-        &mut self,
-        rec_group: &RecGroup,
-        features: &WasmFeatures,
-        types: &mut TypeAlloc,
-        offset: usize,
-    ) -> Result<bool> {
-        /// The subset of `WasmFeatures` for which we know that the
-        /// fast type section validation can be safely applied.
-        ///
-        /// Fast type section validation does not have to canonicalize
-        /// (deduplicate) types and does not have to perform sub-typing
-        /// checks.
-        const FAST_VALIDATION_FEATURES: WasmFeatures = WasmFeatures::WASM2
-            .union(WasmFeatures::CUSTOM_PAGE_SIZES)
-            .union(WasmFeatures::EXTENDED_CONST)
-            .union(WasmFeatures::MEMORY64)
-            .union(WasmFeatures::MULTI_MEMORY)
-            .union(WasmFeatures::RELAXED_SIMD)
-            .union(WasmFeatures::TAIL_CALL)
-            .union(WasmFeatures::THREADS)
-            .union(WasmFeatures::WIDE_ARITHMETIC);
-        if !FAST_VALIDATION_FEATURES.contains(*features) {
-            return Ok(false);
-        }
-        if rec_group.is_explicit_rec_group() {
-            bail!(offset, "requires `gc` proposal to be enabled")
-        }
-        for ty in rec_group.types() {
-            let id = types.push(ty.clone());
-            self.add_type_id(id);
-            self.check_composite_type(&ty.composite_type, features, &types, offset)?;
-        }
-        Ok(true)
     }
 
     pub fn add_import(

--- a/crates/wasmparser/src/validator/core/canonical.rs
+++ b/crates/wasmparser/src/validator/core/canonical.rs
@@ -99,10 +99,13 @@ pub(crate) trait InternRecGroup {
                 "rec group usage requires `gc` proposal to be enabled"
             );
         }
-        TypeCanonicalizer::new(self, offset)
-            .with_features(features)
-            .canonicalize_rec_group(&mut rec_group)?;
-        let (is_new, rec_group_id) = types.intern_canonical_rec_group(rec_group);
+        if features.needs_type_canonicalization() {
+            TypeCanonicalizer::new(self, offset)
+                .with_features(features)
+                .canonicalize_rec_group(&mut rec_group)?;
+        }
+        let (is_new, rec_group_id) =
+            types.intern_canonical_rec_group(features.needs_type_canonicalization(), rec_group);
         let range = &types[rec_group_id];
         let start = range.start.index();
         let end = range.end.index();

--- a/tests/local/missing-features/rec-group.wast
+++ b/tests/local/missing-features/rec-group.wast
@@ -9,3 +9,15 @@
 (assert_invalid
   (module (rec (type (func)) (type (func))))
   "requires `gc` proposal to be enabled")
+
+(assert_invalid
+  (module (type $t (func (param (ref $t)))))
+  "reference types support is not enabled")
+
+(assert_invalid
+  (module (type $t (sub (func))))
+  "gc proposal must be enabled")
+
+(assert_invalid
+  (module (type $t (func)) (type (sub $t (func))))
+  "gc proposal must be enabled")

--- a/tests/local/missing-features/reference-types/gc.wast
+++ b/tests/local/missing-features/reference-types/gc.wast
@@ -31,3 +31,15 @@
 (assert_invalid
   (module (func ref.null array drop))
   "heap types not supported without the gc feature")
+
+(assert_invalid
+  (module (type $t (func (param (ref $t)))))
+  "function references required for index")
+
+(assert_invalid
+  (module (type $t (sub (func))))
+  "gc proposal must be enabled")
+
+(assert_invalid
+  (module (type $t (func)) (type (sub $t (func))))
+  "gc proposal must be enabled")

--- a/tests/snapshots/local/missing-features/rec-group.wast.json
+++ b/tests/snapshots/local/missing-features/rec-group.wast.json
@@ -21,6 +21,27 @@
       "filename": "rec-group.2.wasm",
       "module_type": "binary",
       "text": "requires `gc` proposal to be enabled"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 14,
+      "filename": "rec-group.3.wasm",
+      "module_type": "binary",
+      "text": "reference types support is not enabled"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 18,
+      "filename": "rec-group.4.wasm",
+      "module_type": "binary",
+      "text": "gc proposal must be enabled"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 22,
+      "filename": "rec-group.5.wasm",
+      "module_type": "binary",
+      "text": "gc proposal must be enabled"
     }
   ]
 }

--- a/tests/snapshots/local/missing-features/reference-types/gc.wast.json
+++ b/tests/snapshots/local/missing-features/reference-types/gc.wast.json
@@ -77,6 +77,27 @@
       "filename": "gc.10.wasm",
       "module_type": "binary",
       "text": "heap types not supported without the gc feature"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 36,
+      "filename": "gc.11.wasm",
+      "module_type": "binary",
+      "text": "function references required for index"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 40,
+      "filename": "gc.12.wasm",
+      "module_type": "binary",
+      "text": "gc proposal must be enabled"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 44,
+      "filename": "gc.13.wasm",
+      "module_type": "binary",
+      "text": "gc proposal must be enabled"
     }
   ]
 }


### PR DESCRIPTION
This commit fixes an issue from https://github.com/bytecodealliance/wasm-tools/pull/1906 which is preventing the upgrade of
wasm-tools in Wasmtime. That commit implemented a fast path by skipping
a function and reimplementing parts of it internally, but that then
caused Wasmtime to panic when other data structures weren't filled out.
The intention was that the user-facing interface doesn't change
depending on features, so this is an attempt at fixing the mistake in
that commit.

The fix here is to remove the fast path added and restructure it
differently. Instead now the fast and normal paths have much less
divergence which should prevent this issue from re-surfacing. This is
15% slower than `main` but it doesn't have the same bug as `main` so for
now that may be the best that can be done.