### PR TITLE
[cargo-metadata] add a README

### DIFF
--- a/crates/wasm-metadata/README.md
+++ b/crates/wasm-metadata/README.md
@@ -1,0 +1,27 @@
+<div align="center">
+  <h1><code>wasm-metadata</code></h1>
+  <strong>A <a href="https://bytecodealliance.org/">Bytecode Alliance</a> project</strong>
+  <p><strong>Read and manipulate WebAssembly metadata.</strong></p>
+  <p>
+    <a href="https://crates.io/crates/wasm-metadata"><img src="https://img.shields.io/crates/v/wasm-metadata.svg?style=flat-square" alt="Crates.io version" /></a>
+    <a href="https://crates.io/crates/wasm-metadata"><img src="https://img.shields.io/crates/d/wasm-metadata.svg?style=flat-square" alt="Download" /></a>
+    <a href="https://docs.rs/wasm-metadata/"><img src="https://img.shields.io/static/v1?label=docs&message=wasm-metadata&color=blue&style=flat-square" alt="docs.rs docs" /></a>
+  </p>
+</div>
+
+## Installation
+
+```sh
+$ cargo add wasm-metadata
+```
+
+# License
+
+This project is licensed under the Apache 2.0 license with the LLVM exception.
+See [LICENSE](LICENSE) for more details.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in this project by you, as defined in the Apache-2.0 license,
+shall be licensed as above, without any additional terms or conditions.


### PR DESCRIPTION
The crate was missing a README, this adds a basic one. I'm holding off on adding an example for now since I want to experiment with changing the API. Thanks!