### PR TITLE
Force using `sync` resource-drop during fuzzing

### DIFF
--- a/crates/wit-component/src/dummy.rs
+++ b/crates/wit-component/src/dummy.rs
@@ -147,7 +147,9 @@ pub fn dummy_module(resolve: &Resolve, world: WorldId, mangling: ManglingAndAbi)
             _ => return,
         }
         let (module, name) = resolve.wasm_import_name(
-            mangling,
+            // Force using a sync ABI here at this time as support for async
+            // resource drop isn't implemented yet.
+            mangling.sync(),
             WasmImport::ResourceIntrinsic {
                 interface,
                 resource,

--- a/crates/wit-parser/src/lib.rs
+++ b/crates/wit-parser/src/lib.rs
@@ -947,6 +947,15 @@ impl ManglingAndAbi {
             Self::Legacy(abi) => abi.export_variant(),
         }
     }
+
+    /// Switch the ABI to be sync if it's async.
+    pub fn sync(self) -> Self {
+        match self {
+            Self::Standard32 | Self::Legacy(LiftLowerAbi::Sync) => self,
+            Self::Legacy(LiftLowerAbi::AsyncCallback)
+            | Self::Legacy(LiftLowerAbi::AsyncStackful) => Self::Legacy(LiftLowerAbi::Sync),
+        }
+    }
 }
 
 impl Function {


### PR DESCRIPTION
This commit fixes fuzzer fallout from #2065 and related PRs where previously async destructor imports were being generated but were actually bound with synchronous destructor imports. Now `wit-component` is generating an error on async resource destructors so this fixes the generator to avoid generating such imports for now while there's not support for lowering them.