### PR TITLE
Promote an `assert!` to a `bail!`

### DIFF
--- a/crates/wit-parser/src/resolve.rs
+++ b/crates/wit-parser/src/resolve.rs
@@ -2644,7 +2644,13 @@ impl Remap {
             worlds: Default::default(),
         });
         let prev = resolve.package_names.insert(unresolved.name.clone(), pkgid);
-        assert!(prev.is_none());
+        if let Some(prev) = prev {
+            resolve.package_names.insert(unresolved.name.clone(), prev);
+            bail!(
+                "attempting to re-add package `{}` when it's already present in this `Resolve`",
+                unresolved.name,
+            );
+        }
 
         self.process_foreign_deps(resolve, pkgid, &unresolved)?;
 


### PR DESCRIPTION
This commit fixes a runtime assertion tripping to instead being a first-class error returned by `bail!`. This cannot currently be triggered from the CLI and is only reachable through API usage of the `wit_parser::Resolve` type. This usage is reachable through generators such as `wit_bindgen::generate!`, though.

The error here happens when a package is re-added to a `Resolve` twice. This currently isn't supported and would require some large refactoring to support. This should probably be fixed at some point in the future to actually be supported but until that happens it's best to have a first-class error for this case instead of an internal assertion tripping.

Closes #1996