### PR TITLE
Sort dependencies in `Cargo.toml` files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,37 +70,37 @@ version = "0.224.0"
 rust-version = "1.76.0"
 
 [workspace.dependencies]
+ahash = { version = "0.8.11", default-features = false }
 anyhow = "1.0.58"
 arbitrary = "1.1.0"
+bitflags = "2.5.0"
 clap = { version = "4.0.0", features = ["derive"] }
 clap_complete = "4.4.7"
 comfy-table = { version = "7.1.3", default-features = false }
 criterion = { version = "0.5.1", default-features = false }
 env_logger = "0.11"
+gimli = "0.30.0"
+hashbrown = { version = "0.15.2", default-features = false, features = ['default-hasher'] }
+id-arena = "2"
 indexmap = { version = "2.7.0", default-features = false }
+indoc = "2.0.5"
 leb128fmt = { version = "0.1.0", default-features = false }
 libfuzzer-sys = "0.4.0"
+libtest-mimic = "0.7.0"
 log = "0.4.17"
 num_cpus = "1.13"
+pretty_assertions = "1.3.0"
 rand = { version = "0.8.4", features = ["small_rng"] }
 rayon = "1.3"
+semver = { version = "1.0.0", default-features = false }
 serde = { version = "1.0.166", default-features = false, features = ['alloc'] }
 serde_derive = "1.0.166"
 serde_json = { version = "1" }
-spdx = "0.10.1"
-wasmtime = { version = "28.0.0", default-features = false, features = ['cranelift', 'component-model', 'runtime', 'gc-drc'] }
-url = "2.0.0"
-pretty_assertions = "1.3.0"
-semver = { version = "1.0.0", default-features = false }
 smallvec = "1.11.1"
-libtest-mimic = "0.7.0"
-bitflags = "2.5.0"
-hashbrown = { version = "0.15.2", default-features = false, features = ['default-hasher'] }
-ahash = { version = "0.8.11", default-features = false }
+spdx = "0.10.1"
 termcolor = "1.2.0"
-indoc = "2.0.5"
-gimli = "0.30.0"
-id-arena = "2"
+url = "2.0.0"
+wasmtime = { version = "28.0.0", default-features = false, features = ['cranelift', 'component-model', 'runtime', 'gc-drc'] }
 
 wasm-compose = { version = "0.224.0", path = "crates/wasm-compose" }
 wasm-encoder = { version = "0.224.0", path = "crates/wasm-encoder", default-features = false }
@@ -119,19 +119,19 @@ wit-smith = { version = "0.224.0", path = "crates/wit-smith" }
 
 [dependencies]
 anyhow = { workspace = true }
-env_logger = { workspace = true }
-log = { workspace = true }
 clap = { workspace = true, features = ['wrap_help'] }
 clap_complete = { workspace = true, optional = true }
 comfy-table = { workspace = true }
+env_logger = { workspace = true }
+log = { workspace = true }
 tempfile = "3.2.0"
-wat = { workspace = true, features = ['dwarf', 'component-model'] }
 termcolor = { workspace = true }
+wat = { workspace = true, features = ['dwarf', 'component-model'] }
 
 # Dependencies of `validate`
-wasmparser = { workspace = true, optional = true, features = ['std', 'component-model', 'simd'] }
-rayon = { workspace = true, optional = true }
 bitflags = { workspace = true, optional = true }
+rayon = { workspace = true, optional = true }
+wasmparser = { workspace = true, optional = true, features = ['std', 'component-model', 'simd'] }
 
 # Dependencies of `print`
 wasmprinter = { workspace = true, features = ['component-model'] }
@@ -150,21 +150,21 @@ wasm-shrink = { workspace = true, features = ["clap"], optional = true }
 wasm-mutate = { workspace = true, features = ["clap"], optional = true }
 
 # Dependencies of `strip`
-wasm-encoder = { workspace = true, features = ["std"], optional = true }
 regex = { version = "1.6.0", optional = true }
+wasm-encoder = { workspace = true, features = ["std"], optional = true }
 
 # Dependencies of `compose`
 wasm-compose = { workspace = true, optional = true }
 
 # Dependencies of `demangle`
-rustc-demangle = { version = "0.1.21", optional = true }
 cpp_demangle = { version = "0.4.0", optional = true }
+rustc-demangle = { version = "0.1.21", optional = true }
 
 # Dependencies of `component`
+wast = { workspace = true, optional = true }
 wit-component = { workspace = true, optional = true, features = ['dummy-module', 'wat', 'semver-check'] }
 wit-encoder = { workspace = true, optional = true }
 wit-parser = { workspace = true, optional = true, features = ['decoding', 'wat', 'serde'] }
