### PR TITLE
Preserve the version metadata in wit merge

### DIFF
--- a/crates/wit-component/tests/merge/success/from/deps/foo/shared.wit
+++ b/crates/wit-component/tests/merge/success/from/deps/foo/shared.wit
@@ -33,6 +33,10 @@ world shared-world-with-versions {
   @since(version = 1.0.0)
   import shared-version-on-from;
   import shared-version-on-into;
+
+  @since(version = 1.0.0)
+  export shared-version-on-from;
+  export shared-version-on-into;
 }
 
 world shared-world-with-versions-and-include {

--- a/crates/wit-component/tests/merge/success/into/deps/foo/shared.wit
+++ b/crates/wit-component/tests/merge/success/into/deps/foo/shared.wit
@@ -31,6 +31,10 @@ world shared-world-with-versions {
   import shared-version-on-from;
   @since(version = 1.0.0)
   import shared-version-on-into;
+
+  export shared-version-on-from;
+  @since(version = 1.0.0)
+  export shared-version-on-into;
 }
 
 world shared-world-with-versions-and-include {

--- a/crates/wit-component/tests/merge/success/merge/foo.wit
+++ b/crates/wit-component/tests/merge/success/merge/foo.wit
@@ -58,10 +58,20 @@ world shared-world-with-versions {
   import shared-version-on-from;
   @since(version = 1.0.0)
   import shared-version-on-into;
+
+  @since(version = 1.0.0)
+  export shared-version-on-from;
+  @since(version = 1.0.0)
+  export shared-version-on-into;
 }
 world shared-world-with-versions-and-include {
   @since(version = 1.0.0)
   import shared-version-on-from;
   @since(version = 1.0.0)
   import shared-version-on-into;
+
+  @since(version = 1.0.0)
+  export shared-version-on-from;
+  @since(version = 1.0.0)
+  export shared-version-on-into;
 }

--- a/crates/wit-component/tests/merge/success/merge/foo.wit
+++ b/crates/wit-component/tests/merge/success/merge/foo.wit
@@ -54,11 +54,13 @@ world shared-world {
   export shared-items;
 }
 world shared-world-with-versions {
+  @since(version = 1.0.0)
   import shared-version-on-from;
   @since(version = 1.0.0)
   import shared-version-on-into;
 }
 world shared-world-with-versions-and-include {
+  @since(version = 1.0.0)
   import shared-version-on-from;
   @since(version = 1.0.0)
   import shared-version-on-into;


### PR DESCRIPTION
Follow up to #2076 where I found this issue. 

It is expected that when merging two worlds the versions are preserved.  For instance the merge should preserve the `@since` for the into and the from.

given shared world 1:
```
world shared-world-with-versions-and-include {
  import shared-version-on-from;
  @since(version = 1.0.0)
  import shared-version-on-into;
}
```

And shared world 2:
```
world shared-world-with-versions-and-include {
  @since(version = 1.0.0)
  import shared-version-on-from;
  import shared-version-on-into;
}
```

It is expected to see:

```
world shared-world-with-versions-and-include {
  @since(version = 1.0.0)
  import shared-version-on-from;
  @since(version = 1.0.0)
  import shared-version-on-into;
}
```