### PR TITLE
[wasm-metadata] add support for OCI version and revision

### DIFF
--- a/crates/wasm-metadata/src/add_metadata.rs
+++ b/crates/wasm-metadata/src/add_metadata.rs
@@ -1,4 +1,6 @@
-use crate::{rewrite_wasm, Author, Description, Homepage, Licenses, Producers, Revision, Source};
+use crate::{
+    rewrite_wasm, Author, Description, Homepage, Licenses, Producers, Revision, Source, Version,
+};
 
 use anyhow::Result;
 
@@ -49,6 +51,10 @@ pub struct AddMetadata {
     /// Source control revision identifier for the packaged software.
     #[cfg_attr(feature = "clap", clap(long, value_name = "NAME"))]
     pub revision: Option<Revision>,
+
+    /// Version of the packaged software
+    #[cfg_attr(feature = "clap", clap(long, value_name = "NAME"))]
+    pub version: Option<Version>,
 }
 
 #[cfg(feature = "clap")]
@@ -72,6 +78,7 @@ impl AddMetadata {
             &self.source,
             &self.homepage,
             &self.revision,
+            &self.version,
             input,
         )
     }

--- a/crates/wasm-metadata/src/add_metadata.rs
+++ b/crates/wasm-metadata/src/add_metadata.rs
@@ -1,4 +1,4 @@
-use crate::{rewrite_wasm, Author, Description, Homepage, Licenses, Producers, Source};
+use crate::{rewrite_wasm, Author, Description, Homepage, Licenses, Producers, Revision, Source};
 
 use anyhow::Result;
 
@@ -45,6 +45,10 @@ pub struct AddMetadata {
     /// URL to find more information on the binary
     #[cfg_attr(feature = "clap", clap(long, value_name = "NAME"))]
     pub homepage: Option<Homepage>,
+
+    /// Source control revision identifier for the packaged software.
+    #[cfg_attr(feature = "clap", clap(long, value_name = "NAME"))]
+    pub revision: Option<Revision>,
 }
 
 #[cfg(feature = "clap")]
@@ -67,6 +71,7 @@ impl AddMetadata {
             &self.licenses,
             &self.source,
             &self.homepage,
+            &self.revision,
             input,
         )
     }

--- a/crates/wasm-metadata/src/lib.rs
+++ b/crates/wasm-metadata/src/lib.rs
@@ -5,7 +5,7 @@
 pub use add_metadata::AddMetadata;
 pub use metadata::Metadata;
 pub use names::{ComponentNames, ModuleNames};
-pub use oci_annotations::{Author, Description, Homepage, Licenses, Revision, Source};
+pub use oci_annotations::{Author, Description, Homepage, Licenses, Revision, Source, Version};
 pub use payload::Payload;
 pub use producers::{Producers, ProducersField};
 

--- a/crates/wasm-metadata/src/lib.rs
+++ b/crates/wasm-metadata/src/lib.rs
@@ -5,7 +5,7 @@
 pub use add_metadata::AddMetadata;
 pub use metadata::Metadata;
 pub use names::{ComponentNames, ModuleNames};
-pub use oci_annotations::{Author, Description, Homepage, Licenses, Source};
+pub use oci_annotations::{Author, Description, Homepage, Licenses, Revision, Source};
 pub use payload::Payload;
 pub use producers::{Producers, ProducersField};
 

--- a/crates/wasm-metadata/src/metadata.rs
+++ b/crates/wasm-metadata/src/metadata.rs
@@ -1,7 +1,7 @@
 use serde_derive::Serialize;
 use std::ops::Range;
 
-use crate::{Author, Description, Homepage, Licenses, Producers, Revision, Source};
+use crate::{Author, Description, Homepage, Licenses, Producers, Revision, Source, Version};
 
 /// Metadata associated with a Wasm Component or Module
 #[derive(Debug, Serialize, Default)]
