### PR TITLE
Add public interface for adding continuation types to `CoreTypeEncoder`

### DIFF
--- a/crates/wasm-encoder/src/core/types.rs
+++ b/crates/wasm-encoder/src/core/types.rs
@@ -635,6 +635,11 @@ impl<'a> CoreTypeEncoder<'a> {
         }
     }
 
+    /// Define a continuation type in this subsection
+    pub fn cont(mut self, ty: &ContType) {
+        self.encode_cont(ty)
+    }
+
     fn encode_cont(&mut self, ty: &ContType) {
         self.bytes.push(0x5d);
         i64::from(ty.0).encode(self.bytes);


### PR DESCRIPTION
The machinery for encoding continuation types (from the stack switching proposal) already exists, but there was no public method to add them. This resolves that - it's such a minor change that I didn't think it was worth opening an issue for it.