### PR TITLE
[wasm-metadata] Parse dependency information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "auditable-serde"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7bf8143dfc3c0258df908843e169b5cc5fcf76c7718bd66135ef4a9cd558c5"
+dependencies = [
+ "semver",
+ "serde",
+ "serde_json",
+ "topological-sort",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "11faaf5a5236997af9848be0bef4db95824b1d534ebc64d0f0c6cf3e67bd38dc"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1217,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
+checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
 ]
@@ -1757,6 +1769,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "topological-sort"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
+
+[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1937,7 +1955,9 @@ name = "wasm-metadata"
 version = "0.226.0"
 dependencies = [
  "anyhow",
+ "auditable-serde",
  "clap",
+ "flate2",
  "indexmap 2.7.1",
  "serde",
  "serde_derive",

--- a/crates/wasm-metadata/Cargo.toml
+++ b/crates/wasm-metadata/Cargo.toml
@@ -20,4 +20,10 @@ serde_json = { workspace = true }
 spdx = { workspace = true }
 url = { workspace = true }
 wasm-encoder = { workspace = true, features = ['std', 'component-model'] }
-wasmparser = { workspace = true, features = ['std', 'component-model', 'hash-collections'] }
+wasmparser = { workspace = true, features = [
+    'std',
+    'component-model',
+    'hash-collections',
+] }
+auditable-serde = "0.8.0"
+flate2 = "1.1.0"

--- a/crates/wasm-metadata/src/add_metadata.rs
+++ b/crates/wasm-metadata/src/add_metadata.rs
@@ -1,8 +1,9 @@
 use crate::{
-    rewrite_wasm, Authors, Description, Homepage, Licenses, Producers, Revision, Source, Version,
+    rewrite_wasm, Authors, Dependencies, Description, Homepage, Licenses, Producers, Revision, Source, Version
 };
 
 use anyhow::Result;
+use auditable_serde::{Package, VersionInfo};
 
 /// Add metadata (module name, producers) to a WebAssembly file.
 ///

--- a/crates/wasm-metadata/src/dependencies.rs
+++ b/crates/wasm-metadata/src/dependencies.rs
@@ -36,7 +36,8 @@ impl Dependencies {
         })
     }
 
-    fn new(dependency_tree: auditable_serde::VersionInfo) -> Self {
+    /// Create a new instance of `Dependencies`.
+    pub fn new(dependency_tree: auditable_serde::VersionInfo) -> Self {
         let data = serde_json::to_string(&dependency_tree).unwrap();
 
         let mut ret_vec = Vec::new();
@@ -50,6 +51,10 @@ impl Dependencies {
                 data: ret_vec.into(),
             },
         }
+    }
+
+    pub fn version_info(&self) -> &VersionInfo {
+        &self.version_info
     }
 }
 

--- a/crates/wasm-metadata/src/dependencies.rs
+++ b/crates/wasm-metadata/src/dependencies.rs
@@ -1,0 +1,110 @@
+use std::fmt::{self, Display};
+use std::str::FromStr;
+
+use anyhow::{ensure, Error, Result};
+use auditable_serde::VersionInfo;
+// use auditable_serde::Auditable;
+use flate2::read::GzDecoder;
+// use miniz_oxide::inflate::decompress_to_vec_zlib;
+use serde::Serialize;
+use wasm_encoder::{ComponentSection, CustomSection, Encode, Section};
+use wasmparser::CustomSectionReader;
+
+/// Human-readable description of the binary
+#[derive(Debug, Clone, PartialEq)]
+pub struct Dependencies(VersionInfo);
+
+impl Dependencies {
+    /// Parse an `description` custom section from a wasm binary.
+    pub(crate) fn parse_custom_section(reader: &CustomSectionReader<'_>) -> Result<Self> {
+        ensure!(
+            reader.name() == ".dep-v0",
+            "The `dependencies` custom section should have a name of '.dep-v0'"
+        );
+        // let decompressed_data = decompress_to_vec_zlib(reader.data())?;
+        let decompressed_data = GzDecoder::new(reader.data());
+        let decompressed_data = std::io::read_to_string(decompressed_data)?;
+        let dependency_tree = auditable_serde::VersionInfo::from_str(&decompressed_data)?;
+
+        Ok(Self::new(dependency_tree))
+    }
+
+    fn new(dependency_tree: auditable_serde::VersionInfo) -> Self {
+        Self(dependency_tree)
+    }
+}
+
+// impl FromStr for Dependencies {
+//     type Err = Error;
+
+//     fn from_str(s: &str) -> Result<Self, Self::Err> {
+//         Ok(Self::new(s.to_owned()))
+//     }
+// }
+
+impl Serialize for Dependencies {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl Display for Dependencies {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // NOTE: this will never panic since we always guarantee the data is
+        // encoded as utf8, even if we internally store it as [u8].
+        // let data = String::from_utf8(self.0.data.to_vec()).unwrap();
+        write!(f, "")
+    }
+}
+
+impl ComponentSection for Dependencies {
+    fn id(&self) -> u8 {
+        ComponentSection::id(&self.0)
+    }
+}
+
+impl Section for Dependencies {
+    fn id(&self) -> u8 {
+        Section::id(&self.0)
+    }
+}
+
+impl Encode for Dependencies {
+    fn encode(&self, sink: &mut Vec<u8>) {
+        self.0.encode(sink);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use wasm_encoder::Component;
+    use wasmparser::Payload;
+
+    #[test]
+    fn roundtrip() {
+        let mut component = Component::new();
+        component.section(&Dependencies::new("Nori likes chicken"));
+        let component = component.finish();
+
+        let mut parsed = false;
+        for section in wasmparser::Parser::new(0).parse_all(&component) {
+            if let Payload::CustomSection(reader) = section.unwrap() {
+                let description = Dependencies::parse_custom_section(&reader).unwrap();
+                assert_eq!(description.to_string(), "Nori likes chicken");
+                parsed = true;
+            }
+        }
+        assert!(parsed);
+    }
+
+    #[test]
+    fn serialize() {
+        let description = Dependencies::new("Chashu likes tuna");
+        let json = serde_json::to_string(&description).unwrap();
+        assert_eq!(r#""Chashu likes tuna""#, json);
+    }
+}

--- a/crates/wasm-metadata/src/dependencies.rs
+++ b/crates/wasm-metadata/src/dependencies.rs
@@ -75,7 +75,8 @@ impl Display for Dependencies {
         // NOTE: this will never panic since we always guarantee the data is
         // encoded as utf8, even if we internally store it as [u8].
         // let data = String::from_utf8(self.0.data.to_vec()).unwrap();
-        write!(f, "")
+        let data = serde_json::to_string(&self.version_info).unwrap();
+        write!(f, "{}", data)
     }
 }
 
@@ -107,11 +108,7 @@ mod test {
 
     #[test]
     fn roundtrip() {
-        let json_str = r#"{"packages":[{
-        "name":"adler",
-        "version":"0.2.3",
-        "source":"registry"
-        }]}"#;
+        let json_str = r#"{"packages":[{"name":"adler","version":"0.2.3","source":"registry"}]}"#;
         let info = VersionInfo::from_str(json_str).unwrap();
         assert_eq!(&info.packages[0].name, "adler");
         let mut component = Component::new();

