### PR TITLE
Update some async intrinsic signatures

### DIFF
--- a/crates/wasmparser/src/validator/component.rs
+++ b/crates/wasmparser/src/validator/component.rs
@@ -1552,7 +1552,7 @@ impl ComponentState {
         };
 
         self.core_funcs
-            .push(types.intern_func_type(FuncType::new([], [ValType::I32]), offset));
+            .push(types.intern_func_type(FuncType::new([ValType::I32], []), offset));
         Ok(())
     }
 
@@ -1700,7 +1700,7 @@ impl ComponentState {
         };
 
         self.core_funcs
-            .push(types.intern_func_type(FuncType::new([ValType::I32; 2], []), offset));
+            .push(types.intern_func_type(FuncType::new([ValType::I32], []), offset));
         Ok(())
     }
 
@@ -1724,7 +1724,7 @@ impl ComponentState {
         };
 
         self.core_funcs
-            .push(types.intern_func_type(FuncType::new([ValType::I32; 2], []), offset));
+            .push(types.intern_func_type(FuncType::new([ValType::I32], []), offset));
         Ok(())
     }
 

--- a/crates/wit-component/src/dummy.rs
+++ b/crates/wit-component/src/dummy.rs
@@ -192,13 +192,13 @@ fn push_imported_future_and_stream_intrinsics(
             TypeDefKind::Future(_) => {
                 wat.push_str(&format!(
                     r#"
-(import {module:?} "[future-new-{i}]{name}" (func (result i32)))
+(import {module:?} "[future-new-{i}]{name}" (func (param i32)))
 (import {module:?} "[future-read-{i}]{name}" (func (param i32 i32) (result i32)))
 (import {module:?} "[future-write-{i}]{name}" (func (param i32 i32) (result i32)))
 (import {module:?} "[future-cancel-read-{i}]{name}" (func (param i32) (result i32)))
 (import {module:?} "[future-cancel-write-{i}]{name}" (func (param i32) (result i32)))
-(import {module:?} "[future-close-readable-{i}]{name}" (func (param i32 i32)))
-(import {module:?} "[future-close-writable-{i}]{name}" (func (param i32 i32)))
+(import {module:?} "[future-close-readable-{i}]{name}" (func (param i32)))
+(import {module:?} "[future-close-writable-{i}]{name}" (func (param i32)))
 (import {module:?} "[async-lower][future-read-{i}]{name}" (func (param i32 i32) (result i32)))
 (import {module:?} "[async-lower][future-write-{i}]{name}" (func (param i32 i32) (result i32)))
 

--- a/crates/wit-component/src/validation.rs
+++ b/crates/wit-component/src/validation.rs
@@ -877,7 +877,7 @@ impl ImportMap {
             if async_ {
                 bail!("async `future.new` calls not supported");
             }
-            validate_func_sig(name, &FuncType::new([], [ValType::I32]), ty)?;
+            validate_func_sig(name, &FuncType::new([ValType::I32], []), ty)?;
             Import::FutureNew(info)
         } else if let Some(info) = prefixed_payload("[future-write-") {
             validate_func_sig(name, &FuncType::new([ValType::I32; 2], [ValType::I32]), ty)?;
@@ -895,13 +895,13 @@ impl ImportMap {
             if async_ {
                 bail!("async `future.close-writable` calls not supported");
             }
-            validate_func_sig(name, &FuncType::new([ValType::I32; 2], []), ty)?;
+            validate_func_sig(name, &FuncType::new([ValType::I32], []), ty)?;
             Import::FutureCloseWritable(info)
         } else if let Some(info) = prefixed_payload("[future-close-readable-") {
             if async_ {
                 bail!("async `future.close-readable` calls not supported");
             }
-            validate_func_sig(name, &FuncType::new([ValType::I32; 2], []), ty)?;
+            validate_func_sig(name, &FuncType::new([ValType::I32], []), ty)?;
             Import::FutureCloseReadable(info)
         } else if let Some(info) = prefixed_payload("[stream-new-") {
             if async_ {

--- a/tests/cli/component-model-async/futures.wast
+++ b/tests/cli/component-model-async/futures.wast
@@ -3,7 +3,7 @@
 ;; future.new
 (component
   (core module $m
-    (import "" "future.new" (func $future-new (result i32)))
+    (import "" "future.new" (func $future-new (param i32)))
   )
   (type $future-type (future u8))
   (core func $future-new (canon future.new $future-type))
@@ -171,7 +171,7 @@
 ;; future.close-readable
 (component
   (core module $m
-    (import "" "future.close-readable" (func $future-close-readable (param i32 i32)))
+    (import "" "future.close-readable" (func $future-close-readable (param i32)))
   )
   (type $future-type (future u8))
   (core func $future-close-readable (canon future.close-readable $future-type))
@@ -194,7 +194,7 @@
 ;; future.close-writable
 (component
   (core module $m
-    (import "" "future.close-writable" (func $future-close-writable (param i32 i32)))
+    (import "" "future.close-writable" (func $future-close-writable (param i32)))
   )
   (type $future-type (future u8))
   (core func $future-close-writable (canon future.close-writable $future-type))

--- a/tests/snapshots/cli/component-model-async/futures.wast/0.print
+++ b/tests/snapshots/cli/component-model-async/futures.wast/0.print
@@ -1,6 +1,6 @@
 (component
   (core module $m (;0;)
-    (type (;0;) (func (result i32)))
+    (type (;0;) (func (param i32)))
     (import "" "future.new" (func $future-new (;0;) (type 0)))
   )
   (type $future-type (;0;) (future u8))

--- a/tests/snapshots/cli/component-model-async/futures.wast/13.print
+++ b/tests/snapshots/cli/component-model-async/futures.wast/13.print
@@ -1,6 +1,6 @@
 (component
   (core module $m (;0;)
-    (type (;0;) (func (param i32 i32)))
+    (type (;0;) (func (param i32)))
     (import "" "future.close-readable" (func $future-close-readable (;0;) (type 0)))
   )
   (type $future-type (;0;) (future u8))

--- a/tests/snapshots/cli/component-model-async/futures.wast/15.print
+++ b/tests/snapshots/cli/component-model-async/futures.wast/15.print
@@ -1,6 +1,6 @@
 (component
   (core module $m (;0;)
-    (type (;0;) (func (param i32 i32)))
+    (type (;0;) (func (param i32)))
     (import "" "future.close-writable" (func $future-close-writable (;0;) (type 0)))
   )
   (type $future-type (;0;) (future u8))


### PR DESCRIPTION
* `future.new` - takes a pointer parameter instead of returning a result.
* `future.close-{readable,writable}` - drop the `error-context` argument second field.