### PR TITLE
Revert "Release wasm-tools 1.217.1 (#2017)"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@
 name: Publish Artifacts
 on:
   push:
-    branches: [main, 'release-*']
+    branches: [main]
 
 permissions:
   contents: write

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 name = "component"
 version = "0.0.0"
 dependencies = [
- "wasmprinter 0.217.1",
+ "wasmprinter 0.217.0",
  "wat",
  "wit-bindgen-rt",
 ]
@@ -1593,7 +1593,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-compose"
-version = "0.217.1"
+version = "0.217.0"
 dependencies = [
  "anyhow",
  "glob",
@@ -1607,11 +1607,11 @@ dependencies = [
  "serde_derive",
  "serde_yaml",
  "smallvec",
- "wasm-encoder 0.217.1",
- "wasmparser 0.217.1",
- "wasmprinter 0.217.1",
+ "wasm-encoder 0.217.0",
+ "wasmparser 0.217.0",
+ "wasmprinter 0.217.0",
  "wat",
- "wit-component 0.217.1",
+ "wit-component 0.217.0",
 ]
 
 [[package]]
@@ -1635,12 +1635,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.217.1"
+version = "0.217.0"
 dependencies = [
  "anyhow",
  "leb128",
  "tempfile",
- "wasmparser 0.217.1",
+ "wasmparser 0.217.0",
 ]
 
 [[package]]
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "wasm-metadata"
-version = "0.217.1"
+version = "0.217.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1670,14 +1670,14 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder 0.217.1",
- "wasmparser 0.217.1",
+ "wasm-encoder 0.217.0",
+ "wasmparser 0.217.0",
  "wat",
 ]
 
 [[package]]
 name = "wasm-mutate"
-version = "0.217.1"
+version = "0.217.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1686,9 +1686,9 @@ dependencies = [
  "log",
  "rand",
  "thiserror",
- "wasm-encoder 0.217.1",
- "wasmparser 0.217.1",
- "wasmprinter 0.217.1",
+ "wasm-encoder 0.217.0",
+ "wasmparser 0.217.0",
+ "wasmprinter 0.217.0",
  "wat",
 ]
 
@@ -1705,14 +1705,14 @@ dependencies = [
  "num_cpus",
  "rand",
  "wasm-mutate",
- "wasmparser 0.217.1",
- "wasmprinter 0.217.1",
+ "wasmparser 0.217.0",
+ "wasmprinter 0.217.0",
  "wasmtime",
 ]
 
 [[package]]
 name = "wasm-shrink"
-version = "0.217.1"
+version = "0.217.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1721,14 +1721,14 @@ dependencies = [
  "log",
  "rand",
  "wasm-mutate",
- "wasmparser 0.217.1",
- "wasmprinter 0.217.1",
+ "wasmparser 0.217.0",
+ "wasmprinter 0.217.0",
  "wat",
 ]
 
 [[package]]
 name = "wasm-smith"
-version = "0.217.1"
+version = "0.217.0"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -1741,15 +1741,15 @@ dependencies = [
  "rand",
  "serde",
  "serde_derive",
- "wasm-encoder 0.217.1",
- "wasmparser 0.217.1",
- "wasmprinter 0.217.1",
+ "wasm-encoder 0.217.0",
+ "wasmparser 0.217.0",
+ "wasmprinter 0.217.0",
  "wat",
 ]
 
 [[package]]
 name = "wasm-tools"
-version = "1.217.1"
+version = "1.217.0"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -1774,18 +1774,18 @@ dependencies = [
  "tempfile",
  "termcolor",
  "wasm-compose",
- "wasm-encoder 0.217.1",
- "wasm-metadata 0.217.1",
+ "wasm-encoder 0.217.0",
+ "wasm-metadata 0.217.0",
  "wasm-mutate",
  "wasm-shrink",
  "wasm-smith",
- "wasmparser 0.217.1",
- "wasmprinter 0.217.1",
+ "wasmparser 0.217.0",
+ "wasmprinter 0.217.0",
  "wast",
  "wat",
- "wit-component 0.217.1",
+ "wit-component 0.217.0",
  "wit-encoder",
- "wit-parser 0.217.1",
+ "wit-parser 0.217.0",
  "wit-smith",
 ]
 
