### PR TITLE
Reduce dependencies of `wasm-metadata`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -274,6 +274,9 @@ jobs:
       - run: cargo check --no-default-features -p wasm-smith --features component-model
       - run: cargo check --no-default-features -p wasm-smith --features wasmparser
       - run: cargo check --no-default-features -p wasm-smith --features wasmparser,component-model
+      - run: cargo check --no-default-features -p wasm-metadata
+      - run: cargo check --no-default-features -p wasm-metadata --features serde
+      - run: cargo check --no-default-features -p wasm-metadata --features oci
       - run: |
           if cargo tree -p wasm-smith --no-default-features -e no-dev | grep wasmparser; then
             echo wasm-smith without default features should not depend on wasmparser

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ wasmtime = { version = "29.0.1", default-features = false, features = ['cranelif
 
 wasm-compose = { version = "0.227.1", path = "crates/wasm-compose" }
 wasm-encoder = { version = "0.227.1", path = "crates/wasm-encoder", default-features = false }
-wasm-metadata = { version = "0.227.1", path = "crates/wasm-metadata" }
+wasm-metadata = { version = "0.227.1", path = "crates/wasm-metadata", default-features = false }
 wasm-mutate = { version = "0.227.1", path = "crates/wasm-mutate" }
 wasm-shrink = { version = "0.227.1", path = "crates/wasm-shrink" }
 wasm-smith = { version = "0.227.1", path = "crates/wasm-smith" }
@@ -168,7 +168,7 @@ wit-encoder = { workspace = true, optional = true }
 wit-parser = { workspace = true, optional = true, features = ['decoding', 'wat', 'serde'] }
 
 # Dependencies of `metadata`
-wasm-metadata = { workspace = true, features = ["clap"], optional = true }
+wasm-metadata = { workspace = true, features = ["clap", "default"], optional = true }
 bytesize = { workspace = true }
 
 # Dependencies of `wit-smith`

--- a/crates/wasm-metadata/Cargo.toml
+++ b/crates/wasm-metadata/Cargo.toml
@@ -14,16 +14,25 @@ workspace = true
 anyhow = { workspace = true }
 clap = { workspace = true, optional = true }
 indexmap = { workspace = true, features = ["serde"] }
-serde = { workspace = true }
-serde_derive = { workspace = true }
-serde_json = { workspace = true }
-spdx = { workspace = true }
-url = { workspace = true }
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
+spdx = { workspace = true, optional = true }
+url = { workspace = true, optional = true }
 wasm-encoder = { workspace = true, features = ['std', 'component-model'] }
-wasmparser = { workspace = true, features = [
-    'std',
-    'component-model',
-    'hash-collections',
-] }
-auditable-serde = "0.8.0"
-flate2 = "1.1.0"
+wasmparser = { workspace = true, features = ['std', 'component-model', 'hash-collections'] }
+auditable-serde = { version = "0.8.0", optional = true }
+flate2 = { version = "1.1.0", optional = true }
+
+[features]
+default = ['oci', 'serde']
+oci = [
+  'dep:auditable-serde',
+  'dep:flate2',
+  'dep:url',
+  'dep:spdx',
+  'dep:serde_json',
+  'serde',
+]
+
+serde = ['dep:serde_derive', 'dep:serde']

--- a/crates/wasm-metadata/src/add_metadata.rs
+++ b/crates/wasm-metadata/src/add_metadata.rs
@@ -1,7 +1,4 @@
-use crate::{
-    rewrite_wasm, Authors, Description, Homepage, Licenses, Producers, Revision, Source, Version,
-};
-
+use crate::{rewrite_wasm, Producers};
 use anyhow::Result;
 
 /// Add metadata (module name, producers) to a WebAssembly file.
@@ -10,6 +7,7 @@ use anyhow::Result;
 /// metadata will be added to the outermost component.
 #[cfg_attr(feature = "clap", derive(clap::Parser))]
 #[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct AddMetadata {
     /// Add a module or component name to the names section
     #[cfg_attr(feature = "clap", clap(long, value_name = "NAME"))]
@@ -30,31 +28,38 @@ pub struct AddMetadata {
     /// Contact details of the people or organization responsible,
     /// encoded as a freeform string.
     #[cfg_attr(feature = "clap", clap(long, value_name = "NAME"))]
-    pub authors: Option<Authors>,
+    #[cfg(feature = "oci")]
+    pub authors: Option<crate::Authors>,
 
     /// A human-readable description of the binary
     #[cfg_attr(feature = "clap", clap(long, value_name = "NAME"))]
-    pub description: Option<Description>,
+    #[cfg(feature = "oci")]
+    pub description: Option<crate::Description>,
 
     /// License(s) under which contained software is distributed as an SPDX License Expression.
     #[cfg_attr(feature = "clap", clap(long, value_name = "NAME"))]
-    pub licenses: Option<Licenses>,
+    #[cfg(feature = "oci")]
+    pub licenses: Option<crate::Licenses>,
 
     /// URL to get source code for building the image
     #[cfg_attr(feature = "clap", clap(long, value_name = "NAME"))]
-    pub source: Option<Source>,
+    #[cfg(feature = "oci")]
+    pub source: Option<crate::Source>,
 
     /// URL to find more information on the binary
     #[cfg_attr(feature = "clap", clap(long, value_name = "NAME"))]
-    pub homepage: Option<Homepage>,
+    #[cfg(feature = "oci")]
+    pub homepage: Option<crate::Homepage>,
 
     /// Source control revision identifier for the packaged software.
     #[cfg_attr(feature = "clap", clap(long, value_name = "NAME"))]
-    pub revision: Option<Revision>,
+    #[cfg(feature = "oci")]
+    pub revision: Option<crate::Revision>,
 
     /// Version of the packaged software
     #[cfg_attr(feature = "clap", clap(long, value_name = "NAME"))]
-    pub version: Option<Version>,
+    #[cfg(feature = "oci")]
+    pub version: Option<crate::Version>,
 }
 
 #[cfg(feature = "clap")]
@@ -69,17 +74,7 @@ impl AddMetadata {
     /// components. The module and component will have, at very least, an empty name and producers
     /// section created.
     pub fn to_wasm(&self, input: &[u8]) -> Result<Vec<u8>> {
-        rewrite_wasm(
-            &self.name,
-            &Producers::from_meta(self),
-            &self.authors,
-            &self.description,
-            &self.licenses,
-            &self.source,
-            &self.homepage,
-            &self.revision,
-            &self.version,
-            input,
-        )
+        let add_producers = Producers::from_meta(self);
+        rewrite_wasm(self, &add_producers, input)
     }
 }

--- a/crates/wasm-metadata/src/lib.rs
+++ b/crates/wasm-metadata/src/lib.rs
@@ -25,44 +25,53 @@
 //!
 //! let wasm = fs::read("program.wasm")?;
 //!
-//! let metadata = AddMetadata {
-//!     name: Some("program".to_owned()),
-//!     language: vec![("tunalang".to_owned(), "1.0.0".to_owned())],
-//!     processed_by: vec![("chashu-tools".to_owned(), "1.0.1".to_owned())],
-//!     sdk: vec![],
-//!     authors: Some(Authors::new("Chashu Cat")),
-//!     description: Some(Description::new("Chashu likes tuna")),
-//!     licenses: Some(Licenses::new("Apache-2.0 WITH LLVM-exception")?),
-//!     source: Some(Source::new("https://github.com/chashu/chashu-tools")?),
-//!     homepage: Some(Homepage::new("https://github.com/chashu/chashu-tools")?),
-//!     revision: Some(Revision::new("de978e17a80c1118f606fce919ba9b7d5a04a5ad")),
-//!     version: Some(Version::new("1.0.0")),
-//! };
+//! let mut add = AddMetadata ::default();
+//! add.name = Some("program".to_owned());
+//! add.language = vec![("tunalang".to_owned(), "1.0.0".to_owned())];
+//! add.processed_by = vec![("chashu-tools".to_owned(), "1.0.1".to_owned())];
+//! add.sdk = vec![];
+//! add.authors = Some(Authors::new("Chashu Cat"));
+//! add.description = Some(Description::new("Chashu likes tuna"));
+//! add.licenses = Some(Licenses::new("Apache-2.0 WITH LLVM-exception")?);
+//! add.source = Some(Source::new("https://github.com/chashu/chashu-tools")?);
+//! add.homepage = Some(Homepage::new("https://github.com/chashu/chashu-tools")?);
+//! add.revision = Some(Revision::new("de978e17a80c1118f606fce919ba9b7d5a04a5ad"));
+//! add.version = Some(Version::new("1.0.0"));
 //!
-//! let wasm = metadata.to_wasm(&wasm)?;
+//! let wasm = add.to_wasm(&wasm)?;
 //! fs::write("program.wasm", &wasm)?;
 //! # Ok(()) }
 //! ```
 
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![warn(missing_debug_implementations, missing_docs)]
 
 pub use add_metadata::AddMetadata;
-pub use dependencies::Dependencies;
-pub use metadata::Metadata;
 pub use names::{ComponentNames, ModuleNames};
-pub use oci_annotations::{Authors, Description, Homepage, Licenses, Revision, Source, Version};
-pub use payload::Payload;
 pub use producers::{Producers, ProducersField};
 
 pub(crate) use rewrite::rewrite_wasm;
 
 mod add_metadata;
-mod dependencies;
-mod metadata;
 mod names;
-mod oci_annotations;
-mod payload;
 mod producers;
 mod rewrite;
 
 pub(crate) mod utils;
+
+#[cfg(feature = "oci")]
+mod dependencies;
+#[cfg(feature = "oci")]
+pub use dependencies::Dependencies;
+#[cfg(feature = "oci")]
+mod oci_annotations;
+#[cfg(feature = "oci")]
+pub use oci_annotations::{Authors, Description, Homepage, Licenses, Revision, Source, Version};
+#[cfg(feature = "oci")]
+mod metadata;
+#[cfg(feature = "oci")]
+pub use metadata::Metadata;
+#[cfg(feature = "oci")]
+mod payload;
+#[cfg(feature = "oci")]
+pub use payload::Payload;

--- a/crates/wasm-metadata/src/payload.rs
+++ b/crates/wasm-metadata/src/payload.rs
@@ -93,6 +93,7 @@ impl Payload {
                             .metadata_mut()
                             .producers = Some(producers);
                     }
+                    #[cfg(feature = "oci")]
                     KnownCustom::Unknown if c.name() == "authors" => {
                         let a = Authors::parse_custom_section(&c)?;
                         let Metadata {
@@ -103,6 +104,7 @@ impl Payload {
                             .metadata_mut();
                         *author = Some(a);
                     }
+                    #[cfg(feature = "oci")]
                     KnownCustom::Unknown if c.name() == "description" => {
                         let a = Description::parse_custom_section(&c)?;
                         let Metadata { description, .. } = output
@@ -111,6 +113,7 @@ impl Payload {
                             .metadata_mut();
                         *description = Some(a);
                     }
+                    #[cfg(feature = "oci")]
                     KnownCustom::Unknown if c.name() == "licenses" => {
                         let a = Licenses::parse_custom_section(&c)?;
                         let Metadata { licenses, .. } = output
@@ -119,6 +122,7 @@ impl Payload {
                             .metadata_mut();
                         *licenses = Some(a);
                     }
+                    #[cfg(feature = "oci")]
                     KnownCustom::Unknown if c.name() == "source" => {
                         let a = Source::parse_custom_section(&c)?;
                         let Metadata { source, .. } = output
@@ -127,6 +131,7 @@ impl Payload {
                             .metadata_mut();
                         *source = Some(a);
                     }
+                    #[cfg(feature = "oci")]
                     KnownCustom::Unknown if c.name() == "homepage" => {
                         let a = Homepage::parse_custom_section(&c)?;
                         let Metadata { homepage, .. } = output
@@ -135,6 +140,7 @@ impl Payload {
                             .metadata_mut();
                         *homepage = Some(a);
                     }
+                    #[cfg(feature = "oci")]
                     KnownCustom::Unknown if c.name() == "revision" => {
                         let a = Revision::parse_custom_section(&c)?;
                         let Metadata { revision, .. } = output
@@ -143,6 +149,7 @@ impl Payload {
                             .metadata_mut();
                         *revision = Some(a);
                     }
+                    #[cfg(feature = "oci")]
                     KnownCustom::Unknown if c.name() == "version" => {
                         let a = crate::Version::parse_custom_section(&c)?;
                         let Metadata { version, .. } = output
@@ -151,6 +158,7 @@ impl Payload {
                             .metadata_mut();
                         *version = Some(a);
                     }
+                    #[cfg(feature = "oci")]
                     KnownCustom::Unknown if c.name() == ".dep-v0" => {
                         let a = crate::Dependencies::parse_custom_section(&c)?;
                         let Metadata { dependencies, .. } = output

--- a/crates/wasm-metadata/src/producers.rs
+++ b/crates/wasm-metadata/src/producers.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use indexmap::{map::Entry, IndexMap};
-use serde_derive::Serialize;
 use wasm_encoder::Encode;
 use wasmparser::{BinaryReader, KnownCustom, Parser, ProducersSectionReader};
 
@@ -8,9 +7,13 @@ use crate::{rewrite_wasm, AddMetadata};
 /// A representation of a WebAssembly producers section.
 ///
 /// Spec: <https://github.com/WebAssembly/tool-conventions/blob/main/ProducersSection.md>
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde_derive::Serialize))]
 pub struct Producers(
-    #[serde(serialize_with = "indexmap::map::serde_seq::serialize")]
+    #[cfg_attr(
+        feature = "serde",
+        serde(serialize_with = "indexmap::map::serde_seq::serialize")
+    )]
     IndexMap<String, IndexMap<String, String>>,
 );
 
@@ -147,9 +150,7 @@ impl Producers {
     /// Merge into an existing wasm module. Rewrites the module with this producers section
     /// merged into its existing one, or adds this producers section if none is present.
     pub fn add_to_wasm(&self, input: &[u8]) -> Result<Vec<u8>> {
-        rewrite_wasm(
-            &None, self, &None, &None, &None, &None, &None, &None, &None, input,
-        )
+        rewrite_wasm(&Default::default(), self, input)
     }
 }
 

--- a/crates/wasm-metadata/tests/component.rs
+++ b/crates/wasm-metadata/tests/component.rs
@@ -6,21 +6,19 @@ use wasm_metadata::*;
 
 #[test]
 fn add_to_empty_component() {
-    let add = AddMetadata {
-        name: Some("foo".to_owned()),
-        language: vec![("bar".to_owned(), "1.0".to_owned())],
-        processed_by: vec![("baz".to_owned(), "1.0".to_owned())],
-        sdk: vec![],
-        authors: Some(Authors::new("Chashu Cat")),
-        description: Some(Description::new("Chashu likes tuna")),
-        licenses: Some(
-            Licenses::new("Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT").unwrap(),
-        ),
-        source: Some(Source::new("https://github.com/bytecodealliance/wasm-tools").unwrap()),
-        homepage: Some(Homepage::new("https://github.com/bytecodealliance/wasm-tools").unwrap()),
-        revision: Some(Revision::new("de978e17a80c1118f606fce919ba9b7d5a04a5ad")),
-        version: Some(Version::new("1.0.0")),
-    };
+    let mut add = AddMetadata::default();
+    add.name = Some("foo".to_owned());
+    add.language = vec![("bar".to_owned(), "1.0".to_owned())];
+    add.processed_by = vec![("baz".to_owned(), "1.0".to_owned())];
+    add.sdk = vec![];
+    add.authors = Some(Authors::new("Chashu Cat"));
+    add.description = Some(Description::new("Chashu likes tuna"));
+    add.licenses =
+        Some(Licenses::new("Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT").unwrap());
+    add.source = Some(Source::new("https://github.com/bytecodealliance/wasm-tools").unwrap());
+    add.homepage = Some(Homepage::new("https://github.com/bytecodealliance/wasm-tools").unwrap());
+    add.revision = Some(Revision::new("de978e17a80c1118f606fce919ba9b7d5a04a5ad"));
+    add.version = Some(Version::new("1.0.0"));
 
     let json_str = r#"{"packages":[{"name":"adler","version":"0.2.3","source":"registry"}]}"#;
     let info = VersionInfo::from_str(json_str).unwrap();
@@ -90,21 +88,20 @@ fn add_to_empty_component() {
 #[test]
 fn add_to_nested_component() {
     // Create the same old module, stick some metadata into it
-    let add = AddMetadata {
-        name: Some("foo".to_owned()),
-        language: vec![("bar".to_owned(), "1.0".to_owned())],
-        processed_by: vec![("baz".to_owned(), "1.0".to_owned())],
-        sdk: vec![],
-        authors: Some(Authors::new("Chashu Cat")),
-        description: Some(Description::new("Chashu likes tuna")),
-        licenses: Some(
-            Licenses::new("Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT").unwrap(),
-        ),
-        source: Some(Source::new("https://github.com/bytecodealliance/wasm-tools").unwrap()),
-        homepage: Some(Homepage::new("https://github.com/bytecodealliance/wasm-tools").unwrap()),
-        revision: Some(Revision::new("de978e17a80c1118f606fce919ba9b7d5a04a5ad")),
-        version: Some(Version::new("1.0.0")),
-    };
+    let mut add = AddMetadata::default();
+    add.name = Some("foo".to_owned());
+    add.language = vec![("bar".to_owned(), "1.0".to_owned())];
+    add.processed_by = vec![("baz".to_owned(), "1.0".to_owned())];
+    add.sdk = vec![];
+    add.authors = Some(Authors::new("Chashu Cat"));
+    add.description = Some(Description::new("Chashu likes tuna"));
+    add.licenses =
+        Some(Licenses::new("Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT").unwrap());
+    add.source = Some(Source::new("https://github.com/bytecodealliance/wasm-tools").unwrap());
+    add.homepage = Some(Homepage::new("https://github.com/bytecodealliance/wasm-tools").unwrap());
+    add.revision = Some(Revision::new("de978e17a80c1118f606fce919ba9b7d5a04a5ad"));
+    add.version = Some(Version::new("1.0.0"));
+
     let json_str = r#"{"packages":[{"name":"adler","version":"0.2.3","source":"registry"}]}"#;
     let info = VersionInfo::from_str(json_str).unwrap();
     let mut component = Module::new();
@@ -122,11 +119,9 @@ fn add_to_nested_component() {
     let component = component.finish();
 
     // Add some different metadata to the component.
-    let add = AddMetadata {
-        name: Some("gussie".to_owned()),
-        sdk: vec![("willa".to_owned(), "sparky".to_owned())],
-        ..Default::default()
-    };
+    let mut add = AddMetadata::default();
+    add.name = Some("gussie".to_owned());
+    add.sdk = vec![("willa".to_owned(), "sparky".to_owned())];
     let component = add.to_wasm(&component).unwrap();
 
     match Payload::from_binary(&component).unwrap() {

--- a/crates/wasm-metadata/tests/module.rs
+++ b/crates/wasm-metadata/tests/module.rs
@@ -6,21 +6,19 @@ use wasm_metadata::*;
 
 #[test]
 fn add_to_empty_module() {
-    let add = AddMetadata {
-        name: Some("foo".to_owned()),
-        language: vec![("bar".to_owned(), "1.0".to_owned())],
-        processed_by: vec![("baz".to_owned(), "1.0".to_owned())],
-        sdk: vec![],
-        authors: Some(Authors::new("Chashu Cat")),
-        description: Some(Description::new("Chashu likes tuna")),
-        licenses: Some(
-            Licenses::new("Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT").unwrap(),
-        ),
-        source: Some(Source::new("https://github.com/bytecodealliance/wasm-tools").unwrap()),
-        homepage: Some(Homepage::new("https://github.com/bytecodealliance/wasm-tools").unwrap()),
-        revision: Some(Revision::new("de978e17a80c1118f606fce919ba9b7d5a04a5ad")),
-        version: Some(Version::new("1.0.0")),
-    };
+    let mut add = AddMetadata::default();
+    add.name = Some("foo".to_owned());
+    add.language = vec![("bar".to_owned(), "1.0".to_owned())];
+    add.processed_by = vec![("baz".to_owned(), "1.0".to_owned())];
+    add.sdk = vec![];
+    add.authors = Some(Authors::new("Chashu Cat"));
+    add.description = Some(Description::new("Chashu likes tuna"));
+    add.licenses =
+        Some(Licenses::new("Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT").unwrap());
+    add.source = Some(Source::new("https://github.com/bytecodealliance/wasm-tools").unwrap());
+    add.homepage = Some(Homepage::new("https://github.com/bytecodealliance/wasm-tools").unwrap());
+    add.revision = Some(Revision::new("de978e17a80c1118f606fce919ba9b7d5a04a5ad"));
+    add.version = Some(Version::new("1.0.0"));
 
     let json_str = r#"{"packages":[{"name":"adler","version":"0.2.3","source":"registry"}]}"#;
     let info = VersionInfo::from_str(json_str).unwrap();

--- a/crates/wit-component/src/encoding.rs
+++ b/crates/wit-component/src/encoding.rs
@@ -394,14 +394,12 @@ impl<'a> EncodingState<'a> {
         self.module_index = Some(idx);
 
         for (name, adapter) in self.info.adapters.iter() {
-            let add_meta = wasm_metadata::AddMetadata {
-                name: Some(if adapter.library_info.is_some() {
-                    name.to_string()
-                } else {
-                    format!("wit-component:adapter:{name}")
-                }),
-                ..Default::default()
-            };
+            let mut add_meta = wasm_metadata::AddMetadata::default();
+            add_meta.name = Some(if adapter.library_info.is_some() {
+                name.to_string()
+            } else {
+                format!("wit-component:adapter:{name}")
+            });
             let wasm = add_meta
                 .to_wasm(&adapter.wasm)
                 .expect("core wasm can get name added");


### PR DESCRIPTION
This crate is depended on by `wit-component` which shows up in a lot of places, but most of the dependencies of `wasm-metadata` are not needed for `wit-component`. This commit gates most of the OCI-related information behind a compile-time `oci` feature which is enabled by default. The workspace dependency now disables default features and only the CLI itself enables the default features of `wasm-metadata`.