@@ -23,6 +23,8 @@ pub struct Metadata {
     pub homepage: Option<Homepage>,
     /// Source control revision identifier for the packaged software.
     pub revision: Option<Revision>,
+    /// Version of the packaged software
+    pub version: Option<Version>,
     /// Byte range of the module in the parent binary
     pub range: Range<usize>,
 }

--- a/crates/wasm-metadata/src/metadata.rs
+++ b/crates/wasm-metadata/src/metadata.rs
@@ -1,7 +1,7 @@
 use serde_derive::Serialize;
 use std::ops::Range;
 
-use crate::{Author, Description, Homepage, Licenses, Producers, Source};
+use crate::{Author, Description, Homepage, Licenses, Producers, Revision, Source};
 
 /// Metadata associated with a Wasm Component or Module
 #[derive(Debug, Serialize, Default)]
@@ -21,6 +21,8 @@ pub struct Metadata {
     pub source: Option<Source>,
     /// URL to find more information on the binary
     pub homepage: Option<Homepage>,
+    /// Source control revision identifier for the packaged software.
+    pub revision: Option<Revision>,
     /// Byte range of the module in the parent binary
     pub range: Range<usize>,
 }

--- a/crates/wasm-metadata/src/oci_annotations/mod.rs
+++ b/crates/wasm-metadata/src/oci_annotations/mod.rs
@@ -19,10 +19,12 @@ pub use author::Author;
 pub use description::Description;
 pub use homepage::Homepage;
 pub use licenses::Licenses;
+pub use revision::Revision;
 pub use source::Source;
 
 mod author;
 mod description;
 mod homepage;
 mod licenses;
+mod revision;
 mod source;

--- a/crates/wasm-metadata/src/oci_annotations/mod.rs
+++ b/crates/wasm-metadata/src/oci_annotations/mod.rs
@@ -21,6 +21,7 @@ pub use homepage::Homepage;
 pub use licenses::Licenses;
 pub use revision::Revision;
 pub use source::Source;
+pub use version::Version;
 
 mod author;
 mod description;
@@ -28,3 +29,4 @@ mod homepage;
 mod licenses;
 mod revision;
 mod source;
+mod version;