@@ -1797,8 +1797,8 @@ dependencies = [
  "wasm-mutate",
  "wasm-shrink",
  "wasm-smith",
- "wasmparser 0.217.1",
- "wasmprinter 0.217.1",
+ "wasmparser 0.217.0",
+ "wasmprinter 0.217.0",
  "wast",
  "wat",
 ]
@@ -1813,30 +1813,30 @@ dependencies = [
  "libfuzzer-sys",
  "log",
  "tempfile",
- "wasm-encoder 0.217.1",
+ "wasm-encoder 0.217.0",
  "wasm-mutate",
  "wasm-smith",
- "wasmparser 0.217.1",
- "wasmprinter 0.217.1",
+ "wasmparser 0.217.0",
+ "wasmprinter 0.217.0",
  "wasmtime",
  "wast",
  "wat",
  "wit-component 0.214.0",
- "wit-component 0.217.1",
+ "wit-component 0.217.0",
  "wit-parser 0.214.0",
- "wit-parser 0.217.1",
+ "wit-parser 0.217.0",
  "wit-smith",
 ]
 
 [[package]]
 name = "wasm-wave"
-version = "0.217.1"
+version = "0.217.0"
 dependencies = [
  "anyhow",
  "indexmap 2.4.0",
  "logos",
  "thiserror",
- "wit-parser 0.217.1",
+ "wit-parser 0.217.0",
 ]
 
 [[package]]
@@ -1868,7 +1868,7 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.217.1"
+version = "0.217.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -1882,7 +1882,7 @@ dependencies = [
  "rayon",
  "semver",
  "serde",
- "wasm-encoder 0.217.1",
+ "wasm-encoder 0.217.0",
  "wast",
  "wat",
 ]
@@ -1900,14 +1900,14 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.217.1"
+version = "0.217.0"
 dependencies = [
  "anyhow",
  "diff",
  "rayon",
  "tempfile",
  "termcolor",
- "wasmparser 0.217.1",
+ "wasmparser 0.217.0",
  "wast",
  "wat",
 ]
@@ -2109,7 +2109,7 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "217.0.1"
+version = "217.0.0"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -2119,14 +2119,14 @@ dependencies = [
  "memchr",
  "rand",
  "unicode-width",
- "wasm-encoder 0.217.1",
- "wasmparser 0.217.1",
+ "wasm-encoder 0.217.0",
+ "wasmparser 0.217.0",
  "wat",
 ]
 
 [[package]]
 name = "wat"
-version = "1.217.1"
+version = "1.217.0"
 dependencies = [
  "wast",
 ]
@@ -2357,7 +2357,7 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.217.1"
+version = "0.217.0"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -2370,26 +2370,26 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.217.1",
- "wasm-metadata 0.217.1",
- "wasmparser 0.217.1",
- "wasmprinter 0.217.1",
+ "wasm-encoder 0.217.0",
+ "wasm-metadata 0.217.0",
+ "wasmparser 0.217.0",
+ "wasmprinter 0.217.0",
  "wasmtime",
  "wast",
  "wat",
- "wit-parser 0.217.1",
+ "wit-parser 0.217.0",
 ]
 
 [[package]]
 name = "wit-encoder"
-version = "0.217.1"
+version = "0.217.0"
 dependencies = [
  "id-arena",
  "indoc",
  "pretty_assertions",
  "semver",
  "serde",
- "wit-parser 0.217.1",
+ "wit-parser 0.217.0",
 ]
 
 [[package]]
@@ -2430,7 +2430,7 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.217.1"
+version = "0.217.0"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -2444,9 +2444,9 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.217.1",
+ "wasmparser 0.217.0",
  "wat",
- "wit-parser 0.217.1",
+ "wit-parser 0.217.0",
 ]
 
 [[package]]
