### PR TITLE
[wasm-metadata] update description

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,8 +235,8 @@ implemented in this repository as well. These libraries are:
   files and interfaces.
 * [**`wit-component`**](crates/wit-component) - a crate to create components
   from core wasm modules.
-* [**`wasm-metadata`**](crates/wasm-metadata) - a crate to manipulate name and
-  producer metadata (custom sections) in a wasm module or component.
+* [**`wasm-metadata`**](crates/wasm-metadata) - a crate to read and manipulate
+  WebAssembly metadata
 
 It's recommended to use the libraries directly rather than the CLI tooling when
 embedding into a separate project.


### PR DESCRIPTION
In the context of #1922 and #1924, we're expanding the scope of the `wasm-metadata` crate. The description on the README seemed a little too narrow. This PR changes it to match the existing crate description in `Cargo.toml`. Thanks! 