### PR TITLE
Prepare for 2024 edition migration

### DIFF
--- a/crates/wasm-mutate-stats/src/bin/wasm-mutate-stats.rs
+++ b/crates/wasm-mutate-stats/src/bin/wasm-mutate-stats.rs
@@ -480,7 +480,7 @@ impl State {
         let wasmcp = wasm.clone();
 
         while !self.timeout_reached.load(Relaxed) {
-            let seed = rng.gen();
+            let seed = rng.r#gen();
             wasmmutate.seed(seed);
             wasmmutate.fuel(1000);
             wasmmutate.preserve_semantics(true);

--- a/crates/wasm-mutate/src/lib.rs
+++ b/crates/wasm-mutate/src/lib.rs
@@ -296,7 +296,7 @@ impl<'wasm> WasmMutate<'wasm> {
         // Next a length of the replacement is chosen. Note that the replacement
         // is always smaller than the input if reduction is requested, otherwise
         // we choose some arbitrary length of bytes to insert.
-        let max_size = if self.reduce || self.rng().gen() {
+        let max_size = if self.reduce || self.rng().r#gen() {
             0
         } else {
             max_size

--- a/crates/wasm-mutate/src/mutators/modify_const_exprs.rs
+++ b/crates/wasm-mutate/src/mutators/modify_const_exprs.rs
@@ -112,7 +112,7 @@ impl<'cfg, 'wasm> Reencode for InitTranslator<'cfg, 'wasm> {
         // removing the offset) as other values may not necessarily be valid
         // (e.g. maximum table size is limited)
         let is_element_offset = matches!(self.kind, ConstExpressionMutator::ElementOffset);
-        let should_zero = is_element_offset || self.config.rng().gen::<u8>() & 0b11 == 0;
+        let should_zero = is_element_offset || self.config.rng().r#gen::<u8>() & 0b11 == 0;
         let new_op = match ty {
             T::I32 if should_zero => CE::i32_const(0),
             T::I64 if should_zero => CE::i64_const(0),
@@ -123,28 +123,28 @@ impl<'cfg, 'wasm> Reencode for InitTranslator<'cfg, 'wasm> {
                 let range = if value < 0 { value..0 } else { 0..value };
                 self.config.rng().gen_range(range)
             } else {
-                self.config.rng().gen()
+                self.config.rng().r#gen()
             }),
             T::I64 => CE::i64_const(if let O::I64Const { value } = op {
                 let range = if value < 0 { value..0 } else { 0..value };
                 self.config.rng().gen_range(range)
             } else {
-                self.config.rng().gen()
+                self.config.rng().r#gen()
             }),
             T::V128 => CE::v128_const(if let O::V128Const { value } = op {
                 self.config.rng().gen_range(0..value.i128() as u128) as i128
             } else {
-                self.config.rng().gen()
+                self.config.rng().r#gen()
             }),
             T::F32 => CE::f32_const(if let O::F32Const { value } = op {
                 f32::from_bits(value.bits()) / 2.0
             } else {
-                f32::from_bits(self.config.rng().gen())
+                f32::from_bits(self.config.rng().r#gen())
             }),
             T::F64 => CE::f64_const(if let O::F64Const { value } = op {
                 f64::from_bits(value.bits()) / 2.0
             } else {
-                f64::from_bits(self.config.rng().gen())
+                f64::from_bits(self.config.rng().r#gen())
             }),
             T::FuncRef => CE::ref_null(wasm_encoder::HeapType::FUNC),
             T::ExternRef => CE::ref_null(wasm_encoder::HeapType::EXTERN),

--- a/crates/wasm-mutate/src/mutators/peephole.rs
+++ b/crates/wasm-mutate/src/mutators/peephole.rs
@@ -244,7 +244,7 @@ impl PeepholeMutator {
                     root,
                     egraph.clone(),
                     self.max_tree_depth,
-                    config.rng().gen(),
+                    config.rng().r#gen(),
                 ));
 
                 // Filter expression equal to the original one

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder/expr2wasm.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder/expr2wasm.rs
@@ -116,16 +116,16 @@ pub fn expr2wasm(
                     Lang::I64Load16S(memarg, _) => insn(Instruction::I64Load16S(memarg.into())),
                     Lang::I64Load32U(memarg, _) => insn(Instruction::I64Load32U(memarg.into())),
                     Lang::I64Load32S(memarg, _) => insn(Instruction::I64Load32S(memarg.into())),
-                    Lang::RandI32 => insn(Instruction::I32Const(config.rng().gen())),
-                    Lang::RandI64 => insn(Instruction::I64Const(config.rng().gen())),
+                    Lang::RandI32 => insn(Instruction::I32Const(config.rng().r#gen())),
+                    Lang::RandI64 => insn(Instruction::I64Const(config.rng().r#gen())),
                     Lang::RandF32 => {
                         newfunc.instruction(&Instruction::F32Const(f32::from_bits(
-                            config.rng().gen(),
+                            config.rng().r#gen(),
                         )));
                     }
                     Lang::RandF64 => {
                         newfunc.instruction(&Instruction::F64Const(f64::from_bits(
-                            config.rng().gen(),
+                            config.rng().r#gen(),
                         )));
                     }
                     Lang::Undef => { /* Do nothig */ }
@@ -135,7 +135,7 @@ pub fn expr2wasm(
                             Lang::I32(value) => {
                                 // Getting type from eclass.
 
-                                let r: i32 = config.rng().gen();
+                                let r: i32 = config.rng().r#gen();
                                 insn(Instruction::I32Const(r));
                                 insn(Instruction::I32Const(
                                     (Wrapping(*value as i32) - Wrapping(r)).0,
@@ -156,7 +156,7 @@ pub fn expr2wasm(
                             Lang::I64(value) => {
                                 // Getting type from eclass.
 
-                                let r: i64 = config.rng().gen();
+                                let r: i64 = config.rng().r#gen();
                                 insn(Instruction::I64Const(r));
                                 insn(Instruction::I64Const((Wrapping(*value) - Wrapping(r)).0));
                                 insn(Instruction::I64Add);

--- a/crates/wasm-shrink/src/lib.rs
+++ b/crates/wasm-shrink/src/lib.rs
@@ -294,7 +294,7 @@ impl ShrinkRun {
             self.attempt += 1;
 
             let mut mutate = WasmMutate::default();
-            let seed = self.rng.gen();
+            let seed = self.rng.r#gen();
             mutate.reduce(true).seed(seed);
             log::trace!("Attempt #{}: seed: {}", self.attempt, seed);
 

--- a/crates/wast/src/component/expand.rs
+++ b/crates/wast/src/component/expand.rs
@@ -490,7 +490,7 @@ impl<'a> Expander<'a> {
                         t.index = Some(*idx);
                         return;
                     }
-                    let id = gensym::gen(item.span);
+                    let id = gensym::generate(item.span);
                     to_prepend.push(ModuleTypeDecl::Type(core::Type {
                         span: item.span,
                         id: Some(id),
@@ -612,7 +612,7 @@ impl<'a> Expander<'a> {
         // And if this type isn't already defined we append it to the index
         // space with a fresh and unique name.
         let span = Span::from_offset(0); // FIXME(#613): don't manufacture
-        let id = gensym::gen(span);
+        let id = gensym::generate(span);
 
         self.types_to_prepend.push(inline.into_any_type(span, id));
 
@@ -658,7 +658,7 @@ impl<'a> Expander<'a> {
 
         // And if this type isn't already defined we append it to the index
         // space with a fresh and unique name.
-        let id = gensym::gen(span);
+        let id = gensym::generate(span);
 
         self.types_to_prepend.push(inline.into_any_type(span, id));
 
@@ -711,7 +711,7 @@ impl<'a> Expander<'a> {
 
         // And if this type isn't already defined we append it to the index
         // space with a fresh and unique name.
-        let id = gensym::gen(span);
+        let id = gensym::generate(span);
 
         self.types_to_prepend.push(inline.into_any_type(span, id));
 
@@ -731,7 +731,7 @@ impl<'a> Expander<'a> {
             CoreInstantiationArgKind::Instance(_) => return,
             CoreInstantiationArgKind::BundleOfExports(span, exports) => (*span, mem::take(exports)),
         };
-        let id = gensym::gen(span);
+        let id = gensym::generate(span);
         self.component_fields_to_prepend
             .push(ComponentField::CoreInstance(CoreInstance {
                 span,
@@ -751,7 +751,7 @@ impl<'a> Expander<'a> {
             InstantiationArgKind::Item(_) => return,
             InstantiationArgKind::BundleOfExports(span, exports) => (*span, mem::take(exports)),
         };
-        let id = gensym::gen(span);
+        let id = gensym::generate(span);
         self.component_fields_to_prepend
             .push(ComponentField::Instance(Instance {
                 span,

--- a/crates/wast/src/core/resolve/names.rs
+++ b/crates/wast/src/core/resolve/names.rs
@@ -681,14 +681,11 @@ impl<'a, 'b> ExprResolver<'a, 'b> {
     fn resolve_resume_table(&self, table: &mut ResumeTable<'a>) -> Result<(), Error> {
         for handle in &mut table.handlers {
             match handle {
-                Handle::OnLabel {
-                    ref mut tag,
-                    ref mut label,
-                } => {
+                Handle::OnLabel { tag, label } => {
                     self.resolver.resolve(tag, Ns::Tag)?;
                     self.resolve_label(label)?;
                 }
-                Handle::OnSwitch { ref mut tag } => {
+                Handle::OnSwitch { tag } => {
                     self.resolver.resolve(tag, Ns::Tag)?;
                 }
             }

--- a/crates/wast/src/core/resolve/types.rs
+++ b/crates/wast/src/core/resolve/types.rs
@@ -209,7 +209,7 @@ impl<'a> Expander<'a> {
         }
 
         // ... and failing that we insert a new type definition.
-        let id = gensym::gen(span);
+        let id = gensym::generate(span);
         self.to_prepend.push(ModuleField::Type(Type {
             span,
             id: Some(id),

--- a/crates/wast/src/gensym.rs
+++ b/crates/wast/src/gensym.rs
@@ -7,14 +7,14 @@ pub fn reset() {
     NEXT.with(|c| c.set(0));
 }
 
-pub fn gen(span: Span) -> Id<'static> {
+pub fn generate(span: Span) -> Id<'static> {
     NEXT.with(|next| {
-        let gen = next.get() + 1;
-        next.set(gen);
-        Id::gensym(span, gen)
+        let generation = next.get() + 1;
+        next.set(generation);
+        Id::gensym(span, generation)
     })
 }
 
 pub fn fill<'a>(span: Span, slot: &mut Option<Id<'a>>) -> Id<'a> {
-    *slot.get_or_insert_with(|| gen(span))
+    *slot.get_or_insert_with(|| generate(span))
 }

--- a/crates/wast/src/token.rs
+++ b/crates/wast/src/token.rs
@@ -53,7 +53,7 @@ impl Span {
 #[derive(Copy, Clone)]
 pub struct Id<'a> {
     name: &'a str,
-    gen: u32,
+    generation: u32,
     span: Span,
 }
 
@@ -63,14 +63,18 @@ impl<'a> Id<'a> {
     /// Note that `name` can be any arbitrary string according to the
     /// WebAssembly/annotations proposal.
     pub fn new(name: &'a str, span: Span) -> Id<'a> {
-        Id { name, gen: 0, span }
+        Id {
+            name,
+            generation: 0,
+            span,
+        }
     }
 
     #[cfg(feature = "wasm-module")]
-    pub(crate) fn gensym(span: Span, gen: u32) -> Id<'a> {
+    pub(crate) fn gensym(span: Span, generation: u32) -> Id<'a> {
         Id {
             name: "gensym",
-            gen,
+            generation,
             span,
         }
     }
@@ -89,20 +93,20 @@ impl<'a> Id<'a> {
 
     #[cfg(feature = "wasm-module")]
     pub(crate) fn is_gensym(&self) -> bool {
-        self.gen != 0
+        self.generation != 0
     }
 }
 
 impl<'a> Hash for Id<'a> {
     fn hash<H: Hasher>(&self, hasher: &mut H) {
         self.name.hash(hasher);
-        self.gen.hash(hasher);
+        self.generation.hash(hasher);
     }
 }
 
 impl<'a> PartialEq for Id<'a> {
     fn eq(&self, other: &Id<'a>) -> bool {
-        self.name == other.name && self.gen == other.gen
+        self.name == other.name && self.generation == other.generation
     }
 }
 
@@ -115,7 +119,7 @@ impl<'a> Parse<'a> for Id<'a> {
                 return Ok((
                     Id {
                         name,
-                        gen: 0,
+                        generation: 0,
                         span: c.cur_span(),
                     },
                     rest,
@@ -128,8 +132,10 @@ impl<'a> Parse<'a> for Id<'a> {
 
 impl fmt::Debug for Id<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.gen != 0 {
-            f.debug_struct("Id").field("gen", &self.gen).finish()
+        if self.generation != 0 {
+            f.debug_struct("Id")
+                .field("generation", &self.generation)
+                .finish()
         } else {
             self.name.fmt(f)
         }

--- a/crates/wit-smith/src/lib.rs
+++ b/crates/wit-smith/src/lib.rs
@@ -17,7 +17,7 @@ mod generate;
 /// The `config` guides the generation of the document and the `u` bytes are
 /// used as input to construct the document.
 pub fn smith(config: &Config, u: &mut Unstructured<'_>) -> Result<Vec<u8>> {
-    let pkgs = generate::Generator::new(config.clone()).gen(u)?;
+    let pkgs = generate::Generator::new(config.clone()).generate(u)?;
     let mut resolve = Resolve::default();
     let mut last = None;
     for pkg in pkgs {


### PR DESCRIPTION
Rename all `gen` functions/methods/variables/etc to something else. When using upstream crates (e.g. `Rng::gen`) use `r#gen`, otherwise use "generate" or "generator" as appropriately locally throughout the codebase.