### PR TITLE
feat(wasmparser): enable component-model `async` ABI

### DIFF
--- a/crates/wasmparser/src/features.rs
+++ b/crates/wasmparser/src/features.rs
@@ -230,7 +230,7 @@ define_wasm_features! {
         /// The WebAssembly [wide-arithmetic proposal](https://github.com/WebAssembly/wide-arithmetic).
         pub wide_arithmetic: WIDE_ARITHMETIC(1 << 28) = false;
         /// Support for component model async lift/lower ABI, as well as streams, futures, and errors.
-        pub component_model_async: COMPONENT_MODEL_ASYNC(1 << 29) = false;
+        pub component_model_async: COMPONENT_MODEL_ASYNC(1 << 29) = true;
     }
 }
 


### PR DESCRIPTION
Enable component-model `async` ABI by default in `wasmparser`

According to the doc:

>   /// The [`Default`] implementation for this structure returns the set of
>   /// supported WebAssembly proposals this crate implements. All features are
>   /// required to be in Phase 4 or above in the WebAssembly standardization
>   /// process.

https://github.com/bytecodealliance/wasm-tools/blob/b237793139c81f8cf3b6bd4b7baf3f2c5c8f93f2/crates/wasmparser/src/features.rs#L120-L123

I'm not quite sure where to track the progress of this proposal, but I'm guessing we're not there yet, so leaving this in draft for now.