### PR TITLE
Fix a component text format panic

### DIFF
--- a/crates/wast/src/component/resolve.rs
+++ b/crates/wast/src/component/resolve.rs
@@ -841,7 +841,21 @@ impl<'a> Resolver<'a> {
                 target: AliasTarget::Outer {
                     outer: Index::Num(depth, span),
                     index: Index::Num(found, span),
-                    kind: ns.into(),
+                    kind: match ns {
+                        Ns::CoreModule => ComponentOuterAliasKind::CoreModule,
+                        Ns::CoreType => ComponentOuterAliasKind::CoreType,
+                        Ns::Type => ComponentOuterAliasKind::Type,
+                        Ns::Component => ComponentOuterAliasKind::Component,
+                        _ => {
+                            return Err(Error::new(
+                                span,
+                                format!(
+                                    "outer item `{}` is not a module, type, or component",
+                                    id.name(),
+                                ),
+                            ))
+                        }
+                    },
                 },
             };
             let local_index = self.current().register_alias(&alias)?;
@@ -1112,18 +1126,6 @@ impl From<Ns> for ComponentExportAliasKind {
             Ns::Component => Self::Component,
             Ns::Value => Self::Value,
             _ => unreachable!("not a component exportable namespace"),
-        }
-    }
-}
-
-impl From<Ns> for ComponentOuterAliasKind {
-    fn from(ns: Ns) -> Self {
-        match ns {
-            Ns::CoreModule => Self::CoreModule,
-            Ns::CoreType => Self::CoreType,
-            Ns::Type => Self::Type,
-            Ns::Component => Self::Component,
-            _ => unreachable!("not an outer alias namespace"),
         }
     }
 }

--- a/tests/cli/component-model/invalid.wast
+++ b/tests/cli/component-model/invalid.wast
@@ -26,3 +26,9 @@
     "(alias outer $nonexistent $foo (type $foo))"
   )
   "outer component `nonexistent` not found")
+
+(assert_malformed
+  (component quote
+    "(import \"x\" (func $x))"
+    "(component (export \"x\" (func $x)))")
+  "outer item `x` is not a module, type, or component")

--- a/tests/snapshots/cli/component-model/invalid.wast.json
+++ b/tests/snapshots/cli/component-model/invalid.wast.json
@@ -28,6 +28,13 @@
       "filename": "invalid.3.wat",
       "module_type": "text",
       "text": "outer component `nonexistent` not found"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 31,
+      "filename": "invalid.4.wat",
+      "module_type": "text",
+      "text": "outer item `x` is not a module, type, or component"
     }
   ]
 }


### PR DESCRIPTION
Outer aliases to non-component/module/type items should return an error since it can't be encoded rather than panicking.

Closes #2106