--- a/crates/wasm-metadata/src/oci_annotations/revision.rs
+++ b/crates/wasm-metadata/src/oci_annotations/revision.rs
@@ -1,0 +1,113 @@
+use std::borrow::Cow;
+use std::fmt::{self, Display};
+use std::str::FromStr;
+
+use anyhow::{ensure, Error, Result};
+use serde::Serialize;
+use wasm_encoder::{ComponentSection, CustomSection, Encode, Section};
+use wasmparser::CustomSectionReader;
+
+/// Source control revision identifier for the packaged software.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Revision(CustomSection<'static>);
+
+impl Revision {
+    /// Create a new instance of `Desrciption`.
+    pub fn new<S: Into<Cow<'static, str>>>(s: S) -> Self {
+        Self(CustomSection {
+            name: "revision".into(),
+            data: match s.into() {
+                Cow::Borrowed(s) => Cow::Borrowed(s.as_bytes()),
+                Cow::Owned(s) => Cow::Owned(s.into()),
+            },
+        })
+    }
+
+    /// Parse an `revision` custom section from a wasm binary.
+    pub(crate) fn parse_custom_section(reader: &CustomSectionReader<'_>) -> Result<Self> {
+        ensure!(
+            reader.name() == "revision",
+            "The `revision` custom section should have a name of 'revision'"
+        );
+        let data = String::from_utf8(reader.data().to_owned())?;
+        Ok(Self::new(data))
+    }
+}
+
+impl FromStr for Revision {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::new(s.to_owned()))
+    }
+}
+
+impl Serialize for Revision {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl Display for Revision {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // NOTE: this will never panic since we always guarantee the data is
+        // encoded as utf8, even if we internally store it as [u8].
+        let data = String::from_utf8(self.0.data.to_vec()).unwrap();
+        write!(f, "{data}")
+    }
+}
+
+impl ComponentSection for Revision {
+    fn id(&self) -> u8 {
+        ComponentSection::id(&self.0)
+    }
+}
+
+impl Section for Revision {
+    fn id(&self) -> u8 {
+        Section::id(&self.0)
+    }
+}
+
+impl Encode for Revision {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        self.0.encode(sink);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use wasm_encoder::Component;
+    use wasmparser::Payload;
+
+    #[test]
+    fn roundtrip() {
+        let mut component = Component::new();
+        component.section(&Revision::new("de978e17a80c1118f606fce919ba9b7d5a04a5ad"));
+        let component = component.finish();
+
+        let mut parsed = false;
+        for section in wasmparser::Parser::new(0).parse_all(&component) {
+            if let Payload::CustomSection(reader) = section.unwrap() {
+                let revision = Revision::parse_custom_section(&reader).unwrap();
+                assert_eq!(
+                    revision.to_string(),
+                    "de978e17a80c1118f606fce919ba9b7d5a04a5ad"
+                );
+                parsed = true;
+            }
+        }
+        assert!(parsed);
+    }
+
+    #[test]
+    fn serialize() {
+        let revision = Revision::new("de978e17a80c1118f606fce919ba9b7d5a04a5ad");
+        let json = serde_json::to_string(&revision).unwrap();
+        assert_eq!(r#""de978e17a80c1118f606fce919ba9b7d5a04a5ad""#, json);
+    }
+}

--- a/crates/wasm-metadata/src/oci_annotations/version.rs
+++ b/crates/wasm-metadata/src/oci_annotations/version.rs
@@ -1,0 +1,110 @@
+use std::borrow::Cow;
+use std::fmt::{self, Display};
+use std::str::FromStr;
+
+use anyhow::{ensure, Error, Result};
+use serde::Serialize;
+use wasm_encoder::{ComponentSection, CustomSection, Encode, Section};
+use wasmparser::CustomSectionReader;
+
+/// Version of the packaged software
+#[derive(Debug, Clone, PartialEq)]
+pub struct Version(CustomSection<'static>);
+
+impl Version {
+    /// Create a new instance of `Desrciption`.
+    pub fn new<S: Into<Cow<'static, str>>>(s: S) -> Self {
+        Self(CustomSection {
+            name: "version".into(),
+            data: match s.into() {
+                Cow::Borrowed(s) => Cow::Borrowed(s.as_bytes()),
+                Cow::Owned(s) => Cow::Owned(s.into()),
+            },
+        })
+    }
+
+    /// Parse an `version` custom section from a wasm binary.
+    pub(crate) fn parse_custom_section(reader: &CustomSectionReader<'_>) -> Result<Self> {
+        ensure!(
+            reader.name() == "version",
+            "The `version` custom section should have a name of 'version'"
+        );
+        let data = String::from_utf8(reader.data().to_owned())?;
+        Ok(Self::new(data))
+    }
+}
+
+impl FromStr for Version {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self::new(s.to_owned()))
+    }
+}
+
+impl Serialize for Version {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // NOTE: this will never panic since we always guarantee the data is
+        // encoded as utf8, even if we internally store it as [u8].
+        let data = String::from_utf8(self.0.data.to_vec()).unwrap();
+        write!(f, "{data}")
+    }
+}
+
+impl ComponentSection for Version {
+    fn id(&self) -> u8 {
+        ComponentSection::id(&self.0)
+    }
+}
+
+impl Section for Version {
+    fn id(&self) -> u8 {
+        Section::id(&self.0)
+    }
+}
+
+impl Encode for Version {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        self.0.encode(sink);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use wasm_encoder::Component;
+    use wasmparser::Payload;
+
+    #[test]
+    fn roundtrip() {
+        let mut component = Component::new();
+        component.section(&Version::new("1.0.0"));
+        let component = component.finish();
+
+        let mut parsed = false;
+        for section in wasmparser::Parser::new(0).parse_all(&component) {
+            if let Payload::CustomSection(reader) = section.unwrap() {
+                let version = Version::parse_custom_section(&reader).unwrap();
+                assert_eq!(version.to_string(), "1.0.0");
+                parsed = true;
+            }
+        }
+        assert!(parsed);
+    }
+
+    #[test]
+    fn serialize() {
+        let version = Version::new("1.0.0");
+        let json = serde_json::to_string(&version).unwrap();
+        assert_eq!(r#""1.0.0""#, json);
+    }
+}

--- a/crates/wasm-metadata/src/payload.rs
+++ b/crates/wasm-metadata/src/payload.rs
@@ -6,7 +6,7 @@ use wasmparser::{KnownCustom, Parser, Payload::*};
 
 use crate::{
     Author, ComponentNames, Description, Homepage, Licenses, Metadata, ModuleNames, Producers,
-    Source,
+    Revision, Source,
 };
 
 /// Data representing either a Wasm Component or module
@@ -132,6 +132,14 @@ impl Payload {
                             .expect("non-empty metadata stack")
                             .metadata_mut();
                         *homepage = Some(a);
+                    }
+                    KnownCustom::Unknown if c.name() == "revision" => {
+                        let a = Revision::parse_custom_section(&c)?;
+                        let Metadata { revision, .. } = output
+                            .last_mut()
+                            .expect("non-empty metadata stack")
+                            .metadata_mut();
+                        *revision = Some(a);
                     }
                     _ => {}
                 },

