### PR TITLE
wasmparser: Fix subtyping depth indexing

### DIFF
--- a/crates/wasmparser/src/validator/types.rs
+++ b/crates/wasmparser/src/validator/types.rs
@@ -995,7 +995,7 @@ impl TypeList {
         let depth = self
             .core_type_to_depth
             .as_ref()
-            .expect("cannot get subtype depth from a committed list")[id.index()];
+            .expect("cannot get subtype depth from a committed list")[&id];
         debug_assert!(usize::from(depth) <= crate::limits::MAX_WASM_SUBTYPING_DEPTH);
         depth
     }

--- a/tests/local/component-model/gc.wast
+++ b/tests/local/component-model/gc.wast
@@ -124,3 +124,12 @@
     ))
   )
   "sub type cannot have a final super type")
+
+(component
+  (type $t (resource (rep i32)))
+  (core func (canon resource.drop $t))
+  (core module
+    (type $t1 (sub (func)))
+    (type (sub $t1 (func)))
+  )
+)

--- a/tests/snapshots/local/component-model/gc.wast.json
+++ b/tests/snapshots/local/component-model/gc.wast.json
@@ -78,6 +78,12 @@
       "filename": "gc.11.wasm",
       "module_type": "binary",
       "text": "sub type cannot have a final super type"
+    },
+    {
+      "type": "module",
+      "line": 128,
+      "filename": "gc.12.wasm",
+      "module_type": "binary"
     }
   ]
 }

--- a/tests/snapshots/local/component-model/gc.wast/12.print
+++ b/tests/snapshots/local/component-model/gc.wast/12.print
@@ -1,0 +1,8 @@
+(component
+  (type $t (;0;) (resource (rep i32)))
+  (core func (;0;) (canon resource.drop $t))
+  (core module (;0;)
+    (type $t1 (;0;) (sub (func)))
+    (type (;1;) (sub $t1 (func)))
+  )
+)


### PR DESCRIPTION
fix: https://github.com/bytecodealliance/wasm-tools/issues/1967

This patch addresses an issue in subtyping depth checking where `set_subtyping_depth` indexes the depth by `CoreTypeId`, but `get_subtyping_depth` accesses it using `CoreTypeId#index` (`u32`). This leads to "IndexMap: index out of bounds" error when validating WasmGC components with subtypes.
