### PR TITLE
Add support for relaxed-simd to wasm-mutate

### DIFF
--- a/crates/wasm-mutate/src/mutators/peephole/dfg.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/dfg.rs
@@ -1076,6 +1076,35 @@ impl<'a> DFGBuilder {
                 Operator::F32x4DemoteF64x2Zero => self.unop(idx, Lang::F32x4DemoteF64x2Zero),
                 Operator::F64x2PromoteLowF32x4 => self.unop(idx, Lang::F64x2PromoteLowF32x4),
 
+                Operator::I8x16RelaxedSwizzle => self.binop(idx, Lang::I8x16RelaxedSwizzle),
+                Operator::I32x4RelaxedTruncF32x4S => self.unop(idx, Lang::I32x4RelaxedTruncF32x4S),
+                Operator::I32x4RelaxedTruncF32x4U => self.unop(idx, Lang::I32x4RelaxedTruncF32x4U),
+                Operator::I32x4RelaxedTruncF64x2SZero => {
+                    self.unop(idx, Lang::I32x4RelaxedTruncF64x2SZero)
+                }
+                Operator::I32x4RelaxedTruncF64x2UZero => {
+                    self.unop(idx, Lang::I32x4RelaxedTruncF64x2UZero)
+                }
+                Operator::F32x4RelaxedMadd => self.ternop(idx, Lang::F32x4RelaxedMadd),
+                Operator::F32x4RelaxedNmadd => self.ternop(idx, Lang::F32x4RelaxedNmadd),
+                Operator::F64x2RelaxedMadd => self.ternop(idx, Lang::F64x2RelaxedMadd),
+                Operator::F64x2RelaxedNmadd => self.ternop(idx, Lang::F64x2RelaxedNmadd),
+                Operator::I8x16RelaxedLaneselect => self.ternop(idx, Lang::I8x16RelaxedLaneselect),
+                Operator::I16x8RelaxedLaneselect => self.ternop(idx, Lang::I16x8RelaxedLaneselect),
+                Operator::I32x4RelaxedLaneselect => self.ternop(idx, Lang::I32x4RelaxedLaneselect),
+                Operator::I64x2RelaxedLaneselect => self.ternop(idx, Lang::I64x2RelaxedLaneselect),
+                Operator::F32x4RelaxedMin => self.binop(idx, Lang::F32x4RelaxedMin),
+                Operator::F32x4RelaxedMax => self.binop(idx, Lang::F32x4RelaxedMax),
+                Operator::F64x2RelaxedMin => self.binop(idx, Lang::F64x2RelaxedMin),
+                Operator::F64x2RelaxedMax => self.binop(idx, Lang::F64x2RelaxedMax),
+                Operator::I16x8RelaxedQ15mulrS => self.binop(idx, Lang::I16x8RelaxedQ15mulrS),
+                Operator::I16x8RelaxedDotI8x16I7x16S => {
+                    self.binop(idx, Lang::I16x8RelaxedDotI8x16I7x16S)
+                }
+                Operator::I32x4RelaxedDotI8x16I7x16AddS => {
+                    self.ternop(idx, Lang::I32x4RelaxedDotI8x16I7x16AddS)
+                }
+
                 op => {
                     // If the operator is not implemented, warn and bail out. We
                     // can't use `undef` for these because if we try to rewrite

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/analysis.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/analysis.rs
@@ -545,6 +545,27 @@ impl PeepholeMutationAnalysis {
             Lang::F64x2ConvertLowI32x4U(_) => Ok(PrimitiveTypeInfo::V128),
             Lang::F32x4DemoteF64x2Zero(_) => Ok(PrimitiveTypeInfo::V128),
             Lang::F64x2PromoteLowF32x4(_) => Ok(PrimitiveTypeInfo::V128),
+
+            Lang::I8x16RelaxedSwizzle(_) => Ok(PrimitiveTypeInfo::V128),
+            Lang::I32x4RelaxedTruncF32x4S(_) => Ok(PrimitiveTypeInfo::V128),
+            Lang::I32x4RelaxedTruncF32x4U(_) => Ok(PrimitiveTypeInfo::V128),
+            Lang::I32x4RelaxedTruncF64x2SZero(_) => Ok(PrimitiveTypeInfo::V128),
+            Lang::I32x4RelaxedTruncF64x2UZero(_) => Ok(PrimitiveTypeInfo::V128),
+            Lang::F32x4RelaxedMadd(_) => Ok(PrimitiveTypeInfo::V128),
+            Lang::F32x4RelaxedNmadd(_) => Ok(PrimitiveTypeInfo::V128),
+            Lang::F64x2RelaxedMadd(_) => Ok(PrimitiveTypeInfo::V128),
+            Lang::F64x2RelaxedNmadd(_) => Ok(PrimitiveTypeInfo::V128),
+            Lang::I8x16RelaxedLaneselect(_) => Ok(PrimitiveTypeInfo::V128),
+            Lang::I16x8RelaxedLaneselect(_) => Ok(PrimitiveTypeInfo::V128),
+            Lang::I32x4RelaxedLaneselect(_) => Ok(PrimitiveTypeInfo::V128),
+            Lang::I64x2RelaxedLaneselect(_) => Ok(PrimitiveTypeInfo::V128),
+            Lang::F32x4RelaxedMin(_) => Ok(PrimitiveTypeInfo::V128),
+            Lang::F32x4RelaxedMax(_) => Ok(PrimitiveTypeInfo::V128),
+            Lang::F64x2RelaxedMin(_) => Ok(PrimitiveTypeInfo::V128),
+            Lang::F64x2RelaxedMax(_) => Ok(PrimitiveTypeInfo::V128),
+            Lang::I16x8RelaxedQ15mulrS(_) => Ok(PrimitiveTypeInfo::V128),
+            Lang::I16x8RelaxedDotI8x16I7x16S(_) => Ok(PrimitiveTypeInfo::V128),
+            Lang::I32x4RelaxedDotI8x16I7x16AddS(_) => Ok(PrimitiveTypeInfo::V128),
         }
     }
 }

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder/expr2wasm.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/encoder/expr2wasm.rs
@@ -733,6 +733,35 @@ pub fn expr2wasm(
                     Lang::F64x2ConvertLowI32x4U(_) => insn(Instruction::F64x2ConvertLowI32x4U),
                     Lang::F32x4DemoteF64x2Zero(_) => insn(Instruction::F32x4DemoteF64x2Zero),
                     Lang::F64x2PromoteLowF32x4(_) => insn(Instruction::F64x2PromoteLowF32x4),
+
+                    Lang::I8x16RelaxedSwizzle(_) => insn(Instruction::I8x16RelaxedSwizzle),
+                    Lang::I32x4RelaxedTruncF32x4S(_) => insn(Instruction::I32x4RelaxedTruncF32x4S),
+                    Lang::I32x4RelaxedTruncF32x4U(_) => insn(Instruction::I32x4RelaxedTruncF32x4U),
+                    Lang::I32x4RelaxedTruncF64x2SZero(_) => {
+                        insn(Instruction::I32x4RelaxedTruncF64x2SZero)
+                    }
+                    Lang::I32x4RelaxedTruncF64x2UZero(_) => {
+                        insn(Instruction::I32x4RelaxedTruncF64x2UZero)
+                    }
+                    Lang::F32x4RelaxedMadd(_) => insn(Instruction::F32x4RelaxedMadd),
+                    Lang::F32x4RelaxedNmadd(_) => insn(Instruction::F32x4RelaxedNmadd),
+                    Lang::F64x2RelaxedMadd(_) => insn(Instruction::F64x2RelaxedMadd),
+                    Lang::F64x2RelaxedNmadd(_) => insn(Instruction::F64x2RelaxedNmadd),
+                    Lang::I8x16RelaxedLaneselect(_) => insn(Instruction::I8x16RelaxedLaneselect),
+                    Lang::I16x8RelaxedLaneselect(_) => insn(Instruction::I16x8RelaxedLaneselect),
+                    Lang::I32x4RelaxedLaneselect(_) => insn(Instruction::I32x4RelaxedLaneselect),
+                    Lang::I64x2RelaxedLaneselect(_) => insn(Instruction::I64x2RelaxedLaneselect),
+                    Lang::F32x4RelaxedMin(_) => insn(Instruction::F32x4RelaxedMin),
+                    Lang::F32x4RelaxedMax(_) => insn(Instruction::F32x4RelaxedMax),
+                    Lang::F64x2RelaxedMin(_) => insn(Instruction::F64x2RelaxedMin),
+                    Lang::F64x2RelaxedMax(_) => insn(Instruction::F64x2RelaxedMax),
+                    Lang::I16x8RelaxedQ15mulrS(_) => insn(Instruction::I16x8RelaxedQ15mulrS),
+                    Lang::I16x8RelaxedDotI8x16I7x16S(_) => {
+                        insn(Instruction::I16x8RelaxedDotI8x16I7x16S)
+                    }
+                    Lang::I32x4RelaxedDotI8x16I7x16AddS(_) => {
+                        insn(Instruction::I32x4RelaxedDotI8x16I7x16AddS)
+                    }
                 }
             }
         }

