### PR TITLE
Improve text-format parsing of offset/align and update spec testsuite

### DIFF
--- a/tests/snapshots/testsuite/proposals/custom-page-sizes/memory_max.wast.json
+++ b/tests/snapshots/testsuite/proposals/custom-page-sizes/memory_max.wast.json
@@ -16,15 +16,15 @@
       "text": "unknown import"
     },
     {
-      "type": "assert_malformed",
-      "line": 32,
-      "filename": "memory_max.2.wat",
-      "module_type": "text",
-      "text": "constant out of range"
+      "type": "assert_invalid",
+      "line": 29,
+      "filename": "memory_max.2.wasm",
+      "module_type": "binary",
+      "text": "memory size must be at most"
     },
     {
       "type": "assert_invalid",
-      "line": 37,
+      "line": 35,
       "filename": "memory_max.3.wasm",
       "module_type": "binary",
       "text": "memory size must be at most"

--- a/tests/snapshots/testsuite/proposals/wasm-3.0/align.wast.json
+++ b/tests/snapshots/testsuite/proposals/wasm-3.0/align.wast.json
@@ -1873,6 +1873,33 @@
       "filename": "align.112.wasm",
       "module_type": "binary",
       "text": "type mismatch"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 968,
+      "filename": "align.113.wasm",
+      "module_type": "binary",
+      "text": "malformed memop flags"
+    },
+    {
+      "type": "assert_malformed",
+      "line": 987,
+      "filename": "align.114.wasm",
+      "module_type": "binary",
+      "text": "malformed memop flags"
+    },
+    {
+      "type": "module",
+      "line": 1005,
+      "filename": "align.115.wasm",
+      "module_type": "binary"
+    },
+    {
+      "type": "assert_invalid",
+      "line": 1015,
+      "filename": "align.116.wasm",
+      "module_type": "binary",
+      "text": "alignment must not be larger than natural"
     }
   ]
 }

--- a/tests/snapshots/testsuite/proposals/wasm-3.0/align.wast/163.print
+++ b/tests/snapshots/testsuite/proposals/wasm-3.0/align.wast/163.print
@@ -1,0 +1,9 @@
+(module
+  (type (;0;) (func))
+  (memory (;0;) i64 1)
+  (func (;0;) (type 0)
+    i64.const 0
+    i32.load offset=18446744073709551615
+    drop
+  )
+)


### PR DESCRIPTION
The memory64/wasm-3.0 features update the type of memop `align=`_N_ and `offset=`_N_ to u64 in the text format. The `align.wast` test now includes an example with the largest possible values and also uses underscores in them (https://github.com/WebAssembly/spec/pull/1888). This updates the `wast` parsing logic to support this (by using the lexer), and updates the spec testsuite.