### PR TITLE
Fix `cargo doc` warnings

### DIFF
--- a/crates/wasm-encoder/src/core/code.rs
+++ b/crates/wasm-encoder/src/core/code.rs
@@ -244,7 +244,7 @@ impl Function {
     ///
     /// This encoding doesn't include the variable-width size field
     /// that `encode` will write before the added bytes. As such, its
-    /// length will match the return value of [`byte_len`].
+    /// length will match the return value of [`Function::byte_len`].
     ///
     /// # Use Case
     ///

--- a/crates/wasm-smith/src/config.rs
+++ b/crates/wasm-smith/src/config.rs
@@ -263,6 +263,9 @@ define_config! {
         /// `allowed_instruction()` does not include vector instructions, the
         /// generated programs will not include these instructions but could
         /// contain vector types.
+        ///
+        /// [`InstructionKind::Numeric`]: crate::InstructionKind::Numeric
+        /// [`InstructionKind::NumericInt`]: crate::InstructionKind::NumericInt
         pub allowed_instructions: InstructionKinds = InstructionKinds::all(),
 
         /// Determines whether we generate floating point instructions and types.

--- a/crates/wasmparser/src/validator/func.rs
+++ b/crates/wasmparser/src/validator/func.rs
@@ -177,7 +177,7 @@ impl<T: WasmModuleResources> FuncValidator<T> {
         self.validator.with_resources(&self.resources, offset)
     }
 
-    /// Same as [`FuncValidator::visit`] except that the returned type
+    /// Same as [`FuncValidator::visitor`] except that the returned type
     /// implements the [`VisitSimdOperator`](crate::VisitSimdOperator) trait as
     /// well.
     #[cfg(feature = "simd")]

--- a/crates/wit-parser/src/ast.rs
+++ b/crates/wit-parser/src/ast.rs
@@ -1613,6 +1613,8 @@ fn eat_id(tokens: &mut Tokenizer<'_>, expected: &str) -> Result<Span> {
 
 /// A listing of source files which are used to get parsed into an
 /// [`UnresolvedPackage`].
+///
+/// [`UnresolvedPackage`]: crate::UnresolvedPackage
 #[derive(Clone, Default)]
 pub struct SourceMap {
     sources: Vec<Source>,


### PR DESCRIPTION
This PR fixes a few warnings that currently appear when running `cargo doc`.