--- a/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
+++ b/crates/wasm-mutate/src/mutators/peephole/eggsy/lang.rs
@@ -919,6 +919,29 @@ lang! {
         F32x4DemoteF64x2Zero([Id; 1]) = "f32x4.demote_f64x2_zero",
         F64x2PromoteLowF32x4([Id; 1]) = "f64x2.promote_low_f32x4",
 
+        // relaxed-simd instructions
+
+        I8x16RelaxedSwizzle([Id; 2]) = "i8x16.relaxed_swizzle",
+        I32x4RelaxedTruncF32x4S([Id; 1]) = "i32x4.relaxed_trunc_f32x4_s",
+        I32x4RelaxedTruncF32x4U([Id; 1]) = "i32x4.relaxed_trunc_f32x4_u",
+        I32x4RelaxedTruncF64x2SZero([Id; 1]) = "i32x4.relaxed_trunc_f64x2_s_zero",
+        I32x4RelaxedTruncF64x2UZero([Id; 1]) = "i32x4.relaxed_trunc_f64x2_u_zero",
+        F32x4RelaxedMadd([Id; 3]) = "f32x4.relaxed_madd",
+        F32x4RelaxedNmadd([Id; 3]) = "f32x4.relaxed_nmadd",
+        F64x2RelaxedMadd([Id; 3]) = "f64x2.relaxed_madd",
+        F64x2RelaxedNmadd([Id; 3]) = "f64x2.relaxed_nmadd",
+        I8x16RelaxedLaneselect([Id; 3]) = "i8x16.relaxed_laneselect",
+        I16x8RelaxedLaneselect([Id; 3]) = "i16x8.relaxed_laneselect",
+        I32x4RelaxedLaneselect([Id; 3]) = "i32x4.relaxed_laneselect",
+        I64x2RelaxedLaneselect([Id; 3]) = "i64x2.relaxed_laneselect",
+        F32x4RelaxedMin([Id; 2]) = "f32x4.relaxed_min",
+        F32x4RelaxedMax([Id; 2]) = "f32x4.relaxed_max",
+        F64x2RelaxedMin([Id; 2]) = "f64x2.relaxed_min",
+        F64x2RelaxedMax([Id; 2]) = "f64x2.relaxed_max",
+        I16x8RelaxedQ15mulrS([Id; 2]) = "i16x8.relaxed_q15_mulr_s",
+        I16x8RelaxedDotI8x16I7x16S([Id; 2]) = "i16x8.relaxed_dot_i8x16_i7x16_s",
+        I32x4RelaxedDotI8x16I7x16AddS([Id; 3]) = "i32x4.relaxed_dot_i8x16_i7x16_add_s",
+
         /// Add custom or others operator nodes below
 
         /// Custom mutation operations and instructions


### PR DESCRIPTION
Enables running `wasm-tools shrink` over modules that contain relaxed-simd instructions.