### PR TITLE
Improve support for memory64/shared-everything-threads in components

### DIFF
--- a/tests/cli/component-model/memory64.wast
+++ b/tests/cli/component-model/memory64.wast
@@ -22,20 +22,33 @@
   )
   "mismatch in index type used for memories")
 
+(component
+  (core module $A
+    (memory (export "m") i64 1))
+  (core instance $A (instantiate $A))
+  (alias core export $A "m" (core memory $m))
+
+  (core module $B (import "" "" (memory i64 1)))
+  (core instance (instantiate $B (with "" (instance (export "" (memory $m))))))
+)
+
+(component
+  (core module $A
+    (table (export "m") i64 1 funcref))
+  (core instance $A (instantiate $A))
+  (alias core export $A "m" (core table $m))
+
+  (core module $B (import "" "" (table i64 1 funcref)))
+  (core instance (instantiate $B (with "" (instance (export "" (table $m))))))
+)
+
 (assert_invalid
   (component
+    (import "x" (func $x (param "x" string)))
     (core module $A
       (memory (export "m") i64 1))
     (core instance $A (instantiate $A))
     (alias core export $A "m" (core memory $m))
+    (core func (canon lower (func $x) (memory $m)))
   )
-  "64-bit linear memories are not compatible with components yet")
-
-(assert_invalid
-  (component
-    (core module $A
-      (table (export "m") i64 1 funcref))
-    (core instance $A (instantiate $A))
-    (alias core export $A "m" (core table $m))
-  )
-  "64-bit tables are not compatible with components yet")
+  "canonical ABI memory is not a 32-bit linear memory")

--- a/tests/cli/component-model/shared-everything-threads/not-accepted.wast
+++ b/tests/cli/component-model/shared-everything-threads/not-accepted.wast
@@ -1,20 +1,34 @@
 ;; RUN: wast --assert default --snapshot tests/snapshots % -f shared-everything-threads
 
+(component
+  (core module $A
+    (memory (export "m") 1 2 shared))
+  (core instance $A (instantiate $A))
+  (alias core export $A "m" (core memory $m))
+
+  (core module $B (import "" "" (memory 1 2 shared)))
+  (core instance (instantiate $B (with "" (instance (export "" (memory $m))))))
+)
+
+(component
+  (core module $A
+    (table (export "m") shared 1 2 (ref null (shared func)))
+  )
+  (core instance $A (instantiate $A))
+  (alias core export $A "m" (core table $m))
+
+  (core module $B (import "" "" (table shared 1 2 (ref null (shared func)))))
+  (core instance (instantiate $B (with "" (instance (export "" (table $m))))))
+)
+
 (assert_invalid
   (component
+    (import "x" (func $x (param "x" string)))
+
     (core module $A
       (memory (export "m") 1 2 shared))
     (core instance $A (instantiate $A))
     (alias core export $A "m" (core memory $m))
+    (core func (canon lower (func $x) (memory $m)))
   )
-  "shared linear memories are not compatible with components yet")
-
-(assert_invalid
-  (component
-    (core module $A
-      (table (export "m") shared 1 2 (ref null (shared func)))
-    )
-    (core instance $A (instantiate $A))
-    (alias core export $A "m" (core table $m))
-  )
-  "shared tables are not compatible with components yet")
+  "canonical ABI memory is not a 32-bit linear memory")

--- a/tests/snapshots/cli/component-model/memory64.wast.json
+++ b/tests/snapshots/cli/component-model/memory64.wast.json
@@ -16,18 +16,23 @@
       "text": "mismatch in index type used for memories"
     },
     {
-      "type": "assert_invalid",
-      "line": 26,
+      "type": "module",
+      "line": 25,
       "filename": "memory64.2.wasm",
-      "module_type": "binary",
-      "text": "64-bit linear memories are not compatible with components yet"
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 35,
+      "filename": "memory64.3.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 35,
-      "filename": "memory64.3.wasm",
+      "line": 46,
+      "filename": "memory64.4.wasm",
       "module_type": "binary",
-      "text": "64-bit tables are not compatible with components yet"
+      "text": "canonical ABI memory is not a 32-bit linear memory"
     }
   ]
 }

--- a/tests/snapshots/cli/component-model/memory64.wast/2.print
+++ b/tests/snapshots/cli/component-model/memory64.wast/2.print
@@ -1,0 +1,18 @@
+(component
+  (core module $A (;0;)
+    (memory (;0;) i64 1)
+    (export "m" (memory 0))
+  )
+  (core instance $A (;0;) (instantiate $A))
+  (alias core export $A "m" (core memory $m (;0;)))
+  (core module $B (;1;)
+    (import "" "" (memory (;0;) i64 1))
+  )
+  (core instance (;1;)
+    (export "" (memory $m))
+  )
+  (core instance (;2;) (instantiate $B
+      (with "" (instance 1))
+    )
+  )
+)

--- a/tests/snapshots/cli/component-model/memory64.wast/3.print
+++ b/tests/snapshots/cli/component-model/memory64.wast/3.print
@@ -1,0 +1,18 @@
+(component
+  (core module $A (;0;)
+    (table (;0;) i64 1 funcref)
+    (export "m" (table 0))
+  )
+  (core instance $A (;0;) (instantiate $A))
+  (alias core export $A "m" (core table $m (;0;)))
+  (core module $B (;1;)
+    (import "" "" (table (;0;) i64 1 funcref))
+  )
+  (core instance (;1;)
+    (export "" (table $m))
+  )
+  (core instance (;2;) (instantiate $B
+      (with "" (instance 1))
+    )
+  )
+)

