### PR TITLE
Refactor some wit-component internals related to async component model bits

### DIFF
--- a/crates/wit-component/src/validation.rs
+++ b/crates/wit-component/src/validation.rs
@@ -12,8 +12,8 @@ use wasmparser::{
 };
 use wit_parser::{
     abi::{AbiVariant, WasmSignature, WasmType},
-    Function, InterfaceId, PackageName, Resolve, TypeDefKind, TypeId, World, WorldId, WorldItem,
-    WorldKey,
+    Function, InterfaceId, PackageName, Resolve, Type, TypeDefKind, TypeId, World, WorldId,
+    WorldItem, WorldKey,
 };
 
 fn wasm_sig_to_func_type(signature: WasmSignature) -> FuncType {
@@ -152,6 +152,16 @@ pub struct PayloadInfo {
     /// This may affect how we emit the declaration of the built-in, e.g. if the
     /// payload type is an exported resource.
     pub imported: bool,
+}
+
+impl PayloadInfo {
+    /// Returns the payload type that this future/stream type is using.
+    pub fn payload(&self, resolve: &Resolve) -> Option<Type> {
+        match resolve.types[self.ty].kind {
+            TypeDefKind::Future(payload) | TypeDefKind::Stream(payload) => payload,
+            _ => unreachable!(),
+        }
+    }
 }
 
 impl Hash for PayloadInfo {


### PR DESCRIPTION
In grappling with adding canonical ABI options to `task.return` I was staring at a lot of code in this file so this refactors things with what I saw lying around here and there in preparation to make adding ABI opts to `task.return` a bit easier (in theory)