### PR TITLE
add async support to `wit_component::dummy_module`

### DIFF
--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -2823,7 +2823,7 @@ impl ComponentWorld<'_> {
 mod test {
     use super::*;
     use crate::{dummy_module, embed_component_metadata};
-    use wit_parser::Mangling;
+    use wit_parser::ManglingAndAbi;
 
     #[test]
     fn it_renames_imports() {
@@ -2849,7 +2849,7 @@ world test {
             .unwrap();
         let world = resolve.select_world(pkg, None).unwrap();
 
-        let mut module = dummy_module(&resolve, world, Mangling::Standard32);
+        let mut module = dummy_module(&resolve, world, ManglingAndAbi::Standard32);
 
         embed_component_metadata(&mut module, &resolve, world, StringEncoding::UTF8).unwrap();
 

--- a/crates/wit-component/src/semver_check.rs
+++ b/crates/wit-component/src/semver_check.rs
@@ -5,7 +5,7 @@ use crate::{
 use anyhow::{bail, Context, Result};
 use wasm_encoder::{ComponentBuilder, ComponentExportKind, ComponentTypeRef};
 use wasmparser::Validator;
-use wit_parser::{Mangling, Resolve, WorldId};
+use wit_parser::{ManglingAndAbi, Resolve, WorldId};
 
 /// Tests whether `new` is a semver-compatible upgrade from the world `prev`.
 ///
@@ -63,7 +63,7 @@ pub fn semver_check(mut resolve: Resolve, prev: WorldId, new: WorldId) -> Result
     let mut root_component = ComponentBuilder::default();
 
     // (1) above - create a dummy component which has the shape of `prev`.
-    let mut prev_as_module = dummy_module(&resolve, prev, Mangling::Standard32);
+    let mut prev_as_module = dummy_module(&resolve, prev, ManglingAndAbi::Standard32);
     embed_component_metadata(&mut prev_as_module, &resolve, prev, StringEncoding::UTF8)
         .context("failed to embed component metadata")?;
     let prev_as_component = ComponentEncoder::default()

--- a/crates/wit-parser/src/resolve.rs
+++ b/crates/wit-parser/src/resolve.rs
@@ -18,9 +18,9 @@ use crate::ast::{parse_use_path, ParsedUsePath};
 use crate::serde_::{serialize_arena, serialize_id_map};
 use crate::{
     AstItem, Docs, Error, Function, FunctionKind, Handle, IncludeName, Interface, InterfaceId,
-    InterfaceSpan, Mangling, PackageName, PackageNotFoundError, Results, SourceMap, Stability,
-    Type, TypeDef, TypeDefKind, TypeId, TypeIdVisitor, TypeOwner, UnresolvedPackage,
-    UnresolvedPackageGroup, World, WorldId, WorldItem, WorldKey, WorldSpan,
+    InterfaceSpan, LiftLowerAbi, ManglingAndAbi, PackageName, PackageNotFoundError, Results,
+    SourceMap, Stability, Type, TypeDef, TypeDefKind, TypeId, TypeIdVisitor, TypeOwner,
+    UnresolvedPackage, UnresolvedPackageGroup, World, WorldId, WorldItem, WorldKey, WorldSpan,
 };
 
 mod clone;
@@ -2287,9 +2287,13 @@ package {name} is defined in two different locations:\n\
     /// use `import` with the name `mangling` scheme specified as well. This can
     /// be useful for bindings generators, for example, and these names are
     /// recognized by `wit-component` and `wasm-tools component new`.
-    pub fn wasm_import_name(&self, mangling: Mangling, import: WasmImport<'_>) -> (String, String) {
+    pub fn wasm_import_name(
+        &self,
+        mangling: ManglingAndAbi,
+        import: WasmImport<'_>,
+    ) -> (String, String) {
         match mangling {
-            Mangling::Standard32 => match import {
+            ManglingAndAbi::Standard32 => match import {
                 WasmImport::Func { interface, func } => {
                     let module = match interface {
                         Some(key) => format!("cm32p2|{}", self.name_canonicalized_world_key(key)),
@@ -2321,13 +2325,13 @@ package {name} is defined in two different locations:\n\
                     (module, name)
                 }
             },
-            Mangling::Legacy => match import {
+            ManglingAndAbi::Legacy(abi) => match import {
                 WasmImport::Func { interface, func } => {
                     let module = match interface {
                         Some(key) => self.name_world_key(key),
                         None => format!("$root"),
                     };
-                    (module, func.name.clone())
+                    (module, format!("{}{}", abi.import_prefix(), func.name))
                 }
                 WasmImport::ResourceIntrinsic {
                     interface,
@@ -2354,22 +2358,22 @@ package {name} is defined in two different locations:\n\
                             format!("$root")
                         }
                     };
-                    (module, name)
+                    (module, format!("{}{name}", abi.import_prefix()))
                 }
             },
         }
     }
 
-    /// Returns the core wasm export name for the specified `import`.
+    /// Returns the core wasm export name for the specified `export`.
     ///
-    /// This is the same as [`Resovle::wasm_import_name`], except for exports.
-    pub fn wasm_export_name(&self, mangling: Mangling, import: WasmExport<'_>) -> String {
+    /// This is the same as [`Resolve::wasm_import_name`], except for exports.
+    pub fn wasm_export_name(&self, mangling: ManglingAndAbi, export: WasmExport<'_>) -> String {
         match mangling {
-            Mangling::Standard32 => match import {
+            ManglingAndAbi::Standard32 => match export {
                 WasmExport::Func {
                     interface,
                     func,
-                    post_return,
+                    kind,
                 } => {
                     let mut name = String::from("cm32p2|");
                     if let Some(interface) = interface {
@@ -2378,8 +2382,13 @@ package {name} is defined in two different locations:\n\
                     }
                     name.push_str("|");
                     name.push_str(&func.name);
-                    if post_return {
-                        name.push_str("_post");
+                    match kind {
+                        WasmExportKind::Normal => {}
+                        WasmExportKind::PostReturn => name.push_str("_post"),
+                        WasmExportKind::Callback => todo!(
+                            "not yet supported: \
+                             async callback functions using standard name mangling"
+                        ),
                     }
                     name
                 }
@@ -2395,15 +2404,20 @@ package {name} is defined in two different locations:\n\
                 WasmExport::Initialize => "cm32p2_initialize".to_string(),
                 WasmExport::Realloc => "cm32p2_realloc".to_string(),
             },
-            Mangling::Legacy => match import {
+            ManglingAndAbi::Legacy(abi) => match export {
                 WasmExport::Func {
                     interface,
                     func,
-                    post_return,
+                    kind,
                 } => {
-                    let mut name = String::new();
-                    if post_return {
-                        name.push_str("cabi_post_");
+                    let mut name = abi.export_prefix().to_string();
+                    match kind {
+                        WasmExportKind::Normal => {}
+                        WasmExportKind::PostReturn => name.push_str("cabi_post_"),
+                        WasmExportKind::Callback => {
+                            assert!(matches!(abi, LiftLowerAbi::AsyncCallback));
+                            name = format!("[callback]{name}")
+                        }
                     }
                     if let Some(interface) = interface {
                         let s = self.name_world_key(interface);
@@ -2419,7 +2433,7 @@ package {name} is defined in two different locations:\n\
                 } => {
                     let name = self.types[resource].name.as_ref().unwrap();
                     let interface = self.name_world_key(interface);
-                    format!("{interface}#[dtor]{name}")
+                    format!("{}{interface}#[dtor]{name}", abi.export_prefix())
                 }
                 WasmExport::Memory => "memory".to_string(),
                 WasmExport::Initialize => "_initialize".to_string(),
@@ -2467,6 +2481,20 @@ pub enum ResourceIntrinsic {
     ExportedRep,
 }
 
+/// Indicates whether a function export is a normal export, a post-return
+/// function, or a callback function.
+#[derive(Debug)]
+pub enum WasmExportKind {
+    /// Normal function export.
+    Normal,
+
+    /// Post-return function.
+    PostReturn,
+
+    /// Async callback function.
+    Callback,
+}
+
 /// Different kinds of exports that can be passed to
 /// [`Resolve::wasm_export_name`] to export from core wasm modules.
 #[derive(Debug)]
@@ -2480,8 +2508,8 @@ pub enum WasmExport<'a> {
         /// The function being exported.
         func: &'a Function,
 
-        /// Whether or not this is a post-return function or not.
-        post_return: bool,
+        /// Kind of function (normal, post-return, or callback) being exported.
+        kind: WasmExportKind,
     },
 
     /// A destructor for a resource exported from this module.

--- a/src/bin/wasm-tools/component.rs
+++ b/src/bin/wasm-tools/component.rs
@@ -16,7 +16,7 @@ use wit_component::{
     embed_component_metadata, metadata, ComponentEncoder, DecodedWasm, Linker, StringEncoding,
     WitPrinter,
 };
-use wit_parser::{Mangling, PackageId, Resolve};
+use wit_parser::{LiftLowerAbi, Mangling, ManglingAndAbi, PackageId, Resolve};
 
 /// WebAssembly wit-based component tooling.
 #[derive(Parser)]
@@ -306,6 +306,26 @@ pub struct EmbedOpts {
     #[clap(long, conflicts_with = "dummy")]
     dummy_names: Option<Mangling>,
 
+    /// With `--dummy-names legacy`, this will generate a core module such that
+    /// all the imports are lowered using the async ABI and the exports are
+    /// lifted using the async-with-callback ABI.
+    ///
+    /// Note that this does not yet work with `--dummy` or `--dummy-names
+    /// standard32` because the standard name mangling scheme does not yet
+    /// support async-related features as of this writing.
+    #[clap(long, requires = "dummy_names", conflicts_with = "async_stackful")]
+    async_callback: bool,
+
+    /// With `--dummy-names legacy`, this will generate a core module such that
+    /// all the imports are lowered using the async ABI and the exports are
+    /// lifted using the async-without-callback (i.e. stackful) ABI.
+    ///
+    /// Note that this does not yet work with `--dummy` or `--dummy-names
+    /// standard32` because the standard name mangling scheme does not yet
+    /// support async-related features as of this writing.
+    #[clap(long, requires = "dummy_names", conflicts_with = "async_callback")]
+    async_stackful: bool,
+
     /// Print the output in the WebAssembly text format instead of binary.
     #[clap(long, short = 't')]
     wat: bool,
@@ -344,9 +364,27 @@ impl EmbedOpts {
         }
 
         let mut wasm = if self.dummy {
-            wit_component::dummy_module(&resolve, world, Mangling::Standard32)
+            wit_component::dummy_module(&resolve, world, ManglingAndAbi::Standard32)
         } else if let Some(mangling) = self.dummy_names {
-            wit_component::dummy_module(&resolve, world, mangling)
+            wit_component::dummy_module(
+                &resolve,
+                world,
+                match mangling {
+                    Mangling::Standard32 => {
+                        if self.async_callback || self.async_stackful {
+                            bail!("non-legacy mangling not yet supported when generating async dummy modules");
+                        }
+                        ManglingAndAbi::Standard32
+                    }
+                    Mangling::Legacy => ManglingAndAbi::Legacy(if self.async_callback {
+                        LiftLowerAbi::AsyncCallback
+                    } else if self.async_stackful {
+                        LiftLowerAbi::AsyncStackful
+                    } else {
+                        LiftLowerAbi::Sync
+                    }),
+                },
+            )
         } else {
             self.io.parse_input_wasm()?
         };


### PR DESCRIPTION
This allows us to round-trip fuzz test using the async ABI(s) as well as the sync one.  I've also added corresponding `--async-callback` and `--async-stackful` options to the `component embed --dummy` subcommand for generating dummy modules which use the new ABIs.

Note that this currently only generates ultra-minimal, non-functional modules. A real module would import the `task.return` intrinsic with the appropriate signature for each async export, and would presumably use other new intrinsics such as `subtask.drop`, `task.backpressure`, etc. -- not to mention the various `stream.*`, `future.*`, and `error-context.*` intrinsics.  For more thorough fuzz testing, we'll want to generate imports for all known intrinsics (although we probably wouldn't do that for `component embed --dummy` modules, since it would be more confusing than helpful).