--- a/tests/snapshots/cli/component-model/shared-everything-threads/not-accepted.wast.json
+++ b/tests/snapshots/cli/component-model/shared-everything-threads/not-accepted.wast.json
@@ -2,18 +2,23 @@
   "source_filename": "tests/cli/component-model/shared-everything-threads/not-accepted.wast",
   "commands": [
     {
-      "type": "assert_invalid",
-      "line": 4,
+      "type": "module",
+      "line": 3,
       "filename": "not-accepted.0.wasm",
-      "module_type": "binary",
-      "text": "shared linear memories are not compatible with components yet"
+      "module_type": "binary"
+    },
+    {
+      "type": "module",
+      "line": 13,
+      "filename": "not-accepted.1.wasm",
+      "module_type": "binary"
     },
     {
       "type": "assert_invalid",
-      "line": 13,
-      "filename": "not-accepted.1.wasm",
+      "line": 25,
+      "filename": "not-accepted.2.wasm",
       "module_type": "binary",
-      "text": "shared tables are not compatible with components yet"
+      "text": "canonical ABI memory is not a 32-bit linear memory"
     }
   ]
 }

--- a/tests/snapshots/cli/component-model/shared-everything-threads/not-accepted.wast/0.print
+++ b/tests/snapshots/cli/component-model/shared-everything-threads/not-accepted.wast/0.print
@@ -1,0 +1,18 @@
+(component
+  (core module $A (;0;)
+    (memory (;0;) 1 2 shared)
+    (export "m" (memory 0))
+  )
+  (core instance $A (;0;) (instantiate $A))
+  (alias core export $A "m" (core memory $m (;0;)))
+  (core module $B (;1;)
+    (import "" "" (memory (;0;) 1 2 shared))
+  )
+  (core instance (;1;)
+    (export "" (memory $m))
+  )
+  (core instance (;2;) (instantiate $B
+      (with "" (instance 1))
+    )
+  )
+)

--- a/tests/snapshots/cli/component-model/shared-everything-threads/not-accepted.wast/1.print
+++ b/tests/snapshots/cli/component-model/shared-everything-threads/not-accepted.wast/1.print
@@ -1,0 +1,18 @@
+(component
+  (core module $A (;0;)
+    (table (;0;) shared 1 2 (ref null (shared func)))
+    (export "m" (table 0))
+  )
+  (core instance $A (;0;) (instantiate $A))
+  (alias core export $A "m" (core table $m (;0;)))
+  (core module $B (;1;)
+    (import "" "" (table (;0;) shared 1 2 (ref null (shared func))))
+  )
+  (core instance (;1;)
+    (export "" (table $m))
+  )
+  (core instance (;2;) (instantiate $B
+      (with "" (instance 1))
+    )
+  )
+)

--- a/tests/snapshots/cli/shared-everything-threads/builtins.wast.json
+++ b/tests/snapshots/cli/shared-everything-threads/builtins.wast.json
@@ -25,7 +25,7 @@
       "line": 51,
       "filename": "builtins.3.wasm",
       "module_type": "binary",
-      "text": "spawn type must be shared"
+      "text": "unknown table 0: table index out of bounds"
     },
     {
       "type": "assert_invalid",
@@ -43,17 +43,10 @@
     },
     {
       "type": "assert_invalid",
-      "line": 77,
+      "line": 79,
       "filename": "builtins.6.wasm",
       "module_type": "binary",
-      "text": "unknown table"
-    },
-    {
-      "type": "assert_invalid",
-      "line": 85,
-      "filename": "builtins.7.wasm",
-      "module_type": "binary",
-      "text": "expected a table of shared `funcref`"
+      "text": "mismatch in the shared flag for tables"
     }
   ]
 }

--- a/tests/snapshots/cli/shared-everything-threads/builtins.wast/0.print
+++ b/tests/snapshots/cli/shared-everything-threads/builtins.wast/0.print
@@ -2,7 +2,7 @@
   (core type $start (;0;) (shared (func (param i32))))
   (core func $spawn_ref (;0;) (canon thread.spawn_ref $start))
   (core module $libc (;0;)
-    (table (;0;) 1 (ref null (shared func)))
+    (table (;0;) shared 1 (ref null (shared func)))
     (export "start-table" (table 0))
   )
   (core instance $libc (;0;) (instantiate $libc))

--- a/tests/snapshots/cli/shared-everything-threads/builtins.wast/1.print
+++ b/tests/snapshots/cli/shared-everything-threads/builtins.wast/1.print
@@ -2,7 +2,7 @@
   (core type $start (;0;) (shared (func (param i32))))
   (core func $spawn_ref (;0;) (canon thread.spawn_ref $start))
   (core module $libc (;0;)
-    (table (;0;) 1 (ref null (shared func)))
+    (table (;0;) shared 1 (ref null (shared func)))
     (export "start-table" (table 0))
   )
   (core instance $libc (;0;) (instantiate $libc))


### PR DESCRIPTION
Previously the validator in wasm-tools was updated to conservatively reject all aliases of exports of core memories/tables that were 64-bit or shared. This is a coarse approximation of the actual rules though which today disallow using 64-bit memories in the canonical ABI. Instead this commit updates with a few minor changes to improve the situation here, namely:

* Aliasing core exports is now allowed for any table and memory type.
* Usage of memories in canonical ABI positions now verifies that the memory is of the expected type, using the standard sub-typing.
* Usage of tables in `canon thread.spawn_indirect` now performs a type-check via a similar method to ensure the table is of the right type.

This adjusts the behavior of a few tests here and there as well to account for some slight differences in behavior with these proposals.