### PR TITLE
Remove unneeded wast helper function

### DIFF
--- a/crates/wast/src/component/func.rs
+++ b/crates/wast/src/component/func.rs
@@ -530,10 +530,7 @@ impl<'a> Parse<'a> for CanonWaitableSetWait<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
         parser.parse::<kw::waitable_set_wait>()?;
         let async_ = parser.parse::<Option<kw::r#async>>()?.is_some();
-        let memory = parser.parens(|parser| {
-            let span = parser.parse::<kw::memory>()?.0;
-            parse_trailing_item_ref(kw::memory(span), parser)
-        })?;
+        let memory = parser.parens(|p| p.parse())?;
 
         Ok(Self { async_, memory })
     }
@@ -553,10 +550,7 @@ impl<'a> Parse<'a> for CanonWaitableSetPoll<'a> {
     fn parse(parser: Parser<'a>) -> Result<Self> {
         parser.parse::<kw::waitable_set_poll>()?;
         let async_ = parser.parse::<Option<kw::r#async>>()?.is_some();
-        let memory = parser.parens(|parser| {
-            let span = parser.parse::<kw::memory>()?.0;
-            parse_trailing_item_ref(kw::memory(span), parser)
-        })?;
+        let memory = parser.parens(|p| p.parse())?;
 
         Ok(Self { async_, memory })
     }
@@ -919,11 +913,7 @@ impl<'a> Parse<'a> for CanonOpt<'a> {
             parser.parens(|parser| {
                 let mut l = parser.lookahead1();
                 if l.peek::<kw::memory>()? {
-                    let span = parser.parse::<kw::memory>()?.0;
-                    Ok(CanonOpt::Memory(parse_trailing_item_ref(
-                        kw::memory(span),
-                        parser,
-                    )?))
+                    Ok(CanonOpt::Memory(parser.parse()?))
                 } else if l.peek::<kw::realloc>()? {
                     parser.parse::<kw::realloc>()?;
                     Ok(CanonOpt::Realloc(
@@ -969,14 +959,6 @@ impl Peek for CanonOpt<'_> {
     fn display() -> &'static str {
         "canonical option"
     }
-}
-
-fn parse_trailing_item_ref<T>(kind: T, parser: Parser) -> Result<CoreItemRef<T>> {
-    Ok(CoreItemRef {
-        kind,
-        idx: parser.parse()?,
-        export_name: parser.parse()?,
-    })
 }
 
 impl<'a> Parse<'a> for Vec<CanonOpt<'a>> {


### PR DESCRIPTION
Through the various iterations of the component model text format this was needed at some point but is no longer needed today, so this is removed.