### PR TITLE
Use typed indices via a new `wasm-types` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,6 +970,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "index_vec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44faf5bb8861a9c72e20d3fb0fdbd59233e43056e2b80475ab0aacdc2e781355"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1904,8 +1910,10 @@ name = "wasm-encoder"
 version = "0.225.0"
 dependencies = [
  "anyhow",
+ "index_vec",
  "leb128fmt",
  "tempfile",
+ "wasm-types",
  "wasmparser 0.225.0",
  "wasmprinter 0.225.0",
 ]
@@ -1932,6 +1940,7 @@ version = "0.225.0"
 dependencies = [
  "anyhow",
  "clap",
+ "index_vec",
  "indexmap 2.7.1",
  "serde",
  "serde_derive",
@@ -1950,10 +1959,12 @@ dependencies = [
  "clap",
  "egg",
  "env_logger",
+ "index_vec",
  "log",
  "rand",
  "thiserror",
  "wasm-encoder 0.225.0",
+ "wasm-types",
  "wasmparser 0.225.0",
  "wasmprinter 0.225.0",
  "wat",
@@ -2002,11 +2013,13 @@ dependencies = [
  "clap",
  "criterion",
  "flagset",
+ "index_vec",
  "libfuzzer-sys",
  "rand",
  "serde",
  "serde_derive",
  "wasm-encoder 0.225.0",
+ "wasm-types",
  "wasmparser 0.225.0",
  "wasmprinter 0.225.0",
  "wat",
@@ -2095,6 +2108,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-types"
+version = "0.225.0"
+dependencies = [
+ "index_vec",
+]
+
+[[package]]
 name = "wasm-wave"
 version = "0.225.0"
 dependencies = [
@@ -2140,6 +2160,7 @@ dependencies = [
  "criterion",
  "env_logger",
  "hashbrown 0.15.2",
+ "index_vec",
  "indexmap 2.7.1",
  "log",
  "once_cell",
@@ -2147,6 +2168,7 @@ dependencies = [
  "semver",
  "serde",
  "wasm-encoder 0.225.0",
+ "wasm-types",
  "wast",
  "wat",
 ]
@@ -2167,7 +2189,9 @@ name = "wasmprinter"
 version = "0.225.0"
 dependencies = [
  "anyhow",
+ "index_vec",
  "termcolor",
+ "wasm-types",
  "wasmparser 0.225.0",
  "wat",
 ]
@@ -2387,12 +2411,14 @@ dependencies = [
  "anyhow",
  "bumpalo",
  "gimli",
+ "index_vec",
  "leb128fmt",
  "libtest-mimic",
  "memchr",
  "rand",
  "unicode-width",
  "wasm-encoder 0.225.0",
+ "wasm-types",
  "wasmparser 0.225.0",
  "wat",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ env_logger = "0.11"
 gimli = "0.31.1"
 hashbrown = { version = "0.15.2", default-features = false, features = ['default-hasher'] }
 id-arena = "2"
+index_vec = "0.1"
 indexmap = { version = "2.7.0", default-features = false }
 indoc = "2.0.5"
 leb128fmt = { version = "0.1.0", default-features = false }
@@ -108,6 +109,7 @@ wasm-metadata = { version = "0.225.0", path = "crates/wasm-metadata" }
 wasm-mutate = { version = "0.225.0", path = "crates/wasm-mutate" }
 wasm-shrink = { version = "0.225.0", path = "crates/wasm-shrink" }
 wasm-smith = { version = "0.225.0", path = "crates/wasm-smith" }
+wasm-types = { version = "0.225.0", path = "crates/wasm-types" }
 wasmparser = { version = "0.225.0", path = "crates/wasmparser", default-features = false, features = ['simd'] }
 wasmprinter = { version = "0.225.0", path = "crates/wasmprinter", default-features = false }
 wast = { version = "225.0.0", path = "crates/wast", default-features = false }

--- a/crates/wasm-encoder/Cargo.toml
+++ b/crates/wasm-encoder/Cargo.toml
@@ -20,7 +20,9 @@ all-features = true
 workspace = true
 
 [dependencies]
+index_vec.workspace = true
 leb128fmt.workspace = true
+wasm-types.workspace = true
 
 # Enable this dependency to get a bunch of `From<wasmparser::Foo> for
 # wasm_encoder::Foo` impls.

--- a/crates/wasm-encoder/src/component/aliases.rs
+++ b/crates/wasm-encoder/src/component/aliases.rs
@@ -3,6 +3,7 @@ use crate::{
     encode_section, ComponentExportKind, ComponentSection, ComponentSectionId, Encode, ExportKind,
 };
 use alloc::vec::Vec;
+use wasm_types::{ComponentInstanceIdx, CoreInstanceIdx};
 
 /// Represents the kinds of outer aliasable items in a component.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -40,10 +41,19 @@ impl Encode for ComponentOuterAliasKind {
 ///
 /// ```rust
 /// use wasm_encoder::{Component, Alias, ComponentAliasSection, ComponentExportKind, ComponentOuterAliasKind};
+/// use wasm_types::ComponentInstanceIdx;
 ///
 /// let mut aliases = ComponentAliasSection::new();
-/// aliases.alias(Alias::InstanceExport { instance: 0, kind: ComponentExportKind::Func, name: "f" });
-/// aliases.alias(Alias::Outer { count: 0, kind: ComponentOuterAliasKind::Type, index: 1 });
+/// aliases.alias(Alias::InstanceExport {
+///     instance: ComponentInstanceIdx(0),
+///     kind: ComponentExportKind::Func,
+///     name: "f",
+/// });
+/// aliases.alias(Alias::Outer {
+///     count: 0,
+///     kind: ComponentOuterAliasKind::Type,
+///     index: 1,
+/// });
 ///
 /// let mut component = Component::new();
 /// component.section(&aliases);
@@ -63,7 +73,7 @@ pub enum Alias<'a> {
     /// An alias of a component instance export.
     InstanceExport {
         /// The index of the component instance that's being aliased from.
-        instance: u32,
+        instance: ComponentInstanceIdx,
         /// The kind of item that's being extracted from the component
         /// instance.
         kind: ComponentExportKind,
@@ -73,7 +83,7 @@ pub enum Alias<'a> {
     /// Same as `InstanceExport`, but for core instances.
     #[allow(missing_docs)]
     CoreInstanceExport {
-        instance: u32,
+        instance: CoreInstanceIdx,
         kind: ExportKind,
         name: &'a str,
     },

--- a/crates/wasm-encoder/src/component/imports.rs
+++ b/crates/wasm-encoder/src/component/imports.rs
@@ -3,12 +3,13 @@ use crate::{
     Encode,
 };
 use alloc::vec::Vec;
+use wasm_types::{ComponentTypeIdx, TypeIdx};
 
 /// Represents the possible type bounds for type references.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum TypeBounds {
     /// The type is bounded by equality to the type index specified.
-    Eq(u32),
+    Eq(ComponentTypeIdx),
     /// This type is a fresh resource type,
     SubResource,
 }
@@ -31,11 +32,11 @@ pub enum ComponentTypeRef {
     /// The reference is to a core module type.
     ///
     /// The index is expected to be core type index to a core module type.
-    Module(u32),
+    Module(TypeIdx),
     /// The reference is to a function type.
     ///
     /// The index is expected to be a type index to a function type.
-    Func(u32),
+    Func(ComponentTypeIdx),
     /// The reference is to a value type.
     Value(ComponentValType),
     /// The reference is to a bounded type.
@@ -43,11 +44,11 @@ pub enum ComponentTypeRef {
     /// The reference is to an instance type.
     ///
     /// The index is expected to be a type index to an instance type.
-    Instance(u32),
+    Instance(ComponentTypeIdx),
     /// The reference is to a component type.
     ///
     /// The index is expected to be a type index to a component type.
-    Component(u32),
+    Component(ComponentTypeIdx),
 }
 
 impl ComponentTypeRef {
@@ -69,9 +70,10 @@ impl Encode for ComponentTypeRef {
         self.kind().encode(sink);
 
         match self {
-            Self::Module(idx) | Self::Func(idx) | Self::Instance(idx) | Self::Component(idx) => {
-                idx.encode(sink);
-            }
+            Self::Module(idx) => idx.encode(sink),
+            Self::Func(idx) => idx.encode(sink),
+            Self::Instance(idx) => idx.encode(sink),
+            Self::Component(idx) => idx.encode(sink),
             Self::Value(ty) => ty.encode(sink),
             Self::Type(bounds) => bounds.encode(sink),
         }
@@ -84,6 +86,7 @@ impl Encode for ComponentTypeRef {
 ///
 /// ```rust
 /// use wasm_encoder::{Component, ComponentTypeSection, PrimitiveValType, ComponentImportSection, ComponentTypeRef};
+/// use wasm_types::ComponentTypeIdx;
 ///
 /// let mut types = ComponentTypeSection::new();
 ///
@@ -100,7 +103,7 @@ impl Encode for ComponentTypeRef {
 ///
 /// // This imports a function named `f` with the type defined above
 /// let mut imports = ComponentImportSection::new();
-/// imports.import("f", ComponentTypeRef::Func(0));
+/// imports.import("f", ComponentTypeRef::Func(ComponentTypeIdx(0)));
 ///
 /// let mut component = Component::new();
 /// component.section(&types);

--- a/crates/wasm-encoder/src/component/instances.rs
+++ b/crates/wasm-encoder/src/component/instances.rs
@@ -3,12 +3,13 @@ use crate::{
     encode_section, ComponentExportKind, ComponentSection, ComponentSectionId, Encode, ExportKind,
 };
 use alloc::vec::Vec;
+use wasm_types::{ComponentIdx, CoreInstanceIdx, CoreModuleIdx};
 
 /// Represents an argument to a module instantiation.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ModuleArg {
     /// The argument is an instance.
-    Instance(u32),
+    Instance(CoreInstanceIdx),
 }
 
 impl Encode for ModuleArg {
@@ -27,10 +28,11 @@ impl Encode for ModuleArg {
 ///
 /// ```rust
 /// use wasm_encoder::{Component, InstanceSection, ExportKind, ModuleArg};
+/// use wasm_types::{CoreInstanceIdx, CoreModuleIdx};
 ///
 /// let mut instances = InstanceSection::new();
 /// instances.export_items([("foo", ExportKind::Func, 0)]);
-/// instances.instantiate(1, [("foo", ModuleArg::Instance(0))]);
+/// instances.instantiate(CoreModuleIdx(1), [("foo", ModuleArg::Instance(CoreInstanceIdx(0)))]);
 ///
 /// let mut component = Component::new();
 /// component.section(&instances);
@@ -60,7 +62,7 @@ impl InstanceSection {
     }
 
     /// Define an instance by instantiating a core module.
-    pub fn instantiate<A, S>(&mut self, module_index: u32, args: A) -> &mut Self
+    pub fn instantiate<A, S>(&mut self, module_index: CoreModuleIdx, args: A) -> &mut Self
     where
         A: IntoIterator<Item = (S, ModuleArg)>,
         A::IntoIter: ExactSizeIterator,
@@ -116,10 +118,11 @@ impl ComponentSection for InstanceSection {
 ///
 /// ```rust
 /// use wasm_encoder::{Component, ComponentInstanceSection, ComponentExportKind};
+/// use wasm_types::ComponentIdx;
 ///
 /// let mut instances = ComponentInstanceSection::new();
 /// instances.export_items([("foo", ComponentExportKind::Func, 0)]);
-/// instances.instantiate(1, [("foo", ComponentExportKind::Instance, 0)]);
+/// instances.instantiate(ComponentIdx(1), [("foo", ComponentExportKind::Instance, 0)]);
 ///
 /// let mut component = Component::new();
 /// component.section(&instances);
@@ -149,7 +152,7 @@ impl ComponentInstanceSection {
     }
 
     /// Define an instance by instantiating a component.
-    pub fn instantiate<A, S>(&mut self, component_index: u32, args: A) -> &mut Self
+    pub fn instantiate<A, S>(&mut self, component_index: ComponentIdx, args: A) -> &mut Self
     where
         A: IntoIterator<Item = (S, ComponentExportKind, u32)>,
         A::IntoIter: ExactSizeIterator,

--- a/crates/wasm-encoder/src/component/names.rs
+++ b/crates/wasm-encoder/src/component/names.rs
@@ -1,5 +1,10 @@
 use alloc::borrow::Cow;
 use alloc::vec::Vec;
+use index_vec::Idx;
+use wasm_types::{
+    ComponentFuncIdx, ComponentIdx, ComponentInstanceIdx, ComponentTypeIdx, ComponentValueIdx,
+    CoreInstanceIdx, CoreModuleIdx, FuncIdx, GlobalIdx, MemIdx, TableIdx, TypeIdx,
+};
 
 use super::*;
 use crate::{encoding_size, ExportKind, NameMap, SectionId};
@@ -35,73 +40,73 @@ impl ComponentNameSection {
 
     /// Appends a decls name subsection to name core functions within the
     /// component.
-    pub fn core_funcs(&mut self, names: &NameMap) {
+    pub fn core_funcs(&mut self, names: &NameMap<FuncIdx>) {
         self.core_decls(ExportKind::Func as u8, names)
     }
 
     /// Appends a decls name subsection to name core tables within the
     /// component.
-    pub fn core_tables(&mut self, names: &NameMap) {
+    pub fn core_tables(&mut self, names: &NameMap<TableIdx>) {
         self.core_decls(ExportKind::Table as u8, names)
     }
 
     /// Appends a decls name subsection to name core memories within the
     /// component.
-    pub fn core_memories(&mut self, names: &NameMap) {
+    pub fn core_memories(&mut self, names: &NameMap<MemIdx>) {
         self.core_decls(ExportKind::Memory as u8, names)
     }
 
     /// Appends a decls name subsection to name core globals within the
     /// component.
-    pub fn core_globals(&mut self, names: &NameMap) {
+    pub fn core_globals(&mut self, names: &NameMap<GlobalIdx>) {
         self.core_decls(ExportKind::Global as u8, names)
     }
 
     /// Appends a decls name subsection to name core types within the
     /// component.
-    pub fn core_types(&mut self, names: &NameMap) {
+    pub fn core_types(&mut self, names: &NameMap<TypeIdx>) {
         self.core_decls(CORE_TYPE_SORT, names)
     }
 
     /// Appends a decls name subsection to name core modules within the
     /// component.
-    pub fn core_modules(&mut self, names: &NameMap) {
+    pub fn core_modules(&mut self, names: &NameMap<CoreModuleIdx>) {
         self.core_decls(CORE_MODULE_SORT, names)
     }
 
     /// Appends a decls name subsection to name core instances within the
     /// component.
-    pub fn core_instances(&mut self, names: &NameMap) {
+    pub fn core_instances(&mut self, names: &NameMap<CoreInstanceIdx>) {
         self.core_decls(CORE_INSTANCE_SORT, names)
     }
 
     /// Appends a decls name subsection to name component functions within the
     /// component.
-    pub fn funcs(&mut self, names: &NameMap) {
+    pub fn funcs(&mut self, names: &NameMap<ComponentFuncIdx>) {
         self.component_decls(FUNCTION_SORT, names)
     }
 
     /// Appends a decls name subsection to name component values within the
     /// component.
-    pub fn values(&mut self, names: &NameMap) {
+    pub fn values(&mut self, names: &NameMap<ComponentValueIdx>) {
         self.component_decls(VALUE_SORT, names)
     }
 
     /// Appends a decls name subsection to name component type within the
     /// component.
-    pub fn types(&mut self, names: &NameMap) {
+    pub fn types(&mut self, names: &NameMap<ComponentTypeIdx>) {
         self.component_decls(TYPE_SORT, names)
     }
 
     /// Appends a decls name subsection to name components within the
     /// component.
-    pub fn components(&mut self, names: &NameMap) {
+    pub fn components(&mut self, names: &NameMap<ComponentIdx>) {
         self.component_decls(COMPONENT_SORT, names)
     }
 
     /// Appends a decls name subsection to name component instances within the
     /// component.
-    pub fn instances(&mut self, names: &NameMap) {
+    pub fn instances(&mut self, names: &NameMap<ComponentInstanceIdx>) {
         self.component_decls(INSTANCE_SORT, names)
     }
 
@@ -111,13 +116,13 @@ impl ComponentNameSection {
         data.encode(&mut self.bytes);
     }
 
-    fn component_decls(&mut self, kind: u8, names: &NameMap) {
+    fn component_decls<I: Idx + Encode>(&mut self, kind: u8, names: &NameMap<I>) {
         self.subsection_header(Subsection::Decls, 1 + names.size());
         self.bytes.push(kind);
         names.encode(&mut self.bytes);
     }
 
-    fn core_decls(&mut self, kind: u8, names: &NameMap) {
+    fn core_decls<I: Idx + Encode>(&mut self, kind: u8, names: &NameMap<I>) {
         self.subsection_header(Subsection::Decls, 2 + names.size());
         self.bytes.push(CORE_SORT);
         self.bytes.push(kind);

--- a/crates/wasm-encoder/src/component/start.rs
+++ b/crates/wasm-encoder/src/component/start.rs
@@ -1,5 +1,6 @@
 use crate::{ComponentSection, ComponentSectionId, Encode};
 use alloc::vec::Vec;
+use wasm_types::{ComponentFuncIdx, ComponentValueIdx};
 
 /// An encoder for the start section of WebAssembly components.
 ///
@@ -7,8 +8,13 @@ use alloc::vec::Vec;
 ///
 /// ```
 /// use wasm_encoder::{Component, ComponentStartSection};
+/// use wasm_types::{ComponentFuncIdx, ComponentValueIdx};
 ///
-/// let start = ComponentStartSection { function_index: 0, args: [0, 1], results: 1 };
+/// let start = ComponentStartSection {
+///     function_index: ComponentFuncIdx(0),
+///     args: [0, 1].map(ComponentValueIdx),
+///     results: 1,
+/// };
 ///
 /// let mut component = Component::new();
 /// component.section(&start);
@@ -18,7 +24,7 @@ use alloc::vec::Vec;
 #[derive(Clone, Debug)]
 pub struct ComponentStartSection<A> {
     /// The index to the start function.
-    pub function_index: u32,
+    pub function_index: ComponentFuncIdx,
     /// The arguments to pass to the start function.
     ///
     /// An argument is an index to a value.
@@ -32,7 +38,7 @@ pub struct ComponentStartSection<A> {
 
 impl<A> Encode for ComponentStartSection<A>
 where
-    A: AsRef<[u32]>,
+    A: AsRef<[ComponentValueIdx]>,
 {
     fn encode(&self, sink: &mut Vec<u8>) {
         let mut bytes = Vec::new();
@@ -45,7 +51,7 @@ where
 
 impl<A> ComponentSection for ComponentStartSection<A>
 where
-    A: AsRef<[u32]>,
+    A: AsRef<[ComponentValueIdx]>,
 {
     fn id(&self) -> u8 {
         ComponentSectionId::Start.into()

--- a/crates/wasm-encoder/src/core/branch_hints.rs
+++ b/crates/wasm-encoder/src/core/branch_hints.rs
@@ -1,6 +1,7 @@
 use crate::{CustomSection, Encode, Section, SectionId};
 use alloc::borrow::Cow;
 use alloc::vec::Vec;
+use wasm_types::FuncIdx;
 
 /// Helper structure to encode the `metadata.code.branch_hint` custom section.
 ///
@@ -11,6 +12,7 @@ use alloc::vec::Vec;
 ///
 /// ```
 /// use wasm_encoder::*;
+/// use wasm_types::*;
 ///
 /// let mut module = Module::new();
 ///
@@ -19,7 +21,7 @@ use alloc::vec::Vec;
 /// module.section(&types);
 ///
 /// let mut funcs = FunctionSection::new();
-/// funcs.function(0);
+/// funcs.function(TypeIdx(0));
 /// module.section(&funcs);
 ///
 /// let mut code = CodeSection::new();
@@ -33,7 +35,7 @@ use alloc::vec::Vec;
 /// code.function(&body);
 ///
 /// let mut hints = BranchHints::new();
-/// hints.function_hints(0, [BranchHint {
+/// hints.function_hints(FuncIdx(0), [BranchHint {
 ///     branch_func_offset: if_offset as u32,
 ///     branch_hint_value: 1, // taken
 /// }]);
@@ -77,7 +79,7 @@ impl BranchHints {
     }
 
     /// Adds a new set of function hints for the `func` specified.
-    pub fn function_hints<I>(&mut self, func: u32, hints: I)
+    pub fn function_hints<I>(&mut self, func: FuncIdx, hints: I)
     where
         I: IntoIterator<Item = BranchHint>,
         I::IntoIter: ExactSizeIterator,

--- a/crates/wasm-encoder/src/core/data.rs
+++ b/crates/wasm-encoder/src/core/data.rs
@@ -1,5 +1,6 @@
 use crate::{encode_section, encoding_size, ConstExpr, Encode, Section, SectionId};
 use alloc::vec::Vec;
+use wasm_types::MemIdx;
 
 /// An encoder for the data section.
 ///
@@ -12,6 +13,7 @@ use alloc::vec::Vec;
 ///     ConstExpr, DataSection, Instruction, MemorySection, MemoryType,
 ///     Module,
 /// };
+/// use wasm_types::MemIdx;
 ///
 /// let mut memory = MemorySection::new();
 /// memory.memory(MemoryType {
@@ -23,7 +25,7 @@ use alloc::vec::Vec;
 /// });
 ///
 /// let mut data = DataSection::new();
-/// let memory_index = 0;
+/// let memory_index = MemIdx(0);
 /// let offset = ConstExpr::i32_const(42);
 /// let segment_data = b"hello";
 /// data.active(memory_index, &offset, segment_data.iter().copied());
@@ -56,7 +58,7 @@ pub enum DataSegmentMode<'a> {
     /// An active data segment.
     Active {
         /// The memory this segment applies to.
-        memory_index: u32,
+        memory_index: MemIdx,
         /// The offset where this segment's data is initialized at.
         offset: &'a ConstExpr,
     },
@@ -93,7 +95,7 @@ impl DataSection {
                 self.bytes.push(0x01);
             }
             DataSegmentMode::Active {
-                memory_index: 0,
+                memory_index: MemIdx(0),
                 offset,
             } => {
                 self.bytes.push(0x00);
@@ -118,7 +120,7 @@ impl DataSection {
     }
 
     /// Define an active data segment.
-    pub fn active<D>(&mut self, memory_index: u32, offset: &ConstExpr, data: D) -> &mut Self
+    pub fn active<D>(&mut self, memory_index: MemIdx, offset: &ConstExpr, data: D) -> &mut Self
     where
         D: IntoIterator<Item = u8>,
         D::IntoIter: ExactSizeIterator,

--- a/crates/wasm-encoder/src/core/dump.rs
+++ b/crates/wasm-encoder/src/core/dump.rs
@@ -338,6 +338,7 @@ impl Encode for CoreDumpValue {
 mod tests {
     use super::*;
     use crate::Module;
+    use wasm_types::FuncIdx;
     use wasmparser::{KnownCustom, Parser, Payload};
 
     // Create new core dump section and test whether it is properly encoded and
@@ -488,7 +489,7 @@ mod tests {
                     .first()
                     .expect("frame is encoded in corestack");
                 assert_eq!(frame.instanceidx, 0);
-                assert_eq!(frame.funcidx, 12);
+                assert_eq!(frame.funcidx, FuncIdx(12));
                 assert_eq!(frame.codeoffset, 0);
                 assert_eq!(frame.locals.len(), 1);
                 match frame.locals.first().expect("frame contains a local") {

--- a/crates/wasm-encoder/src/core/functions.rs
+++ b/crates/wasm-encoder/src/core/functions.rs
@@ -1,5 +1,6 @@
 use crate::{encode_section, Encode, Section, SectionId};
 use alloc::vec::Vec;
+use wasm_types::TypeIdx;
 
 /// An encoder for the function section of WebAssembly modules.
 ///
@@ -7,9 +8,10 @@ use alloc::vec::Vec;
 ///
 /// ```
 /// use wasm_encoder::{Module, FunctionSection, ValType};
+/// use wasm_types::TypeIdx;
 ///
 /// let mut functions = FunctionSection::new();
-/// let type_index = 0;
+/// let type_index = TypeIdx(0);
 /// functions.function(type_index);
 ///
 /// let mut module = Module::new();
@@ -44,7 +46,7 @@ impl FunctionSection {
     }
 
     /// Define a function in a module's function section.
-    pub fn function(&mut self, type_index: u32) -> &mut Self {
+    pub fn function(&mut self, type_index: TypeIdx) -> &mut Self {
         type_index.encode(&mut self.bytes);
         self.num_added += 1;
         self

--- a/crates/wasm-encoder/src/core/imports.rs
+++ b/crates/wasm-encoder/src/core/imports.rs
@@ -3,14 +3,14 @@ use crate::{
     CORE_FUNCTION_SORT, CORE_GLOBAL_SORT, CORE_MEMORY_SORT, CORE_TABLE_SORT, CORE_TAG_SORT,
 };
 use alloc::vec::Vec;
-
+use wasm_types::TypeIdx;
 /// The type of an entity.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EntityType {
     /// A function type.
     ///
     /// The value is an index into the types section.
-    Function(u32),
+    Function(TypeIdx),
     /// A table type.
     Table(TableType),
     /// A memory type.

--- a/crates/wasm-encoder/src/core/start.rs
+++ b/crates/wasm-encoder/src/core/start.rs
@@ -1,5 +1,6 @@
 use crate::{encoding_size, Encode, Section, SectionId};
 use alloc::vec::Vec;
+use wasm_types::FuncIdx;
 
 /// An encoder for the start section of WebAssembly modules.
 ///
@@ -12,8 +13,9 @@ use alloc::vec::Vec;
 ///
 /// ```
 /// use wasm_encoder::{Module, StartSection};
+/// use wasm_types::FuncIdx;
 ///
-/// let start = StartSection { function_index: 0 };
+/// let start = StartSection { function_index: FuncIdx(0) };
 ///
 /// let mut module = Module::new();
 /// module.section(&start);
@@ -23,12 +25,12 @@ use alloc::vec::Vec;
 #[derive(Clone, Copy, Debug)]
 pub struct StartSection {
     /// The index of the start function.
-    pub function_index: u32,
+    pub function_index: FuncIdx,
 }
 
 impl Encode for StartSection {
     fn encode(&self, sink: &mut Vec<u8>) {
-        encoding_size(self.function_index).encode(sink);
+        encoding_size(self.function_index.0).encode(sink);
         self.function_index.encode(sink);
     }
 }

--- a/crates/wasm-encoder/src/core/tags.rs
+++ b/crates/wasm-encoder/src/core/tags.rs
@@ -1,17 +1,18 @@
 use crate::{encode_section, Encode, Section, SectionId};
 use alloc::vec::Vec;
-
+use wasm_types::TypeIdx;
 /// An encoder for the tag section.
 ///
 /// # Example
 ///
 /// ```
 /// use wasm_encoder::{Module, TagSection, TagType, TagKind};
+/// use wasm_types::TypeIdx;
 ///
 /// let mut tags = TagSection::new();
 /// tags.tag(TagType {
 ///     kind: TagKind::Exception,
-///     func_type_idx: 0,
+///     func_type_idx: TypeIdx(0),
 /// });
 ///
 /// let mut module = Module::new();
@@ -75,7 +76,7 @@ pub struct TagType {
     /// The kind of tag
     pub kind: TagKind,
     /// The function type this tag uses
-    pub func_type_idx: u32,
+    pub func_type_idx: TypeIdx,
 }
 
 impl Encode for TagType {

--- a/crates/wasm-encoder/src/core/types.rs
+++ b/crates/wasm-encoder/src/core/types.rs
@@ -1,6 +1,7 @@
 use crate::{encode_section, Encode, Section, SectionId};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
+use wasm_types::TypeIdx;
 
 /// Represents a subtype of possible other types in a WebAssembly module.
 #[derive(Debug, Clone)]
@@ -9,7 +10,7 @@ pub struct SubType {
     pub is_final: bool,
     /// The list of supertype indexes. As of GC MVP, there can be at most one
     /// supertype.
-    pub supertype_idx: Option<u32>,
+    pub supertype_idx: Option<TypeIdx>,
     /// The composite type of the subtype.
     pub composite_type: CompositeType,
 }
@@ -94,7 +95,7 @@ impl StorageType {
 
 /// Represents a type of a continuation in a WebAssembly module.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
-pub struct ContType(pub u32);
+pub struct ContType(pub TypeIdx);
 
 /// The type of a core WebAssembly value.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
@@ -361,7 +362,7 @@ pub enum HeapType {
     },
 
     /// A concrete Wasm-defined type at the given index.
-    Concrete(u32),
+    Concrete(TypeIdx),
 }
 
 impl HeapType {
@@ -401,7 +402,7 @@ impl Encode for HeapType {
             }
             // Note that this is encoded as a signed type rather than unsigned
             // as it's decoded as an s33
-            HeapType::Concrete(i) => i64::from(*i).encode(sink),
+            HeapType::Concrete(i) => i64::from(i.0).encode(sink),
         }
     }
 }
@@ -637,7 +638,7 @@ impl<'a> CoreTypeEncoder<'a> {
 
     fn encode_cont(&mut self, ty: &ContType) {
         self.bytes.push(0x5d);
-        i64::from(ty.0).encode(self.bytes);
+        i64::from(ty.0 .0).encode(self.bytes);
     }
 
     /// Define an explicit subtype in this type section.

--- a/crates/wasm-encoder/src/lib.rs
+++ b/crates/wasm-encoder/src/lib.rs
@@ -29,6 +29,7 @@
 //!     CodeSection, ExportKind, ExportSection, Function, FunctionSection, Instruction,
 //!     Module, TypeSection, ValType,
 //! };
+//! use wasm_types::{LocalIdx, TypeIdx};
 //!
 //! let mut module = Module::new();
 //!
@@ -41,7 +42,7 @@
 //!
 //! // Encode the function section.
 //! let mut functions = FunctionSection::new();
-//! let type_index = 0;
+//! let type_index = TypeIdx(0);
 //! functions.function(type_index);
 //! module.section(&functions);
 //!
@@ -54,8 +55,8 @@
 //! let mut codes = CodeSection::new();
 //! let locals = vec![];
 //! let mut f = Function::new(locals);
-//! f.instruction(&Instruction::LocalGet(0));
-//! f.instruction(&Instruction::LocalGet(1));
+//! f.instruction(&Instruction::LocalGet(LocalIdx(0)));
+//! f.instruction(&Instruction::LocalGet(LocalIdx(1)));
 //! f.instruction(&Instruction::I32Add);
 //! f.instruction(&Instruction::End);
 //! codes.function(&f);
@@ -90,6 +91,11 @@ pub use self::core::*;
 pub use self::raw::*;
 
 use alloc::vec::Vec;
+use wasm_types::{
+    AbsoluteLabelIdx, ComponentFuncIdx, ComponentIdx, ComponentInstanceIdx, ComponentTypeIdx,
+    ComponentValueIdx, CoreInstanceIdx, CoreModuleIdx, DataIdx, ElemIdx, FieldIdx, FuncIdx,
+    GlobalIdx, LabelIdx, LocalIdx, MemIdx, TableIdx, TagIdx, TypeIdx,
+};
 
 /// Implemented by types that can be encoded into a byte sink.
 pub trait Encode {
@@ -137,6 +143,120 @@ impl Encode for u32 {
     fn encode(&self, sink: &mut Vec<u8>) {
         let (value, pos) = leb128fmt::encode_u32(*self).unwrap();
         sink.extend_from_slice(&value[..pos]);
+    }
+}
+
+impl Encode for TypeIdx {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        self.0.encode(sink);
+    }
+}
+
+impl Encode for FuncIdx {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        self.0.encode(sink);
+    }
+}
+
+impl Encode for TableIdx {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        self.0.encode(sink);
+    }
+}
+
+impl Encode for MemIdx {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        self.0.encode(sink);
+    }
+}
+
+impl Encode for TagIdx {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        self.0.encode(sink);
+    }
+}
+
+impl Encode for GlobalIdx {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        self.0.encode(sink);
+    }
+}
+
+impl Encode for ElemIdx {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        self.0.encode(sink);
+    }
+}
+
+impl Encode for DataIdx {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        self.0.encode(sink);
+    }
+}
+
+impl Encode for LocalIdx {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        self.0.encode(sink);
+    }
+}
+
+impl Encode for LabelIdx {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        self.0.encode(sink);
+    }
+}
+
+impl Encode for FieldIdx {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        self.0.encode(sink);
+    }
+}
+
+impl Encode for AbsoluteLabelIdx {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        self.0.encode(sink);
+    }
+}
+
+impl Encode for CoreModuleIdx {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        self.0.encode(sink);
+    }
+}
+
+impl Encode for CoreInstanceIdx {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        self.0.encode(sink);
+    }
+}
+
+impl Encode for ComponentTypeIdx {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        self.0.encode(sink);
+    }
+}
+
+impl Encode for ComponentFuncIdx {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        self.0.encode(sink);
+    }
+}
+
+impl Encode for ComponentIdx {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        self.0.encode(sink);
+    }
+}
+
+impl Encode for ComponentInstanceIdx {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        self.0.encode(sink);
+    }
+}
+
+impl Encode for ComponentValueIdx {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        self.0.encode(sink);
     }
 }
 

--- a/crates/wasm-encoder/src/reencode/component.rs
+++ b/crates/wasm-encoder/src/reencode/component.rs
@@ -1,52 +1,56 @@
 use crate::reencode::{Error, Reencode, RoundtripReencoder};
 use alloc::boxed::Box;
+use wasm_types::{
+    ComponentFuncIdx, ComponentIdx, ComponentInstanceIdx, ComponentTypeIdx, ComponentValueIdx,
+    CoreInstanceIdx, CoreModuleIdx, TypeIdx,
+};
 
 #[allow(missing_docs)] // FIXME
 pub trait ReencodeComponent: Reencode {
-    fn component_type_index(&mut self, ty: u32) -> u32 {
+    fn component_type_index(&mut self, ty: ComponentTypeIdx) -> ComponentTypeIdx {
         ty
     }
 
-    fn component_instance_index(&mut self, ty: u32) -> u32 {
+    fn component_instance_index(&mut self, ty: ComponentInstanceIdx) -> ComponentInstanceIdx {
         ty
     }
 
-    fn component_func_index(&mut self, ty: u32) -> u32 {
+    fn component_func_index(&mut self, ty: ComponentFuncIdx) -> ComponentFuncIdx {
         ty
     }
 
-    fn component_index(&mut self, ty: u32) -> u32 {
+    fn component_index(&mut self, ty: ComponentIdx) -> ComponentIdx {
         ty
     }
 
-    fn module_index(&mut self, ty: u32) -> u32 {
+    fn module_index(&mut self, ty: CoreModuleIdx) -> CoreModuleIdx {
         ty
     }
 
-    fn instance_index(&mut self, ty: u32) -> u32 {
+    fn instance_index(&mut self, ty: CoreInstanceIdx) -> CoreInstanceIdx {
         ty
     }
 
-    fn component_value_index(&mut self, ty: u32) -> u32 {
+    fn component_value_index(&mut self, ty: ComponentValueIdx) -> ComponentValueIdx {
         ty
     }
 
-    fn outer_type_index(&mut self, count: u32, ty: u32) -> u32 {
+    fn outer_type_index(&mut self, count: u32, ty: TypeIdx) -> TypeIdx {
         let _ = count;
         self.type_index(ty)
     }
 
-    fn outer_component_type_index(&mut self, count: u32, ty: u32) -> u32 {
+    fn outer_component_type_index(&mut self, count: u32, ty: ComponentTypeIdx) -> ComponentTypeIdx {
         let _ = count;
         self.component_type_index(ty)
     }
 
-    fn outer_component_index(&mut self, count: u32, component: u32) -> u32 {
+    fn outer_component_index(&mut self, count: u32, component: ComponentIdx) -> ComponentIdx {
         let _ = count;
         self.component_index(component)
     }
 
-    fn outer_module_index(&mut self, count: u32, module: u32) -> u32 {
+    fn outer_module_index(&mut self, count: u32, module: CoreModuleIdx) -> CoreModuleIdx {
         let _ = count;
         self.module_index(module)
     }
@@ -61,12 +65,22 @@ pub trait ReencodeComponent: Reencode {
         index: u32,
     ) -> u32 {
         match kind {
-            wasmparser::ComponentExternalKind::Func => self.component_func_index(index),
-            wasmparser::ComponentExternalKind::Module => self.module_index(index),
-            wasmparser::ComponentExternalKind::Component => self.component_index(index),
-            wasmparser::ComponentExternalKind::Type => self.component_type_index(index),
-            wasmparser::ComponentExternalKind::Instance => self.component_instance_index(index),
-            wasmparser::ComponentExternalKind::Value => self.component_value_index(index),
+            wasmparser::ComponentExternalKind::Func => {
+                self.component_func_index(ComponentFuncIdx(index)).0
+            }
+            wasmparser::ComponentExternalKind::Module => self.module_index(CoreModuleIdx(index)).0,
+            wasmparser::ComponentExternalKind::Component => {
+                self.component_index(ComponentIdx(index)).0
+            }
+            wasmparser::ComponentExternalKind::Type => {
+                self.component_type_index(ComponentTypeIdx(index)).0
+            }
+            wasmparser::ComponentExternalKind::Instance => {
+                self.component_instance_index(ComponentInstanceIdx(index)).0
+            }
+            wasmparser::ComponentExternalKind::Value => {
+                self.component_value_index(ComponentValueIdx(index)).0
+            }
         }
     }
 
@@ -389,6 +403,7 @@ pub mod component_utils {
     use crate::reencode::Error;
     use alloc::boxed::Box;
     use alloc::vec::Vec;
+    use wasm_types::{ComponentIdx, ComponentTypeIdx, CoreInstanceIdx, CoreModuleIdx, TypeIdx};
 
     pub fn parse_component<T: ?Sized + ReencodeComponent>(
         reencoder: &mut T,
@@ -841,7 +856,7 @@ pub mod component_utils {
                 count,
                 index,
             } => {
-                let index = reencoder.outer_type_index(count, index);
+                let index = reencoder.outer_type_index(count, TypeIdx(index));
                 module.alias_outer_core_type(count, index);
             }
             wasmparser::ModuleTypeDeclaration::Import(import) => {
@@ -883,16 +898,20 @@ pub mod component_utils {
                 count,
                 index: match kind {
                     wasmparser::ComponentOuterAliasKind::CoreModule => {
-                        reencoder.outer_module_index(count, index)
+                        reencoder.outer_module_index(count, CoreModuleIdx(index)).0
                     }
                     wasmparser::ComponentOuterAliasKind::CoreType => {
-                        reencoder.outer_type_index(count, index)
+                        reencoder.outer_type_index(count, TypeIdx(index)).0
                     }
                     wasmparser::ComponentOuterAliasKind::Type => {
-                        reencoder.outer_component_type_index(count, index)
+                        reencoder
+                            .outer_component_type_index(count, ComponentTypeIdx(index))
+                            .0
                     }
                     wasmparser::ComponentOuterAliasKind::Component => {
-                        reencoder.outer_component_index(count, index)
+                        reencoder
+                            .outer_component_index(count, ComponentIdx(index))
+                            .0
                     }
                 },
             }),
@@ -1133,7 +1152,9 @@ pub mod component_utils {
                     args.iter().map(|arg| match arg.kind {
                         wasmparser::InstantiationArgKind::Instance => (
                             arg.name,
-                            crate::ModuleArg::Instance(reencoder.instance_index(arg.index)),
+                            crate::ModuleArg::Instance(
+                                reencoder.instance_index(CoreInstanceIdx(arg.index)),
+                            ),
                         ),
                     }),
                 );

--- a/crates/wasm-metadata/Cargo.toml
+++ b/crates/wasm-metadata/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true, optional = true }
+index_vec = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 serde = { workspace = true }
 serde_derive = { workspace = true }

--- a/crates/wasm-metadata/src/utils.rs
+++ b/crates/wasm-metadata/src/utils.rs
@@ -1,6 +1,11 @@
 use anyhow::Result;
+use index_vec::Idx;
+use wasm_encoder::Encode;
+use wasmparser::FromReader;
 
-pub(crate) fn name_map(map: &wasmparser::NameMap<'_>) -> Result<wasm_encoder::NameMap> {
+pub(crate) fn name_map<'a, I: Idx + FromReader<'a> + Encode>(
+    map: &wasmparser::NameMap<'a, I>,
+) -> Result<wasm_encoder::NameMap<I>> {
     let mut out = wasm_encoder::NameMap::new();
     for m in map.clone().into_iter() {
         let m = m?;
@@ -9,9 +14,13 @@ pub(crate) fn name_map(map: &wasmparser::NameMap<'_>) -> Result<wasm_encoder::Na
     Ok(out)
 }
 
-pub(crate) fn indirect_name_map(
-    map: &wasmparser::IndirectNameMap<'_>,
-) -> Result<wasm_encoder::IndirectNameMap> {
+pub(crate) fn indirect_name_map<
+    'a,
+    I: Idx + FromReader<'a> + Encode,
+    J: Idx + FromReader<'a> + Encode,
+>(
+    map: &wasmparser::IndirectNameMap<'a, I, J>,
+) -> Result<wasm_encoder::IndirectNameMap<I>> {
     let mut out = wasm_encoder::IndirectNameMap::new();
     for m in map.clone().into_iter() {
         let m = m?;

--- a/crates/wasm-mutate/Cargo.toml
+++ b/crates/wasm-mutate/Cargo.toml
@@ -13,10 +13,12 @@ workspace = true
 [dependencies]
 clap = { workspace = true, optional = true }
 egg = "0.6.0"
+index_vec = { workspace = true }
 log = { workspace = true }
 rand = { workspace = true }
 thiserror = "1.0.28"
 wasm-encoder = { workspace = true, features = ['std', 'wasmparser'] }
+wasm-types = { workspace = true }
 wasmparser = { workspace = true, features = ['std', 'simd'] }
 
 [dev-dependencies]

--- a/crates/wasm-mutate/src/info.rs
+++ b/crates/wasm-mutate/src/info.rs
@@ -2,9 +2,11 @@ use crate::{
     module::{PrimitiveTypeInfo, TypeInfo},
     Error, Result,
 };
+use index_vec::IndexVec;
 use std::collections::HashSet;
 use std::ops::Range;
 use wasm_encoder::{RawSection, SectionId};
+use wasm_types::{FuncIdx, TypeIdx};
 use wasmparser::{BinaryReader, Chunk, Parser, Payload};
 
 /// Provides module information for future usage during mutation
@@ -32,7 +34,7 @@ pub struct ModuleInfo<'a> {
     pub exports_count: u32,
     elements_count: u32,
     data_segments_count: u32,
-    start_function: Option<u32>,
+    start_function: Option<FuncIdx>,
     memory_count: u32,
     table_count: u32,
     tag_count: u32,
@@ -44,10 +46,10 @@ pub struct ModuleInfo<'a> {
     imported_tags_count: u32,
 
     // types for inner functions
-    pub types_map: Vec<TypeInfo>,
+    pub types_map: IndexVec<TypeIdx, TypeInfo>,
 
     // function idx to type idx
-    pub function_map: Vec<u32>,
+    pub function_map: IndexVec<FuncIdx, TypeIdx>,
     pub global_types: Vec<PrimitiveTypeInfo>,
     pub table_types: Vec<wasmparser::TableType>,
     pub memory_types: Vec<wasmparser::MemoryType>,
@@ -262,8 +264,8 @@ impl<'a> ModuleInfo<'a> {
 
     /// Returns the function type based on the index of the function type
     /// `types[functions[idx]]`
-    pub fn get_functype_idx(&self, idx: u32) -> &TypeInfo {
-        let functpeindex = self.function_map[idx as usize] as usize;
+    pub fn get_functype_idx(&self, idx: FuncIdx) -> &TypeInfo {
+        let functpeindex = self.function_map[idx];
         &self.types_map[functpeindex]
     }
 

--- a/crates/wasm-mutate/src/mutators/remove_item.rs
+++ b/crates/wasm-mutate/src/mutators/remove_item.rs
@@ -14,6 +14,7 @@ use rand::Rng;
 use std::collections::HashSet;
 use wasm_encoder::reencode::Reencode;
 use wasm_encoder::*;
+use wasm_types::FuncIdx;
 
 /// Mutator that removes a random item in a wasm module (function, global,
 /// table, etc).
@@ -100,7 +101,7 @@ struct RemoveItem<'a> {
     item: Item,
     idx: u32,
     function_reference_action: Funcref,
-    referenced_functions: HashSet<u32>,
+    referenced_functions: HashSet<FuncIdx>,
     used_index_that_was_removed: bool,
 }
 

--- a/crates/wasm-smith/Cargo.toml
+++ b/crates/wasm-smith/Cargo.toml
@@ -27,9 +27,11 @@ anyhow = { workspace = true }
 arbitrary = { workspace = true, features = ["derive"] }
 clap = { workspace = true, optional = true }
 flagset = "0.4"
+index_vec = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 wasm-encoder = { workspace = true, features = ['std'] }
+wasm-types = { workspace = true }
 wasmparser = { workspace = true, optional = true, features = ['std', 'validate', 'features', 'simd'] }
 wat = { workspace = true, optional = true }
 

--- a/crates/wasm-smith/src/core.rs
+++ b/crates/wasm-smith/src/core.rs
@@ -8,6 +8,7 @@ use crate::{arbitrary_loop, limited_string, unique_string, Config};
 use arbitrary::{Arbitrary, Result, Unstructured};
 use code_builder::CodeBuilderAllocations;
 use flagset::{flags, FlagSet};
+use index_vec::IndexVec;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::mem;
@@ -19,6 +20,7 @@ use wasm_encoder::{
     StorageType, StructType, ValType,
 };
 pub(crate) use wasm_encoder::{GlobalType, MemoryType, TableType};
+use wasm_types::TypeIdx;
 
 // NB: these constants are used to control the rate at which various events
 // occur. For more information see where these constants are used. Their values
@@ -50,7 +52,7 @@ pub struct Module {
 
     /// All types locally defined in this module (available in the type index
     /// space).
-    types: Vec<SubType>,
+    types: IndexVec<TypeIdx, SubType>,
 
     /// Non-overlapping ranges within `types` that belong to the same rec
     /// group. All of `types` is covered by these ranges. When GC is not
@@ -2637,7 +2639,7 @@ impl Module {
     fn is_shared_ref_type(&self, ty: RefType) -> bool {
         match ty.heap_type {
             HeapType::Abstract { shared, .. } => shared,
-            HeapType::Concrete(i) => self.types[i as usize].composite_type.shared,
+            HeapType::Concrete(i) => self.types[i].composite_type.shared,
         }
     }
 

--- a/crates/wasm-types/Cargo.toml
+++ b/crates/wasm-types/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "wasm-types"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = """
+Basic WebAssembly types.
+"""
+homepage = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-types"
+repository = "https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-types"
+license.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+index_vec.workspace = true

--- a/crates/wasm-types/README.md
+++ b/crates/wasm-types/README.md
@@ -1,0 +1,12 @@
+# `wasm-types`
+
+**A [Bytecode Alliance](https://bytecodealliance.org/) project**
+
+[![crates.io link](https://img.shields.io/crates/v/wasm-types.svg)](https://crates.io/crates/wasm-types)
+[![docs.rs docs](https://img.shields.io/static/v1?label=docs&message=wasm-types&color=blue&style=flat-square)](https://docs.rs/wasm-types/)
+
+Basic WebAssembly types.
+
+## Documentation
+
+Documentation and examples can be found at https://docs.rs/wasm-types/

--- a/crates/wasm-types/src/lib.rs
+++ b/crates/wasm-types/src/lib.rs
@@ -1,0 +1,129 @@
+//! Basic WebAssembly types.
+//!
+//! These are simple types, mostly from the WebAssembly spec, that can be shared across different
+//! crates like `wasmparser`, `wasmprinter`, and `wasm-encoder`.
+
+use core::fmt;
+use index_vec::Idx;
+
+/// A Wasm _typeidx_.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct TypeIdx(pub u32);
+
+/// A Wasm _funcidx_.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct FuncIdx(pub u32);
+
+/// A Wasm _tableidx_.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct TableIdx(pub u32);
+
+/// A Wasm _memidx_.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct MemIdx(pub u32);
+
+/// A Wasm _tagidx_.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct TagIdx(pub u32);
+
+/// A Wasm _globalidx_.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct GlobalIdx(pub u32);
+
+/// A Wasm _elemidx_.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ElemIdx(pub u32);
+
+/// A Wasm _dataidx_.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct DataIdx(pub u32);
+
+/// A Wasm _localidx_.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct LocalIdx(pub u32);
+
+/// A Wasm _labelidx_.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct LabelIdx(pub u32);
+
+/// A Wasm _fieldidx_.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct FieldIdx(pub u32);
+
+/// An absolute label index within a Wasm function.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct AbsoluteLabelIdx(pub u32);
+
+/// A Wasm core module index.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct CoreModuleIdx(pub u32);
+
+/// A Wasm core instance index.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct CoreInstanceIdx(pub u32);
+
+/// A Wasm component type index.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ComponentTypeIdx(pub u32);
+
+/// A Wasm component function index.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ComponentFuncIdx(pub u32);
+
+/// A Wasm component index.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ComponentIdx(pub u32);
+
+/// A Wasm component instance index.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ComponentInstanceIdx(pub u32);
+
+/// A Wasm component value index.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ComponentValueIdx(pub u32);
+
+macro_rules! idx_impls {
+    ($name:ident) => {
+        impl AsMut<u32> for $name {
+            fn as_mut(&mut self) -> &mut u32 {
+                &mut self.0
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                write!(f, "{}", self.0)
+            }
+        }
+
+        impl Idx for $name {
+            fn from_usize(idx: usize) -> Self {
+                Self(idx.try_into().unwrap())
+            }
+
+            fn index(self) -> usize {
+                self.0 as usize
+            }
+        }
+    };
+}
+
+idx_impls!(TypeIdx);
+idx_impls!(FuncIdx);
+idx_impls!(TableIdx);
+idx_impls!(MemIdx);
+idx_impls!(TagIdx);
+idx_impls!(GlobalIdx);
+idx_impls!(ElemIdx);
+idx_impls!(DataIdx);
+idx_impls!(LocalIdx);
+idx_impls!(LabelIdx);
+idx_impls!(FieldIdx);
+idx_impls!(AbsoluteLabelIdx);
+idx_impls!(CoreModuleIdx);
+idx_impls!(CoreInstanceIdx);
+idx_impls!(ComponentTypeIdx);
+idx_impls!(ComponentFuncIdx);
+idx_impls!(ComponentIdx);
+idx_impls!(ComponentInstanceIdx);
+idx_impls!(ComponentValueIdx);

--- a/crates/wasmparser/Cargo.toml
+++ b/crates/wasmparser/Cargo.toml
@@ -22,9 +22,11 @@ all-features = true
 [dependencies]
 bitflags = "2.4.1"
 hashbrown = { workspace = true, optional = true }
+index_vec = { workspace = true }
 indexmap = { workspace = true, optional = true }
 semver = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
+wasm-types = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/wasmparser/src/lib.rs
+++ b/crates/wasmparser/src/lib.rs
@@ -78,19 +78,19 @@ macro_rules! _for_each_operator_group {
                 If { blockty: $crate::BlockType } => visit_if (arity 1 block -> ~block)
                 Else => visit_else (arity ~end -> ~end)
                 End => visit_end (arity implicit_else ~end -> implicit_else end)
-                Br { relative_depth: u32 } => visit_br (arity br -> 0)
-                BrIf { relative_depth: u32 } => visit_br_if (arity 1 br -> br)
+                Br { relative_depth: ::wasm_types::LabelIdx } => visit_br (arity br -> 0)
+                BrIf { relative_depth: ::wasm_types::LabelIdx } => visit_br_if (arity 1 br -> br)
                 BrTable { targets: $crate::BrTable<'a> } => visit_br_table (arity 1 br_table -> 0)
                 Return => visit_return (arity ~ret -> 0)
-                Call { function_index: u32 } => visit_call (arity func -> func)
-                CallIndirect { type_index: u32, table_index: u32 } => visit_call_indirect (arity 1 type -> type)
+                Call { function_index: ::wasm_types::FuncIdx } => visit_call (arity func -> func)
+                CallIndirect { type_index: ::wasm_types::TypeIdx, table_index: ::wasm_types::TableIdx } => visit_call_indirect (arity 1 type -> type)
                 Drop => visit_drop (arity 1 -> 0)
                 Select => visit_select (arity 3 -> 1)
-                LocalGet { local_index: u32 } => visit_local_get (arity 0 -> 1)
-                LocalSet { local_index: u32 } => visit_local_set (arity 1 -> 0)
-                LocalTee { local_index: u32 } => visit_local_tee (arity 1 -> 1)
-                GlobalGet { global_index: u32 } => visit_global_get (arity 0 -> 1)
-                GlobalSet { global_index: u32 } => visit_global_set (arity 1 -> 0)
+                LocalGet { local_index: ::wasm_types::LocalIdx } => visit_local_get (arity 0 -> 1)
+                LocalSet { local_index: ::wasm_types::LocalIdx } => visit_local_set (arity 1 -> 0)
+                LocalTee { local_index: ::wasm_types::LocalIdx } => visit_local_tee (arity 1 -> 1)
+                GlobalGet { global_index: ::wasm_types::GlobalIdx } => visit_global_get (arity 0 -> 1)
+                GlobalSet { global_index: ::wasm_types::GlobalIdx } => visit_global_set (arity 1 -> 0)
                 I32Load { memarg: $crate::MemArg } => visit_i32_load (load i32)
                 I64Load { memarg: $crate::MemArg } => visit_i64_load (load i64)
                 F32Load { memarg: $crate::MemArg } => visit_f32_load (load f32)
@@ -114,8 +114,8 @@ macro_rules! _for_each_operator_group {
                 I64Store8 { memarg: $crate::MemArg } => visit_i64_store8 (store i64)
                 I64Store16 { memarg: $crate::MemArg } => visit_i64_store16 (store i64)
                 I64Store32 { memarg: $crate::MemArg } => visit_i64_store32 (store i64)
-                MemorySize { mem: u32 } => visit_memory_size (arity 0 -> 1)
-                MemoryGrow { mem: u32 } => visit_memory_grow (arity 1 -> 1)
+                MemorySize { mem: ::wasm_types::MemIdx } => visit_memory_size (arity 0 -> 1)
+                MemoryGrow { mem: ::wasm_types::MemIdx } => visit_memory_grow (arity 1 -> 1)
                 I32Const { value: i32 } => visit_i32_const (push i32)
                 I64Const { value: i64 } => visit_i64_const (push i64)
                 F32Const { value: $crate::Ieee32 } => visit_f32_const (push f32)
@@ -258,37 +258,37 @@ macro_rules! _for_each_operator_group {
             // http://github.com/WebAssembly/gc
             @gc {
                 RefEq => visit_ref_eq (arity 2 -> 1)
-                StructNew { struct_type_index: u32 } => visit_struct_new (arity type -> 1)
-                StructNewDefault { struct_type_index: u32 } => visit_struct_new_default (arity 0 -> 1)
-                StructGet { struct_type_index: u32, field_index: u32 } => visit_struct_get (arity 1 -> 1)
-                StructGetS { struct_type_index: u32, field_index: u32 } => visit_struct_get_s (arity 1 -> 1)
-                StructGetU { struct_type_index: u32, field_index: u32 } => visit_struct_get_u (arity 1 -> 1)
-                StructSet { struct_type_index: u32, field_index: u32 } => visit_struct_set (arity 2 -> 0)
-                ArrayNew { array_type_index: u32 } => visit_array_new (arity 2 -> 1)
-                ArrayNewDefault { array_type_index: u32 } => visit_array_new_default (arity 1 -> 1)
-                ArrayNewFixed { array_type_index: u32, array_size: u32 } => visit_array_new_fixed (arity size -> 1)
-                ArrayNewData { array_type_index: u32, array_data_index: u32 } => visit_array_new_data (arity 2 -> 1)
-                ArrayNewElem { array_type_index: u32, array_elem_index: u32 } => visit_array_new_elem (arity 2 -> 1)
-                ArrayGet { array_type_index: u32 } => visit_array_get (arity 2 -> 1)
-                ArrayGetS { array_type_index: u32 } => visit_array_get_s (arity 2 -> 1)
-                ArrayGetU { array_type_index: u32 } => visit_array_get_u (arity 2 -> 1)
-                ArraySet { array_type_index: u32 } => visit_array_set (arity 3 -> 0)
+                StructNew { struct_type_index: ::wasm_types::TypeIdx } => visit_struct_new (arity type -> 1)
+                StructNewDefault { struct_type_index: ::wasm_types::TypeIdx } => visit_struct_new_default (arity 0 -> 1)
+                StructGet { struct_type_index: ::wasm_types::TypeIdx, field_index: ::wasm_types::FieldIdx } => visit_struct_get (arity 1 -> 1)
+                StructGetS { struct_type_index: ::wasm_types::TypeIdx, field_index: ::wasm_types::FieldIdx } => visit_struct_get_s (arity 1 -> 1)
+                StructGetU { struct_type_index: ::wasm_types::TypeIdx, field_index: ::wasm_types::FieldIdx } => visit_struct_get_u (arity 1 -> 1)
+                StructSet { struct_type_index: ::wasm_types::TypeIdx, field_index: ::wasm_types::FieldIdx } => visit_struct_set (arity 2 -> 0)
+                ArrayNew { array_type_index: ::wasm_types::TypeIdx } => visit_array_new (arity 2 -> 1)
+                ArrayNewDefault { array_type_index: ::wasm_types::TypeIdx } => visit_array_new_default (arity 1 -> 1)
+                ArrayNewFixed { array_type_index: ::wasm_types::TypeIdx, array_size: u32 } => visit_array_new_fixed (arity size -> 1)
+                ArrayNewData { array_type_index: ::wasm_types::TypeIdx, array_data_index: ::wasm_types::DataIdx } => visit_array_new_data (arity 2 -> 1)
+                ArrayNewElem { array_type_index: ::wasm_types::TypeIdx, array_elem_index: ::wasm_types::ElemIdx } => visit_array_new_elem (arity 2 -> 1)
+                ArrayGet { array_type_index: ::wasm_types::TypeIdx } => visit_array_get (arity 2 -> 1)
+                ArrayGetS { array_type_index: ::wasm_types::TypeIdx } => visit_array_get_s (arity 2 -> 1)
+                ArrayGetU { array_type_index: ::wasm_types::TypeIdx } => visit_array_get_u (arity 2 -> 1)
+                ArraySet { array_type_index: ::wasm_types::TypeIdx } => visit_array_set (arity 3 -> 0)
                 ArrayLen => visit_array_len (arity 1 -> 1)
-                ArrayFill { array_type_index: u32 } => visit_array_fill (arity 4 -> 0)
-                ArrayCopy { array_type_index_dst: u32, array_type_index_src: u32 } => visit_array_copy (arity 5 -> 0)
-                ArrayInitData { array_type_index: u32, array_data_index: u32 } => visit_array_init_data (arity 4 -> 0)
-                ArrayInitElem { array_type_index: u32, array_elem_index: u32 } => visit_array_init_elem (arity 4 -> 0)
+                ArrayFill { array_type_index: ::wasm_types::TypeIdx } => visit_array_fill (arity 4 -> 0)
+                ArrayCopy { array_type_index_dst: ::wasm_types::TypeIdx, array_type_index_src: ::wasm_types::TypeIdx } => visit_array_copy (arity 5 -> 0)
+                ArrayInitData { array_type_index: ::wasm_types::TypeIdx, array_data_index: ::wasm_types::DataIdx } => visit_array_init_data (arity 4 -> 0)
+                ArrayInitElem { array_type_index: ::wasm_types::TypeIdx, array_elem_index: ::wasm_types::ElemIdx } => visit_array_init_elem (arity 4 -> 0)
                 RefTestNonNull { hty: $crate::HeapType } => visit_ref_test_non_null (arity 1 -> 1)
                 RefTestNullable { hty: $crate::HeapType } => visit_ref_test_nullable (arity 1 -> 1)
                 RefCastNonNull { hty: $crate::HeapType } => visit_ref_cast_non_null (arity 1 -> 1)
                 RefCastNullable { hty: $crate::HeapType } => visit_ref_cast_nullable (arity 1 -> 1)
                 BrOnCast {
-                    relative_depth: u32,
+                    relative_depth: ::wasm_types::LabelIdx,
                     from_ref_type: $crate::RefType,
                     to_ref_type: $crate::RefType
                 } => visit_br_on_cast (arity br -> br)
                 BrOnCastFail {
-                    relative_depth: u32,
+                    relative_depth: ::wasm_types::LabelIdx,
                     from_ref_type: $crate::RefType,
                     to_ref_type: $crate::RefType
                 } => visit_br_on_cast_fail (arity br -> br)
@@ -317,13 +317,13 @@ macro_rules! _for_each_operator_group {
             // bulk memory operations
             // https://github.com/WebAssembly/bulk-memory-operations
             @bulk_memory {
-                MemoryInit { data_index: u32, mem: u32 } => visit_memory_init (arity 3 -> 0)
-                DataDrop { data_index: u32 } => visit_data_drop (arity 0 -> 0)
-                MemoryCopy { dst_mem: u32, src_mem: u32 } => visit_memory_copy (arity 3 -> 0)
-                MemoryFill { mem: u32 } => visit_memory_fill (arity 3 -> 0)
-                TableInit { elem_index: u32, table: u32 } => visit_table_init (arity 3 -> 0)
-                ElemDrop { elem_index: u32 } => visit_elem_drop (arity 0 -> 0)
-                TableCopy { dst_table: u32, src_table: u32 } => visit_table_copy (arity 3 -> 0)
+                MemoryInit { data_index: ::wasm_types::DataIdx, mem: ::wasm_types::MemIdx } => visit_memory_init (arity 3 -> 0)
+                DataDrop { data_index: ::wasm_types::DataIdx } => visit_data_drop (arity 0 -> 0)
+                MemoryCopy { dst_mem: ::wasm_types::MemIdx, src_mem: ::wasm_types::MemIdx } => visit_memory_copy (arity 3 -> 0)
+                MemoryFill { mem: ::wasm_types::MemIdx } => visit_memory_fill (arity 3 -> 0)
+                TableInit { elem_index: ::wasm_types::ElemIdx, table: ::wasm_types::TableIdx } => visit_table_init (arity 3 -> 0)
+                ElemDrop { elem_index: ::wasm_types::ElemIdx } => visit_elem_drop (arity 0 -> 0)
+                TableCopy { dst_table: ::wasm_types::TableIdx, src_table: ::wasm_types::TableIdx } => visit_table_copy (arity 3 -> 0)
             }
 
             // 0xFC prefixed operators
@@ -333,26 +333,26 @@ macro_rules! _for_each_operator_group {
                 TypedSelect { ty: $crate::ValType } => visit_typed_select (arity 3 -> 1)
                 RefNull { hty: $crate::HeapType } => visit_ref_null (arity 0 -> 1)
                 RefIsNull => visit_ref_is_null (arity 1 -> 1)
-                RefFunc { function_index: u32 } => visit_ref_func (arity 0 -> 1)
-                TableFill { table: u32 } => visit_table_fill (arity 3 -> 0)
-                TableGet { table: u32 } => visit_table_get (arity 1 -> 1)
-                TableSet { table: u32 } => visit_table_set (arity 2 -> 0)
-                TableGrow { table: u32 } => visit_table_grow (arity 2 -> 1)
-                TableSize { table: u32 } => visit_table_size (arity 0 -> 1)
+                RefFunc { function_index: ::wasm_types::FuncIdx } => visit_ref_func (arity 0 -> 1)
+                TableFill { table: ::wasm_types::TableIdx } => visit_table_fill (arity 3 -> 0)
+                TableGet { table: ::wasm_types::TableIdx } => visit_table_get (arity 1 -> 1)
+                TableSet { table: ::wasm_types::TableIdx } => visit_table_set (arity 2 -> 0)
+                TableGrow { table: ::wasm_types::TableIdx } => visit_table_grow (arity 2 -> 1)
+                TableSize { table: ::wasm_types::TableIdx } => visit_table_size (arity 0 -> 1)
             }
 
             // Wasm tail-call proposal
             // https://github.com/WebAssembly/tail-call
             @tail_call {
-                ReturnCall { function_index: u32 } => visit_return_call (arity func -> 0)
-                ReturnCallIndirect { type_index: u32, table_index: u32 } => visit_return_call_indirect (arity 1 type -> 0)
+                ReturnCall { function_index: ::wasm_types::FuncIdx } => visit_return_call (arity func -> 0)
+                ReturnCallIndirect { type_index: ::wasm_types::TypeIdx, table_index: ::wasm_types::TableIdx } => visit_return_call_indirect (arity 1 type -> 0)
             }
 
             // OxFC prefixed operators
             // memory control (experimental)
             // https://github.com/WebAssembly/design/issues/1439
             @memory_control {
-                MemoryDiscard { mem: u32 } => visit_memory_discard (arity 2 -> 0)
+                MemoryDiscard { mem: ::wasm_types::MemIdx } => visit_memory_discard (arity 2 -> 0)
             }
 
             // 0xFE prefixed operators
@@ -698,15 +698,15 @@ macro_rules! _for_each_operator_group {
 
             @exceptions {
                 TryTable { try_table: $crate::TryTable } => visit_try_table (arity try_table -> ~try_table)
-                Throw { tag_index: u32 } => visit_throw (arity tag -> 0)
+                Throw { tag_index: ::wasm_types::TagIdx } => visit_throw (arity tag -> 0)
                 ThrowRef => visit_throw_ref (arity 1 -> 0)
             }
             // Deprecated old instructions from the exceptions proposal
             @legacy_exceptions {
                 Try { blockty: $crate::BlockType } => visit_try (arity block -> ~block)
-                Catch { tag_index: u32 } => visit_catch (arity ~end -> ~tag)
-                Rethrow { relative_depth: u32 } => visit_rethrow (arity 0 -> 0)
-                Delegate { relative_depth: u32 } => visit_delegate (arity ~end -> end)
+                Catch { tag_index: ::wasm_types::TagIdx } => visit_catch (arity ~end -> ~tag)
+                Rethrow { relative_depth: ::wasm_types::LabelIdx } => visit_rethrow (arity 0 -> 0)
+                Delegate { relative_depth: ::wasm_types::LabelIdx } => visit_delegate (arity ~end -> end)
                 CatchAll => visit_catch_all (arity ~end -> 0)
             }
 
@@ -714,61 +714,61 @@ macro_rules! _for_each_operator_group {
             // shared-everything threads
             // https://github.com/WebAssembly/shared-everything-threads
             @shared_everything_threads {
-                GlobalAtomicGet { ordering: $crate::Ordering, global_index: u32 } => visit_global_atomic_get (arity 0 -> 1)
-                GlobalAtomicSet { ordering: $crate::Ordering, global_index: u32 } => visit_global_atomic_set (arity 1 -> 0)
-                GlobalAtomicRmwAdd { ordering: $crate::Ordering, global_index: u32 } => visit_global_atomic_rmw_add (unary atomic global)
-                GlobalAtomicRmwSub { ordering: $crate::Ordering, global_index: u32 } => visit_global_atomic_rmw_sub (unary atomic global)
-                GlobalAtomicRmwAnd { ordering: $crate::Ordering, global_index: u32 } => visit_global_atomic_rmw_and (unary atomic global)
-                GlobalAtomicRmwOr { ordering: $crate::Ordering, global_index: u32 } => visit_global_atomic_rmw_or (unary atomic global)
-                GlobalAtomicRmwXor { ordering: $crate::Ordering, global_index: u32 } => visit_global_atomic_rmw_xor (unary atomic global)
-                GlobalAtomicRmwXchg { ordering: $crate::Ordering, global_index: u32 } => visit_global_atomic_rmw_xchg (arity 1 -> 1)
-                GlobalAtomicRmwCmpxchg { ordering: $crate::Ordering, global_index: u32 } => visit_global_atomic_rmw_cmpxchg (arity 2 -> 1)
-                TableAtomicGet { ordering: $crate::Ordering, table_index: u32 } => visit_table_atomic_get (arity 1 -> 1)
-                TableAtomicSet { ordering: $crate::Ordering, table_index: u32 } => visit_table_atomic_set (arity 2 -> 0)
-                TableAtomicRmwXchg { ordering: $crate::Ordering, table_index: u32 } => visit_table_atomic_rmw_xchg (arity 2 -> 1)
-                TableAtomicRmwCmpxchg { ordering: $crate::Ordering, table_index: u32 } => visit_table_atomic_rmw_cmpxchg (arity 3 -> 1)
-                StructAtomicGet { ordering: $crate::Ordering, struct_type_index: u32, field_index: u32  } => visit_struct_atomic_get (arity 1 -> 1)
-                StructAtomicGetS { ordering: $crate::Ordering, struct_type_index: u32, field_index: u32  } => visit_struct_atomic_get_s (arity 1 -> 1)
-                StructAtomicGetU { ordering: $crate::Ordering, struct_type_index: u32, field_index: u32  } => visit_struct_atomic_get_u (arity 1 -> 1)
-                StructAtomicSet { ordering: $crate::Ordering, struct_type_index: u32, field_index: u32  } => visit_struct_atomic_set (arity 2 -> 0)
-                StructAtomicRmwAdd { ordering: $crate::Ordering, struct_type_index: u32, field_index: u32  } => visit_struct_atomic_rmw_add (atomic rmw struct add)
-                StructAtomicRmwSub { ordering: $crate::Ordering, struct_type_index: u32, field_index: u32  } => visit_struct_atomic_rmw_sub (atomic rmw struct sub)
-                StructAtomicRmwAnd { ordering: $crate::Ordering, struct_type_index: u32, field_index: u32  } => visit_struct_atomic_rmw_and (atomic rmw struct and)
-                StructAtomicRmwOr { ordering: $crate::Ordering, struct_type_index: u32, field_index: u32  } => visit_struct_atomic_rmw_or (atomic rmw struct or)
-                StructAtomicRmwXor { ordering: $crate::Ordering, struct_type_index: u32, field_index: u32  } => visit_struct_atomic_rmw_xor (atomic rmw struct xor)
-                StructAtomicRmwXchg { ordering: $crate::Ordering, struct_type_index: u32, field_index: u32  } => visit_struct_atomic_rmw_xchg (arity 2 -> 1)
-                StructAtomicRmwCmpxchg { ordering: $crate::Ordering, struct_type_index: u32, field_index: u32  } => visit_struct_atomic_rmw_cmpxchg (arity 3 -> 1)
-                ArrayAtomicGet { ordering: $crate::Ordering, array_type_index: u32 } => visit_array_atomic_get (arity 2 -> 1)
-                ArrayAtomicGetS { ordering: $crate::Ordering, array_type_index: u32 } => visit_array_atomic_get_s (arity 2 -> 1)
-                ArrayAtomicGetU { ordering: $crate::Ordering, array_type_index: u32 } => visit_array_atomic_get_u (arity 2 -> 1)
-                ArrayAtomicSet { ordering: $crate::Ordering, array_type_index: u32 } => visit_array_atomic_set (arity 3 -> 0)
-                ArrayAtomicRmwAdd { ordering: $crate::Ordering, array_type_index: u32 } => visit_array_atomic_rmw_add (atomic rmw array add)
-                ArrayAtomicRmwSub { ordering: $crate::Ordering, array_type_index: u32 } => visit_array_atomic_rmw_sub (atomic rmw array sub)
-                ArrayAtomicRmwAnd { ordering: $crate::Ordering, array_type_index: u32 } => visit_array_atomic_rmw_and (atomic rmw array and)
-                ArrayAtomicRmwOr { ordering: $crate::Ordering, array_type_index: u32 } => visit_array_atomic_rmw_or (atomic rmw array or)
-                ArrayAtomicRmwXor { ordering: $crate::Ordering, array_type_index: u32 } => visit_array_atomic_rmw_xor (atomic rmw array xor)
-                ArrayAtomicRmwXchg { ordering: $crate::Ordering, array_type_index: u32 } => visit_array_atomic_rmw_xchg (arity 3 -> 1)
-                ArrayAtomicRmwCmpxchg { ordering: $crate::Ordering, array_type_index: u32 } => visit_array_atomic_rmw_cmpxchg (arity 4 -> 1)
+                GlobalAtomicGet { ordering: $crate::Ordering, global_index: ::wasm_types::GlobalIdx } => visit_global_atomic_get (arity 0 -> 1)
+                GlobalAtomicSet { ordering: $crate::Ordering, global_index: ::wasm_types::GlobalIdx } => visit_global_atomic_set (arity 1 -> 0)
+                GlobalAtomicRmwAdd { ordering: $crate::Ordering, global_index: ::wasm_types::GlobalIdx } => visit_global_atomic_rmw_add (unary atomic global)
+                GlobalAtomicRmwSub { ordering: $crate::Ordering, global_index: ::wasm_types::GlobalIdx } => visit_global_atomic_rmw_sub (unary atomic global)
+                GlobalAtomicRmwAnd { ordering: $crate::Ordering, global_index: ::wasm_types::GlobalIdx } => visit_global_atomic_rmw_and (unary atomic global)
+                GlobalAtomicRmwOr { ordering: $crate::Ordering, global_index: ::wasm_types::GlobalIdx } => visit_global_atomic_rmw_or (unary atomic global)
+                GlobalAtomicRmwXor { ordering: $crate::Ordering, global_index: ::wasm_types::GlobalIdx } => visit_global_atomic_rmw_xor (unary atomic global)
+                GlobalAtomicRmwXchg { ordering: $crate::Ordering, global_index: ::wasm_types::GlobalIdx } => visit_global_atomic_rmw_xchg (arity 1 -> 1)
+                GlobalAtomicRmwCmpxchg { ordering: $crate::Ordering, global_index: ::wasm_types::GlobalIdx } => visit_global_atomic_rmw_cmpxchg (arity 2 -> 1)
+                TableAtomicGet { ordering: $crate::Ordering, table_index: ::wasm_types::TableIdx } => visit_table_atomic_get (arity 1 -> 1)
+                TableAtomicSet { ordering: $crate::Ordering, table_index: ::wasm_types::TableIdx } => visit_table_atomic_set (arity 2 -> 0)
+                TableAtomicRmwXchg { ordering: $crate::Ordering, table_index: ::wasm_types::TableIdx } => visit_table_atomic_rmw_xchg (arity 2 -> 1)
+                TableAtomicRmwCmpxchg { ordering: $crate::Ordering, table_index: ::wasm_types::TableIdx } => visit_table_atomic_rmw_cmpxchg (arity 3 -> 1)
+                StructAtomicGet { ordering: $crate::Ordering, struct_type_index: ::wasm_types::TypeIdx, field_index: ::wasm_types::FieldIdx  } => visit_struct_atomic_get (arity 1 -> 1)
+                StructAtomicGetS { ordering: $crate::Ordering, struct_type_index: ::wasm_types::TypeIdx, field_index: ::wasm_types::FieldIdx  } => visit_struct_atomic_get_s (arity 1 -> 1)
+                StructAtomicGetU { ordering: $crate::Ordering, struct_type_index: ::wasm_types::TypeIdx, field_index: ::wasm_types::FieldIdx  } => visit_struct_atomic_get_u (arity 1 -> 1)
+                StructAtomicSet { ordering: $crate::Ordering, struct_type_index: ::wasm_types::TypeIdx, field_index: ::wasm_types::FieldIdx  } => visit_struct_atomic_set (arity 2 -> 0)
+                StructAtomicRmwAdd { ordering: $crate::Ordering, struct_type_index: ::wasm_types::TypeIdx, field_index: ::wasm_types::FieldIdx  } => visit_struct_atomic_rmw_add (atomic rmw struct add)
+                StructAtomicRmwSub { ordering: $crate::Ordering, struct_type_index: ::wasm_types::TypeIdx, field_index: ::wasm_types::FieldIdx  } => visit_struct_atomic_rmw_sub (atomic rmw struct sub)
+                StructAtomicRmwAnd { ordering: $crate::Ordering, struct_type_index: ::wasm_types::TypeIdx, field_index: ::wasm_types::FieldIdx  } => visit_struct_atomic_rmw_and (atomic rmw struct and)
+                StructAtomicRmwOr { ordering: $crate::Ordering, struct_type_index: ::wasm_types::TypeIdx, field_index: ::wasm_types::FieldIdx  } => visit_struct_atomic_rmw_or (atomic rmw struct or)
+                StructAtomicRmwXor { ordering: $crate::Ordering, struct_type_index: ::wasm_types::TypeIdx, field_index: ::wasm_types::FieldIdx  } => visit_struct_atomic_rmw_xor (atomic rmw struct xor)
+                StructAtomicRmwXchg { ordering: $crate::Ordering, struct_type_index: ::wasm_types::TypeIdx, field_index: ::wasm_types::FieldIdx  } => visit_struct_atomic_rmw_xchg (arity 2 -> 1)
+                StructAtomicRmwCmpxchg { ordering: $crate::Ordering, struct_type_index: ::wasm_types::TypeIdx, field_index: ::wasm_types::FieldIdx  } => visit_struct_atomic_rmw_cmpxchg (arity 3 -> 1)
+                ArrayAtomicGet { ordering: $crate::Ordering, array_type_index: ::wasm_types::TypeIdx } => visit_array_atomic_get (arity 2 -> 1)
+                ArrayAtomicGetS { ordering: $crate::Ordering, array_type_index: ::wasm_types::TypeIdx } => visit_array_atomic_get_s (arity 2 -> 1)
+                ArrayAtomicGetU { ordering: $crate::Ordering, array_type_index: ::wasm_types::TypeIdx } => visit_array_atomic_get_u (arity 2 -> 1)
+                ArrayAtomicSet { ordering: $crate::Ordering, array_type_index: ::wasm_types::TypeIdx } => visit_array_atomic_set (arity 3 -> 0)
+                ArrayAtomicRmwAdd { ordering: $crate::Ordering, array_type_index: ::wasm_types::TypeIdx } => visit_array_atomic_rmw_add (atomic rmw array add)
+                ArrayAtomicRmwSub { ordering: $crate::Ordering, array_type_index: ::wasm_types::TypeIdx } => visit_array_atomic_rmw_sub (atomic rmw array sub)
+                ArrayAtomicRmwAnd { ordering: $crate::Ordering, array_type_index: ::wasm_types::TypeIdx } => visit_array_atomic_rmw_and (atomic rmw array and)
+                ArrayAtomicRmwOr { ordering: $crate::Ordering, array_type_index: ::wasm_types::TypeIdx } => visit_array_atomic_rmw_or (atomic rmw array or)
+                ArrayAtomicRmwXor { ordering: $crate::Ordering, array_type_index: ::wasm_types::TypeIdx } => visit_array_atomic_rmw_xor (atomic rmw array xor)
+                ArrayAtomicRmwXchg { ordering: $crate::Ordering, array_type_index: ::wasm_types::TypeIdx } => visit_array_atomic_rmw_xchg (arity 3 -> 1)
+                ArrayAtomicRmwCmpxchg { ordering: $crate::Ordering, array_type_index: ::wasm_types::TypeIdx } => visit_array_atomic_rmw_cmpxchg (arity 4 -> 1)
                 RefI31Shared => visit_ref_i31_shared (arity 1 -> 1)
             }
 
             // Typed Function references
             @function_references {
-                CallRef { type_index: u32 } => visit_call_ref (arity 1 type -> type)
-                ReturnCallRef { type_index: u32 } => visit_return_call_ref (arity 1 type -> 0)
+                CallRef { type_index: ::wasm_types::TypeIdx } => visit_call_ref (arity 1 type -> type)
+                ReturnCallRef { type_index: ::wasm_types::TypeIdx } => visit_return_call_ref (arity 1 type -> 0)
                 RefAsNonNull => visit_ref_as_non_null (arity 1 -> 1)
-                BrOnNull { relative_depth: u32 } => visit_br_on_null (arity 1 br -> 1 br)
-                BrOnNonNull { relative_depth: u32 } => visit_br_on_non_null (arity br -> br -1)
+                BrOnNull { relative_depth: ::wasm_types::LabelIdx } => visit_br_on_null (arity 1 br -> 1 br)
+                BrOnNonNull { relative_depth: ::wasm_types::LabelIdx } => visit_br_on_non_null (arity br -> br -1)
             }
 
             // Stack switching
             @stack_switching {
-                ContNew { cont_type_index: u32 } => visit_cont_new (arity 1 -> 1)
-                ContBind { argument_index: u32, result_index: u32 } => visit_cont_bind (arity type_diff 1 -> 1)
-                Suspend { tag_index: u32 } => visit_suspend (arity tag -> tag)
-                Resume { cont_type_index: u32, resume_table: $crate::ResumeTable } => visit_resume (arity 1 type -> type)
-                ResumeThrow { cont_type_index: u32, tag_index: u32, resume_table: $crate::ResumeTable } => visit_resume_throw (arity 1 tag -> type)
-                Switch { cont_type_index: u32, tag_index: u32 } => visit_switch (arity type -> ~switch)
+                ContNew { cont_type_index: ::wasm_types::TypeIdx } => visit_cont_new (arity 1 -> 1)
+                ContBind { argument_index: ::wasm_types::TypeIdx, result_index: ::wasm_types::TypeIdx } => visit_cont_bind (arity type_diff 1 -> 1)
+                Suspend { tag_index: ::wasm_types::TagIdx } => visit_suspend (arity tag -> tag)
+                Resume { cont_type_index: ::wasm_types::TypeIdx, resume_table: $crate::ResumeTable } => visit_resume (arity 1 type -> type)
+                ResumeThrow { cont_type_index: ::wasm_types::TypeIdx, tag_index: ::wasm_types::TagIdx, resume_table: $crate::ResumeTable } => visit_resume_throw (arity 1 tag -> type)
+                Switch { cont_type_index: ::wasm_types::TypeIdx, tag_index: ::wasm_types::TagIdx } => visit_switch (arity type -> ~switch)
             }
 
             @wide_arithmetic {

--- a/crates/wasmparser/src/parser.rs
+++ b/crates/wasmparser/src/parser.rs
@@ -17,6 +17,7 @@ use crate::{
 use core::fmt;
 use core::iter;
 use core::ops::Range;
+use wasm_types::FuncIdx;
 
 pub(crate) const WASM_MODULE_VERSION: u16 = 0x1;
 
@@ -151,7 +152,7 @@ pub enum Payload<'a> {
     /// A module start section was received.
     StartSection {
         /// The start function index
-        func: u32,
+        func: FuncIdx,
         /// The range of bytes that specify the `func` field, specified in
         /// offsets relative to the start of the byte stream.
         range: Range<usize>,

--- a/crates/wasmparser/src/readers.rs
+++ b/crates/wasmparser/src/readers.rs
@@ -17,6 +17,11 @@ use crate::{BinaryReader, BinaryReaderError, Result};
 use ::core::fmt;
 use ::core::marker;
 use ::core::ops::Range;
+use wasm_types::{
+    AbsoluteLabelIdx, ComponentFuncIdx, ComponentIdx, ComponentInstanceIdx, ComponentTypeIdx,
+    ComponentValueIdx, CoreInstanceIdx, CoreModuleIdx, DataIdx, ElemIdx, FieldIdx, FuncIdx,
+    GlobalIdx, LabelIdx, LocalIdx, MemIdx, TableIdx, TagIdx, TypeIdx,
+};
 
 #[cfg(feature = "component-model")]
 mod component;
@@ -53,6 +58,120 @@ impl<'a> FromReader<'a> for bool {
 impl<'a> FromReader<'a> for u32 {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
         reader.read_var_u32()
+    }
+}
+
+impl<'a> FromReader<'a> for TypeIdx {
+    fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        reader.read_typeidx()
+    }
+}
+
+impl<'a> FromReader<'a> for FuncIdx {
+    fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        reader.read_funcidx()
+    }
+}
+
+impl<'a> FromReader<'a> for TableIdx {
+    fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        reader.read_tableidx()
+    }
+}
+
+impl<'a> FromReader<'a> for MemIdx {
+    fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        reader.read_memidx()
+    }
+}
+
+impl<'a> FromReader<'a> for TagIdx {
+    fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        reader.read_tagidx()
+    }
+}
+
+impl<'a> FromReader<'a> for GlobalIdx {
+    fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        reader.read_globalidx()
+    }
+}
+
+impl<'a> FromReader<'a> for ElemIdx {
+    fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        reader.read_elemidx()
+    }
+}
+
+impl<'a> FromReader<'a> for DataIdx {
+    fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        reader.read_dataidx()
+    }
+}
+
+impl<'a> FromReader<'a> for LocalIdx {
+    fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        reader.read_localidx()
+    }
+}
+
+impl<'a> FromReader<'a> for LabelIdx {
+    fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        reader.read_labelidx()
+    }
+}
+
+impl<'a> FromReader<'a> for FieldIdx {
+    fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        reader.read_fieldidx()
+    }
+}
+
+impl<'a> FromReader<'a> for AbsoluteLabelIdx {
+    fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        reader.read_absolute_label_idx()
+    }
+}
+
+impl<'a> FromReader<'a> for CoreModuleIdx {
+    fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        reader.read_core_module_idx()
+    }
+}
+
+impl<'a> FromReader<'a> for CoreInstanceIdx {
+    fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        reader.read_core_instance_idx()
+    }
+}
+
+impl<'a> FromReader<'a> for ComponentTypeIdx {
+    fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        reader.read_component_type_idx()
+    }
+}
+
+impl<'a> FromReader<'a> for ComponentFuncIdx {
+    fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        reader.read_component_func_idx()
+    }
+}
+
+impl<'a> FromReader<'a> for ComponentIdx {
+    fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        reader.read_component_idx()
+    }
+}
+
+impl<'a> FromReader<'a> for ComponentInstanceIdx {
+    fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        reader.read_component_instance_idx()
+    }
+}
+
+impl<'a> FromReader<'a> for ComponentValueIdx {
+    fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
+        reader.read_component_value_idx()
     }
 }
 

--- a/crates/wasmparser/src/readers/component/aliases.rs
+++ b/crates/wasmparser/src/readers/component/aliases.rs
@@ -1,3 +1,5 @@
+use wasm_types::{ComponentInstanceIdx, CoreInstanceIdx};
+
 use crate::{BinaryReader, ComponentExternalKind, ExternalKind, FromReader, Result};
 
 /// Represents the kind of an outer alias in a WebAssembly component.
@@ -21,7 +23,7 @@ pub enum ComponentAlias<'a> {
         /// The alias kind.
         kind: ComponentExternalKind,
         /// The instance index.
-        instance_index: u32,
+        instance_index: ComponentInstanceIdx,
         /// The export name.
         name: &'a str,
     },
@@ -30,7 +32,7 @@ pub enum ComponentAlias<'a> {
         /// The alias kind.
         kind: ExternalKind,
         /// The instance index.
-        instance_index: u32,
+        instance_index: CoreInstanceIdx,
         /// The export name.
         name: &'a str,
     },
@@ -62,7 +64,7 @@ impl<'a> FromReader<'a> for ComponentAlias<'a> {
         Ok(match reader.read_u8()? {
             0x00 => ComponentAlias::InstanceExport {
                 kind: ComponentExternalKind::from_bytes(byte1, byte2, offset)?,
-                instance_index: reader.read_var_u32()?,
+                instance_index: reader.read_component_instance_idx()?,
                 name: reader.read_string()?,
             },
             0x01 => ComponentAlias::CoreInstanceExport {
@@ -76,7 +78,7 @@ impl<'a> FromReader<'a> for ComponentAlias<'a> {
                     })?,
                     offset,
                 )?,
-                instance_index: reader.read_var_u32()?,
+                instance_index: reader.read_core_instance_idx()?,
                 name: reader.read_string()?,
             },
             0x02 => ComponentAlias::Outer {

--- a/crates/wasmparser/src/readers/component/imports.rs
+++ b/crates/wasmparser/src/readers/component/imports.rs
@@ -1,12 +1,13 @@
 use crate::{
     BinaryReader, ComponentExternalKind, ComponentValType, FromReader, Result, SectionLimited,
 };
+use wasm_types::{ComponentTypeIdx, TypeIdx};
 
 /// Represents the type bounds for imports and exports.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum TypeBounds {
     /// The type is bounded by equality.
-    Eq(u32),
+    Eq(ComponentTypeIdx),
     /// A fresh resource type,
     SubResource,
 }
@@ -27,11 +28,11 @@ pub enum ComponentTypeRef {
     /// The reference is to a core module type.
     ///
     /// The index is expected to be core type index to a core module type.
-    Module(u32),
+    Module(TypeIdx),
     /// The reference is to a function type.
     ///
     /// The index is expected to be a type index to a function type.
-    Func(u32),
+    Func(ComponentTypeIdx),
     /// The reference is to a value type.
     Value(ComponentValType),
     /// The reference is to a bounded type.
@@ -41,11 +42,11 @@ pub enum ComponentTypeRef {
     /// The reference is to an instance type.
     ///
     /// The index is a type index to an instance type.
-    Instance(u32),
+    Instance(ComponentTypeIdx),
     /// The reference is to a component type.
     ///
     /// The index is a type index to a component type.
-    Component(u32),
+    Component(ComponentTypeIdx),
 }
 
 impl ComponentTypeRef {

--- a/crates/wasmparser/src/readers/component/instances.rs
+++ b/crates/wasmparser/src/readers/component/instances.rs
@@ -1,3 +1,5 @@
+use wasm_types::{ComponentIdx, CoreModuleIdx};
+
 use crate::limits::{MAX_WASM_INSTANTIATION_ARGS, MAX_WASM_INSTANTIATION_EXPORTS};
 use crate::prelude::*;
 use crate::{
@@ -29,7 +31,7 @@ pub enum Instance<'a> {
     /// The instance is from instantiating a WebAssembly module.
     Instantiate {
         /// The module index.
-        module_index: u32,
+        module_index: CoreModuleIdx,
         /// The module's instantiation arguments.
         args: Box<[InstantiationArg<'a>]>,
     },
@@ -56,7 +58,7 @@ impl<'a> FromReader<'a> for Instance<'a> {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
         Ok(match reader.read_u8()? {
             0x00 => Instance::Instantiate {
-                module_index: reader.read_var_u32()?,
+                module_index: reader.read_core_module_idx()?,
                 args: reader
                     .read_iter(MAX_WASM_INSTANTIATION_ARGS, "core instantiation arguments")?
                     .collect::<Result<_>>()?,
@@ -107,7 +109,7 @@ pub enum ComponentInstance<'a> {
     /// The instance is from instantiating a WebAssembly component.
     Instantiate {
         /// The component index.
-        component_index: u32,
+        component_index: ComponentIdx,
         /// The component's instantiation arguments.
         args: Box<[ComponentInstantiationArg<'a>]>,
     },
@@ -134,7 +136,7 @@ impl<'a> FromReader<'a> for ComponentInstance<'a> {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
         Ok(match reader.read_u8()? {
             0x00 => ComponentInstance::Instantiate {
-                component_index: reader.read_var_u32()?,
+                component_index: reader.read_component_idx()?,
                 args: reader
                     .read_iter(MAX_WASM_INSTANTIATION_ARGS, "instantiation arguments")?
                     .collect::<Result<_>>()?,

--- a/crates/wasmparser/src/readers/component/names.rs
+++ b/crates/wasmparser/src/readers/component/names.rs
@@ -1,5 +1,9 @@
 use crate::{BinaryReader, BinaryReaderError, NameMap, Result, Subsection, Subsections};
 use core::ops::Range;
+use wasm_types::{
+    ComponentFuncIdx, ComponentIdx, ComponentInstanceIdx, ComponentTypeIdx, ComponentValueIdx,
+    CoreInstanceIdx, CoreModuleIdx, FuncIdx, GlobalIdx, MemIdx, TableIdx, TypeIdx,
+};
 
 /// Type used to iterate and parse the contents of the `component-name` custom
 /// section in compnents, similar to the `name` section of core modules.
@@ -13,18 +17,18 @@ pub enum ComponentName<'a> {
         name: &'a str,
         name_range: Range<usize>,
     },
-    CoreFuncs(NameMap<'a>),
-    CoreGlobals(NameMap<'a>),
-    CoreMemories(NameMap<'a>),
-    CoreTables(NameMap<'a>),
-    CoreModules(NameMap<'a>),
-    CoreInstances(NameMap<'a>),
-    CoreTypes(NameMap<'a>),
-    Types(NameMap<'a>),
-    Instances(NameMap<'a>),
-    Components(NameMap<'a>),
-    Funcs(NameMap<'a>),
-    Values(NameMap<'a>),
+    CoreFuncs(NameMap<'a, FuncIdx>),
+    CoreGlobals(NameMap<'a, GlobalIdx>),
+    CoreMemories(NameMap<'a, MemIdx>),
+    CoreTables(NameMap<'a, TableIdx>),
+    CoreModules(NameMap<'a, CoreModuleIdx>),
+    CoreInstances(NameMap<'a, CoreInstanceIdx>),
+    CoreTypes(NameMap<'a, TypeIdx>),
+    Types(NameMap<'a, ComponentTypeIdx>),
+    Instances(NameMap<'a, ComponentInstanceIdx>),
+    Components(NameMap<'a, ComponentIdx>),
+    Funcs(NameMap<'a, ComponentFuncIdx>),
+    Values(NameMap<'a, ComponentValueIdx>),
 
     /// An unknown [name subsection](https://webassembly.github.io/spec/core/appendix/custom.html#subsections).
     Unknown {
@@ -36,6 +40,10 @@ pub enum ComponentName<'a> {
         /// stream, that the contents of this subsection reside in.
         range: Range<usize>,
     },
+}
+
+fn name_map<'a, I>(reader: &BinaryReader<'a>) -> Result<NameMap<'a, I>> {
+    NameMap::new(reader.shrink())
 }
 
 impl<'a> Subsection<'a> for ComponentName<'a> {
@@ -56,29 +64,15 @@ impl<'a> Subsection<'a> for ComponentName<'a> {
                     name_range: offset..reader.original_position(),
                 }
             }
-            1 => {
-                let ctor: fn(NameMap<'a>) -> ComponentName<'a> = match reader.read_u8()? {
-                    0x00 => match reader.read_u8()? {
-                        0x00 => ComponentName::CoreFuncs,
-                        0x01 => ComponentName::CoreTables,
-                        0x02 => ComponentName::CoreMemories,
-                        0x03 => ComponentName::CoreGlobals,
-                        0x10 => ComponentName::CoreTypes,
-                        0x11 => ComponentName::CoreModules,
-                        0x12 => ComponentName::CoreInstances,
-                        _ => {
-                            return Ok(ComponentName::Unknown {
-                                ty: 1,
-                                data,
-                                range: offset..offset + data.len(),
-                            });
-                        }
-                    },
-                    0x01 => ComponentName::Funcs,
-                    0x02 => ComponentName::Values,
-                    0x03 => ComponentName::Types,
-                    0x04 => ComponentName::Components,
-                    0x05 => ComponentName::Instances,
+            1 => match reader.read_u8()? {
+                0x00 => match reader.read_u8()? {
+                    0x00 => ComponentName::CoreFuncs(name_map(&reader)?),
+                    0x01 => ComponentName::CoreTables(name_map(&reader)?),
+                    0x02 => ComponentName::CoreMemories(name_map(&reader)?),
+                    0x03 => ComponentName::CoreGlobals(name_map(&reader)?),
+                    0x10 => ComponentName::CoreTypes(name_map(&reader)?),
+                    0x11 => ComponentName::CoreModules(name_map(&reader)?),
+                    0x12 => ComponentName::CoreInstances(name_map(&reader)?),
                     _ => {
                         return Ok(ComponentName::Unknown {
                             ty: 1,
@@ -86,9 +80,20 @@ impl<'a> Subsection<'a> for ComponentName<'a> {
                             range: offset..offset + data.len(),
                         });
                     }
-                };
-                ctor(NameMap::new(reader.shrink())?)
-            }
+                },
+                0x01 => ComponentName::Funcs(name_map(&reader)?),
+                0x02 => ComponentName::Values(name_map(&reader)?),
+                0x03 => ComponentName::Types(name_map(&reader)?),
+                0x04 => ComponentName::Components(name_map(&reader)?),
+                0x05 => ComponentName::Instances(name_map(&reader)?),
+                _ => {
+                    return Ok(ComponentName::Unknown {
+                        ty: 1,
+                        data,
+                        range: offset..offset + data.len(),
+                    });
+                }
+            },
             ty => ComponentName::Unknown {
                 ty,
                 data,

--- a/crates/wasmparser/src/readers/component/start.rs
+++ b/crates/wasmparser/src/readers/component/start.rs
@@ -1,23 +1,24 @@
 use crate::limits::{MAX_WASM_FUNCTION_RETURNS, MAX_WASM_START_ARGS};
 use crate::prelude::*;
 use crate::{BinaryReader, FromReader, Result};
+use wasm_types::{ComponentFuncIdx, ComponentValueIdx};
 
 /// Represents the start function in a WebAssembly component.
 #[derive(Debug, Clone)]
 pub struct ComponentStartFunction {
     /// The index to the start function.
-    pub func_index: u32,
+    pub func_index: ComponentFuncIdx,
     /// The start function arguments.
     ///
     /// The arguments are specified by value index.
-    pub arguments: Box<[u32]>,
+    pub arguments: Box<[ComponentValueIdx]>,
     /// The number of expected results for the start function.
     pub results: u32,
 }
 
 impl<'a> FromReader<'a> for ComponentStartFunction {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
-        let func_index = reader.read_var_u32()?;
+        let func_index = reader.read_component_func_idx()?;
         let arguments = reader
             .read_iter(MAX_WASM_START_ARGS, "start function arguments")?
             .collect::<Result<_>>()?;

--- a/crates/wasmparser/src/readers/component/types.rs
+++ b/crates/wasmparser/src/readers/component/types.rs
@@ -6,6 +6,7 @@ use crate::{
     FromReader, Import, Result, SectionLimited, TypeRef, ValType,
 };
 use core::fmt;
+use wasm_types::{ComponentTypeIdx, FuncIdx};
 
 /// Represents the kind of an outer core alias in a WebAssembly component.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -132,7 +133,7 @@ pub enum ComponentValType {
     /// The value type is a primitive type.
     Primitive(PrimitiveValType),
     /// The value type is a reference to a defined type.
-    Type(u32),
+    Type(ComponentTypeIdx),
 }
 
 impl<'a> FromReader<'a> for ComponentValType {
@@ -142,7 +143,9 @@ impl<'a> FromReader<'a> for ComponentValType {
             return Ok(ComponentValType::Primitive(ty));
         }
 
-        Ok(ComponentValType::Type(reader.read_var_s33()? as u32))
+        Ok(ComponentValType::Type(ComponentTypeIdx(
+            reader.read_var_s33()? as u32,
+        )))
     }
 }
 
@@ -263,7 +266,7 @@ pub enum ComponentType<'a> {
         rep: ValType,
         /// An optionally-specified destructor to use for when this resource is
         /// no longer needed.
-        dtor: Option<u32>,
+        dtor: Option<FuncIdx>,
     },
 }
 
@@ -502,9 +505,9 @@ pub enum ComponentDefinedType<'a> {
         err: Option<ComponentValType>,
     },
     /// An owned handle to a resource.
-    Own(u32),
+    Own(ComponentTypeIdx),
     /// A borrowed handle to a resource.
-    Borrow(u32),
+    Borrow(ComponentTypeIdx),
     /// A future type with the specified payload type.
     Future(Option<ComponentValType>),
     /// A stream type with the specified payload type.

--- a/crates/wasmparser/src/readers/core/branch_hinting.rs
+++ b/crates/wasmparser/src/readers/core/branch_hinting.rs
@@ -1,4 +1,5 @@
 use crate::{BinaryReader, FromReader, Result, SectionLimited};
+use wasm_types::FuncIdx;
 
 /// A reader for the `metadata.code.branch_hint` custom section.
 pub type BranchHintSectionReader<'a> = SectionLimited<'a, BranchHintFunction<'a>>;
@@ -9,14 +10,14 @@ pub type BranchHintSectionReader<'a> = SectionLimited<'a, BranchHintFunction<'a>
 #[derive(Debug, Clone)]
 pub struct BranchHintFunction<'a> {
     /// The function that these branch hints apply to.
-    pub func: u32,
+    pub func: FuncIdx,
     /// The branch hints available for this function.
     pub hints: SectionLimited<'a, BranchHint>,
 }
 
 impl<'a> FromReader<'a> for BranchHintFunction<'a> {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
-        let func = reader.read_var_u32()?;
+        let func = reader.read_funcidx()?;
         // FIXME(#188) ideally wouldn't have to do skips here
         let hints = reader.skip(|reader| {
             let items_count = reader.read_var_u32()?;

--- a/crates/wasmparser/src/readers/core/data.rs
+++ b/crates/wasmparser/src/readers/core/data.rs
@@ -15,6 +15,7 @@
 
 use crate::{BinaryReader, BinaryReaderError, ConstExpr, FromReader, Result, SectionLimited};
 use core::ops::Range;
+use wasm_types::MemIdx;
 
 /// Represents a data segment in a core WebAssembly module.
 #[derive(Debug, Clone)]
@@ -35,7 +36,7 @@ pub enum DataKind<'a> {
     /// The data segment is active.
     Active {
         /// The memory index for the data segment.
-        memory_index: u32,
+        memory_index: MemIdx,
         /// The initialization expression for the data segment.
         offset_expr: ConstExpr<'a>,
     },
@@ -65,11 +66,11 @@ impl<'a> FromReader<'a> for Data<'a> {
         let kind = match flags {
             1 => DataKind::Passive,
             0 | 2 => {
-                let memory_index = if flags == 0 {
+                let memory_index = MemIdx(if flags == 0 {
                     0
                 } else {
                     reader.read_var_u32()?
-                };
+                });
                 let offset_expr = reader.read()?;
                 DataKind::Active {
                     memory_index,

--- a/crates/wasmparser/src/readers/core/elements.rs
+++ b/crates/wasmparser/src/readers/core/elements.rs
@@ -18,6 +18,7 @@ use crate::{
     SectionLimited,
 };
 use core::ops::Range;
+use wasm_types::{FuncIdx, TableIdx};
 
 /// Represents a core WebAssembly element segment.
 #[derive(Clone)]
@@ -38,7 +39,7 @@ pub enum ElementKind<'a> {
     /// The element segment is active.
     Active {
         /// The index of the table being initialized.
-        table_index: Option<u32>,
+        table_index: Option<TableIdx>,
         /// The initial expression of the element segment.
         offset_expr: ConstExpr<'a>,
     },
@@ -50,7 +51,7 @@ pub enum ElementKind<'a> {
 #[derive(Clone)]
 pub enum ElementItems<'a> {
     /// This element contains function indices.
-    Functions(SectionLimited<'a, u32>),
+    Functions(SectionLimited<'a, FuncIdx>),
     /// This element contains constant expressions used to initialize the table.
     Expressions(RefType, SectionLimited<'a, ConstExpr<'a>>),
 }
@@ -91,7 +92,7 @@ impl<'a> FromReader<'a> for Element<'a> {
             let table_index = if flags & 0b010 == 0 {
                 None
             } else {
-                Some(reader.read_var_u32()?)
+                Some(reader.read_tableidx()?)
             };
             let offset_expr = reader.read()?;
             ElementKind::Active {

--- a/crates/wasmparser/src/readers/core/functions.rs
+++ b/crates/wasmparser/src/readers/core/functions.rs
@@ -13,5 +13,7 @@
  * limitations under the License.
  */
 
+use wasm_types::TypeIdx;
+
 /// A reader for the function section of a WebAssembly module.
-pub type FunctionSectionReader<'a> = crate::SectionLimited<'a, u32>;
+pub type FunctionSectionReader<'a> = crate::SectionLimited<'a, TypeIdx>;

--- a/crates/wasmparser/src/readers/core/imports.rs
+++ b/crates/wasmparser/src/readers/core/imports.rs
@@ -17,6 +17,7 @@ use crate::{
     BinaryReader, ExternalKind, FromReader, GlobalType, MemoryType, Result, SectionLimited,
     TableType, TagType,
 };
+use wasm_types::TypeIdx;
 
 /// Represents a reference to a type definition in a WebAssembly module.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -24,7 +25,7 @@ pub enum TypeRef {
     /// The type is a function.
     ///
     /// The value is an index into the type section.
-    Func(u32),
+    Func(TypeIdx),
     /// The type is a table.
     Table(TableType),
     /// The type is a memory.
@@ -66,7 +67,7 @@ impl<'a> FromReader<'a> for Import<'a> {
 impl<'a> FromReader<'a> for TypeRef {
     fn from_reader(reader: &mut BinaryReader<'a>) -> Result<Self> {
         Ok(match reader.read()? {
-            ExternalKind::Func => TypeRef::Func(reader.read_var_u32()?),
+            ExternalKind::Func => TypeRef::Func(reader.read_typeidx()?),
             ExternalKind::Table => TypeRef::Table(reader.read()?),
             ExternalKind::Memory => TypeRef::Memory(reader.read()?),
             ExternalKind::Global => TypeRef::Global(reader.read()?),

--- a/crates/wasmparser/src/readers/core/linking.rs
+++ b/crates/wasmparser/src/readers/core/linking.rs
@@ -3,6 +3,7 @@ use crate::{
     BinaryReader, BinaryReaderError, FromReader, Result, SectionLimited, Subsection, Subsections,
 };
 use core::ops::Range;
+use wasm_types::{FuncIdx, GlobalIdx, TableIdx};
 
 bitflags::bitflags! {
     /// Flags for WebAssembly symbols.
@@ -229,7 +230,7 @@ pub enum SymbolInfo<'a> {
         /// The flags for the symbol.
         flags: SymbolFlags,
         /// The index of the function corresponding to this symbol.
-        index: u32,
+        index: FuncIdx,
         /// The name for the function, if it is defined or uses an explicit name.
         name: Option<&'a str>,
     },
@@ -247,7 +248,7 @@ pub enum SymbolInfo<'a> {
         /// The flags for the symbol.
         flags: SymbolFlags,
         /// The index of the global corresponding to this symbol.
-        index: u32,
+        index: GlobalIdx,
         /// The name for the global, if it is defined or uses an explicit name.
         name: Option<&'a str>,
     },
@@ -272,7 +273,7 @@ pub enum SymbolInfo<'a> {
         /// The flags for the symbol.
         flags: SymbolFlags,
         /// The index of the table corresponding to this symbol.
-        index: u32,
+        index: TableIdx,
         /// The name for the table, if it is defined or uses an explicit name.
         name: Option<&'a str>,
     },
@@ -303,10 +304,22 @@ impl<'a> FromReader<'a> for SymbolInfo<'a> {
                     false => None,
                 };
                 Ok(match kind {
-                    SYMTAB_FUNCTION => Self::Func { flags, index, name },
-                    SYMTAB_GLOBAL => Self::Global { flags, index, name },
+                    SYMTAB_FUNCTION => Self::Func {
+                        flags,
+                        index: FuncIdx(index),
+                        name,
+                    },
+                    SYMTAB_GLOBAL => Self::Global {
+                        flags,
+                        index: GlobalIdx(index),
+                        name,
+                    },
                     SYMTAB_EVENT => Self::Event { flags, index, name },
-                    SYMTAB_TABLE => Self::Table { flags, index, name },
+                    SYMTAB_TABLE => Self::Table {
+                        flags,
+                        index: TableIdx(index),
+                        name,
+                    },
                     _ => unreachable!(),
                 })
             }

--- a/crates/wasmparser/src/readers/core/tags.rs
+++ b/crates/wasmparser/src/readers/core/tags.rs
@@ -26,7 +26,7 @@ impl<'a> FromReader<'a> for TagType {
         }
         Ok(TagType {
             kind: TagKind::Exception,
-            func_type_idx: reader.read_var_u32()?,
+            func_type_idx: reader.read_typeidx()?,
         })
     }
 }

--- a/crates/wasmparser/src/resources.rs
+++ b/crates/wasmparser/src/resources.rs
@@ -17,6 +17,7 @@ use crate::{
     types::CoreTypeId, BinaryReaderError, FuncType, GlobalType, HeapType, MemoryType, RefType,
     SubType, TableType, ValType, WasmFeatures,
 };
+use wasm_types::{ElemIdx, FuncIdx, GlobalIdx, MemIdx, TableIdx, TagIdx, TypeIdx};
 
 /// Types that qualify as Wasm validation database.
 ///
@@ -30,39 +31,39 @@ pub trait WasmModuleResources {
     /// Returns the table at given index if any.
     ///
     /// The table element type must be canonicalized.
-    fn table_at(&self, at: u32) -> Option<TableType>;
+    fn table_at(&self, at: TableIdx) -> Option<TableType>;
 
     /// Returns the linear memory at given index.
-    fn memory_at(&self, at: u32) -> Option<MemoryType>;
+    fn memory_at(&self, at: MemIdx) -> Option<MemoryType>;
 
     /// Returns the tag at given index.
     ///
     /// The tag's function type must be canonicalized.
-    fn tag_at(&self, at: u32) -> Option<&FuncType>;
+    fn tag_at(&self, at: TagIdx) -> Option<&FuncType>;
 
     /// Returns the global variable at given index.
     ///
     /// The global's value type must be canonicalized.
-    fn global_at(&self, at: u32) -> Option<GlobalType>;
+    fn global_at(&self, at: GlobalIdx) -> Option<GlobalType>;
 
     /// Returns the `SubType` associated with the given type index.
     ///
     /// The sub type must be canonicalized.
-    fn sub_type_at(&self, type_index: u32) -> Option<&SubType>;
+    fn sub_type_at(&self, type_index: TypeIdx) -> Option<&SubType>;
 
     /// Returns the `SubType` associated with the given core type id.
     fn sub_type_at_id(&self, id: CoreTypeId) -> &SubType;
 
     /// Returns the type ID associated with the given function index.
-    fn type_id_of_function(&self, func_idx: u32) -> Option<CoreTypeId>;
+    fn type_id_of_function(&self, func_idx: FuncIdx) -> Option<CoreTypeId>;
 
     /// Returns the type index associated with the given function index.
-    fn type_index_of_function(&self, func_index: u32) -> Option<u32>;
+    fn type_index_of_function(&self, func_index: FuncIdx) -> Option<TypeIdx>;
 
     /// Returns the element type at the given index.
     ///
     /// The `RefType` must be canonicalized.
-    fn element_type_at(&self, at: u32) -> Option<RefType>;
+    fn element_type_at(&self, at: ElemIdx) -> Option<RefType>;
 
     /// Is `a` a subtype of `b`?
     fn is_subtype(&self, a: ValType, b: ValType) -> bool;
@@ -128,35 +129,35 @@ pub trait WasmModuleResources {
 
     /// Returns whether the function index is referenced in the module anywhere
     /// outside of the start/function sections.
-    fn is_function_referenced(&self, idx: u32) -> bool;
+    fn is_function_referenced(&self, idx: FuncIdx) -> bool;
 }
 
 impl<T> WasmModuleResources for &'_ T
 where
     T: ?Sized + WasmModuleResources,
 {
-    fn table_at(&self, at: u32) -> Option<TableType> {
+    fn table_at(&self, at: TableIdx) -> Option<TableType> {
         T::table_at(self, at)
     }
-    fn memory_at(&self, at: u32) -> Option<MemoryType> {
+    fn memory_at(&self, at: MemIdx) -> Option<MemoryType> {
         T::memory_at(self, at)
     }
-    fn tag_at(&self, at: u32) -> Option<&FuncType> {
+    fn tag_at(&self, at: TagIdx) -> Option<&FuncType> {
         T::tag_at(self, at)
     }
-    fn global_at(&self, at: u32) -> Option<GlobalType> {
+    fn global_at(&self, at: GlobalIdx) -> Option<GlobalType> {
         T::global_at(self, at)
     }
-    fn sub_type_at(&self, at: u32) -> Option<&SubType> {
+    fn sub_type_at(&self, at: TypeIdx) -> Option<&SubType> {
         T::sub_type_at(self, at)
     }
     fn sub_type_at_id(&self, at: CoreTypeId) -> &SubType {
         T::sub_type_at_id(self, at)
     }
-    fn type_id_of_function(&self, func_idx: u32) -> Option<CoreTypeId> {
+    fn type_id_of_function(&self, func_idx: FuncIdx) -> Option<CoreTypeId> {
         T::type_id_of_function(self, func_idx)
     }
-    fn type_index_of_function(&self, func_idx: u32) -> Option<u32> {
+    fn type_index_of_function(&self, func_idx: FuncIdx) -> Option<TypeIdx> {
         T::type_index_of_function(self, func_idx)
     }
     fn check_heap_type(&self, t: &mut HeapType, offset: usize) -> Result<(), BinaryReaderError> {
@@ -165,7 +166,7 @@ where
     fn top_type(&self, heap_type: &HeapType) -> HeapType {
         T::top_type(self, heap_type)
     }
-    fn element_type_at(&self, at: u32) -> Option<RefType> {
+    fn element_type_at(&self, at: ElemIdx) -> Option<RefType> {
         T::element_type_at(self, at)
     }
     fn is_subtype(&self, a: ValType, b: ValType) -> bool {
@@ -180,7 +181,7 @@ where
     fn data_count(&self) -> Option<u32> {
         T::data_count(self)
     }
-    fn is_function_referenced(&self, idx: u32) -> bool {
+    fn is_function_referenced(&self, idx: FuncIdx) -> bool {
         T::is_function_referenced(self, idx)
     }
 }
@@ -189,23 +190,23 @@ impl<T> WasmModuleResources for alloc::sync::Arc<T>
 where
     T: WasmModuleResources,
 {
-    fn table_at(&self, at: u32) -> Option<TableType> {
+    fn table_at(&self, at: TableIdx) -> Option<TableType> {
         T::table_at(self, at)
     }
 
-    fn memory_at(&self, at: u32) -> Option<MemoryType> {
+    fn memory_at(&self, at: MemIdx) -> Option<MemoryType> {
         T::memory_at(self, at)
     }
 
-    fn tag_at(&self, at: u32) -> Option<&FuncType> {
+    fn tag_at(&self, at: TagIdx) -> Option<&FuncType> {
         T::tag_at(self, at)
     }
 
-    fn global_at(&self, at: u32) -> Option<GlobalType> {
+    fn global_at(&self, at: GlobalIdx) -> Option<GlobalType> {
         T::global_at(self, at)
     }
 
-    fn sub_type_at(&self, type_idx: u32) -> Option<&SubType> {
+    fn sub_type_at(&self, type_idx: TypeIdx) -> Option<&SubType> {
         T::sub_type_at(self, type_idx)
     }
 
@@ -213,11 +214,11 @@ where
         T::sub_type_at_id(self, id)
     }
 
-    fn type_id_of_function(&self, func_idx: u32) -> Option<CoreTypeId> {
+    fn type_id_of_function(&self, func_idx: FuncIdx) -> Option<CoreTypeId> {
         T::type_id_of_function(self, func_idx)
     }
 
-    fn type_index_of_function(&self, func_idx: u32) -> Option<u32> {
+    fn type_index_of_function(&self, func_idx: FuncIdx) -> Option<TypeIdx> {
         T::type_index_of_function(self, func_idx)
     }
 
@@ -229,7 +230,7 @@ where
         T::top_type(self, heap_type)
     }
 
-    fn element_type_at(&self, at: u32) -> Option<RefType> {
+    fn element_type_at(&self, at: ElemIdx) -> Option<RefType> {
         T::element_type_at(self, at)
     }
 
@@ -249,7 +250,7 @@ where
         T::data_count(self)
     }
 
-    fn is_function_referenced(&self, idx: u32) -> bool {
+    fn is_function_referenced(&self, idx: FuncIdx) -> bool {
         T::is_function_referenced(self, idx)
     }
 }

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -22,6 +22,7 @@ use ::core::mem;
 use ::core::ops::Range;
 use ::core::sync::atomic::{AtomicUsize, Ordering};
 use alloc::sync::Arc;
+use wasm_types::FuncIdx;
 
 /// Test whether the given buffer contains a valid WebAssembly module or component,
 /// analogous to [`WebAssembly.validate`][js] in the JS API.
@@ -924,7 +925,7 @@ impl Validator {
     /// Validates [`Payload::StartSection`](crate::Payload).
     ///
     /// This method should only be called when parsing a module.
-    pub fn start_section(&mut self, func: u32, range: &Range<usize>) -> Result<()> {
+    pub fn start_section(&mut self, func: FuncIdx, range: &Range<usize>) -> Result<()> {
         let offset = range.start;
         self.state.ensure_module("start", offset)?;
         let state = self.module.as_mut().unwrap();

--- a/crates/wasmparser/src/validator/component_types.rs
+++ b/crates/wasmparser/src/validator/component_types.rs
@@ -15,6 +15,7 @@ use core::{
     hash::{Hash, Hasher},
     mem,
 };
+use wasm_types::TypeIdx;
 
 /// The maximum number of parameters in the canonical ABI that can be passed by value.
 ///
@@ -1259,10 +1260,10 @@ impl<'a> TypesRef<'a> {
     /// # Panics
     ///
     /// This will panic if the `index` provided is out of bounds.
-    pub fn core_type_at_in_component(&self, index: u32) -> ComponentCoreTypeId {
+    pub fn core_type_at_in_component(&self, index: TypeIdx) -> ComponentCoreTypeId {
         match &self.kind {
             TypesRefKind::Module(_) => panic!("use `component_type_at_in_module` instead"),
-            TypesRefKind::Component(component) => component.core_types[index as usize],
+            TypesRefKind::Component(component) => component.core_types[index],
         }
     }
 

--- a/crates/wasmparser/src/validator/func.rs
+++ b/crates/wasmparser/src/validator/func.rs
@@ -1,6 +1,7 @@
 use super::operators::{Frame, OperatorValidator, OperatorValidatorAllocations};
 use crate::{BinaryReader, Result, ValType, VisitOperator};
 use crate::{FunctionBody, ModuleArity, Operator, WasmFeatures, WasmModuleResources};
+use wasm_types::{FuncIdx, LocalIdx, TypeIdx};
 
 /// Resources necessary to perform validation of a function.
 ///
@@ -14,10 +15,10 @@ pub struct FuncToValidate<T> {
     /// Reusable, heap allocated resources to drive the Wasm validation.
     pub resources: T,
     /// The core Wasm function index being validated.
-    pub index: u32,
+    pub index: FuncIdx,
     /// The core Wasm type index of the function being validated,
     /// defining the results and parameters to the function.
-    pub ty: u32,
+    pub ty: TypeIdx,
     /// The Wasm features enabled to validate the function.
     pub features: WasmFeatures,
 }
@@ -60,7 +61,7 @@ impl<T: WasmModuleResources> FuncToValidate<T> {
 pub struct FuncValidator<T> {
     validator: OperatorValidator,
     resources: T,
-    index: u32,
+    index: FuncIdx,
 }
 
 /// External handle to the internal allocations used during function validation.
@@ -212,7 +213,7 @@ impl<T: WasmModuleResources> FuncValidator<T> {
 
     /// The index of the function within the module's function index space that
     /// is being validated.
-    pub fn index(&self) -> u32 {
+    pub fn index(&self) -> FuncIdx {
         self.index
     }
 
@@ -222,7 +223,7 @@ impl<T: WasmModuleResources> FuncValidator<T> {
     }
 
     /// Returns the type of the local variable at the given `index` if any.
-    pub fn get_local_type(&self, index: u32) -> Option<ValType> {
+    pub fn get_local_type(&self, index: LocalIdx) -> Option<ValType> {
         self.validator.locals.get(index)
     }
 
@@ -301,28 +302,28 @@ mod tests {
     }
 
     impl WasmModuleResources for EmptyResources {
-        fn table_at(&self, _at: u32) -> Option<crate::TableType> {
+        fn table_at(&self, _at: TableIdx) -> Option<crate::TableType> {
             todo!()
         }
-        fn memory_at(&self, _at: u32) -> Option<crate::MemoryType> {
+        fn memory_at(&self, _at: MemIdx) -> Option<crate::MemoryType> {
             todo!()
         }
-        fn tag_at(&self, _at: u32) -> Option<&crate::FuncType> {
+        fn tag_at(&self, _at: TagIdx) -> Option<&crate::FuncType> {
             todo!()
         }
-        fn global_at(&self, _at: u32) -> Option<crate::GlobalType> {
+        fn global_at(&self, _at: GlobalIdx) -> Option<crate::GlobalType> {
             todo!()
         }
-        fn sub_type_at(&self, _type_idx: u32) -> Option<&crate::SubType> {
+        fn sub_type_at(&self, _type_idx: CoreTypeId) -> Option<&crate::SubType> {
             Some(&self.0)
         }
         fn sub_type_at_id(&self, _id: CoreTypeId) -> &crate::SubType {
             todo!()
         }
-        fn type_id_of_function(&self, _at: u32) -> Option<CoreTypeId> {
+        fn type_id_of_function(&self, _at: FuncIdx) -> Option<CoreTypeId> {
             todo!()
         }
-        fn type_index_of_function(&self, _at: u32) -> Option<u32> {
+        fn type_index_of_function(&self, _at: FuncIdx) -> Option<TypeIdx> {
             todo!()
         }
         fn check_heap_type(&self, _t: &mut HeapType, _offset: usize) -> Result<()> {
@@ -331,7 +332,7 @@ mod tests {
         fn top_type(&self, _heap_type: &HeapType) -> HeapType {
             todo!()
         }
-        fn element_type_at(&self, _at: u32) -> Option<crate::RefType> {
+        fn element_type_at(&self, _at: ElemIdx) -> Option<crate::RefType> {
             todo!()
         }
         fn is_subtype(&self, _t1: ValType, _t2: ValType) -> bool {
@@ -346,7 +347,7 @@ mod tests {
         fn data_count(&self) -> Option<u32> {
             todo!()
         }
-        fn is_function_referenced(&self, _idx: u32) -> bool {
+        fn is_function_referenced(&self, _idx: FuncIdx) -> bool {
             todo!()
         }
     }

--- a/crates/wasmprinter/Cargo.toml
+++ b/crates/wasmprinter/Cargo.toml
@@ -18,7 +18,9 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+index_vec = { workspace = true }
 termcolor = { workspace = true }
+wasm-types = { workspace = true }
 wasmparser = { workspace = true, features = ['std', 'simd'] }
 
 [dev-dependencies]

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -22,10 +22,12 @@ workspace = true
 [dependencies]
 bumpalo = "3.14.0"
 gimli = { workspace = true, optional = true }
+index_vec = { workspace = true}
 leb128fmt = { workspace = true }
 memchr = "2.4.1"
 unicode-width = "0.2.0"
 wasm-encoder = { workspace = true, features = ['std'] }
+wasm-types = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/wast/src/component/alias.rs
+++ b/crates/wast/src/component/alias.rs
@@ -1,3 +1,5 @@
+use wasm_types::{ComponentInstanceIdx, CoreInstanceIdx};
+
 use crate::core::ExportKind;
 use crate::kw;
 use crate::parser::{Parse, Parser, Result};
@@ -9,7 +11,7 @@ use crate::token::{Id, Index, NameAnnotation, Span};
 #[derive(Debug)]
 pub struct InlineExportAlias<'a, const CORE: bool> {
     /// The instance to alias the export from.
-    pub instance: Index<'a>,
+    pub instance: Index<'a, u32>,
     /// The name of the export to alias.
     pub name: &'a str,
 }
@@ -231,7 +233,7 @@ pub enum AliasTarget<'a> {
     /// The alias is to an export of a component instance.
     Export {
         /// The component instance exporting the item.
-        instance: Index<'a>,
+        instance: Index<'a, ComponentInstanceIdx>,
         /// The name of the exported item to alias.
         name: &'a str,
         /// The export kind of the alias.
@@ -240,7 +242,7 @@ pub enum AliasTarget<'a> {
     /// The alias is to an export of a module instance.
     CoreExport {
         /// The module instance exporting the item.
-        instance: Index<'a>,
+        instance: Index<'a, CoreInstanceIdx>,
         /// The name of the exported item to alias.
         name: &'a str,
         /// The export kind of the alias.
@@ -249,9 +251,9 @@ pub enum AliasTarget<'a> {
     /// The alias is to an item from an outer component.
     Outer {
         /// The number of enclosing components to skip.
-        outer: Index<'a>,
+        outer: Index<'a, u32>,
         /// The index of the item being aliased.
-        index: Index<'a>,
+        index: Index<'a, u32>,
         /// The outer alias kind.
         kind: ComponentOuterAliasKind,
     },

--- a/crates/wast/src/component/expand.rs
+++ b/crates/wast/src/component/expand.rs
@@ -303,7 +303,7 @@ impl<'a> Expander<'a> {
                 id: func.id,
                 name: func.name,
                 target: AliasTarget::CoreExport {
-                    instance: a.instance,
+                    instance: a.instance.into(),
                     name: a.name,
                     kind: core::ExportKind::Func,
                 },
@@ -541,7 +541,7 @@ impl<'a> Expander<'a> {
                 id: func.id,
                 name: func.name,
                 target: AliasTarget::Export {
-                    instance: a.instance,
+                    instance: a.instance.into(),
                     name: a.name,
                     kind: ComponentExportAliasKind::Func,
                 },

--- a/crates/wast/src/component/export.rs
+++ b/crates/wast/src/component/export.rs
@@ -2,6 +2,10 @@ use super::{ComponentExternName, ItemRef, ItemSigNoName};
 use crate::kw;
 use crate::parser::{Cursor, Parse, Parser, Peek, Result};
 use crate::token::{Id, Index, NameAnnotation, Span};
+use wasm_types::{
+    ComponentFuncIdx, ComponentIdx, ComponentInstanceIdx, ComponentTypeIdx, ComponentValueIdx,
+    CoreModuleIdx,
+};
 
 /// An entry in a WebAssembly component's export section.
 #[derive(Debug)]
@@ -60,17 +64,17 @@ pub enum ComponentExportKind<'a> {
     ///
     /// Note this isn't a core item ref as currently only
     /// components can export core modules.
-    CoreModule(ItemRef<'a, kw::module>),
+    CoreModule(ItemRef<'a, kw::module, CoreModuleIdx>),
     /// The export is a function.
-    Func(ItemRef<'a, kw::func>),
+    Func(ItemRef<'a, kw::func, ComponentFuncIdx>),
     /// The export is a value.
-    Value(ItemRef<'a, kw::value>),
+    Value(ItemRef<'a, kw::value, ComponentValueIdx>),
     /// The export is a type.
-    Type(ItemRef<'a, kw::r#type>),
+    Type(ItemRef<'a, kw::r#type, ComponentTypeIdx>),
     /// The export is a component.
-    Component(ItemRef<'a, kw::component>),
+    Component(ItemRef<'a, kw::component, ComponentIdx>),
     /// The export is an instance.
-    Instance(ItemRef<'a, kw::instance>),
+    Instance(ItemRef<'a, kw::instance, ComponentInstanceIdx>),
 }
 
 impl<'a> ComponentExportKind<'a> {
@@ -160,7 +164,7 @@ impl Peek for ComponentExportKind<'_> {
             _ => return Ok(false),
         };
 
-        Index::peek(cursor)
+        Index::<u32>::peek(cursor)
     }
 
     fn display() -> &'static str {

--- a/crates/wast/src/component/func.rs
+++ b/crates/wast/src/component/func.rs
@@ -2,6 +2,7 @@ use crate::component::*;
 use crate::kw;
 use crate::parser::{Parse, Parser, Result};
 use crate::token::{Id, Index, LParen, NameAnnotation, Span};
+use wasm_types::{ComponentFuncIdx, ComponentTypeIdx, FuncIdx, MemIdx, TypeIdx};
 
 /// A declared core function.
 ///
@@ -372,7 +373,7 @@ pub enum CanonicalFuncKind<'a> {
 #[derive(Debug)]
 pub struct CanonLift<'a> {
     /// The core function being lifted.
-    pub func: CoreItemRef<'a, kw::func>,
+    pub func: CoreItemRef<'a, kw::func, FuncIdx>,
     /// The canonical options for the lifting.
     pub opts: Vec<CanonOpt<'a>>,
 }
@@ -397,7 +398,7 @@ impl Default for CanonLift<'_> {
         Self {
             func: CoreItemRef {
                 kind: kw::func(span),
-                idx: Index::Num(0, span),
+                idx: Index::Num(FuncIdx(0), span),
                 export_name: None,
             },
             opts: Vec::new(),
@@ -409,7 +410,7 @@ impl Default for CanonLift<'_> {
 #[derive(Debug)]
 pub struct CanonLower<'a> {
     /// The function being lowered.
-    pub func: ItemRef<'a, kw::func>,
+    pub func: ItemRef<'a, kw::func, ComponentFuncIdx>,
     /// The canonical options for the lowering.
     pub opts: Vec<CanonOpt<'a>>,
 }
@@ -431,7 +432,7 @@ impl Default for CanonLower<'_> {
         Self {
             func: ItemRef {
                 kind: kw::func(span),
-                idx: Index::Num(0, span),
+                idx: Index::Num(ComponentFuncIdx(0), span),
                 export_names: Vec::new(),
             },
             opts: Vec::new(),
@@ -443,7 +444,7 @@ impl Default for CanonLower<'_> {
 #[derive(Debug)]
 pub struct CanonResourceNew<'a> {
     /// The resource type that this intrinsic creates an owned reference to.
-    pub ty: Index<'a>,
+    pub ty: Index<'a, ComponentTypeIdx>,
 }
 
 impl<'a> Parse<'a> for CanonResourceNew<'a> {
@@ -460,7 +461,7 @@ impl<'a> Parse<'a> for CanonResourceNew<'a> {
 #[derive(Debug)]
 pub struct CanonResourceDrop<'a> {
     /// The resource type that this intrinsic is dropping.
-    pub ty: Index<'a>,
+    pub ty: Index<'a, ComponentTypeIdx>,
 }
 
 impl<'a> Parse<'a> for CanonResourceDrop<'a> {
@@ -477,7 +478,7 @@ impl<'a> Parse<'a> for CanonResourceDrop<'a> {
 #[derive(Debug)]
 pub struct CanonResourceRep<'a> {
     /// The resource type that this intrinsic is accessing.
-    pub ty: Index<'a>,
+    pub ty: Index<'a, ComponentTypeIdx>,
 }
 
 impl<'a> Parse<'a> for CanonResourceRep<'a> {
@@ -494,7 +495,7 @@ impl<'a> Parse<'a> for CanonResourceRep<'a> {
 #[derive(Debug)]
 pub struct CanonThreadSpawn<'a> {
     /// The function type that is being spawned.
-    pub ty: Index<'a>,
+    pub ty: Index<'a, TypeIdx>,
 }
 
 impl<'a> Parse<'a> for CanonThreadSpawn<'a> {
@@ -549,7 +550,7 @@ pub struct CanonTaskWait<'a> {
     /// intrinsic.
     pub async_: bool,
     /// The memory to use when returning an event to the caller.
-    pub memory: CoreItemRef<'a, kw::memory>,
+    pub memory: CoreItemRef<'a, kw::memory, MemIdx>,
 }
 
 impl<'a> Parse<'a> for CanonTaskWait<'a> {
@@ -572,7 +573,7 @@ pub struct CanonTaskPoll<'a> {
     /// intrinsic.
     pub async_: bool,
     /// The memory to use when returning an event to the caller.
-    pub memory: CoreItemRef<'a, kw::memory>,
+    pub memory: CoreItemRef<'a, kw::memory, MemIdx>,
 }
 
 impl<'a> Parse<'a> for CanonTaskPoll<'a> {
@@ -609,7 +610,7 @@ impl<'a> Parse<'a> for CanonTaskYield {
 #[derive(Debug)]
 pub struct CanonStreamNew<'a> {
     /// The stream type to instantiate.
-    pub ty: Index<'a>,
+    pub ty: Index<'a, ComponentTypeIdx>,
 }
 
 impl<'a> Parse<'a> for CanonStreamNew<'a> {
@@ -626,7 +627,7 @@ impl<'a> Parse<'a> for CanonStreamNew<'a> {
 #[derive(Debug)]
 pub struct CanonStreamRead<'a> {
     /// The stream type to instantiate.
-    pub ty: Index<'a>,
+    pub ty: Index<'a, ComponentTypeIdx>,
     /// The canonical options for storing values.
     pub opts: Vec<CanonOpt<'a>>,
 }
@@ -646,7 +647,7 @@ impl<'a> Parse<'a> for CanonStreamRead<'a> {
 #[derive(Debug)]
 pub struct CanonStreamWrite<'a> {
     /// The stream type to instantiate.
-    pub ty: Index<'a>,
+    pub ty: Index<'a, ComponentTypeIdx>,
     /// The canonical options for loading values.
     pub opts: Vec<CanonOpt<'a>>,
 }
@@ -666,7 +667,7 @@ impl<'a> Parse<'a> for CanonStreamWrite<'a> {
 #[derive(Debug)]
 pub struct CanonStreamCancelRead<'a> {
     /// The stream type to instantiate.
-    pub ty: Index<'a>,
+    pub ty: Index<'a, ComponentTypeIdx>,
     /// If false, block until cancel is finished; otherwise return BLOCKED if
     /// necessary.
     pub async_: bool,
@@ -687,7 +688,7 @@ impl<'a> Parse<'a> for CanonStreamCancelRead<'a> {
 #[derive(Debug)]
 pub struct CanonStreamCancelWrite<'a> {
     /// The stream type to instantiate.
-    pub ty: Index<'a>,
+    pub ty: Index<'a, ComponentTypeIdx>,
     /// If false, block until cancel is finished; otherwise return BLOCKED if
     /// necessary.
     pub async_: bool,
@@ -708,7 +709,7 @@ impl<'a> Parse<'a> for CanonStreamCancelWrite<'a> {
 #[derive(Debug)]
 pub struct CanonStreamCloseReadable<'a> {
     /// The stream type to close.
-    pub ty: Index<'a>,
+    pub ty: Index<'a, ComponentTypeIdx>,
 }
 
 impl<'a> Parse<'a> for CanonStreamCloseReadable<'a> {
@@ -725,7 +726,7 @@ impl<'a> Parse<'a> for CanonStreamCloseReadable<'a> {
 #[derive(Debug)]
 pub struct CanonStreamCloseWritable<'a> {
     /// The stream type to close.
-    pub ty: Index<'a>,
+    pub ty: Index<'a, ComponentTypeIdx>,
 }
 
 impl<'a> Parse<'a> for CanonStreamCloseWritable<'a> {
@@ -742,7 +743,7 @@ impl<'a> Parse<'a> for CanonStreamCloseWritable<'a> {
 #[derive(Debug)]
 pub struct CanonFutureNew<'a> {
     /// The future type to instantiate.
-    pub ty: Index<'a>,
+    pub ty: Index<'a, ComponentTypeIdx>,
 }
 
 impl<'a> Parse<'a> for CanonFutureNew<'a> {
@@ -759,7 +760,7 @@ impl<'a> Parse<'a> for CanonFutureNew<'a> {
 #[derive(Debug)]
 pub struct CanonFutureRead<'a> {
     /// The future type to instantiate.
-    pub ty: Index<'a>,
+    pub ty: Index<'a, ComponentTypeIdx>,
     /// The canonical options for storing values.
     pub opts: Vec<CanonOpt<'a>>,
 }
@@ -779,7 +780,7 @@ impl<'a> Parse<'a> for CanonFutureRead<'a> {
 #[derive(Debug)]
 pub struct CanonFutureWrite<'a> {
     /// The future type to instantiate.
-    pub ty: Index<'a>,
+    pub ty: Index<'a, ComponentTypeIdx>,
     /// The canonical options for loading values.
     pub opts: Vec<CanonOpt<'a>>,
 }
@@ -799,7 +800,7 @@ impl<'a> Parse<'a> for CanonFutureWrite<'a> {
 #[derive(Debug)]
 pub struct CanonFutureCancelRead<'a> {
     /// The future type to instantiate.
-    pub ty: Index<'a>,
+    pub ty: Index<'a, ComponentTypeIdx>,
     /// If false, block until cancel is finished; otherwise return BLOCKED if
     /// necessary.
     pub async_: bool,
@@ -820,7 +821,7 @@ impl<'a> Parse<'a> for CanonFutureCancelRead<'a> {
 #[derive(Debug)]
 pub struct CanonFutureCancelWrite<'a> {
     /// The future type to instantiate.
-    pub ty: Index<'a>,
+    pub ty: Index<'a, ComponentTypeIdx>,
     /// If false, block until cancel is finished; otherwise return BLOCKED if
     /// necessary.
     pub async_: bool,
@@ -841,7 +842,7 @@ impl<'a> Parse<'a> for CanonFutureCancelWrite<'a> {
 #[derive(Debug)]
 pub struct CanonFutureCloseReadable<'a> {
     /// The future type to close.
-    pub ty: Index<'a>,
+    pub ty: Index<'a, ComponentTypeIdx>,
 }
 
 impl<'a> Parse<'a> for CanonFutureCloseReadable<'a> {
@@ -858,7 +859,7 @@ impl<'a> Parse<'a> for CanonFutureCloseReadable<'a> {
 #[derive(Debug)]
 pub struct CanonFutureCloseWritable<'a> {
     /// The future type to close.
-    pub ty: Index<'a>,
+    pub ty: Index<'a, ComponentTypeIdx>,
 }
 
 impl<'a> Parse<'a> for CanonFutureCloseWritable<'a> {
@@ -915,15 +916,15 @@ pub enum CanonOpt<'a> {
     /// Encode strings as "compact UTF-16".
     StringLatin1Utf16,
     /// Use the specified memory for canonical ABI memory access.
-    Memory(CoreItemRef<'a, kw::memory>),
+    Memory(CoreItemRef<'a, kw::memory, MemIdx>),
     /// Use the specified reallocation function for memory allocations.
-    Realloc(CoreItemRef<'a, kw::func>),
+    Realloc(CoreItemRef<'a, kw::func, FuncIdx>),
     /// Call the specified function after the lifted function has returned.
-    PostReturn(CoreItemRef<'a, kw::func>),
+    PostReturn(CoreItemRef<'a, kw::func, FuncIdx>),
     /// Use the async ABI for lifting or lowering.
     Async,
     /// Use the specified function to deliver async events to stackless coroutines.
-    Callback(CoreItemRef<'a, kw::func>),
+    Callback(CoreItemRef<'a, kw::func, FuncIdx>),
 }
 
 impl<'a> Parse<'a> for CanonOpt<'a> {
@@ -953,17 +954,17 @@ impl<'a> Parse<'a> for CanonOpt<'a> {
                 } else if l.peek::<kw::realloc>()? {
                     parser.parse::<kw::realloc>()?;
                     Ok(CanonOpt::Realloc(
-                        parser.parse::<IndexOrCoreRef<'_, _>>()?.0,
+                        parser.parse::<IndexOrCoreRef<'_, _, FuncIdx>>()?.0,
                     ))
                 } else if l.peek::<kw::post_return>()? {
                     parser.parse::<kw::post_return>()?;
                     Ok(CanonOpt::PostReturn(
-                        parser.parse::<IndexOrCoreRef<'_, _>>()?.0,
+                        parser.parse::<IndexOrCoreRef<'_, _, FuncIdx>>()?.0,
                     ))
                 } else if l.peek::<kw::callback>()? {
                     parser.parse::<kw::callback>()?;
                     Ok(CanonOpt::Callback(
-                        parser.parse::<IndexOrCoreRef<'_, _>>()?.0,
+                        parser.parse::<IndexOrCoreRef<'_, _, FuncIdx>>()?.0,
                     ))
                 } else {
                     Err(l.error())
@@ -975,7 +976,10 @@ impl<'a> Parse<'a> for CanonOpt<'a> {
     }
 }
 
-fn parse_trailing_item_ref<T>(kind: T, parser: Parser) -> Result<CoreItemRef<T>> {
+fn parse_trailing_item_ref<'a, T, I>(kind: T, parser: Parser<'a>) -> Result<CoreItemRef<'a, T, I>>
+where
+    (I, Span): Parse<'a>,
+{
     Ok(CoreItemRef {
         kind,
         idx: parser.parse()?,

--- a/crates/wast/src/component/import.rs
+++ b/crates/wast/src/component/import.rs
@@ -2,6 +2,7 @@ use crate::component::*;
 use crate::kw;
 use crate::parser::{Cursor, Parse, Parser, Peek, Result};
 use crate::token::{Id, Index, LParen, NameAnnotation, Span};
+use wasm_types::ComponentTypeIdx;
 
 /// An `import` statement and entry in a WebAssembly component.
 #[derive(Debug)]
@@ -134,7 +135,7 @@ pub enum ItemSigKind<'a> {
 #[derive(Debug)]
 pub enum TypeBounds<'a> {
     /// The equality type bounds.
-    Eq(Index<'a>),
+    Eq(Index<'a, ComponentTypeIdx>),
     /// A resource type is imported/exported,
     SubResource,
 }

--- a/crates/wast/src/component/types.rs
+++ b/crates/wast/src/component/types.rs
@@ -7,6 +7,7 @@ use crate::parser::{Parse, Parser, Result};
 use crate::token::Index;
 use crate::token::LParen;
 use crate::token::{Id, NameAnnotation, Span};
+use wasm_types::ComponentTypeIdx;
 
 /// A core type declaration.
 #[derive(Debug)]
@@ -1014,7 +1015,7 @@ impl<T> Default for CoreTypeUse<'_, T> {
 #[derive(Debug, Clone)]
 pub enum ComponentTypeUse<'a, T> {
     /// The type that we're referencing.
-    Ref(ItemRef<'a, kw::r#type>),
+    Ref(ItemRef<'a, kw::r#type, ComponentTypeIdx>),
     /// The inline type.
     Inline(T),
 }

--- a/crates/wast/src/core/binary/dwarf_disabled.rs
+++ b/crates/wast/src/core/binary/dwarf_disabled.rs
@@ -4,6 +4,7 @@
 use crate::core::binary::{EncodeOptions, Encoder, Names, RecOrType};
 use crate::core::Local;
 use crate::token::Span;
+use wasm_types::{FuncIdx, TypeIdx};
 
 pub struct Dwarf<'a> {
     uninhabited: &'a std::convert::Infallible,
@@ -11,7 +12,7 @@ pub struct Dwarf<'a> {
 
 impl<'a> Dwarf<'a> {
     pub fn new(
-        _func_imports: u32,
+        _func_imports: FuncIdx,
         _opts: &EncodeOptions<'a>,
         _names: &Names<'a>,
         _types: &'a [RecOrType<'a>],
@@ -19,7 +20,7 @@ impl<'a> Dwarf<'a> {
         None
     }
 
-    pub fn start_func(&mut self, _span: Span, _ty: u32, _locals: &[Local<'_>]) {
+    pub fn start_func(&mut self, _span: Span, _ty: TypeIdx, _locals: &[Local<'_>]) {
         match *self.uninhabited {}
     }
 

--- a/crates/wast/src/core/export.rs
+++ b/crates/wast/src/core/export.rs
@@ -12,7 +12,7 @@ pub struct Export<'a> {
     /// The kind of item being exported.
     pub kind: ExportKind,
     /// What's being exported from the module.
-    pub item: Index<'a>,
+    pub item: Index<'a, u32>,
 }
 
 /// Different kinds of elements that can be exported from a WebAssembly module,

--- a/crates/wast/src/core/memory.rs
+++ b/crates/wast/src/core/memory.rs
@@ -2,6 +2,7 @@ use crate::core::*;
 use crate::kw;
 use crate::parser::{Lookahead1, Parse, Parser, Peek, Result};
 use crate::token::*;
+use wasm_types::MemIdx;
 
 /// A defined WebAssembly memory instance inside of a module.
 #[derive(Debug)]
@@ -130,7 +131,7 @@ pub enum DataKind<'a> {
     /// memory on module instantiation.
     Active {
         /// The memory that this `Data` will be associated with.
-        memory: Index<'a>,
+        memory: Index<'a, MemIdx>,
 
         /// Initial offset to load this data segment at
         offset: Expression<'a>,
@@ -149,7 +150,7 @@ impl<'a> Parse<'a> for Data<'a> {
         // ... and otherwise we must be attached to a particular memory as well
         // as having an initialization offset.
         } else {
-            let memory = if parser.peek::<u32>()? {
+            let memory = if parser.peek::<MemIdx>()? {
                 // FIXME: this is only here to accomodate
                 // proposals/threads/imports.wast at this current moment in
                 // time, this probably should get removed when the threads
@@ -161,7 +162,7 @@ impl<'a> Parse<'a> for Data<'a> {
                     p.parse()
                 })?
             } else {
-                Index::Num(0, span)
+                Index::Num(MemIdx(0), span)
             };
             let offset = parser.parens(|parser| {
                 if parser.peek::<kw::offset>()? {

--- a/crates/wast/src/core/module.rs
+++ b/crates/wast/src/core/module.rs
@@ -3,6 +3,7 @@ use crate::core::*;
 use crate::parser::{Parse, Parser, Result};
 use crate::token::{Id, Index, NameAnnotation, Span};
 use crate::{annotation, kw};
+use wasm_types::FuncIdx;
 
 pub use crate::core::resolve::Names;
 
@@ -151,7 +152,7 @@ pub enum ModuleField<'a> {
     Memory(Memory<'a>),
     Global(Global<'a>),
     Export(Export<'a>),
-    Start(Index<'a>),
+    Start(Index<'a, FuncIdx>),
     Elem(Elem<'a>),
     Data(Data<'a>),
     Tag(Tag<'a>),

--- a/crates/wast/src/core/resolve/mod.rs
+++ b/crates/wast/src/core/resolve/mod.rs
@@ -1,6 +1,7 @@
 use crate::core::*;
 use crate::token::Index;
 use crate::{gensym, Error};
+use wasm_types::{FuncIdx, GlobalIdx, MemIdx, TableIdx};
 
 mod deinline_import_export;
 mod names;
@@ -75,8 +76,8 @@ impl<'a> Names<'a> {
     /// If `idx` is a `Num`, it is ignored, but if it's an `Id` then it will be
     /// looked up in the function namespace and converted to a `Num`. If the
     /// `Id` is not defined then an error will be returned.
-    pub fn resolve_func(&self, idx: &mut Index<'a>) -> Result<(), Error> {
-        self.resolver.resolve(idx, Ns::Func)?;
+    pub fn resolve_func(&self, idx: &mut Index<'a, FuncIdx>) -> Result<(), Error> {
+        self.resolver.resolve_funcidx(idx)?;
         Ok(())
     }
 
@@ -85,8 +86,8 @@ impl<'a> Names<'a> {
     /// If `idx` is a `Num`, it is ignored, but if it's an `Id` then it will be
     /// looked up in the memory namespace and converted to a `Num`. If the
     /// `Id` is not defined then an error will be returned.
-    pub fn resolve_memory(&self, idx: &mut Index<'a>) -> Result<(), Error> {
-        self.resolver.resolve(idx, Ns::Memory)?;
+    pub fn resolve_memory(&self, idx: &mut Index<'a, MemIdx>) -> Result<(), Error> {
+        self.resolver.resolve_memidx(idx)?;
         Ok(())
     }
 
@@ -95,8 +96,8 @@ impl<'a> Names<'a> {
     /// If `idx` is a `Num`, it is ignored, but if it's an `Id` then it will be
     /// looked up in the table namespace and converted to a `Num`. If the
     /// `Id` is not defined then an error will be returned.
-    pub fn resolve_table(&self, idx: &mut Index<'a>) -> Result<(), Error> {
-        self.resolver.resolve(idx, Ns::Table)?;
+    pub fn resolve_table(&self, idx: &mut Index<'a, TableIdx>) -> Result<(), Error> {
+        self.resolver.resolve_tableidx(idx)?;
         Ok(())
     }
 
@@ -105,8 +106,8 @@ impl<'a> Names<'a> {
     /// If `idx` is a `Num`, it is ignored, but if it's an `Id` then it will be
     /// looked up in the global namespace and converted to a `Num`. If the
     /// `Id` is not defined then an error will be returned.
-    pub fn resolve_global(&self, idx: &mut Index<'a>) -> Result<(), Error> {
-        self.resolver.resolve(idx, Ns::Global)?;
+    pub fn resolve_global(&self, idx: &mut Index<'a, GlobalIdx>) -> Result<(), Error> {
+        self.resolver.resolve_globalidx(idx)?;
         Ok(())
     }
 }

--- a/crates/wast/src/core/table.rs
+++ b/crates/wast/src/core/table.rs
@@ -2,6 +2,7 @@ use crate::core::*;
 use crate::kw;
 use crate::parser::{Parse, Parser, Peek, Result};
 use crate::token::{Id, Index, LParen, NameAnnotation, Span};
+use wasm_types::{FuncIdx, TableIdx};
 
 /// A WebAssembly `table` directive in a module.
 #[derive(Debug)]
@@ -149,7 +150,7 @@ pub enum ElemKind<'a> {
     /// An active segment associated with a table.
     Active {
         /// The table this `elem` is initializing.
-        table: Option<Index<'a>>,
+        table: Option<Index<'a, TableIdx>>,
         /// The offset within `table` that we'll initialize at.
         offset: Expression<'a>,
     },
@@ -159,7 +160,7 @@ pub enum ElemKind<'a> {
 #[derive(Debug)]
 pub enum ElemPayload<'a> {
     /// This element segment has a contiguous list of function indices
-    Indices(Vec<Index<'a>>),
+    Indices(Vec<Index<'a, FuncIdx>>),
 
     /// This element segment has a list of optional function indices,
     /// represented as expressions using `ref.func` and `ref.null`.

--- a/crates/wast/src/core/wast.rs
+++ b/crates/wast/src/core/wast.rs
@@ -2,6 +2,7 @@ use crate::core::{HeapType, V128Const};
 use crate::kw;
 use crate::parser::{Cursor, Parse, Parser, Peek, Result};
 use crate::token::{Index, F32, F64};
+use wasm_types::FuncIdx;
 
 /// Expression that can be used inside of `invoke` expressions for core wasm
 /// functions.
@@ -79,7 +80,7 @@ pub enum WastRetCore<'a> {
     /// A non-null anyref is expected which should contain the specified host value.
     RefHost(u32),
     /// A non-null funcref is expected.
-    RefFunc(Option<Index<'a>>),
+    RefFunc(Option<Index<'a, FuncIdx>>),
     /// A non-null anyref is expected.
     RefAny,
     /// A non-null eqref is expected.

--- a/crates/wast/src/encode.rs
+++ b/crates/wast/src/encode.rs
@@ -1,3 +1,9 @@
+use wasm_types::{
+    AbsoluteLabelIdx, ComponentFuncIdx, ComponentIdx, ComponentInstanceIdx, ComponentTypeIdx,
+    ComponentValueIdx, CoreInstanceIdx, CoreModuleIdx, DataIdx, ElemIdx, FieldIdx, FuncIdx,
+    GlobalIdx, LabelIdx, LocalIdx, MemIdx, TableIdx, TagIdx, TypeIdx,
+};
+
 pub(crate) trait Encode {
     fn encode(&self, e: &mut Vec<u8>);
 }
@@ -53,6 +59,120 @@ impl Encode for u32 {
     fn encode(&self, e: &mut Vec<u8>) {
         let (value, pos) = leb128fmt::encode_u32(*self).unwrap();
         e.extend_from_slice(&value[..pos]);
+    }
+}
+
+impl Encode for TypeIdx {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.0.encode(e);
+    }
+}
+
+impl Encode for FuncIdx {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.0.encode(e);
+    }
+}
+
+impl Encode for TableIdx {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.0.encode(e);
+    }
+}
+
+impl Encode for MemIdx {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.0.encode(e);
+    }
+}
+
+impl Encode for TagIdx {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.0.encode(e);
+    }
+}
+
+impl Encode for GlobalIdx {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.0.encode(e);
+    }
+}
+
+impl Encode for ElemIdx {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.0.encode(e);
+    }
+}
+
+impl Encode for DataIdx {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.0.encode(e);
+    }
+}
+
+impl Encode for LocalIdx {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.0.encode(e);
+    }
+}
+
+impl Encode for LabelIdx {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.0.encode(e);
+    }
+}
+
+impl Encode for FieldIdx {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.0.encode(e);
+    }
+}
+
+impl Encode for AbsoluteLabelIdx {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.0.encode(e);
+    }
+}
+
+impl Encode for CoreModuleIdx {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.0.encode(e);
+    }
+}
+
+impl Encode for CoreInstanceIdx {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.0.encode(e);
+    }
+}
+
+impl Encode for ComponentTypeIdx {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.0.encode(e);
+    }
+}
+
+impl Encode for ComponentFuncIdx {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.0.encode(e);
+    }
+}
+
+impl Encode for ComponentIdx {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.0.encode(e);
+    }
+}
+
+impl Encode for ComponentInstanceIdx {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.0.encode(e);
+    }
+}
+
+impl Encode for ComponentValueIdx {
+    fn encode(&self, e: &mut Vec<u8>) {
+        self.0.encode(e);
     }
 }
 


### PR DESCRIPTION
Following up on some conversation in #1985, this draft PR is a start on what it might look like to use typed indices throughout the whole codebase. I was originally planning to _finish_ this before coming back to #1985, but it eventually became clear to me that this is considerably bigger than I expected.

In any case, I'm opening this PR to gauge whether there's any interest in going further down this path, or if I should just call this an interesting experiment and abandon it. There were some unintuitive cases, so maybe there is some potential value in these from a codebase documentation/consistency perspective? For example:

https://github.com/bytecodealliance/wasm-tools/blob/beac7de36a6747a9061b8fa497a130aa4f7da185/crates/wasm-encoder/src/reencode/component.rs#L963-L966

This code made me mark the `func_ty_index` field of the `CanonicalFunction::ThreadSpawn` variant as `TypeIdx` instead of `ComponentTypeIdx`, unlike all the fields in all the `Resource` variants. Is this correct? I don't know much about the component model, so maybe threads just happen to use core type indices while other similar-looking things use component type indices. Maybe it's clear from the spec (?), but it's not clear from the docstring:

https://github.com/bytecodealliance/wasm-tools/blob/beac7de36a6747a9061b8fa497a130aa4f7da185/crates/wasmparser/src/readers/component/canonicals.rs#L70-L74

Another random question I had while working on this: why do both [`wasm_encoder::NameSection::tag`](https://docs.rs/wasm-encoder/0.225.0/wasm_encoder/struct.NameSection.html#method.tag) and [`wasm_encoder::NameSection::tags`](https://docs.rs/wasm-encoder/0.225.0/wasm_encoder/struct.NameSection.html#method.tags) exist? Don't they do the same thing?