### PR TITLE
[wasm-metadata] rename `Author` to `Authors`

### DIFF
--- a/crates/wasm-metadata/src/add_metadata.rs
+++ b/crates/wasm-metadata/src/add_metadata.rs
@@ -30,7 +30,7 @@ pub struct AddMetadata {
     /// Contact details of the people or organization responsible,
     /// encoded as a freeform string.
     #[cfg_attr(feature = "clap", clap(long, value_name = "NAME"))]
-    pub author: Option<Authors>,
+    pub authors: Option<Authors>,
 
     /// A human-readable description of the binary
     #[cfg_attr(feature = "clap", clap(long, value_name = "NAME"))]
@@ -72,7 +72,7 @@ impl AddMetadata {
         rewrite_wasm(
             &self.name,
             &Producers::from_meta(self),
-            &self.author,
+            &self.authors,
             &self.description,
             &self.licenses,
             &self.source,

--- a/crates/wasm-metadata/src/add_metadata.rs
+++ b/crates/wasm-metadata/src/add_metadata.rs
@@ -1,5 +1,5 @@
 use crate::{
-    rewrite_wasm, Author, Description, Homepage, Licenses, Producers, Revision, Source, Version,
+    rewrite_wasm, Authors, Description, Homepage, Licenses, Producers, Revision, Source, Version,
 };
 
 use anyhow::Result;
@@ -30,7 +30,7 @@ pub struct AddMetadata {
     /// Contact details of the people or organization responsible,
     /// encoded as a freeform string.
     #[cfg_attr(feature = "clap", clap(long, value_name = "NAME"))]
-    pub author: Option<Author>,
+    pub author: Option<Authors>,
 
     /// A human-readable description of the binary
     #[cfg_attr(feature = "clap", clap(long, value_name = "NAME"))]

--- a/crates/wasm-metadata/src/lib.rs
+++ b/crates/wasm-metadata/src/lib.rs
@@ -5,7 +5,7 @@
 pub use add_metadata::AddMetadata;
 pub use metadata::Metadata;
 pub use names::{ComponentNames, ModuleNames};
-pub use oci_annotations::{Author, Description, Homepage, Licenses, Revision, Source, Version};
+pub use oci_annotations::{Authors, Description, Homepage, Licenses, Revision, Source, Version};
 pub use payload::Payload;
 pub use producers::{Producers, ProducersField};
 

--- a/crates/wasm-metadata/src/metadata.rs
+++ b/crates/wasm-metadata/src/metadata.rs
@@ -1,7 +1,7 @@
 use serde_derive::Serialize;
 use std::ops::Range;
 
-use crate::{Author, Description, Homepage, Licenses, Producers, Revision, Source, Version};
+use crate::{Authors, Description, Homepage, Licenses, Producers, Revision, Source, Version};
 
 /// Metadata associated with a Wasm Component or Module
 #[derive(Debug, Serialize, Default)]
@@ -12,7 +12,7 @@ pub struct Metadata {
     /// The component's producers section, if any.
     pub producers: Option<Producers>,
     /// The component's author section, if any.
-    pub author: Option<Author>,
+    pub author: Option<Authors>,
     /// Human-readable description of the binary
     pub description: Option<Description>,
     /// License(s) under which contained software is distributed as an SPDX License Expression.

--- a/crates/wasm-metadata/src/metadata.rs
+++ b/crates/wasm-metadata/src/metadata.rs
@@ -11,8 +11,8 @@ pub struct Metadata {
     pub name: Option<String>,
     /// The component's producers section, if any.
     pub producers: Option<Producers>,
-    /// The component's author section, if any.
-    pub author: Option<Authors>,
+    /// The component's authors section, if any.
+    pub authors: Option<Authors>,
     /// Human-readable description of the binary
     pub description: Option<Description>,
     /// License(s) under which contained software is distributed as an SPDX License Expression.

--- a/crates/wasm-metadata/src/oci_annotations/authors.rs
+++ b/crates/wasm-metadata/src/oci_annotations/authors.rs
@@ -10,13 +10,13 @@ use wasmparser::CustomSectionReader;
 /// Contact details of the people or organization responsible,
 /// encoded as a freeform string.
 #[derive(Debug, Clone, PartialEq)]
-pub struct Author(CustomSection<'static>);
+pub struct Authors(CustomSection<'static>);
 
-impl Author {
+impl Authors {
     /// Create a new instance of `Author`.
     pub fn new<S: Into<Cow<'static, str>>>(s: S) -> Self {
         Self(CustomSection {
-            name: "author".into(),
+            name: "authors".into(),
             data: match s.into() {
                 Cow::Borrowed(s) => Cow::Borrowed(s.as_bytes()),
                 Cow::Owned(s) => Cow::Owned(s.into()),
@@ -27,15 +27,15 @@ impl Author {
     /// Parse an `author` custom section from a wasm binary.
     pub(crate) fn parse_custom_section(reader: &CustomSectionReader<'_>) -> Result<Self> {
         ensure!(
-            reader.name() == "author",
-            "The `author` custom section should have a name of 'author'"
+            reader.name() == "authors",
+            "The `authors` custom section should have a name of 'authors'"
         );
         let data = String::from_utf8(reader.data().to_owned())?;
         Ok(Self::new(data))
     }
 }
 
-impl FromStr for Author {
+impl FromStr for Authors {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -43,7 +43,7 @@ impl FromStr for Author {
     }
 }
 
-impl Serialize for Author {
+impl Serialize for Authors {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
@@ -52,7 +52,7 @@ impl Serialize for Author {
     }
 }
 
-impl Display for Author {
+impl Display for Authors {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // NOTE: this will never panic since we always guarantee the data is
         // encoded as utf8, even if we internally store it as [u8].
@@ -61,19 +61,19 @@ impl Display for Author {
     }
 }
 
-impl ComponentSection for Author {
+impl ComponentSection for Authors {
     fn id(&self) -> u8 {
         ComponentSection::id(&self.0)
     }
 }
 
-impl Section for Author {
+impl Section for Authors {
     fn id(&self) -> u8 {
         Section::id(&self.0)
     }
 }
 
-impl Encode for Author {
+impl Encode for Authors {
     fn encode(&self, sink: &mut Vec<u8>) {
         self.0.encode(sink);
     }
@@ -88,13 +88,13 @@ mod test {
     #[test]
     fn roundtrip() {
         let mut component = Component::new();
-        component.section(&Author::new("Nori Cat"));
+        component.section(&Authors::new("Nori Cat"));
         let component = component.finish();
 
         let mut parsed = false;
         for section in wasmparser::Parser::new(0).parse_all(&component) {
             if let Payload::CustomSection(reader) = section.unwrap() {
-                let author = Author::parse_custom_section(&reader).unwrap();
+                let author = Authors::parse_custom_section(&reader).unwrap();
                 assert_eq!(author.to_string(), "Nori Cat");
                 parsed = true;
             }
@@ -104,7 +104,7 @@ mod test {
 
     #[test]
     fn serialize() {
-        let author = Author::new("Chashu Cat");
+        let author = Authors::new("Chashu Cat");
         let json = serde_json::to_string(&author).unwrap();
         assert_eq!(r#""Chashu Cat""#, json);
     }

--- a/crates/wasm-metadata/src/oci_annotations/mod.rs
+++ b/crates/wasm-metadata/src/oci_annotations/mod.rs
@@ -15,7 +15,7 @@
 //!
 //! [OCI Annotations Spec]: https://specs.opencontainers.org/image-spec/annotations/
 
-pub use author::Author;
+pub use authors::Authors;
 pub use description::Description;
 pub use homepage::Homepage;
 pub use licenses::Licenses;
@@ -23,7 +23,7 @@ pub use revision::Revision;
 pub use source::Source;
 pub use version::Version;
 
-mod author;
+mod authors;
 mod description;
 mod homepage;
 mod licenses;

--- a/crates/wasm-metadata/src/payload.rs
+++ b/crates/wasm-metadata/src/payload.rs
@@ -5,7 +5,7 @@ use serde_derive::Serialize;
 use wasmparser::{KnownCustom, Parser, Payload::*};
 
 use crate::{
-    Author, ComponentNames, Description, Homepage, Licenses, Metadata, ModuleNames, Producers,
+    Authors, ComponentNames, Description, Homepage, Licenses, Metadata, ModuleNames, Producers,
     Revision, Source,
 };
 
@@ -94,7 +94,7 @@ impl Payload {
                             .producers = Some(producers);
                     }
                     KnownCustom::Unknown if c.name() == "author" => {
-                        let a = Author::parse_custom_section(&c)?;
+                        let a = Authors::parse_custom_section(&c)?;
                         let Metadata { author, .. } = output
                             .last_mut()
                             .expect("non-empty metadata stack")

--- a/crates/wasm-metadata/src/payload.rs
+++ b/crates/wasm-metadata/src/payload.rs
@@ -93,9 +93,11 @@ impl Payload {
                             .metadata_mut()
                             .producers = Some(producers);
                     }
-                    KnownCustom::Unknown if c.name() == "author" => {
+                    KnownCustom::Unknown if c.name() == "authors" => {
                         let a = Authors::parse_custom_section(&c)?;
-                        let Metadata { author, .. } = output
+                        let Metadata {
+                            authors: author, ..
+                        } = output
                             .last_mut()
                             .expect("non-empty metadata stack")
                             .metadata_mut();

--- a/crates/wasm-metadata/src/rewrite.rs
+++ b/crates/wasm-metadata/src/rewrite.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Author, ComponentNames, Description, Homepage, Licenses, ModuleNames, Producers, Revision,
+    Authors, ComponentNames, Description, Homepage, Licenses, ModuleNames, Producers, Revision,
     Source,
 };
 use anyhow::Result;
@@ -11,7 +11,7 @@ use wasmparser::{KnownCustom, Parser, Payload::*};
 pub(crate) fn rewrite_wasm(
     add_name: &Option<String>,
     add_producers: &Producers,
-    add_author: &Option<Author>,
+    add_author: &Option<Authors>,
     add_description: &Option<Description>,
     add_licenses: &Option<Licenses>,
     add_source: &Option<Source>,
@@ -86,7 +86,7 @@ pub(crate) fn rewrite_wasm(
                     }
                     KnownCustom::Unknown if c.name() == "author" => {
                         if add_author.is_none() {
-                            let author = Author::parse_custom_section(c)?;
+                            let author = Authors::parse_custom_section(c)?;
                             author.append_to(&mut output);
                             continue;
                         }

--- a/crates/wasm-metadata/tests/component.rs
+++ b/crates/wasm-metadata/tests/component.rs
@@ -11,7 +11,7 @@ fn add_to_empty_component() {
         language: vec![("bar".to_owned(), "1.0".to_owned())],
         processed_by: vec![("baz".to_owned(), "1.0".to_owned())],
         sdk: vec![],
-        author: Some(Authors::new("Chashu Cat")),
+        authors: Some(Authors::new("Chashu Cat")),
         description: Some(Description::new("Chashu likes tuna")),
         licenses: Some(
             Licenses::new("Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT").unwrap(),
@@ -30,7 +30,7 @@ fn add_to_empty_component() {
                 Metadata {
                     name,
                     producers,
-                    author,
+                    authors: author,
                     description,
                     licenses,
                     source,
@@ -73,7 +73,7 @@ fn add_to_empty_component() {
             assert_eq!(version.unwrap(), Version::new("1.0.0"));
 
             assert_eq!(range.start, 0);
-            assert_eq!(range.end, 374);
+            assert_eq!(range.end, 375);
         }
         _ => panic!("metadata should be component"),
     }
@@ -88,7 +88,7 @@ fn add_to_nested_component() {
         language: vec![("bar".to_owned(), "1.0".to_owned())],
         processed_by: vec![("baz".to_owned(), "1.0".to_owned())],
         sdk: vec![],
-        author: Some(Authors::new("Chashu Cat")),
+        authors: Some(Authors::new("Chashu Cat")),
         description: Some(Description::new("Chashu likes tuna")),
         licenses: Some(
             Licenses::new("Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT").unwrap(),
@@ -137,7 +137,7 @@ fn add_to_nested_component() {
                 Payload::Module(Metadata {
                     name,
                     producers,
-                    author,
+                    authors: author,
                     licenses,
                     source,
                     range,
@@ -186,7 +186,7 @@ fn add_to_nested_component() {
                     assert_eq!(version, &Some(Version::new("1.0.0")));
 
                     assert_eq!(range.start, 11);
-                    assert_eq!(range.end, 375);
+                    assert_eq!(range.end, 376);
                 }
                 _ => panic!("child is a module"),
             }

--- a/crates/wasm-metadata/tests/component.rs
+++ b/crates/wasm-metadata/tests/component.rs
@@ -11,7 +11,7 @@ fn add_to_empty_component() {
         language: vec![("bar".to_owned(), "1.0".to_owned())],
         processed_by: vec![("baz".to_owned(), "1.0".to_owned())],
         sdk: vec![],
-        author: Some(Author::new("Chashu Cat")),
+        author: Some(Authors::new("Chashu Cat")),
         description: Some(Description::new("Chashu likes tuna")),
         licenses: Some(
             Licenses::new("Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT").unwrap(),
@@ -52,7 +52,7 @@ fn add_to_empty_component() {
                 "1.0"
             );
 
-            assert_eq!(author.unwrap(), Author::new("Chashu Cat"));
+            assert_eq!(author.unwrap(), Authors::new("Chashu Cat"));
             assert_eq!(description.unwrap(), Description::new("Chashu likes tuna"));
             assert_eq!(
                 licenses.unwrap(),
@@ -88,7 +88,7 @@ fn add_to_nested_component() {
         language: vec![("bar".to_owned(), "1.0".to_owned())],
         processed_by: vec![("baz".to_owned(), "1.0".to_owned())],
         sdk: vec![],
-        author: Some(Author::new("Chashu Cat")),
+        author: Some(Authors::new("Chashu Cat")),
         description: Some(Description::new("Chashu likes tuna")),
         licenses: Some(
             Licenses::new("Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT").unwrap(),
@@ -157,7 +157,7 @@ fn add_to_nested_component() {
                         "1.0"
                     );
 
-                    assert_eq!(author, &Some(Author::new("Chashu Cat")));
+                    assert_eq!(author, &Some(Authors::new("Chashu Cat")));
                     assert_eq!(description, &Some(Description::new("Chashu likes tuna")));
                     assert_eq!(
                         licenses,

--- a/crates/wasm-metadata/tests/module.rs
+++ b/crates/wasm-metadata/tests/module.rs
@@ -11,7 +11,7 @@ fn add_to_empty_module() {
         language: vec![("bar".to_owned(), "1.0".to_owned())],
         processed_by: vec![("baz".to_owned(), "1.0".to_owned())],
         sdk: vec![],
-        author: Some(Author::new("Chashu Cat")),
+        author: Some(Authors::new("Chashu Cat")),
         description: Some(Description::new("Chashu likes tuna")),
         licenses: Some(
             Licenses::new("Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT").unwrap(),
@@ -47,7 +47,7 @@ fn add_to_empty_module() {
                 "1.0"
             );
 
-            assert_eq!(author.unwrap(), Author::new("Chashu Cat"));
+            assert_eq!(author.unwrap(), Authors::new("Chashu Cat"));
             assert_eq!(description.unwrap(), Description::new("Chashu likes tuna"));
             assert_eq!(
                 licenses.unwrap(),

--- a/crates/wasm-metadata/tests/module.rs
+++ b/crates/wasm-metadata/tests/module.rs
@@ -11,7 +11,7 @@ fn add_to_empty_module() {
         language: vec![("bar".to_owned(), "1.0".to_owned())],
         processed_by: vec![("baz".to_owned(), "1.0".to_owned())],
         sdk: vec![],
-        author: Some(Authors::new("Chashu Cat")),
+        authors: Some(Authors::new("Chashu Cat")),
         description: Some(Description::new("Chashu likes tuna")),
         licenses: Some(
             Licenses::new("Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT").unwrap(),
@@ -27,7 +27,7 @@ fn add_to_empty_module() {
         Payload::Module(Metadata {
             name,
             producers,
-            author,
+            authors: author,
             licenses,
             source,
             range,
@@ -68,7 +68,7 @@ fn add_to_empty_module() {
             assert_eq!(version.unwrap(), Version::new("1.0.0"));
 
             assert_eq!(range.start, 0);
-            assert_eq!(range.end, 364);
+            assert_eq!(range.end, 365);
         }
         _ => panic!("metadata should be module"),
     }

--- a/src/bin/wasm-tools/metadata.rs
+++ b/src/bin/wasm-tools/metadata.rs
@@ -99,7 +99,7 @@ fn fmt_payload(payload: &Payload, f: &mut Box<dyn WriteColor>) -> Result<()> {
         .set_header(vec!["KIND", "VALUE"]);
     let Metadata {
         name,
-        authors: author,
+        authors,
         description,
         producers,
         licenses,
@@ -130,8 +130,8 @@ fn fmt_payload(payload: &Payload, f: &mut Box<dyn WriteColor>) -> Result<()> {
     if let Some(licenses) = licenses {
         table.add_row(vec!["licenses", &licenses.to_string()]);
     }
-    if let Some(author) = author {
-        table.add_row(vec!["author", &author.to_string()]);
+    if let Some(authors) = authors {
+        table.add_row(vec!["authors", &authors.to_string()]);
     }
     if let Some(source) = source {
         table.add_row(vec!["source", &source.to_string()]);

--- a/src/bin/wasm-tools/metadata.rs
+++ b/src/bin/wasm-tools/metadata.rs
@@ -99,7 +99,7 @@ fn fmt_payload(payload: &Payload, f: &mut Box<dyn WriteColor>) -> Result<()> {
         .set_header(vec!["KIND", "VALUE"]);
     let Metadata {
         name,
-        author,
+        authors: author,
         description,
         producers,
         licenses,


### PR DESCRIPTION
While filing https://github.com/bytecodealliance/wasm-pkg-tools/pull/150 I realized the OCI annotation is called `org.opencontainers.image.authors`. While in `wasm-metadata` we called it `Author`. The lack of pluralization was unintentional from my part, and this PR fixes that. Thanks!

cc/ @bytecodealliance/sig-packaging 