### PR TITLE
Catch `cargo doc` warnings in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -277,7 +277,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: cargo doc --all
+      - run: RUSTDOCFLAGS="-Dwarnings" cargo doc --all
 
   clippy:
     runs-on: ubuntu-latest

--- a/crates/wasm-wave/src/wasm/ty.rs
+++ b/crates/wasm-wave/src/wasm/ty.rs
@@ -62,7 +62,7 @@ impl std::fmt::Display for WasmTypeKind {
 
 /// The WasmType trait may be implemented to represent types to be
 /// (de)serialized with WAVE, notably [`value::Type`](crate::value::Type).
-/// The [`wasmtime`] crate provides an impl for [`wasmtime::component::Type`].
+/// The `wasmtime` crate provides an impl for `wasmtime::component::Type`.
 ///
 /// The `Self`-returning methods should be called only for corresponding
 /// [`WasmTypeKind`]s.

--- a/crates/wasm-wave/src/wasm/val.rs
+++ b/crates/wasm-wave/src/wasm/val.rs
@@ -4,7 +4,7 @@ use crate::wasm::{WasmType, WasmTypeKind, WasmValueError};
 
 /// The WasmValue trait may be implemented to represent values to be
 /// (de)serialized with WAVE, notably [`value::Value`](crate::value::Value).
-/// The `wasmtime` crate provides an impl for [`wasmtime::component::Val`].
+/// The `wasmtime` crate provides an impl for `wasmtime::component::Val`.
 ///
 /// The `make_*` and `unwrap_*` methods should be called only for corresponding
 /// [`WasmTypeKind`](crate::wasm::WasmTypeKind)s.


### PR DESCRIPTION
Following up on https://github.com/bytecodealliance/wasm-tools/pull/1986#pullrequestreview-2576325105. That PR fixed all warnings from `cargo doc` but not from `cargo doc --all`, so this PR fixes those too.