### PR TITLE
[wit-component] Extend the WIT printer for use in syntax highlighting

### DIFF
--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -86,10 +86,11 @@ impl WitPrinter {
         }
 
         if is_main {
-            self.print_semicolon();
-            self.output.push_str("\n\n");
+            self.output.semicolon();
+            self.output.push_str("\n");
         } else {
             self.output.push_str(" {\n");
+            //self.output.indent_start();
         }
 
         for (name, id) in pkg.interfaces.iter() {
@@ -121,10 +122,6 @@ impl WitPrinter {
             writeln!(&mut self.output, "}}")?;
         }
         Ok(())
-    }
-
-    fn print_semicolon(&mut self) {
-        self.output.push_str(";");
     }
 
     fn new_item(&mut self) {
@@ -166,8 +163,7 @@ impl WitPrinter {
             self.print_name(name);
             self.output.push_str(": ");
             self.print_function(resolve, func)?;
-            self.print_semicolon();
-            self.output.push_str("\n");
+            self.output.semicolon();
         }
 
         self.any_items = prev_items;
@@ -251,8 +247,7 @@ impl WitPrinter {
                 }
             }
             write!(&mut self.output, "}}")?;
-            self.print_semicolon();
-            self.output.push_str("\n");
+            self.output.semicolon();
         }
 
         for id in types_to_declare {
@@ -278,8 +273,7 @@ impl WitPrinter {
         self.output.push_str(" ");
         self.print_name(ty.name.as_ref().expect("resources must be named"));
         if funcs.is_empty() {
-            self.print_semicolon();
-            self.output.push_str("\n");
+            self.output.semicolon();
             return Ok(());
         }
         self.output.push_str(" {\n");
@@ -302,8 +296,7 @@ impl WitPrinter {
                 FunctionKind::Freestanding => unreachable!(),
             }
             self.print_function(resolve, func)?;
-            self.print_semicolon();
-            self.output.push_str("\n");
+            self.output.semicolon();
         }
         self.output.push_str("}\n");
 
@@ -445,8 +438,7 @@ impl WitPrinter {
                     }
                     WorldItem::Function(f) => {
                         self.print_function(resolve, f)?;
-                        self.print_semicolon();
-                        self.output.push_str("\n");
+                        self.output.semicolon();
                     }
                     // Types are handled separately
                     WorldItem::Type(_) => unreachable!(),
@@ -458,8 +450,7 @@ impl WitPrinter {
                     _ => unreachable!(),
                 }
                 self.print_path_to_interface(resolve, *id, cur_pkg)?;
-                self.print_semicolon();
-                self.output.push_str("\n");
+                self.output.semicolon();
             }
         }
         Ok(())
@@ -723,8 +714,7 @@ impl WitPrinter {
                             self.print_name(name);
                             self.output.push_str(" = ");
                             self.print_type_name(resolve, inner)?;
-                            self.print_semicolon();
-                            self.output.push_str("\n");
+                            self.output.semicolon();
                         }
                         None => bail!("unnamed type in document"),
                     },
@@ -755,8 +745,7 @@ impl WitPrinter {
                 // own<b>`. By forcing a handle to be printed here it's staying
                 // true to what's in the WIT document.
                 self.print_handle_type(resolve, handle, true)?;
-                self.print_semicolon();
-                self.output.push_str("\n");
+                self.output.semicolon();
 
                 Ok(())
             }
@@ -802,8 +791,7 @@ impl WitPrinter {
             self.print_name(name);
             self.output.push_str(" = ");
             self.print_tuple_type(resolve, tuple)?;
-            self.print_semicolon();
-            self.output.push_str("\n");
+            self.output.semicolon();
         }
         Ok(())
     }
@@ -867,8 +855,7 @@ impl WitPrinter {
             self.print_name(name);
             self.output.push_str(" = ");
             self.print_option_type(resolve, payload)?;
-            self.print_semicolon();
-            self.output.push_str("\n");
+            self.output.semicolon();
         }
         Ok(())
     }
@@ -885,8 +872,7 @@ impl WitPrinter {
             self.print_name(name);
             self.output.push_str(" = ");
             self.print_result_type(resolve, result)?;
-            self.print_semicolon();
-            self.output.push_str("\n");
+            self.output.semicolon();
         }
         Ok(())
     }
@@ -919,8 +905,7 @@ impl WitPrinter {
             self.output.push_str("<");
             self.print_type_name(resolve, ty)?;
             self.output.push_str(">");
-            self.print_semicolon();
-            self.output.push_str("\n");
+            self.output.semicolon();
             return Ok(());
         }
 