-wast = { workspace = true, optional = true }
 
 # Dependencies of `metadata`
 wasm-metadata = { workspace = true, features = ["clap"], optional = true }
@@ -180,12 +180,12 @@ gimli = { workspace = true, optional = true }
 is_executable = { version = "1.0.1", optional = true }
 
 [dev-dependencies]
+indexmap = { workspace = true }
+libtest-mimic = { workspace = true }
+pretty_assertions = { workspace = true }
 serde_json = "1.0"
 tempfile = "3.1"
 wast = { workspace = true }
-pretty_assertions = { workspace = true }
-libtest-mimic = { workspace = true }
-indexmap = { workspace = true }
 
 [[test]]
 name = "cli"

--- a/crates/wasm-compose/Cargo.toml
+++ b/crates/wasm-compose/Cargo.toml
@@ -15,19 +15,19 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-wat = { workspace = true }
-wasm-encoder = { workspace = true, features = ['std', 'wasmparser', 'component-model'] }
-wasmparser = { workspace = true, features = ['std', 'validate', 'component-model', 'features'] }
-indexmap = { workspace = true, features = ["serde"] }
 anyhow = { workspace = true }
-serde = { workspace = true }
-serde_derive = { workspace = true }
-petgraph = "0.6.2"
-log = { workspace = true }
-serde_yaml = "0.9.22"
-smallvec = "1.10.0"
 heck = "0.4.0"
 im-rc = "15.1.0"
+indexmap = { workspace = true, features = ["serde"] }
+log = { workspace = true }
+petgraph = "0.6.2"
+serde = { workspace = true }
+serde_derive = { workspace = true }
+serde_yaml = "0.9.22"
+smallvec = "1.10.0"
+wasm-encoder = { workspace = true, features = ['std', 'wasmparser', 'component-model'] }
+wasmparser = { workspace = true, features = ['std', 'validate', 'component-model', 'features'] }
+wat = { workspace = true }
 
 [dev-dependencies]
 glob = "0.3.0"

--- a/crates/wasm-compose/example/middleware/Cargo.toml
+++ b/crates/wasm-compose/example/middleware/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 rust-version.workspace = true
 
 [dependencies]
-flate2 = "1.0.24"
 cargo-component-bindings = "0.6.0"
+flate2 = "1.0.24"
 
 [lib]
 crate-type = ["cdylib"]

--- a/crates/wasm-compose/example/server/Cargo.toml
+++ b/crates/wasm-compose/example/server/Cargo.toml
@@ -6,14 +6,14 @@ publish = false
 rust-version.workspace = true
 
 [dependencies]
+anyhow = "1.0.72"
 async-std = { version = "1.12.0", features = ["attributes"] }
+async-trait = "0.1.74"
 clap = { version = "4.3.19", features = ["derive"] }
 driftwood = "0.0.7"
 tide = "0.16.0"
+wasi-cap-std-sync = { version = "16.0" }
 wasmtime = { version = "16.0", features = ["component-model"] }
 wasmtime-wasi = { version = "16.0" }
-wasi-cap-std-sync = { version = "16.0" }
-anyhow = "1.0.72"
-async-trait = "0.1.74"
 
 [workspace]

--- a/crates/wasm-metadata/Cargo.toml
+++ b/crates/wasm-metadata/Cargo.toml
@@ -11,13 +11,13 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-clap = { workspace = true, optional = true }
 anyhow = { workspace = true }
-wasmparser = { workspace = true, features = ['std', 'component-model', 'hash-collections'] }
-wasm-encoder = { workspace = true, features = ['std', 'component-model'] }
+clap = { workspace = true, optional = true }
 indexmap = { workspace = true, features = ["serde"] }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
 spdx = { workspace = true }
 url = { workspace = true }
+wasm-encoder = { workspace = true, features = ['std', 'component-model'] }
+wasmparser = { workspace = true, features = ['std', 'component-model', 'hash-collections'] }

--- a/crates/wasm-mutate-stats/Cargo.toml
+++ b/crates/wasm-mutate-stats/Cargo.toml
@@ -10,16 +10,16 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 arbitrary = { workspace = true }
+clap = { workspace = true }
+env_logger = { workspace = true }
+itertools = "0.13.0"
+log = { workspace = true }
 num_cpus = { workspace = true }
 rand = { workspace = true }
 wasm-mutate = { workspace = true }
-wasmprinter = { workspace = true }
 wasmparser = { workspace = true, features = ['std', 'validate'] }
+wasmprinter = { workspace = true }
 wasmtime = { workspace = true }
-env_logger = { workspace = true }
-itertools = "0.13.0"
-clap = { workspace = true }
-log = { workspace = true }
 
 [lib]
 doctest = false