@@ -2457,21 +2457,21 @@ dependencies = [
  "env_logger",
  "libfuzzer-sys",
  "log",
- "wasmprinter 0.217.1",
- "wit-parser 0.217.1",
+ "wasmprinter 0.217.0",
+ "wit-parser 0.217.0",
 ]
 
 [[package]]
 name = "wit-smith"
-version = "0.217.1"
+version = "0.217.0"
 dependencies = [
  "arbitrary",
  "clap",
  "indexmap 2.4.0",
  "log",
  "semver",
- "wit-component 0.217.1",
- "wit-parser 0.217.1",
+ "wit-component 0.217.0",
+ "wit-parser 0.217.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasm-tools"
-version = "1.217.1"
+version = "1.217.0"
 authors = ["The Wasmtime Project Developers"]
 edition.workspace = true
 description = "CLI tools for interoperating with WebAssembly files"
@@ -60,7 +60,7 @@ manual_strip = 'warn'
 [workspace.package]
 edition = '2021'
 license = "Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT"
-version = "0.217.1"
+version = "0.217.0"
 # Current policy for wasm-tools is the same as Wasmtime which is that this
 # number can be no larger than the current stable release of Rust minus 2.
 rust-version = "1.76.0"
@@ -96,20 +96,20 @@ indoc = "2.0.5"
 gimli = "0.30.0"
 id-arena = "2"
 
-wasm-compose = { version = "0.217.1", path = "crates/wasm-compose" }
-wasm-encoder = { version = "0.217.1", path = "crates/wasm-encoder" }
-wasm-metadata = { version = "0.217.1", path = "crates/wasm-metadata" }
-wasm-mutate = { version = "0.217.1", path = "crates/wasm-mutate" }
-wasm-shrink = { version = "0.217.1", path = "crates/wasm-shrink" }
-wasm-smith = { version = "0.217.1", path = "crates/wasm-smith" }
-wasmparser = { version = "0.217.1", path = "crates/wasmparser", default-features = false, features = ['std'] }
-wasmprinter = { version = "0.217.1", path = "crates/wasmprinter" }
-wast = { version = "217.0.1", path = "crates/wast" }
-wat = { version = "1.217.1", path = "crates/wat" }
-wit-component = { version = "0.217.1", path = "crates/wit-component" }
-wit-encoder = { version = "0.217.1", path = "crates/wit-encoder" }
-wit-parser = { version = "0.217.1", path = "crates/wit-parser" }
-wit-smith = { version = "0.217.1", path = "crates/wit-smith" }
+wasm-compose = { version = "0.217.0", path = "crates/wasm-compose" }
+wasm-encoder = { version = "0.217.0", path = "crates/wasm-encoder" }
+wasm-metadata = { version = "0.217.0", path = "crates/wasm-metadata" }
+wasm-mutate = { version = "0.217.0", path = "crates/wasm-mutate" }
+wasm-shrink = { version = "0.217.0", path = "crates/wasm-shrink" }
+wasm-smith = { version = "0.217.0", path = "crates/wasm-smith" }
+wasmparser = { version = "0.217.0", path = "crates/wasmparser", default-features = false, features = ['std'] }
+wasmprinter = { version = "0.217.0", path = "crates/wasmprinter" }
+wast = { version = "217.0.0", path = "crates/wast" }
+wat = { version = "1.217.0", path = "crates/wat" }
+wit-component = { version = "0.217.0", path = "crates/wit-component" }
+wit-encoder = { version = "0.217.0", path = "crates/wit-encoder" }
+wit-parser = { version = "0.217.0", path = "crates/wit-parser" }
+wit-smith = { version = "0.217.0", path = "crates/wit-smith" }
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wast"
-version = "217.0.1"
+version = "217.0.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license.workspace = true

--- a/crates/wat/Cargo.toml
+++ b/crates/wat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wat"
-version = "1.217.1"
+version = "1.217.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
This reverts commit 93168662c05360ceb1ad750e7183ca24013ec141. Same as https://github.com/bytecodealliance/wasm-tools/pull/2020, the release failed, so backing this out to redo it once CI is sorted out.