--- a/crates/wasm-metadata/src/payload.rs
+++ b/crates/wasm-metadata/src/payload.rs
@@ -141,6 +141,14 @@ impl Payload {
                             .metadata_mut();
                         *revision = Some(a);
                     }
+                    KnownCustom::Unknown if c.name() == "version" => {
+                        let a = crate::Version::parse_custom_section(&c)?;
+                        let Metadata { version, .. } = output
+                            .last_mut()
+                            .expect("non-empty metadata stack")
+                            .metadata_mut();
+                        *version = Some(a);
+                    }
                     _ => {}
                 },
                 _ => {}

--- a/crates/wasm-metadata/src/producers.rs
+++ b/crates/wasm-metadata/src/producers.rs
@@ -147,7 +147,7 @@ impl Producers {
     /// Merge into an existing wasm module. Rewrites the module with this producers section
     /// merged into its existing one, or adds this producers section if none is present.
     pub fn add_to_wasm(&self, input: &[u8]) -> Result<Vec<u8>> {
-        rewrite_wasm(&None, self, &None, &None, &None, &None, &None, input)
+        rewrite_wasm(&None, self, &None, &None, &None, &None, &None, &None, input)
     }
 }
 

--- a/crates/wasm-metadata/src/producers.rs
+++ b/crates/wasm-metadata/src/producers.rs
@@ -147,7 +147,9 @@ impl Producers {
     /// Merge into an existing wasm module. Rewrites the module with this producers section
     /// merged into its existing one, or adds this producers section if none is present.
     pub fn add_to_wasm(&self, input: &[u8]) -> Result<Vec<u8>> {
-        rewrite_wasm(&None, self, &None, &None, &None, &None, &None, &None, input)
+        rewrite_wasm(
+            &None, self, &None, &None, &None, &None, &None, &None, &None, input,
+        )
     }
 }
 

--- a/crates/wasm-metadata/src/rewrite.rs
+++ b/crates/wasm-metadata/src/rewrite.rs
@@ -1,5 +1,6 @@
 use crate::{
-    Author, ComponentNames, Description, Homepage, Licenses, ModuleNames, Producers, Source,
+    Author, ComponentNames, Description, Homepage, Licenses, ModuleNames, Producers, Revision,
+    Source,
 };
 use anyhow::Result;
 use std::mem;