@@ -1062,6 +1047,11 @@ impl Output {
     fn push_doc(&mut self, doc: &str) {
         self.push_str("/// ");
         self.push_str(doc);
+        self.push_str("\n");
+    }
+
+    fn semicolon(&mut self) {
+        self.push_str(";");
         self.push_str("\n");
     }
 

--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -76,13 +76,13 @@ impl WitPrinter {
     ) -> Result<()> {
         let pkg = &resolve.packages[pkg];
         self.print_docs(&pkg.docs);
-        self.output.push_keyword("package");
-        self.output.push_str(" ");
+        self.output.keyword("package");
+        self.output.str(" ");
         self.print_name(&pkg.name.namespace);
-        self.output.push_str(":");
+        self.output.str(":");
         self.print_name(&pkg.name.name);
         if let Some(version) = &pkg.name.version {
-            self.output.push_str(&format!("@{version}"));
+            self.output.str(&format!("@{version}"));
         }
 
         if is_main {
@@ -95,8 +95,8 @@ impl WitPrinter {
         for (name, id) in pkg.interfaces.iter() {
             self.print_docs(&resolve.interfaces[*id].docs);
             self.print_stability(&resolve.interfaces[*id].stability);
-            self.output.push_keyword("interface");
-            self.output.push_str(" ");
+            self.output.keyword("interface");
+            self.output.str(" ");
             self.print_name(name);
             self.output.indent_start();
             self.print_interface(resolve, *id)?;
@@ -111,8 +111,8 @@ impl WitPrinter {
         for (name, id) in pkg.worlds.iter() {
             self.print_docs(&resolve.worlds[*id].docs);
             self.print_stability(&resolve.worlds[*id].stability);
-            self.output.push_keyword("world");
-            self.output.push_str(" ");
+            self.output.keyword("world");
+            self.output.str(" ");
             self.print_name(name);
             self.output.indent_start();
             self.print_world(resolve, *id)?;
@@ -161,7 +161,7 @@ impl WitPrinter {
             self.print_docs(&func.docs);
             self.print_stability(&func.stability);
             self.print_name(name);
-            self.output.push_str(": ");
+            self.output.str(": ");
             self.print_function(resolve, func)?;
             self.output.semicolon();
         }
@@ -222,8 +222,8 @@ impl WitPrinter {
         for (owner, stability, tys) in types_to_import {
             self.any_items = true;
             self.print_stability(stability);
-            self.output.push_keyword("use");
-            self.output.push_str(" ");
+            self.output.keyword("use");
+            self.output.str(" ");
             let id = match owner {
                 TypeOwner::Interface(id) => id,
                 // it's only possible to import types from interfaces at
@@ -231,22 +231,22 @@ impl WitPrinter {
                 _ => unreachable!(),
             };
             self.print_path_to_interface(resolve, id, my_pkg)?;
-            self.output.push_str(".{"); // Note: not changing the indentation.
+            self.output.str(".{"); // Note: not changing the indentation.
             for (i, (my_name, other_name)) in tys.into_iter().enumerate() {
                 if i > 0 {
-                    self.output.push_str(", ");
+                    self.output.str(", ");
                 }
                 if my_name == other_name {
                     self.print_name(my_name);
                 } else {
                     self.print_name(other_name);
-                    self.output.push_str(" ");
-                    self.output.push_keyword("as");
-                    self.output.push_str(" ");
+                    self.output.str(" ");
+                    self.output.keyword("as");
+                    self.output.str(" ");
                     self.print_name(my_name);
                 }
             }
-            self.output.push_str("}");
+            self.output.str("}");
             self.output.semicolon();
         }
 
@@ -269,8 +269,8 @@ impl WitPrinter {
 
     fn print_resource(&mut self, resolve: &Resolve, id: TypeId, funcs: &[&Function]) -> Result<()> {
         let ty = &resolve.types[id];
-        self.output.push_keyword("resource");
-        self.output.push_str(" ");
+        self.output.keyword("resource");
+        self.output.str(" ");
         self.print_name(ty.name.as_ref().expect("resources must be named"));
         if funcs.is_empty() {
             self.output.semicolon();
@@ -285,13 +285,13 @@ impl WitPrinter {
                 FunctionKind::Constructor(_) => {}
                 FunctionKind::Method(_) => {
                     self.print_name(func.item_name());
-                    self.output.push_str(": ");
+                    self.output.str(": ");
                 }
                 FunctionKind::Static(_) => {
                     self.print_name(func.item_name());
-                    self.output.push_str(": ");
-                    self.output.push_keyword("static");
-                    self.output.push_str(" ");
+                    self.output.str(": ");
+                    self.output.keyword("static");
+                    self.output.str(" ");
                 }
                 FunctionKind::Freestanding => unreachable!(),
             }
@@ -307,12 +307,12 @@ impl WitPrinter {
         // Constructors are named slightly differently.
         match &func.kind {
             FunctionKind::Constructor(_) => {
-                self.output.push_keyword("constructor");
-                self.output.push_str("(");
+                self.output.keyword("constructor");
+                self.output.str("(");
             }
             _ => {
-                self.output.push_keyword("func");
-                self.output.push_str("(");
+                self.output.keyword("func");
+                self.output.str("(");
             }
         }
 
@@ -323,13 +323,13 @@ impl WitPrinter {
         };
         for (i, (name, ty)) in func.params.iter().skip(params_to_skip).enumerate() {
             if i > 0 {
-                self.output.push_str(", ");
+                self.output.str(", ");
             }
             self.print_name(name);
-            self.output.push_str(": ");
+            self.output.str(": ");
             self.print_type_name(resolve, ty)?;
         }
-        self.output.push_str(")");
+        self.output.str(")");
 
         // constructors don't have their results printed
         if let FunctionKind::Constructor(_) = func.kind {
@@ -340,20 +340,20 @@ impl WitPrinter {
             Results::Named(rs) => match rs.len() {
                 0 => (),
                 _ => {
-                    self.output.push_str(" -> (");
+                    self.output.str(" -> (");
                     for (i, (name, ty)) in rs.iter().enumerate() {
                         if i > 0 {
-                            self.output.push_str(", ");
+                            self.output.str(", ");
                         }
                         self.print_name(name);
-                        self.output.push_str(": ");
+                        self.output.str(": ");
                         self.print_type_name(resolve, ty)?;
                     }
-                    self.output.push_str(")");
+                    self.output.str(")");
                 }
             },
             Results::Anon(ty) => {
-                self.output.push_str(" -> ");
+                self.output.str(" -> ");
                 self.print_type_name(resolve, ty)?;
             }
         }
@@ -422,16 +422,16 @@ impl WitPrinter {
         }
 
         self.print_stability(item.stability(resolve));
-        self.output.push_keyword(import_or_export_keyword);
-        self.output.push_str(" ");
+        self.output.keyword(import_or_export_keyword);
+        self.output.str(" ");
         match name {
             WorldKey::Name(name) => {
                 self.print_name(name);
-                self.output.push_str(": ");
+                self.output.str(": ");
                 match item {
                     WorldItem::Interface { id, .. } => {
                         assert!(resolve.interfaces[*id].name.is_none());
-                        self.output.push_keyword("interface");
+                        self.output.keyword("interface");
                         self.output.indent_start();
                         self.print_interface(resolve, *id)?;
                         self.output.indent_end();
@@ -468,12 +468,12 @@ impl WitPrinter {
         } else {
             let pkg = &resolve.packages[iface.package.unwrap()].name;
             self.print_name(&pkg.namespace);
-            self.output.push_str(":");
+            self.output.str(":");
             self.print_name(&pkg.name);
-            self.output.push_str("/");
+            self.output.str("/");
             self.print_name(iface.name.as_ref().unwrap());
             if let Some(version) = &pkg.version {
-                self.output.push_str(&format!("@{version}"));
+                self.output.str(&format!("@{version}"));
             }
         }
         Ok(())
@@ -482,31 +482,31 @@ impl WitPrinter {
     /// Print the name of type `ty`.
     pub fn print_type_name(&mut self, resolve: &Resolve, ty: &Type) -> Result<()> {
         match ty {
-            Type::Bool => self.output.push_keyword("bool"),
-            Type::U8 => self.output.push_keyword("u8"),
-            Type::U16 => self.output.push_keyword("u16"),
-            Type::U32 => self.output.push_keyword("u32"),
-            Type::U64 => self.output.push_keyword("u64"),
-            Type::S8 => self.output.push_keyword("s8"),
-            Type::S16 => self.output.push_keyword("s16"),
-            Type::S32 => self.output.push_keyword("s32"),
-            Type::S64 => self.output.push_keyword("s64"),
+            Type::Bool => self.output.keyword("bool"),
+            Type::U8 => self.output.keyword("u8"),
+            Type::U16 => self.output.keyword("u16"),
+            Type::U32 => self.output.keyword("u32"),
+            Type::U64 => self.output.keyword("u64"),
+            Type::S8 => self.output.keyword("s8"),
+            Type::S16 => self.output.keyword("s16"),
+            Type::S32 => self.output.keyword("s32"),
+            Type::S64 => self.output.keyword("s64"),
             Type::F32 => {
                 if self.print_f32_f64 {
-                    self.output.push_keyword("f32")
+                    self.output.keyword("f32")
                 } else {
-                    self.output.push_keyword("f32")
+                    self.output.keyword("f32")
                 }
             }
             Type::F64 => {
                 if self.print_f32_f64 {
-                    self.output.push_keyword("f64")
+                    self.output.keyword("f64")
                 } else {
-                    self.output.push_keyword("f64")
+                    self.output.keyword("f64")
                 }
             }
-            Type::Char => self.output.push_keyword("char"),
-            Type::String => self.output.push_keyword("string"),
+            Type::Char => self.output.keyword("char"),
+            Type::String => self.output.keyword("string"),
 
             Type::Id(id) => {
                 let ty = &resolve.types[*id];
@@ -544,10 +544,10 @@ impl WitPrinter {
                         bail!("resolve has unnamed variant type")
                     }
                     TypeDefKind::List(ty) => {
-                        self.output.push_keyword("list");
-                        self.output.push_str("<");
+                        self.output.keyword("list");
+                        self.output.str("<");
                         self.print_type_name(resolve, ty)?;
-                        self.output.push_str(">");
+                        self.output.str(">");
                     }
                     TypeDefKind::Type(ty) => self.print_type_name(resolve, ty)?,
                     TypeDefKind::Future(_) => {
@@ -574,8 +574,8 @@ impl WitPrinter {
             Handle::Own(ty) => {
                 let ty = &resolve.types[*ty];
                 if force_handle_type_printed {
-                    self.output.push_keyword("own");
-                    self.output.push_str("<");
+                    self.output.keyword("own");
+                    self.output.str("<");
                 }
                 self.print_name(
                     ty.name
@@ -583,20 +583,20 @@ impl WitPrinter {
                         .ok_or_else(|| anyhow!("unnamed resource type"))?,
                 );
                 if force_handle_type_printed {
-                    self.output.push_str(">");
+                    self.output.str(">");
                 }
             }
 
             Handle::Borrow(ty) => {
-                self.output.push_keyword("borrow");
-                self.output.push_str("<");
+                self.output.keyword("borrow");
+                self.output.str("<");
                 let ty = &resolve.types[*ty];
                 self.print_name(
                     ty.name
                         .as_ref()
                         .ok_or_else(|| anyhow!("unnamed resource type"))?,
                 );
-                self.output.push_str(">");
+                self.output.str(">");
             }
         }
 
@@ -604,24 +604,24 @@ impl WitPrinter {
     }
 
     fn print_tuple_type(&mut self, resolve: &Resolve, tuple: &Tuple) -> Result<()> {
-        self.output.push_keyword("tuple");
-        self.output.push_str("<");
+        self.output.keyword("tuple");
+        self.output.str("<");
         for (i, ty) in tuple.types.iter().enumerate() {
             if i > 0 {
-                self.output.push_str(", ");
+                self.output.str(", ");
             }
             self.print_type_name(resolve, ty)?;
         }
-        self.output.push_str(">");
+        self.output.str(">");
 
         Ok(())
     }
 
     fn print_option_type(&mut self, resolve: &Resolve, payload: &Type) -> Result<()> {
-        self.output.push_keyword("option");
-        self.output.push_str("<");
+        self.output.keyword("option");
+        self.output.str("<");
         self.print_type_name(resolve, payload)?;
-        self.output.push_str(">");
+        self.output.str(">");
         Ok(())
     }
 
@@ -631,36 +631,36 @@ impl WitPrinter {
                 ok: Some(ok),
                 err: Some(err),
             } => {
-                self.output.push_keyword("result");
-                self.output.push_str("<");
+                self.output.keyword("result");
+                self.output.str("<");
                 self.print_type_name(resolve, ok)?;
-                self.output.push_str(", ");
+                self.output.str(", ");
                 self.print_type_name(resolve, err)?;
-                self.output.push_str(">");
+                self.output.str(">");
             }
             Result_ {
                 ok: None,
                 err: Some(err),
             } => {
-                self.output.push_keyword("result");
-                self.output.push_str("<_, ");
+                self.output.keyword("result");
+                self.output.str("<_, ");
                 self.print_type_name(resolve, err)?;
-                self.output.push_str(">");
+                self.output.str(">");
             }
             Result_ {
                 ok: Some(ok),
                 err: None,
             } => {
-                self.output.push_keyword("result");
-                self.output.push_str("<");
+                self.output.keyword("result");
+                self.output.str("<");
                 self.print_type_name(resolve, ok)?;
-                self.output.push_str(">");
+                self.output.str(">");
             }
             Result_ {
                 ok: None,
                 err: None,
             } => {
-                self.output.push_keyword("result");
+                self.output.keyword("result");
             }
         }
         Ok(())
@@ -709,10 +709,10 @@ impl WitPrinter {
                     }
                     TypeDefKind::Type(inner) => match ty.name.as_deref() {
                         Some(name) => {
-                            self.output.push_keyword("type");
-                            self.output.push_str(" ");
+                            self.output.keyword("type");
+                            self.output.str(" ");
                             self.print_name(name);
-                            self.output.push_str(" = ");
+                            self.output.str(" = ");
                             self.print_type_name(resolve, inner)?;
                             self.output.semicolon();
                         }
@@ -735,10 +735,10 @@ impl WitPrinter {
     ) -> Result<()> {
         match name {
             Some(name) => {
-                self.output.push_keyword("type");
-                self.output.push_str(" ");
+                self.output.keyword("type");
+                self.output.str(" ");
                 self.print_name(name);
-                self.output.push_str(" = ");
+                self.output.str(" = ");
                 // Note that the `true` here forces owned handles to be printed
                 // as `own<T>`. The purpose of this is because `type a = b`, if
                 // `b` is a resource, is encoded differently as `type a =
@@ -761,16 +761,16 @@ impl WitPrinter {
     ) -> Result<()> {
         match name {
             Some(name) => {
-                self.output.push_keyword("record");
-                self.output.push_str(" ");
+                self.output.keyword("record");
+                self.output.str(" ");
                 self.print_name(name);
                 self.output.indent_start();
                 for field in &record.fields {
                     self.print_docs(&field.docs);
                     self.print_name(&field.name);
-                    self.output.push_str(": ");
+                    self.output.str(": ");
                     self.print_type_name(resolve, &field.ty)?;
-                    self.output.push_str(",");
+                    self.output.str(",");
                     self.output.newline();
                 }
                 self.output.indent_end();
@@ -787,10 +787,10 @@ impl WitPrinter {
         tuple: &Tuple,
     ) -> Result<()> {
         if let Some(name) = name {
-            self.output.push_keyword("type");
-            self.output.push_str(" ");
+            self.output.keyword("type");
+            self.output.str(" ");
             self.print_name(name);
-            self.output.push_str(" = ");
+            self.output.str(" = ");
             self.print_tuple_type(resolve, tuple)?;
             self.output.semicolon();
         }
@@ -800,14 +800,14 @@ impl WitPrinter {
     fn declare_flags(&mut self, name: Option<&str>, flags: &Flags) -> Result<()> {
         match name {
             Some(name) => {
-                self.output.push_keyword("flags");
-                self.output.push_str(" ");
+                self.output.keyword("flags");
+                self.output.str(" ");
                 self.print_name(name);
                 self.output.indent_start();
                 for flag in &flags.flags {
                     self.print_docs(&flag.docs);
                     self.print_name(&flag.name);
-                    self.output.push_str(",");
+                    self.output.str(",");
                     self.output.newline();
                 }
                 self.output.indent_end();
@@ -827,19 +827,19 @@ impl WitPrinter {
             Some(name) => name,
             None => bail!("document has unnamed variant type"),
         };
-        self.output.push_keyword("variant");
-        self.output.push_str(" ");
+        self.output.keyword("variant");
+        self.output.str(" ");
         self.print_name(name);
         self.output.indent_start();
         for case in &variant.cases {
             self.print_docs(&case.docs);
             self.print_name(&case.name);
             if let Some(ty) = case.ty {
-                self.output.push_str("(");
+                self.output.str("(");
                 self.print_type_name(resolve, &ty)?;
-                self.output.push_str(")");
+                self.output.str(")");
             }
-            self.output.push_str(",");
+            self.output.str(",");
             self.output.newline();
         }
         self.output.indent_end();
@@ -853,10 +853,10 @@ impl WitPrinter {
         payload: &Type,
     ) -> Result<()> {
         if let Some(name) = name {
-            self.output.push_keyword("type");
-            self.output.push_str(" ");
+            self.output.keyword("type");
+            self.output.str(" ");
             self.print_name(name);
-            self.output.push_str(" = ");
+            self.output.str(" = ");
             self.print_option_type(resolve, payload)?;
             self.output.semicolon();
         }
@@ -870,10 +870,10 @@ impl WitPrinter {
         result: &Result_,
     ) -> Result<()> {
         if let Some(name) = name {
-            self.output.push_keyword("type");
-            self.output.push_str(" ");
+            self.output.keyword("type");
+            self.output.str(" ");
             self.print_name(name);
-            self.output.push_str(" = ");
+            self.output.str(" = ");
             self.print_result_type(resolve, result)?;
             self.output.semicolon();
         }
@@ -885,14 +885,14 @@ impl WitPrinter {
             Some(name) => name,
             None => bail!("document has unnamed enum type"),
         };
-        self.output.push_keyword("enum");
-        self.output.push_str(" ");
+        self.output.keyword("enum");
+        self.output.str(" ");
         self.print_name(name);
         self.output.indent_start();
         for case in &enum_.cases {
             self.print_docs(&case.docs);
             self.print_name(&case.name);
-            self.output.push_str(",");
+            self.output.str(",");
             self.output.newline();
         }
         self.output.indent_end();
@@ -901,14 +901,14 @@ impl WitPrinter {
 
     fn declare_list(&mut self, resolve: &Resolve, name: Option<&str>, ty: &Type) -> Result<()> {
         if let Some(name) = name {
-            self.output.push_keyword("type");
-            self.output.push_str(" ");
+            self.output.keyword("type");
+            self.output.str(" ");
             self.print_name(name);
-            self.output.push_str(" = ");
-            self.output.push_keyword("list");
-            self.output.push_str("<");
+            self.output.str(" = ");
+            self.output.keyword("list");
+            self.output.str("<");
             self.print_type_name(resolve, ty)?;
-            self.output.push_str(">");
+            self.output.str(">");
             self.output.semicolon();
             return Ok(());
         }
@@ -918,16 +918,16 @@ impl WitPrinter {
 
     fn print_name(&mut self, name: &str) {
         if is_keyword(name) {
-            self.output.push_str("%");
+            self.output.str("%");
         }
-        self.output.push_str(name);
+        self.output.str(name);
     }
 
     fn print_docs(&mut self, docs: &Docs) {
         if self.emit_docs {
             if let Some(contents) = &docs.contents {
                 for line in contents.lines() {
-                    self.output.push_doc(line);
+                    self.output.doc(line);
                 }
             }
         }
@@ -937,20 +937,20 @@ impl WitPrinter {
         match stability {
             Stability::Unknown => {}
             Stability::Stable { since, deprecated } => {
-                self.output.push_keyword("@since");
-                self.output.push_str("(");
-                self.output.push_keyword("version");
-                self.output.push_str(" = ");
-                self.output.push_str(&since.to_string());
-                self.output.push_str(")");
+                self.output.keyword("@since");
+                self.output.str("(");
+                self.output.keyword("version");
+                self.output.str(" = ");
+                self.output.str(&since.to_string());
+                self.output.str(")");
                 self.output.newline();
                 if let Some(version) = deprecated {
-                    self.output.push_keyword("@deprecated");
-                    self.output.push_str("(");
-                    self.output.push_keyword("version");
-                    self.output.push_str(" = ");
-                    self.output.push_str(&version.to_string());
-                    self.output.push_str(")");
+                    self.output.keyword("@deprecated");
+                    self.output.str("(");
+                    self.output.keyword("version");
+                    self.output.str(" = ");
+                    self.output.str(&version.to_string());
+                    self.output.str(")");
                     self.output.newline();
                 }
             }
@@ -958,20 +958,20 @@ impl WitPrinter {
                 feature,
                 deprecated,
             } => {
-                self.output.push_keyword("@unstable");
-                self.output.push_str("(");
-                self.output.push_keyword("feature");
-                self.output.push_str(" = ");
-                self.output.push_str(feature);
-                self.output.push_str(")");
+                self.output.keyword("@unstable");
+                self.output.str("(");
+                self.output.keyword("feature");
+                self.output.str(" = ");
+                self.output.str(feature);
+                self.output.str(")");
                 self.output.newline();
                 if let Some(version) = deprecated {
-                    self.output.push_keyword("@deprecated");
-                    self.output.push_str("(");
-                    self.output.push_keyword("version");
-                    self.output.push_str(" = ");
-                    self.output.push_str(&version.to_string());
-                    self.output.push_str(")");
+                    self.output.keyword("@deprecated");
+                    self.output.str("(");
+                    self.output.keyword("version");
+                    self.output.str(" = ");
+                    self.output.str(&version.to_string());
+                    self.output.str(")");
                     self.output.newline();
                 }
             }
@@ -1062,34 +1062,34 @@ impl Output {
         }
     }
 
-    fn push_keyword(&mut self, src: &str) {
+    fn keyword(&mut self, src: &str) {
         assert!(!src.contains('\n'));
         assert_eq!(src, src.trim());
-        self.push_str(src);
+        self.str(src);
     }
 
-    fn push_doc(&mut self, doc: &str) {
-        self.push_str("/// ");
-        self.push_str(doc);
+    fn doc(&mut self, doc: &str) {
+        self.str("/// ");
+        self.str(doc);
         self.newline();
     }
 
     fn semicolon(&mut self) {
-        self.push_str(";");
+        self.str(";");
         self.newline();
     }
 
     fn indent_start(&mut self) {
-        self.push_str(" {");
+        self.str(" {");
         self.newline();
     }
 
     fn indent_end(&mut self) {
-        self.push_str("}");
+        self.str("}");
         self.newline();
     }
 
-    fn push_str(&mut self, src: &str) {
+    fn str(&mut self, src: &str) {
         assert!(!src.contains('\n'));
         let trimmed = src.trim();
         if trimmed.starts_with('}') && self.output.ends_with("  ") {

--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -9,7 +9,46 @@ use wit_parser::*;
 const PRINT_F32_F64_DEFAULT: bool = true;
 
 /// A utility for printing WebAssembly interface definitions to a string.
-pub struct WitPrinter<O: Output = OutputToString> {
+pub struct WitPrinter {
+    ext: WitPrinterExt<OutputToString>,
+}
+
+impl Default for WitPrinter {
+    fn default() -> Self {
+        Self {
+            ext: WitPrinterExt::new(OutputToString::default()),
+        }
+    }
+}
+
+impl WitPrinter {
+    /// Prints the specified `pkg` which is located in `resolve` to a string.
+    ///
+    /// The `nested` list of packages are other packages to include at the end
+    /// of the output in `package ... { ... }` syntax.
+    pub fn print(
+        &mut self,
+        resolve: &Resolve,
+        pkg: PackageId,
+        nested: &[PackageId],
+    ) -> Result<String> {
+        let old_ext = mem::replace(&mut self.ext, WitPrinterExt::new(OutputToString::default()));
+        old_ext
+            .print_all(resolve, pkg, nested)
+            .map(|output| output.output)
+    }
+
+    /// Configure whether doc comments will be printed.
+    ///
+    /// Defaults to true.
+    pub fn emit_docs(&mut self, enabled: bool) -> &mut Self {
+        self.ext.emit_docs = enabled;
+        self
+    }
+}
+
+/// An extensible utility for printing WebAssembly interface definitions to a parametrized `Output`.
+pub struct WitPrinterExt<O: Output> {
     /// Visitor that holds the WIT document being printed.
     pub output: O,
 
@@ -23,35 +62,11 @@ pub struct WitPrinter<O: Output = OutputToString> {
     print_f32_f64: bool,
 }
 
-impl Default for WitPrinter {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl<O: Output> WitPrinter<O>
-where
-    String: From<O>,
-{
-    /// Prints the specified `pkg` which is located in `resolve` to a string.
-    ///
-    /// The `nested` list of packages are other packages to include at the end
-    /// of the output in `package ... { ... }` syntax.
-    pub fn print(
-        &mut self,
-        resolve: &Resolve,
-        pkg: PackageId,
-        nested: &[PackageId],
-    ) -> Result<String> {
-        self.print_all(resolve, pkg, nested).map(String::from)
-    }
-}
-
-impl<O: Output> WitPrinter<O> {
+impl<O: Output> WitPrinterExt<O> {
     /// Craete new instance.
-    pub fn new() -> Self {
+    pub fn new(output: O) -> Self {
         Self {
-            output: O::default(),
+            output,
             any_items: false,
             emit_docs: true,
             print_f32_f64: match std::env::var("WIT_REQUIRE_F32_F64") {
@@ -66,7 +81,7 @@ impl<O: Output> WitPrinter<O> {
     /// The `nested` list of packages are other packages to include at the end
     /// of the output in `package ... { ... }` syntax.
     pub fn print_all(
-        &mut self,
+        mut self,
         resolve: &Resolve,
         pkg: PackageId,
         nested: &[PackageId],
@@ -80,7 +95,7 @@ impl<O: Output> WitPrinter<O> {
             self.print_package(resolve, *pkg_id, false)?;
         }
 
-        Ok(std::mem::take(&mut self.output))
+        Ok(self.output)
     }
 
     /// Configure whether doc comments will be printed.
@@ -1101,7 +1116,7 @@ fn is_keyword(name: &str) -> bool {
 }
 
 /// A visitor that receives tokens emitted by `WitPrinter`.
-pub trait Output: Default {
+pub trait Output {
     /// A newline is added.
     fn newline(&mut self);
     /// A keyword is added. Keywords are hardcoded strings from `[a-z]`, but can start with `@`

--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -308,7 +308,7 @@ impl<O: Output> WitPrinter<O> {
 
     fn print_resource(&mut self, resolve: &Resolve, id: TypeId, funcs: &[&Function]) -> Result<()> {
         let ty = &resolve.types[id];
-        self.output.r#type("resource", TypeKind::BuiltIn);
+        self.output.ty("resource", TypeKind::BuiltIn);
         self.output.str(" ");
         self.print_name_type(
             ty.name.as_ref().expect("resources must be named"),
@@ -524,31 +524,31 @@ impl<O: Output> WitPrinter<O> {
     /// Print the name of type `ty`.
     pub fn print_type_name(&mut self, resolve: &Resolve, ty: &Type) -> Result<()> {
         match ty {
-            Type::Bool => self.output.r#type("bool", TypeKind::BuiltIn),
-            Type::U8 => self.output.r#type("u8", TypeKind::BuiltIn),
-            Type::U16 => self.output.r#type("u16", TypeKind::BuiltIn),
-            Type::U32 => self.output.r#type("u32", TypeKind::BuiltIn),
-            Type::U64 => self.output.r#type("u64", TypeKind::BuiltIn),
-            Type::S8 => self.output.r#type("s8", TypeKind::BuiltIn),
-            Type::S16 => self.output.r#type("s16", TypeKind::BuiltIn),
-            Type::S32 => self.output.r#type("s32", TypeKind::BuiltIn),
-            Type::S64 => self.output.r#type("s64", TypeKind::BuiltIn),
+            Type::Bool => self.output.ty("bool", TypeKind::BuiltIn),
+            Type::U8 => self.output.ty("u8", TypeKind::BuiltIn),
+            Type::U16 => self.output.ty("u16", TypeKind::BuiltIn),
+            Type::U32 => self.output.ty("u32", TypeKind::BuiltIn),
+            Type::U64 => self.output.ty("u64", TypeKind::BuiltIn),
+            Type::S8 => self.output.ty("s8", TypeKind::BuiltIn),
+            Type::S16 => self.output.ty("s16", TypeKind::BuiltIn),
+            Type::S32 => self.output.ty("s32", TypeKind::BuiltIn),
+            Type::S64 => self.output.ty("s64", TypeKind::BuiltIn),
             Type::F32 => {
                 if self.print_f32_f64 {
-                    self.output.r#type("f32", TypeKind::BuiltIn)
+                    self.output.ty("f32", TypeKind::BuiltIn)
                 } else {
-                    self.output.r#type("f32", TypeKind::BuiltIn)
+                    self.output.ty("f32", TypeKind::BuiltIn)
                 }
             }
             Type::F64 => {
                 if self.print_f32_f64 {
-                    self.output.r#type("f64", TypeKind::BuiltIn)
+                    self.output.ty("f64", TypeKind::BuiltIn)
                 } else {
-                    self.output.r#type("f64", TypeKind::BuiltIn)
+                    self.output.ty("f64", TypeKind::BuiltIn)
                 }
             }
-            Type::Char => self.output.r#type("char", TypeKind::BuiltIn),
-            Type::String => self.output.r#type("string", TypeKind::BuiltIn),
+            Type::Char => self.output.ty("char", TypeKind::BuiltIn),
+            Type::String => self.output.ty("string", TypeKind::BuiltIn),
 
             Type::Id(id) => {
                 let ty = &resolve.types[*id];
@@ -586,7 +586,7 @@ impl<O: Output> WitPrinter<O> {
                         bail!("resolve has unnamed variant type")
                     }
                     TypeDefKind::List(ty) => {
-                        self.output.r#type("list", TypeKind::BuiltIn);
+                        self.output.ty("list", TypeKind::BuiltIn);
                         self.output.generic_args_start();
                         self.print_type_name(resolve, ty)?;
                         self.output.generic_args_end();
@@ -616,7 +616,7 @@ impl<O: Output> WitPrinter<O> {
             Handle::Own(ty) => {
                 let ty = &resolve.types[*ty];
                 if force_handle_type_printed {
-                    self.output.r#type("own", TypeKind::BuiltIn);
+                    self.output.ty("own", TypeKind::BuiltIn);
                     self.output.generic_args_start();
                 }
                 self.print_name_type(
@@ -631,7 +631,7 @@ impl<O: Output> WitPrinter<O> {
             }
 
             Handle::Borrow(ty) => {
-                self.output.r#type("borrow", TypeKind::BuiltIn);
+                self.output.ty("borrow", TypeKind::BuiltIn);
                 self.output.generic_args_start();
                 let ty = &resolve.types[*ty];
                 self.print_name_type(
@@ -648,7 +648,7 @@ impl<O: Output> WitPrinter<O> {
     }
 
     fn print_tuple_type(&mut self, resolve: &Resolve, tuple: &Tuple) -> Result<()> {
-        self.output.r#type("tuple", TypeKind::BuiltIn);
+        self.output.ty("tuple", TypeKind::BuiltIn);
         self.output.generic_args_start();
         for (i, ty) in tuple.types.iter().enumerate() {
             if i > 0 {
@@ -662,7 +662,7 @@ impl<O: Output> WitPrinter<O> {
     }
 
     fn print_option_type(&mut self, resolve: &Resolve, payload: &Type) -> Result<()> {
-        self.output.r#type("option", TypeKind::BuiltIn);
+        self.output.ty("option", TypeKind::BuiltIn);
         self.output.generic_args_start();
         self.print_type_name(resolve, payload)?;
         self.output.generic_args_end();
@@ -675,7 +675,7 @@ impl<O: Output> WitPrinter<O> {
                 ok: Some(ok),
                 err: Some(err),
             } => {
-                self.output.r#type("result", TypeKind::BuiltIn);
+                self.output.ty("result", TypeKind::BuiltIn);
                 self.output.generic_args_start();
                 self.print_type_name(resolve, ok)?;
                 self.output.str(", ");
@@ -686,7 +686,7 @@ impl<O: Output> WitPrinter<O> {
                 ok: None,
                 err: Some(err),
             } => {
-                self.output.r#type("result", TypeKind::BuiltIn);
+                self.output.ty("result", TypeKind::BuiltIn);
                 self.output.generic_args_start();
                 self.output.str("_, ");
                 self.print_type_name(resolve, err)?;
@@ -696,7 +696,7 @@ impl<O: Output> WitPrinter<O> {
                 ok: Some(ok),
                 err: None,
             } => {
-                self.output.r#type("result", TypeKind::BuiltIn);
+                self.output.ty("result", TypeKind::BuiltIn);
                 self.output.generic_args_start();
                 self.print_type_name(resolve, ok)?;
                 self.output.generic_args_end();
@@ -705,7 +705,7 @@ impl<O: Output> WitPrinter<O> {
                 ok: None,
                 err: None,
             } => {
-                self.output.r#type("result", TypeKind::BuiltIn);
+                self.output.ty("result", TypeKind::BuiltIn);
             }
         }
         Ok(())
@@ -950,7 +950,7 @@ impl<O: Output> WitPrinter<O> {
             self.output.str(" ");
             self.print_name_type(name, TypeKind::List);
             self.output.str(" = ");
-            self.output.r#type("list", TypeKind::BuiltIn);
+            self.output.ty("list", TypeKind::BuiltIn);
             self.output.str("<");
             self.print_type_name(resolve, ty)?;
             self.output.str(">");
@@ -970,7 +970,7 @@ impl<O: Output> WitPrinter<O> {
     }
 
     fn print_name_type(&mut self, name: &str, kind: TypeKind) {
-        self.output.r#type(Self::escape_name(name).deref(), kind);
+        self.output.ty(Self::escape_name(name).deref(), kind);
     }
 
     fn print_name_param(&mut self, name: &str) {
@@ -1103,7 +1103,7 @@ pub trait Output {
     /// when printing a [Feature Gate](https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md#feature-gates)
     fn keyword(&mut self, src: &str);
     /// A type is added.
-    fn r#type(&mut self, src: &str, kind: TypeKind);
+    fn ty(&mut self, src: &str, kind: TypeKind);
     /// A parameter name of a function, record or a named return is added.
     fn param(&mut self, src: &str);
     /// A case belonging to a variant, enum or flags is added.
@@ -1236,7 +1236,7 @@ impl Output for OutputToString {
         self.indent_and_print(src);
     }
 
-    fn r#type(&mut self, src: &str, _kind: TypeKind) {
+    fn ty(&mut self, src: &str, _kind: TypeKind) {
         self.indent_and_print(src);
     }
 

--- a/crates/wit-component/src/printing.rs
+++ b/crates/wit-component/src/printing.rs
@@ -25,7 +25,7 @@ pub struct WitPrinter<O: Output = OutputToString> {
 
 impl Default for WitPrinter {
     fn default() -> Self {
-        Self::new()
+        Self::new(OutputToString::default())
     }
 }
 
@@ -33,25 +33,20 @@ impl<O: Output> WitPrinter<O>
 where
     String: From<O>,
 {
-    /// Prints the specified `pkg` which is located in `resolve` to a string.
+    /// Convenience wrapper around [`print_all`](WitPrinter::print_all) that prints the specified `pkg` which is located in `resolve` to a string.
     ///
     /// The `nested` list of packages are other packages to include at the end
     /// of the output in `package ... { ... }` syntax.
-    pub fn print(
-        &mut self,
-        resolve: &Resolve,
-        pkg: PackageId,
-        nested: &[PackageId],
-    ) -> Result<String> {
+    pub fn print(self, resolve: &Resolve, pkg: PackageId, nested: &[PackageId]) -> Result<String> {
         self.print_all(resolve, pkg, nested).map(String::from)
     }
 }
 
 impl<O: Output> WitPrinter<O> {
     /// Craete new instance.
-    pub fn new() -> Self {
+    pub fn new(output: O) -> Self {
         Self {
-            output: O::default(),
+            output,
             any_items: false,
             emit_docs: true,
             print_f32_f64: match std::env::var("WIT_REQUIRE_F32_F64") {
@@ -66,7 +61,7 @@ impl<O: Output> WitPrinter<O> {
     /// The `nested` list of packages are other packages to include at the end
     /// of the output in `package ... { ... }` syntax.
     pub fn print_all(
-        &mut self,
+        mut self,
         resolve: &Resolve,
         pkg: PackageId,
         nested: &[PackageId],
@@ -80,7 +75,7 @@ impl<O: Output> WitPrinter<O> {
             self.print_package(resolve, *pkg_id, false)?;
         }
 
-        Ok(std::mem::take(&mut self.output))
+        Ok(self.output)
     }
 
     /// Configure whether doc comments will be printed.
@@ -1101,7 +1096,7 @@ fn is_keyword(name: &str) -> bool {
 }
 
 /// A visitor that receives tokens emitted by `WitPrinter`.
-pub trait Output: Default {
+pub trait Output {
     /// A newline is added.
     fn newline(&mut self);
     /// A keyword is added. Keywords are hardcoded strings from `[a-z]`, but can start with `@`

--- a/crates/wit-component/tests/components.rs
+++ b/crates/wit-component/tests/components.rs
@@ -159,9 +159,11 @@ fn run_test(path: &Path) -> Result<()> {
         DecodedWasm::WitPackage(..) => unreachable!(),
         DecodedWasm::Component(resolve, world) => (resolve.worlds[world].package.unwrap(), resolve),
     };
-    let wit = WitPrinter::default()
+    let mut printer = WitPrinter::default();
+    printer
         .print(&resolve, pkg, &[])
         .context("failed to print WIT")?;
+    let wit = printer.output.to_string();
     assert_output(&wit, &component_wit_path)?;
 
     UnresolvedPackageGroup::parse(&component_wit_path, &wit)

--- a/crates/wit-component/tests/interfaces.rs
+++ b/crates/wit-component/tests/interfaces.rs
@@ -86,7 +86,9 @@ fn run_test(path: &Path, is_dir: bool) -> Result<()> {
 }
 
 fn assert_print(resolve: &Resolve, pkg_id: PackageId, path: &Path, is_dir: bool) -> Result<()> {
-    let output = WitPrinter::default().print(resolve, pkg_id, &[])?;
+    let mut printer = WitPrinter::default();
+    printer.print(resolve, pkg_id, &[])?;
+    let output = printer.output.to_string();
     let pkg = &resolve.packages[pkg_id];
     let expected = if is_dir {
         path.join(format!("{}.wit.print", &pkg.name.name))

--- a/crates/wit-component/tests/merge.rs
+++ b/crates/wit-component/tests/merge.rs
@@ -46,7 +46,9 @@ fn merging() -> Result<()> {
                         .join("merge")
                         .join(&pkg.name.name)
                         .with_extension("wit");
-                    let output = WitPrinter::default().print(&into, id, &[])?;
+                    let mut printer = WitPrinter::default();
+                    printer.print(&into, id, &[])?;
+                    let output = printer.output.to_string();
                     assert_output(&expected, &output)?;
                 }
             }

--- a/fuzz/src/roundtrip_wit.rs
+++ b/fuzz/src/roundtrip_wit.rs
@@ -110,9 +110,9 @@ fn roundtrip_through_printing(file: &str, resolve: &Resolve, pkg: PackageId, was
         .map(|p| p.0)
         .filter(|k| *k != pkg)
         .collect::<Vec<_>>();
-    let doc = WitPrinter::default()
-        .print(resolve, pkg, &package_deps)
-        .unwrap();
+    let mut printer = WitPrinter::default();
+    printer.print(resolve, pkg, &package_deps).unwrap();
+    let doc = printer.output.to_string();
     let new_pkg = new_resolve
         .push_str(&format!("printed-{file}.wit"), &doc)
         .unwrap();

--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -828,7 +828,9 @@ impl WitOpts {
                 let main = decoded.package();
                 for (id, pkg) in resolve.packages.iter() {
                     let is_main = id == main;
-                    let output = configure_printer().print(resolve, id, &[])?;
+                    let mut printer = configure_printer();
+                    printer.print(resolve, id, &[])?;
+                    let output = printer.output.to_string();
                     let out_dir = if is_main {
                         dir.clone()
                     } else {

--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -801,8 +801,11 @@ impl WitOpts {
 
         let resolve = decoded.resolve();
 
-        let mut printer = WitPrinter::default();
-        printer.emit_docs(!self.no_docs);
+        let configure_printer = || {
+            let mut wit_printer = WitPrinter::default();
+            wit_printer.emit_docs(!self.no_docs);
+            wit_printer
+        };
 
         match &self.out_dir {
             Some(dir) => {
@@ -825,7 +828,7 @@ impl WitOpts {
                 let main = decoded.package();
                 for (id, pkg) in resolve.packages.iter() {
                     let is_main = id == main;
-                    let output = printer.print(resolve, id, &[])?;
+                    let output = configure_printer().print(resolve, id, &[])?;
                     let out_dir = if is_main {
                         dir.clone()
                     } else {
@@ -864,7 +867,7 @@ impl WitOpts {
                     &self.general,
                     Output::Wit {
                         wit: &decoded,
-                        printer,
+                        printer: configure_printer(),
                     },
                 )?;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,7 +236,7 @@ impl OutputArg {
             }
             Output::Json(s) => self.output_str(s),
             #[cfg(feature = "component")]
-            Output::Wit { wit, mut printer } => {
+            Output::Wit { wit, printer } => {
                 let resolve = wit.resolve();
                 let ids = resolve
                     .packages

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,7 +236,7 @@ impl OutputArg {
             }
             Output::Json(s) => self.output_str(s),
             #[cfg(feature = "component")]
-            Output::Wit { wit, printer } => {
+            Output::Wit { wit, mut printer } => {
                 let resolve = wit.resolve();
                 let ids = resolve
                     .packages
@@ -244,7 +244,8 @@ impl OutputArg {
                     .map(|(id, _)| id)
                     .filter(|id| *id != wit.package())
                     .collect::<Vec<_>>();
-                let output = printer.print(resolve, wit.package(), &ids)?;
+                printer.print(resolve, wit.package(), &ids)?;
+                let output = printer.output.to_string();
                 self.output_str(&output)
             }
         }


### PR DESCRIPTION
Introduce Output trait as a visitor for collecting syntax tokens.
This trait enables syntax highlighting and supports advanced use cases, such as filtering tokens by package, interface, or function.