### PR TITLE
Add `wasm-module` to `wast` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,7 +162,7 @@ cpp_demangle = { version = "0.4.0", optional = true }
 rustc-demangle = { version = "0.1.21", optional = true }
 
 # Dependencies of `component`
-wast = { workspace = true, optional = true }
+wast = { workspace = true, optional = true, features = ['wasm-module'] }
 wit-component = { workspace = true, optional = true, features = ['dummy-module', 'wat', 'semver-check'] }
 wit-encoder = { workspace = true, optional = true }
 wit-parser = { workspace = true, optional = true, features = ['decoding', 'wat', 'serde'] }


### PR DESCRIPTION
This fixes an unfortunate series of events which renders most historical builds of `wasm-tools` un-buildable from crates.io without `--locked`. The basic problem here is of this shape:

* The `wasm-tools` CLI requires the `wasm-module` feature to be enabled in `wast` but doesn't explicitly enable it.
* The `wasm-tools` crate depends on `wat`, which by default enables this feature. This is why everything "works" today.
* Once published the `wat` crate has semver-compatible releases, meaning that a historical `wasm-tools` may pull in a newer `wat`.
* If a historical `wasm-tools` pulls in a newer `wat` then it'll activate the `wasm-module` dependency in a different version of `wast`, meaning the CLI doesn't have the feature enabled in its dependency of `wast`.

I'm not sure how it would be possible to detect this on CI and fix this or otherwise have a check against it. Thankfully using `--locked` at least for historical builds works (but that shouldn't be required).