### PR TITLE
update async lift callback validation

### DIFF
--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -2345,7 +2345,7 @@ impl ComponentState {
 
                             let ty = types[self.core_function_at(*idx, offset)?].unwrap_func();
 
-                            if ty.params() != [ValType::I32; 4] && ty.params() != [ValType::I32] {
+                            if ty.params() != [ValType::I32; 3] && ty.params() != [ValType::I32] {
                                 return Err(BinaryReaderError::new(
                                     "canonical option `callback` uses a core function with an incorrect signature",
                                     offset,

--- a/crates/wit-component/src/dummy.rs
+++ b/crates/wit-component/src/dummy.rs
@@ -341,7 +341,7 @@ fn push_func_export(
                 },
             );
             wat.push_str(&format!(
-                "(func (export \"{name}\") (param i32 i32 i32 i32) (result i32) unreachable)\n"
+                "(func (export \"{name}\") (param i32 i32 i32) (result i32) unreachable)\n"
             ));
         }
         ManglingAndAbi::Legacy(LiftLowerAbi::AsyncStackful) => {}

--- a/crates/wit-component/src/validation.rs
+++ b/crates/wit-component/src/validation.rs
@@ -1207,7 +1207,7 @@ impl ExportMap {
             if let Some((key, id, f)) = names.match_wit_export(suffix, resolve, world, exports) {
                 validate_func_sig(
                     full_name,
-                    &FuncType::new([ValType::I32; 4], [ValType::I32]),
+                    &FuncType::new([ValType::I32; 3], [ValType::I32]),
                     ty,
                 )?;
                 return Ok(Some(if id.is_some() {

--- a/crates/wit-component/tests/components/async-export-with-callback/component.wat
+++ b/crates/wit-component/tests/components/async-export-with-callback/component.wat
@@ -1,7 +1,8 @@
 (component
   (core module (;0;)
     (type (;0;) (func (param i32 i32) (result i32)))
-    (type (;1;) (func (param i32 i32 i32 i32) (result i32)))
+    (type (;1;) (func (param i32 i32 i32) (result i32)))
+    (type (;2;) (func (param i32 i32 i32 i32) (result i32)))
     (memory (;0;) 1)
     (export "[async-lift]foo" (func 0))
     (export "[callback][async-lift]foo" (func 1))
@@ -12,16 +13,16 @@
     (func (;0;) (type 0) (param i32 i32) (result i32)
       unreachable
     )
-    (func (;1;) (type 1) (param i32 i32 i32 i32) (result i32)
+    (func (;1;) (type 1) (param i32 i32 i32) (result i32)
       unreachable
     )
     (func (;2;) (type 0) (param i32 i32) (result i32)
       unreachable
     )
-    (func (;3;) (type 1) (param i32 i32 i32 i32) (result i32)
+    (func (;3;) (type 1) (param i32 i32 i32) (result i32)
       unreachable
     )
-    (func (;4;) (type 1) (param i32 i32 i32 i32) (result i32)
+    (func (;4;) (type 2) (param i32 i32 i32 i32) (result i32)
       unreachable
     )
     (@producers

--- a/crates/wit-component/tests/components/async-export-with-callback/module.wat
+++ b/crates/wit-component/tests/components/async-export-with-callback/module.wat
@@ -1,8 +1,8 @@
 (module
   (func (export "[async-lift]foo") (param i32 i32) (result i32) unreachable)
-  (func (export "[callback][async-lift]foo") (param i32 i32 i32 i32) (result i32) unreachable)
+  (func (export "[callback][async-lift]foo") (param i32 i32 i32) (result i32) unreachable)
   (func (export "[async-lift]foo:foo/bar#foo") (param i32 i32) (result i32) unreachable)
-  (func (export "[callback][async-lift]foo:foo/bar#foo") (param i32 i32 i32 i32) (result i32) unreachable)
+  (func (export "[callback][async-lift]foo:foo/bar#foo") (param i32 i32 i32) (result i32) unreachable)
   (memory (export "memory") 1)
   (func (export "cabi_realloc") (param i32 i32 i32 i32) (result i32) unreachable)
 )

--- a/tests/cli/component-model-async/lift.wast
+++ b/tests/cli/component-model-async/lift.wast
@@ -31,7 +31,7 @@
 ;; async lift; with callback
 (component
   (core module $m
-    (func (export "callback") (param i32 i32 i32 i32) (result i32) unreachable)
+    (func (export "callback") (param i32 i32 i32) (result i32) unreachable)
     (func (export "foo") (param i32) (result i32) unreachable)
   )
   (core instance $i (instantiate $m))
@@ -45,7 +45,7 @@
 (assert_invalid
   (component
     (core module $m
-      (func (export "callback") (param i32 i32 f32 i32) (result i32) unreachable)
+      (func (export "callback") (param i32 f32 i32) (result i32) unreachable)
       (func (export "foo") (param i32) (result i32) unreachable)
     )
     (core instance $i (instantiate $m))
@@ -61,7 +61,7 @@
 (assert_invalid
   (component
     (core module $m
-      (func (export "callback") (param i32 i32 i32 i32) (result i32) unreachable)
+      (func (export "callback") (param i32 i32 i32) (result i32) unreachable)
       (func (export "foo") (param i32) (result i32) unreachable)
       (func (export "post-return-foo") (param i32) unreachable)
     )
@@ -78,7 +78,7 @@
 (assert_invalid
   (component
     (core module $m
-      (func (export "callback") (param i32 i32 i32 i32) (result i32) unreachable)
+      (func (export "callback") (param i32 i32 i32) (result i32) unreachable)
       (func (export "foo") (param i32 i32) (result i32) unreachable)
     )
     (core instance $i (instantiate $m))
@@ -109,7 +109,7 @@
 (assert_invalid
   (component
     (core module $m
-      (func (export "callback") (param i32 i32 i32 i32) (result i32) unreachable)
+      (func (export "callback") (param i32 i32 i32) (result i32) unreachable)
       (func (export "foo") (param i32) (result i32) unreachable)
     )
     (core instance $i (instantiate $m))

--- a/tests/snapshots/cli/component-model-async/lift.wast/2.print
+++ b/tests/snapshots/cli/component-model-async/lift.wast/2.print
@@ -1,10 +1,10 @@
 (component
   (core module $m (;0;)
-    (type (;0;) (func (param i32 i32 i32 i32) (result i32)))
+    (type (;0;) (func (param i32 i32 i32) (result i32)))
     (type (;1;) (func (param i32) (result i32)))
     (export "callback" (func 0))
     (export "foo" (func 1))
-    (func (;0;) (type 0) (param i32 i32 i32 i32) (result i32)
+    (func (;0;) (type 0) (param i32 i32 i32) (result i32)
       unreachable
     )
     (func (;1;) (type 1) (param i32) (result i32)


### PR DESCRIPTION
As of the current spec, the callback function takes 3 parameters, not 4.