### PR TITLE
smith: Fix types recorded in `ref.func`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
-    - uses: bytecodealliance/wasmtime/.github/actions/binary-compatible-builds@main
+    - uses: bytecodealliance/wasmtime/.github/actions/binary-compatible-builds@release-28.0.0
       with:
         name: ${{ matrix.build }}
       if: matrix.build != 'wasm32-wasip1'

--- a/crates/wasm-smith/src/core/code_builder.rs
+++ b/crates/wasm-smith/src/core/code_builder.rs
@@ -5442,13 +5442,9 @@ fn ref_func(
 ) -> Result<()> {
     let i = *u.choose(&builder.allocs.referenced_functions)?;
     let ty = module.funcs[usize::try_from(i).unwrap()].0;
-    builder.push_operand(Some(ValType::Ref(if module.config.gc_enabled {
-        RefType {
-            nullable: false,
-            heap_type: HeapType::Concrete(ty),
-        }
-    } else {
-        RefType::FUNCREF
+    builder.push_operand(Some(ValType::Ref(RefType {
+        nullable: false,
+        heap_type: HeapType::Concrete(ty),
     })));
     instructions.push(Instruction::RefFunc(i));
     Ok(())


### PR DESCRIPTION
This commit fixes a minor issue in `wasm-smith` when generating the `ref.func` instruction when the GC proposal is disabled but shared-everything-threads is enabled. In this situation all `ref.func` instructions were recorded as `RefType::FUNCREF` but this wasn't correct for shared function types. The logic here is applicable both with and without the GC proposal is enabled so the precise type is always pushed now.