@@ -15,6 +16,7 @@ pub(crate) fn rewrite_wasm(
     add_licenses: &Option<Licenses>,
     add_source: &Option<Source>,
     add_homepage: &Option<Homepage>,
+    add_revision: &Option<Revision>,
     input: &[u8],
 ) -> Result<Vec<u8>> {
     let mut producers_found = false;
@@ -116,6 +118,13 @@ pub(crate) fn rewrite_wasm(
                             continue;
                         }
                     }
+                    KnownCustom::Unknown if c.name() == "revision" => {
+                        if add_source.is_none() {
+                            let revision = Revision::parse_custom_section(c)?;
+                            revision.append_to(&mut output);
+                            continue;
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -159,6 +168,9 @@ pub(crate) fn rewrite_wasm(
     }
     if let Some(homepage) = add_homepage {
         homepage.append_to(&mut output);
+    }
+    if let Some(revision) = add_revision {
+        revision.append_to(&mut output);
     }
     Ok(output)
 }

--- a/crates/wasm-metadata/src/rewrite.rs
+++ b/crates/wasm-metadata/src/rewrite.rs
@@ -17,6 +17,7 @@ pub(crate) fn rewrite_wasm(
     add_source: &Option<Source>,
     add_homepage: &Option<Homepage>,
     add_revision: &Option<Revision>,
+    add_version: &Option<crate::Version>,
     input: &[u8],
 ) -> Result<Vec<u8>> {
     let mut producers_found = false;
@@ -125,6 +126,13 @@ pub(crate) fn rewrite_wasm(
                             continue;
                         }
                     }
+                    KnownCustom::Unknown if c.name() == "version" => {
+                        if add_version.is_none() {
+                            let version = crate::Version::parse_custom_section(c)?;
+                            version.append_to(&mut output);
+                            continue;
+                        }
+                    }
                     _ => {}
                 }
             }
@@ -171,6 +179,9 @@ pub(crate) fn rewrite_wasm(
     }
     if let Some(revision) = add_revision {
         revision.append_to(&mut output);
+    }
+    if let Some(version) = add_version {
+        version.append_to(&mut output);
     }
     Ok(output)
 }

--- a/crates/wasm-metadata/tests/component.rs
+++ b/crates/wasm-metadata/tests/component.rs
@@ -19,6 +19,7 @@ fn add_to_empty_component() {
         source: Some(Source::new("https://github.com/bytecodealliance/wasm-tools").unwrap()),
         homepage: Some(Homepage::new("https://github.com/bytecodealliance/wasm-tools").unwrap()),
         revision: Some(Revision::new("de978e17a80c1118f606fce919ba9b7d5a04a5ad")),
+        version: Some(Version::new("1.0.0")),
     };
     let component = add.to_wasm(&component).unwrap();
 
@@ -36,6 +37,7 @@ fn add_to_empty_component() {
                     range,
                     homepage,
                     revision,
+                    version,
                 },
         } => {
             assert!(children.is_empty());
@@ -68,9 +70,10 @@ fn add_to_empty_component() {
                 revision.unwrap(),
                 Revision::new("de978e17a80c1118f606fce919ba9b7d5a04a5ad")
             );
+            assert_eq!(version.unwrap(), Version::new("1.0.0"));
 
             assert_eq!(range.start, 0);
-            assert_eq!(range.end, 308);
+            assert_eq!(range.end, 374);
         }
         _ => panic!("metadata should be component"),
     }
@@ -93,6 +96,7 @@ fn add_to_nested_component() {
         source: Some(Source::new("https://github.com/bytecodealliance/wasm-tools").unwrap()),
         homepage: Some(Homepage::new("https://github.com/bytecodealliance/wasm-tools").unwrap()),
         revision: Some(Revision::new("de978e17a80c1118f606fce919ba9b7d5a04a5ad")),
+        version: Some(Version::new("1.0.0")),
     };
     let module = add.to_wasm(&module).unwrap();
 
