### PR TITLE
Fix/improve validation of components with tags

### DIFF
--- a/crates/wasm-encoder/src/component/names.rs
+++ b/crates/wasm-encoder/src/component/names.rs
@@ -57,6 +57,12 @@ impl ComponentNameSection {
         self.core_decls(ExportKind::Global as u8, names)
     }
 
+    /// Appends a decls name subsection to name core tags within the
+    /// component.
+    pub fn core_tags(&mut self, names: &NameMap) {
+        self.core_decls(ExportKind::Tag as u8, names)
+    }
+
     /// Appends a decls name subsection to name core types within the
     /// component.
     pub fn core_types(&mut self, names: &NameMap) {

--- a/crates/wasmparser/src/validator.rs
+++ b/crates/wasmparser/src/validator.rs
@@ -1117,11 +1117,11 @@ impl Validator {
                 current.core_instances.reserve(count as usize);
                 Ok(())
             },
-            |components, types, _, instance, offset| {
+            |components, types, features, instance, offset| {
                 components
                     .last_mut()
                     .unwrap()
-                    .add_core_instance(instance, types, offset)
+                    .add_core_instance(instance, features, types, offset)
             },
         )
     }

--- a/crates/wast/src/component/binary.rs
+++ b/crates/wast/src/component/binary.rs
@@ -160,6 +160,7 @@ struct Encoder<'a> {
     core_type_names: Vec<Option<&'a str>>,
     core_module_names: Vec<Option<&'a str>>,
     core_instance_names: Vec<Option<&'a str>>,
+    core_tag_names: Vec<Option<&'a str>>,
     func_names: Vec<Option<&'a str>>,
     value_names: Vec<Option<&'a str>>,
     type_names: Vec<Option<&'a str>>,
@@ -609,6 +610,7 @@ impl<'a> Encoder<'a> {
         funcs(&self.core_table_names, ComponentNameSection::core_tables);
         funcs(&self.core_memory_names, ComponentNameSection::core_memories);
         funcs(&self.core_global_names, ComponentNameSection::core_globals);
+        funcs(&self.core_tag_names, ComponentNameSection::core_tags);
         funcs(&self.core_type_names, ComponentNameSection::core_types);
         funcs(&self.core_module_names, ComponentNameSection::core_modules);
         funcs(
@@ -658,7 +660,7 @@ impl<'a> Encoder<'a> {
             core::ExportKind::Global => &mut self.core_global_names,
             core::ExportKind::Table => &mut self.core_table_names,
             core::ExportKind::Memory => &mut self.core_memory_names,
-            core::ExportKind::Tag => unimplemented!(),
+            core::ExportKind::Tag => &mut self.core_tag_names,
         }
     }
 

--- a/tests/cli/component-model/gated-tags.wast
+++ b/tests/cli/component-model/gated-tags.wast
@@ -1,0 +1,18 @@
+;; RUN: wast --features=-exceptions %
+
+(assert_invalid
+  (component
+    (core module $m (func (export "")))
+    (core instance $i (instantiate $m))
+    (alias core export $i "" (core tag $t))
+  )
+  "exceptions proposal not enabled")
+
+(assert_invalid
+  (component
+    (core module $m (func (export "")))
+    (core instance $i (instantiate $m))
+    (core instance
+      (export "" (tag 0)))
+  )
+  "exceptions proposal not enabled")

--- a/tests/cli/component-model/tags.wast
+++ b/tests/cli/component-model/tags.wast
@@ -1,0 +1,30 @@
+;; RUN: wast %
+
+(assert_invalid
+  (component
+    (core module $m (func (export "")))
+    (core instance $i (instantiate $m))
+    (alias core export $i "" (core tag $t))
+  )
+  "export `` for core instance 0 is not a tag")
+
+(component
+  (core module $m (tag (export "")))
+  (core instance $i (instantiate $m))
+  (alias core export $i "" (core tag $t))
+)
+
+(component
+  (core module $m (tag (export "")))
+  (core instance $i (instantiate $m))
+  (core instance
+    (export "" (tag $i ""))))
+
+(assert_invalid
+  (component
+    (core module $m (func (export "")))
+    (core instance $i (instantiate $m))
+    (core instance
+      (export "" (tag 0)))
+  )
+  "unknown tag 0")


### PR DESCRIPTION
This commit fixes an issue where the `Tag` kind of core item was allowed to "leak through" validation of components without the exceptions proposal active. Additionally creating a core instance with a tag was consulting the wrong index space and needed fixing too. The end result is that the `exceptions` proposal is now required for tags to appear within components.

This so far has been glossed over because any valid component would require a core module with a tag and those are properly gated, but it's possible to construct an invalid component with a tag "kind" within it which doesn't actually have any tags. By forgetting to gate on the exception-handling proposal it was leaking this "kind" to callers which weren't necessarily prepared for it.

Finally this also fixes a panic in the text format for components where named tags still had an `unimplemented!()` for when they were being registered.