### PR TITLE
Return an error earlier on instructions-after-function-end

### DIFF
--- a/crates/wasmparser/src/validator/operators.rs
+++ b/crates/wasmparser/src/validator/operators.rs
@@ -931,6 +931,14 @@ where
     /// breaks interact with this block's type. Additionally the type signature
     /// of the block is specified by `ty`.
     fn push_ctrl(&mut self, kind: FrameKind, ty: BlockType) -> Result<()> {
+        // If the control stack is already empty then that means that the
+        // function has already ended and it's invalid to have operators.
+        // Prevent pushing more frames to the control stack and immediately
+        // return an error.
+        if self.control.is_empty() {
+            return Err(self.err_beyond_end(self.offset));
+        }
+
         // Push a new frame which has a snapshot of the height of the current
         // operand stack.
         let height = self.operands.len();

--- a/tests/cli/block-after-frame.wat
+++ b/tests/cli/block-after-frame.wat
@@ -1,0 +1,16 @@
+;; FAIL: validate %
+
+(module
+  (func (param i32) (result i32)
+    i32.const 0
+    i32.const 0
+    br_if 0
+    i32.const 0
+    return
+    end
+    block
+      i32.const 0
+      return
+    end
+  )
+)

--- a/tests/cli/block-after-frame.wat.stderr
+++ b/tests/cli/block-after-frame.wat.stderr
@@ -1,0 +1,4 @@
+error: func 0 failed to validate
+
+Caused by:
+    0: operators remaining after end of function (at offset 0x23)


### PR DESCRIPTION
WebAssembly considers any instructions after the final `end` in a function to be invalid, and `wasmparser` correctly identifies such modules as invalid. Currently though if "valid code" is present until the actual byte end of the function this error is delayed until the function is finalized. This is currently to avoid the overhead of checking if we're at the end of the function during the validation of all operators.

This can have adverse side effects on consumers, however. For example for the included test case it currently causes `wasmtime compile` to panic. The reason for this is that compilation continues after the end of the function and Wasmtime ends up panicking before an error is returned from wasmparser. The exact reason for the error is a mismatch in the understanding where Wasmtime thinks a `return` must match the function's types, but due to the way validation-after-end-of-function works the validator was validating whatever block was pushed prior. This mismatch led to a panic in Wasmtime.

The fix here is to prevent the control stack from growing in height after it has been emptied out. That forces the error to be returned sooner and also ensures that once the control stack is emptied again it'll never grow. This continues to avoid a (hopefully unnecessary) check on all instructions as to whether the function has ended and keeps the cost localized to just control-frame-modification instructions.