### PR TITLE
chore: update broken link

### DIFF
--- a/crates/wasm-smith/src/component.rs
+++ b/crates/wasm-smith/src/component.rs
@@ -22,7 +22,7 @@ mod encode;
 /// Construct instances of this type with [the `Arbitrary`
 /// trait](https://docs.rs/arbitrary/*/arbitrary/trait.Arbitrary.html).
 ///
-/// [component]: https://github.com/WebAssembly/component-model/blob/ast-and-binary/design/MVP/Explainer.md
+/// [component]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md
 ///
 /// ## Configured Generated Components
 ///


### PR DESCRIPTION
Hi! I fixed a broken link to the `WebAssembly` component model explainer documentation.