### PR TITLE
add stream/future/error-context to wit-smith

### DIFF
--- a/crates/wit-smith/src/generate.rs
+++ b/crates/wit-smith/src/generate.rs
@@ -716,6 +716,9 @@ impl<'a> InterfaceGenerator<'a> {
             Option,
             Result,
             List,
+            Stream,
+            Future,
+            ErrorContext,
         }
 
         *fuel = match fuel.checked_sub(1) {
@@ -822,6 +825,31 @@ impl<'a> InterfaceGenerator<'a> {
                         }
                         (false, false) => {}
                     }
+                }
+                Kind::Stream => {
+                    *fuel = match fuel.checked_sub(1) {
+                        Some(fuel) => fuel,
+                        None => continue,
+                    };
+                    dst.push_str("stream<");
+                    self.gen_type(u, fuel, dst)?;
+                    dst.push_str(">");
+                }
+                Kind::Future => {
+                    *fuel = match fuel.checked_sub(1) {
+                        Some(fuel) => fuel,
+                        None => continue,
+                    };
+                    if u.arbitrary()? {
+                        dst.push_str("future<");
+                        self.gen_type(u, fuel, dst)?;
+                        dst.push_str(">");
+                    } else {
+                        dst.push_str("future");
+                    }
+                }
+                Kind::ErrorContext => {
+                    dst.push_str("error-context");
                 }
             };
         }

--- a/fuzz/src/wit64.rs
+++ b/fuzz/src/wit64.rs
@@ -9,7 +9,12 @@ pub fn run(u: &mut Unstructured<'_>) -> Result<()> {
         wit_smith::smith(&config, u)
     })?;
     write_file("doc.wasm", &wasm);
-    let r1 = wit_component_old::decode(&wasm).unwrap();
+    let Ok(r1) = wit_component_old::decode(&wasm) else {
+        // Presumably this is because the old version of `wit-component` doesn't
+        // understand the new `stream`, `future`, or `error-context` types, in
+        // which case there's no point in continuing, so we just return early.
+        return Ok(());
+    };
     let r1 = r1.resolve();
     let r2 = wit_component_new::decode(&wasm).unwrap();
     let r2 = r2.resolve();


### PR DESCRIPTION
I had to tweak fuzz/src/wit64.rs because otherwise the old version of `wit-component` it was using choked on these new types.  Now we just return early when that happens.

Otherwise, there was just one other failure in the 15+ minutes I've been running the fuzzer: I had neglected to support the new types in `WitPrinter::declare_type` thinking it wasn't necessary, but I was wrong.