### PR TITLE
[222] Remove now-unneeded `publish.yml` on release branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@
 name: Publish Artifacts
 on:
   push:
-    branches: [main, 'release-*']
+    branches: [main]
 
 permissions:
   contents: write


### PR DESCRIPTION
This was me thrashing trying to find a good solution. I forgot to remove this before merging the release PRs.