@@ -140,6 +144,7 @@ fn add_to_nested_component() {
                     description,
                     homepage,
                     revision,
+                    version,
                 }) => {
                     assert_eq!(name, &Some("foo".to_owned()));
                     let producers = producers.as_ref().expect("some producers");
@@ -178,9 +183,10 @@ fn add_to_nested_component() {
                         revision,
                         &Some(Revision::new("de978e17a80c1118f606fce919ba9b7d5a04a5ad"))
                     );
+                    assert_eq!(version, &Some(Version::new("1.0.0")));
 
                     assert_eq!(range.start, 11);
-                    assert_eq!(range.end, 309);
+                    assert_eq!(range.end, 375);
                 }
                 _ => panic!("child is a module"),
             }

--- a/crates/wasm-metadata/tests/component.rs
+++ b/crates/wasm-metadata/tests/component.rs
@@ -18,6 +18,7 @@ fn add_to_empty_component() {
         ),
         source: Some(Source::new("https://github.com/bytecodealliance/wasm-tools").unwrap()),
         homepage: Some(Homepage::new("https://github.com/bytecodealliance/wasm-tools").unwrap()),
+        revision: Some(Revision::new("de978e17a80c1118f606fce919ba9b7d5a04a5ad")),
     };
     let component = add.to_wasm(&component).unwrap();
 
@@ -34,6 +35,7 @@ fn add_to_empty_component() {
                     source,
                     range,
                     homepage,
+                    revision,
                 },
         } => {
             assert!(children.is_empty());
@@ -62,6 +64,10 @@ fn add_to_empty_component() {
                 homepage.unwrap(),
                 Homepage::new("https://github.com/bytecodealliance/wasm-tools").unwrap(),
             );
+            assert_eq!(
+                revision.unwrap(),
+                Revision::new("de978e17a80c1118f606fce919ba9b7d5a04a5ad")
+            );
 
             assert_eq!(range.start, 0);
             assert_eq!(range.end, 308);
@@ -86,6 +92,7 @@ fn add_to_nested_component() {
         ),
         source: Some(Source::new("https://github.com/bytecodealliance/wasm-tools").unwrap()),
         homepage: Some(Homepage::new("https://github.com/bytecodealliance/wasm-tools").unwrap()),
+        revision: Some(Revision::new("de978e17a80c1118f606fce919ba9b7d5a04a5ad")),
     };
     let module = add.to_wasm(&module).unwrap();
 
@@ -132,6 +139,7 @@ fn add_to_nested_component() {
                     range,
                     description,
                     homepage,
+                    revision,
                 }) => {
                     assert_eq!(name, &Some("foo".to_owned()));
                     let producers = producers.as_ref().expect("some producers");
@@ -165,6 +173,10 @@ fn add_to_nested_component() {
                             Homepage::new("https://github.com/bytecodealliance/wasm-tools")
                                 .unwrap()
                         ),
+                    );
+                    assert_eq!(
+                        revision,
+                        &Some(Revision::new("de978e17a80c1118f606fce919ba9b7d5a04a5ad"))
                     );
 
                     assert_eq!(range.start, 11);

--- a/crates/wasm-metadata/tests/module.rs
+++ b/crates/wasm-metadata/tests/module.rs
@@ -19,6 +19,7 @@ fn add_to_empty_module() {
         source: Some(Source::new("https://github.com/bytecodealliance/wasm-tools").unwrap()),
         homepage: Some(Homepage::new("https://github.com/bytecodealliance/wasm-tools").unwrap()),
         revision: Some(Revision::new("de978e17a80c1118f606fce919ba9b7d5a04a5ad")),
+        version: Some(Version::new("1.0.0")),
     };
     let module = add.to_wasm(&module).unwrap();
 