--- a/crates/wasm-metadata/src/lib.rs
+++ b/crates/wasm-metadata/src/lib.rs
@@ -47,6 +47,7 @@
 #![warn(missing_debug_implementations, missing_docs)]
 
 pub use add_metadata::AddMetadata;
+pub use dependencies::Dependencies;
 pub use metadata::Metadata;
 pub use names::{ComponentNames, ModuleNames};
 pub use oci_annotations::{Authors, Description, Homepage, Licenses, Revision, Source, Version};
@@ -56,6 +57,7 @@ pub use producers::{Producers, ProducersField};
 pub(crate) use rewrite::rewrite_wasm;
 
 mod add_metadata;
+mod dependencies;
 mod metadata;
 mod names;
 mod oci_annotations;

--- a/crates/wasm-metadata/src/metadata.rs
+++ b/crates/wasm-metadata/src/metadata.rs
@@ -1,7 +1,9 @@
 use serde_derive::Serialize;
 use std::ops::Range;
 
-use crate::{Authors, Description, Homepage, Licenses, Producers, Revision, Source, Version};
+use crate::{
+    Authors, Dependencies, Description, Homepage, Licenses, Producers, Revision, Source, Version,
+};
 
 /// Metadata associated with a Wasm Component or Module
 #[derive(Debug, Serialize, Default)]
@@ -27,4 +29,6 @@ pub struct Metadata {
     pub version: Option<Version>,
     /// Byte range of the module in the parent binary
     pub range: Range<usize>,
+    // Dependencies of the component
+    pub dependencies: Option<Dependencies>,
 }

--- a/crates/wasm-metadata/src/metadata.rs
+++ b/crates/wasm-metadata/src/metadata.rs
@@ -29,6 +29,6 @@ pub struct Metadata {
     pub version: Option<Version>,
     /// Byte range of the module in the parent binary
     pub range: Range<usize>,
-    // Dependencies of the component
+    /// Dependencies of the component
     pub dependencies: Option<Dependencies>,
 }

--- a/crates/wasm-metadata/src/payload.rs
+++ b/crates/wasm-metadata/src/payload.rs
@@ -1,12 +1,12 @@
-use std::ops::Range;
+use std::{fs::read, ops::Range};
 
 use anyhow::Result;
 use serde_derive::Serialize;
 use wasmparser::{KnownCustom, Parser, Payload::*};
 
 use crate::{
-    Authors, ComponentNames, Description, Homepage, Licenses, Metadata, ModuleNames, Producers,
-    Revision, Source,
+    Authors, ComponentNames, Dependencies, Description, Homepage, Licenses, Metadata, ModuleNames,
+    Producers, Revision, Source,
 };
 
 /// Data representing either a Wasm Component or module