--- a/crates/wasm-mutate/Cargo.toml
+++ b/crates/wasm-mutate/Cargo.toml
@@ -12,16 +12,16 @@ workspace = true
 
 [dependencies]
 clap = { workspace = true, optional = true }
-thiserror = "1.0.28"
-wasmparser = { workspace = true, features = ['std', 'simd'] }
-wasm-encoder = { workspace = true, features = ['std', 'wasmparser'] }
-rand = { workspace = true }
-log = { workspace = true }
 egg = "0.6.0"
+log = { workspace = true }
+rand = { workspace = true }
+thiserror = "1.0.28"
+wasm-encoder = { workspace = true, features = ['std', 'wasmparser'] }
+wasmparser = { workspace = true, features = ['std', 'simd'] }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-wat = { workspace = true }
-wasmprinter = { workspace = true }
 env_logger = { workspace = true }
 wasmparser = { workspace = true, features = ['std', 'validate', 'features', 'simd'] }
+wasmprinter = { workspace = true }
+wat = { workspace = true }

--- a/crates/wasm-shrink/Cargo.toml
+++ b/crates/wasm-shrink/Cargo.toml
@@ -17,9 +17,9 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 blake3 = "1.2.0"
+clap = { workspace = true, optional = true }
 log = { workspace = true }
 rand = { workspace = true }
-clap = { workspace = true, optional = true }
 wasm-mutate = { workspace = true }
 wasmparser = { workspace = true, features = ['std', 'validate', 'features'] }
 

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -21,21 +21,21 @@ all-features = true
 
 [dependencies]
 bitflags = "2.4.1"
+hashbrown = { workspace = true, optional = true }
 indexmap = { workspace = true, optional = true }
 semver = { workspace = true, optional = true }
-hashbrown = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
 criterion = { workspace = true }
-wat = { path = "../wat" }
-wast = { path = "../wast" }
-rayon = { workspace = true }
-once_cell = "1.13.0"
-wasm-encoder = { path = "../wasm-encoder" }
 env_logger.workspace = true
 log.workspace = true
+once_cell = "1.13.0"
+rayon = { workspace = true }
+wasm-encoder = { path = "../wasm-encoder" }
+wast = { path = "../wast" }
+wat = { path = "../wat" }
 
 [[bench]]
 name = "benchmark"
@@ -57,7 +57,7 @@ hash-collections = [
   'dep:hashbrown',
   'dep:indexmap',
 ]
-# Tells the `wasmparser` crate to prefer using its built-in btree-based collections 
+# Tells the `wasmparser` crate to prefer using its built-in btree-based collections
 # even if `hash-collections` is enabled.
 prefer-btree-collections = []
 

--- a/crates/wasmprinter/Cargo.toml
+++ b/crates/wasmprinter/Cargo.toml
@@ -18,8 +18,8 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-wasmparser = { workspace = true, features = ['std', 'simd'] }
 termcolor = { workspace = true }
+wasmparser = { workspace = true, features = ['std', 'simd'] }
 
 [dev-dependencies]
 wat = { path = "../wat" }

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -20,19 +20,19 @@ all-features = true
 workspace = true
 
 [dependencies]
-leb128fmt = { workspace = true }
-unicode-width = "0.2.0"
-memchr = "2.4.1"
-wasm-encoder = { workspace = true, features = ['std'] }
 bumpalo = "3.14.0"
 gimli = { workspace = true, optional = true }
+leb128fmt = { workspace = true }
+memchr = "2.4.1"
+unicode-width = "0.2.0"
+wasm-encoder = { workspace = true, features = ['std'] }
 
 [dev-dependencies]
 anyhow = { workspace = true }
 libtest-mimic = { workspace = true }
+rand = { workspace = true }
 wasmparser = { path = "../wasmparser" }
 wat = { path = "../wat" }
-rand = { workspace = true }
 
 [features]
 default = ['wasm-module', 'component-model']

--- a/crates/wit-component/Cargo.toml
+++ b/crates/wit-component/Cargo.toml
@@ -20,28 +20,28 @@ workspace = true
 all-features = true
 
 [dependencies]
-wasmparser = { workspace = true, features = ['std', 'component-model', 'simd'] }
-wasm-encoder = { workspace = true, features = ['std', 'wasmparser'] }
-wasm-metadata = { workspace = true }
-wit-parser = { workspace = true, features = ['decoding', 'serde'] }
 anyhow = { workspace = true }
-log = "0.4.17"
 bitflags = "2.3.3"
 indexmap = { workspace = true }
