### PR TITLE
[wasm-metadata] use workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,7 @@ rayon = "1.3"
 serde = { version = "1.0.166", default-features = false, features = ['alloc'] }
 serde_derive = "1.0.166"
 serde_json = { version = "1" }
+spdx = "0.10.1"
 wasmtime = { version = "25.0.0", default-features = false, features = ['cranelift', 'component-model', 'runtime', 'gc'] }
 url = "2.0.0"
 pretty_assertions = "1.3.0"

--- a/crates/wasm-metadata/Cargo.toml
+++ b/crates/wasm-metadata/Cargo.toml
@@ -18,6 +18,6 @@ wasm-encoder = { workspace = true, features = ['component-model'] }
 indexmap = { workspace = true, features = ["serde"] }
 serde = { workspace = true }
 serde_derive = { workspace = true }
-serde_json = { version = "1" }
-spdx = "0.10.1"
+serde_json = { workspace = true }
+spdx = { workspace = true }
 url = { workspace = true }


### PR DESCRIPTION
A litte bit of housekeeping in wasm-tools' `Cargo.toml`. Thanks!