@@ -150,6 +150,14 @@ impl Payload {
                             .expect("non-empty metadata stack")
                             .metadata_mut();
                         *version = Some(a);
+                    }
+                    KnownCustom::Unknown if c.name() == ".dep-v0" => {
+                        let a = crate::Dependencies::parse_custom_section(&c)?;
+                        let Metadata { dependencies, .. } = output
+                            .last_mut()
+                            .expect("non-empty metadata stack")
+                            .metadata_mut();
+                        *dependencies = Some(a);
                     }
                     _ => {}
                 },

--- a/crates/wasm-metadata/tests/component.rs
+++ b/crates/wasm-metadata/tests/component.rs
@@ -38,6 +38,7 @@ fn add_to_empty_component() {
                     homepage,
                     revision,
                     version,
+                    dependencies,
                 },
         } => {
             assert!(children.is_empty());
@@ -145,6 +146,7 @@ fn add_to_nested_component() {
                     homepage,
                     revision,
                     version,
+                    dependencies,
                 }) => {
                     assert_eq!(name, &Some("foo".to_owned()));
                     let producers = producers.as_ref().expect("some producers");

--- a/crates/wasm-metadata/tests/module.rs
+++ b/crates/wasm-metadata/tests/module.rs
@@ -35,6 +35,7 @@ fn add_to_empty_module() {
             homepage,
             revision,
             version,
+            dependencies,
         }) => {
             assert_eq!(name, Some("foo".to_owned()));
             let producers = producers.expect("some producers");

--- a/src/bin/wasm-tools/metadata.rs
+++ b/src/bin/wasm-tools/metadata.rs
@@ -227,6 +227,7 @@ fn write_details_table(payload: &Payload, f: &mut Box<dyn WriteColor>) -> Result
         range,
         revision,
         version,
+        dependencies,
     } = payload.metadata();
 
     // Add the basic information to the table first


### PR DESCRIPTION
Closes #1924 Parses & displays dependency information contained in the `.dep-v0` custom section.


How to use this with [cargo-auditable](https://github.com/rust-secure-code/cargo-auditable) installed:

```sh
cargo auditable build --release
cargo run -- metadata show yourWasmFileName.wasm
```

Sample output:

```sh
╭──────────────┬───────────────────────────────────────────────────────╮
│ KIND         ┆ VALUE                                                 │
╞══════════════╪═══════════════════════════════════════════════════════╡
│ name         ┆ <unknown>                                             │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ kind         ┆ component                                             │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ range        ┆ 0x0..0x3f520                                          │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ processed-by ┆ wit-component [0.219.0]                               │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ child        ┆ rust_wasi_hello.wasm [module]                         │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ child        ┆ wit-component:adapter:wasi_snapshot_preview1 [module] │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ child        ┆ wit-component:shim [module]                           │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ child        ┆ wit-component:fixups [module]                         │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ child        ┆ <unknown> [component]                                 │
╰──────────────┴───────────────────────────────────────────────────────╯
╭──────────────┬───────────────────────────────────────────────────────────────╮
│ KIND         ┆ VALUE                                                         │
╞══════════════╪═══════════════════════════════════════════════════════════════╡
│ name         ┆ rust_wasi_hello.wasm                                          │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ kind         ┆ module                                                        │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ range        ┆ 0x15f6..0x39f6c                                               │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ language     ┆ Rust                                                          │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ language     ┆ C11                                                           │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ processed-by ┆ rustc [1.83.0 (90b35a623 2024-11-26)]                         │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ processed-by ┆ clang [18.1.2-wasi-sdk (https://github.com/llvm/llvm-project  │
│              ┆ 26a1d6601d727a96f4301d0d8647b5a42760ae0c)]                    │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ processed-by ┆ wit-component [0.20.1]                                        │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ processed-by ┆ wit-bindgen-rust [0.37.0]                                     │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ processed-by ┆ wit-bindgen-c [0.17.0]                                        │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ dependency   ┆ autocfg [1.4.0]                                               │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ dependency   ┆ bitflags [2.5.0]                                              │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ dependency   ┆ bytes [1.9.0]                                                 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ dependency   ┆ fnv [1.0.7]                                                   │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ dependency   ┆ futures-core [0.3.31]                                         │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ dependency   ┆ http [1.2.0]                                                  │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ dependency   ┆ itoa [1.0.14]                                                 │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ dependency   ┆ pin-project-lite [0.2.16]                                     │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ dependency   ┆ proc-macro2 [1.0.93]                                          │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ dependency   ┆ quote [1.0.38]                                                │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ dependency   ┆ rust-wasi-hello [0.0.0]                                       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ dependency   ┆ slab [0.4.9]                                                  │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ dependency   ┆ syn [2.0.96]                                                  │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ dependency   ┆ unicode-ident [1.0.15]                                        │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ dependency   ┆ wasi [0.14.0+wasi-0.2.3]                                      │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ dependency   ┆ wit-bindgen-rt [0.37.0]                                       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ dependency   ┆ wit-bindgen-rt [0.39.0]                                       │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ dependency   ┆ wstd [0.5.1]                                                  │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
│ dependency   ┆ wstd-macro [0.5.1]                                            │
╰──────────────┴───────────────────────────────────────────────────────────────╯
```