@@ -33,6 +34,7 @@ fn add_to_empty_module() {
             description,
             homepage,
             revision,
+            version,
         }) => {
             assert_eq!(name, Some("foo".to_owned()));
             let producers = producers.expect("some producers");
@@ -63,9 +65,10 @@ fn add_to_empty_module() {
                 revision.unwrap(),
                 Revision::new("de978e17a80c1118f606fce919ba9b7d5a04a5ad")
             );
+            assert_eq!(version.unwrap(), Version::new("1.0.0"));
 
             assert_eq!(range.start, 0);
-            assert_eq!(range.end, 298);
+            assert_eq!(range.end, 364);
         }
         _ => panic!("metadata should be module"),
     }

--- a/crates/wasm-metadata/tests/module.rs
+++ b/crates/wasm-metadata/tests/module.rs
@@ -18,6 +18,7 @@ fn add_to_empty_module() {
         ),
         source: Some(Source::new("https://github.com/bytecodealliance/wasm-tools").unwrap()),
         homepage: Some(Homepage::new("https://github.com/bytecodealliance/wasm-tools").unwrap()),
+        revision: Some(Revision::new("de978e17a80c1118f606fce919ba9b7d5a04a5ad")),
     };
     let module = add.to_wasm(&module).unwrap();
 
@@ -31,6 +32,7 @@ fn add_to_empty_module() {
             range,
             description,
             homepage,
+            revision,
         }) => {
             assert_eq!(name, Some("foo".to_owned()));
             let producers = producers.expect("some producers");
@@ -56,6 +58,10 @@ fn add_to_empty_module() {
             assert_eq!(
                 homepage.unwrap(),
                 Homepage::new("https://github.com/bytecodealliance/wasm-tools").unwrap(),
+            );
+            assert_eq!(
+                revision.unwrap(),
+                Revision::new("de978e17a80c1118f606fce919ba9b7d5a04a5ad")
             );
 
             assert_eq!(range.start, 0);

--- a/src/bin/wasm-tools/metadata.rs
+++ b/src/bin/wasm-tools/metadata.rs
@@ -106,6 +106,7 @@ fn fmt_payload(payload: &Payload, f: &mut Box<dyn WriteColor>) -> Result<()> {
         source,
         homepage,
         range,
+        revision,
     } = payload.metadata();
 
     // Print the basic information
@@ -136,6 +137,9 @@ fn fmt_payload(payload: &Payload, f: &mut Box<dyn WriteColor>) -> Result<()> {
     }
     if let Some(homepage) = homepage {
         table.add_row(vec!["homepage", &homepage.to_string()]);
+    }
+    if let Some(revision) = revision {
+        table.add_row(vec!["revision", &revision.to_string()]);
     }
 
     if let Some(producers) = producers {

--- a/src/bin/wasm-tools/metadata.rs
+++ b/src/bin/wasm-tools/metadata.rs
@@ -107,6 +107,7 @@ fn fmt_payload(payload: &Payload, f: &mut Box<dyn WriteColor>) -> Result<()> {
         homepage,
         range,
         revision,
+        version,
     } = payload.metadata();
 
     // Print the basic information
@@ -140,6 +141,9 @@ fn fmt_payload(payload: &Payload, f: &mut Box<dyn WriteColor>) -> Result<()> {
     }
     if let Some(revision) = revision {
         table.add_row(vec!["revision", &revision.to_string()]);
+    }
+    if let Some(version) = version {
+        table.add_row(vec!["version", &version.to_string()]);
     }
 
     if let Some(producers) = producers {


### PR DESCRIPTION
Closes #1922 by implementing the last two OCI annotations. As explained in https://github.com/bytecodealliance/wasm-tools/issues/1922#issuecomment-2532776880 I'm intentionally foregoing the `created` annotation because of reproducibility concerns. Once this is merged, the next step would be to integrate it into `cargo-component` and `wkg`, and upstream it to `webassembly/tool-conventions` and the wasm OCI spec. Thanks!