-wast = { workspace = true, optional = true }
-wat = { workspace = true, optional = true }
+log = "0.4.17"
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
+wasm-encoder = { workspace = true, features = ['std', 'wasmparser'] }
+wasm-metadata = { workspace = true }
+wasmparser = { workspace = true, features = ['std', 'component-model', 'simd'] }
+wast = { workspace = true, optional = true }
+wat = { workspace = true, optional = true }
+wit-parser = { workspace = true, features = ['decoding', 'serde'] }
 
 [dev-dependencies]
+env_logger = { workspace = true }
+glob = "0.3.0"
+libtest-mimic = { workspace = true }
+pretty_assertions = "1.3.0"
 wasmparser = { workspace = true, features = ['std', 'component-model', 'features'] }
 wasmprinter = { workspace = true, features = ['component-model'] }
-glob = "0.3.0"
-pretty_assertions = "1.3.0"
-env_logger = { workspace = true }
 wat = { workspace = true, features = ['component-model'] }
-libtest-mimic = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 wasmtime = { workspace = true }

--- a/crates/wit-encoder/Cargo.toml
+++ b/crates/wit-encoder/Cargo.toml
@@ -26,11 +26,11 @@ serde = ["dep:serde", "semver/serde"]
 from-parser = ["wit-parser", "id-arena"]
 
 [dependencies]
-semver = { workspace = true }
+id-arena = { workspace = true, optional = true }
 pretty_assertions = { workspace = true }
+semver = { workspace = true }
 serde = { workspace = true, optional = true, features = ["derive"] }
 wit-parser = { workspace = true, optional = true }
-id-arena = { workspace = true, optional = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/wit-parser/Cargo.toml
+++ b/crates/wit-parser/Cargo.toml
@@ -17,16 +17,16 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-id-arena = { workspace = true }
 anyhow = { workspace = true }
+id-arena = { workspace = true }
 indexmap = { workspace = true, features = ['std'] }
-unicode-xid = "0.2.2"
 log = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
-wasmparser = { workspace = true, optional = true, features = ['std', 'validate', 'component-model', 'features'] }
 serde_json = { workspace = true, optional = true }
+unicode-xid = "0.2.2"
+wasmparser = { workspace = true, optional = true, features = ['std', 'validate', 'component-model', 'features'] }
 wat = { workspace = true, optional = true }
 
 [features]
@@ -46,10 +46,10 @@ wat = ['decoding', 'dep:wat']
 
 [dev-dependencies]
 env_logger = { workspace = true }
+libtest-mimic = { workspace = true }
 pretty_assertions = { workspace = true }
 serde_json = { workspace = true }
 wit-parser = { path = '.', features = ['serde', 'wat'] }
-libtest-mimic = { workspace = true }
 
 [[test]]
 name = "all"

--- a/crates/wit-smith/Cargo.toml
+++ b/crates/wit-smith/Cargo.toml
@@ -13,9 +13,9 @@ workspace = true
 
 [dependencies]
 arbitrary = { workspace = true, features = ["derive"] }
-wit-component = { workspace = true }
-wit-parser = { workspace = true }
 clap = { workspace = true, optional = true }
 indexmap = { workspace = true }
 log = { workspace = true }
 semver = { workspace = true }
+wit-component = { workspace = true }
+wit-parser = { workspace = true }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -17,6 +17,7 @@ env_logger = { workspace = true }
 libfuzzer-sys = { workspace = true }
 log = { workspace = true }
 tempfile = "3.0"
+wasm-encoder = { workspace = true }
 wasm-mutate = { workspace = true }
 wasm-smith = { workspace = true, features = ['component-model', 'wasmparser'] }
 wasmparser = { workspace = true, features = ['std', 'features'] }
@@ -24,10 +25,9 @@ wasmprinter = { workspace = true, features = ['component-model'] }
 wasmtime = { workspace = true, optional = true }
 wast = { workspace = true }
 wat = { workspace = true }
+wit-component = { workspace = true, features = ['dummy-module'] }
 wit-parser = { workspace = true }
 wit-smith = { workspace = true }
-wit-component = { workspace = true, features = ['dummy-module'] }
-wasm-encoder = { workspace = true }
 
 [dependencies.wit-parser-old]
 package = 'wit-parser'

--- a/playground/component/Cargo.toml
+++ b/playground/component/Cargo.toml
@@ -4,9 +4,9 @@ publish = false
 edition.workspace = true
 
 [dependencies]
-wit-bindgen-rt = { version = "0.26.0", features = ["bitflags"] }
-wat = { workspace = true }
 wasmprinter = { workspace = true }
+wat = { workspace = true }
+wit-bindgen-rt = { version = "0.26.0", features = ["bitflags"] }
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
Currently most of the `[dependencies]` lists in `Cargo.toml` files are close to sorted but not quite, making it a bit confusing to figure out where to insert a new dependency. This PR sorts them all.