### PR TITLE
Fix handling stability of `use` of "foreign" types

### DIFF
--- a/crates/wit-parser/src/ast.rs
+++ b/crates/wit-parser/src/ast.rs
@@ -142,6 +142,7 @@ impl<'a> DeclList<'a> {
         &'b self,
         f: &mut dyn FnMut(
             Option<&'b Id<'a>>,
+            &'b [Attribute<'a>],
             &'b UsePath<'a>,
             Option<&'b [UseName<'a>]>,
             WorldOrInterface,
@@ -158,42 +159,58 @@ impl<'a> DeclList<'a> {
                     let mut exports = Vec::new();
                     for item in world.items.iter() {
                         match item {
-                            WorldItem::Use(u) => {
-                                f(None, &u.from, Some(&u.names), WorldOrInterface::Interface)?
-                            }
-                            WorldItem::Include(i) => {
-                                f(Some(&world.name), &i.from, None, WorldOrInterface::World)?
-                            }
+                            WorldItem::Use(u) => f(
+                                None,
+                                &u.attributes,
+                                &u.from,
+                                Some(&u.names),
+                                WorldOrInterface::Interface,
+                            )?,
+                            WorldItem::Include(i) => f(
+                                Some(&world.name),
+                                &i.attributes,
+                                &i.from,
+                                None,
+                                WorldOrInterface::World,
+                            )?,
                             WorldItem::Type(_) => {}
-                            WorldItem::Import(Import { kind, .. }) => imports.push(kind),
-                            WorldItem::Export(Export { kind, .. }) => exports.push(kind),
+                            WorldItem::Import(Import {
+                                kind, attributes, ..
+                            }) => imports.push((kind, attributes)),
+                            WorldItem::Export(Export {
+                                kind, attributes, ..
+                            }) => exports.push((kind, attributes)),
                         }
                     }
 
-                    let mut visit_kind = |kind: &'b ExternKind<'a>| match kind {
-                        ExternKind::Interface(_, items) => {
-                            for item in items {
-                                match item {
-                                    InterfaceItem::Use(u) => f(
-                                        None,
-                                        &u.from,
-                                        Some(&u.names),
-                                        WorldOrInterface::Interface,
-                                    )?,
-                                    _ => {}
+                    let mut visit_kind =
+                        |kind: &'b ExternKind<'a>, attrs: &'b [Attribute<'a>]| match kind {
+                            ExternKind::Interface(_, items) => {
+                                for item in items {
+                                    match item {
+                                        InterfaceItem::Use(u) => f(
+                                            None,
+                                            &u.attributes,
+                                            &u.from,
+                                            Some(&u.names),
+                                            WorldOrInterface::Interface,
+                                        )?,
+                                        _ => {}
+                                    }
                                 }
+                                Ok(())
                             }
-                            Ok(())
-                        }
-                        ExternKind::Path(path) => f(None, path, None, WorldOrInterface::Interface),
-                        ExternKind::Func(..) => Ok(()),
-                    };
+                            ExternKind::Path(path) => {
+                                f(None, attrs, path, None, WorldOrInterface::Interface)
+                            }
+                            ExternKind::Func(..) => Ok(()),
+                        };
 
-                    for kind in imports {
-                        visit_kind(kind)?;
+                    for (kind, attrs) in imports {
+                        visit_kind(kind, attrs)?;
                     }
-                    for kind in exports {
-                        visit_kind(kind)?;
+                    for (kind, attrs) in exports {
+                        visit_kind(kind, attrs)?;
                     }
                 }
                 AstItem::Interface(i) => {
@@ -201,6 +218,7 @@ impl<'a> DeclList<'a> {
                         match item {
                             InterfaceItem::Use(u) => f(
                                 Some(&i.name),
+                                &u.attributes,
                                 &u.from,
                                 Some(&u.names),
                                 WorldOrInterface::Interface,
@@ -212,7 +230,13 @@ impl<'a> DeclList<'a> {
                 AstItem::Use(u) => {
                     // At the top-level, we don't know if this is a world or an interface
                     // It is up to the resolver to decides how to handle this ambiguity.
-                    f(None, &u.item, None, WorldOrInterface::Unknown)?;
+                    f(
+                        None,
+                        &u.attributes,
+                        &u.item,
+                        None,
+                        WorldOrInterface::Unknown,
+                    )?;
                 }
 
                 AstItem::Package(pkg) => pkg.decl_list.for_each_path(f)?,

--- a/crates/wit-parser/tests/ui/gated-use.wit
+++ b/crates/wit-parser/tests/ui/gated-use.wit
@@ -1,0 +1,13 @@
+package wasmtime:test;
+
+interface types {
+  @unstable(feature = inactive)
+  use wasi:dep2/stable@0.2.3.{unstable-resource};
+}
+
+package wasi:dep2@0.2.3 {
+  interface stable {
+    @unstable(feature = inactive)
+    resource unstable-resource;
+  }
+}

--- a/crates/wit-parser/tests/ui/gated-use.wit.json
+++ b/crates/wit-parser/tests/ui/gated-use.wit.json
@@ -1,0 +1,34 @@
+{
+  "worlds": [],
+  "interfaces": [
+    {
+      "name": "stable",
+      "types": {},
+      "functions": {},
+      "package": 0
+    },
+    {
+      "name": "types",
+      "types": {},
+      "functions": {},
+      "package": 1
+    }
+  ],
+  "types": [],
+  "packages": [
+    {
+      "name": "wasi:dep2@0.2.3",
+      "interfaces": {
+        "stable": 0
+      },
+      "worlds": {}
+    },
+    {
+      "name": "wasmtime:test",
+      "interfaces": {
+        "types": 1
+      },
+      "worlds": {}
+    }
+  ]
+}

--- a/crates/wit-parser/tests/ui/parse-fail/bad-pkg6.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/bad-pkg6.wit.result
@@ -1,5 +1,6 @@
 failed to resolve directory while parsing WIT for path [tests/ui/parse-fail/bad-pkg6]: package 'foo:bar' not found. known packages:
     foo:baz
+    foo:foo
 
      --> tests/ui/parse-fail/bad-pkg6/root.wit:3:7
       |

--- a/crates/wit-parser/tests/ui/parse-fail/unresolved-interface4.wit.result
+++ b/crates/wit-parser/tests/ui/parse-fail/unresolved-interface4.wit.result
@@ -1,4 +1,6 @@
-package 'some:dependency' not found. no known packages.
+package 'some:dependency' not found. known packages:
+    foo:foo
+
      --> tests/ui/parse-fail/unresolved-interface4.wit:6:10
       |
     6 |   import some:dependency/iface;


### PR DESCRIPTION
This commit addresses an issue where stability attributes on a `use` didn't quite work as expected when a type to another package was referred to. This fix was to update the "merging" process to skip types being processed in one more location which involved threading some more contexts around. Additionally `use` items, when elaborated, now contain their stability instead of the default stability to ensure that's propagated correctly as well.

cc #1995 but doesn't fix it