### PR TITLE
wast.rs: add explicit --assert for test-folded/no-test-folded

### DIFF
--- a/tests/cli/legacy-exceptions/legacy-exceptions.wast
+++ b/tests/cli/legacy-exceptions/legacy-exceptions.wast
@@ -1,6 +1,5 @@
-;; RUN: wast --assert default --snapshot tests/snapshots % -f legacy-exceptions
+;; RUN: wast --assert default,no-test-folded --snapshot tests/snapshots % -f legacy-exceptions
 
-;; --enable-legacy-exceptions
 (module
   (type (;0;) (func))
   (func (;0;) (type 0)

--- a/tests/cli/legacy-exceptions/rethrow.wast
+++ b/tests/cli/legacy-exceptions/rethrow.wast
@@ -1,4 +1,4 @@
-;; RUN: wast --assert default --snapshot tests/snapshots % -f legacy-exceptions
+;; RUN: wast --assert default,no-test-folded --snapshot tests/snapshots % -f legacy-exceptions
 
 ;; Test rethrow instruction.
 

--- a/tests/cli/legacy-exceptions/throw.wast
+++ b/tests/cli/legacy-exceptions/throw.wast
@@ -1,4 +1,4 @@
-;; RUN: wast --assert default --snapshot tests/snapshots % -f legacy-exceptions
+;; RUN: wast --assert default,no-test-folded --snapshot tests/snapshots % -f legacy-exceptions
 
 ;; Test throw instruction.
 

--- a/tests/cli/legacy-exceptions/try_catch.wast
+++ b/tests/cli/legacy-exceptions/try_catch.wast
@@ -1,4 +1,4 @@
-;; RUN: wast --assert default --snapshot tests/snapshots % -f legacy-exceptions
+;; RUN: wast --assert default,no-test-folded --snapshot tests/snapshots % -f legacy-exceptions
 
 ;; Test try-catch blocks.
 

--- a/tests/cli/legacy-exceptions/try_delegate.wast
+++ b/tests/cli/legacy-exceptions/try_delegate.wast
@@ -1,4 +1,4 @@
-;; RUN: wast --assert default --snapshot tests/snapshots % -f legacy-exceptions
+;; RUN: wast --assert default,no-test-folded --snapshot tests/snapshots % -f legacy-exceptions
 
 ;; Test try-delegate blocks.
 

--- a/tests/snapshots/cli/legacy-exceptions/legacy-exceptions.wast.json
+++ b/tests/snapshots/cli/legacy-exceptions/legacy-exceptions.wast.json
@@ -3,7 +3,7 @@
   "commands": [
     {
       "type": "module",
-      "line": 4,
+      "line": 3,
       "filename": "legacy-exceptions.0.wasm",
       "module_type": "binary"
     }


### PR DESCRIPTION
This PR gives the `wast` subcommand a command-line `--assert` to configure whether to test the folded-instructions printer. Currently this is set more implicitly (`!self.features.features().legacy_exceptions()`).